### PR TITLE
fix: remove invalid pg function and trigger

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -666,34 +666,6 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_idx ON chat_messages (chat_id);
 
--- Function to update the total_tokens in chats table
-CREATE OR REPLACE FUNCTION update_chat_total_tokens()
-RETURNS TRIGGER AS $$
-BEGIN
-  -- Update the total_tokens in the chats table
-  UPDATE chats
-  SET total_tokens = (
-    SELECT COALESCE(SUM(total_tokens), 0)
-    FROM chat_messages
-    WHERE chat_id = CASE
-      WHEN TG_OP = 'DELETE' THEN OLD.chat_id
-      ELSE NEW.chat_id
-    END
-  )
-  WHERE id = CASE
-    WHEN TG_OP = 'DELETE' THEN OLD.chat_id
-    ELSE NEW.chat_id
-  END;
-  
-  RETURN NULL;
-END;
-$$ LANGUAGE plpgsql;
-
--- Trigger to update total_tokens when chat_messages are inserted, updated, or deleted
-CREATE TRIGGER update_chat_total_tokens_trigger
-AFTER INSERT OR UPDATE OR DELETE ON chat_messages
-FOR EACH ROW EXECUTE FUNCTION update_chat_total_tokens();
-
 CREATE TABLE IF NOT EXISTS slack_app_connections (
   slack_team_id TEXT NOT NULL,
   organization_id TEXT NOT NULL,


### PR DESCRIPTION
This change removes the postgres function `update_chat_total_tokens` and `update_chat_total_tokens_trigger` which were never applied to prod or dev database.

The `update_chat_total_tokens function` in particular is invalid because it is trying to update the `chats.total_tokens` which does not exist.