### PR TITLE
feat: add consistent trace id to tool requests

### DIFF
--- a/.changeset/pink-singers-speak.md
+++ b/.changeset/pink-singers-speak.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+feat: add consistent trace id to tool call requests

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -39,24 +39,6 @@ const (
 	ToolCallSourceMCP    ToolCallSource = "mcp"
 )
 
-// gramTrackPropagator is a custom OpenTelemetry propagator that only injects X-Gram-Track-Id header
-type gramTrackPropagator struct{}
-
-func (gramTrackPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
-	spanCtx := trace.SpanContextFromContext(ctx)
-	if spanCtx.HasTraceID() {
-		carrier.Set("X-Gram-Track-Id", spanCtx.TraceID().String())
-	}
-}
-
-func (gramTrackPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
-	return ctx // Not extracting anything
-}
-
-func (gramTrackPropagator) Fields() []string {
-	return []string{"X-Gram-Track-Id"}
-}
-
 const (
 	HeaderProxiedResponse  = "X-Gram-Proxy-Response"
 	HeaderFilteredResponse = "X-Gram-Proxy-ResponseFiltered"
@@ -474,7 +456,7 @@ func reverseProxyRequest(ctx context.Context,
 		Timeout: 60 * time.Second,
 		Transport: otelhttp.NewTransport(
 			transport,
-			otelhttp.WithPropagators(gramTrackPropagator{}),
+			otelhttp.WithPropagators(propagation.TraceContext{}),
 		),
 	}
 

--- a/server/internal/gateway/security.go
+++ b/server/internal/gateway/security.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 )
@@ -279,7 +281,13 @@ func processClientCredentials(ctx context.Context, logger *slog.Logger, req *htt
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	// Make the token request
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: otelhttp.NewTransport(
+			http.DefaultTransport,
+			otelhttp.WithPropagators(gramTrackPropagator{}),
+		),
+	}
 	resp, err := client.Do(tokenReq)
 	if err != nil {
 		return fmt.Errorf("failed to make client credentials token request: %w", err)
@@ -300,7 +308,7 @@ func processClientCredentials(ctx context.Context, logger *slog.Logger, req *htt
 				logger.ErrorContext(ctx, "failed to close original response body", attr.SlogError(closeErr))
 			}
 
-			retryResp, retryErr := retryTokenRequestWithBasicAuth(ctx, tokenURL, clientID, clientSecret, requestedScopes)
+			retryResp, retryErr := retryTokenRequestWithBasicAuth(ctx, client, tokenURL, clientID, clientSecret, requestedScopes)
 			if retryErr != nil {
 				return fmt.Errorf("failed to make client credentials token request: %w", retryErr)
 			}
@@ -377,7 +385,7 @@ func parseClientCredentialsTokenResponse(body []byte) (string, int, error) {
 	return accessToken, expiresIn, nil
 }
 
-func retryTokenRequestWithBasicAuth(ctx context.Context, tokenURL, clientID, clientSecret string, requestedScopes []string) (*http.Response, error) {
+func retryTokenRequestWithBasicAuth(ctx context.Context, client *http.Client, tokenURL, clientID, clientSecret string, requestedScopes []string) (*http.Response, error) {
 	values := url.Values{}
 	values.Set("grant_type", "client_credentials")
 	if len(requestedScopes) > 0 {
@@ -394,7 +402,6 @@ func retryTokenRequestWithBasicAuth(ctx context.Context, tokenURL, clientID, cli
 	retryReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	retryReq.SetBasicAuth(clientID, clientSecret)
 
-	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(retryReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make retry token request: %w", err)

--- a/server/internal/gateway/security.go
+++ b/server/internal/gateway/security.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -285,7 +286,7 @@ func processClientCredentials(ctx context.Context, logger *slog.Logger, req *htt
 		Timeout: 10 * time.Second,
 		Transport: otelhttp.NewTransport(
 			http.DefaultTransport,
-			otelhttp.WithPropagators(gramTrackPropagator{}),
+			otelhttp.WithPropagators(propagation.TraceContext{}),
 		),
 	}
 	resp, err := client.Do(tokenReq)


### PR DESCRIPTION
- Adds consistent trace id to tool call requests that the customer can use to search their entire logs from gram logs
- Can discuss if we actually want to use the `otelhttp` transport. This is possible with out it.