### PR TITLE
fix: Settings page table overflow [AGE-356]

### DIFF
--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -279,7 +279,7 @@ export default function Settings() {
           columns={apiKeyColumns}
           data={keysData?.keys ?? []}
           rowKey={(row) => row.id}
-          className="h-fit max-h-[500px] overflow-y-auto"
+          className="min-h-fit max-h-[500px] overflow-y-auto"
           noResultsMessage={
             <Stack
               gap={2}


### PR DESCRIPTION
Fixes an issue where the tables on the settings page would get all tiny