### PR TITLE
chore: call changeset publish to create/push tags

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,6 @@
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "skipCI": false,
   "privatePackages": {
     "version": true,
     "tag": true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: "chore: version packages"
-          publish: pnpm run -s release
+          publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: "not-set" # intentionally not set for now

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "scripts": {
     "dev": "pnpm --filter ./client/dashboard dev",
     "lint": "tsc --noEmit && pnpm -r lint",
-    "build": "pnpm -r build",
-    "release": "echo 'Releasing is currently a no-op.'"
+    "build": "pnpm -r build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The changesets action has a `publish` option that points to a script or command it should use for publishing packages. One requirement that we missed is that the script must call `changeset publish` at the end. This would create tags and push them to the git remote.

After this change we are calling `pnpm changeset publish` explicitly (`pnpm run release` is not needed).