### PR TITLE
feat: add informational box to deployments page

### DIFF
--- a/client/dashboard/src/pages/deployments/Deployments.tsx
+++ b/client/dashboard/src/pages/deployments/Deployments.tsx
@@ -206,6 +206,28 @@ function DeploymentsTable() {
     <>
       <Heading variant="h2">Recent Deployments</Heading>
 
+      <div className="bg-secondary p-6 rounded-lg mb-6 space-y-4">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Each time you upload a new OpenAPI document or update a previously
+            uploaded one, you create a new deployment in Gram.
+          </p>
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            For each deployment, Gram analyzes all related OpenAPI documents to
+            generate or update the corresponding tool definitions.
+          </p>
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Gram generates logs for every deployment, showing what was processed
+            successfully and which operations or endpoints failed to convert
+            into tools.
+          </p>
+        </div>
+      </div>
+
       <Table<DeploymentSummary>
         columns={columnsWithData}
         rowKey={(row) => row.id}

--- a/client/dashboard/src/pages/deployments/Deployments.tsx
+++ b/client/dashboard/src/pages/deployments/Deployments.tsx
@@ -217,8 +217,8 @@ function DeploymentsTable() {
         </p>
         <p className="text-sm text-muted-foreground">
           Gram generates logs for every deployment, showing what was processed
-          successfully and which operations or endpoints failed to convert
-          into tools.
+          successfully and which operations or endpoints failed to convert into
+          tools.
         </p>
       </div>
 

--- a/client/dashboard/src/pages/deployments/Deployments.tsx
+++ b/client/dashboard/src/pages/deployments/Deployments.tsx
@@ -207,25 +207,19 @@ function DeploymentsTable() {
       <Heading variant="h2">Recent Deployments</Heading>
 
       <div className="bg-secondary p-6 rounded-lg mb-6 space-y-4">
-        <div>
-          <p className="text-sm text-muted-foreground">
-            Each time you upload a new OpenAPI document or update a previously
-            uploaded one, you create a new deployment in Gram.
-          </p>
-        </div>
-        <div>
-          <p className="text-sm text-muted-foreground">
-            For each deployment, Gram analyzes all related OpenAPI documents to
-            generate or update the corresponding tool definitions.
-          </p>
-        </div>
-        <div>
-          <p className="text-sm text-muted-foreground">
-            Gram generates logs for every deployment, showing what was processed
-            successfully and which operations or endpoints failed to convert
-            into tools.
-          </p>
-        </div>
+        <p className="text-sm text-muted-foreground">
+          Each time you upload a new OpenAPI document or update a previously
+          uploaded one, you create a new deployment in Gram.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          For each deployment, Gram analyzes all related OpenAPI documents to
+          generate or update the corresponding tool definitions.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Gram generates logs for every deployment, showing what was processed
+          successfully and which operations or endpoints failed to convert
+          into tools.
+        </p>
       </div>
 
       <Table<DeploymentSummary>


### PR DESCRIPTION
## Summary

Adds an informational box to the deployments page that explains how deployments work in Gram.

<img width="2284" height="790" alt="CleanShot 2025-10-06 at 09 55 58@2x" src="https://github.com/user-attachments/assets/48f20499-ce9b-43a3-a9c2-f84093198111" />

## Changes

- Added informational box below "Recent Deployments" heading. Without this its not clear to a user what is a Deployment and why they should care.
- Uses same styling as the prompt templates page (gray background with muted text)
- Explains the deployment creation, analysis, and logging process

## UI

The box appears below the "Recent Deployments" heading and contains three paragraphs explaining:
1. How deployments are created when uploading OpenAPI documents
2. How Gram analyzes documents to generate tool definitions
3. How logs are generated for each deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)