### PR TITLE
chore: add security notice about environment inheritance in functions runner

### DIFF
--- a/functions/internal/runner/handle_tool_call.go
+++ b/functions/internal/runner/handle_tool_call.go
@@ -84,7 +84,17 @@ func (s *Service) callTool(ctx context.Context, payload CallToolPayload, w http.
 	cmd.Dir = s.workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	// 🚨🚨🚨🚨🚨
+	// <NOTICE>
+	// YOU MUST ALWAYS SET CMD.ENV TO A NON-NIL VALUE SO THE PROCESS DOES NOT
+	// INHERIT THE PARENT PROCESS'S ENVIRONMENT.
+	// 🚨🚨🚨🚨🚨
 	cmd.Env = make([]string, 0, len(payload.Environment))
+	// 🚨🚨🚨🚨🚨
+	// </NOTICE>
+	// 🚨🚨🚨🚨🚨
+
 	for key, value := range payload.Environment {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}


### PR DESCRIPTION
This change adds a clear notice to always initialize (*exec.Cmd).Env in Gram Functions runner so sub-processes do not inherit parent process environment which contains sensitive data such as the auth secret.