### PR TITLE
feat: disable add domain button

### DIFF
--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -458,9 +458,15 @@ export default function Settings() {
               <Button
                 size="sm"
                 variant="secondary"
-                onClick={() => setIsAddDomainDialogOpen(true)}
                 icon={"globe"}
-                disabled={session.gramAccountType === "free"}
+                onClick={() => {
+                  if (session.gramAccountType === "free") {
+                    setIsCustomDomainModalOpen(true);
+                  } else {
+                    setIsAddDomainDialogOpen(true);
+                  }
+                }}
+                disabled={domain?.isUpdating}
               >
                 Add Domain
               </Button>


### PR DESCRIPTION
Disable the Add Domain button if account type is free. 

The backend still would have blocked the add request, but the UX is weird if you can open the domain model by clicking on a different Add Domain button.