### PR TITLE
feat: Allow plain HTTP for local development

### DIFF
--- a/.mise-tasks/zero/tls.sh
+++ b/.mise-tasks/zero/tls.sh
@@ -23,13 +23,54 @@ ensure_dir() {
   fi
 }
 
+is_https() {
+  case "$1" in
+    https://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_tls() {
+  is_https "$GRAM_SERVER_URL" || is_https "$GRAM_SITE_URL"
+}
+
+show_urls() {
+  printf "\t%s: %s\n\t%s: %s\n" \
+    GRAM_SERVER_URL "$GRAM_SERVER_URL" \
+    GRAM_SITE_URL "$GRAM_SITE_URL" >&2;
+}
+
+turn_off_tls() {
+  echo "No https endpoints: skipping TLS"
+  show_urls
+
+  mise set --file mise.local.toml GRAM_SSL_CERT_FILE=
+  mise set --file mise.local.toml GRAM_SSL_KEY_FILE=
+}
+
+turn_on_tls() {
+  echo "Found https endpoints: enabling TLS"
+  show_urls
+
+  mise set --file mise.local.toml GRAM_SSL_CERT_FILE="{{config_root}}/local/ssl/certs/local.pem"
+  mise set --file mise.local.toml GRAM_SSL_KEY_FILE="{{config_root}}/local/ssl/keys/local-key.pem"
+
+}
+
 trust_local_ca() {
   echo "Trusting local certificate."
   mkcert -install >/dev/null 2>&1
   echo "Local certificate is trusted."
 }
 
+found_keypair() {
+  [ -f "$CERT_PATH" ] && [ -f "$KEY_PATH" ]
+}
+
 gen_keypair() {
+  ensure_dir "$(dirname "$CERT_PATH")"
+  ensure_dir "$(dirname "$KEY_PATH")"
+
   echo "Generating cert and key..."
   mkcert \
     -cert-file "$CERT_PATH" -key-file "$KEY_PATH" localhost 127.0.0.1 ::1
@@ -39,15 +80,12 @@ gen_keypair() {
 }
 
 main() {
+  if ! detect_tls; then turn_off_tls && exit 0; fi
+
   check_command mkcert
-
+  turn_on_tls
   trust_local_ca
-  ensure_dir "$(dirname "$CERT_PATH")"
-  ensure_dir "$(dirname "$KEY_PATH")"
-
-  if [ ! -f "$CERT_PATH" ] || [ ! -f "$KEY_PATH" ]; then
-    gen_keypair
-  fi
+  if ! found_keypair; then gen_keypair; fi
 }
 
 main "$@"


### PR DESCRIPTION
Allow turning off TLS by changing the scheme of all endpoints to `http`.

_The supported flow for all browsers is to keep TLS enabled. But, this change is an escape hatch for local devs who don’t want to trust a new root CA, or if their local development environment makes it unwieldy (e.g. certain local VM development)._

# Testing
## Prompts for user password on first `mkcert -install`
1. `mkcert -uninstall` (this also requires system password)
2. Run `./zero`
3. Script prompts for sudo password at the `mkcert -install` step with a log for how to turn it off.
4. Open :5173 in any browser, and it works.

## Honors http endpoints
1. Update both `GRAM_SERVER_URL` and `GRAM_SITE_URL` to use `http://` instead of `https://`
2. Run `./zero`
3. Script warns that TLS is off, and updates `mise.local.toml` with empty values for `GRAM_SSL_CERT_FILE` and `GRAM_SSL_KEY_FILE`
5. Open :5173 in Chrome, and it works.

## Honors https endpoints
1. Keep both endpoints as `https`
2. Run `./zero`
3. Open :5173 in any browser, and it works.