### PR TITLE
fix: add sleep to testvariationsservice listglobal orderedbyid

### DIFF
--- a/.changeset/four-apes-sneeze.md
+++ b/.changeset/four-apes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+Fix flakes in global ordering unit test.

--- a/server/internal/variations/listglobal_test.go
+++ b/server/internal/variations/listglobal_test.go
@@ -3,6 +3,7 @@ package variations_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -239,6 +240,8 @@ func TestVariationsService_ListGlobal_OrderedByID(t *testing.T) {
 		Summarizer:       nil,
 	})
 	require.NoError(t, err, "create first variation")
+
+	time.Sleep(2 * time.Millisecond)
 
 	second, err := ti.service.UpsertGlobal(ctx, &gen.UpsertGlobalPayload{
 		ApikeyToken:      nil,


### PR DESCRIPTION
## Description
Example of a flaking test: https://github.com/speakeasy-api/gram/actions/runs/17747820124/job/50436818163?pr=260