### PR TITLE
chore: modify workflow sleeps for polar rate limits

### DIFF
--- a/server/internal/background/platform_usage_metrics.go
+++ b/server/internal/background/platform_usage_metrics.go
@@ -16,7 +16,7 @@ import (
 // safely wait for polar rate limits
 const (
 	platformUsageMetricsBatchSize    = 25
-	platformUsageMetricsWaitInterval = 5 * time.Second
+	platformUsageMetricsWaitInterval = 30 * time.Second
 )
 
 type PlatformUsageMetricsClient struct {
@@ -115,7 +115,7 @@ func AddPlatformUsageMetricsSchedule(ctx context.Context, temporalClient client.
 			ID:                 workflowID,
 			Workflow:           CollectPlatformUsageMetricsWorkflow,
 			TaskQueue:          string(TaskQueueMain),
-			WorkflowRunTimeout: 10 * time.Minute,
+			WorkflowRunTimeout: 30 * time.Minute,
 		},
 	})
 	if err != nil {

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -14,7 +14,7 @@ import (
 // safely wait for polar rate limits
 const (
 	refreshBillingUsageBatchSize     = 25
-	refreshBillingUsagesWaitInterval = 5 * time.Second
+	refreshBillingUsagesWaitInterval = 10 * time.Second
 )
 
 type RefreshBillingUsageClient struct {
@@ -94,7 +94,7 @@ func AddRefreshBillingUsageSchedule(ctx context.Context, temporalClient client.C
 			ID:                 workflowID,
 			Workflow:           RefreshBillingUsageWorkflow,
 			TaskQueue:          string(TaskQueueMain),
-			WorkflowRunTimeout: 10 * time.Minute,
+			WorkflowRunTimeout: 15 * time.Minute,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
- `CollectPlatformUsageMetricsWorkflow` is the one that's been having rate limit issues. It runs once daily, so we can extend it out quite a bit.
- `RefreshBillingUsageWorkflow` has generally been fine. Just giving it slightly more breathing room.