### PR TITLE
fix: solve div inside p tag issue in CardSkeleton

### DIFF
--- a/client/dashboard/src/components/ui/skeleton.tsx
+++ b/client/dashboard/src/components/ui/skeleton.tsx
@@ -1,11 +1,14 @@
 import { cn } from "@/lib/utils";
 import { Column, Stack, Table } from "@speakeasy-api/moonshine";
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+function Skeleton({ className, ...props }: React.ComponentProps<"span">) {
   return (
-    <div
+    <span
       data-slot="skeleton"
-      className={cn("bg-foreground/7 animate-pulse rounded-md", className)}
+      className={cn(
+        "block bg-foreground/7 animate-pulse rounded-md",
+        className
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
This change addresses a recurring console error in Chrome that is due to rendering a `<div>` inside a `<p>` tag. The `CardSkeleton` component was the root cause and the fix involves replacing the `<div>` with a `<span>` in the `Skeleton` component allowing it to be used in more contexts.