### PR TITLE
fix: allow api-based deployment creation

### DIFF
--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -284,7 +284,7 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 		attr.OrganizationID(authCtx.ActiveOrganizationID),
 		attr.ProjectID(projectID.String()),
 		attr.UserID(authCtx.UserID),
-		attr.SessionID(*authCtx.SessionID),
+		attr.SessionID(conv.PtrValOr(authCtx.SessionID, "")),
 	)
 
 	dbtx, err := s.db.Begin(ctx)


### PR DESCRIPTION
## Desription
Avoid a nil pointer dereference on API-based requests to create deployments.

When Gram-Key is set, Gram-Session is nil.

## Reproduce locally

### Pull the ID of an asset and its project
<details>
<summary>Local sql query 👇</summary>

```bash
$ docker exec -it gram-gram-db-1 psql -U gram -c ‘
  select a.id asset_id, p.slug project_slug
  from assets a inner join projects p
  on a.project_id = p.id
  order by a.created_at desc
  limit 1’ ;
               asset_id               | project_slug
--------------------------------------+———————
 01991c01-ce0d-7403-8c6b-07afd7608732 | default
(1 row)
```

</details>

### Send a request to the backend
<details>
<summary>HTTP Request 👇</summary>

```
POST {{baseUrl}}/rpc/deployments.create HTTP/1.1
Gram-Key: {{apiKey}}
Gram-Project: default
Content-Type: application/json
Idempotency-Key: anything

{
    "openapiv3_assets": [
        {
            "asset_id": "01991b43-f9ce-78f4-8ea8-d8b59ccd44f3”,
            "name": “My Petstore”,
            "slug": “my-petstore”
        }
    ]
}
```

</details>

### Succesful response

Previously: 5xx error (socket hangup). Now:

```
HTTP/1.1 200 OK
<SNIP>

{
  "deployment": {
    "id": "019946b2-a459-795c-807b-f9d414dbaa4c”,
<SNIP>
}
```
