### PR TITLE
chore: force git tag

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           $version = (Get-Content cli/package.json | ConvertFrom-Json).version
           $tag = "@gram/cli@$version"
-          git tag $tag
+          git tag -f $tag
           Write-Host "Created local tag $tag"
       - name: goreleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
GoReleaser expects `HEAD` to contain the `@gram/cli` version tag. However, tags from `changeset` are attached to feature commits, not to the version bump that’s currently being committed.

This has no effect on external users, who just want to install the package and start using it. The net effect is that git tags for CLI versions point at the actual version bump PR, and not to the feature commit. 

In case a tag is already correctly on HEAD, do not fail the workflow run. Motivating example: https://github.com/speakeasy-api/gram/actions/runs/18475187444/job/52637961127

1. I manually pushed a tag
2. Triggered CLI release
3. “Tag already exists” error