### PR TITLE
chore: move events logger to deployments subpackage

### DIFF
--- a/server/internal/deployments/events/log.go
+++ b/server/internal/deployments/events/log.go
@@ -1,4 +1,4 @@
-package openapi
+package events
 
 import (
 	"context"

--- a/server/internal/openapi/process.go
+++ b/server/internal/openapi/process.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/deployments/events"
 	"github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/inv"
@@ -152,7 +153,7 @@ func (p *ToolExtractor) Do(
 		attr.SlogOrganizationSlug(task.OrgSlug),
 	}
 
-	eventsHandler := NewLogHandler()
+	eventsHandler := events.NewLogHandler()
 	logger := slog.New(slogmulti.Fanout(
 		p.logger.Handler(),
 		eventsHandler,


### PR DESCRIPTION
This change moves the deployment events logger to an events package under the deployments package. It used to be in the openapi package but the exact functionality is needed to log events when processing Gram functions so it was lifted out to a more appropriate package.