### PR TITLE
chore: add traces for deployment processing

### DIFF
--- a/server/internal/openapi/extract_speakeasy.go
+++ b/server/internal/openapi/extract_speakeasy.go
@@ -63,17 +63,15 @@ func (p *ToolExtractor) doSpeakeasy(
 	tx *repo.Queries,
 	data []byte,
 	task ToolExtractorTask,
-) (*ToolExtractorResult, error) {
+) (result *ToolExtractorResult, err error) {
 	ctx, rootSpan := tracer.Start(ctx, "openapi.doSpeakeasy")
-	var spanFailed bool
 
 	failSpan := func(span trace.Span, msg string) {
 		span.SetStatus(codes.Error, msg)
-		spanFailed = true
 	}
 
 	defer func() {
-		if spanFailed {
+		if err != nil {
 			rootSpan.SetStatus(codes.Error, "one or more child operations failed")
 		}
 		rootSpan.End()

--- a/server/internal/openapi/extract_speakeasy.go
+++ b/server/internal/openapi/extract_speakeasy.go
@@ -72,10 +72,12 @@ func (p *ToolExtractor) doSpeakeasy(
 	}
 
 	upgradeStart := time.Now()
+	ctx, upgradeSpan := tracer.Start(ctx, "openapiv3.doSpeakeasy.upgradeOpenAPI30To31Speakeasy")
 	upgradeResult, err := upgradeOpenAPI30To31Speakeasy(ctx, doc)
 	upgradeDuration := time.Since(upgradeStart)
 	var upgradeOutcome *o11y.Outcome
 	if err != nil {
+		upgradeSpan.SetStatus(codes.Error, err.Error())
 		upgradeOutcome = pointer.From(o11y.OutcomeFailure)
 		logger.ErrorContext(ctx, "Unable to upgrade OpenAPI v3.0 document to v3.1. Proceeding with v3.0 document.", attr.SlogEvent("openapi-upgrade:error"))
 		logger.ErrorContext(ctx, err.Error(), attr.SlogEvent("openapi-upgrade:error"))
@@ -97,13 +99,19 @@ func (p *ToolExtractor) doSpeakeasy(
 			}
 		}
 	}
+	upgradeSpan.End()
 
 	globalSecurity, err := serializeSecuritySpeakeasy(doc.GetSecurity())
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "error serializing global security").Log(ctx, logger)
 	}
 
+	ctx, securitySpan := tracer.Start(ctx, "openapiv3.doSpeakeasy.extractSecuritySchemesSpeakeasy")
 	securitySchemesParams, errs := extractSecuritySchemesSpeakeasy(ctx, logger, docInfo, doc, task)
