### PR TITLE
fix: Improve error boundary

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -128,7 +128,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
 const FreeTierExceededNotification = () => {
   const session = useSession();
-  const { data: usage } = useGetPeriodUsage();
+  const { data: usage } = useGetPeriodUsage(undefined, undefined, {
+    throwOnError: false,
+  });
   const routes = useRoutes();
 
   if (!usage || !session || session.gramAccountType !== "free") {

--- a/client/dashboard/src/components/content-error-boundary.tsx
+++ b/client/dashboard/src/components/content-error-boundary.tsx
@@ -17,7 +17,7 @@ function ContentErrorFallback({ error }: ContentErrorFallbackProps) {
   handleError(error, { silent: true });
 
   return (
-    <Card className="w-full max-w-lg my-8 py-8">
+    <Card className="w-full max-w-lg m-8 py-8">
       <Card.Header>
         <Card.Title>
           <Stack direction="horizontal" gap={2} align="center">

--- a/client/dashboard/src/components/page-layout.tsx
+++ b/client/dashboard/src/components/page-layout.tsx
@@ -15,7 +15,7 @@ function PageLayout({ children }: { children: React.ReactNode }) {
   return (
     // The height calculation accounts for the page body "visual" gutter
     <div className="h-[calc(100vh-16px)] flex flex-col overflow-hidden">
-      {children}
+      <ContentErrorBoundary>{children}</ContentErrorBoundary>
     </div>
   );
 }
@@ -39,7 +39,7 @@ function PageBody({
           className
         )}
       >
-        <ContentErrorBoundary>{children}</ContentErrorBoundary>
+        {children}
       </div>
     </div>
   );

--- a/client/dashboard/src/pages/toolsets/Toolset.tsx
+++ b/client/dashboard/src/pages/toolsets/Toolset.tsx
@@ -85,7 +85,9 @@ export function ToolsetRoot() {
       <Page.Header>
         <Page.Header.Breadcrumbs />
       </Page.Header>
-      <Outlet />
+      <Page.Body>
+        <Outlet />
+      </Page.Body>
     </Page>
   );
 }
@@ -250,7 +252,7 @@ export function ToolsetView({
   }
 
   return (
-    <Page.Body className={cn("flex flex-col gap-6", className)}>
+    <div className={cn("flex flex-col gap-6", className)}>
       {toolset && (
         <ToolsetAuthAlert
           toolset={toolset}
@@ -314,6 +316,6 @@ export function ToolsetView({
           onOpenChange={setAddToolsDialogOpen}
         />
       )}
-    </Page.Body>
+    </div>
   );
 }

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -123,7 +123,6 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 }
 
 func (s *Service) GetPeriodUsage(ctx context.Context, payload *gen.GetPeriodUsagePayload) (res *gen.PeriodUsage, err error) {
-	return nil, errors.New("not implemented")
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
 		return nil, oops.C(oops.CodeUnauthorized)

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -123,6 +123,7 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 }
 
 func (s *Service) GetPeriodUsage(ctx context.Context, payload *gen.GetPeriodUsagePayload) (res *gen.PeriodUsage, err error) {
+	return nil, errors.New("not implemented")
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
 		return nil, oops.C(oops.CodeUnauthorized)


### PR DESCRIPTION
Improves the content error boundary to capture more cases
Also, prevents a billing endpoint failure from crashing the page due to the sidebar notification being out of the error boundary


<img width="1852" height="1384" alt="CleanShot 2025-09-05 at 14 58 05@2x" src="https://github.com/user-attachments/assets/8c6c8d16-6d77-4bc6-8a92-83531c72d806" />
