### PR TITLE
chore: release cli when version changes

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,9 +1,10 @@
 name: Release Gram CLI
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
+    paths:
+      - 'cli/package.json'
   workflow_dispatch:
 permissions:
   contents: write
@@ -13,7 +14,6 @@ jobs:
     # NOTE(cjea): Using Windows runner for future Chocolatey/Winget
     # compatibility.
     runs-on: windows-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Setup environment
         run: |-
@@ -22,31 +22,16 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
         with:
           fetch-depth: 0
-      - name: Check if CLI was released
-        id: check-release
-        shell: pwsh
-        run: |
-          $tag = git tag --points-at HEAD | Select-String -Pattern "^@gram/cli@"
-          if ($tag) {
-            echo "released=true" >> $env:GITHUB_OUTPUT
-            echo "CLI release tag found: $tag"
-          } else {
-            echo "released=false" >> $env:GITHUB_OUTPUT
-            echo "No CLI release tag found at HEAD"
-          }
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-        if: steps.check-release.outputs.released == 'true'
         with:
           go-version-file: "cli/go.mod"
           # Reference: https://github.com/actions/setup-go/issues/495
           cache: false
       - name: Setup Choco
-        if: steps.check-release.outputs.released == 'true'
         uses: crazy-max/ghaction-chocolatey@2526f467ccbd337d307fe179959cabbeca0bc8c0 # v3.4.0
         with:
           args: --version
       - name: Generate GitHub App Token for Gram Bot
-        if: steps.check-release.outputs.released == 'true'
         id: bot-token
         uses: actions/create-github-app-token@v2
         with:
@@ -55,7 +40,6 @@ jobs:
           owner: speakeasy-api
           repositories: gram,homebrew-tap
       - name: goreleaser
-        if: steps.check-release.outputs.released == 'true'
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser-pro


### PR DESCRIPTION
The changeset action will bump cli/package.json, and that is what indicates that the CLI should be released.

The previous setup was built on the misunderstanding that `changeset` tags head with the current release version. Really, it tags the relevant commits with their package versions. So instead of the complexity, just check to see if package.json has updated, and if so, release the CLI.