### PR TITLE
Credit limit improvements

### DIFF
--- a/client/dashboard/src/components/ui/sidebar.tsx
+++ b/client/dashboard/src/components/ui/sidebar.tsx
@@ -525,7 +525,8 @@ function SidebarMenuButton({
       className={cn(
         sidebarMenuButtonVariants({ variant, size }),
         className,
-        "cursor-pointer trans"
+        "cursor-pointer trans",
+        props.href && "hover:no-underline"
       )}
       {...(props.href && { to: props.href })}
       {...(props.href && props.href.startsWith("http") && { external: true })}

--- a/client/dashboard/src/pages/playground/ChatWindow.tsx
+++ b/client/dashboard/src/pages/playground/ChatWindow.tsx
@@ -335,6 +335,13 @@ function ChatInner({
             displayMessage +=
               " Please start a new chat history and consider enabling *Auto-Summarize* for your tool or revise your prompt.";
           }
+
+          // Improve the error message for the case where the model is out of credits
+          if (displayMessage.includes("requires more credits")) {
+            displayMessage =
+              "You have reached your monthly credit limit. Reach out to the Speakeasy team to upgrade your account.";
+          }
+
           appendDisplayOnlyMessage(`**Model Error:** *${displayMessage}*`);
         }
       },


### PR DESCRIPTION
Improvements to credit limits:
- better message in playground that doesn't leak OpenRouter information
- special case for speakeasy-team that causes it to refresh at $500 limit

<img width="1298" height="416" alt="CleanShot 2025-08-14 at 11 12 22@2x" src="https://github.com/user-attachments/assets/647cfaae-49f5-4bb7-bbdf-8c32ddcc5a38" />
