### PR TITLE
fix: Display org name instead of slug in sidebar

### DIFF
--- a/client/dashboard/src/components/project-menu.tsx
+++ b/client/dashboard/src/components/project-menu.tsx
@@ -163,7 +163,7 @@ export function ProjectMenu() {
                 {project?.slug ?? "Select Project"}
               </Type>
               <Type variant="small" muted className="truncate max-w-[120px]">
-                {organization?.slug}
+                {organization?.name}
               </Type>
             </Stack>
           </Stack>
@@ -175,7 +175,7 @@ export function ProjectMenu() {
           {adminOverride}
           <Stack gap={1}>
             <Type variant="small" className="px-2">
-              {organization?.slug}
+              {organization?.name}
             </Type>
             <Type muted variant="small" className="px-2 truncate">
               {session.user.email}


### PR DESCRIPTION
[Ticket](https://linear.app/speakeasy/issue/AGE-423/bug-show-org-display-name-instead-of-slug-in-dashboard)

# Org data
```sql
select name, slug from organization_metadata ;
       name       |       slug
------------------+------------------
 Organization 123 | organization-123
(1 row)
```

# Footer (screenshot)
<img width="248" height="213" alt="image" src="https://github.com/user-attachments/assets/284a4fe8-530f-40ba-a14d-4151644d61eb" />

# Popover (screenshot)
<img width="216" height="573" alt="image" src="https://github.com/user-attachments/assets/dac12d7d-e0dd-4dd8-869c-2e318d6c1809" />
