### PR TITLE
fix: denote active deployment in deployments page

### DIFF
--- a/client/dashboard/package.json
+++ b/client/dashboard/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@speakeasy-api/moonshine": "1.28.3",
+    "@speakeasy-api/moonshine": "1.28.4",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-query": "catalog:",

--- a/client/dashboard/src/pages/deployments/Deployments.tsx
+++ b/client/dashboard/src/pages/deployments/Deployments.tsx
@@ -1,5 +1,5 @@
 import { Page } from "@/components/page-layout";
-import { Button } from "@speakeasy-api/moonshine";
+import { Badge, Button } from "@speakeasy-api/moonshine";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -61,11 +61,11 @@ const RedeploySuccessToast = ({ href }: { href: string | undefined }) => {
 };
 
 function DeploymentActionsDropdown({
-  deploymentId,
-  deployments,
+  deployment,
+  latest,
 }: {
-  deploymentId: string;
-  deployments: DeploymentSummary[];
+  deployment: DeploymentSummary;
+  latest: boolean;
 }) {
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
@@ -97,18 +97,13 @@ function DeploymentActionsDropdown({
     },
   });
 
-  // Check if this is the latest deployment (first item, assuming sorted by date desc)
-  const isLatestDeployment =
-    deployments.length > 0 && deployments[0]?.id === deploymentId;
-
   // Find the current deployment to check its status
-  const currentDeployment = deployments.find((d) => d.id === deploymentId);
-  const isCompletedDeployment = currentDeployment?.status === "completed";
+  const isCompletedDeployment = deployment.status === "completed";
 
   // Show actions for:
   // 1. Latest deployment (regardless of status) - shows "Retry"
   // 2. Completed deployments that are not the latest - shows "Redeploy"
