### PR TITLE
fix: openrouter key refresh

### DIFF
--- a/.changeset/four-seals-count.md
+++ b/.changeset/four-seals-count.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+fix openrouter key refresh

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -20,7 +20,7 @@ WHERE organization_id = @organization_id
 
 -- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
-SET monthly_credits = @monthly_credits
+SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key
 WHERE organization_id = @organization_id
   AND deleted IS FALSE
 RETURNING *;

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -79,19 +79,26 @@ func (q *Queries) GetOpenRouterAPIKey(ctx context.Context, organizationID string
 
 const updateOpenRouterKey = `-- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
-SET monthly_credits = $1
-WHERE organization_id = $2
+SET monthly_credits = $1, key_hash = $2, key = $3
+WHERE organization_id = $4
   AND deleted IS FALSE
 RETURNING organization_id, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateOpenRouterKeyParams struct {
 	MonthlyCredits int64
+	KeyHash        string
+	Key            string
 	OrganizationID string
 }
 
 func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterKeyParams) (OpenrouterApiKey, error) {
-	row := q.db.QueryRow(ctx, updateOpenRouterKey, arg.MonthlyCredits, arg.OrganizationID)
+	row := q.db.QueryRow(ctx, updateOpenRouterKey,
+		arg.MonthlyCredits,
+		arg.KeyHash,
+		arg.Key,
+		arg.OrganizationID,
+	)
 	var i OpenrouterApiKey
 	err := row.Scan(
 		&i.OrganizationID,


### PR DESCRIPTION
The current openrouter key refresh logic was flawed. Although we set the credit limit of the key correctly, with the way openrouter works the usage that is applied to that key never resets.

The best option right now is to create a new fresh key on the monthly refresh and clean up the old one.

Eventually we've talked about moving this to be centrally metered and not creating keys per org. We should still eventually move in that direction, but this is a change that will make our current system behave correctly.