### PR TITLE
chore: release/cli 0.1.3

### DIFF
--- a/server/cmd/cli/gram/api/deployments.go
+++ b/server/cmd/cli/gram/api/deployments.go
@@ -48,7 +48,7 @@ func (c *DeploymentsClient) CreateDeployment(
 		ProjectSlugInput: &projectSlug,
 		IdempotencyKey:   dc.GetIdempotencyKey(),
 		Openapiv3Assets:  dc.GetOpenAPIv3Assets(),
-		Functions:        nil,
+		Functions:        []*deployments.AddFunctionsForm{},
 		SessionToken:     nil,
 		GithubRepo:       nil,
 		GithubPr:         nil,

--- a/server/cmd/cli/gram/api/deployments.go
+++ b/server/cmd/cli/gram/api/deployments.go
@@ -48,6 +48,7 @@ func (c *DeploymentsClient) CreateDeployment(
 		ProjectSlugInput: &projectSlug,
 		IdempotencyKey:   dc.GetIdempotencyKey(),
 		Openapiv3Assets:  dc.GetOpenAPIv3Assets(),
+		Functions:        nil,
 		SessionToken:     nil,
 		GithubRepo:       nil,
 		GithubPr:         nil,

--- a/server/cmd/cli/gram/go.mod
+++ b/server/cmd/cli/gram/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/speakeasy-api/gram/server v0.0.0-20250915224933-8e5a6705e482
+	github.com/speakeasy-api/gram/server v0.0.0-20250918181346-155c2e1bd291
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
 	goa.design/goa/v3 v3.22.2

--- a/server/cmd/cli/gram/go.mod
+++ b/server/cmd/cli/gram/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/speakeasy-api/gram/server v0.0.0-20250918181346-155c2e1bd291
+	github.com/speakeasy-api/gram/server v0.0.0-20250918191855-47da0e45ec63
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
 	goa.design/goa/v3 v3.22.2

--- a/server/cmd/cli/gram/go.sum
+++ b/server/cmd/cli/gram/go.sum
@@ -24,8 +24,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/speakeasy-api/gram/server v0.0.0-20250918181346-155c2e1bd291 h1:oKAbCdSK6+fmEBGJvyIE928E+dYcS3mjpvVUsSBpF/s=
-github.com/speakeasy-api/gram/server v0.0.0-20250918181346-155c2e1bd291/go.mod h1:9sycybmes3tNuFM3+gFhvAkjYx3cpVIAqXNnXaQE3po=
+github.com/speakeasy-api/gram/server v0.0.0-20250918191855-47da0e45ec63 h1:0gGH0QGDZevLQ0GJFGcKwjpNJ7nUorLu4WpbusxQTbs=
+github.com/speakeasy-api/gram/server v0.0.0-20250918191855-47da0e45ec63/go.mod h1:9sycybmes3tNuFM3+gFhvAkjYx3cpVIAqXNnXaQE3po=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=

--- a/server/cmd/cli/gram/go.sum
+++ b/server/cmd/cli/gram/go.sum
@@ -24,8 +24,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/speakeasy-api/gram/server v0.0.0-20250915224933-8e5a6705e482 h1:efoCqukWg2+sJs849VtWIfdv1M9Ww9LcbkuoemVD2GQ=
-github.com/speakeasy-api/gram/server v0.0.0-20250915224933-8e5a6705e482/go.mod h1:UU+DjxAFd4eB2QpeXTcFg999Gjkct2MJfbANdGC1FdY=
+github.com/speakeasy-api/gram/server v0.0.0-20250918181346-155c2e1bd291 h1:oKAbCdSK6+fmEBGJvyIE928E+dYcS3mjpvVUsSBpF/s=
+github.com/speakeasy-api/gram/server v0.0.0-20250918181346-155c2e1bd291/go.mod h1:9sycybmes3tNuFM3+gFhvAkjYx3cpVIAqXNnXaQE3po=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=

--- a/server/cmd/cli/gram/version/version.go
+++ b/server/cmd/cli/gram/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.1.2"
+const Version = "v0.1.3"

--- a/server/cmd/cli/gram/version/version.go
+++ b/server/cmd/cli/gram/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.1.0"
+const Version = "v0.1.1"

--- a/server/cmd/cli/gram/version/version.go
+++ b/server/cmd/cli/gram/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "v0.1.1"
+const Version = "v0.1.2"


### PR DESCRIPTION
Release CLI v0.1.3

Includes new `Functions` field in deployments request body.

Local test:
```bash
env GRAM_API_KEY="$(cat /var/folders/rs/ckkrw20d32v0g1rzf6jccrzh0000gn/T/tmp.CxMPGzIFHy/key.txt)" \
  go run . push \
  --project cj \
  --file /Users/babe/code/speakeasy/gram_demo/fixtures/gram.json
Deploying to project: cj
2025/09/18 15:04:48 [DEBUG] GET https://raw.githubusercontent.com/speakeasy-api/gram/refs/heads/main/server/gen/http/openapi3.yaml
Deployment created successfully: &{ID:01995edb-d253-7bd3-ba78-bcbde6ea0e44 OrganizationID:5a25158b-24dc-4d49-b03d-e85acfbea59c ProjectID:01991b59-0ac9-7523-a66d-09c81ab76026 UserID:a22f63a2-00ce-415a-811f-6936a54493ad CreatedAt:2025-09-18T22:04:48Z Status:completed IdempotencyKey:0x1400028e9b0 GithubRepo:<nil> GithubPr:<nil> GithubSha:<nil> ExternalID:<nil> ExternalURL:<nil> ClonedFrom:<nil> Openapiv3ToolCount:90 Openapiv3Assets:[0x14000294140 0x14000294180 0x14000294200] FunctionsToolCount:0 FunctionsAssets:[] Packages:[]}
```