### PR TITLE
chore: pin actions to Git SHAs instead of tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/workflows/composite/build-push"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"

--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -38,11 +38,11 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
     - name: Extract Docker metadata
       id: meta
-      uses: docker/metadata-action@v4.0.0
+      uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
       with:
         images: ${{ inputs.registry }}/${{ inputs.image }}
         tags: |
@@ -116,7 +116,7 @@ runs:
       run: echo "GIT_SHA=$(echo $GITHUB_SHA | cut -c1-8)" >> $GITHUB_ENV
 
     - name: Build and push registry Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}

--- a/.github/workflows/public-oas-generation.yml
+++ b/.github/workflows/public-oas-generation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install Speakeasy CLI
         run: curl -fsSL https://go.speakeasy.com/cli-install.sh | sh


### PR DESCRIPTION
This change updates various action references to use specific commit SHAs instead of floating tags. This prevents issues where tags are moved to point to different commits by malicious actors.