### PR TITLE
chore: output public openapi spec to speakeasy folder

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -14,6 +14,8 @@ sources:
         overlays:
             - location: overlays/goa.yaml
             - location: overlays/public-sdk.yaml
+        output:
+            - location: .speakeasy/openapi-public.yaml
         registry:
             location: registry.speakeasyapi.dev/gram/gram/gram-public-api-description
 targets:


### PR DESCRIPTION
- Output the public openapi specification, after overlays have been applied to a path in the speakeasy folder