### PR TITLE
chore: cla exemption

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: 'https://github.com/speakeasyapi/gram/blob/main/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla-signatures'
-          allowlist: speakeasy-api,dependabot,renovate
+          allowlist: speakeasy-api/*,dependabot,renovate
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
Update CLA workflow to exempt all members of the speakeasy-api organization from signing the CLA by using the `speakeasy-api/*` wildcard pattern in the allowlist.