### PR TITLE
Init GoReleaser

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,55 @@
+name: Release Gram CLI
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  release:
+    name: Release
+    # NOTE(cjea): Using Windows runner for Chocolatey/Winget compatibility.
+    # Would a cheaper ubuntu-latest machine work instead?
+    runs-on:
+      group: windows-latest-large
+    if: |
+      startsWith(github.event.head_commit.message, 'feat') || startsWith(github.event.head_commit.message, 'fix')
+    steps:
+      - name: Setup environment
+        run: |-
+          chcp 65001 #set code page to utf-8
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Conventional Commits
+        uses: TriPSs/conventional-changelog-action@5f00b899ccbbcbc112bd6d715d5e76e7a9e4501d # v6.1.0
+        with:
+          github-token: ${{ secrets.github_token }}
+          skip-commit: "true"
+          output-file: "false"
+          skip-on-empty: "false"
+          preset: conventionalcommits
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: "go.mod"
+          # Reference: https://github.com/actions/setup-go/issues/495
+          cache: false
+      - name: Setup Choco
+        uses: crazy-max/ghaction-chocolatey@2526f467ccbd337d307fe179959cabbeca0bc8c0 # v3.4.0
+        with:
+          args: --version
+      - name: goreleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+      - name: Trigger changelog reconcile
+        run: gh workflow run changelog-reconcile.yml --repo speakeasy-api/marketing-site --ref main
+        env:
+          GH_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,97 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - dir: ./cli
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.artifactArch={{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    format: zip
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+brews:
+  - name: gram
+    repository:
+      owner: speakeasy-api
+      name: homebrew-tap
+    homepage: https://app.getgram.ai
+    description: The Gram CLI for interacting with the Gram Platform
+    license: Apache-2.0
+    test: |
+      system "#{bin}/gram --version"
+
+  - name: gram@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+    repository:
+      owner: speakeasy-api
+      name: homebrew-tap
+    homepage: https://app.getgram.ai
+    description: The Gram CLI for interacting with the Gram Platform
+    license: Apache-2.0
+    test: |
+      system "#{bin}/gram --version"
+
+chocolateys:
+  - name: gram
+    title: Gram CLI
+    authors: Speakeasy Inc
+    project_url: https://github.com/speakeasy-api/gram
+    url_template: "https://github.com/speakeasy-api/gram/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    copyright: 2025 Speakeasy, Inc
+    license_url: https://github.com/speakeasy-api/gram/blob/main/LICENSE
+    project_source_url: https://github.com/speakeasy-api/gram
+    docs_url: https://docs.getgram.ai
+    bug_tracker_url: https://github.com/speakeasy-api/gram/issues
+    tags: openapi api speakeasy gram tools agents llm client-libraries
+    summary: Everything you need to build powerful integrations for agents and LLMs.
+    description: |-
+      A command line interface for the Gram platform. Get started at https://docs.getgram.ai/
+      Bring the functionality of Gram into your development workflow. It can be run locally or in your CI/CD pipeline.
+    release_notes: "https://github.com/speakeasy-api/gram/releases/tag/v{{ .Version }}"
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+    source_repo: "https://push.chocolatey.org/"
+winget:
+  - name: gram
+    publisher: Gram
+    short_description: Everything you need to build powerful integrations for agents and LLMs.
+    license_url: https://github.com/speakeasy-api/gram/blob/main/LICENSE
+    license: "elastic"
+    publisher_url: https://app.getgram.ai
+    publisher_support_url: https://github.com/speakeasy-api/gram/issues
+    homepage: https://app.getgram.ai
+    description: |-
+      A command line interface for the Gram platform. Get started at https://docs.getgram.ai/
+      Bring the functionality of Gram into your development workflow. It can be run locally or in your CI/CD pipeline.
+    copyright: 2025 Speakeasy, Inc
+    skip_upload: auto
+    release_notes: "https://github.com/speakeasy-api/gram/releases/tag/v{{ .Version }}"
+    release_notes_url: "https://github.com/speakeasy-api/gram/releases/tag/v{{ .Version }}"
+
+    repository:
+      owner: speakeasy-api
+      name: winget-pkgs
+      branch: "gram-{{.Version}}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: main

--- a/cli/internal/app/push.go
+++ b/cli/internal/app/push.go
@@ -48,7 +48,7 @@ NOTE: Names and slugs must be unique across all sources.`[1:],
 			},
 			&cli.StringFlag{
 				Name:     "api-key",
-				Usage:    "The Gram project to push to",
+				Usage:    "Your Gram API key (must be scoped as a 'Provider')",
 				EnvVars:  []string{"GRAM_API_KEY"},
 				Required: true,
 			},
@@ -60,7 +60,7 @@ NOTE: Names and slugs must be unique across all sources.`[1:],
 			},
 			&cli.PathFlag{
 				Name:     "config",
-				Usage:    "Path to the deployment file (relative locations resolve to the deployment file's directory)",
+				Usage:    "Path to the deployment file",
 				Required: true,
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
_Will leave this PR in draft while testing the integration from GitHub Actions to avoid merging an invalid release._

## Description

Release the Gram CLI to HomeBrew via GoReleaser.

## Versioning

Versions are not explicitly set. Instead, `conventional-changelog-action` automatically determines the version bump based on commit types:

  - fix: commits → patch version bump (1.0.0 → 1.0.1)
  - feat: commits → minor version bump (1.0.0 → 1.1.0)
  - feat!: or BREAKING CHANGE: → major version bump (1.0.0 → 2.0.0)

  The process:
  1. Action scans commits since the last release tag
  2. Finds the highest impact change (major > minor > patch)
  3. Automatically calculates next version
  4. Creates and pushes the new tag

  So if the last release was v1.2.3, and the new commits are:
  - fix: button styling
  - feat: add dark mode

  It will create tag v1.3.0 (minor bump due to the feat:).
