### PR TITLE
feat: gram status

### DIFF
--- a/.changeset/ready-aliens-end.md
+++ b/.changeset/ready-aliens-end.md
@@ -1,0 +1,5 @@
+---
+"@gram/cli": minor
+---
+
+Implement status command

--- a/cli/internal/api/deployments.go
+++ b/cli/internal/api/deployments.go
@@ -74,3 +74,41 @@ func (c *DeploymentsClient) CreateDeployment(
 
 	return result, nil
 }
+
+// GetDeployment retrieves a deployment by its ID.
+func (c *DeploymentsClient) GetDeployment(
+	ctx context.Context,
+	apiKey secret.Secret,
+	projectSlug string,
+	deploymentID string,
+) (*deployments.GetDeploymentResult, error) {
+	key := apiKey.Reveal()
+	result, err := c.client.GetDeployment(ctx, &deployments.GetDeploymentPayload{
+		ApikeyToken:      &key,
+		ProjectSlugInput: &projectSlug,
+		ID:               deploymentID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment: %w", err)
+	}
+
+	return result, nil
+}
+
+// GetLatestDeployment retrieves the latest deployment for a project.
+func (c *DeploymentsClient) GetLatestDeployment(
+	ctx context.Context,
+	apiKey secret.Secret,
+	projectSlug string,
+) (*deployments.GetLatestDeploymentResult, error) {
+	key := apiKey.Reveal()
+	result, err := c.client.GetLatestDeployment(ctx, &deployments.GetLatestDeploymentPayload{
+		ApikeyToken:      &key,
+		ProjectSlugInput: &projectSlug,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest deployment: %w", err)
+	}
+
+	return result, nil
+}

--- a/cli/internal/app/app.go
+++ b/cli/internal/app/app.go
@@ -23,6 +23,7 @@ func newApp() *cli.App {
 		Version: fmt.Sprintf("%s (%s)", Version, shortSha),
 		Commands: []*cli.Command{
 			newPushCommand(),
+			newStatusCommand(),
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cli/internal/app/push.go
+++ b/cli/internal/app/push.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -8,11 +9,13 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/speakeasy-api/gram/cli/internal/api"
 	"github.com/speakeasy-api/gram/cli/internal/deploy"
 	"github.com/speakeasy-api/gram/cli/internal/o11y"
 	"github.com/speakeasy-api/gram/cli/internal/secret"
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/urfave/cli/v2"
 )
 
@@ -127,7 +130,94 @@ NOTE: Names and slugs must be unique across all sources.`[1:],
 
 			logger.InfoContext(ctx, "Deployment created successfully", slog.Any("id", result.Deployment.ID))
 
+			deploymentResult, err := pollDeploymentStatus(ctx, logger, deploymentsClient, req.APIKey, req.ProjectSlug, result.Deployment.ID)
+			if err != nil {
+				logger.WarnContext(ctx, "Failed to poll deployment status", slog.String("error", err.Error()))
+				logger.InfoContext(ctx, "You can check deployment status with", slog.String("command", fmt.Sprintf("gram status %s", result.Deployment.ID)))
+				return nil
+			}
+
+			switch deploymentResult.Status {
+			case "completed":
+				logger.InfoContext(ctx, "Deployment completed successfully", slog.String("deployment_id", deploymentResult.ID))
+			case "failed":
+				logger.ErrorContext(ctx, "Deployment failed", slog.String("deployment_id", deploymentResult.ID))
+				return fmt.Errorf("deployment failed")
+			default:
+				logger.InfoContext(ctx, "Deployment is still in progress", slog.String("status", deploymentResult.Status), slog.String("deployment_id", deploymentResult.ID))
+			}
+
 			return nil
 		},
+	}
+}
+
+// pollDeploymentStatus polls for deployment status until it reaches a terminal
+// state or times out
+func pollDeploymentStatus(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *api.DeploymentsClient,
+	apiKey secret.Secret,
+	projectSlug string,
+	deploymentID string,
+) (*types.Deployment, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	logger.InfoContext(ctx, "Polling deployment status...", slog.String("deployment_id", deploymentID))
+
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				return nil, fmt.Errorf("deployment polling timed out after 2 minutes")
+			}
+			return nil, fmt.Errorf("deployment polling cancelled: %w", ctx.Err())
+
+		case <-ticker.C:
+			result, err := client.GetDeployment(ctx, apiKey, projectSlug, deploymentID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get deployment status: %w", err)
+			}
+
+			deployment := &types.Deployment{
+				ID:                 result.ID,
+				OrganizationID:     result.OrganizationID,
+				ProjectID:          result.ProjectID,
+				UserID:             result.UserID,
+				CreatedAt:          result.CreatedAt,
+				Status:             result.Status,
+				IdempotencyKey:     result.IdempotencyKey,
+				GithubRepo:         result.GithubRepo,
+				GithubPr:           result.GithubPr,
+				GithubSha:          result.GithubSha,
+				ExternalID:         result.ExternalID,
+				ExternalURL:        result.ExternalURL,
+				ClonedFrom:         result.ClonedFrom,
+				Openapiv3ToolCount: result.Openapiv3ToolCount,
+				Openapiv3Assets:    result.Openapiv3Assets,
+				FunctionsToolCount: result.FunctionsToolCount,
+				FunctionsAssets:    result.FunctionsAssets,
+				Packages:           result.Packages,
+			}
+
+			logger.DebugContext(ctx, "Deployment status check",
+				slog.String("deployment_id", deploymentID),
+				slog.String("status", deployment.Status))
+
+			switch deployment.Status {
+			case "completed", "failed":
+				return deployment, nil
+			case "pending":
+				continue
+			default:
+				logger.WarnContext(ctx, "Unknown deployment status", slog.String("status", deployment.Status))
+				continue
+			}
+		}
 	}
 }

--- a/cli/internal/app/status.go
+++ b/cli/internal/app/status.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/speakeasy-api/gram/cli/internal/api"
+	"github.com/speakeasy-api/gram/cli/internal/secret"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/urfave/cli/v2"
+)
+
+func newStatusCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "status",
+		Usage: "Check the status of a deployment",
+		Description: `
+Check the status of a deployment.
+
+If no deployment ID is provided, shows the status of the latest deployment.`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "api-url",
+				Usage:   "The base URL to use for API calls.",
+				EnvVars: []string{"GRAM_API_URL"},
+				Value:   "https://app.getgram.ai",
+			},
+			&cli.StringFlag{
+				Name:     "api-key",
+				Usage:    "Your Gram API key (must be scoped as a 'Provider')",
+				EnvVars:  []string{"GRAM_API_KEY"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "project",
+				Usage:    "The Gram project to check status for",
+				EnvVars:  []string{"GRAM_PROJECT"},
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "id",
+				Usage: "The deployment ID to check status for (if not provided, shows latest deployment)",
+			},
+			&cli.BoolFlag{
+				Name:  "json",
+				Usage: "Output deployment status as JSON",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			ctx, cancel := signal.NotifyContext(c.Context, os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+
+			logger := PullLogger(ctx)
+			projectSlug := c.String("project")
+			deploymentID := c.String("id")
+			jsonOutput := c.Bool("json")
+
+			apiURLArg := c.String("api-url")
+			apiURL, err := url.Parse(apiURLArg)
+			if err != nil {
+				return fmt.Errorf("failed to parse API URL '%s': %w", apiURLArg, err)
+			}
+			if apiURL.Scheme == "" || apiURL.Host == "" {
+				return fmt.Errorf("API URL '%s' must include scheme and host", apiURLArg)
+			}
+
+			deploymentsClient := api.NewDeploymentsClient(&api.DeploymentsClientOptions{
+				Scheme: apiURL.Scheme,
+				Host:   apiURL.Host,
+			})
+
+			apiKey := secret.Secret(c.String("api-key"))
+
+			var deployment *types.Deployment
+			if deploymentID != "" {
+				logger.InfoContext(ctx, "Getting deployment status", slog.String("deployment_id", deploymentID))
+				result, err := deploymentsClient.GetDeployment(ctx, apiKey, projectSlug, deploymentID)
+				if err != nil {
+					return fmt.Errorf("failed to get deployment: %w", err)
+				}
+				deployment = &types.Deployment{
+					ID:                 result.ID,
+					OrganizationID:     result.OrganizationID,
+					ProjectID:          result.ProjectID,
+					UserID:             result.UserID,
+					CreatedAt:          result.CreatedAt,
+					Status:             result.Status,
+					IdempotencyKey:     result.IdempotencyKey,
+					GithubRepo:         result.GithubRepo,
+					GithubPr:           result.GithubPr,
+					GithubSha:          result.GithubSha,
+					ExternalID:         result.ExternalID,
+					ExternalURL:        result.ExternalURL,
+					ClonedFrom:         result.ClonedFrom,
+					Openapiv3ToolCount: result.Openapiv3ToolCount,
+					Openapiv3Assets:    result.Openapiv3Assets,
+					FunctionsToolCount: result.FunctionsToolCount,
+					FunctionsAssets:    result.FunctionsAssets,
+					Packages:           result.Packages,
+				}
+			} else {
+				logger.InfoContext(ctx, "Getting latest deployment status")
+				result, err := deploymentsClient.GetLatestDeployment(ctx, apiKey, projectSlug)
+				if err != nil {
+					return fmt.Errorf("failed to get latest deployment: %w", err)
+				}
+				if result.Deployment == nil {
+					if jsonOutput {
+						fmt.Println("{}")
+					} else {
+						fmt.Println("No deployments found for this project")
+					}
+					return nil
+				}
+				deployment = result.Deployment
+			}
+
+			if jsonOutput {
+				return printDeploymentStatusJSON(deployment)
+			} else {
+				printDeploymentStatus(deployment)
+			}
+			return nil
+		},
+	}
+}
+
+func printDeploymentStatus(deployment *types.Deployment) {
+	fmt.Printf("Deployment Status\n")
+	fmt.Printf("=================\n\n")
+
+	fmt.Printf("ID:           %s\n", deployment.ID)
+	fmt.Printf("Status:       %s\n", deployment.Status)
+
+	if deployment.ExternalID != nil {
+		fmt.Printf("External ID:  %s\n", *deployment.ExternalID)
+	}
+
+	if deployment.GithubRepo != nil {
+		fmt.Printf("Repository:   %s\n", *deployment.GithubRepo)
+	}
+
+	if deployment.GithubPr != nil {
+		fmt.Printf("Pull Request: %s\n", *deployment.GithubPr)
+	}
+
+	if deployment.GithubSha != nil {
+		fmt.Printf("Commit SHA:   %s\n", *deployment.GithubSha)
+	}
+
+	if deployment.ExternalURL != nil {
+		fmt.Printf("External URL: %s\n", *deployment.ExternalURL)
+	}
+
+	fmt.Printf("\nAssets:\n")
+	fmt.Printf("  OpenAPI Tools: %d\n", deployment.Openapiv3ToolCount)
+	fmt.Printf("  Functions:     %d\n", deployment.FunctionsToolCount)
+
+	if len(deployment.Openapiv3Assets) > 0 {
+		fmt.Printf("\nOpenAPI Assets:\n")
+		for _, asset := range deployment.Openapiv3Assets {
+			fmt.Printf("  - %s (%s)\n", asset.Name, asset.Slug)
+		}
+	}
+
+	if len(deployment.FunctionsAssets) > 0 {
+		fmt.Printf("\nFunctions Assets:\n")
+		for _, asset := range deployment.FunctionsAssets {
+			fmt.Printf("  - %s (%s) - %s\n", asset.Name, asset.Slug, asset.Runtime)
+		}
+	}
+
+}
+
+func printDeploymentStatusJSON(deployment *types.Deployment) error {
+	jsonData, err := json.MarshalIndent(deployment, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal deployment to JSON: %w", err)
+	}
+	fmt.Println(string(jsonData))
+	return nil
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@gram/cli",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true
 }


### PR DESCRIPTION
Add `gram status` command to display deployment information.

Use the implementation for polling a new deployment after `gram push`.

Optionally skip polling with `—skip-poll`.

## Examples
<details>
<summary>Polling after push</summary>

```bash
$ go run . push --config config-22.json --idempotency-key $(uuidgen) \
  --api-url https://dev.getgram.ai \
  --api-key “$(dev-api-key)" \
  --project test-4

{"time":"2025-09-24T16:58:14.716232-07:00","level":"INFO","source":{"function":"github.com/speakeasy-api/gram/cli/internal/app.newPushCommand.func1","file":"/Users/babe/code/speakeasy/gram/cli/internal/app/push.go","line":118},"msg":"Deploying to project","project":"test-4","config":"/Users/babe/code/speakeasy/gram/cj_stuff/bulk-insert-regression-test/configs/config-22.json"}
{"time":"2025-09-24T16:58:15.832574-07:00","level":"INFO","source":{"function":"github.com/speakeasy-api/gram/cli/internal/app.newPushCommand.func1","file":"/Users/babe/code/speakeasy/gram/cli/internal/app/push.go","line":131},"msg":"Deployment created successfully","id":"01997e29-d5f6-7a19-9de7-71662e6b47b3"}
{"time":"2025-09-24T16:58:15.832672-07:00","level":"INFO","source":{"function":"github.com/speakeasy-api/gram/cli/internal/app.pollDeploymentStatus","file":"/Users/babe/code/speakeasy/gram/cli/internal/app/push.go","line":172},"msg":"Polling deployment status...","deployment_id":"01997e29-d5f6-7a19-9de7-71662e6b47b3"}
{"time":"2025-09-24T16:58:20.880165-07:00","level":"INFO","source":{"function":"github.com/speakeasy-api/gram/cli/internal/app.newPushCommand.func1","file":"/Users/babe/code/speakeasy/gram/cli/internal/app/push.go","line":143},"msg":"Deployment completed successfully","deployment_id":"01997e29-d5f6-7a19-9de7-71662e6b47b3"}
```
</details>

<details>
<summary>Deployment status by ID</summary>

```bash
$ go run . status --id 01997e29-d5f6-7a19-9de7-71662e6b47b3 \
  --api-url https://dev.getgram.ai \
  --api-key “$(dev-api-key)" \
  --project test-4

Deployment Status
=================

ID:           01997e29-d5f6-7a19-9de7-71662e6b47b3
Status:       completed
Created:      2025-09-24 23:58:15 UTC

Assets:
  OpenAPI Tools: 3
  Functions:     0

OpenAPI Assets:
  - openapi-bf62ac4ae2af (openapi-bf62ac4ae2af)
```
</details>

<details>
<summary>Latest status JSON</summary>

```bash
$ go run . status —json \
  --api-url https://dev.getgram.ai \
  --api-key “$(dev-api-key)" \
  --project test-4

{
  "ID": "01997e29-d5f6-7a19-9de7-71662e6b47b3",
  "OrganizationID": "a5d8c893-67b6-4e6f-8d4c-9f71485b38c8",
  "ProjectID": "01997cd7-9bea-740b-8d8a-c418b204436b",
  "UserID": "394bd8b0-80da-429f-9233-4ce718bcfe03",
  "CreatedAt": "2025-09-24T23:58:15Z",
  "Status": "completed",
  "IdempotencyKey": "BE5FF6FE-ABB0-4992-9E50-77A6DBF9EE0F",
  "GithubRepo": null,
  "GithubPr": null,
  "GithubSha": null,
  "ExternalID": null,
  "ExternalURL": null,
  "ClonedFrom": null,
  "Openapiv3ToolCount": 3,
  "Openapiv3Assets": [
    {
      "ID": "01997e29-d5f9-7c5c-8b10-63d3b63e3a3a",
      "AssetID": "01997d66-227d-7efd-b31a-6ff7b6555252",
      "Name": "openapi-bf62ac4ae2af",
      "Slug": "openapi-bf62ac4ae2af"
    }
  ],
  "FunctionsToolCount": 0,
  "FunctionsAssets": null,
  "Packages": []
}
```
</details>