### PR TITLE
feat: support YAML and TOML deployment configs

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=

--- a/cli/internal/app/push.go
+++ b/cli/internal/app/push.go
@@ -107,7 +107,7 @@ NOTE: Names and slugs must be unique across all sources.`[1:],
 				return configFile.Close()
 			})
 
-			config, err := deploy.NewConfig(configFile, filepath.Dir(configFilename))
+			config, err := deploy.NewConfig(configFile, configFilename)
 			if err != nil {
 				return fmt.Errorf("failed to parseread deployment config: %w", err)
 			}


### PR DESCRIPTION
Allow users to pass in YAML or TOML configs.

Example TOML:
```toml
schema_version = “1.0.0”
type = “deployment”

[[sources]]
type = “openapiv3”
...

```