### PR TITLE
fix: disable auto-loading env in mise-action

### DIFF
--- a/.github/workflows/migrations.yaml
+++ b/.github/workflows/migrations.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           install: true
           cache: true
+          env: false
       - name: Prepare GitHub Actions environment
         run: mise run github
       - name: Lint migrations

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,6 +131,7 @@ jobs:
         with:
           install: true
           cache: true
+          env: false
 
       - name: Prepare GitHub Actions environment
         if: ${{ needs.changes.outputs.server == 'true' }}
@@ -197,6 +198,7 @@ jobs:
         with:
           install: true
           cache: true
+          env: false
 
       - name: Prepare GitHub Actions environment
         if: ${{ needs.changes.outputs.server == 'true' }}
@@ -242,6 +244,7 @@ jobs:
         with:
           install: true
           cache: true
+          env: false
 
       - name: Prepare GitHub Actions environment
         if: ${{ needs.changes.outputs.client == 'true' }}
@@ -336,6 +339,7 @@ jobs:
         with:
           install: true
           cache: true
+          env: false
 
       - name: Prepare GitHub Actions environment
         if: ${{ needs.changes.outputs.client == 'true' }}


### PR DESCRIPTION
The recently released mise-action v3 switched automatic loading of env variables including ones defined in mise.toml. This causes issues with the dashboard build because now `GRAM_SERVER_URL=http://localhost:8080` is always set in CI. This is then baked into the vite build of the dashboard which will fail to communicate with the backend when deploying to dev/prod environments.