### PR TITLE
fix: restore install page location

### DIFF
--- a/.changeset/tender-views-cry.md
+++ b/.changeset/tender-views-cry.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+restore old location for install page (no /install)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -505,8 +505,9 @@ func newStartCommand() *cli.Command {
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env)
 			oauth.Attach(mux, oauthService)
 			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, env, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, billingTracker))
-			mcpmetadata.Attach(mux, mcpmetadata.NewService(logger, db, sessionManager, serverURL))
-			mcp.Attach(mux, mcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, env, posthogClient, serverURL, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, oauthService, billingTracker, billingRepo))
+			mcpMetadataService := mcpmetadata.NewService(logger, db, sessionManager, serverURL)
+			mcpmetadata.Attach(mux, mcpMetadataService)
+			mcp.Attach(mux, mcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, env, posthogClient, serverURL, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, oauthService, billingTracker, billingRepo), mcpMetadataService)
 			chat.Attach(mux, chat.NewService(logger, db, sessionManager, openRouter))
 			if slackClient.Enabled() {
 				slack.Attach(mux, slack.NewService(logger, db, sessionManager, encryptionClient, redisClient, slackClient, temporalClient, slack.Configurations{

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"net/url"
 	"slices"
@@ -33,6 +34,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oauth"
@@ -125,11 +127,19 @@ func NewService(
 	}
 }
 
-func Attach(mux goahttp.Muxer, service *Service) {
+func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Service) {
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}", func(w http.ResponseWriter, r *http.Request) {
 		oops.ErrHandle(service.logger, service.ServePublic).ServeHTTP(w, r)
 	})
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}", func(w http.ResponseWriter, r *http.Request) {
+		// Check if this is a browser request (HTML Accept header)
+		for mediaTypeFull := range strings.SplitSeq(r.Header.Get("Accept"), ",") {
+			if mediatype, _, err := mime.ParseMediaType(mediaTypeFull); err == nil && (mediatype == "text/html" || mediatype == "application/xhtml+xml") {
+				oops.ErrHandle(service.logger, metadataService.ServeHostedPage).ServeHTTP(w, r)
+				return
+			}
+		}
+
 		body, err := json.Marshal(rpcError{
 			ID:      msgID{format: 0, String: "", Number: 0},
 			Code:    methodNotAllowed,


### PR DESCRIPTION
Broke this while moving handlers around per: https://speakeasy-dev.slack.com/archives/C07ME0HG1V5/p1759506656578509?thread_ts=1758576660.197199&cid=C07ME0HG1V5