### PR TITLE
chore: groupd redis updates in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
       kubernetes:
         patterns:
           - "k8s.io/*"
+      redis:
+        patterns:
+          - "github.com/redis/go-redis/*"
   - package-ecosystem: "docker"
     directory: "/server"
     schedule:


### PR DESCRIPTION
This change ensures Go packages under `github.com/redis/go-redis` are updated in lockstep by Dependabot.