### PR TITLE
fix: always add trace.id and span.id attributes

### DIFF
--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -104,18 +104,16 @@ func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if spanCtx.HasTraceID() {
 		id := spanCtx.TraceID().String()
+		record.Add(attr.SlogTraceID(id))
 		if h.DataDogAttr {
 			record.Add(attr.SlogDataDogTraceID(id))
-		} else {
-			record.Add(attr.SlogTraceID(id))
 		}
 	}
 	if spanCtx.HasSpanID() {
 		id := spanCtx.SpanID().String()
+		record.Add(attr.SlogSpanID(id))
 		if h.DataDogAttr {
 			record.Add(attr.SlogDataDogSpanID(id))
-		} else {
-			record.Add(attr.SlogSpanID(id))
 		}
 	}
 


### PR DESCRIPTION
This change updates ContextHandler to always add the `trace.id` and `span.id` regardless of whether datadog support is enabled or not.

The issue is that datadog deliberately extracts their attributes from log events such that they are not present in the log record when going through the log explorer. The UX to surface the hidden trace id is also very unintuitive. This change gets around that because the vendor agnostic attributes will be present like any other regular attribute.

The trade-off is that we will be shipping redundant data with each log entry using up more bandwidth.