### PR TITLE
fix: disable skip ci directive in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,13 +1,19 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": true,
+  "commit": [
+    "@changesets/cli/commit",
+    {
+      "skipCI": false
+    }
+  ],
   "fixed": [],
   "linked": [],
   "ignore": [],
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
+  "skipCI": false,
   "privatePackages": {
     "version": true,
     "tag": true


### PR DESCRIPTION
The automated version PR that the changesets action creates contains a `s-kip ci` directive (dash inserted deliberately) which prevents the CI jobs from running. This in turn means that branch protection rules that require certain jobs to pass will never be satisfied and the versioning PR cannot be merged.

This change disables the directive in changesets so that the CI jobs run.