### PR TITLE
chore: provision encryption key for each functions

### DIFF
--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -22,19 +22,20 @@ import (
 )
 
 type Activities struct {
-	processDeployment             *activities.ProcessDeployment
-	transitionDeployment          *activities.TransitionDeployment
-	getSlackProjectContext        *activities.GetSlackProjectContext
-	postSlackMessage              *activities.PostSlackMessage
-	slackChatCompletion           *activities.SlackChatCompletion
-	refreshOpenRouterKey          *activities.RefreshOpenRouterKey
-	verifyCustomDomain            *activities.VerifyCustomDomain
-	customDomainIngress           *activities.CustomDomainIngress
 	collectPlatformUsageMetrics   *activities.CollectPlatformUsageMetrics
+	customDomainIngress           *activities.CustomDomainIngress
 	firePlatformUsageMetrics      *activities.FirePlatformUsageMetrics
 	freeTierReportingUsageMetrics *activities.FreeTierReportingUsageMetrics
-	refreshBillingUsage           *activities.RefreshBillingUsage
 	getAllOrganizations           *activities.GetAllOrganizations
+	getSlackProjectContext        *activities.GetSlackProjectContext
+	postSlackMessage              *activities.PostSlackMessage
+	processDeployment             *activities.ProcessDeployment
+	provisionFunctionsAccess      *activities.ProvisionFunctionsAccess
+	refreshBillingUsage           *activities.RefreshBillingUsage
+	refreshOpenRouterKey          *activities.RefreshOpenRouterKey
+	slackChatCompletion           *activities.SlackChatCompletion
+	transitionDeployment          *activities.TransitionDeployment
+	verifyCustomDomain            *activities.VerifyCustomDomain
 }
 
 func NewActivities(
@@ -54,19 +55,20 @@ func NewActivities(
 	posthogClient *posthog.Posthog,
 ) *Activities {
 	return &Activities{
-		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, db, features, assetStorage),
-		transitionDeployment:          activities.NewTransitionDeployment(logger, db),
-		getSlackProjectContext:        activities.NewSlackProjectContextActivity(logger, db, slackClient),
-		postSlackMessage:              activities.NewPostSlackMessageActivity(logger, slackClient),
-		slackChatCompletion:           activities.NewSlackChatCompletionActivity(logger, slackClient, chatClient),
-		refreshOpenRouterKey:          activities.NewRefreshOpenRouterKey(logger, db, openrouter),
-		verifyCustomDomain:            activities.NewVerifyCustomDomain(logger, db, expectedTargetCNAME),
-		customDomainIngress:           activities.NewCustomDomainIngress(logger, db, k8sClient),
 		collectPlatformUsageMetrics:   activities.NewCollectPlatformUsageMetrics(logger, db),
+		customDomainIngress:           activities.NewCustomDomainIngress(logger, db, k8sClient),
 		firePlatformUsageMetrics:      activities.NewFirePlatformUsageMetrics(logger, billingTracker),
 		freeTierReportingUsageMetrics: activities.NewFreeTierReportingMetrics(logger, db, billingRepo, posthogClient),
-		refreshBillingUsage:           activities.NewRefreshBillingUsage(logger, db, billingRepo),
 		getAllOrganizations:           activities.NewGetAllOrganizations(logger, db),
+		getSlackProjectContext:        activities.NewSlackProjectContextActivity(logger, db, slackClient),
+		postSlackMessage:              activities.NewPostSlackMessageActivity(logger, slackClient),
+		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, db, features, assetStorage),
+		provisionFunctionsAccess:      activities.NewProvisionFunctionsAccess(logger, db),
+		refreshBillingUsage:           activities.NewRefreshBillingUsage(logger, db, billingRepo),
+		refreshOpenRouterKey:          activities.NewRefreshOpenRouterKey(logger, db, openrouter),
+		slackChatCompletion:           activities.NewSlackChatCompletionActivity(logger, slackClient, chatClient),
+		transitionDeployment:          activities.NewTransitionDeployment(logger, db),
+		verifyCustomDomain:            activities.NewVerifyCustomDomain(logger, db, expectedTargetCNAME),
 	}
 }
 
@@ -120,4 +122,8 @@ func (a *Activities) RefreshBillingUsage(ctx context.Context, orgIDs []string) e
 
 func (a *Activities) GetAllOrganizations(ctx context.Context) ([]string, error) {
 	return a.getAllOrganizations.Do(ctx)
+}
+
+func (a *Activities) ProvisionFunctionsAccess(ctx context.Context, projectID uuid.UUID, deploymentID uuid.UUID) error {
+	return a.provisionFunctionsAccess.Do(ctx, projectID, deploymentID)
 }

