### PR TITLE
chore: print all issues found during go linting

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -2,6 +2,10 @@
 
 version: "2"
 
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 run:
   relative-path-mode: wd
 


### PR DESCRIPTION
This change updates golangci-lint configuration to ensure that all issues found during linting are printed, without any limits.