### PR TITLE
feat: change text wrap for more pleasing layout

### DIFF
--- a/client/dashboard/src/components/ui/tooltip.tsx
+++ b/client/dashboard/src/components/ui/tooltip.tsx
@@ -47,8 +47,9 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          "max-w-[400px]",
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-pretty",
+          'w-fit',
+          "max-w-sm",
           inverted &&
             "bg-background [&_svg]:fill-background [&_svg]:bg-background shadow-md dark:border-1",
           className
@@ -75,7 +76,7 @@ function SimpleTooltip({
         <TooltipTrigger asChild>
           <div>{children}</div>
         </TooltipTrigger>
-        <TooltipContent className="max-w-[500px]">{tooltip}</TooltipContent>
+        <TooltipContent>{tooltip}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/client/dashboard/src/components/ui/tooltip.tsx
+++ b/client/dashboard/src/components/ui/tooltip.tsx
@@ -47,9 +47,9 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-pretty",
-          'w-fit',
-          "max-w-sm",
+          "bg-primary text-primary-foreground",
+          "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin) ",
+          "z-50 rounded-md px-3 py-1.5 text-xs text-pretty w-fit max-w-sm",
           inverted &&
             "bg-background [&_svg]:fill-background [&_svg]:bg-background shadow-md dark:border-1",
           className


### PR DESCRIPTION
## The trouble
The esteemed @chase-crumbaugh points out that our tooltips have some strange text layout behavior. Line wraps seem to produce excessive whitespace on the right margin. For example,

<img width="610" height="303" alt="image" src="https://github.com/user-attachments/assets/67fd9320-4032-44ae-aa5e-3db1bbcf4fde" />
<img width="468" height="215" alt="image" src="https://github.com/user-attachments/assets/bfaf10a3-6a30-42af-b50f-15fe94d7c6f0" />

## A solution 🤷‍♂️

This is somewhat not obvious how to fix uniformly because I think text layout is calculated after width is, so it's difficult to convince CSS to go back and adjust to working layouts. One remediation is to switch from `text-wrap: balance` to `text-wrap: pretty`. Balance is intended to work with extremely short text (like titles) rather than prose where pretty is more suitable.

We can also reduce the width of these containers in general from 600px to tailwind's small container size (384px). We should probably keep an eye out for larger content, but Chase and I did a spot check and things are seemingly pretty reasonable.

Here are a few examples. This does not eliminate the strangeness of the layout appearance completely, but it does seem to significantly reduce the issue.

<img width="682" height="200" alt="image" src="https://github.com/user-attachments/assets/b9402e2a-96e4-4a5d-ae40-b2ba5177d7e5" />


