### PR TITLE
fix: don't replace hyphens with underscores

### DIFF
--- a/server/internal/deployments/createdeployment_test.go
+++ b/server/internal/deployments/createdeployment_test.go
@@ -76,18 +76,18 @@ func TestDeploymentsService_CreateDeployment(t *testing.T) {
 			return t.Name
 		})
 		require.ElementsMatch(t, names, []string{
-			"test_doc_get_todos",
-			"test_doc_create_todo",
-			"test_doc_get_todo_by_id",
-			"test_doc_update_todo",
-			"test_doc_delete_todo",
+			"test-doc_get_todos",
+			"test-doc_create_todo",
+			"test-doc_get_todo_by_id",
+			"test-doc_update_todo",
+			"test-doc_delete_todo",
 		}, "mismatched tool names")
 	})
 
 	t.Run("tool attributes", func(t *testing.T) {
 		t.Parallel()
 
-		name := "test_doc_get_todo_by_id"
+		name := "test-doc_get_todo_by_id"
 
 		tool, ok := lo.Find(tools, func(t testrepo.HttpToolDefinition) bool {
 			return t.Name == name
@@ -180,11 +180,11 @@ func TestDeploymentsService_CreateDeployment_Idempotency(t *testing.T) {
 		return t.Name
 	})
 	require.ElementsMatch(t, names, []string{
-		"test_doc_get_todos",
-		"test_doc_create_todo",
-		"test_doc_get_todo_by_id",
-		"test_doc_update_todo",
-		"test_doc_delete_todo",
+		"test-doc_get_todos",
+		"test-doc_create_todo",
+		"test-doc_get_todo_by_id",
+		"test-doc_update_todo",
+		"test-doc_delete_todo",
 	}, "mismatched tool names")
 }
 
@@ -260,23 +260,23 @@ func TestDeploymentsService_CreateDeployment_MultipleDocuments(t *testing.T) {
 		})
 		require.ElementsMatch(t, names, []string{
 			// Petstore tools
-			"petstore_api_list_pets",
-			"petstore_api_create_pets",
-			"petstore_api_show_pet_by_id",
-			"petstore_api_delete_pet",
+			"petstore-api_list_pets",
+			"petstore-api_create_pets",
+			"petstore-api_show_pet_by_id",
+			"petstore-api_delete_pet",
 			// Todo tools
-			"todo_api_get_todos",
-			"todo_api_create_todo",
-			"todo_api_get_todo_by_id",
-			"todo_api_update_todo",
-			"todo_api_delete_todo",
+			"todo-api_get_todos",
+			"todo-api_create_todo",
+			"todo-api_get_todo_by_id",
+			"todo-api_update_todo",
+			"todo-api_delete_todo",
 		}, "mismatched tool names")
 	})
 
 	t.Run("verify petstore tool attributes", func(t *testing.T) {
 		t.Parallel()
 
-		name := "petstore_api_show_pet_by_id"
+		name := "petstore-api_show_pet_by_id"
 
 		tool, ok := lo.Find(tools, func(t testrepo.HttpToolDefinition) bool {
 			return t.Name == name
@@ -292,7 +292,7 @@ func TestDeploymentsService_CreateDeployment_MultipleDocuments(t *testing.T) {
 	t.Run("verify todo tool attributes", func(t *testing.T) {
 		t.Parallel()
 
-		name := "todo_api_get_todo_by_id"
+		name := "todo-api_get_todo_by_id"
 
 		tool, ok := lo.Find(tools, func(t testrepo.HttpToolDefinition) bool {
 			return t.Name == name

--- a/server/internal/openapi/process.go
+++ b/server/internal/openapi/process.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net/url"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/ettle/strcase"
@@ -297,10 +296,8 @@ type toolDescriptor struct {
 func parseToolDescriptor(ctx context.Context, logger *slog.Logger, docInfo *types.OpenAPIv3DeploymentAsset, opID string, op operation) toolDescriptor {
 	// gramExtNode, _ := op.Extensions.Get("x-gram")
 	// speakeasyExtNode, _ := op.Extensions.Get("x-speakeasy-mcp")
-	// Convert doc slug hyphens to underscores for consistency with tool naming
-	sanitizedSlug := strings.ReplaceAll(string(docInfo.Slug), "-", "_")
 	snakeCasedOp := strcase.ToSnake(opID)
-	untruncatedName := tools.SanitizeName(fmt.Sprintf("%s_%s", sanitizedSlug, snakeCasedOp))
+	untruncatedName := tools.SanitizeName(fmt.Sprintf("%s_%s", docInfo.Slug, snakeCasedOp))
 	// we limit actual tool name to 60 character by default to stay in line with common MCP client restrictions
 	name := truncateWithHash(untruncatedName, 60)
 


### PR DESCRIPTION
Unnecessary change. Prefer to keep names as similar to the original as possible