### PR TITLE
fix: log internal errors in usage service/client

### DIFF
--- a/server/internal/conv/from.go
+++ b/server/internal/conv/from.go
@@ -145,3 +145,10 @@ func AnySlice[T any](vals []T) []any {
 	}
 	return anyVals
 }
+
+func Ternary[T any](condition bool, trueVal, falseVal T) T {
+	if condition {
+		return trueVal
+	}
+	return falseVal
+}

--- a/server/internal/mv/organization.go
+++ b/server/internal/mv/organization.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
-	"github.com/speakeasy-api/gram/server/internal/usage/types"
+	usage_types "github.com/speakeasy-api/gram/server/internal/usage/types"
 )
 
 // Necessary to properly populate account type
@@ -27,7 +27,7 @@ func DescribeOrganization(ctx context.Context, logger *slog.Logger, orgRepo *org
 		return &org, nil
 	}
 
-	// This is used during auth, so try to avoid failing 
+	// This is used during auth, so try to avoid failing
 	customerState, err := customerProvider.GetCustomerState(ctx, orgID)
 	if err != nil {
 		logger.ErrorContext(ctx, "error getting customer state", attr.SlogError(err)) // TODO: set up an alert for this


### PR DESCRIPTION
This change updates the error handling in usage client to return plain wrapped errors and ensures that consumers of the usage client are logging these errors appropriately.

Currently, the usage client uses oops.E which results in internal error messages being masked and only public-facing messages being logged. The purpose of oops.E is to be used in service layers of the codebase and not lower levels.