### PR TITLE
chore: upgrade pnpm to 10.18.2 and node to 24.10.0

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@10.18.2",
   "devDependencies": {
     "@types/node": "^22.13.17",
     "msw": "^2.11.3",

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,6 @@
 # well as overriding environment variables.
 [tools]
 "aqua:ariga/atlas" = "0.34.0"
-"aqua:pnpm/pnpm" = "10.8.1"
 "aqua:pvolok/mprocs" = "0.7.2"
 "ubi:sbdchd/squawk" = "1.6.1"
 "ubi:speakeasy-api/speakeasy" = "1.606.9"
@@ -15,11 +14,12 @@ apko = "0.30.13"
 flyctl = "0.3.189"
 go = "1.25.0"
 golangci-lint = "2.4.0"
+gum = "0.16.0"
 jq = "1.7.1"
 melange = "0.30.6"
-nodejs = "22.14.0"
+nodejs = "24.10.0"
+pnpm = "10.18.2"
 watchexec = "2.3.0"
-gum = "0.16.0"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.14.0",
+  "packageManager": "pnpm@10.18.2",
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
     "@datadog/datadog-ci": "^3.20.0",

--- a/server/package.json
+++ b/server/package.json
@@ -10,5 +10,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.14.0"
+  "packageManager": "pnpm@10.18.2"
 }


### PR DESCRIPTION
This change upgrades pnpm and node.js versions used for local development.