### PR TITLE
fix: update to openapi parser v1.0.0 to fix schema inlining on shared schemas

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/samber/slog-multi v1.4.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
-	github.com/speakeasy-api/openapi v1.0.0
+	github.com/speakeasy-api/openapi v1.0.1
 	github.com/testcontainers/testcontainers-go v0.38.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.38.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.38.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -477,8 +477,8 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/speakeasy-api/jsonpath v0.6.2 h1:Mys71yd6u8kuowNCR0gCVPlVAHCmKtoGXYoAtcEbqXQ=
 github.com/speakeasy-api/jsonpath v0.6.2/go.mod h1:ymb2iSkyOycmzKwbEAYPJV/yi2rSmvBCLZJcyD+VVWw=
-github.com/speakeasy-api/openapi v1.0.0 h1:indbG470DxCipr7fkzAYvdlFkMTkF3e+zrUnwDq4hwA=
-github.com/speakeasy-api/openapi v1.0.0/go.mod h1:ldAGYMd+ho4YLhTDrjPpWsn3iOXWBll9xFjj0J1PMm4=
+github.com/speakeasy-api/openapi v1.0.1 h1:xlXIfmGNXNAENy3lypwsRs2BmiBIeCpqdraZgWBqD1k=
+github.com/speakeasy-api/openapi v1.0.1/go.mod h1:HK+i+u4IyDkBY6gn4QI/658v0Vi8SQ2/395GclcLC44=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=


### PR DESCRIPTION
https://speakeasyapi.slack.com/archives/C08H55TP4HZ/p1755217624665999?thread_ts=1755093197.932159&cid=C08H55TP4HZ