### PR TITLE
fix: access-control-allow-origin: * to js in external

### DIFF
--- a/server/gen/keys/service.go
+++ b/server/gen/keys/service.go
@@ -41,7 +41,7 @@ const APIVersion = "0.0.1"
 // key.
 const ServiceName = "keys"
 
-// MethodNames lists the service method names so as defined in the design. These
+// MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
 var MethodNames = [3]string{"createKey", "listKeys", "revokeKey"}

--- a/server/internal/mcp/hosted_page.html.tmpl
+++ b/server/internal/mcp/hosted_page.html.tmpl
@@ -922,5 +922,6 @@ export {{ . }}="your-{{ . }}-value"{{- end }}</code>
       type="module"
       src="{{ .SiteURL }}/external/hosted-install-page-8b2e430d.js"
     ></script>
+    <!-- touch -->
   </body>
 </html>


### PR DESCRIPTION
JS is excluded from `allow-origin: *` but this is necessary for install pages to work on custom domains.