### PR TITLE
feat: use summary as description if description is missing

### DIFF
--- a/server/internal/openapi/process.go
+++ b/server/internal/openapi/process.go
@@ -300,6 +300,11 @@ func parseToolDescriptor(ctx context.Context, logger *slog.Logger, docInfo *type
 	description := op.description
 	summary := op.summary
 
+	// Soon we will stop storing summary. Still we want to make sure that we do a best-effort to set a description.
+	if description == "" {
+		description = summary
+	}
+
 	toolDesc := toolDescriptor{
 		xGramFound:          false,
 		xSpeakeasyMCPFound:  false,


### PR DESCRIPTION
Very minor thing to start reducing our reliance on `summary` in pursuit of eventually dropping it. Now, we will populate tool descriptions with the `summary` openapi field if the openapi `description` is empty