### PR TITLE
chore: add health check for temporal dev server in docker compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      test: ["CMD-SHELL", "pg_isready", "-U", "${DB_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -46,6 +46,11 @@ services:
       ]
     volumes:
       - temporal_data:/home/temporal
+    healthcheck:
+      test: ["CMD", "temporal", "operator", "cluster", "health"]
+      interval: 5s
+      timeout: 30s
+      retries: 5
 
   grafana:
     profiles: [observability]


### PR DESCRIPTION
This changes adds a health check definition to the temporal dev server in docker compose to ensure the container is ready to accept connections.