### PR TITLE
fix: prune pnpm store after CI jobs

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -100,3 +100,7 @@ jobs:
             exit 1
             fi
             echo "✅ Changeset validation passed!"
+
+      - name: Prune PNPM store
+        if: ${{ steps.check.outputs.lint == 'true' }}
+        run: pnpm store prune

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,11 @@ jobs:
         id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
+          title: "chore: version packages"
           publish: pnpm run -s release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: "not-set" # intentionally not set for now
+
+      - name: Prune PNPM store
+        run: pnpm store prune


### PR DESCRIPTION
This change updates the release and hygiene workflows to prune the pnpm store after the jobs complete. This helps to free up disk space and result in a smaller package cache size.