### PR TITLE
fix: don't error if part of route is missing in link

### DIFF
--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -342,7 +342,9 @@ export const useRoutes = (): RoutesWithGoTo => {
           } else {
             const v = params.shift();
             if (!v) {
-              throw new Error(`No value provided for ${part}`);
+              // Instead of throwing an error, fallback to home page
+              console.warn(`No value provided for ${part}, falling back to home page`);
+              return `/${orgSlug}/${projectSlug}`;
             }
             finalParts.push(v);
           }


### PR DESCRIPTION
Resolves an issue where the playground would crash if a link was missing. This makes us handle interim states more gracefully