### PR TITLE
chore: use node.js alpine image for docker builds

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 AS build
+FROM node:22.18.0-alpine3.22@sha256:dbb65b3b08bd9d4d4a85299ad4d668b0e709a0601cecb5969f4dbb1dd89408aa AS build
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}


### PR DESCRIPTION
This change switches the Dockerfile for the dashboard to use the node:22.18.0-alpine image instead of the node:18 image. The current image had several vulnerabilities flagged by pentests. The alpine image has no know vulnerabilities at the time of this commit.

[node:18 scan](https://hub.docker.com/layers/library/node/18/images/sha256-eb29363371ee2859fad6a3c5af88d4abc6ff7d399addb13b7de3c1f11bdee6b9)
[node:22.18.0-alpine scan](https://hub.docker.com/layers/library/node/22.18.0-alpine/images/sha256-dbb65b3b08bd9d4d4a85299ad4d668b0e709a0601cecb5969f4dbb1dd89408aa)