### PR TITLE
chore: add shared URN type to Goa design layer

### DIFF
--- a/server/design/shared/datatypes.go
+++ b/server/design/shared/datatypes.go
@@ -11,3 +11,7 @@ var Slug = Type("Slug", String, func() {
 	Pattern(constants.SlugPattern)
 	MaxLength(40)
 })
+
+var URN = Type("URN", String, func() {
+	Meta("struct:field:type", "urn.Tool", "github.com/speakeasy-api/gram/server/internal/urn")
+})


### PR DESCRIPTION
This change introduces a URN type to be used in Goa designs. It is backed by `urn.Tool` meaning all marshalling/unmarshalling and validation is handled by that type instead of delegated to application code.