### PR TITLE
chore: document utility packages in server package

### DIFF
--- a/server/internal/conv/from.go
+++ b/server/internal/conv/from.go
@@ -10,10 +10,20 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+// Ptr returns a pointer to the given value. This function is useful because it
+// allows you to create pointers to literal values like conv.Ptr(2) or return
+// values from functions/methods.
 func Ptr[T any](v T) *T {
 	return &v
 }
 
+// PtrEmpty returns a pointer to the given value or nil if the value is equal
+// to the zero value of the same type. Example:
+//
+//	PtrEmpty(0)      // returns nil
+//	PtrEmpty("")     // returns nil
+//	PtrEmpty(false)  // returns nil
+//	PtrEmpty(2)      // returns *int with value 2
 func PtrEmpty[T comparable](v T) *T {
 	var zero T
 	if v == zero {
@@ -23,6 +33,12 @@ func PtrEmpty[T comparable](v T) *T {
 	return &v
 }
 
+// PtrValOr returns a value of a given pointer or a default if the pointer is
+// is nil. Example:
+//
+//	PtrValOr[int](nil, 5)         // returns *int with value 5
+//	PtrValOr(Ptr(""), "foo")      // returns ""
+//	PtrValOr(Ptr("jane"), "joe")  // returns *string with value "jane"
 func PtrValOr[T any](ptr *T, def T) T {
 	if ptr == nil {
 		return def
@@ -31,6 +47,12 @@ func PtrValOr[T any](ptr *T, def T) T {
 	return *ptr
 }
 
+// PtrValOrEmpty returns a value of a given pointer or a default if the pointer
+// is is nil or the zero value. Example:
+//
+//	PtrValOrEmpty[int](nil, 5)         // returns *int with value 5
+//	PtrValOrEmpty(Ptr(""), "foo")      // returns "foo"
+//	PtrValOrEmpty(Ptr("jane"), "joe")  // returns *string with value "jane"
 func PtrValOrEmpty[T comparable](ptr *T, def T) T {
 	if ptr == nil {
 		return def
@@ -39,6 +61,12 @@ func PtrValOrEmpty[T comparable](ptr *T, def T) T {
 	return Default(*ptr, def)
 }
 
+// Default returns the given value or a default if the value is equal to the
+// zero value of the same type. Example:
+//
+//	Default(0, 5)      // returns 5
+//	Default("", "foo")  // returns "foo"
+//	Default("jane", "joe") // returns "jane"
 func Default[T comparable](val T, def T) T {
 	var zero T
 	if val == zero {
@@ -48,6 +76,8 @@ func Default[T comparable](val T, def T) T {
 	return val
 }
 
+// FromNullableUUID converts a uuid.NullUUID to a *string. If the NullUUID is
+// not valid, it returns nil.
 func FromNullableUUID(u uuid.NullUUID) *string {
 	if !u.Valid {
 		return nil
@@ -57,6 +87,8 @@ func FromNullableUUID(u uuid.NullUUID) *string {
 	return &val
 }
 
+// FromPGText converts a pgtype.Text to a *string. If the Text is not valid, it
+// returns nil.
 func FromPGText[T ~string](t pgtype.Text) *T {
 	if !t.Valid {
 		return nil
@@ -66,14 +98,20 @@ func FromPGText[T ~string](t pgtype.Text) *T {
 	return &val
 }
 
+// ToPGText converts a string to a pgtype.Text with Valid set to true regardless
+// of whether the input is an empty string or not.
 func ToPGText(t string) pgtype.Text {
 	return pgtype.Text{String: t, Valid: true}
 }
 
+// ToPGTextEmpty converts a string to a pgtype.Text with Valid set to true only
+// if the input value is not an empty string.
 func ToPGTextEmpty(t string) pgtype.Text {
 	return pgtype.Text{String: t, Valid: t != ""}
 }
 
+// PtrToPGText converts a string pointer to a pgtype.Text with Valid set to true
+// regardless of whether the input is an empty string or not.
 func PtrToPGText(t *string) pgtype.Text {
 	if t == nil {
 		return pgtype.Text{Valid: false, String: ""}
@@ -82,6 +120,8 @@ func PtrToPGText(t *string) pgtype.Text {
 	return pgtype.Text{String: *t, Valid: true}
 }
 
+// ToPGTextEmpty converts a string pointer to a pgtype.Text with Valid set to
+// true only if the input value is not an empty string.
 func PtrToPGTextEmpty(t *string) pgtype.Text {
 	if t == nil {
 		return pgtype.Text{Valid: false, String: ""}
@@ -90,6 +130,8 @@ func PtrToPGTextEmpty(t *string) pgtype.Text {
 	return pgtype.Text{String: *t, Valid: *t != ""}
 }
 
+// FromPGBool converts a pgtype.Bool to a bool or subtype of bool. If Bool is
+// not valid, it returns nil.
 func FromPGBool[T ~bool](t pgtype.Bool) *T {
 	if !t.Valid {
 		return nil
@@ -99,6 +141,8 @@ func FromPGBool[T ~bool](t pgtype.Bool) *T {
 	return &val
 }
 
+// FromBytes converts a byte slice to a string pointer. If the byte slice is
+// empty, it returns nil.
 func FromBytes(b []byte) *string {
 	if len(b) == 0 {
 		return nil
@@ -110,6 +154,9 @@ func FromBytes(b []byte) *string {
 var cleanSlugRegex = regexp.MustCompile(`[^a-zA-Z0-9\s-]`) // Remove special characters leaving dashes
 var dashCollapseRegex = regexp.MustCompile(`[-\s]+`)       // collapses multiple dashes or spaces into a single dash
 
+// ToSlug converts a string to a URL-friendly "slug". It removes special
+// characters, converts to lowercase, collapses multiple dashes or spaces into
+// a single dash, and trims leading and trailing dashes.
 func ToSlug(s string) string {
 	s = cleanSlugRegex.ReplaceAllString(s, "")
 	s = strings.ToLower(s)
@@ -118,6 +165,8 @@ func ToSlug(s string) string {
 	return s
 }
 
+// GenerateRandomSlug generates a random slug of the given size using lowercase
+// letters and digits. It returns an error if it fails to generate random bytes.
 func GenerateRandomSlug(size int) (string, error) {
 	const charset = "abcdefghijklmnopqrstuvwxyz123456789"
 
@@ -134,10 +183,12 @@ func GenerateRandomSlug(size int) (string, error) {
 	return string(result), nil
 }
 
+// ToLower converts a string or subtype of string to lowercase.
 func ToLower[T ~string](s T) string {
 	return strings.ToLower(string(s))
 }
 
+// AnySlice converts a slice of any type to a slice of empty interfaces.
 func AnySlice[T any](vals []T) []any {
 	anyVals := make([]any, len(vals))
 	for i, v := range vals {
@@ -146,6 +197,7 @@ func AnySlice[T any](vals []T) []any {
 	return anyVals
 }
 
+// Ternary returns trueVal if condition is true, otherwise it returns falseVal.
 func Ternary[T any](condition bool, trueVal, falseVal T) T {
 	if condition {
 		return trueVal

--- a/server/internal/must/helpers.go
+++ b/server/internal/must/helpers.go
@@ -1,11 +1,13 @@
 package must
 
+// Nil panics if err is non-nil.
 func Nil(err error) {
 	if err != nil {
 		panic(err)
 	}
 }
 
+// Value returns v if err is nil, otherwise panics.
 func Value[T any](v T, err error) T {
 	Nil(err)
 	return v

--- a/server/internal/must/uuid.go
+++ b/server/internal/must/uuid.go
@@ -2,6 +2,7 @@ package must
 
 import "github.com/google/uuid"
 
+// UUID returns the UUID if valid, otherwise panics.
 func UUID(v uuid.NullUUID) uuid.UUID {
 	if !v.Valid {
 		panic("uuid is not valid")

--- a/server/internal/oops/http.go
+++ b/server/internal/oops/http.go
@@ -11,6 +11,12 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
 
+// ErrHandle returns a middleware that wraps an http handler. It calls the
+// underlying handler and captures any returned error. The error is
+// appropriately serialized back to the client. It recognizes ShareableError and
+// goa.ServiceError types. Any other error types are treated as internal server
+// errors and a generic message is returned to the client. All errors are logged
+// with the provided logger.
 func ErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.Request) error) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		err := handler(w, r)

--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -19,6 +19,10 @@ import (
 
 var funcMemo sync.Map
 
+// E creates a new ShareableError with the given code, cause, public message,
+// and optional formatting arguments to interpolate into the public message. The
+// cause can be nil if there is no underlying error to capture.
+//
 //go:noinline
 func E(code Code, cause error, public string, args ...any) *ShareableError {
 	var pc [1]uintptr
@@ -39,21 +43,10 @@ func E(code Code, cause error, public string, args ...any) *ShareableError {
 	}
 }
 
-//go:noinline
-func EE(code Code, cause error, public string, private string) *ShareableError {
-	var pc [1]uintptr
-	runtime.Callers(2, pc[:])
-
-	return &ShareableError{
-		Code:    code,
-		id:      goa.NewErrorID(),
-		cause:   cause,
-		public:  public,
-		private: private,
-		pc:      pc[0],
-	}
-}
-
+// C creates a new ShareableError with the given code and a public message
+// derived from the code. It is a convenience function to quickly create errors
+// with canned messages.
+//
 //go:noinline
 func C(code Code) *ShareableError {
 	var pc [1]uintptr
@@ -69,6 +62,10 @@ func C(code Code) *ShareableError {
 	}
 }
 
+// ShareableError is an error that can be shared with clients. It contains a
+// public-facing message and an underlying cause that is not shared. This error
+// type is designed to be used within service methods that are at the HTTP
+// server boundary.
 type ShareableError struct {
 	Code    Code
 	id      string
@@ -78,10 +75,13 @@ type ShareableError struct {
 	pc      uintptr
 }
 
+// Error implements the error interface.
 func (e *ShareableError) Error() string {
 	return e.public
 }
 
+// String returns a detailed string representation of the error, including the
+// private message and the cause, if any.
 func (e *ShareableError) String() string {
 	msg := e.private
 	if msg == "" {
@@ -95,10 +95,12 @@ func (e *ShareableError) String() string {
 	return fmt.Sprintf("%s: %s [%s]", msg, e.cause.Error(), funcForPC(e.pc))
 }
 
+// Unwrap returns the underlying cause of the error, if any.
 func (e *ShareableError) Unwrap() error {
 	return e.cause
 }
 
+// MarshalJSON implements the json.Marshaler interface.
 func (e *ShareableError) MarshalJSON() ([]byte, error) {
 	bs, err := json.Marshal(e.public)
 	if err != nil {
@@ -108,14 +110,19 @@ func (e *ShareableError) MarshalJSON() ([]byte, error) {
 	return bs, nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
 func (e *ShareableError) MarshalText() (text []byte, err error) {
 	return []byte(e.public), nil
 }
 
+// LogValue implements the slog.LogValuer interface.
 func (e *ShareableError) LogValue() slog.Value {
 	return slog.StringValue(e.Error())
 }
 
+// Log logs the error using the provided logger and context. It also sets the
+// OpenTelemetry span status to error. Additional arguments can be provided to
+// include more context in the log entry.
 func (e *ShareableError) Log(ctx context.Context, logger *slog.Logger, args ...any) *ShareableError {
 	trace.SpanFromContext(ctx).SetStatus(codes.Error, e.String())
 
@@ -127,6 +134,9 @@ func (e *ShareableError) Log(ctx context.Context, logger *slog.Logger, args ...a
 	return e
 }
 
+// AsGoa converts the ShareableError to a goa.ServiceError, preserving the error
+// code, id, and cause. It also sets the timeout, temporary, and fault flags
+// based on the error code and cause.
 func (e *ShareableError) AsGoa() *goa.ServiceError {
 	var timeout, temporary, fault bool
 
@@ -147,6 +157,9 @@ func (e *ShareableError) AsGoa() *goa.ServiceError {
 	return goaErr
 }
 
+// HTTPStatus returns the appropriate HTTP status code for the error based on
+// its code. If the code is not recognized, it defaults to 500 Internal Server
+// Error.
 func (e *ShareableError) HTTPStatus() int {
 	return conv.Default(StatusCodes[e.Code], http.StatusInternalServerError)
 }


### PR DESCRIPTION
This change adds package-level documentation to the `must`, `oops`, and `conv` internal packages in the server codebase.