### PR TITLE
fix: deduplicate slashes

### DIFF
--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -355,7 +355,7 @@ export const useRoutes = (): RoutesWithGoTo => {
         }
       }
 
-      return "/" + finalParts.join("/");
+      return ("/" + finalParts.join("/")).replace(/\/+/g, "/");
     };
 
     const goTo = (...params: string[]) => {


### PR DESCRIPTION
## Description

Never redirect to a URL with duplicated slashes. Avoids this error:
```
Something went wrong:
Failed to execute 'assign' on 'Location': '//' is not a valid URL.
```

## Details

When navigating directly to `/login` on an authenticated browser, the `useSlugs` hook has not had a chance to set the `orgSlug` and `projectSlug`.
<img width="882" height="360" alt="image" src="https://github.com/user-attachments/assets/0bfe3d97-7b8c-49d1-ad24-b56b1bb94f44" />
