### PR TITLE
feat: local dev logged error token revocation

### DIFF
--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -95,6 +95,10 @@ func (s *Manager) ExchangeTokenFromSpeakeasy(ctx context.Context, code string) (
 }
 
 func (s *Manager) RevokeTokenFromSpeakeasy(ctx context.Context, idToken string) error {
+	if s.unsafeLocal {
+		return nil
+	}
+
 	// Create the HTTP request
 	req, err := http.NewRequestWithContext(ctx, "POST", s.speakeasyServerAddress+"/v1/speakeasy_provider/revoke", nil)
 	if err != nil {


### PR DESCRIPTION
There is no revoking a token in local dev since auth in stubbed. Annoying error fires in console log right now, otherwise harmless