### PR TITLE
chore: move domain logic to customdomains package

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -481,7 +481,7 @@ func newStartCommand() *cli.Command {
 
 			mux.Use(middleware.CORSMiddleware(c.String("environment"), c.String("server-url")))
 			mux.Use(middleware.NewHTTPLoggingMiddleware(logger))
-			mux.Use(middleware.CustomDomainsMiddleware(logger, db, c.String("environment"), serverURL))
+			mux.Use(customdomains.Middleware(logger, db, c.String("environment"), serverURL))
 			mux.Use(middleware.SessionMiddleware)
 			mux.Use(middleware.AdminOverrideMiddleware)
 

--- a/server/internal/constants/http.go
+++ b/server/internal/constants/http.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	HeaderProxiedResponse  = "X-Gram-Proxy-Response"
+	HeaderFilteredResponse = "X-Gram-Proxy-ResponseFiltered"
+)

--- a/server/internal/customdomains/context.go
+++ b/server/internal/customdomains/context.go
@@ -1,4 +1,4 @@
-package gateway
+package customdomains
 
 import (
 	"context"
@@ -12,23 +12,23 @@ const (
 	domainKey ctxKey = iota
 )
 
-type DomainContext struct {
+type Context struct {
 	OrganizationID string
 	Domain         string
 	DomainID       uuid.UUID
 }
 
-func DomainWithContext(ctx context.Context, value *DomainContext) context.Context {
+func WithContext(ctx context.Context, value *Context) context.Context {
 	return context.WithValue(ctx, domainKey, value)
 }
 
-func DomainFromContext(ctx context.Context) *DomainContext {
+func FromContext(ctx context.Context) *Context {
 	val := ctx.Value(domainKey)
 	if val == nil {
 		return nil
 	}
 
-	domain, ok := val.(*DomainContext)
+	domain, ok := val.(*Context)
 	if !ok || domain == nil {
 		return nil
 	}

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -1,4 +1,4 @@
-package middleware
+package customdomains
 
 import (
 	"database/sql"
@@ -10,14 +10,12 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	domainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
-	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-func CustomDomainsMiddleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *url.URL) func(next http.Handler) http.Handler {
+func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *url.URL) func(next http.Handler) http.Handler {
 	domainsRepo := domainsRepo.New(db)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +70,7 @@ func CustomDomainsMiddleware(logger *slog.Logger, db *pgxpool.Pool, env string, 
 				return
 			}
 
-			ctx = gateway.DomainWithContext(ctx, &gateway.DomainContext{
+			ctx = WithContext(ctx, &Context{
 				OrganizationID: domain.OrganizationID,
 				Domain:         domain.Domain,
 				DomainID:       domain.ID,

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -37,11 +38,6 @@ type ToolCallSource string
 const (
 	ToolCallSourceDirect ToolCallSource = "direct"
 	ToolCallSourceMCP    ToolCallSource = "mcp"
-)
-
-const (
-	HeaderProxiedResponse  = "X-Gram-Proxy-Response"
-	HeaderFilteredResponse = "X-Gram-Proxy-ResponseFiltered"
 )
 
 var proxiedHeaders = []string{
@@ -536,7 +532,7 @@ func reverseProxyRequest(ctx context.Context,
 	}
 
 	span.SetAttributes(attr.HTTPResponseExternal(true))
-	w.Header().Set(HeaderProxiedResponse, "1")
+	w.Header().Set(constants.HeaderProxiedResponse, "1")
 
 	finalStatusCode := resp.StatusCode
 	if strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
@@ -573,7 +569,7 @@ func reverseProxyRequest(ctx context.Context,
 		result := handleResponseFiltering(ctx, logger, tool, responseFilter, resp)
 		if result != nil {
 			w.Header().Set("Content-Type", result.contentType)
-			w.Header().Set(HeaderFilteredResponse, "1")
+			w.Header().Set(constants.HeaderFilteredResponse, "1")
 			span.SetAttributes(attr.HTTPResponseFiltered(true))
 			finalStatusCode = result.statusCode
 			body = result.resp

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
@@ -431,11 +432,11 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, *gateway.DomainContext, error) {
+func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, *customdomains.Context, error) {
 	var toolset toolsets_repo.Toolset
 	var toolsetErr error
-	var customDomainCtx *gateway.DomainContext
-	if domainCtx := gateway.DomainFromContext(ctx); domainCtx != nil {
+	var customDomainCtx *customdomains.Context
+	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
 		toolset, toolsetErr = s.toolsetsRepo.GetToolsetByMcpSlugAndCustomDomain(ctx, toolsets_repo.GetToolsetByMcpSlugAndCustomDomainParams{
 			McpSlug:        conv.ToPGText(mcpSlug),
 			CustomDomainID: uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true},

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -33,7 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/gateway"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -377,11 +377,11 @@ func (s *Service) ServeHostedPage(w http.ResponseWriter, r *http.Request) error 
 	return nil
 }
 
-func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, *gateway.DomainContext, error) {
+func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, *customdomains.Context, error) {
 	var toolset toolsets_repo.Toolset
 	var toolsetErr error
-	var customDomainCtx *gateway.DomainContext
-	if domainCtx := gateway.DomainFromContext(ctx); domainCtx != nil {
+	var customDomainCtx *customdomains.Context
+	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
 		toolset, toolsetErr = s.toolsetRepo.GetToolsetByMcpSlugAndCustomDomain(ctx, toolsets_repo.GetToolsetByMcpSlugAndCustomDomainParams{
 			McpSlug:        conv.ToPGText(mcpSlug),
 			CustomDomainID: uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true},

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -84,12 +84,12 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 				attrs = append(attrs, attr.SlogHTTPResponseOriginalStatusCode(rw.statusCode))
 			}
 
-			proxied := conv.Default(rw.Header().Get(gateway.HeaderProxiedResponse), "0")
+			proxied := conv.Default(rw.Header().Get(constants.HeaderProxiedResponse), "0")
 			if ok, err := strconv.ParseBool(proxied); err == nil && ok {
 				attrs = append(attrs, attr.SlogHTTPResponseExternal(true))
 			}
 
-			filtered := conv.Default(rw.Header().Get(gateway.HeaderFilteredResponse), "0")
+			filtered := conv.Default(rw.Header().Get(constants.HeaderFilteredResponse), "0")
 			if ok, err := strconv.ParseBool(filtered); err == nil && ok {
 				attrs = append(attrs, attr.SlogHTTPResponseFiltered(true))
 			}

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
@@ -128,7 +129,7 @@ func Attach(mux goahttp.Muxer, service *Service) {
 
 // buildFullMcpSlug builds the full MCP slug with domain prefix
 func (s *Service) buildFullMcpSlug(ctx context.Context, mcpSlug string) string {
-	if domainCtx := gateway.DomainFromContext(ctx); domainCtx != nil {
+	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
 		return fmt.Sprintf("https://%s", domainCtx.Domain) + "/mcp/" + mcpSlug
 	}
 
@@ -136,12 +137,12 @@ func (s *Service) buildFullMcpSlug(ctx context.Context, mcpSlug string) string {
 }
 
 // loadToolsetFromMcpSlug loads a toolset from the MCP slug
-func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, *gateway.DomainContext, error) {
+func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, *customdomains.Context, error) {
 	var toolset toolsets_repo.Toolset
 	var toolsetErr error
-	var customDomainCtx *gateway.DomainContext
+	var customDomainCtx *customdomains.Context
 
-	if domainCtx := gateway.DomainFromContext(ctx); domainCtx != nil {
+	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
 		toolset, toolsetErr = s.toolsetsRepo.GetToolsetByMcpSlugAndCustomDomain(ctx, toolsets_repo.GetToolsetByMcpSlugAndCustomDomainParams{
 			McpSlug:        conv.ToPGText(mcpSlug),
 			CustomDomainID: uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true},


### PR DESCRIPTION
This change moves logic related to custom domains into the customdomains package and a couple of headers to the constants package to prevent the following import cycle in test code:

```
  internal/gateway (test)
    ↓ imports
  internal/testenv
    ↓ imports
  internal/functions
    ↓ imports
  internal/assets
    ↓ imports
  internal/middleware
    ↓ imports
  internal/gateway (customdomains.go:16, logging.go:15)
    ↓ CYCLE!
```

This cycle is found in #420 and presents a blocker for the `functions` package to depend on the `assets` package.