### PR TITLE
chore: make runtime types constants with helpers

### DIFF
--- a/server/internal/functions/runtimes.go
+++ b/server/internal/functions/runtimes.go
@@ -1,27 +1,45 @@
 package functions
 
 import (
+	"fmt"
 	"maps"
 	"slices"
-	"strings"
 )
 
-type Runtimes map[string]struct{}
+type Runtime string
+
+const (
+	RuntimeNodeJS22  Runtime = "nodejs:22"
+	RuntimePython312 Runtime = "python:3.12"
+)
+
+func (r Runtime) OCITag() string {
+	switch r {
+	case RuntimeNodeJS22:
+		return "nodejs22"
+	case RuntimePython312:
+		return "python3.12"
+	default:
+		return ""
+	}
+}
+
+type Runtimes map[Runtime]struct{}
 
 func (r Runtimes) String() string {
-	return strings.Join(slices.Sorted(maps.Keys(supportedRuntimes)), ", ")
+	return fmt.Sprintf("%v", slices.Sorted(maps.Keys(supportedRuntimes)))
 }
 
 func SupportedRuntimes() Runtimes {
 	return Runtimes{
-		"nodejs:22":   {},
-		"python:3.12": {},
+		RuntimeNodeJS22:  {},
+		RuntimePython312: {},
 	}
 }
 
 var supportedRuntimes = SupportedRuntimes()
 
 func IsSupportedRuntime(runtime string) bool {
-	_, ok := supportedRuntimes[runtime]
+	_, ok := supportedRuntimes[Runtime(runtime)]
 	return ok
 }


### PR DESCRIPTION
This change declares Gram Functions runtimes as constants in the codebase and adds useful helper functions used later on to provision runners.