### PR TITLE
fix: prevent asset names from being cut off in deployments overview

### DIFF
--- a/.changeset/curly-balloons-taste.md
+++ b/.changeset/curly-balloons-taste.md
@@ -1,0 +1,5 @@
+---
+"@gram/dashboard": patch
+---
+
+fix: prevent asset names from being cut off in deployments overview

--- a/client/dashboard/src/pages/deployments/DeploymentTabs.tsx
+++ b/client/dashboard/src/pages/deployments/DeploymentTabs.tsx
@@ -832,11 +832,11 @@ export const AssetsTabContents = () => {
           return (
             <li key={asset.id}>
               <MiniCard className="w-full max-w-full bg-surface-secondary-default border-neutral-softest p-6">
-                <MiniCard.Title className="truncate max-w-48">
+                <MiniCard.Title>
                   <div className="flex gap-4 w-full items-center">
                     <FileCodeIcon size={48} strokeWidth={1} />
-                    <div className="flex flex-col">
-                      <span className="text-base leading-7">{asset.name}</span>
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="text-base leading-7 break-words">{asset.name}</span>
                       <span className="text-xs text-muted leading-5">
                         OpenAPI Document
                       </span>

--- a/client/dashboard/src/pages/deployments/DeploymentTabs.tsx
+++ b/client/dashboard/src/pages/deployments/DeploymentTabs.tsx
@@ -836,7 +836,9 @@ export const AssetsTabContents = () => {
                   <div className="flex gap-4 w-full items-center">
                     <FileCodeIcon size={48} strokeWidth={1} />
                     <div className="flex flex-col min-w-0 flex-1">
-                      <span className="text-base leading-7 break-words">{asset.name}</span>
+                      <span className="text-base leading-7 break-words">
+                        {asset.name}
+                      </span>
                       <span className="text-xs text-muted leading-5">
                         OpenAPI Document
                       </span>


### PR DESCRIPTION
## Summary
Fixes asset names being truncated in the Deployments Overview > Assets section. Names now wrap to multiple lines instead of being cut off with ellipsis.
<img width="2366" height="1080" alt="CleanShot 2025-10-07 at 08 08 44@2x" src="https://github.com/user-attachments/assets/98957862-3923-48d4-bea4-5be25f4c6f3e" />

## Changes
- Removed `truncate max-w-48` className from MiniCard.Title
- Added `min-w-0 flex-1` to text container for proper flex wrapping  
- Added `break-words` to asset name span for long name handling

## Test plan
- [ ] Navigate to Deployments Overview > Assets
- [ ] Verify asset names with long names are fully visible and wrap properly
- [ ] Verify the layout still looks good with short names

Fixes https://linear.app/speakeasy/issue/AGE-674

🤖 Generated with [Claude Code](https://claude.com/claude-code)