### PR TITLE
chore: start writing tool_urns to existing tool types

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -257,6 +257,7 @@ CREATE TABLE IF NOT EXISTS deployments_packages (
 
 CREATE TABLE IF NOT EXISTS http_tool_definitions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
+  tool_urn TEXT,
 
   project_id uuid NOT NULL,
   deployment_id uuid NOT NULL,
@@ -726,6 +727,7 @@ WHERE deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS prompt_templates (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
+  tool_urn TEXT,
   project_id uuid NOT NULL,
 
   history_id uuid NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -218,6 +218,7 @@ type HttpSecurity struct {
 
 type HttpToolDefinition struct {
 	ID                  uuid.UUID
+	ToolUrn             pgtype.Text
 	ProjectID           uuid.UUID
 	DeploymentID        uuid.UUID
 	Openapiv3DocumentID uuid.NullUUID
@@ -374,6 +375,7 @@ type ProjectToolVariation struct {
 
 type PromptTemplate struct {
 	ID            uuid.UUID
+	ToolUrn       pgtype.Text
 	ProjectID     uuid.UUID
 	HistoryID     uuid.UUID
 	PredecessorID uuid.NullUUID

--- a/server/internal/deployments/queries.sql
+++ b/server/internal/deployments/queries.sql
@@ -398,6 +398,7 @@ INSERT INTO http_tool_definitions (
     project_id
   , deployment_id
   , openapiv3_document_id
+  , tool_urn
   , name
   , untruncated_name
   , openapiv3_operation
@@ -426,6 +427,7 @@ INSERT INTO http_tool_definitions (
     @project_id
   , @deployment_id
   , @openapiv3_document_id
+  , @tool_urn
   , @name
   , @untruncated_name
   , @openapiv3_operation

--- a/server/internal/deployments/repo/models.go
+++ b/server/internal/deployments/repo/models.go
@@ -74,6 +74,7 @@ type HttpSecurity struct {
 
 type HttpToolDefinition struct {
 	ID                  uuid.UUID
+	ToolUrn             pgtype.Text
 	ProjectID           uuid.UUID
 	DeploymentID        uuid.UUID
 	Openapiv3DocumentID uuid.NullUUID

--- a/server/internal/deployments/repo/queries.sql.go
+++ b/server/internal/deployments/repo/queries.sql.go
@@ -459,6 +459,7 @@ INSERT INTO http_tool_definitions (
     project_id
   , deployment_id
   , openapiv3_document_id
+  , tool_urn
   , name
   , untruncated_name
   , openapiv3_operation
@@ -511,14 +512,16 @@ INSERT INTO http_tool_definitions (
   , $25
   , $26
   , $27
+  , $28
 )
-RETURNING id, project_id, deployment_id, openapiv3_document_id, confirm, confirm_prompt, summarizer, name, untruncated_name, summary, description, openapiv3_operation, tags, x_gram, original_name, original_summary, original_description, server_env_var, default_server_url, security, http_method, path, schema_version, schema, header_settings, query_settings, path_settings, request_content_type, response_filter, created_at, updated_at, deleted_at, deleted
+RETURNING id, tool_urn, project_id, deployment_id, openapiv3_document_id, confirm, confirm_prompt, summarizer, name, untruncated_name, summary, description, openapiv3_operation, tags, x_gram, original_name, original_summary, original_description, server_env_var, default_server_url, security, http_method, path, schema_version, schema, header_settings, query_settings, path_settings, request_content_type, response_filter, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateOpenAPIv3ToolDefinitionParams struct {
 	ProjectID           uuid.UUID
 	DeploymentID        uuid.UUID
 	Openapiv3DocumentID uuid.NullUUID
+	ToolUrn             pgtype.Text
 	Name                string
 	UntruncatedName     pgtype.Text
 	Openapiv3Operation  pgtype.Text
@@ -550,6 +553,7 @@ func (q *Queries) CreateOpenAPIv3ToolDefinition(ctx context.Context, arg CreateO
 		arg.ProjectID,
 		arg.DeploymentID,
 		arg.Openapiv3DocumentID,
+		arg.ToolUrn,
 		arg.Name,
 		arg.UntruncatedName,
 		arg.Openapiv3Operation,
@@ -578,6 +582,7 @@ func (q *Queries) CreateOpenAPIv3ToolDefinition(ctx context.Context, arg CreateO
 	var i HttpToolDefinition
 	err := row.Scan(
 		&i.ID,
+		&i.ToolUrn,
 		&i.ProjectID,
 		&i.DeploymentID,
 		&i.Openapiv3DocumentID,

--- a/server/internal/openapi/extract_libopenapi.go
+++ b/server/internal/openapi/extract_libopenapi.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/orderedmap"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"gopkg.in/yaml.v3"
 )
 
@@ -491,10 +492,13 @@ func extractToolDefLibOpenAPI(ctx context.Context, logger *slog.Logger, tx *repo
 		tags = []string{}
 	}
 
+	toolURN := urn.NewTool(urn.ToolKindHTTP, string(docInfo.Slug), descriptor.name)
+
 	return repo.CreateOpenAPIv3ToolDefinitionParams{
 		ProjectID:           projectID,
 		DeploymentID:        deploymentID,
 		Openapiv3DocumentID: uuid.NullUUID{UUID: openapiDocID, Valid: openapiDocID != uuid.Nil},
+		ToolUrn:             conv.ToPGTextEmpty(toolURN.String()),
 		Security:            security,
 		Path:                path,
 		HttpMethod:          strings.ToUpper(method),

--- a/server/internal/openapi/extract_speakeasy.go
+++ b/server/internal/openapi/extract_speakeasy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/orderedmap"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/openapi/hashing"
 	"github.com/speakeasy-api/openapi/jsonschema/oas3"
 	"github.com/speakeasy-api/openapi/marshaller"
@@ -543,10 +544,13 @@ func extractToolDefSpeakeasy(ctx context.Context, logger *slog.Logger, tx *repo.
 		tags = []string{}
 	}
 
+	toolURN := urn.NewTool(urn.ToolKindHTTP, string(docInfo.Slug), descriptor.name)
+
 	return repo.CreateOpenAPIv3ToolDefinitionParams{
 		ProjectID:           projectID,
 		DeploymentID:        deploymentID,
 		Openapiv3DocumentID: uuid.NullUUID{UUID: openapiDocID, Valid: openapiDocID != uuid.Nil},
+		ToolUrn:             conv.ToPGTextEmpty(toolURN.String()),
 		Security:            security,
 		Path:                path,
 		HttpMethod:          strings.ToUpper(method),

--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -196,7 +196,7 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 		return nil, oops.E(oops.CodeBadRequest, nil, "kind cannot be changed").Log(ctx, logger)
 	}
 
-	toolURN := urn.NewTool(urn.ToolKindPrompt, *payload.Kind, string(current.Name))
+	toolURN := urn.NewTool(urn.ToolKindPrompt, current.Kind.String, current.Name)
 
 	newid, err := tr.UpdateTemplate(ctx, repo.UpdateTemplateParams{
 		ProjectID:   uuid.NullUUID{UUID: projectID, Valid: projectID != uuid.Nil},

--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/templates/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type Service struct {
@@ -104,8 +105,11 @@ func (s *Service) CreateTemplate(ctx context.Context, payload *gen.CreateTemplat
 		}
 	}
 
+	toolURN := urn.NewTool(urn.ToolKindPrompt, payload.Kind, string(payload.Name))
+
 	id, err := tr.CreateTemplate(ctx, repo.CreateTemplateParams{
 		ProjectID:   projectID,
+		ToolUrn:     conv.ToPGTextEmpty(toolURN.String()),
 		Name:        string(payload.Name),
 		Prompt:      payload.Prompt,
 		Description: conv.PtrToPGTextEmpty(payload.Description),
@@ -188,9 +192,16 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 		}
 	}
 
+	if payload.Kind != nil && *payload.Kind != current.Kind.String {
+		return nil, oops.E(oops.CodeBadRequest, nil, "kind cannot be changed").Log(ctx, logger)
+	}
+
+	toolURN := urn.NewTool(urn.ToolKindPrompt, *payload.Kind, string(current.Name))
+
 	newid, err := tr.UpdateTemplate(ctx, repo.UpdateTemplateParams{
 		ProjectID:   uuid.NullUUID{UUID: projectID, Valid: projectID != uuid.Nil},
 		ID:          uuid.NullUUID{UUID: id, Valid: id != uuid.Nil},
+		ToolUrn:     conv.ToPGTextEmpty(toolURN.String()),
 		Prompt:      conv.PtrToPGTextEmpty(payload.Prompt),
 		Description: conv.PtrToPGTextEmpty(payload.Description),
 		Arguments:   args,

--- a/server/internal/templates/queries.sql
+++ b/server/internal/templates/queries.sql
@@ -19,6 +19,7 @@ ORDER BY pt.project_id, pt.name, pt.id DESC;
 INSERT INTO prompt_templates (
   project_id,
   history_id,
+  tool_urn,
   name,
   prompt,
   description,
@@ -30,6 +31,7 @@ INSERT INTO prompt_templates (
 SELECT
   @project_id,
   generate_uuidv7(),
+  @tool_urn,
   @name,
   @prompt,
   NULLIF(@description, ''),
@@ -44,6 +46,7 @@ INSERT INTO prompt_templates (
   project_id,
   history_id,
   predecessor_id,
+  tool_urn,
   name,
   prompt,
   description,
@@ -56,6 +59,7 @@ SELECT
   c.project_id,
   c.history_id,
   c.id,
+  COALESCE(sqlc.narg(tool_urn), c.tool_urn),
   c.name,
   COALESCE(sqlc.narg(prompt), c.prompt),
   NULLIF(sqlc.narg(description), ''),

--- a/server/internal/templates/repo/models.go
+++ b/server/internal/templates/repo/models.go
@@ -11,6 +11,7 @@ import (
 
 type PromptTemplate struct {
 	ID            uuid.UUID
+	ToolUrn       pgtype.Text
 	ProjectID     uuid.UUID
 	HistoryID     uuid.UUID
 	PredecessorID uuid.NullUUID

--- a/server/internal/testenv/testrepo/models.go
+++ b/server/internal/testenv/testrepo/models.go
@@ -29,6 +29,7 @@ type FunctionToolDefinition struct {
 
 type HttpToolDefinition struct {
 	ID                  uuid.UUID
+	ToolUrn             pgtype.Text
 	ProjectID           uuid.UUID
 	DeploymentID        uuid.UUID
 	Openapiv3DocumentID uuid.NullUUID

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -52,7 +52,7 @@ func (q *Queries) ListDeploymentFunctionsTools(ctx context.Context, deploymentID
 }
 
 const listDeploymentHTTPTools = `-- name: ListDeploymentHTTPTools :many
-SELECT id, project_id, deployment_id, openapiv3_document_id, confirm, confirm_prompt, summarizer, name, untruncated_name, summary, description, openapiv3_operation, tags, x_gram, original_name, original_summary, original_description, server_env_var, default_server_url, security, http_method, path, schema_version, schema, header_settings, query_settings, path_settings, request_content_type, response_filter, created_at, updated_at, deleted_at, deleted
+SELECT id, tool_urn, project_id, deployment_id, openapiv3_document_id, confirm, confirm_prompt, summarizer, name, untruncated_name, summary, description, openapiv3_operation, tags, x_gram, original_name, original_summary, original_description, server_env_var, default_server_url, security, http_method, path, schema_version, schema, header_settings, query_settings, path_settings, request_content_type, response_filter, created_at, updated_at, deleted_at, deleted
 FROM http_tool_definitions
 WHERE deployment_id = $1
 `
@@ -68,6 +68,7 @@ func (q *Queries) ListDeploymentHTTPTools(ctx context.Context, deploymentID uuid
 		var i HttpToolDefinition
 		if err := rows.Scan(
 			&i.ID,
+			&i.ToolUrn,
 			&i.ProjectID,
 			&i.DeploymentID,
 			&i.Openapiv3DocumentID,

--- a/server/internal/tools/repo/models.go
+++ b/server/internal/tools/repo/models.go
@@ -12,6 +12,7 @@ import (
 
 type HttpToolDefinition struct {
 	ID                  uuid.UUID
+	ToolUrn             pgtype.Text
 	ProjectID           uuid.UUID
 	DeploymentID        uuid.UUID
 	Openapiv3DocumentID uuid.NullUUID

--- a/server/internal/tools/repo/queries.sql.go
+++ b/server/internal/tools/repo/queries.sql.go
@@ -95,7 +95,7 @@ external_deployments AS (
   WHERE deployments_packages.deployment_id = (SELECT id FROM deployment)
 )
 SELECT 
-  http_tool_definitions.id, http_tool_definitions.project_id, http_tool_definitions.deployment_id, http_tool_definitions.openapiv3_document_id, http_tool_definitions.confirm, http_tool_definitions.confirm_prompt, http_tool_definitions.summarizer, http_tool_definitions.name, http_tool_definitions.untruncated_name, http_tool_definitions.summary, http_tool_definitions.description, http_tool_definitions.openapiv3_operation, http_tool_definitions.tags, http_tool_definitions.x_gram, http_tool_definitions.original_name, http_tool_definitions.original_summary, http_tool_definitions.original_description, http_tool_definitions.server_env_var, http_tool_definitions.default_server_url, http_tool_definitions.security, http_tool_definitions.http_method, http_tool_definitions.path, http_tool_definitions.schema_version, http_tool_definitions.schema, http_tool_definitions.header_settings, http_tool_definitions.query_settings, http_tool_definitions.path_settings, http_tool_definitions.request_content_type, http_tool_definitions.response_filter, http_tool_definitions.created_at, http_tool_definitions.updated_at, http_tool_definitions.deleted_at, http_tool_definitions.deleted,
+  http_tool_definitions.id, http_tool_definitions.tool_urn, http_tool_definitions.project_id, http_tool_definitions.deployment_id, http_tool_definitions.openapiv3_document_id, http_tool_definitions.confirm, http_tool_definitions.confirm_prompt, http_tool_definitions.summarizer, http_tool_definitions.name, http_tool_definitions.untruncated_name, http_tool_definitions.summary, http_tool_definitions.description, http_tool_definitions.openapiv3_operation, http_tool_definitions.tags, http_tool_definitions.x_gram, http_tool_definitions.original_name, http_tool_definitions.original_summary, http_tool_definitions.original_description, http_tool_definitions.server_env_var, http_tool_definitions.default_server_url, http_tool_definitions.security, http_tool_definitions.http_method, http_tool_definitions.path, http_tool_definitions.schema_version, http_tool_definitions.schema, http_tool_definitions.header_settings, http_tool_definitions.query_settings, http_tool_definitions.path_settings, http_tool_definitions.request_content_type, http_tool_definitions.response_filter, http_tool_definitions.created_at, http_tool_definitions.updated_at, http_tool_definitions.deleted_at, http_tool_definitions.deleted,
   (select id from deployment) as owning_deployment_id,
   (CASE
     WHEN http_tool_definitions.project_id = $1 THEN ''
@@ -133,6 +133,7 @@ func (q *Queries) FindToolsByName(ctx context.Context, arg FindToolsByNameParams
 		var i FindToolsByNameRow
 		if err := rows.Scan(
 			&i.HttpToolDefinition.ID,
+			&i.HttpToolDefinition.ToolUrn,
 			&i.HttpToolDefinition.ProjectID,
 			&i.HttpToolDefinition.DeploymentID,
 			&i.HttpToolDefinition.Openapiv3DocumentID,
@@ -198,7 +199,7 @@ third_party AS (
     AND NOT EXISTS(SELECT 1 FROM first_party)
   LIMIT 1
 )
-SELECT id, project_id, deployment_id, openapiv3_document_id, confirm, confirm_prompt, summarizer, name, untruncated_name, summary, description, openapiv3_operation, tags, x_gram, original_name, original_summary, original_description, server_env_var, default_server_url, security, http_method, path, schema_version, schema, header_settings, query_settings, path_settings, request_content_type, response_filter, created_at, updated_at, deleted_at, deleted
+SELECT id, tool_urn, project_id, deployment_id, openapiv3_document_id, confirm, confirm_prompt, summarizer, name, untruncated_name, summary, description, openapiv3_operation, tags, x_gram, original_name, original_summary, original_description, server_env_var, default_server_url, security, http_method, path, schema_version, schema, header_settings, query_settings, path_settings, request_content_type, response_filter, created_at, updated_at, deleted_at, deleted
 FROM http_tool_definitions
 WHERE id = COALESCE((SELECT id FROM first_party), (SELECT id FROM  third_party))
 `
@@ -214,6 +215,7 @@ func (q *Queries) GetHTTPToolDefinitionByID(ctx context.Context, arg GetHTTPTool
 	var i HttpToolDefinition
 	err := row.Scan(
 		&i.ID,
+		&i.ToolUrn,
 		&i.ProjectID,
 		&i.DeploymentID,
 		&i.Openapiv3DocumentID,

--- a/server/internal/toolsets/repo/queries.sql.go
+++ b/server/internal/toolsets/repo/queries.sql.go
@@ -235,13 +235,13 @@ func (q *Queries) GetHTTPSecurityDefinitions(ctx context.Context, arg GetHTTPSec
 const getPromptTemplatesForToolset = `-- name: GetPromptTemplatesForToolset :many
 WITH ranked_templates AS (
   SELECT 
-    pt.id, pt.project_id, pt.history_id, pt.predecessor_id, pt.name, pt.description, pt.arguments, pt.prompt, pt.engine, pt.kind, pt.tools_hint, pt.created_at, pt.updated_at, pt.deleted_at, pt.deleted,
+    pt.id, pt.tool_urn, pt.project_id, pt.history_id, pt.predecessor_id, pt.name, pt.description, pt.arguments, pt.prompt, pt.engine, pt.kind, pt.tools_hint, pt.created_at, pt.updated_at, pt.deleted_at, pt.deleted,
     ROW_NUMBER() OVER (PARTITION BY pt.history_id ORDER BY pt.id DESC) as rn
   FROM prompt_templates pt
   WHERE project_id = $2
     AND pt.deleted IS FALSE
 )
-SELECT rel.id as tp_id, rt.id, rt.project_id, rt.history_id, rt.predecessor_id, rt.name, rt.description, rt.arguments, rt.prompt, rt.engine, rt.kind, rt.tools_hint, rt.created_at, rt.updated_at, rt.deleted_at, rt.deleted, rt.rn
+SELECT rel.id as tp_id, rt.id, rt.tool_urn, rt.project_id, rt.history_id, rt.predecessor_id, rt.name, rt.description, rt.arguments, rt.prompt, rt.engine, rt.kind, rt.tools_hint, rt.created_at, rt.updated_at, rt.deleted_at, rt.deleted, rt.rn
 FROM toolset_prompts rel
 JOIN ranked_templates rt ON (
   (rel.prompt_template_id IS NOT NULL AND rt.id = rel.prompt_template_id)
@@ -261,6 +261,7 @@ type GetPromptTemplatesForToolsetParams struct {
 type GetPromptTemplatesForToolsetRow struct {
 	TpID          uuid.UUID
 	ID            uuid.UUID
+	ToolUrn       pgtype.Text
 	ProjectID     uuid.UUID
 	HistoryID     uuid.UUID
 	PredecessorID uuid.NullUUID
@@ -290,6 +291,7 @@ func (q *Queries) GetPromptTemplatesForToolset(ctx context.Context, arg GetPromp
 		if err := rows.Scan(
 			&i.TpID,
 			&i.ID,
+			&i.ToolUrn,
 			&i.ProjectID,
 			&i.HistoryID,
 			&i.PredecessorID,

--- a/server/internal/urn/format.go
+++ b/server/internal/urn/format.go
@@ -13,9 +13,11 @@ type ToolKind string
 const (
 	ToolKindFunction ToolKind = "function"
 	ToolKindHTTP     ToolKind = "http"
+	ToolKindPrompt   ToolKind = "prompt"
 )
 
 var toolKinds = map[ToolKind]struct{}{
 	ToolKindFunction: {},
 	ToolKindHTTP:     {},
+	ToolKindPrompt:   {},
 }

--- a/server/migrations/20250918183732_add-tool-urn-to-tables.sql
+++ b/server/migrations/20250918183732_add-tool-urn-to-tables.sql
@@ -1,0 +1,4 @@
+-- Modify "http_tool_definitions" table
+ALTER TABLE "http_tool_definitions" ADD COLUMN "tool_urn" text NULL;
+-- Modify "prompt_templates" table
+ALTER TABLE "prompt_templates" ADD COLUMN "tool_urn" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:szpx4vo7v8KTf+t4TXXlqUQ/A59Xaf4pQQhrUAYEMKs=
+h1:eOebuXbQYLzorHGgKL2HhS7o9ITxNhyPCx/yLkvA4L4=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -48,3 +48,4 @@ h1:szpx4vo7v8KTf+t4TXXlqUQ/A59Xaf4pQQhrUAYEMKs=
 20250911203425_add-http-security-fkeys.sql h1:I0uZsFFAZcDazOebRiP4h95SdrZGh6Cb7fT1vPNzhlg=
 20250916174416_add-asset-table-migration.sql h1:hSNaGyCYtT0hYHWiwkuIlJqhrzcuc62xFgpLwHUB0VQ=
 20250917213300_add-tool-functions.sql h1:FvR4XxH5LHi9SRy15dyDfn45EPVUmUWkB8G9/EH/Ols=
+20250918183732_add-tool-urn-to-tables.sql h1:MARJ8WJyN1A4tEjpBP15feOJTG4hGrP19vn11S0JePE=


### PR DESCRIPTION
This PR:
- Adds `tool_urn` (nullable) columns to `http_tool_definitions` and `prompt_templates`
- Begins writing to these columns. The URN structure for `prompt_templates` is `tools:prompt:<kind>:<name>`

This change is virtually riskless as it is write-only and the columns are nullable

Next steps:
- Write + run backfill script to fill these columns
- Make the columns non-nullable