--- a/server/internal/background/activities/provision_functions_access.go
+++ b/server/internal/background/activities/provision_functions_access.go
@@ -1,0 +1,88 @@
+package activities
+
+import (
+	"context"
+	"crypto/rand"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/deployments/repo"
+	"github.com/speakeasy-api/gram/server/internal/inv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+type ProvisionFunctionsAccess struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+}
+
+func NewProvisionFunctionsAccess(
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+) *ProvisionFunctionsAccess {
+	return &ProvisionFunctionsAccess{
+		logger: logger.With(attr.SlogComponent("get-all-organizations")),
+		db:     db,
+	}
+}
+
+func (p *ProvisionFunctionsAccess) Do(ctx context.Context, projectID uuid.UUID, deploymentID uuid.UUID) error {
+	logger := p.logger.With(
+		attr.SlogProjectID(projectID.String()),
+		attr.SlogDeploymentID(deploymentID.String()),
+	)
+
+	if err := inv.Check(
+		"provision functions access inputs",
+		"project id cannot be nil", projectID != uuid.Nil,
+		"deployment id cannot be nil", deploymentID != uuid.Nil,
+	); err != nil {
+		return oops.E(oops.CodeInvalid, err, "invalid inputs").Log(ctx, logger)
+	}
+
+	dbtx, err := p.db.Begin(ctx)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error accessing deployments").Log(ctx, p.logger)
+	}
+	defer o11y.NoLogDefer(func() error {
+		return dbtx.Rollback(ctx)
+	})
+
+	deprepo := repo.New(dbtx)
+	attachments, err := deprepo.GetDeploymentFunctionsWithoutAccess(ctx, repo.GetDeploymentFunctionsWithoutAccessParams{
+		DeploymentID: deploymentID,
+		ProjectID:    projectID,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to get functions missing access").Log(ctx, logger)
+	}
+
+	for _, aid := range attachments {
+		key := make([]byte, 32)
+		if _, err := rand.Read(key); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to generate encryption key").Log(ctx, logger)
+		}
+
+		_, err = deprepo.CreateDeploymentFunctionsAccess(ctx, repo.CreateDeploymentFunctionsAccessParams{
+			ProjectID:     projectID,
+			DeploymentID:  deploymentID,
+			FunctionID:    aid,
+			EncryptionKey: key,
+			BearerFormat:  conv.ToPGText("GramV1"),
+		})
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to create functions access").Log(ctx, logger, attr.SlogDeploymentFunctionsID(aid.String()))
+		}
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error committing functions access creation").Log(ctx, logger)
+	}
+
+	return nil
+}

--- a/server/internal/background/deployments.go
+++ b/server/internal/background/deployments.go
@@ -98,6 +98,22 @@ func ProcessDeploymentWorkflow(ctx workflow.Context, params ProcessDeploymentWor
 		)
 	}
 