-  if (!isLatestDeployment && !isCompletedDeployment) {
+  if (!latest && !isCompletedDeployment) {
     return null;
   }
 
@@ -116,14 +111,14 @@ function DeploymentActionsDropdown({
     redeployMutation.mutate({
       request: {
         redeployRequestBody: {
-          deploymentId,
+          deploymentId: deployment.id,
         },
       },
     });
   };
 
   const isRedeploying = redeployMutation.isPending;
-  const actionText = isLatestDeployment ? "Retry Deployment" : "Redeploy";
+  const actionText = latest ? "Retry Deployment" : "Redeploy";
   const buttonText = isRedeploying ? "Redeploying..." : actionText;
 
   return (
@@ -148,89 +143,87 @@ function DeploymentActionsDropdown({
   );
 }
 
-const columns: TableProps<DeploymentSummary>["columns"] = [
-  {
-    key: "status",
-    header: "",
-    width: "50px",
-    render: (row) => {
-      switch (row.status) {
-        case "completed":
-          return (
-            <div className="flex items-center justify-center rounded-full bg-success p-1">
-              <Icon name="check" className="text-success-foreground" />
-            </div>
-          );
-        case "failed":
-          return (
-            <div className="flex items-center justify-center rounded-full bg-destructive/20 p-1">
-              <Icon name="x" className="text-destructive-foreground" />
-            </div>
-          );
-        default:
-          return (
-            <div className="flex items-center justify-center rounded-full bg-warning p-1">
-              <Icon name="circle-dashed" className="text-warning-foreground" />
-            </div>
-          );
-      }
-    },
-  },
-  {
-    key: "id",
-    header: "ID",
-    render: (row) => {
-      const createdAt = relativeTime(row.createdAt);
-
-      return (
-        <div>
-          <DeploymentLink id={row.id} />
-          <p className="text-muted-foreground text-sm">{createdAt}</p>
-        </div>
-      );
-    },
-  },
-  {
-    key: "assetCount",
-    header: "Assets",
-    render: (row) => row.openapiv3AssetCount,
-    width: "150px",
-  },
-  {
-    key: "toolCount",
-    header: "Tools",
-    render: (row) => row.openapiv3ToolCount,
-    width: "0.5fr",
-  },
-  {
-    key: "actions",
-    header: "",
-    render: () => {
-      // This will be overridden in DeploymentsTable with proper deployments prop
-      return null;
-    },
-    width: "auto",
-  },
-];
-
 function DeploymentsTable() {
   const { data: res } = useListDeploymentsSuspense();
   const deployments = res.items ?? [];
+  const activeDeployment = deployments.find((d) => d.status === "completed");
 
   if (deployments.length === 0) {
     return <DeploymentsEmptyState />;
   }
 
   const columnsWithData: TableProps<DeploymentSummary>["columns"] = [
-    ...columns.slice(0, -1), // All columns except the last one (actions)
+    {
+      key: "status",
+      header: "",
+      width: "50px",
+      render: (row) => {
+        switch (row.status) {
+          case "completed":
+            return (
+              <div className="flex items-center justify-center rounded-full bg-success p-1">
+                <Icon name="check" className="text-success-foreground" />
+              </div>
+            );
+          case "failed":
+            return (
+              <div className="flex items-center justify-center rounded-full bg-destructive/20 p-1">
+                <Icon name="x" className="text-destructive-foreground" />
+              </div>
+            );
+          default:
+            return (
+              <div className="flex items-center justify-center rounded-full bg-warning p-1">
+                <Icon
+                  name="circle-dashed"
+                  className="text-warning-foreground"
+                />
+              </div>
+            );
+        }
+      },
+    },
+    {
+      key: "id",
+      header: "ID",
+      render: (row) => {
+        const createdAt = relativeTime(row.createdAt);
+
+        return (
+          <div>
+            <DeploymentLink id={row.id} />
+            <div className="flex gap-2">
+              <p className="text-muted-foreground text-sm">{createdAt}</p>
+              {activeDeployment === row && (
+                <Badge size="xs" variant="success" className="py-0.25 px-1.5">
+                  Active
+                </Badge>
+              )}
+            </div>
+          </div>
+        );
+      },
+    },
+    {
+      key: "assetCount",
+      header: "Assets",
+      render: (row) => row.openapiv3AssetCount,
+      width: "150px",
+    },
+    {
+      key: "toolCount",
+      header: "Tools",
+      render: (row) => row.openapiv3ToolCount,
+      width: "0.5fr",
+    },
     {
       key: "actions",
       header: "",
       render: (row) => {
         return (
           <DeploymentActionsDropdown
-            deploymentId={row.id}
-            deployments={deployments}
+            deployment={row}
+            latest={deployments[0] === row}
           />
         );
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@speakeasy-api/moonshine':
-        specifier: 1.28.3
-        version: 1.28.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(lucide-react@0.542.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)
+        specifier: 1.28.4
+        version: 1.28.4(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(lucide-react@0.542.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.13)
@@ -1972,8 +1972,8 @@ packages:
     resolution: {integrity: sha512-IUuj2zpGdeKaY5OdGnU83BUJsv7OA9uw3rNVSOuvzLMXMpBTU+W6V0SsQh6iI32lKUJArlnEU4BIzp83hghR/g==}
     engines: {node: '>=18.0.0'}
 
-  '@speakeasy-api/moonshine@1.28.3':
-    resolution: {integrity: sha512-QqGHIybznQKoKJpeD6CLcJMUby1yPBf4tLKmvnkYj7IaELvsdRK0kU4a6Y0Uf733a3ikeCHzJmuxefIkccBdKA==}
+  '@speakeasy-api/moonshine@1.28.4':
+    resolution: {integrity: sha512-UlNX7EvAZHVdgJ/MWAkZ/0j9H/k6hsQQefUjDg/Dti7udxSQEB2h1E39hZx/XR0yG89CjTzKfUYhNS2x4P7O1w==}
     peerDependencies:
       '@types/react': ^18.3.11 || ^19.0.0
       lucide-react: ^0.453.0
@@ -7238,7 +7238,7 @@ snapshots:
       '@smithy/types': 4.4.0
       tslib: 2.8.1
 
-  '@speakeasy-api/moonshine@1.28.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(lucide-react@0.542.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)':
+  '@speakeasy-api/moonshine@1.28.4(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(lucide-react@0.542.0(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@dnd-kit/modifiers': 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
Adds a badge to the table row that is the active deployment (the latest deployment with a status of "completed").

### Demo:

<img width="2272" height="1506" alt="CleanShot 2025-09-17 at 16 58 40@2x" src="https://github.com/user-attachments/assets/bd9e1f40-c740-4d5d-be75-21d80ec24e85" />

### With Failed Deployment

<img width="2272" height="1506" alt="CleanShot 2025-09-17 at 17 00 45@2x" src="https://github.com/user-attachments/assets/15050d91-0e44-4e36-8259-239c4fbbc4c1" />
