### PR TITLE
fix: Use background context for polar temporal job

### DIFF
--- a/server/internal/background/activities/collect_platform_usage_metrics.go
+++ b/server/internal/background/activities/collect_platform_usage_metrics.go
@@ -47,7 +47,7 @@ func (c *CollectPlatformUsageMetrics) Do(ctx context.Context) error {
 	}
 
 	for _, metric := range metrics {
-		go c.usageClient.TrackPlatformUsage(ctx, usage.PlatformUsageEvent{
+		go c.usageClient.TrackPlatformUsage(context.Background(), usage.PlatformUsageEvent{
 			OrganizationID:    metric.OrganizationID,
 			PublicMCPServers:  metric.PublicMcpServers,
 			PrivateMCPServers: metric.PrivateMcpServers,


### PR DESCRIPTION
The polar calls are failing with context cancelled