### PR TITLE
chore: enable tracing of billing operations

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -375,7 +375,7 @@ func newStartCommand() *cli.Command {
 				features = newLocalFeatureFlags(ctx, logger, c.String("local-feature-flags-csv"))
 			}
 
-			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, redisClient, c)
+			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, redisClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -336,7 +336,7 @@ func newWorkerCommand() *cli.Command {
 			baseChatClient := openrouter.NewChatClient(logger, openRouter)
 			chatClient := chat.NewChatClient(logger, tracerProvider, meterProvider, db, openRouter, baseChatClient, env, cache.NewRedisCacheAdapter(redisClient), guardianPolicy)
 
-			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, redisClient, c)
+			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, redisClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}

--- a/server/internal/assets/setup_test.go
+++ b/server/internal/assets/setup_test.go
@@ -55,6 +55,7 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -62,7 +63,7 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -272,6 +272,7 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 
 	conn, err := infra.CloneTestDatabase(t, "authtest")
 	require.NoError(t, err)
@@ -288,7 +289,7 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host")
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager := sessions.NewManager(logger, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient)
 

--- a/server/internal/billing/stub.go
+++ b/server/internal/billing/stub.go
@@ -12,17 +12,20 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/usage"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/must"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
-	"github.com/speakeasy-api/openapi/pointer"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type StubClient struct {
 	mut    sync.Mutex
 	logger *slog.Logger
+	tracer trace.Tracer
 }
 
