### PR TITLE
chore: fix race condition in key revocation unit tests

### DIFF
--- a/server/internal/keys/createkey_test.go
+++ b/server/internal/keys/createkey_test.go
@@ -26,10 +26,9 @@ func randstr(length int) string {
 func TestKeysService_CreateKey(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestKeysService(t)
-
 	t.Run("successful key creation with default scope", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		name := "test-api-key" + randstr(6)
 
@@ -60,6 +59,7 @@ func TestKeysService_CreateKey(t *testing.T) {
 
 	t.Run("successful key creation with custom scope", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		name := "test-api-key" + randstr(6)
 
@@ -90,6 +90,7 @@ func TestKeysService_CreateKey(t *testing.T) {
 
 	t.Run("successful key creation with multiple scopes", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		name := "test-api-key" + randstr(6)
 
@@ -120,6 +121,7 @@ func TestKeysService_CreateKey(t *testing.T) {
 
 	t.Run("successful key creation with invalid scope", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{
 			SessionToken: nil,
@@ -135,6 +137,7 @@ func TestKeysService_CreateKey(t *testing.T) {
 
 	t.Run("successful key creation with invalid scopes", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{
 			SessionToken: nil,
@@ -150,6 +153,7 @@ func TestKeysService_CreateKey(t *testing.T) {
 
 	t.Run("key creation without project context", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		// Ensure there's no project ID in the auth context
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -178,6 +182,7 @@ func TestKeysService_CreateKey(t *testing.T) {
 
 	t.Run("unauthorized without auth context", func(t *testing.T) {
 		t.Parallel()
+		_, ti := newTestKeysService(t)
 
 		// Create a context without auth
 		ctxWithoutAuth := t.Context()
@@ -196,6 +201,7 @@ func TestKeysService_CreateKey(t *testing.T) {
 
 	t.Run("multiple keys have unique tokens", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		key1, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{
 			SessionToken: nil,

--- a/server/internal/keys/revokekey_test.go
+++ b/server/internal/keys/revokekey_test.go
@@ -13,10 +13,9 @@ import (
 func TestKeysService_RevokeKey(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestKeysService(t)
-
 	t.Run("successful key revocation", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		// Create a key first
 		key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{
@@ -47,6 +46,7 @@ func TestKeysService_RevokeKey(t *testing.T) {
 
 	t.Run("revoke non-existent key", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		// Try to revoke a non-existent key
 		nonExistentID := uuid.New().String()
@@ -62,6 +62,7 @@ func TestKeysService_RevokeKey(t *testing.T) {
 
 	t.Run("invalid key ID format", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		// Try to revoke with an invalid UUID format
 		err := ti.service.RevokeKey(ctx, &gen.RevokeKeyPayload{
@@ -78,6 +79,7 @@ func TestKeysService_RevokeKey(t *testing.T) {
 
 	t.Run("unauthorized without auth context", func(t *testing.T) {
 		t.Parallel()
+		_, ti := newTestKeysService(t)
 
 		// Create a context without auth
 		ctxWithoutAuth := t.Context()
@@ -96,6 +98,7 @@ func TestKeysService_RevokeKey(t *testing.T) {
 
 	t.Run("revoke multiple keys", func(t *testing.T) {
 		t.Parallel()
+		ctx, ti := newTestKeysService(t)
 
 		// Create multiple keys
 		key1, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{


### PR DESCRIPTION
Running multiple tests against the shared test context causes race conditions.

<details>
<summary>Proved with a simple test 👇</summary>

```go
package keys_test

import (
	"testing"
	"time"

	"github.com/stretchr/testify/require"

	gen "github.com/speakeasy-api/gram/server/gen/keys"
)

func TestDatabaseIsolation(t *testing.T) {
	t.Parallel()

	// Shared context and service (same pattern as revokekey_test.go)
	ctx, ti := newTestKeysService(t)

	t.Run("test1 creates key", func(t *testing.T) {
		t.Parallel()

		// Create a key
		_, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{
			SessionToken: nil,
			Name:         "isolation-test-key-1",
			Scopes:       []string{"consumer"},
		})
		require.NoError(t, err)

		// Small delay to let other tests see this key
		time.Sleep(50 * time.Millisecond)
	})

	t.Run("test2 counts keys", func(t *testing.T) {
		t.Parallel()

		// Small delay to let test1 create its key
		time.Sleep(10 * time.Millisecond)

		// List all keys - if isolation is broken, we'll see test1's key
		result, err := ti.service.ListKeys(ctx, &gen.ListKeysPayload{
			SessionToken: nil,
		})
		require.NoError(t, err)
		require.NotNil(t, result)

		t.Logf("Found %d keys: %+v", len(result.Keys), result.Keys)

		// This will fail if database isolation is broken
		require.Empty(t, result.Keys, "Should see no keys if isolation works correctly")
	})
}
```
</details>


```
    isolation_test.go:46: Found 1 keys: [0x140002cb0e0]
    isolation_test.go:49:
        	Error Trace:	/Users/babe/code/speakeasy/gram/server/internal/keys/isolation_test.go:49
        	Error:      	Should be empty, but was [0x140002cb0e0]
        	Test:       	TestDatabaseIsolation/test2_counts_keys
        	Messages:   	Should see no keys if isolation works correctly
--- FAIL: TestDatabaseIsolation (0.07s)
    --- FAIL: TestDatabaseIsolation/test2_counts_keys (0.01s)
    --- PASS: TestDatabaseIsolation/test1_creates_key (0.05s)
FAIL
FAIL	github.com/speakeasy-api/gram/server/internal/keys	2.683s
FAIL
```