### PR TITLE
chore: add smoke test for OTel setup code

### DIFF
--- a/server/internal/o11y/setup.go
+++ b/server/internal/o11y/setup.go
@@ -93,7 +93,7 @@ func SetupOTelSDK(ctx context.Context, logger *slog.Logger, options SetupOTelSDK
 		// nil trace exporter tells clue.NewConfig to use a no-op tracer provider
 	}
 
-	cfg, err := NewClueConfig(
+	cfg, err := newClueConfig(
 		ctx,
 		options.ServiceName,
 		options.ServiceVersion,
@@ -123,7 +123,7 @@ func SetupOTelSDK(ctx context.Context, logger *slog.Logger, options SetupOTelSDK
 	return
 }
 
-func NewClueConfig(
+func newClueConfig(
 	ctx context.Context,
 	svcName string,
 	svcVersion string,

--- a/server/internal/o11y/setup_test.go
+++ b/server/internal/o11y/setup_test.go
@@ -1,0 +1,24 @@
+package o11y_test
+
+import (
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupOTelSDK(t *testing.T) {
+	logger := testenv.NewLogger(t)
+	shutdown, err := o11y.SetupOTelSDK(t.Context(), logger, o11y.SetupOTelSDKOptions{
+		ServiceName:    "gram-test",
+		ServiceVersion: "0.1.0",
+		EnableTracing:  true,
+		EnableMetrics:  true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+
+	err = shutdown(t.Context())
+	require.NoError(t, err)
+}

--- a/server/internal/o11y/setup_test.go
+++ b/server/internal/o11y/setup_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestSetupOTelSDK(t *testing.T) {
+	t.Parallel()
+
 	logger := testenv.NewLogger(t)
 	shutdown, err := o11y.SetupOTelSDK(t.Context(), logger, o11y.SetupOTelSDKOptions{
 		ServiceName:    "gram-test",


### PR DESCRIPTION
Fixes AGE-503

This change adds a basic smoke test to ensure OpenTelemetry can be set up with out an error. Previously, updates to the semconv package via dependabot PRs could cause runtime errors like this:

```
create resource: conflicting Schema URL: https://opentelemetry.io/schemas/1.37.0 and https://opentelemetry.io/schemas/1.34.0
```

This is caught by the smoke test now and updates to semconv will cause build failure if the codebase is not updated accordingly to use the new semconv version everywhere.