### PR TITLE
fix: allow leading/trailing hyphens/underscores

### DIFF
--- a/.changeset/major-ducks-crash.md
+++ b/.changeset/major-ducks-crash.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+Allow leading and trailing underscores and dashes in tool names and slugs

--- a/server/internal/constants/tools.go
+++ b/server/internal/constants/tools.go
@@ -7,7 +7,7 @@ const (
 )
 
 const (
-	SlugPattern = `^[a-z0-9]+(?:[a-z0-9_-]*[a-z0-9])?$`
+	SlugPattern = `^[a-z0-9_-]{1,128}$`
 	SlugMessage = "must be lowercase, alphanumeric and can contain dashes (-) and underscores (_)"
 )
 


### PR DESCRIPTION
This change updates the regular expression used for slug validation to permit leading and trailing hyphens and underscores.