### PR TITLE
chore: add `mise run build:functions-local`

### DIFF
--- a/.mise-tasks/build/functions-bin.sh
+++ b/.mise-tasks/build/functions-bin.sh
@@ -7,8 +7,10 @@
 #USAGE flag "--level <level>" help="Set log level for builds" default="info"
 #USAGE flag "--arch <arch>" required=#true help="Comma-separated list of target architectures" default="x86_64"
 #USAGE flag "--melange-private-key <path>" help="Path to melange signing key"
+#USAGE flag "--apk-cache-dir <path>" required=#true help="Path to apko cache directory" default="../local/cache/apk"
 
 archs="${usage_arch:?Error: arch not provided}"
+apk_cache_dir="${usage_apk_cache_dir:?Error: apk cache dir not provided}"
 log_level="${usage_level:-info}"
 
 melange_priv_key=${usage_melange_private_key:-$MELANGE_PRIVATE_KEY}
@@ -19,6 +21,7 @@ fi
 
 rm -rf ./packages
 exec melange build \
+  --apk-cache-dir "$apk_cache_dir" \
   --cache-dir "$(go env GOMODCACHE)" \
   --arch "${archs}" \
   --runner docker \

--- a/.mise-tasks/build/functions-local.sh
+++ b/.mise-tasks/build/functions-local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#MISE description="Build Gram Functions runner images for local use"
+#MISE dir="{{ config_root }}/functions"
+
+set -euo pipefail
+
+arch="$(uname -m)"
+if [ "$arch" = "aarch64" ]; then
+  arch="arm64"
+fi
+
+mise run build:functions-bin --arch "$arch"
+mise run build:functions-image \
+  --arch "$arch" \
+  --apko-config "./images/nodejs22-alpine3.22.yaml" \
+  --image "gram-runner-nodejs22:dev" \
+  --tarball-name "image.tar" \
+  --out "./oci/nodejs22"
+
+docker rmi --force "gram-runner-nodejs22:dev-$arch" gram-runner-nodejs22:dev || true
+docker image load -i ./oci/nodejs22/image.tar
+docker tag "gram-runner-nodejs22:dev-$arch" "gram-runner-nodejs22:dev"
+docker rmi "gram-runner-nodejs22:dev-$arch"

--- a/functions/cmd/runner/main.go
+++ b/functions/cmd/runner/main.go
@@ -145,6 +145,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		}
 	}()
 
+	logger.InfoContext(ctx, "starting server", attr.SlogServerAddress(srv.Addr))
 	err = srv.ListenAndServe()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("server error: %w", err)

--- a/functions/internal/attr/conventions.go
+++ b/functions/internal/attr/conventions.go
@@ -13,8 +13,8 @@ const (
 	ExceptionStacktraceKey = semconv.ExceptionStacktraceKey
 	ErrorMessageKey        = semconv.ErrorMessageKey
 	ErrorIDKey             = attribute.Key("gram.error.id")
-
-	ProcessExitCodeKey = semconv.ProcessExitCodeKey
+	ProcessExitCodeKey     = semconv.ProcessExitCodeKey
+	ServerAddressKey       = semconv.ServerAddressKey
 
 	ComponentKey             = attribute.Key("gram.component")
 	ProjectIDKey             = attribute.Key("gram.project.id")
@@ -44,6 +44,9 @@ func SlogErrorID(v string) slog.Attr      { return slog.String(string(ErrorIDKey
 
 func ProcessExitCode(v int) attribute.KeyValue { return ProcessExitCodeKey.Int(v) }
 func SlogProcessExitCode(v int) slog.Attr      { return slog.Int(string(ProcessExitCodeKey), v) }
+
+func ServerAddress(v string) attribute.KeyValue { return ServerAddressKey.String(v) }
+func SlogServerAddress(v string) slog.Attr      { return slog.String(string(ServerAddressKey), v) }
 
 func Component(v string) attribute.KeyValue { return ComponentKey.String(v) }
 func SlogComponent(v string) slog.Attr      { return slog.String(string(ComponentKey), v) }


### PR DESCRIPTION
This change adds a mise task to build the gram runner nodejs22 image for use during local development. As part of this task, it is loaded into the local docker daemon so that it can be used by the server to provision function runner containers.