### PR TITLE
feat: add skip button to toolify wizard

### DIFF
--- a/client/dashboard/src/pages/toolBuilder/Toolify.tsx
+++ b/client/dashboard/src/pages/toolBuilder/Toolify.tsx
@@ -14,6 +14,7 @@ import { useMiniModel } from "../playground/Openrouter";
 import { ToolsetDropdown } from "../toolsets/ToolsetDropown";
 import { useToolDefinitions } from "../toolsets/types";
 import { useToolset } from "@gram/client/react-query";
+import { ArrowRightIcon } from "lucide-react";
 
 const SuggestionSchema = z.object({
   name: z.string(),
@@ -177,6 +178,14 @@ export const ToolifyDialog = ({
         <Dialog.Footer>
           <Button variant="ghost" onClick={() => setOpen(false)}>
             Back
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => routes.customTools.toolBuilderNew.goTo()}
+            className="sm:ml-auto"
+          >
+            Skip
+            <ArrowRightIcon className="size-4" />
           </Button>
           <Button onClick={onSubmit} disabled={!purpose || inProgress}>
             {inProgress && <Spinner />}


### PR DESCRIPTION
This PR adds a `Skip →` button to the Toolify wizard. 

Desktop:

<img width="2272" height="1506" alt="CleanShot 2025-09-05 at 10 40 58@2x" src="https://github.com/user-attachments/assets/de09e646-739f-472b-8561-b92fb355f816" />

Mobile:

<img width="1124" height="1506" alt="CleanShot 2025-09-05 at 10 42 20@2x" src="https://github.com/user-attachments/assets/de9b44d7-5e17-4b84-b810-23ea09a50fe4" />

Workflow:

![CleanShot 2025-09-05 at 10 43 02](https://github.com/user-attachments/assets/9e5b742d-abb4-4021-98b4-e24787d40b67)


