### PR TITLE
fix: ensure there is a valid container around the sidebar logo

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -51,10 +51,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarMenu>
           <SidebarMenuItem className="group/logo">
             <routes.home.Link className="hover:no-underline!">
-              <SidebarMenuButton
-                asChild
-                className="data-[slot=sidebar-menu-button]:!p-1.5 h-12"
-              >
+              <SidebarMenuButton className="data-[slot=sidebar-menu-button]:!p-1.5 h-12">
                 <GramLogo className="w-25" />
               </SidebarMenuButton>
             </routes.home.Link>


### PR DESCRIPTION
Fixes an issue which caused the logo to drop to 16 x 16

<img width="498" height="1128" alt="CleanShot 2025-10-10 at 11 56 39@2x" src="https://github.com/user-attachments/assets/f33aa8de-e182-49da-af65-8280d2f3b88e" />
