### PR TITLE
chore: upgrade Go to 1.24.6

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,7 @@
 "aqua:pvolok/mprocs" = "0.7.2"
 "ubi:sbdchd/squawk" = "1.6.1"
 "ubi:speakeasy-api/speakeasy" = "1.585.0"
-go = "1.24.5"
+go = "1.24.6"
 jq = "1.7.1"
 nodejs = "22.14.0"
 watchexec = "2.3.0"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5-alpine3.21 AS builder
+FROM golang:1.24.6-alpine3.21 AS builder
 
 ARG GIT_SHA=unset
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/speakeasy-api/gram/server
 
-go 1.24.5
+go 1.24.6
 
 tool (
 	github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy


### PR DESCRIPTION
This change upgrades the Go version used in the project to 1.24.6. It includes fixes to vulnerabilities in os/exec and database/sql.