### PR TITLE
chore: Update toolset authentication alert message

### DIFF
--- a/client/dashboard/src/pages/toolsets/ToolsetAuthAlert.tsx
+++ b/client/dashboard/src/pages/toolsets/ToolsetAuthAlert.tsx
@@ -142,8 +142,7 @@ function ToolsetPageAuthAlert({
   return (
     <Alert variant="warning" dismissible={true} className="rounded-xs">
       <span className="text-sm">
-        Set environment variables to test this toolset in MCP clients using your
-        GRAM_KEY.{" "}
+        Set environment variables to test this toolset in the Playground or to manage authentication with a GRAM_KEY.{" "}
         <button
           type="button"
           onClick={onConfigureClick}


### PR DESCRIPTION
## Summary
Updated the authentication alert message in the dashboard to provide clearer guidance on toolset usage contexts.

## Changes
- Modified `ToolsetAuthAlert.tsx` to change the alert text from "Set environment variables to test this toolset in MCP clients using your GRAM_KEY" to "Set environment variables to test this toolset in the Playground or to manage authentication with a GRAM_KEY"

## Context
This change provides users with clearer guidance on where and how they can use their toolsets, specifically mentioning the Playground as a testing option alongside authentication management.

🤖 Generated with [Claude Code](https://claude.ai/code)