### PR TITLE
chore: add OTel tracing around OpenAPI processing

### DIFF
--- a/.changeset/twenty-tires-enjoy.md
+++ b/.changeset/twenty-tires-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+Add OpenTelemetry tracing around OpenAPI processing

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -539,7 +539,7 @@ func newStartCommand() *cli.Command {
 					close(workerInterruptCh)
 				})
 				group.Go(func() {
-					temporalWorker := background.NewTemporalWorker(temporalClient, logger, meterProvider, &background.WorkerOptions{
+					temporalWorker := background.NewTemporalWorker(temporalClient, logger, tracerProvider, meterProvider, &background.WorkerOptions{
 						DB:                  db,
 						FeatureProvider:     features,
 						AssetStorage:        assetStorage,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -341,7 +341,7 @@ func newWorkerCommand() *cli.Command {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}
 
-			temporalWorker := background.NewTemporalWorker(temporalClient, logger, meterProvider, &background.WorkerOptions{
+			temporalWorker := background.NewTemporalWorker(temporalClient, logger, tracerProvider, meterProvider, &background.WorkerOptions{
 				DB:                  db,
 				FeatureProvider:     features,
 				AssetStorage:        assetStorage,

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -70,6 +70,7 @@ const (
 	DeploymentFunctionsSlugKey     = attribute.Key("gram.deployment.functions.slug")
 	DeploymentOpenAPIIDKey         = attribute.Key("gram.deployment.openapi.id")
 	DeploymentOpenAPINameKey       = attribute.Key("gram.deployment.openapi.name")
+	DeploymentOpenAPIParserKey     = attribute.Key("gram.deployment.openapi_parser")
 	DeploymentOpenAPISlugKey       = attribute.Key("gram.deployment.openapi.slug")
 	DeploymentStatusKey            = attribute.Key("gram.deployment.status")
 	EnvironmentIDKey               = attribute.Key("gram.environment.id")
@@ -307,6 +308,13 @@ func SlogDeploymentOpenAPIID(v string) slog.Attr {
 func DeploymentOpenAPIName(v string) attribute.KeyValue { return DeploymentOpenAPINameKey.String(v) }
 func SlogDeploymentOpenAPIName(v string) slog.Attr {
 	return slog.String(string(DeploymentOpenAPINameKey), v)
+}
+
+func DeploymentOpenAPIParser(v string) attribute.KeyValue {
+	return DeploymentOpenAPIParserKey.String(v)
+}
+func SlogDeploymentOpenAPIParser(v string) slog.Attr {
+	return slog.String(string(DeploymentOpenAPIParserKey), v)
 }
 
 func DeploymentOpenAPISlug(v string) attribute.KeyValue { return DeploymentOpenAPISlugKey.String(v) }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
@@ -38,6 +39,7 @@ type Activities struct {
 
 func NewActivities(
 	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
 	db *pgxpool.Pool,
 	features feature.Provider,
@@ -52,7 +54,7 @@ func NewActivities(
 	posthogClient *posthog.Posthog,
 ) *Activities {
 	return &Activities{
-		processDeployment:             activities.NewProcessDeployment(logger, meterProvider, db, features, assetStorage),
+		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, db, features, assetStorage),
 		transitionDeployment:          activities.NewTransitionDeployment(logger, db),
 		getSlackProjectContext:        activities.NewSlackProjectContextActivity(logger, db, slackClient),
 		postSlackMessage:              activities.NewPostSlackMessageActivity(logger, slackClient),

--- a/server/internal/background/activities/metrics.go
+++ b/server/internal/background/activities/metrics.go
@@ -140,29 +140,37 @@ func (m *metrics) RecordOpenAPIOperationSkipped(ctx context.Context, reason stri
 	}
 }
 
-func (m *metrics) RecordOpenAPIProcessed(ctx context.Context, outcome o11y.Outcome, duration time.Duration, version string) {
+func (m *metrics) RecordOpenAPIProcessed(ctx context.Context, parser string, outcome o11y.Outcome, duration time.Duration, version string) {
 	if counter := m.openAPIProcessedCounter; counter != nil {
 		counter.Add(ctx, 1, metric.WithAttributes(
 			attr.Outcome(outcome),
 			attr.OpenAPIVersion(sanitizeOpenAPIVersion(version)),
+			attr.DeploymentOpenAPIParser(parser),
 		))
 	}
 
 	if histogram := m.openAPIProcessedDuration; histogram != nil {
-		histogram.Record(ctx, duration.Seconds(), metric.WithAttributes(attr.Outcome(string(outcome))))
+		histogram.Record(ctx, duration.Seconds(), metric.WithAttributes(
+			attr.Outcome(outcome),
+			attr.DeploymentOpenAPIParser(parser),
+		))
 	}
 }
 
-func (m *metrics) RecordOpenAPIUpgrade(ctx context.Context, outcome o11y.Outcome, duration time.Duration, version string) {
+func (m *metrics) RecordOpenAPIUpgrade(ctx context.Context, parser string, outcome o11y.Outcome, duration time.Duration, version string) {
 	if counter := m.openAPIUpgradeCounter; counter != nil {
 		counter.Add(ctx, 1, metric.WithAttributes(
 			attr.Outcome(string(outcome)),
 			attr.OpenAPIVersion(sanitizeOpenAPIVersion(version)),
+			attr.DeploymentOpenAPIParser(parser),
 		))
 	}
 
 	if histogram := m.openAPIUpgradeDuration; histogram != nil {
-		histogram.Record(ctx, duration.Seconds(), metric.WithAttributes(attr.Outcome(string(outcome))))
+		histogram.Record(ctx, duration.Seconds(), metric.WithAttributes(
+			attr.Outcome(outcome),
+			attr.DeploymentOpenAPIParser(parser),
+		))
 	}
 }
 

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/temporal"
@@ -61,6 +62,7 @@ func ForDeploymentProcessing(db *pgxpool.Pool, f feature.Provider, assetStorage 
 func NewTemporalWorker(
 	client client.Client,
 	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
 	options ...*WorkerOptions,
 ) worker.Worker {
@@ -106,6 +108,7 @@ func NewTemporalWorker(
 
 	activities := NewActivities(
 		logger,
+		tracerProvider,
 		meterProvider,
 		opts.DB,
 		opts.FeatureProvider,

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -69,7 +69,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	f := &feature.InMemory{}
 
 	temporal, devserver := infra.NewTemporalClient(t)
-	worker := background.NewTemporalWorker(temporal, logger, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage))
+	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage))
 	t.Cleanup(func() {
 		worker.Stop()
 		temporal.Close()

--- a/server/internal/openapi/extract_test.go
+++ b/server/internal/openapi/extract_test.go
@@ -46,6 +46,7 @@ func TestDoProcess_Equal(t *testing.T) {
 	require.NoError(t, err)
 
 	tet := ToolExtractorTask{
+		Parser: "speakeasy",
 		DocInfo: &types.OpenAPIv3DeploymentAsset{
 			Name:    "speakeasy-bar",
 			Slug:    "speakeasy_bar",

--- a/server/internal/openapi/process.go
+++ b/server/internal/openapi/process.go
@@ -81,6 +81,8 @@ var preferredRequestTypes = []*regexp.Regexp{
 }
 
 type ToolExtractorTask struct {
+	Parser string
+
 	ProjectID    uuid.UUID
 	DeploymentID uuid.UUID
 	DocumentID   uuid.UUID
@@ -144,6 +146,7 @@ func (p *ToolExtractor) Do(
 	tx := repo.New(dbtx)
 
 	slogArgs := []any{
+		attr.SlogDeploymentOpenAPIParser(task.Parser),
 		attr.SlogProjectID(projectID.String()),
 		attr.SlogDeploymentOpenAPIName(docInfo.Name),
 		attr.SlogDeploymentOpenAPISlug(string(docInfo.Slug)),
@@ -212,18 +215,14 @@ func (p *ToolExtractor) Do(
 		return nil, oops.E(oops.CodeUnexpected, err, "error reading openapi document").Log(ctx, logger)
 	}
 
-	f := conv.Default[feature.Provider](p.feature, &feature.InMemory{})
-
-	useSpeakeasyParser, err := f.IsFlagEnabled(ctx, feature.FlagSpeakeasyOpenAPIParserV0, task.ProjectID.String())
-	if err != nil {
-		useSpeakeasyParser = false
-		p.logger.ErrorContext(ctx, "error checking openapi parser feature flag for organization", attr.SlogError(err), attr.SlogOrganizationSlug(task.OrgSlug))
-	}
-
 	var res *ToolExtractorResult
-	if useSpeakeasyParser {
+	switch task.Parser {
+	case "speakeasy":
 		res, err = p.doSpeakeasy(ctx, logger, tx, doc, task)
-	} else {
+	default:
+		if task.Parser != "libopenapi" {
+			logger.ErrorContext(ctx, "unrecognized parser specified: defaulting to libopenapi", attr.SlogDeploymentOpenAPIParser(task.Parser))
+		}
 		res, err = p.doLibOpenAPI(ctx, logger, tx, doc, task)
 	}
 	if err != nil {

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -79,7 +79,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	f := &feature.InMemory{}
 
 	temporal, devserver := infra.NewTemporalClient(t)
-	worker := background.NewTemporalWorker(temporal, logger, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage))
+	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage))
 	t.Cleanup(func() {
 		worker.Stop()
 		temporal.Close()

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -81,7 +81,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	f := &feature.InMemory{}
 
 	temporal, devserver := infra.NewTemporalClient(t)
-	worker := background.NewTemporalWorker(temporal, logger, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage))
+	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage))
 	t.Cleanup(func() {
 		worker.Stop()
 		temporal.Close()


### PR DESCRIPTION
This change adds an explicit tracing span around the openapi tool extractor so we can observe processing times and chosen parsers in traces. Additionally, related metrics have also been updated to include the chosen parser as an attribute.