### PR TITLE
chore: move slog attribute setting to each component

### DIFF
--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -54,6 +54,8 @@ var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, storage BlobStore) *Service {
+	logger = logger.With(attr.SlogComponent("assets"))
+
 	return &Service{
 		tracer:   otel.Tracer("github.com/speakeasy-api/gram/server/internal/assets"),
 		logger:   logger,

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -63,6 +63,8 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, cfg AuthConfigurations) *Service {
+	logger = logger.With(attr.SlogComponent("auth"))
+
 	return &Service{
 		tracer:       otel.Tracer("github.com/speakeasy-api/gram/server/internal/auth"),
 		logger:       logger,

--- a/server/internal/auth/sessions/localdev.go
+++ b/server/internal/auth/sessions/localdev.go
@@ -48,6 +48,8 @@ var unsafeSessionData = []byte(`
 `)
 
 func NewUnsafeManager(logger *slog.Logger, db *pgxpool.Pool, redisClient *redis.Client, suffix cache.Suffix, localEnvPath string) (*Manager, error) {
+	logger = logger.With(attr.SlogComponent("sessions"))
+
 	raw := unsafeSessionData
 	if localEnvPath != "" {
 		file, err := os.Open(filepath.Clean(localEnvPath))

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -41,6 +41,8 @@ type Manager struct {
 }
 
 func NewManager(logger *slog.Logger, db *pgxpool.Pool, redisClient *redis.Client, suffix cache.Suffix, speakeasyServerAddress string, speakeasySecretKey string, pylon *pylon.Pylon) *Manager {
+	logger = logger.With(attr.SlogComponent("sessions"))
+
 	return &Manager{
 		logger:                 logger.With(attr.SlogComponent("sessions")),
 		sessionCache:           cache.NewTypedObjectCache[Session](logger.With(attr.SlogCacheNamespace("session")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -52,6 +52,8 @@ type Service struct {
 }
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, openRouter openrouter.Provisioner) *Service {
+	logger = logger.With(attr.SlogComponent("chat"))
+
 	return &Service{
 		auth:           auth.New(logger, db, sessions),
 		sessions:       sessions,

--- a/server/internal/customdomains/impl.go
+++ b/server/internal/customdomains/impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	gen "github.com/speakeasy-api/gram/server/gen/domains"
 	srv "github.com/speakeasy-api/gram/server/gen/http/domains/server"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -40,6 +41,8 @@ type TemporalClient interface {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, temporal TemporalClient) *Service {
+	logger = logger.With(attr.SlogComponent("customdomains"))
+
 	return &Service{
 		tracer:         otel.Tracer("github.com/speakeasy-api/gram/server/internal/customdomains"),
 		logger:         logger,

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -50,6 +50,7 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, temporal client.Client, sessions *sessions.Manager, assetStorage assets.BlobStore) *Service {
+	logger = logger.With(attr.SlogComponent("deployments"))
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/deployments")
 
 	return &Service{

--- a/server/internal/environments/impl.go
+++ b/server/internal/environments/impl.go
@@ -17,6 +17,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/environments"
 	srv "github.com/speakeasy-api/gram/server/gen/http/environments/server"
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -39,7 +40,9 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, enc *encryption.Client) *Service {
+	logger = logger.With(attr.SlogComponent("environments"))
 	envRepo := repo.New(db)
+
 	return &Service{
 		tracer:  otel.Tracer("github.com/speakeasy-api/gram/server/internal/environments"),
 		logger:  logger,

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -68,6 +68,7 @@ func NewService(
 ) *Service {
 	envRepo := environments_repo.New(db)
 	tracer := traceProvider.Tracer("github.com/speakeasy-api/gram/server/internal/instances")
+	logger = logger.With(attr.SlogComponent("instances"))
 
 	return &Service{
 		logger:           logger,

--- a/server/internal/integrations/impl.go
+++ b/server/internal/integrations/impl.go
@@ -17,6 +17,7 @@ import (
 
 	srv "github.com/speakeasy-api/gram/server/gen/http/integrations/server"
 	gen "github.com/speakeasy-api/gram/server/gen/integrations"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -39,6 +40,8 @@ var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+	logger = logger.With(attr.SlogComponent("integrations"))
+
 	return &Service{
 		tracer: otel.Tracer("github.com/speakeasy-api/gram/server/internal/packages"),
 		logger: logger,

--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -17,6 +17,7 @@ import (
 
 	srv "github.com/speakeasy-api/gram/server/gen/http/keys/server"
 	gen "github.com/speakeasy-api/gram/server/gen/keys"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -40,6 +41,8 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, env string) *Service {
+	logger = logger.With(attr.SlogComponent("keys"))
+
 	var keyEnv string
 	switch env {
 	case "local":

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -99,6 +99,7 @@ func NewService(
 ) *Service {
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcp")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcp")
+	logger = logger.With(attr.SlogComponent("mcp"))
 
 	return &Service{
 		logger:       logger,

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -38,6 +38,8 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 }
 
 func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.Handler {
+	logger = logger.With(attr.SlogComponent("http"))
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -69,6 +69,7 @@ type Service struct {
 }
 
 func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, db *pgxpool.Pool, serverURL *url.URL, cacheImpl cache.Cache, enc *encryption.Client) *Service {
+	logger = logger.With(attr.SlogComponent("oauth"))
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/oauth")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/oauth")
 

--- a/server/internal/packages/impl.go
+++ b/server/internal/packages/impl.go
@@ -42,6 +42,8 @@ var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+	logger = logger.With(attr.SlogComponent("packages"))
+
 	return &Service{
 		tracer: otel.Tracer("github.com/speakeasy-api/gram/server/internal/packages"),
 		logger: logger,

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -44,6 +44,8 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+	logger = logger.With(attr.SlogComponent("projects"))
+
 	return &Service{
 		tracer:   otel.Tracer("github.com/speakeasy-api/gram/server/internal/projects"),
 		logger:   logger,

--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -45,6 +45,8 @@ var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+	logger = logger.With(attr.SlogComponent("templates"))
+
 	return &Service{
 		tracer: otel.Tracer("github.com/speakeasy-api/gram/server/internal/templates"),
 		logger: logger,

--- a/server/internal/thirdparty/slack/impl.go
+++ b/server/internal/thirdparty/slack/impl.go
@@ -92,6 +92,8 @@ func SlackClientID(env string) string {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, enc *encryption.Client, redisClient *redis.Client, client *slack_client.SlackClient, temporal client.Client, cfg Configurations) *Service {
+	logger = logger.With(attr.SlogComponent("slack"))
+
 	return &Service{
 		tracer:              otel.Tracer("github.com/speakeasy-api/gram/server/internal/auth"),
 		logger:              logger,

--- a/server/internal/tools/impl.go
+++ b/server/internal/tools/impl.go
@@ -15,6 +15,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/tools/server"
 	gen "github.com/speakeasy-api/gram/server/gen/tools"
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -38,6 +39,8 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+	logger = logger.With(attr.SlogComponent("tools"))
+
 	return &Service{
 		tracer:         otel.Tracer("github.com/speakeasy-api/gram/server/internal/tools"),
 		logger:         logger,

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -55,6 +55,8 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+	logger = logger.With(attr.SlogComponent("toolsets"))
+
 	return &Service{
 		tracer:          otel.Tracer("github.com/speakeasy-api/gram/server/internal/toolsets"),
 		logger:          logger,

--- a/server/internal/variations/impl.go
+++ b/server/internal/variations/impl.go
@@ -17,6 +17,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/variations/server"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	gen "github.com/speakeasy-api/gram/server/gen/variations"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -38,6 +39,8 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 
 func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+	logger = logger.With(attr.SlogComponent("variations"))
+
 	return &Service{
 		tracer: otel.Tracer("github.com/speakeasy-api/gram/server/internal/variations"),
 		logger: logger,


### PR DESCRIPTION
Every component is responsible for decorating o11y instruments appropriately. This change is a precursor to adopting opentelemetry log handler.