### PR TITLE
feat: temperature slider in the playground

### DIFF
--- a/.changeset/fluffy-planets-enjoy.md
+++ b/.changeset/fluffy-planets-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@gram/dashboard": minor
+---
+
+feat: temperature slider in the playground

--- a/client/dashboard/src/components/ui/slider.tsx
+++ b/client/dashboard/src/components/ui/slider.tsx
@@ -1,0 +1,56 @@
+import { cn } from "@/lib/utils";
+import { forwardRef, type InputHTMLAttributes } from "react";
+
+export interface SliderProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+const Slider = forwardRef<HTMLInputElement, SliderProps>(
+  (
+    { className, value, onChange, min = 0, max = 100, step = 1, ...props },
+    ref,
+  ) => {
+    return (
+      <input
+        type="range"
+        ref={ref}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        min={min}
+        max={max}
+        step={step}
+        className={cn(
+          "w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer",
+          "[&::-webkit-slider-thumb]:appearance-none",
+          "[&::-webkit-slider-thumb]:w-4",
+          "[&::-webkit-slider-thumb]:h-4",
+          "[&::-webkit-slider-thumb]:rounded-full",
+          "[&::-webkit-slider-thumb]:bg-foreground",
+          "[&::-webkit-slider-thumb]:cursor-pointer",
+          "[&::-webkit-slider-thumb]:hover:bg-foreground/80",
+          "[&::-webkit-slider-thumb]:transition-colors",
+          "[&::-moz-range-thumb]:w-4",
+          "[&::-moz-range-thumb]:h-4",
+          "[&::-moz-range-thumb]:rounded-full",
+          "[&::-moz-range-thumb]:bg-foreground",
+          "[&::-moz-range-thumb]:border-0",
+          "[&::-moz-range-thumb]:cursor-pointer",
+          "[&::-moz-range-thumb]:hover:bg-foreground/80",
+          "[&::-moz-range-thumb]:transition-colors",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Slider.displayName = "Slider";
+
+export { Slider };


### PR DESCRIPTION
## Summary
- Added temperature slider control in playground chat interface

<img width="1224" height="298" alt="CleanShot 2025-10-07 at 15 06 39@2x" src="https://github.com/user-attachments/assets/adadd077-5bba-4a22-8e02-819b594a4e39" />

<img width="1214" height="276" alt="CleanShot 2025-10-07 at 15 06 44@2x" src="https://github.com/user-attachments/assets/2e4b2a8c-654d-412b-9bf0-6869c4484ee0" />

## Changes
- Added new Slider UI component
- Enhanced ChatWindow with temperature control

## Test plan
- [x] Verify temperature slider works in playground
- [x] Confirm temperature values are applied to chat requests