### PR TITLE
chore: define o11y attributes and metrics for Gram Functions

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -65,6 +65,9 @@ const (
 	ComponentKey                   = attribute.Key("gram.component")
 	DBDeletedRowsCountKey          = attribute.Key("gram.db.deleted_rows_count")
 	DeploymentIDKey                = attribute.Key("gram.deployment.id")
+	DeploymentFunctionsIDKey       = attribute.Key("gram.deployment.functions.id")
+	DeploymentFunctionsNameKey     = attribute.Key("gram.deployment.functions.name")
+	DeploymentFunctionsSlugKey     = attribute.Key("gram.deployment.functions.slug")
 	DeploymentOpenAPIIDKey         = attribute.Key("gram.deployment.openapi.id")
 	DeploymentOpenAPINameKey       = attribute.Key("gram.deployment.openapi.name")
 	DeploymentOpenAPISlugKey       = attribute.Key("gram.deployment.openapi.slug")
@@ -74,6 +77,8 @@ const (
 	EnvVarNameKey                  = attribute.Key("gram.envvar.name")
 	ErrorIDKey                     = attribute.Key("gram.error.id")
 	FilterExpressionKey            = attribute.Key("gram.filter.src")
+	FunctionsManifestVersionKey    = attribute.Key("gram.functions.manifest_version")
+	FunctionsToolRuntimeKey        = attribute.Key("gram.functions.tool_runtime")
 	HTTPEncodingStyleKey           = attribute.Key("gram.http.encoding.style")
 	HTTPParamNameKey               = attribute.Key("gram.http.param.name")
 	HTTPParamValueKey              = attribute.Key("gram.http.param.value")
@@ -275,6 +280,25 @@ func SlogDBDeletedRowsCount(v int64) slog.Attr      { return slog.Int64(string(D
 func DeploymentID(v string) attribute.KeyValue { return DeploymentIDKey.String(v) }
 func SlogDeploymentID(v string) slog.Attr      { return slog.String(string(DeploymentIDKey), v) }
 
+func DeploymentFunctionsID(v string) attribute.KeyValue { return DeploymentFunctionsIDKey.String(v) }
+func SlogDeploymentFunctionsID(v string) slog.Attr {
+	return slog.String(string(DeploymentFunctionsIDKey), v)
+}
+
+func DeploymentFunctionsName(v string) attribute.KeyValue {
+	return DeploymentFunctionsNameKey.String(v)
+}
+func SlogDeploymentFunctionsName(v string) slog.Attr {
+	return slog.String(string(DeploymentFunctionsNameKey), v)
+}
+
+func DeploymentFunctionsSlug(v string) attribute.KeyValue {
+	return DeploymentFunctionsSlugKey.String(v)
+}
+func SlogDeploymentFunctionsSlug(v string) slog.Attr {
+	return slog.String(string(DeploymentFunctionsSlugKey), v)
+}
+
 func DeploymentOpenAPIID(v string) attribute.KeyValue { return DeploymentOpenAPIIDKey.String(v) }
 func SlogDeploymentOpenAPIID(v string) slog.Attr {
 	return slog.String(string(DeploymentOpenAPIIDKey), v)
@@ -307,6 +331,18 @@ func SlogErrorID(v string) slog.Attr      { return slog.String(string(ErrorIDKey
 
 func FilterExpression(v string) attribute.KeyValue { return FilterExpressionKey.String(v) }
 func SlogFilterExpression(v string) slog.Attr      { return slog.String(string(FilterExpressionKey), v) }
+
+func FunctionsManifestVersion(v string) attribute.KeyValue {
+	return FunctionsManifestVersionKey.String(v)
+}
+func SlogFunctionsManifestVersion(v string) slog.Attr {
+	return slog.String(string(FunctionsManifestVersionKey), v)
+}
+
+func FunctionsToolRuntime(v string) attribute.KeyValue { return FunctionsToolRuntimeKey.String(v) }
+func SlogFunctionsToolRuntime(v string) slog.Attr {
+	return slog.String(string(FunctionsToolRuntimeKey), v)
+}
 
 func HTTPEncodingStyle(v string) attribute.KeyValue { return HTTPEncodingStyleKey.String(v) }
 func SlogHTTPEncodingStyle(v string) slog.Attr      { return slog.String(string(HTTPEncodingStyleKey), v) }
@@ -387,8 +423,8 @@ func SlogOrganizationAccountType(v string) slog.Attr {
 	return slog.String(string(OrganizationAccountTypeKey), v)
 }
 
-func Outcome(v string) attribute.KeyValue { return OutcomeKey.String(v) }
-func SlogOutcome(v string) slog.Attr      { return slog.String(string(OutcomeKey), v) }
+func Outcome[V ~string](v V) attribute.KeyValue { return OutcomeKey.String(string(v)) }
+func SlogOutcome(v string) slog.Attr            { return slog.String(string(OutcomeKey), v) }
 
 func PackageName(v string) attribute.KeyValue { return PackageNameKey.String(v) }
 func SlogPackageName(v string) slog.Attr      { return slog.String(string(PackageNameKey), v) }

--- a/server/internal/background/activities/metrics.go
+++ b/server/internal/background/activities/metrics.go
@@ -17,11 +17,15 @@ func newMeter(meterProvider metric.MeterProvider) metric.Meter {
 }
 
 const (
-	metricOpenAPIOperationsSkipped = "openapi.operations.skipped"
-	meterOpenAPIUpgradeCounter     = "openapi.upgrade.count"
-	meterOpenAPIUpgradeDuration    = "openapi.upgrade.duration"
-	meterOpenAPIProcessedCounter   = "openapi.processed.count"
-	meterOpenAPIProcessedDuration  = "openapi.processed.duration"
+	meterOpenAPIOperationsSkipped = "openapi.operations.skipped"
+	meterOpenAPIUpgradeCounter    = "openapi.upgrade.count"
+	meterOpenAPIUpgradeDuration   = "openapi.upgrade.duration"
+	meterOpenAPIProcessedCounter  = "openapi.processed.count"
+	meterOpenAPIProcessedDuration = "openapi.processed.duration"
+
+	meterFunctionsToolsSkipped      = "functions.tools.skipped"
+	meterFunctionsToolsCounter      = "functions.tools.count"
+	meterFunctionsProcessedDuration = "functions.processed.duration"
 )
 
 type metrics struct {
@@ -32,18 +36,22 @@ type metrics struct {
 
 	openAPIProcessedDuration metric.Float64Histogram
 	openAPIUpgradeDuration   metric.Float64Histogram
+
+	functionsToolsSkipped      metric.Int64Counter
+	functionsToolsCounter      metric.Int64Counter
+	functionsProcessedDuration metric.Float64Histogram
 }
 
 func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
 	ctx := context.Background()
 
 	opSkipped, err := meter.Int64Counter(
-		metricOpenAPIOperationsSkipped,
+		meterOpenAPIOperationsSkipped,
 		metric.WithDescription("Number of OpenAPI operations that were skipped due to errors"),
 		metric.WithUnit("{#}"),
 	)
 	if err != nil {
-		logger.ErrorContext(ctx, "create metric error", attr.SlogMetricName(metricOpenAPIOperationsSkipped), attr.SlogError(err))
+		logger.ErrorContext(ctx, "create metric error", attr.SlogMetricName(meterOpenAPIOperationsSkipped), attr.SlogError(err))
 	}
 
 	openAPIUpgradeCounter, err := meter.Int64Counter(
@@ -84,12 +92,43 @@ func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
 		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterOpenAPIUpgradeDuration), attr.SlogError(err))
 	}
 
+	functionsToolsSkipped, err := meter.Int64Counter(
+		meterFunctionsToolsSkipped,
+		metric.WithDescription("Number of functions tools that were skipped due to errors"),
+		metric.WithUnit("{#}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterFunctionsToolsSkipped), attr.SlogError(err))
+	}
+
+	functionsToolsCounter, err := meter.Int64Counter(
+		meterFunctionsToolsCounter,
+		metric.WithDescription("Number of processed functions tools"),
+		metric.WithUnit("{tool}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterFunctionsToolsCounter), attr.SlogError(err))
+	}
+
+	functionsProcessedDuration, err := meter.Float64Histogram(
+		meterFunctionsProcessedDuration,
+		metric.WithDescription("Duration of functions processing in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.1, 0.5, 1, 2, 5, 10, 20, 30, 60, 120, 240),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterFunctionsProcessedDuration), attr.SlogError(err))
+	}
+
 	return &metrics{
-		opSkipped:                opSkipped,
-		openAPIUpgradeCounter:    openAPIUpgradeCounter,
-		openAPIProcessedCounter:  openAPIProcessedCounter,
-		openAPIProcessedDuration: openAPIProcessedDuration,
-		openAPIUpgradeDuration:   openAPIUpgradeDuration,
+		opSkipped:                  opSkipped,
+		openAPIUpgradeCounter:      openAPIUpgradeCounter,
+		openAPIProcessedCounter:    openAPIProcessedCounter,
+		openAPIProcessedDuration:   openAPIProcessedDuration,
+		openAPIUpgradeDuration:     openAPIUpgradeDuration,
+		functionsToolsSkipped:      functionsToolsSkipped,
+		functionsToolsCounter:      functionsToolsCounter,
+		functionsProcessedDuration: functionsProcessedDuration,
 	}
 }
 
@@ -104,7 +143,7 @@ func (m *metrics) RecordOpenAPIOperationSkipped(ctx context.Context, reason stri
 func (m *metrics) RecordOpenAPIProcessed(ctx context.Context, outcome o11y.Outcome, duration time.Duration, version string) {
 	if counter := m.openAPIProcessedCounter; counter != nil {
 		counter.Add(ctx, 1, metric.WithAttributes(
-			attr.Outcome(string(outcome)),
+			attr.Outcome(outcome),
 			attr.OpenAPIVersion(sanitizeOpenAPIVersion(version)),
 		))
 	}
@@ -135,4 +174,35 @@ func sanitizeOpenAPIVersion(version string) string {
 	}
 
 	return v
+}
+
+func (m *metrics) RecordFunctionsToolSkipped(ctx context.Context, reason string) {
+	if counter := m.functionsToolsSkipped; counter != nil {
+		counter.Add(ctx, 1, metric.WithAttributes(
+			attr.Reason(reason),
+		))
+	}
+}
+
+func (m *metrics) RecordFunctionsProcessed(
+	ctx context.Context,
+	duration time.Duration,
+	outcome o11y.Outcome,
+	manifestVersion string,
+	numTools int,
+	toolRuntime string,
+) {
+	if counter := m.functionsToolsCounter; counter != nil {
+		counter.Add(ctx, int64(numTools), metric.WithAttributes(
+			attr.FunctionsToolRuntime(toolRuntime),
+		))
+	}
+
+	if histogram := m.functionsProcessedDuration; histogram != nil {
+		histogram.Record(ctx, duration.Seconds(), metric.WithAttributes(
+			attr.Outcome(outcome),
+			attr.FunctionsManifestVersion(manifestVersion),
+			attr.FunctionsToolRuntime(toolRuntime),
+		))
+	}
 }


### PR DESCRIPTION
This change introduces o11y attributes and metrics used to monitor processing of Gram Functions as part of deployments.