### PR TITLE
chore: setup log <> trace correlation with DataDog

### DIFF
--- a/server/cmd/gram/root.go
+++ b/server/cmd/gram/root.go
@@ -46,7 +46,11 @@ func newApp() *cli.App {
 				GitSHA:  GitSHA,
 			})
 
-			logger := slog.New(o11y.NewLogHandler(c.String("log-level"), c.Bool("log-pretty")))
+			logger := slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
+				RawLevel:    c.String("log-level"),
+				Pretty:      c.Bool("log-pretty"),
+				DataDogAttr: os.Getenv("DD_SERVICE") != "",
+			}))
 
 			// Sets GOMAXPROCS to match the Linux container CPU quota.
 			_, err := maxprocs.Set(maxprocs.Logger(nil))

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -35,9 +35,12 @@ const (
 	ExpectedKey = attribute.Key("expected")
 	NameKey     = attribute.Key("name")
 	ReasonKey   = attribute.Key("reason")
-	SpanIDKey   = attribute.Key("span.id")
-	TraceIDKey  = attribute.Key("trace.id")
 	ValueKey    = attribute.Key("value")
+
+	SpanIDKey         = attribute.Key("span.id")
+	TraceIDKey        = attribute.Key("trace.id")
+	DataDogTraceIDKey = attribute.Key("dd.trace_id")
+	DataDogSpanIDKey  = attribute.Key("dd.span_id")
 
 	GoaServiceKey = attribute.Key("goa.service")
 	GoaMethodKey  = attribute.Key("goa.method")
@@ -201,6 +204,16 @@ func SlogSpanID(v string) slog.Attr      { return slog.String(string(SpanIDKey),
 
 func TraceID(v string) attribute.KeyValue { return TraceIDKey.String(v) }
 func SlogTraceID(v string) slog.Attr      { return slog.String(string(TraceIDKey), v) }
+
+func DataDogTraceID(v string) attribute.KeyValue { return DataDogTraceIDKey.String(v) }
+func SlogDataDogTraceID(v string) slog.Attr {
+	return slog.String(string(DataDogTraceIDKey), v)
+}
+
+func DataDogSpanID(v string) attribute.KeyValue { return DataDogSpanIDKey.String(v) }
+func SlogDataDogSpanID(v string) slog.Attr {
+	return slog.String(string(DataDogSpanIDKey), v)
+}
 
 func ValueAny(v any) attribute.KeyValue       { return ValueKey.String(fmt.Sprintf("%v", v)) }
 func SlogValueAny(v any) slog.Attr            { return slog.Any(string(ValueKey), v) }

--- a/server/internal/testenv/testcontainers.go
+++ b/server/internal/testenv/testcontainers.go
@@ -21,6 +21,10 @@ func (t *testcontainersLogger) Printf(format string, v ...any) {
 
 func NewTestcontainersLogger() log.Logger {
 	return &testcontainersLogger{
-		logger: slog.New(o11y.NewLogHandler(os.Getenv("LOG_LEVEL"), true)),
+		logger: slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
+			RawLevel:    os.Getenv("LOG_LEVEL"),
+			Pretty:      true,
+			DataDogAttr: false,
+		})),
 	}
 }

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -14,7 +14,11 @@ import (
 
 func NewLogger(*testing.T) *slog.Logger {
 	if testing.Verbose() {
-		return slog.New(o11y.NewLogHandler(os.Getenv("LOG_LEVEL"), true))
+		return slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
+			RawLevel:    os.Getenv("LOG_LEVEL"),
+			Pretty:      true,
+			DataDogAttr: false,
+		}))
 	} else {
 		return slog.New(slog.DiscardHandler)
 	}


### PR DESCRIPTION
This change attempts to enable log and trace correlation with DataDog by switching the trace and span id attributes to DataDog-specific conventions.

Vendor-agnostic logging:

```json
{
  "time": "2025-08-11T16:41:49.076973169Z",
  "level": "INFO",
  "msg": "response",
  "service.name": "gram-server",
  "service.version": "be3b621b",
  "deployment.environment.name": "local",
  "gram.component": "http",
  "http.request.method": "GET",
  "url.original": "/rpc/toolsets.get?slug=dub",
  "http.response.status_code": 200,
  "http.server.request.duration": 0.006723816,
  "host.name": "localhost:8080",

  "trace.id": "f864044d040bc0836e73d9e158cbb780",
  "span.id": "2027e5a704435f21"
}
```

With DataDog attributes:

```json
{
  "time": "2025-08-11T16:41:49.076973169Z",
  "level": "INFO",
  "msg": "response",
  "service.name": "gram-server",
  "service.version": "be3b621b",
  "deployment.environment.name": "local",
  "gram.component": "http",
  "http.request.method": "GET",
  "url.original": "/rpc/toolsets.get?slug=dub",
  "http.response.status_code": 200,
  "http.server.request.duration": 0.006723816,
  "host.name": "localhost:8080",

  "dd.trace_id": "45ccc842c62aa83b0ebe60259f58ea1a",
  "dd.span_id": "a8d2d19bf9120afd"
}
```