### PR TITLE
fix: upsert correct stubbed values in describe organization

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -295,7 +295,7 @@ func newBillingProvider(
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse local user: %w", err)
 		}
-		stub := billing.NewStubClient(logger, tracerProvider, *userInfo)
+		stub := billing.NewStubClient(logger, tracerProvider, userInfo)
 		return stub, stub, nil
 	default:
 		return nil, nil, fmt.Errorf("billing provider is not configured")

--- a/server/internal/assets/setup_test.go
+++ b/server/internal/assets/setup_test.go
@@ -63,7 +63,7 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -309,7 +309,7 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 	// Fully unpack the userInfo object
 	organizations := make([]*gen.OrganizationEntry, 0, len(userInfo.Organizations))
 	for _, org := range userInfo.Organizations {
-		// TODO: Not the cleanest but a temporary measue while in POC phase.
+		// TODO: Not the cleanest but a temporary measure while in POC phase.
 		// This may actually be bettter executed from elsewhere
 		projectRows, err := s.getProjectsOrSetupDefaults(ctx, org.ID)
 		if err != nil {

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -17,24 +17,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/pylon"
 	userRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+	"github.com/speakeasy-api/gram/server/internal/users/stub"
 )
-
-type localEnvFile map[string]struct {
-	UserEmail     string `json:"user_email"`
-	Admin         bool   `json:"admin"`
-	Organizations []struct {
-		OrganizationID   string `json:"organization_id"`
-		OrganizationName string `json:"organization_name"`
-		OrganizationSlug string `json:"organization_slug"`
-		AccountType      string `json:"account_type"`
-	} `json:"organizations"`
-}
 
 type Manager struct {
 	logger                 *slog.Logger
 	sessionCache           cache.TypedCacheObject[Session]
 	userInfoCache          cache.TypedCacheObject[CachedUserInfo]
-	localEnvFile           localEnvFile
+	stubbedUser            stub.LocalUser
 	unsafeLocal            bool
 	speakeasyServerAddress string
 	speakeasySecretKey     string
@@ -52,7 +42,7 @@ func NewManager(logger *slog.Logger, db *pgxpool.Pool, redisClient *redis.Client
 		logger:                 logger.With(attr.SlogComponent("sessions")),
 		sessionCache:           cache.NewTypedObjectCache[Session](logger.With(attr.SlogCacheNamespace("session")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
 		userInfoCache:          cache.NewTypedObjectCache[CachedUserInfo](logger.With(attr.SlogCacheNamespace("user_info")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
-		localEnvFile:           localEnvFile{},
+		stubbedUser:            stub.LocalUser{},
 		unsafeLocal:            false,
 		speakeasyServerAddress: speakeasyServerAddress,
 		speakeasySecretKey:     speakeasySecretKey,

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -42,7 +42,7 @@ func NewManager(logger *slog.Logger, db *pgxpool.Pool, redisClient *redis.Client
 		logger:                 logger.With(attr.SlogComponent("sessions")),
 		sessionCache:           cache.NewTypedObjectCache[Session](logger.With(attr.SlogCacheNamespace("session")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
 		userInfoCache:          cache.NewTypedObjectCache[CachedUserInfo](logger.With(attr.SlogCacheNamespace("user_info")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
-		stubbedUser:            stub.LocalUser{},
+		stubbedUser:            nil,
 		unsafeLocal:            false,
 		speakeasyServerAddress: speakeasyServerAddress,
 		speakeasySecretKey:     speakeasySecretKey,

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -289,7 +289,7 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host")
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager := sessions.NewManager(logger, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient)
 

--- a/server/internal/billing/stub.go
+++ b/server/internal/billing/stub.go
@@ -28,16 +28,20 @@ type StubClient struct {
 	localUser stub.LocalUser
 }
 
-func NewStubClient(logger *slog.Logger, tracerProvider trace.TracerProvider, userInfo stub.LocalUser) *StubClient {
+func NewStubClient(logger *slog.Logger, tracerProvider trace.TracerProvider, userInfo *stub.LocalUser) *StubClient {
 	if logger == nil {
 		logger = slog.Default()
+	}
+
+	if userInfo == nil {
+		userInfo = &stub.LocalUser{}
 	}
 
 	return &StubClient{
 		mut:       sync.Mutex{},
 		logger:    logger.With(attr.SlogComponent("billing-stub")),
 		tracer:    tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/billing"),
-		localUser: userInfo,
+		localUser: *userInfo,
 	}
 }
 

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -80,7 +80,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/environments/setup_test.go
+++ b/server/internal/environments/setup_test.go
@@ -60,7 +60,7 @@ func newTestEnvironmentService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/keys/setup_test.go
+++ b/server/internal/keys/setup_test.go
@@ -59,7 +59,7 @@ func newTestKeysService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/projects/setup_test.go
+++ b/server/internal/projects/setup_test.go
@@ -62,7 +62,7 @@ func newTestProjectsService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/templates/setup_test.go
+++ b/server/internal/templates/setup_test.go
@@ -59,7 +59,7 @@ func newTestTemplateService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -69,7 +69,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -92,7 +92,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)

--- a/server/internal/users/stub/stub.go
+++ b/server/internal/users/stub/stub.go
@@ -1,0 +1,76 @@
+package stub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+)
+
+type LocalUser map[string]struct {
+	UserEmail     string `json:"user_email"`
+	Admin         bool   `json:"admin"`
+	Organizations []struct {
+		OrganizationID   string `json:"organization_id"`
+		OrganizationName string `json:"organization_name"`
+		OrganizationSlug string `json:"organization_slug"`
+		AccountType      string `json:"account_type"`
+	} `json:"organizations"`
+}
+
+var unsafeSessionData = []byte(`
+{
+  "1245": {
+    "user_email": "user@example.com",
+    "admin": false,
+    "organizations": [
+      {
+        "organization_id": "550e8400-e29b-41d4-a716-446655440000",
+        "organization_name": "Organization 123",
+        "organization_slug": "organization-123",
+        "account_type": "pro"
+      },
+      {
+        "organization_id": "e0395991-d5c5-4c2f-8c3b-4eae305524ed",
+        "organization_name": "Organization 456",
+        "organization_slug": "organization-456",
+        "account_type": "enterprise"
+      }
+    ]
+  }
+}
+`)
+
+func UnmarshalLocalUser(path string, logger *slog.Logger) (*LocalUser, error) {
+	raw := unsafeSessionData
+
+	var data LocalUser
+
+	if path != "" {
+		file, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			logger.WarnContext(context.Background(), "failed to open local env file, defaulting to inlined data (localdev.go)", attr.SlogError(err))
+		} else if file != nil {
+			defer o11y.LogDefer(context.Background(), logger, func() error {
+				return file.Close()
+			})
+
+			raw, err = io.ReadAll(file)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read local env file: %w", err)
+			}
+		}
+	}
+
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal local env file: %w", err)
+	}
+
+	return &data, nil
+}

--- a/server/internal/variations/setup_test.go
+++ b/server/internal/variations/setup_test.go
@@ -58,7 +58,7 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	billingClient := billing.NewStubClient(logger, tracerProvider)
+	billingClient := billing.NewStubClient(logger, tracerProvider, nil)
 
 	sessionManager, err := sessions.NewUnsafeManager(logger, conn, redisClient, cache.Suffix("gram-local"), "", billingClient)
 	require.NoError(t, err)


### PR DESCRIPTION
Okay this got annoying enough for me to do something about it. Not sure if this is the right fix but it felt like a relatively harmless place to dive into some go.

## Problem

`account_type`s set in .local.env.json are instantly overridden because every time we describe an organization, we update the values. In dev, the stubbed billing repo is set to always return "free" so we always wind up on "free". As far as I can tell a describe always happens in the login flow, and thus we will always override.

## Solution

little self-conscious about my go, but solution is rooted around the idea that if we're gonna stub these values in local, we should consistently read from them even in the billing repo.

I moved the data model and file reading into a `stub` package underneath the user concept where this albatross felt maybe slightly more at home.

Then we inject a stubbed user into the two relevant services/repos: billing repo and the session manager.

Now we can read off the data in both places and get consistent values to shove in our database.

## Improvements?

* We could rename our .local.env.json and downstream concepts to better reflect that they're local account overrides or something and improve consistency a bit?
* Probably could remove the concept of a stubbed user from the SessionManager entirely with a little more thought, but hard to disentangle without 
* Might be some more defensive measures I'm not thinking of to make sure these values aren't used in prod? The stub naming and current environment switching seemed sufficient to me though.
* It seems like somewhat foot gunny that we're writing this data in our describes in the first place, but I don't have quite enough context to make a change in this part of the code.

## Upshot

I have zero attachment to this PR. Just annoyed by the issue. Would happily implement another solution if propagating this local stubbing is uncomfy or there's a more sensible place to change this.