### PR TITLE
chore: add contributor license agreement (CLA) GitHub Action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.4.0
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: 'https://github.com/speakeasyapi/gram/blob/main/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla-signatures'
-          allowlist: speakeasyapi,dependabot,renovate
+          allowlist: speakeasy-api,dependabot,renovate
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is used for sending notification to CLA management team and for PR locking
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/speakeasyapi/gram/blob/main/CLA.md' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'cla-signatures'
+          allowlist: speakeasyapi,dependabot,renovate
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,44 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to Gram (the "Project") by Speakeasy API. By signing this Contributor License Agreement ("CLA"), you agree to the following terms:
+
+## 1. Definitions
+
+- **"You"** means the individual or entity making a Contribution to the Project.
+- **"Contribution"** means any work of authorship, including the original version of the work and any modifications or additions to that work, that is intentionally submitted by You to the Project.
+- **"Project"** means the Gram project maintained by Speakeasy API.
+
+## 2. Grant of Rights
+
+### 2.1 Copyright License
+You hereby grant to the Project and its licensees a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Contribution, and to permit persons to whom the Project is furnished to do so, subject to the terms of the GNU Affero General Public License version 3.0 (AGPL-3.0).
+
+### 2.2 Patent License
+You hereby grant to the Project and its licensees a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Project.
+
+## 3. Representations and Warranties
+
+You represent and warrant that:
+
+- You are legally entitled to grant the above licenses.
+- Each of Your Contributions is Your original creation and/or You have sufficient rights to submit it under these terms.
+- Your Contributions do not, to Your knowledge, violate any third party's copyrights, trademarks, patents, or other intellectual property rights.
+- If Your employer has rights to intellectual property that You create, You represent that You have received permission to make the Contributions on behalf of that employer, or that Your employer has waived such rights.
+
+## 4. Disclaimer
+
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 5. Agreement to AGPL-3.0
+
+You acknowledge that all Contributions to this Project are licensed under the GNU Affero General Public License version 3.0 (AGPL-3.0), and that this CLA does not change the license terms under which Your Contributions are made available to the public.
+
+## 6. Ongoing Effect
+
+This CLA will remain in effect for all future Contributions You make to the Project, unless You provide written notice to the Project maintainers revoking this agreement for future Contributions (such revocation will not affect past Contributions).
+
+---
+
+By commenting "I have read the CLA Document and I hereby sign the CLA" on the pull request, You are signing this CLA electronically and agreeing to its terms.
+
+For questions about this CLA, please contact the project maintainers.


### PR DESCRIPTION
## Summary
This PR adds a Contributor License Agreement (CLA) system to the repository using GitHub Actions.

## Changes
- Added `.github/workflows/cla.yml` workflow using contributor-assistant/github-action v2.4.0
- Created `CLA.md` document tailored for AGPL-3.0 licensed projects
- Configured automatic CLA checking on all pull requests
- Contributors can sign the CLA by commenting "I have read the CLA Document and I hereby sign the CLA" on their PRs

## How it works
1. When a new PR is opened, the CLA bot will check if the contributor has signed the CLA
2. If not signed, it will comment with instructions and fail the status check
3. Contributors sign by posting the required comment on their PR
4. Signatures are stored in a `cla-signatures` branch in JSON format
5. After merging, the bot will lock the PR to prevent signature tampering

## Setup Required
Before merging, you'll need to add a `PERSONAL_ACCESS_TOKEN` secret to the repository settings with `repo` scope. This token is used for PR notifications and locking.

## Test plan
- [x] Merge this PR
- [ ] Add the required `PERSONAL_ACCESS_TOKEN` secret
- [ ] Create a test PR from a different contributor to verify CLA workflow

🤖 Generated with [Claude Code](https://claude.ai/code)