### PR TITLE
fix: client-side validation for text input length

### DIFF
--- a/client/dashboard/src/components/input-dialog.tsx
+++ b/client/dashboard/src/components/input-dialog.tsx
@@ -17,7 +17,6 @@ type InputProps =
       optional?: boolean;
       disabled?: boolean;
       lines?: number;
-      maxLength?: number;
       hint?: string | ((value: string) => React.ReactNode);
     }
   | {
@@ -98,7 +97,6 @@ export function InputDialog({
                   disabled={input.disabled}
                   validate={input.validate}
                   lines={input.lines}
-                  maxLength={input.maxLength}
                 />
               )}
               {input.type === "image" && (

--- a/client/dashboard/src/pages/toolsets/Toolsets.tsx
+++ b/client/dashboard/src/pages/toolsets/Toolsets.tsx
@@ -77,10 +77,14 @@ export default function Toolsets() {
             value: toolsetName,
             onChange: (value) => setToolsetName(value),
             onSubmit: createToolset,
-            validate: (value) => value.length > 0,
-            maxLength: 40,
+            validate: (value) => value.length > 0 && value.length <= 40,
             hint: (value) => (
-              <p className="text-right">{`${value.length}`}/40</p>
+              <div className="flex justify-between w-full">
+                <p className="text-destructive">
+                  {value.length > 40 && "Must be 40 characters or less"}
+                </p>
+                <p>{`${value.length}`}/40</p>
+              </div>
             ),
           }}
         />


### PR DESCRIPTION
## Overview

This PR adds client-side validation to the Toolset creation name input. Two features were added to the InputDialog to achieve this:

- `maxLength` can now be passed to the underlying text input component.
- An optional, dynamic `hint` prop can be passed for each input field.

These are used to (a) prevent the user from being able to submit names >40 chars, and (b) to give the user insight into _why_ they cannot submit their desired name.

## Demo

![CleanShot 2025-09-05 at 13 38 15](https://github.com/user-attachments/assets/c5949a86-b1ef-44cb-8890-f70e7bf07a5d)

