### PR TITLE
chore: add tracing span around openapi parsing

### DIFF
--- a/server/internal/background/activities/process_deployment.go
+++ b/server/internal/background/activities/process_deployment.go
@@ -33,16 +33,17 @@ import (
 )
 
 type ProcessDeployment struct {
-	logger       *slog.Logger
-	tracer       trace.Tracer
-	metrics      *metrics
-	db           *pgxpool.Pool
-	features     feature.Provider
-	repo         *repo.Queries
-	assets       *assetsRepo.Queries
-	tools        *toolsRepo.Queries
-	assetStorage assets.BlobStore
-	projects     *projectsRepo.Queries
+	logger         *slog.Logger
+	tracer         trace.Tracer
+	tracerProvider trace.TracerProvider
+	metrics        *metrics
+	db             *pgxpool.Pool
+	features       feature.Provider
+	repo           *repo.Queries
+	assets         *assetsRepo.Queries
+	tools          *toolsRepo.Queries
+	assetStorage   assets.BlobStore
+	projects       *projectsRepo.Queries
 }
 
 func NewProcessDeployment(
@@ -54,16 +55,17 @@ func NewProcessDeployment(
 	assetStorage assets.BlobStore,
 ) *ProcessDeployment {
 	return &ProcessDeployment{
-		logger:       logger,
-		tracer:       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities"),
-		metrics:      newMetrics(newMeter(meterProvider), logger),
-		db:           db,
-		features:     features,
-		repo:         repo.New(db),
-		assets:       assetsRepo.New(db),
-		assetStorage: assetStorage,
-		tools:        toolsRepo.New(db),
-		projects:     projectsRepo.New(db),
+		logger:         logger,
+		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities"),
+		tracerProvider: tracerProvider,
+		metrics:        newMetrics(newMeter(meterProvider), logger),
+		db:             db,
+		features:       features,
+		repo:           repo.New(db),
+		assets:         assetsRepo.New(db),
+		assetStorage:   assetStorage,
+		tools:          toolsRepo.New(db),
+		projects:       projectsRepo.New(db),
 	}
 }
 
@@ -209,7 +211,7 @@ func (p *ProcessDeployment) doOpenAPIv3(
 
 			start := time.Now()
 
-			processor := openapi.NewToolExtractor(p.logger, p.db, p.features, p.assetStorage)
+			processor := openapi.NewToolExtractor(p.logger, p.tracerProvider, p.db, p.features, p.assetStorage)
 
 			res, err := processor.Do(ctx, openapi.ToolExtractorTask{
 				Parser:       parser,

--- a/server/internal/openapi/extract_test.go
+++ b/server/internal/openapi/extract_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/deployments/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,8 +21,12 @@ import (
 func TestDoProcess_Equal(t *testing.T) {
 	t.Parallel()
 
+	logger := testenv.NewLogger(t)
+	tracer := testenv.NewTracerProvider(t).Tracer("github.com/speakeasy-api/gram/server/internal/openapi")
+
 	p := &ToolExtractor{
-		logger:       nil,
+		logger:       logger,
+		tracer:       tracer,
 		db:           nil,
 		feature:      nil,
 		assetStorage: nil,
@@ -62,10 +67,10 @@ func TestDoProcess_Equal(t *testing.T) {
 		OnOperationSkipped: nil,
 	}
 
-	libOpenAPIResult, err := p.doLibOpenAPI(t.Context(), nil, libopenapiTx, data, tet)
+	libOpenAPIResult, err := p.doLibOpenAPI(t.Context(), logger, tracer, libopenapiTx, data, tet)
 	require.NoError(t, err)
 
-	speakeasyResult, err := p.doSpeakeasy(t.Context(), nil, speakeasyTx, data, tet)
+	speakeasyResult, err := p.doSpeakeasy(t.Context(), logger, tracer, speakeasyTx, data, tet)
 	require.NoError(t, err)
 
 	assert.Equal(t, libOpenAPIResult.DocumentUpgrade, speakeasyResult.DocumentUpgrade)


### PR DESCRIPTION
This change wraps the libopenapi and speakeasy openapi parsing logic with a tracing span, allowing us to analyze the performance of each as part of deployment processing.