### PR TITLE
fix: update openapi dependency to v1.6.5 to resolve spec upgrading issues

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/samber/slog-multi v1.4.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
-	github.com/speakeasy-api/openapi v1.6.2
+	github.com/speakeasy-api/openapi v1.6.5
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/testcontainers/testcontainers-go v0.38.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.38.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -466,8 +466,8 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/speakeasy-api/jsonpath v0.6.2 h1:Mys71yd6u8kuowNCR0gCVPlVAHCmKtoGXYoAtcEbqXQ=
 github.com/speakeasy-api/jsonpath v0.6.2/go.mod h1:ymb2iSkyOycmzKwbEAYPJV/yi2rSmvBCLZJcyD+VVWw=
-github.com/speakeasy-api/openapi v1.6.2 h1:QCJUAac6vbx8FP2C5bBtMin8PPQtcU0Nwf1nCSkWwO4=
-github.com/speakeasy-api/openapi v1.6.2/go.mod h1:AJZiiCik4q+ItdPw4isiozMMUOzHvCT64fPW0rN1QhE=
+github.com/speakeasy-api/openapi v1.6.5 h1:RDmdXFoeLlbkMo2GGmkTRwJALLRhxOtpJItYpf5Voic=
+github.com/speakeasy-api/openapi v1.6.5/go.mod h1:fy+CvRcKj+HDU0QNdnyG6UkfJOEjhqCuNC7o4AtLPAk=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
# Fix: Update openapi dependency to v1.6.5

## Summary
Updates the `github.com/speakeasy-api/openapi` dependency from v1.6.2 to v1.6.5 to resolve critical issues with OpenAPI spec upgrading that were impacting Gram customers.

## Changes
- Updated `github.com/speakeasy-api/openapi` from v1.6.2 to v1.6.5
- Updated corresponding go.sum checksums

## Bug Fix Details
This update includes a critical fix for handling empty objects during marshaller sync that was causing panics during OpenAPI 3.0 to 3.1 upgrades when processing schemas with `nullable: true` properties. The fix ensures:

- Empty schemas are properly represented as `{}` instead of causing nil pointer panics
- Proper conversion of nullable schemas to OpenAPI 3.1 format
- Maintains backward compatibility

## Impact
- Resolves spec upgrading issues affecting Gram customers
- Improves stability of OpenAPI document processing
- No breaking changes expected

## References
- [OpenAPI v1.6.5 Release Notes](https://github.com/speakeasy-api/openapi/releases/tag/v1.6.5)
- [Fix PR #47](https://github.com/speakeasy-api/openapi/pull/47)