### PR TITLE
chore: make changeset check fail if no changesets found

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -53,8 +53,10 @@ jobs:
       # Check out both the base and head refs so changeset status can compare
       # against the base branch
       - name: Checkout base ref
+        if: ${{ steps.check.outputs.lint == 'true' }}
         run: git fetch origin ${{ github.base_ref }} && git checkout ${{ github.base_ref }}
       - name: Checkout head ref
+        if: ${{ steps.check.outputs.lint == 'true' }}
         run: git fetch origin ${{ github.head_ref }} && git checkout ${{ github.head_ref }}
 
       - name: Setup Mise


### PR DESCRIPTION
The current check for changesets does not fail there are no changesets at all in a "signficant" PR. This change makes the check fail by looking at the json output of the `changeset status` command.