### PR TITLE
chore: separate client build and lint

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -224,7 +224,7 @@ jobs:
         if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run test:server
 
-  client-build:
+  docker-build-client:
     runs-on: ubicloud-standard-4
     needs: changes
     env:
@@ -309,7 +309,7 @@ jobs:
         if: ${{ needs.changes.outputs.client == 'true' && success() }}
         run: pnpm store prune
 
-  client-lint-test:
+  client-build-lint:
     runs-on: ubicloud-standard-4
     needs: [changes, client-build]
     steps:


### PR DESCRIPTION
Separate client lint and client build to make external contributor required workflows run

We may want to explore `pull_request_target` trigger separately.