### PR TITLE
chore: update pnpm to 10.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.6.1",
+  "packageManager": "pnpm@10.14.0",
   "devDependencies": {
     "@datadog/datadog-ci": "^3.18.0",
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
This change updates pnpm to v10.14. The current version of pnpm does not update catalog dependencies in pnpm-workspace.yaml. This can lead to dependency confusion i.e. multiple versions of the same dependencies being installed.