### PR TITLE
chore: manually bump cli version to 0.7.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@gram/cli",
-  "version": "0.4.0",
+  "version": "0.7.0",
   "private": true
 }


### PR DESCRIPTION
Previously, GoReleaser moved at a faster clip than the changeset workflow. Bring package.json up to date with what is currently published.

```bash
$ brew update && brew upgrade speakeasy-api/homebrew-tap/gram && gram —version
gram version 0.7.0 (fde5a08)
```