+	err = workflow.ExecuteActivity(
+		ctx,
+		a.ProvisionFunctionsAccess,
+		params.ProjectID,
+		params.DeploymentID,
+	).Get(ctx, nil)
+	if err != nil {
+		finalStatus = "failed"
+		logger.Error(
+			"failed to provision access credentials for functions",
+			"error", err.Error(),
+			string(attr.ProjectIDKey), params.ProjectID,
+			string(attr.DeploymentIDKey), params.DeploymentID,
+		)
+	}
+
 	var finalTransition activities.TransitionDeploymentResult
 	err = workflow.ExecuteActivity(
 		ctx,

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -125,6 +125,7 @@ func NewTemporalWorker(
 
 	temporalWorker.RegisterActivity(activities.ProcessDeployment)
 	temporalWorker.RegisterActivity(activities.TransitionDeployment)
+	temporalWorker.RegisterActivity(activities.ProvisionFunctionsAccess)
 	temporalWorker.RegisterActivity(activities.GetSlackProjectContext)
 	temporalWorker.RegisterActivity(activities.PostSlackMessage)
 	temporalWorker.RegisterActivity(activities.SlackChatCompletion)

--- a/server/internal/deployments/createdeployment_functions_test.go
+++ b/server/internal/deployments/createdeployment_functions_test.go
@@ -65,6 +65,13 @@ func TestCreateDeployment_OnlyFunctions(t *testing.T) {
 	functionTools, err := repo.ListDeploymentFunctionsTools(ctx, uuid.MustParse(dep.Deployment.ID))
 	require.NoError(t, err, "list deployment function tools")
 	require.NotEmpty(t, functionTools, "should have function tools")
+
+	accessCount, err := repo.CountFunctionsAccess(ctx, testrepo.CountFunctionsAccessParams{
+		DeploymentID: uuid.MustParse(dep.Deployment.ID),
+		ProjectID:    uuid.MustParse(dep.Deployment.ProjectID),
+	})
+	require.NoError(t, err, "get functions without access")
+	require.Equal(t, int64(1), accessCount, "all functions should have access credentials")
 }
 
 func TestCreateDeployment_FunctionsWithManifestValidation(t *testing.T) {
@@ -119,6 +126,13 @@ func TestCreateDeployment_FunctionsWithManifestValidation(t *testing.T) {
 		require.NotEmpty(t, tool.Description, "tool should have a description")
 		require.Equal(t, "nodejs:22", tool.Runtime, "tool should have correct runtime")
 	}
+
+	accessCount, err := repo.CountFunctionsAccess(ctx, testrepo.CountFunctionsAccessParams{
+		DeploymentID: uuid.MustParse(dep.Deployment.ID),
+		ProjectID:    uuid.MustParse(dep.Deployment.ProjectID),
+	})
+	require.NoError(t, err, "get functions without access")
+	require.Equal(t, int64(1), accessCount, "all functions should have access credentials")
 }
 
 func TestCreateDeployment_WithFunctions_ValidJS(t *testing.T) {
@@ -169,6 +183,13 @@ func TestCreateDeployment_WithFunctions_ValidJS(t *testing.T) {
 	for _, tool := range functionTools {
 		require.Equal(t, "nodejs:22", tool.Runtime, "tool runtime should match deployment runtime")
 	}
+
+	accessCount, err := repo.CountFunctionsAccess(ctx, testrepo.CountFunctionsAccessParams{
+		DeploymentID: uuid.MustParse(dep.Deployment.ID),
+		ProjectID:    uuid.MustParse(dep.Deployment.ProjectID),
+	})
+	require.NoError(t, err, "get functions without access")
+	require.Equal(t, int64(1), accessCount, "all functions should have access credentials")
 }
 
 func TestCreateDeployment_WithFunctions_ValidPython(t *testing.T) {
@@ -219,6 +240,13 @@ func TestCreateDeployment_WithFunctions_ValidPython(t *testing.T) {
 	for _, tool := range functionTools {
 		require.Equal(t, "python:3.12", tool.Runtime, "tool runtime should match deployment runtime")
 	}
+
+	accessCount, err := repo.CountFunctionsAccess(ctx, testrepo.CountFunctionsAccessParams{
+		DeploymentID: uuid.MustParse(dep.Deployment.ID),
+		ProjectID:    uuid.MustParse(dep.Deployment.ProjectID),
+	})
+	require.NoError(t, err, "get functions without access")
+	require.Equal(t, int64(1), accessCount, "all functions should have access credentials")
 }
 
 func TestCreateDeployment_WithFunctions_ValidTypeScript(t *testing.T) {
@@ -264,6 +292,13 @@ func TestCreateDeployment_WithFunctions_ValidTypeScript(t *testing.T) {
 	functionTools, err := repo.ListDeploymentFunctionsTools(ctx, uuid.MustParse(dep.Deployment.ID))
 	require.NoError(t, err, "list deployment function tools")
 	require.NotEmpty(t, functionTools, "expected function tools to be created")
+
+	accessCount, err := repo.CountFunctionsAccess(ctx, testrepo.CountFunctionsAccessParams{
+		DeploymentID: uuid.MustParse(dep.Deployment.ID),
+		ProjectID:    uuid.MustParse(dep.Deployment.ProjectID),
+	})
+	require.NoError(t, err, "get functions without access")
+	require.Equal(t, int64(1), accessCount, "all functions should have access credentials")
 }
 
 func TestCreateDeployment_WithFunctions_MultipleFiles(t *testing.T) {
@@ -327,6 +362,13 @@ func TestCreateDeployment_WithFunctions_MultipleFiles(t *testing.T) {
 	})
 	require.Contains(t, runtimes, "nodejs:22", "expected nodejs:22 runtime tools")
 	require.Contains(t, runtimes, "python:3.12", "expected python:3.12 runtime tools")
+
+	accessCount, err := repo.CountFunctionsAccess(ctx, testrepo.CountFunctionsAccessParams{
+		DeploymentID: uuid.MustParse(dep.Deployment.ID),
+		ProjectID:    uuid.MustParse(dep.Deployment.ProjectID),
+	})
+	require.NoError(t, err, "get functions without access")
+	require.Equal(t, int64(2), accessCount, "all functions should have access credentials")
 }
 
 func TestCreateDeployment_WithFunctions_AndOpenAPI(t *testing.T) {

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -7,3 +7,10 @@ WHERE deployment_id = @deployment_id;
 SELECT *
 FROM function_tool_definitions
 WHERE deployment_id = @deployment_id;
+
+-- name: CountFunctionsAccess :one
+SELECT count(id)
+FROM functions_access
+WHERE
+  project_id = @project_id
+  AND deployment_id = @deployment_id;

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -11,6 +11,26 @@ import (
 	"github.com/google/uuid"
 )
 
+const countFunctionsAccess = `-- name: CountFunctionsAccess :one
+SELECT count(id)
+FROM functions_access
+WHERE
+  project_id = $1
+  AND deployment_id = $2
+`
+
+type CountFunctionsAccessParams struct {
+	ProjectID    uuid.UUID
+	DeploymentID uuid.UUID
+}
+
+func (q *Queries) CountFunctionsAccess(ctx context.Context, arg CountFunctionsAccessParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countFunctionsAccess, arg.ProjectID, arg.DeploymentID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const listDeploymentFunctionsTools = `-- name: ListDeploymentFunctionsTools :many
 SELECT id, tool_urn, deployment_id, function_id, runtime, name, description, input_schema, variables, created_at, updated_at, deleted_at, deleted
 FROM function_tool_definitions


### PR DESCRIPTION
This change updates the deployment processing workflow to provision encryption keys for each function attached to a deployment. This material will be used to authenticate requests to the functions.
