### PR TITLE
fix: Add success url to polar checkout link

### DIFF
--- a/server/internal/billing/repository.go
+++ b/server/internal/billing/repository.go
@@ -52,7 +52,7 @@ type Repository interface {
 	GetPeriodUsage(ctx context.Context, orgID string) (*gen.PeriodUsage, error)
 	// this enforces that we can only get usage results from a stored value, specifically for hotpath usage with no outbound API call
 	GetStoredPeriodUsage(ctx context.Context, orgID string) (*gen.PeriodUsage, error)
-	CreateCheckout(ctx context.Context, orgID string, serverURL string) (string, error)
+	CreateCheckout(ctx context.Context, orgID string, serverURL string, successURL string) (string, error)
 	CreateCustomerSession(ctx context.Context, orgID string) (string, error)
 	GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error)
 	ValidateAndParseWebhookEvent(ctx context.Context, payload []byte, webhookHeader http.Header) (*PolarWebhookPayload, error)

--- a/server/internal/billing/stub.go
+++ b/server/internal/billing/stub.go
@@ -63,7 +63,7 @@ func (s *StubClient) InvalidateBillingCustomerCaches(ctx context.Context, orgID 
 	return nil
 }
 
-func (s *StubClient) CreateCheckout(ctx context.Context, orgID string, serverURL string) (string, error) {
+func (s *StubClient) CreateCheckout(ctx context.Context, orgID string, serverURL string, successURL string) (string, error) {
 	_, span := s.tracer.Start(ctx, "stub_client.create_checkout")
 	span.SetStatus(codes.Error, "not implemented")
 	defer span.End()

--- a/server/internal/thirdparty/polar/client.go
+++ b/server/internal/thirdparty/polar/client.go
@@ -579,7 +579,7 @@ func (p *Client) GetStoredPeriodUsage(ctx context.Context, orgID string) (pu *ge
 	return &state.PeriodUsage, nil
 }
 
-func (p *Client) CreateCheckout(ctx context.Context, orgID string, serverURL string) (u string, err error) {
+func (p *Client) CreateCheckout(ctx context.Context, orgID string, serverURL string, successURL string) (u string, err error) {
 	ctx, span := p.tracer.Start(ctx, "polar_client.create_checkout")
 	defer func() {
 		if err != nil {
@@ -591,6 +591,7 @@ func (p *Client) CreateCheckout(ctx context.Context, orgID string, serverURL str
 	res, err := p.polar.Checkouts.Create(ctx, polarComponents.CheckoutCreate{
 		ExternalCustomerID: &orgID,
 		EmbedOrigin:        &serverURL,
+		SuccessURL:         &successURL,
 		Products: []string{
 			p.catalog.ProductIDPro,
 		},

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -164,7 +165,9 @@ func (s *Service) CreateCheckout(ctx context.Context, payload *gen.CreateCheckou
 		return "", oops.C(oops.CodeUnauthorized)
 	}
 
-	checkoutURL, err := s.billingRepo.CreateCheckout(ctx, authCtx.ActiveOrganizationID, s.serverURL.String())
+	successURL := fmt.Sprintf("%s/%s/%s/billing", s.serverURL.String(), authCtx.OrganizationSlug, authCtx.ProjectSlug)
+
+	checkoutURL, err := s.billingRepo.CreateCheckout(ctx, authCtx.ActiveOrganizationID, s.serverURL.String(), successURL)
 	if err != nil {
 		return "", oops.E(oops.CodeUnexpected, err, "failed to create checkout").Log(ctx, s.logger)
 	}

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -165,7 +165,10 @@ func (s *Service) CreateCheckout(ctx context.Context, payload *gen.CreateCheckou
 		return "", oops.C(oops.CodeUnauthorized)
 	}
 
-	successURL := fmt.Sprintf("%s/%s/%s/billing", s.serverURL.String(), authCtx.OrganizationSlug, authCtx.ProjectSlug)
+	successURL := s.serverURL.String()
+	if authCtx.ProjectSlug != nil {
+		successURL = fmt.Sprintf("%s/%s/%s/billing", s.serverURL.String(), authCtx.OrganizationSlug, *authCtx.ProjectSlug)
+	}
 
 	checkoutURL, err := s.billingRepo.CreateCheckout(ctx, authCtx.ActiveOrganizationID, s.serverURL.String(), successURL)
 	if err != nil {


### PR DESCRIPTION
Adds a fallback successURL to the polar checkout link in the event that the embedded checkout doesnt work