### PR TITLE
chore: disable publishing of docs to npm

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,10 @@
   "name": "@gram/docs",
   "type": "module",
   "version": "0.0.1",
+  "private": true,
+  "publishConfig": {
+    "access": "restricted"
+  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
This was causing the release workflow in CI to fail because we were attempting to publish the docs package to npm registry.