### PR TITLE
fix: Don't default to dynamic toolsets

### DIFF
--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -206,11 +206,12 @@ export function ToolsetPanel({
     }
   }, [configRef, setSelectedEnvironment, toolset]);
 
-  useEffect(() => {
-    const isDynamic =
-      toolset?.httpTools?.length && toolset.httpTools.length > 40 && isAdmin;
-    setDynamicToolset(!!isDynamic);
-  }, [toolset, isAdmin, setDynamicToolset]);
+  // Don't automatically set dynamic toolset. The generate object API is not working consistently
+  // useEffect(() => {
+  //   const isDynamic =
+  //     toolset?.httpTools?.length && toolset.httpTools.length > 40 && isAdmin;
+  //   setDynamicToolset(!!isDynamic);
+  // }, [toolset, isAdmin, setDynamicToolset]);
 
   let content = (
     <ToolsetView


### PR DESCRIPTION
The generateObject completions endpoint used to power this feature is not working consistently right now for some reason. This is an admin-only feature that isn't really used.