+	if len(errs) > 0 {
+		securitySpan.SetStatus(codes.Error, fmt.Sprintf("encountered %d errors extracting security schemes", len(errs)))
+	}
+	securitySpan.End()
 	if len(errs) > 0 {
 		for _, err := range errs {
 			_ = oops.E(oops.CodeUnexpected, err, "%s: error parsing security schemes: %s", docInfo.Name, err.Error()).Log(ctx, logger)
@@ -114,10 +122,14 @@ func (p *ToolExtractor) doSpeakeasy(
 	var writeErr error
 	securitySchemes := make(map[string]repo.HttpSecurity, len(securitySchemesParams))
 	for key, scheme := range securitySchemesParams {
+		ctx, dbSpan := tracer.Start(ctx, "openapiv3.doSpeakeasy.CreateHTTPSecurity")
 		sec, err := tx.CreateHTTPSecurity(ctx, *scheme)
 		if err != nil {
+			dbSpan.SetStatus(codes.Error, err.Error())
+			dbSpan.End()
 			return nil, oops.E(oops.CodeUnexpected, oops.Permanent(err), "%s: error writing security scheme: %s", docInfo.Name, err.Error()).Log(ctx, logger)
 		}
+		dbSpan.End()
 
 		securitySchemes[key] = sec
 	}
@@ -126,6 +138,7 @@ func (p *ToolExtractor) doSpeakeasy(
 	globalDefaultServer := extractDefaultServerSpeakeasy(ctx, logger, docInfo, doc.GetServers())
 
 	for path, pi := range doc.Paths.All() {
+		ctx, resolveSpan := tracer.Start(ctx, "openapiv3.doSpeakeasy.resolvePath")
 		_, err := pi.Resolve(ctx, openapi.ResolveOptions{
 			TargetLocation:      "/",
 			RootDocument:        doc,
@@ -133,9 +146,12 @@ func (p *ToolExtractor) doSpeakeasy(
 			SkipValidation:      true,
 		})
 		if err != nil {
+			resolveSpan.SetStatus(codes.Error, err.Error())
+			resolveSpan.End()
 			logger.ErrorContext(ctx, fmt.Sprintf("%s: %s %s", docInfo.Name, "error resolving path", err.Error()), attr.SlogEvent("openapi:error"))
 			continue
 		}
+		resolveSpan.End()
 
 		pathItem := pi.GetObject()
 
@@ -163,6 +179,7 @@ func (p *ToolExtractor) doSpeakeasy(
 				opID = fmt.Sprintf("%s_%s", op.method, path)
 			}
 
+			ctx, extractSpan := tracer.Start(ctx, "openapiv3.doSpeakeasy.extractToolDefSpeakeasy")
 			def, err := extractToolDefSpeakeasy(ctx, logger, tx, doc, operationTask[openapi.Operation, openapi.ReferencedParameter]{
 				extractTask:      task,
 				method:           op.method,
@@ -174,6 +191,10 @@ func (p *ToolExtractor) doSpeakeasy(
 				serverEnvVar:     globalServerEnvVar,
 				defaultServer:    globalDefaultServer,
 			})
+			if err != nil {
+				extractSpan.SetStatus(codes.Error, err.Error())
+			}
+			extractSpan.End()
 			if err != nil {
 				if task.OnOperationSkipped != nil {
 					task.OnOperationSkipped(err)


### PR DESCRIPTION
## Description
Add more granular traces for observability. Supports the ongoing effort to track down slow deploys.

## Results
This change revealed the bottleneck in deployment processing.

The `INSERT` statements turn out to be ~50x less impactful than extracting tool definitions.

Previously, they were conflated, and we didn’t know where the missing time was going.

Example DataDog trace [here](https://app.datadoghq.com/apm/traces?query=env%3Adev%20service%3A%28gram-server%20OR%20gram-worker%29%20resource_name%3Aopenapiv3.doSpeakeasy.upgradeOpenAPI30To31Speakeasy&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=950324476936652965&spanType=all&storage=hot&timeHint=1758918149079&tq_query_translation_version=v0&trace=AwAAAZmHsQPXZMvIwQAAABhBWm1Ic1IzdkFBQk1CQ0JkOWNMaWE4ZTIAAAAkMDE5OTg3YjEtYzNiYi00NmE1LWJhOGQtMGQyN2M0ZTY5NzhkAAAB3g&trace_group_by_from=root&traceID=56deb5b8b111cba8b6c7cb0a6dd7bd5f&traceQuery=&view=spans&viz=stream&start=1758918069122&end=1758918969122&paused=false).
<img width="597" height="205" alt="image" src="https://github.com/user-attachments/assets/cb6deb8c-1efe-410c-92ae-e2c20aec38cf" />

<img width="1191" height="109" alt="image" src="https://github.com/user-attachments/assets/95b6738f-2cc1-42ec-b214-59794b405cd7" />

## Repro
Using the `gram` cli:
```bash
$ jq </code/assets/configs/config-99.json
{
  "schema_version": "1.0.0",
  "type": "deployment",
  "sources": [
    {
      "type": "openapiv3",
      "location": "/code/assets/0197b2e4-3791-7ac7-b880-6ac3ac3ebcf3/openapi-948a07251388b3303e0d51c6f2ec45aed96d8f32414afef1473f592ce284dda8.yaml",
      "name": "openapi-948a07251388",
      "slug": "openapi-948a07251388"
    }
  ]
}

$ env GRAM_API_URL=https://dev.getgram.ai GRAM_API_KEY="$(gram-api-key-dev)” \
  $(brew --prefix)/bin/gram push --config /code/assets/configs/config-99.json \
  --idempotency-key="$(uuidgen)” \
  --project test-4
```