-func NewStubClient(logger *slog.Logger) *StubClient {
+func NewStubClient(logger *slog.Logger, tracerProvider trace.TracerProvider) *StubClient {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -30,6 +33,7 @@ func NewStubClient(logger *slog.Logger) *StubClient {
 	return &StubClient{
 		mut:    sync.Mutex{},
 		logger: logger.With(attr.SlogComponent("billing-stub")),
+		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/billing"),
 	}
 }
 
@@ -37,19 +41,39 @@ var _ Tracker = (*StubClient)(nil)
 var _ Repository = (*StubClient)(nil)
 
 func (s *StubClient) GetCustomerTier(ctx context.Context, orgID string) (*Tier, error) {
-	return pointer.From(TierFree), nil
+	_, span := s.tracer.Start(ctx, "stub_client.get_customer")
+	defer span.End()
+
+	return conv.Ptr(TierFree), nil
 }
 
 func (s *StubClient) CreateCheckout(ctx context.Context, orgID string, serverURL string) (string, error) {
+	_, span := s.tracer.Start(ctx, "stub_client.create_checkout")
+	span.SetStatus(codes.Error, "not implemented")
+	defer span.End()
+
 	return "", fmt.Errorf("not implemented")
 }
 
 func (s *StubClient) CreateCustomerSession(ctx context.Context, orgID string) (string, error) {
+	_, span := s.tracer.Start(ctx, "stub_client.create_customer_session")
+	span.SetStatus(codes.Error, "not implemented")
+	defer span.End()
+
 	return "", fmt.Errorf("not implemented")
 }
 
 // GetCustomer implements Repository.
 func (s *StubClient) GetCustomer(ctx context.Context, orgID string) (*Customer, error) {
+	_, span := s.tracer.Start(ctx, "stub_client.get_customer")
+	var err error
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
@@ -65,6 +89,15 @@ func (s *StubClient) GetCustomer(ctx context.Context, orgID string) (*Customer, 
 }
 
 func (s *StubClient) GetPeriodUsage(ctx context.Context, orgID string) (*gen.PeriodUsage, error) {
+	_, span := s.tracer.Start(ctx, "stub_client.get_period_usage")
+	var err error
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
@@ -77,6 +110,9 @@ func (s *StubClient) GetPeriodUsage(ctx context.Context, orgID string) (*gen.Per
 }
 
 func (s *StubClient) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error) {
+	_, span := s.tracer.Start(ctx, "stub_client.get_usage_tiers")
+	defer span.End()
+
 	return &gen.UsageTiers{
 		Free: &gen.TierLimits{
 			BasePrice:                  0,
@@ -96,6 +132,10 @@ func (s *StubClient) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error)
 }
 
 func (s *StubClient) TrackPlatformUsage(ctx context.Context, event PlatformUsageEvent) {
+	var err error
+	ctx, span := s.tracer.Start(ctx, "stub_client.track_platform_usage")
+	defer span.End()
+
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
@@ -109,16 +149,24 @@ func (s *StubClient) TrackPlatformUsage(ctx context.Context, event PlatformUsage
 	pu.ActualPublicServerCount = int(event.PublicMCPServers)
 
 	if err := s.writePeriodUsage(ctx, event.OrganizationID, pu); err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.ErrorContext(ctx, "failed to write period usage file", attr.SlogError(err))
 		return
 	}
 }
 
 func (s *StubClient) TrackPromptCallUsage(ctx context.Context, event PromptCallUsageEvent) {
+	ctx, span := s.tracer.Start(ctx, "stub_client.track_prompt_call_usage")
+	span.SetStatus(codes.Error, "not implemented")
+	span.End()
 	s.logger.ErrorContext(ctx, "failed to track prompt call usage: not implemented")
 }
 
 func (s *StubClient) TrackToolCallUsage(ctx context.Context, event ToolCallUsageEvent) {
+	var err error
+	ctx, span := s.tracer.Start(ctx, "stub_client.track_tool_call_usage")
+	defer span.End()
+
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
@@ -131,6 +179,7 @@ func (s *StubClient) TrackToolCallUsage(ctx context.Context, event ToolCallUsage
 	pu.ToolCalls += 1
 
 	if err := s.writePeriodUsage(ctx, event.OrganizationID, pu); err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.ErrorContext(ctx, "failed to write period usage file", attr.SlogError(err))
 		return
 	}

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -80,7 +80,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/environments/setup_test.go
+++ b/server/internal/environments/setup_test.go
@@ -52,6 +52,7 @@ func newTestEnvironmentService(t *testing.T) (context.Context, *testInstance) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -59,7 +60,7 @@ func newTestEnvironmentService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -324,7 +324,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 	// Capture the usage for billing purposes (async to not block response)
 	outputNumBytes := int64(interceptor.buffer.Len())
 
-	go s.billing.TrackToolCallUsage(context.Background(), billing.ToolCallUsageEvent{
+	go s.billing.TrackToolCallUsage(context.WithoutCancel(ctx), billing.ToolCallUsageEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		RequestBytes:     requestNumBytes,
 		OutputBytes:      outputNumBytes,

--- a/server/internal/keys/setup_test.go
+++ b/server/internal/keys/setup_test.go
@@ -51,6 +51,7 @@ func newTestKeysService(t *testing.T) (context.Context, *testInstance) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -58,7 +59,7 @@ func newTestKeysService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -105,7 +105,7 @@ func handleToolsCall(
 		requestBytes := int64(len(params.Arguments))
 		outputBytes := int64(len(promptData))
 
-		go billingTracker.TrackToolCallUsage(context.Background(), billing.ToolCallUsageEvent{
+		go billingTracker.TrackToolCallUsage(context.WithoutCancel(ctx), billing.ToolCallUsageEvent{
 			OrganizationID:   toolset.OrganizationID,
 			RequestBytes:     requestBytes,
 			OutputBytes:      outputBytes,
@@ -182,7 +182,7 @@ func handleToolsCall(
 	// Track tool call usage
 	outputBytes := int64(rw.body.Len())
 
-	go billingTracker.TrackToolCallUsage(context.Background(), billing.ToolCallUsageEvent{
+	go billingTracker.TrackToolCallUsage(context.WithoutCancel(ctx), billing.ToolCallUsageEvent{
 		OrganizationID:   toolset.OrganizationID,
 		RequestBytes:     requestBytes,
 		OutputBytes:      outputBytes,

--- a/server/internal/templates/setup_test.go
+++ b/server/internal/templates/setup_test.go
@@ -51,6 +51,7 @@ func newTestTemplateService(t *testing.T) (context.Context, *testInstance) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -58,7 +59,7 @@ func newTestTemplateService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -69,7 +69,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -92,7 +92,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/variations/setup_test.go
+++ b/server/internal/variations/setup_test.go
@@ -50,6 +50,7 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -57,7 +58,7 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger)
+	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)


### PR DESCRIPTION
This change updates tracking and repository calls to emit tracing spans that we can observe in o11y dashboards. The key change for tracking:

```diff
- go s.billing.TrackToolCallUsage(context.Background(), billing.ToolCallUsageEvent{
+ go s.billing.TrackToolCallUsage(context.WithoutCancel(ctx), billing.ToolCallUsageEvent{
```

This retains the trace and parent span across tracking calls.