### PR TITLE
chore: refactor tool call planning code for functions

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -121,6 +121,7 @@ const (
 	SlackEventTypeKey              = attribute.Key("gram.slack.event.type")
 	SlackTeamIDKey                 = attribute.Key("gram.slack.team.id")
 	ToolCallDurationKey            = attribute.Key("gram.tool_call.duration")
+	ToolCallKindKey                = attribute.Key("gram.tool_call.kind")
 	ToolCallSourceKey              = attribute.Key("gram.tool_call.source")
 	ToolHTTPResponseContentTypeKey = attribute.Key("gram.tool.http.response.content_type")
 	ToolIDKey                      = attribute.Key("gram.tool.id")
@@ -478,6 +479,11 @@ func SlogSlackEventType(v string) slog.Attr      { return slog.String(string(Sla
 
 func SlackTeamID(v string) attribute.KeyValue { return SlackTeamIDKey.String(v) }
 func SlogSlackTeamID(v string) slog.Attr      { return slog.String(string(SlackTeamIDKey), v) }
+
+func ToolCallKind[V string](v V) attribute.KeyValue { return ToolCallKindKey.String(string(v)) }
+func SlogToolCallKind[V string](v V) slog.Attr {
+	return slog.String(string(ToolCallKindKey), string(v))
+}
 
 func ToolCallSource(v string) attribute.KeyValue { return ToolCallSourceKey.String(v) }
 func SlogToolCallSource(v string) slog.Attr      { return slog.String(string(ToolCallSourceKey), v) }

--- a/server/internal/chat/client.go
+++ b/server/internal/chat/client.go
@@ -239,11 +239,13 @@ func (c *ChatClient) LoadToolsetTools(
 		projID := projectID
 
 		executor := func(ctx context.Context, rawArgs string) (string, error) {
-			executionPlan, err := toolsetHelpers.GetToolExecutionInfoByURN(ctx, *toolURN, projID)
+			plan, err := toolsetHelpers.GetToolCallPlanByURN(ctx, *toolURN, projID)
 			if err != nil {
-				return "", fmt.Errorf("failed to get tool execution info: %w", err)
+				return "", fmt.Errorf("failed to get tool call plan: %w", err)
 			}
-			ctx, _ = o11y.EnrichToolCallContext(ctx, c.logger, executionPlan.OrganizationSlug, executionPlan.ProjectSlug)
+
+			descriptor := plan.Descriptor
+			ctx, _ = o11y.EnrichToolCallContext(ctx, c.logger, descriptor.OrganizationSlug, descriptor.ProjectSlug)
 
 			rw := &toolCallResponseWriter{
 				headers:    make(http.Header),
@@ -261,7 +263,7 @@ func (c *ChatClient) LoadToolsetTools(
 				ciEnv.Set(key, value)
 			}
 
-			err = c.toolProxy.Do(ctx, rw, bytes.NewBufferString(rawArgs), ciEnv, executionPlan.Tool)
+			err = c.toolProxy.Do(ctx, rw, bytes.NewBufferString(rawArgs), ciEnv, plan)
 			if err != nil {
 				return "", fmt.Errorf("tool proxy error: %w", err)
 			}

--- a/server/internal/gateway/filtering.go
+++ b/server/internal/gateway/filtering.go
@@ -27,8 +27,8 @@ type responseFilteringResult struct {
 	contentType string
 }
 
-func handleResponseFiltering(ctx context.Context, logger *slog.Logger, tool *HTTPTool, responseFilterRequest *ResponseFilterRequest, resp *http.Response) *responseFilteringResult {
-	if tool.ResponseFilter == nil || responseFilterRequest == nil {
+func handleResponseFiltering(ctx context.Context, logger *slog.Logger, filterConfig *ResponseFilter, responseFilterRequest *FilterRequest, resp *http.Response) *responseFilteringResult {
+	if responseFilterRequest == nil || filterConfig == nil || filterConfig.Type == FilterTypeNone {
 		return nil
 	}
 
@@ -44,7 +44,7 @@ func handleResponseFiltering(ctx context.Context, logger *slog.Logger, tool *HTT
 		return nil
 	}
 
-	if !slices.Contains(tool.ResponseFilter.ContentTypes, mediaType) || !slices.Contains(tool.ResponseFilter.StatusCodes, fmt.Sprintf("%d", statusCode)) {
+	if !slices.Contains(filterConfig.ContentTypes, mediaType) || !slices.Contains(filterConfig.StatusCodes, fmt.Sprintf("%d", statusCode)) {
 		return nil
 	}
 

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -50,19 +50,19 @@ var proxiedHeaders = []string{
 	"Pragma",
 }
 
-type ResponseFilterRequest struct {
+type FilterRequest struct {
 	Type   string `json:"type"`
 	Filter string `json:"filter"`
 }
 
 type ToolCallBody struct {
-	PathParameters       map[string]any         `json:"pathParameters"`
-	QueryParameters      map[string]any         `json:"queryParameters"`
-	HeaderParameters     map[string]any         `json:"headerParameters"`
-	Body                 json.RawMessage        `json:"body"`
-	ResponseFilter       *ResponseFilterRequest `json:"responseFilter"`
-	EnvironmentVariables map[string]string      `json:"environmentVariables"`
-	GramRequestSummary   string                 `json:"gram-request-summary"`
+	PathParameters       map[string]any    `json:"pathParameters"`
+	QueryParameters      map[string]any    `json:"queryParameters"`
+	HeaderParameters     map[string]any    `json:"headerParameters"`
+	Body                 json.RawMessage   `json:"body"`
+	ResponseFilter       *FilterRequest    `json:"responseFilter"`
+	EnvironmentVariables map[string]string `json:"environmentVariables"`
+	GramRequestSummary   string            `json:"gram-request-summary"`
 }
 
 // CaseInsensitiveEnv provides case-insensitive environment variable lookup.
@@ -127,52 +127,90 @@ func NewToolProxy(
 	}
 }
 
-func (itp *ToolProxy) Do(
+func (tp *ToolProxy) Do(
 	ctx context.Context,
 	w http.ResponseWriter,
 	requestBody io.Reader,
 	env *CaseInsensitiveEnv,
-	gatewayTool *Tool,
-) error {
-	if !gatewayTool.IsHTTP() {
-		return fmt.Errorf("tool type not supported: %s", gatewayTool.Kind())
-	}
-
-	tool := gatewayTool.HTTPTool
-
-	ctx, span := itp.tracer.Start(ctx, "proxyToolCall", trace.WithAttributes(
-		attr.ToolName(tool.Name),
-		attr.ToolID(tool.ID),
-		attr.ProjectID(tool.ProjectID),
-		attr.DeploymentID(tool.DeploymentID),
-		attr.ToolCallSource(string(itp.source)),
-		attr.HTTPRoute(tool.Path), // this is just from the raw OpenAPI spec. It is not a path with any parameters filled in, so not identifiable.
+	plan *ToolCallPlan,
+) (err error) {
+	ctx, span := tp.tracer.Start(ctx, "gateway.toolCall", trace.WithAttributes(
+		attr.ToolName(plan.Descriptor.Name),
+		attr.ToolID(plan.Descriptor.ID),
+		attr.ProjectID(plan.Descriptor.ProjectID),
+		attr.DeploymentID(plan.Descriptor.DeploymentID),
+		attr.ToolCallSource(string(tp.source)),
 	))
-	defer span.End()
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
 
-	logger := itp.logger.With(
-		attr.SlogProjectID(tool.ProjectID),
-		attr.SlogDeploymentID(tool.DeploymentID),
-		attr.SlogToolID(tool.ID),
-		attr.SlogToolName(tool.Name),
-		attr.SlogToolCallSource(string(itp.source)),
-		attr.SlogHTTPRoute(tool.Path), // this is just from the raw OpenAPI spec. It is not a path with any parameters filled in, so not identifiable.
+	logger := tp.logger.With(
+		attr.SlogProjectID(plan.Descriptor.ProjectID),
+		attr.SlogDeploymentID(plan.Descriptor.DeploymentID),
+		attr.SlogToolID(plan.Descriptor.ID),
+		attr.SlogToolName(plan.Descriptor.Name),
+		attr.SlogToolCallSource(string(tp.source)),
 	)
 
 	if env == nil {
 		env = NewCaseInsensitiveEnv()
 	}
 
+	switch plan.Kind {
+	case "":
+		return oops.E(oops.CodeInvariantViolation, nil, "tool kind is not set").Log(ctx, tp.logger)
+	case ToolKindFunction:
+		return tp.doFunction(ctx, logger, w, requestBody, env, plan.Descriptor, plan.Function)
+	case ToolKindHTTP:
+		return tp.doHTTP(ctx, logger, w, requestBody, env, plan.Descriptor, plan.HTTP)
+	default:
+		return fmt.Errorf("tool type not supported: %s", plan.Kind)
+	}
+}
+
+func (tp *ToolProxy) doFunction(
+	ctx context.Context,
+	logger *slog.Logger,
+	w http.ResponseWriter,
+	requestBody io.Reader,
+	env *CaseInsensitiveEnv,
+	descriptor *ToolDescriptor,
+	plan *FunctionToolCallPlan,
+) error {
+	return oops.E(oops.CodeNotImplemented, nil, "function tool calls are not implemented yet").Log(ctx, logger)
+}
+
+func (tp *ToolProxy) doHTTP(
+	ctx context.Context,
+	logger *slog.Logger,
+	w http.ResponseWriter,
+	requestBody io.Reader,
+	env *CaseInsensitiveEnv,
+	descriptor *ToolDescriptor,
+	plan *HTTPToolCallPlan,
+) error {
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attr.HTTPRoute(plan.Path), // this is just from the raw OpenAPI spec. It is not a path with any parameters filled in, so not identifiable.
+	)
+	logger = logger.With(
+		attr.SlogHTTPRoute(plan.Path), // this is just from the raw OpenAPI spec. It is not a path with any parameters filled in, so not identifiable.
+	)
+
 	// Variable to capture status code for metrics
 	var responseStatusCode int
 	defer func() {
-		logger.InfoContext(ctx, "tool call",
+		logger.InfoContext(ctx, "http tool call",
 			attr.SlogHTTPResponseStatusCode(responseStatusCode),
-			attr.SlogHTTPRequestMethod(tool.Method),
-			attr.SlogHTTPResponseHeaderContentType(tool.RequestContentType.Value),
+			attr.SlogHTTPRequestMethod(plan.Method),
+			attr.SlogHTTPResponseHeaderContentType(plan.RequestContentType.Value),
 		)
 		// Record metrics for the tool call, some cardinality is introduced with org and tool name we will keep an eye on it
-		itp.metrics.RecordHTTPToolCall(ctx, tool.OrganizationID, tool.Name, responseStatusCode)
+		tp.metrics.RecordHTTPToolCall(ctx, descriptor.OrganizationID, descriptor.Name, responseStatusCode)
 
 		span.SetAttributes(attr.HTTPResponseStatusCode(responseStatusCode))
 	}()
@@ -191,8 +229,8 @@ func (itp *ToolProxy) Do(
 		return oops.E(oops.CodeBadRequest, err, "invalid request body").Log(ctx, logger)
 	}
 
-	if len(tool.Schema) > 0 {
-		bodyBytes, err = validateAndAttemptHealing(ctx, logger, bodyBytes, string(tool.Schema))
+	if len(plan.Schema) > 0 {
+		bodyBytes, err = validateAndAttemptHealing(ctx, logger, bodyBytes, string(plan.Schema))
 
 		// Extract the body field from healed bodyBytes
 		var healedToolCallBody ToolCallBody
@@ -223,11 +261,11 @@ func (itp *ToolProxy) Do(
 	}
 
 	// Handle path parameters
-	requestPath := tool.Path
+	requestPath := plan.Path
 	if toolCallBody.PathParameters != nil {
 		pathParams := make(map[string]string)
 		for name, value := range toolCallBody.PathParameters {
-			param := tool.PathParams[name]
+			param := plan.PathParams[name]
 			var settings *serialization.HTTPParameter
 			if param == nil {
 				logger.WarnContext(ctx, "no parameter settings found for path parameter", attr.SlogHTTPParamName(name))
@@ -257,16 +295,16 @@ func (itp *ToolProxy) Do(
 
 	// Get the server URL from the tool definition
 	var serverURL string
-	if tool.DefaultServerUrl.Valid {
-		serverURL = tool.DefaultServerUrl.Value
+	if plan.DefaultServerUrl.Valid {
+		serverURL = plan.DefaultServerUrl.Value
 	}
 
-	if envServerURL := processServerEnvVars(ctx, logger, tool, env); envServerURL != "" {
+	if envServerURL := processServerEnvVars(ctx, logger, plan, env); envServerURL != "" {
 		serverURL = envServerURL
 	}
 
 	if serverURL == "" {
-		logger.ErrorContext(ctx, "no server URL provided for tool", attr.SlogToolName(tool.Name))
+		logger.ErrorContext(ctx, "no server URL provided for tool", attr.SlogToolName(descriptor.Name))
 		return oops.E(oops.CodeInvalid, nil, "no server URL provided for tool").Log(ctx, logger)
 	}
 
@@ -282,7 +320,7 @@ func (itp *ToolProxy) Do(
 	}
 
 	var req *http.Request
-	if strings.HasPrefix(tool.RequestContentType.Value, "application/x-www-form-urlencoded") {
+	if strings.HasPrefix(plan.RequestContentType.Value, "application/x-www-form-urlencoded") {
 		encoded := ""
 		if len(toolCallBody.Body) > 0 {
 			// Assume toolCallBody.Body is a JSON object (map[string]interface{})
@@ -298,33 +336,33 @@ func (itp *ToolProxy) Do(
 		}
 		req, err = http.NewRequestWithContext(
 			ctx,
-			tool.Method,
+			plan.Method,
 			fullURL,
 			strings.NewReader(encoded),
 		)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to build url-encoded request").Log(ctx, logger)
 		}
-		req.Header.Set("Content-Type", tool.RequestContentType.Value)
+		req.Header.Set("Content-Type", plan.RequestContentType.Value)
 	} else {
 		req, err = http.NewRequestWithContext(
 			ctx,
-			tool.Method,
+			plan.Method,
 			fullURL,
 			bytes.NewReader(toolCallBody.Body),
 		)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to build json request").Log(ctx, logger)
 		}
-		if tool.RequestContentType.Value != "" {
-			req.Header.Set("Content-Type", tool.RequestContentType.Value)
+		if plan.RequestContentType.Value != "" {
+			req.Header.Set("Content-Type", plan.RequestContentType.Value)
 		}
 	}
 
 	if toolCallBody.QueryParameters != nil {
 		values := url.Values{}
 		for name, value := range toolCallBody.QueryParameters {
-			param := tool.QueryParams[name]
+			param := plan.QueryParams[name]
 			var settings *serialization.HTTPParameter
 			if param == nil {
 				logger.WarnContext(ctx, "no parameter settings found for query parameter", attr.SlogHTTPParamName(name))
@@ -354,7 +392,7 @@ func (itp *ToolProxy) Do(
 	// Handle header parameters (non security schemes)
 	if toolCallBody.HeaderParameters != nil {
 		for name, value := range toolCallBody.HeaderParameters {
-			param := tool.HeaderParams[name]
+			param := plan.HeaderParams[name]
 			var settings *serialization.HTTPParameter
 			if param == nil {
 				logger.WarnContext(ctx, "no parameter settings found for header parameter", attr.SlogHTTPParamName(name))
@@ -376,14 +414,25 @@ func (itp *ToolProxy) Do(
 		}
 	}
 
-	shouldContinue := processSecurity(ctx, logger, req, w, &responseStatusCode, tool, itp.cache, env, serverURL)
+	shouldContinue := processSecurity(ctx, logger, req, w, &responseStatusCode, descriptor, plan, tp.cache, env, serverURL)
 	if !shouldContinue {
 		return nil
 	}
 
 	req.Header.Set("X-Gram-Proxy", "1")
 
-	return reverseProxyRequest(ctx, logger, itp.tracer, tool, toolCallBody.ResponseFilter, w, req, itp.policy, &responseStatusCode)
+	return reverseProxyRequest(
+		ctx,
+		logger,
+		tp.tracer,
+		w,
+		req,
+		descriptor,
+		toolCallBody.ResponseFilter,
+		plan.ResponseFilter,
+		tp.policy,
+		&responseStatusCode,
+	)
 }
 
 type retryConfig struct {
@@ -441,13 +490,15 @@ func retryWithBackoff(
 	return resp, err
 }
 
-func reverseProxyRequest(ctx context.Context,
+func reverseProxyRequest(
+	ctx context.Context,
 	logger *slog.Logger,
 	tracer trace.Tracer,
-	tool *HTTPTool,
-	responseFilter *ResponseFilterRequest,
 	w http.ResponseWriter,
 	req *http.Request,
+	tool *ToolDescriptor,
+	expression *FilterRequest,
+	filterConfig *ResponseFilter,
 	policy *guardian.Policy,
 	responseStatusCodeCapture *int,
 ) error {
@@ -575,7 +626,7 @@ func reverseProxyRequest(ctx context.Context,
 	} else {
 		var body io.Reader = resp.Body
 
-		result := handleResponseFiltering(ctx, logger, tool, responseFilter, resp)
+		result := handleResponseFiltering(ctx, logger, filterConfig, expression, resp)
 		if result != nil {
 			w.Header().Set("Content-Type", result.contentType)
 			w.Header().Set(constants.HeaderFilteredResponse, "1")
@@ -598,7 +649,7 @@ func reverseProxyRequest(ctx context.Context,
 	return nil
 }
 
-func processServerEnvVars(ctx context.Context, logger *slog.Logger, tool *HTTPTool, envVars *CaseInsensitiveEnv) string {
+func processServerEnvVars(ctx context.Context, logger *slog.Logger, tool *HTTPToolCallPlan, envVars *CaseInsensitiveEnv) string {
 	if tool.ServerEnvVar != "" {
 		envVar := envVars.Get(tool.ServerEnvVar)
 		if envVar != "" {

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -270,11 +270,13 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
-	executionInfo, err := s.toolset.GetToolExecutionInfoByID(ctx, uuid.MustParse(toolID), *authCtx.ProjectID)
+	plan, err := s.toolset.GetToolCallPlanByID(ctx, uuid.MustParse(toolID), *authCtx.ProjectID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to load tool execution info").Log(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to load tool call plan").Log(ctx, logger)
 	}
-	ctx, logger = o11y.EnrichToolCallContext(ctx, logger, executionInfo.OrganizationSlug, executionInfo.ProjectSlug)
+
+	descriptor := plan.Descriptor
+	ctx, logger = o11y.EnrichToolCallContext(ctx, logger, descriptor.OrganizationSlug, descriptor.ProjectSlug)
 
 	var toolset *types.Toolset
 	if chatID != "" && toolsetSlug != "" {
@@ -297,7 +299,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 
 	interceptor := newResponseInterceptor(w)
 
-	err = s.toolProxy.Do(ctx, interceptor, requestBody, ciEnv, executionInfo.Tool)
+	err = s.toolProxy.Do(ctx, interceptor, requestBody, ciEnv, plan)
 	if err != nil {
 		return fmt.Errorf("failed to proxy tool call: %w", err)
 	}
@@ -331,13 +333,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 	if toolset != nil {
 		toolsetID = &toolset.ID
 	}
-	toolName := ""
-	switch executionInfo.Tool.Kind() {
-	case gateway.ToolKindHTTP:
-		toolName = executionInfo.Tool.HTTPTool.Name
-	case gateway.ToolKindFunction:
-		toolName = executionInfo.Tool.FunctionTool.Name
-	}
+	toolName := descriptor.Name
 	go s.tracking.TrackToolCallUsage(context.WithoutCancel(ctx), billing.ToolCallUsageEvent{
 		OrganizationID:   organizationID,
 		RequestBytes:     requestNumBytes,
@@ -347,7 +343,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 		ProjectID:        authCtx.ProjectID.String(),
 		ProjectSlug:      authCtx.ProjectSlug,
 		Type:             billing.ToolCallTypeHTTP,
-		OrganizationSlug: &executionInfo.OrganizationSlug,
+		OrganizationSlug: &descriptor.OrganizationSlug,
 		ToolsetSlug:      &toolsetSlug,
 		ChatID:           &chatID,
 		ToolsetID:        toolsetID,

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -15,6 +15,7 @@ const (
 	CodeUnexpected         Code = "unexpected"
 	CodeInvariantViolation Code = "invariant_violation"
 	CodeGatewayError       Code = "gateway_error"
+	CodeNotImplemented     Code = "not_implemented"
 )
 
 var StatusCodes = map[Code]int{
@@ -28,6 +29,7 @@ var StatusCodes = map[Code]int{
 	CodeUnexpected:         http.StatusInternalServerError,
 	CodeInvariantViolation: http.StatusUnprocessableEntity,
 	CodeGatewayError:       http.StatusBadGateway,
+	CodeNotImplemented:     http.StatusNotImplemented,
 }
 
 func (c Code) UserMessage() string {
@@ -46,6 +48,8 @@ func (c Code) UserMessage() string {
 		return "unsupported media type"
 	case CodeInvalid:
 		return "request contains one or more invalidation fields"
+	case CodeNotImplemented:
+		return "requested feature is not implemented"
 	default:
 		return "an unexpected error occurred"
 	}

--- a/server/internal/toolsets/shared.go
+++ b/server/internal/toolsets/shared.go
@@ -32,13 +32,7 @@ func NewToolsets(tx repo.DBTX) *Toolsets {
 	}
 }
 
-type ToolExecutionInfo struct {
-	Tool             *gateway.Tool
-	OrganizationSlug string
-	ProjectSlug      string
-}
-
-func (t *Toolsets) GetToolExecutionInfoByURN(ctx context.Context, toolUrn urn.Tool, projectID uuid.UUID) (*ToolExecutionInfo, error) {
+func (t *Toolsets) GetToolCallPlanByURN(ctx context.Context, toolUrn urn.Tool, projectID uuid.UUID) (*gateway.ToolCallPlan, error) {
 	switch toolUrn.Kind {
 	case urn.ToolKindHTTP:
 		tool, err := t.toolsRepo.GetHTTPToolDefinitionByURN(ctx, toolsRepo.GetHTTPToolDefinitionByURNParams{
@@ -48,7 +42,7 @@ func (t *Toolsets) GetToolExecutionInfoByURN(ctx context.Context, toolUrn urn.To
 		if err != nil {
 			return nil, fmt.Errorf("get http tool definition by urn: %w", err)
 		}
-		return t.extractHTTPToolExecutionInfo(ctx, tool)
+		return t.extractHTTPToolCallPlan(ctx, tool)
 
 	case urn.ToolKindFunction:
 		tool, err := t.toolsRepo.GetFunctionToolDefinitionByURN(ctx, toolsRepo.GetFunctionToolDefinitionByURNParams{
@@ -58,7 +52,7 @@ func (t *Toolsets) GetToolExecutionInfoByURN(ctx context.Context, toolUrn urn.To
 		if err != nil {
 			return nil, fmt.Errorf("get function tool definition by urn: %w", err)
 		}
-		return t.extractFunctionToolExecutionInfo(ctx, tool)
+		return t.extractFunctionToolCallPlan(ctx, tool)
 
 	default:
 		return nil, fmt.Errorf("unsupported tool kind: %s", toolUrn.Kind)
@@ -66,7 +60,7 @@ func (t *Toolsets) GetToolExecutionInfoByURN(ctx context.Context, toolUrn urn.To
 }
 
 // TODO: should we consider moving /rpc/instances.invoke/tool onto URNs, only the playground uses it right now.
-func (t *Toolsets) GetToolExecutionInfoByID(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (*ToolExecutionInfo, error) {
+func (t *Toolsets) GetToolCallPlanByID(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (*gateway.ToolCallPlan, error) {
 	toolUrnStr, err := t.toolsRepo.GetToolUrnByID(ctx, toolsRepo.GetToolUrnByIDParams{
 		ProjectID: projectID,
 		ID:        id,
@@ -81,10 +75,10 @@ func (t *Toolsets) GetToolExecutionInfoByID(ctx context.Context, id uuid.UUID, p
 		return nil, fmt.Errorf("unmarshal tool urn: %w", err)
 	}
 
-	return t.GetToolExecutionInfoByURN(ctx, toolURN, projectID)
+	return t.GetToolCallPlanByURN(ctx, toolURN, projectID)
 }
 
-func (t *Toolsets) extractHTTPToolExecutionInfo(ctx context.Context, tool toolsRepo.HttpToolDefinition) (*ToolExecutionInfo, error) {
+func (t *Toolsets) extractHTTPToolCallPlan(ctx context.Context, tool toolsRepo.HttpToolDefinition) (*gateway.ToolCallPlan, error) {
 	securityKeysMap := make(map[string]bool)
 	securityKeys, securityScopes, err := security.ParseHTTPToolSecurityKeys(tool.Security)
 	if err != nil {
@@ -151,12 +145,17 @@ func (t *Toolsets) extractHTTPToolExecutionInfo(ctx context.Context, tool toolsR
 		return nil, fmt.Errorf("parse path settings: %w", err)
 	}
 
-	gatewayTool := &gateway.HTTPTool{
-		ID:                 tool.ID.String(),
-		DeploymentID:       tool.DeploymentID.String(),
-		ProjectID:          tool.ProjectID.String(),
-		OrganizationID:     orgData.ID,
-		Name:               tool.Name,
+	descriptor := &gateway.ToolDescriptor{
+		ID:               tool.ID.String(),
+		URN:              tool.ToolUrn,
+		DeploymentID:     tool.DeploymentID.String(),
+		ProjectID:        tool.ProjectID.String(),
+		ProjectSlug:      orgData.ProjectSlug,
+		OrganizationID:   orgData.ID,
+		OrganizationSlug: orgData.Slug,
+		Name:             tool.Name,
+	}
+	plan := &gateway.HTTPToolCallPlan{
 		DefaultServerUrl:   gateway.NullString{Valid: tool.DefaultServerUrl.Valid, Value: tool.DefaultServerUrl.String},
 		ServerEnvVar:       tool.ServerEnvVar,
 		Method:             tool.HttpMethod,
@@ -171,36 +170,33 @@ func (t *Toolsets) extractHTTPToolExecutionInfo(ctx context.Context, tool toolsR
 		ResponseFilter:     filter,
 	}
 
-	return &ToolExecutionInfo{
-		Tool:             gateway.NewHTTPTool(gatewayTool),
-		OrganizationSlug: orgData.Slug,
-		ProjectSlug:      orgData.ProjectSlug,
-	}, nil
+	return gateway.NewHTTPToolCallPlan(descriptor, plan), nil
 }
 
-func (t *Toolsets) extractFunctionToolExecutionInfo(ctx context.Context, tool toolsRepo.FunctionToolDefinition) (*ToolExecutionInfo, error) {
+func (t *Toolsets) extractFunctionToolCallPlan(ctx context.Context, tool toolsRepo.FunctionToolDefinition) (*gateway.ToolCallPlan, error) {
 	orgData, err := t.projects.GetProjectWithOrganizationMetadata(ctx, tool.ProjectID)
 	if err != nil {
 		return nil, fmt.Errorf("get project with organization metadata: %w", err)
 	}
 
-	gatewayTool := &gateway.FunctionTool{
-		ID:             tool.ID.String(),
-		DeploymentID:   tool.DeploymentID.String(),
-		ProjectID:      tool.ProjectID.String(),
-		OrganizationID: orgData.ID,
-		FunctionID:     tool.FunctionID.String(),
-		Name:           tool.Name,
-		Runtime:        tool.Runtime,
-		InputSchema:    tool.InputSchema,
-		Variables:      tool.Variables,
+	descriptor := &gateway.ToolDescriptor{
+		ID:               tool.ID.String(),
+		URN:              tool.ToolUrn,
+		DeploymentID:     tool.DeploymentID.String(),
+		ProjectID:        tool.ProjectID.String(),
+		ProjectSlug:      orgData.Slug,
+		OrganizationID:   orgData.ID,
+		OrganizationSlug: orgData.Slug,
+		Name:             tool.Name,
+	}
+	plan := &gateway.FunctionToolCallPlan{
+		FunctionID:  tool.FunctionID.String(),
+		Runtime:     tool.Runtime,
+		InputSchema: tool.InputSchema,
+		Variables:   tool.Variables,
 	}
 
-	return &ToolExecutionInfo{
-		Tool:             gateway.NewFunctionTool(gatewayTool),
-		OrganizationSlug: orgData.Slug,
-		ProjectSlug:      orgData.ProjectSlug,
-	}, nil
+	return gateway.NewFunctionToolCallPlan(descriptor, plan), nil
 }
 
 func UnmarshalParameterSettings(settings []byte) (map[string]*gateway.HTTPParameter, error) {


### PR DESCRIPTION
This change refactors the logic used to build tool call plans for the gateway proxy to make room for the upcoming Gram Functions tools. Namely, we factor out the shared descriptors for both http and function tools and updating call sites that construct and consume the call plans.