### PR TITLE
chore: remove version display from dashboard sidebar

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -55,12 +55,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 asChild
                 className="data-[slot=sidebar-menu-button]:!p-1.5 h-12"
               >
-                <Stack direction={"horizontal"} align={"center"} gap={2}>
-                  <GramLogo className="w-25" />
-                  <Type variant="small" muted>
-                    v0.8.7 (beta)
-                  </Type>
-                </Stack>
+                <GramLogo className="w-25" />
               </SidebarMenuButton>
             </routes.home.Link>
           </SidebarMenuItem>


### PR DESCRIPTION
## Summary
Removes the "v0.8.7 (beta)" version text from the dashboard's left sidebar header.

## Changes
- Removed version display from the sidebar header in `app-sidebar.tsx`
- Logo now displays without accompanying version text

🤖 Generated with [Claude Code](https://claude.com/claude-code)