### PR TITLE
chore: move slug pattern to constants package

### DIFF
--- a/server/design/packages/design.go
+++ b/server/design/packages/design.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/design/security"
 	"github.com/speakeasy-api/gram/server/design/shared"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
 var _ = Service("packages", func() {
@@ -186,7 +187,7 @@ var CreatePackageForm = Type("CreatePackageForm", func() {
 	Attribute("name", String, func() {
 		Description("The name of the package")
 		MaxLength(100)
-		Pattern(shared.SlugPattern)
+		Pattern(constants.SlugPattern)
 	})
 	Attribute("title", String, "The title of the package", func() {
 		MaxLength(100)

--- a/server/design/shared/datatypes.go
+++ b/server/design/shared/datatypes.go
@@ -1,13 +1,12 @@
 package shared
 
 import (
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	. "goa.design/goa/v3/dsl"
 )
 
-const SlugPattern = `^[a-z0-9]+(?:[a-z0-9_-]*[a-z0-9])?$`
-
 var Slug = Type("Slug", String, func() {
 	Description("A short url-friendly label that uniquely identifies a resource.")
-	Pattern(SlugPattern)
+	Pattern(constants.SlugPattern)
 	MaxLength(40)
 })

--- a/server/internal/constants/tools.go
+++ b/server/internal/constants/tools.go
@@ -1,5 +1,11 @@
 package constants
 
+import "regexp"
+
 const (
 	ToolTypeHTTP = "http"
 )
+
+const SlugPattern = `^[a-z0-9]+(?:[a-z0-9_-]*[a-z0-9])?$`
+
+var SlugPatternRE = regexp.MustCompile(SlugPattern)


### PR DESCRIPTION
This change moves the slug pattern and regular expression to the `constants` package because it will be reused in application logic for validating Gram Functions tool names.