### PR TITLE
fix: only capture cmd-f in logs when logs section is focused

### DIFF
--- a/client/dashboard/src/pages/deployments/DeploymentTabs.tsx
+++ b/client/dashboard/src/pages/deployments/DeploymentTabs.tsx
@@ -301,24 +301,39 @@ export const LogsTabContents = () => {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Check if the logs container or its children are focused
+      const logsContainer = logsContainerRef.current;
+      const activeElement = document.activeElement;
+      const isWithinLogsSection = logsContainer?.contains(
+        activeElement as Node,
+      );
+      const isSearchInputFocused =
+        activeElement?.hasAttribute("data-search-input");
+
       if (e.key === "Escape") {
-        e.preventDefault();
-        setFocus("all");
-        setSearchQuery("");
-        setCurrentLogIndex(null);
-        const activeElement = document.activeElement as HTMLElement;
-        if (activeElement && activeElement.tagName === "INPUT") {
-          activeElement.blur();
+        // Only handle Escape if we're within the logs section
+        if (isWithinLogsSection || isSearchInputFocused) {
+          e.preventDefault();
+          setFocus("all");
+          setSearchQuery("");
+          setCurrentLogIndex(null);
+          const activeElement = document.activeElement as HTMLElement;
+          if (activeElement && activeElement.tagName === "INPUT") {
+            activeElement.blur();
+          }
         }
         return;
       }
 
       if ((e.metaKey || e.ctrlKey) && e.key === "f") {
-        e.preventDefault();
-        const searchInput = document.querySelector<HTMLInputElement>(
-          "[data-search-input]",
-        );
-        searchInput?.focus();
+        // Only capture cmd-f if the logs section is already focused
+        if (isWithinLogsSection || isSearchInputFocused) {
+          e.preventDefault();
+          const searchInput = document.querySelector<HTMLInputElement>(
+            "[data-search-input]",
+          );
+          searchInput?.focus();
+        }
         return;
       }
 
@@ -605,7 +620,8 @@ export const LogsTabContents = () => {
 
         <div
           ref={logsContainerRef}
-          className="font-mono text-xs max-h-[500px] overflow-y-auto pb-2"
+          tabIndex={0}
+          className="font-mono text-xs max-h-[500px] overflow-y-auto pb-2 focus:outline-none"
         >
           {parsedLogs.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes [AGE-677](https://linear.app/speakeasy/issue/AGE-677): Previously the cmd-f keybinding was captured globally on the Deployment Overview page, preventing users from using browser search.

## Changes

- Modified keyboard event handler to check if the logs section is focused before capturing cmd-f and Escape keys
- Made logs container focusable by adding `tabIndex={0}` 

## Behavior

- Users can now press cmd-f anywhere on the Deployment Overview page to use browser search
- When users click into the logs container or search input, cmd-f will focus the log search
- This provides an opt-in experience for the log search shortcuts while preserving native browser functionality

## Test plan

- [ ] Navigate to any deployment overview page
- [ ] Press cmd-f without clicking into the logs - browser search should appear
- [ ] Click into the logs container
- [ ] Press cmd-f - the logs search input should be focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)