### PR TITLE
chore: Remove SDKs tab from playground

### DIFF
--- a/client/dashboard/src/pages/environments/EnvironmentDropdown.tsx
+++ b/client/dashboard/src/pages/environments/EnvironmentDropdown.tsx
@@ -7,11 +7,15 @@ import { useMemo } from "react";
 export function EnvironmentDropdown({
   selectedEnvironment,
   setSelectedEnvironment,
+  tooltip = "Switch environments",
+  label,
   visibilityThreshold = 0,
   className,
 }: {
   selectedEnvironment: string | null;
   setSelectedEnvironment: (environment: string) => void;
+  tooltip?: string;
+  label?: string;
   visibilityThreshold?: number;
   className?: string;
 }) {
@@ -34,6 +38,7 @@ export function EnvironmentDropdown({
 
   return (
     <Combobox
+      label={label}
       items={allItems}
       selected={selectedEnvironmentData ? {
         label: selectedEnvironmentData.name,
@@ -42,7 +47,7 @@ export function EnvironmentDropdown({
       onSelectionChange={(item) => {
         setSelectedEnvironment(item.value);
       }}
-      tooltip="Switch environments"
+      tooltip={tooltip}
       className={cn("max-w-fit", className)}
     >
       <Type variant="small">{selectedEnvironmentData?.name || selectedEnvironment}</Type>

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -1,7 +1,6 @@
 import { Page } from "@/components/page-layout";
 import { Button } from "@/components/ui/button";
 import { Combobox, DropdownItem } from "@/components/ui/combobox";
-import { Heading } from "@/components/ui/heading";
 import { Type } from "@/components/ui/type";
 import { useIsAdmin } from "@/contexts/Auth";
 import {
@@ -14,7 +13,6 @@ import { capitalize, cn } from "@/lib/utils";
 import { useRoutes } from "@/routes";
 import {
   useListChats,
-  useListEnvironments,
   useListToolsets,
 } from "@gram/client/react-query/index.js";
 import { Icon, ResizablePanel, Stack } from "@speakeasy-api/moonshine";
@@ -22,7 +20,6 @@ import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { v7 as uuidv7 } from "uuid";
-import { EnvironmentDropdown } from "../environments/EnvironmentDropdown";
 import { ToolsetView } from "../toolsets/Toolset";
 import { ToolsetDropdown } from "../toolsets/ToolsetDropown";
 import { ToolsetsEmptyState } from "../toolsets/ToolsetsEmptyState";
@@ -154,6 +151,7 @@ function PlaygroundInner() {
             <PlaygroundRHS
               configRef={chatConfigRef}
               dynamicToolset={dynamicToolset}
+              setSelectedEnvironment={setSelectedEnvironment}
             />
           </ResizablePanel.Pane>
         </ResizablePanel>
@@ -176,12 +174,10 @@ export function ToolsetPanel({
   setDynamicToolset: (dynamicToolset: boolean) => void;
 }) {
   const { data: toolsetsData } = useListToolsets();
-  const { data: environmentsData } = useListEnvironments();
   const isAdmin = useIsAdmin();
   const routes = useRoutes();
 
   const toolsets = toolsetsData?.toolsets;
-  const environments = environmentsData?.environments;
 
   const selectedToolset = configRef.current.toolsetSlug;
   const selectedEnvironment = configRef.current.environmentSlug;
@@ -198,14 +194,13 @@ export function ToolsetPanel({
   }, [toolsets, configRef, setSelectedToolset, setSelectedEnvironment]);
 
   useEffect(() => {
-    if (environments?.[0] && configRef.current.environmentSlug === null) {
-      if (toolset?.defaultEnvironmentSlug) {
-        setSelectedEnvironment(toolset.defaultEnvironmentSlug);
-      } else {
-        setSelectedEnvironment(environments[0].slug);
-      }
+    if (
+      configRef.current.environmentSlug === null &&
+      toolset?.defaultEnvironmentSlug
+    ) {
+      setSelectedEnvironment(toolset.defaultEnvironmentSlug);
     }
-  }, [environments, configRef, setSelectedEnvironment, toolset]);
+  }, [configRef, setSelectedEnvironment, toolset]);
 
   useEffect(() => {
     const isDynamic =
@@ -262,15 +257,6 @@ export function ToolsetPanel({
               </Stack>
             )}
           </Stack>
-          {environments && environments.length > 0 && (
-            <Stack direction="horizontal" gap={2} align="center">
-              <Heading variant="h5">Active environment: </Heading>
-              <EnvironmentDropdown
-                selectedEnvironment={selectedEnvironment}
-                setSelectedEnvironment={setSelectedEnvironment}
-              />
-            </Stack>
-          )}
         </Stack>
       </PanelHeader>
       {content}
@@ -283,7 +269,7 @@ export const PanelHeader = ({
   children,
 }: {
   side: "left" | "right";
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }) => {
   return (
     <div

--- a/client/dashboard/src/pages/playground/PlaygroundRHS.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundRHS.tsx
@@ -1,21 +1,22 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Type } from "@/components/ui/type";
 import { Message } from "@ai-sdk/react";
-import { Stack } from "@speakeasy-api/moonshine";
-import { useState } from "react";
-import { SdkContent } from "../sdk/SDK";
+import { useListEnvironments } from "@gram/client/react-query";
+import { EnvironmentDropdown } from "../environments/EnvironmentDropdown";
 import { ChatConfig, ChatWindow } from "./ChatWindow";
 import { PanelHeader } from "./Playground";
 
 export function PlaygroundRHS({
   configRef,
   dynamicToolset,
+  setSelectedEnvironment,
 }: {
   configRef: ChatConfig;
   dynamicToolset: boolean;
+  setSelectedEnvironment: (environment: string) => void;
 }) {
-  const [activeTab, setActiveTab] = useState<"chat" | "agents">("chat");
+  const { data: environmentsData } = useListEnvironments();
+  const selectedEnvironment = configRef.current.environmentSlug;
 
+  const environments = environmentsData?.environments;
   const initialMessages: Message[] = [
     {
       id: "1",
@@ -26,35 +27,24 @@ export function PlaygroundRHS({
   ];
 
   return (
-    <Tabs
-      value={activeTab}
-      onValueChange={(value) => setActiveTab(value as "chat" | "agents")}
-      className="h-full relative"
-    >
+    <>
       <PanelHeader side="right">
-        <Stack direction="horizontal" gap={2} align="center">
-          <Type className="font-medium">Use with: </Type>
-          <TabsList>
-            <TabsTrigger value="chat">Chat</TabsTrigger>
-            <TabsTrigger value="agents">SDKs</TabsTrigger>
-          </TabsList>
-        </Stack>
+        {environments && environments.length > 0 && (
+          <EnvironmentDropdown
+            label="Environment"
+            tooltip="Set the active environment"
+            selectedEnvironment={selectedEnvironment}
+            setSelectedEnvironment={setSelectedEnvironment}
+          />
+        )}
       </PanelHeader>
       <div className="h-[calc(100%-61px)] pl-8 pr-4 pt-4">
-        <TabsContent value="chat" className="h-full">
-          <ChatWindow
-            configRef={configRef}
-            dynamicToolset={dynamicToolset}
-            initialMessages={initialMessages}
-          />
-        </TabsContent>
-        <TabsContent value="agents" className="h-full overflow-auto pb-4 pr-4">
-          <SdkContent
-            toolset={configRef.current.toolsetSlug ?? undefined}
-            environment={configRef.current.environmentSlug ?? undefined}
-          />
-        </TabsContent>
+        <ChatWindow
+          configRef={configRef}
+          dynamicToolset={dynamicToolset}
+          initialMessages={initialMessages}
+        />
       </div>
-    </Tabs>
+    </>
   );
 }


### PR DESCRIPTION
Removes the SDKs tab from the playground and uses the newly opened space for the environment switcher

<img width="4136" height="1712" alt="CleanShot 2025-08-25 at 10 43 01@2x" src="https://github.com/user-attachments/assets/ec7d16e9-6a54-4afc-8b64-f89f443fbd25" />
