### PR TITLE
fix: override env vars for vite production builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -266,7 +266,7 @@ jobs:
         if: ${{ needs.changes.outputs.client == 'true' }}
         env:
           NODE_ENV: production
-        run: pnpm build
+        run: mise exec --env viteprod -- pnpm build
 
       - name: Upload source maps to DataDog
         if: ${{ needs.changes.outputs.client == 'true' }}

--- a/client/dashboard/src/vite-env.d.ts
+++ b/client/dashboard/src/vite-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare const __GRAM_SERVER_URL__: string;
+declare const __GRAM_SERVER_URL__: string | undefined;
 declare const __GRAM_GIT_SHA__: string | undefined;
 
 interface ViteTypeOptions {

--- a/mise.viteprod.toml
+++ b/mise.viteprod.toml
@@ -1,0 +1,11 @@
+## This file contains configuration overrides that are used when building the
+## Gram dashboard with Vite for production.
+
+[env]
+## Both the Gram server and dashboard (client) are accesses on https://app.getgram.ai.
+GRAM_SERVER_URL = false
+## Not needed for production builds, but can be useful for local development.
+GRAM_SSL_CERT_FILE = false
+GRAM_SSL_KEY_FILE = false
+## Not needed for production builds, used by vite dev server.
+VITE_DEV_HOSTNAMES = false


### PR DESCRIPTION
Environment variables in mise.toml are intended for local development. The CI build of the dashboard was referring to these which would result in the dashboard not working when deployed. For example, the server url was set to http://localhost:8080 instead of being https://{dev,app}.getgram.ai.

This change fixes this issue by create a custom environment for vite production builds and update the CI pipeline to use it.