### PR TITLE
chore: ignore /local/keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ junit-report.xml
 /server/gram
 /scratch
 /local/ssl
+/local/keys
 .speakeasy/temp
 mprocs.log
 __debug_bin*


### PR DESCRIPTION
This change ignores the folder `/local/keys` which developers use to store ssl, pgp and other keys used in local development.