### PR TITLE
chore: disable changelog from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,12 +20,10 @@ checksum:
   name_template: "checksums.txt"
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
+
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true
+
 brews:
   - name: gram
     repository:


### PR DESCRIPTION
## Description
Only make changelogs using `changsets`.

Only GitHub release changelogs are affected by this change.
## Details

Multiple versioning tags/releases are causing some confusing output. Our environment includes:
1. `pnpm changeset`
2. `TriPSs/conventional-commits`
3. `GoReleaser`

It leads to CLI releases on Github with non-related changelog (example: [0.6.0](https://github.com/speakeasy-api/gram/releases/tag/0.6.0)).

Going forward, we will leave the changelog generation `changeset`, like we do for `@gram/server`. 
