### PR TITLE
chore: sync docs from marketing

### DIFF
--- a/docs/src/content/docs/clients/using-chatgpt-developer-mode-with-gram.mdx
+++ b/docs/src/content/docs/clients/using-chatgpt-developer-mode-with-gram.mdx
@@ -15,7 +15,7 @@ When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 
 ![Screenshot showing Acme To-Do in ChatGPT preview](/img/guides/chatgpt/acme-todo-in-chatgpt-preview.png)
 
-This guide walks you through connecting ChatGPT to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using the example Acme To-Do API. You'll learn to set up the connection, configure the custom connector, and test it with natural language prompts for managing your to-dos.
+This guide walks you through connecting ChatGPT to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using the example Acme To-Do API. You'll learn to set up the connection, configure the custom connector, and test it with natural language prompts for managing your to-dos.
 
 We'll use the Acme To-Do API as our example. It's a simple Python Flask REST API for managing to-do list items. You can find the complete OpenAPI document here: [`acmetodo.yaml`](https://github.com/ritza-co/acme-todo/blob/main/acmetodo.yaml).
 
@@ -29,7 +29,7 @@ To follow this tutorial, you need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram-hosted MCP server configured, skip to the section on [connecting ChatGPT to your Gram-hosted MCP server](#connecting-chatgpt-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](/blog/gram-concepts).
+If you already have a Gram-hosted MCP server configured, skip to the section on [connecting ChatGPT to your Gram-hosted MCP server](#connecting-chatgpt-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts).
 
 ## Setting up a Gram project
 

--- a/docs/src/content/docs/clients/using-claude-code-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-claude-code-with-gram-mcp-servers.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, Claude Code becomes even more useful. Using MCP servers, you can give Claude access to your tools and infrastructure, allowing it to work with your APIs, databases, and other services.
 
-This guide shows you how to connect Claude Code to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Claude Code to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Claude Code.
 

--- a/docs/src/content/docs/clients/using-claude-desktop-with-gram-mcp-server.mdx
+++ b/docs/src/content/docs/clients/using-claude-desktop-with-gram-mcp-server.mdx
@@ -9,7 +9,7 @@ Claude Desktop is Anthropic's standalone AI assistant application that supports 
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, Claude Desktop becomes even more powerful. Using MCP servers, you can give Claude access to your tools and infrastructure, allowing it to work with your APIs, databases, and other services.
 
-This guide shows you how to connect Claude Desktop to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Claude Desktop to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Claude Desktop.
 

--- a/docs/src/content/docs/clients/using-cline-with-gram-mcp-server.mdx
+++ b/docs/src/content/docs/clients/using-cline-with-gram-mcp-server.mdx
@@ -9,7 +9,7 @@ Cline is a [VS Code extension](https://marketplace.visualstudio.com/items?itemNa
 
 When paired with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, you can connect Cline to your APIs, databases, and infrastructure services, granting it contextual access to your tools and data.
 
-This guide shows you how to connect Cline to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Cline to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Cline.
 

--- a/docs/src/content/docs/clients/using-gemini-cli-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-gemini-cli-with-gram-mcp-servers.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, Gemini CLI becomes even more useful. Using MCP servers, you can give Gemini access to your tools and infrastructure, allowing it to work with your APIs, databases, and other services through built-in MCP support.
 
-This guide shows you how to connect Gemini CLI to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Gemini CLI to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Gemini CLI.
 

--- a/docs/src/content/docs/clients/using-mistral-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-mistral-with-gram-mcp-servers.mdx
@@ -11,7 +11,7 @@ When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 
 ![Screenshot showing Acme Todo in Mistral preview](/img/guides/mistral/acme-todo-in-mistral-preview.png)
 
-This guide will walk you through connecting Mistral to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using the example Acme Todo API. You'll learn how to set up the connection, configure the custom connector, and test it with natural language prompts to manage your todos.
+This guide will walk you through connecting Mistral to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using the example Acme Todo API. You'll learn how to set up the connection, configure the custom connector, and test it with natural language prompts to manage your todos.
 
 We'll use the Acme Todo API as our example, it's a simple Python Flask REST API for managing todo items. You can find the complete OpenAPI specification here: [`acmetodo.yaml`](https://github.com/ritza-co/acme-todo/blob/main/acmetodo.yaml).
 
@@ -25,7 +25,7 @@ You'll need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram-hosted MCP server configured, you can skip to [connecting Mistral to your Gram-hosted MCP server](#connecting-mistral-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](/blog/gram-concepts).
+If you already have a Gram-hosted MCP server configured, you can skip to [connecting Mistral to your Gram-hosted MCP server](#connecting-mistral-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts).
 
 ### Setting up a Gram project
 

--- a/docs/src/content/docs/clients/using-n8n-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-n8n-with-gram-mcp-servers.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, n8n can leverage AI agents that have access to your tools and infrastructure, enabling intelligent automation workflows that can interact with your APIs, databases, and other services.
 
-This guide will show you how to connect n8n to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using the example Push Advisor API from the [Gram concepts guide](/blog/gram-concepts). You'll learn how to set up the connection, test it, and use natural language to perform vibe checks before running automated deployments.
+This guide will show you how to connect n8n to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using the example Push Advisor API from the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts). You'll learn how to set up the connection, test it, and use natural language to perform vibe checks before running automated deployments.
 
 Find the full code and OpenAPI document in the [Push Advisor API repository](https://github.com/ritza-co/gram-examples/tree/main/push-advisor-api).
 
@@ -23,7 +23,7 @@ To follow this tutorial, you need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram MCP server configured, you can skip to [connecting n8n to your Gram-hosted MCP server](#connecting-n8n-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on how to create a Gram-hosted MCP server, check out the [Gram concepts guide](/blog/gram-concepts).
+If you already have a Gram MCP server configured, you can skip to [connecting n8n to your Gram-hosted MCP server](#connecting-n8n-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on how to create a Gram-hosted MCP server, check out the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts).
 
 ### Setting up a Gram project
 

--- a/docs/src/content/docs/clients/using-roo-code-with-gram-mcp-server.mdx
+++ b/docs/src/content/docs/clients/using-roo-code-with-gram-mcp-server.mdx
@@ -9,7 +9,7 @@ Roo Code is a [VS Code extension](https://marketplace.visualstudio.com/items?ite
 
 When paired with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, you can connect Roo Code to your APIs, databases, and infrastructure services, granting it contextual access to your tools and data.
 
-This guide shows you how to connect Roo Code to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Roo Code to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Roo Code.
 

--- a/docs/src/content/docs/examples/adding-ai-chat-to-your-app.mdx
+++ b/docs/src/content/docs/examples/adding-ai-chat-to-your-app.mdx
@@ -15,7 +15,7 @@ If you have any kind of SaaS application, you're probably used to your users usi
 
 This guide shows you how to add a chat interface to an existing application. You can give your users natural language interaction, while your current backend, security model, and business logic remain unchanged.
 
-<video width="600" controls style="display: block; margin: 0 auto;">
+<video width="600" controls={true} muted={true}>
   <source src="/videos/taskboard-show-tasks.mp4" type="video/mp4" />
     Your browser does not support the video tag.
 </video>
@@ -178,7 +178,7 @@ If you're using Gram for the first time:
 3. Upload the OpenAPI document (`public/swagger.json`).
 4. Name the API (for example, "TaskBoard"), toolset, and server slug (for example, "taskboard-demo").
 
-<video width="600" controls style="display: block; margin: 0 auto;">
+<video width="600" controls={true} muted={true}>
   <source src="/videos/taskboard-mcp-create.mp4" type="video/mp4" />
     Your browser does not support the video tag.
 </video>
@@ -831,7 +831,7 @@ You should see:
 2. **Automatic TaskBoard updates** when the agent performs actions
 3. **Only your tasks** are visible and editable (user permissions respected)
 
-<video width="600" controls style="display: block; margin: 0 auto;">
+<video width="600" controls={true} muted={true}>
   <source src="/videos/taskboard-new-task.mp4" type="video/mp4" />
     Your browser does not support the video tag.
 </video>


### PR DESCRIPTION
### Sync from Marketing Site

**Source commit:** `a5b28de874f84c0c987694a9e8c36abe80e5b169`

**Grouped file changes:**
#### `docs/src/`
M	docs/src/content/docs/clients/using-chatgpt-developer-mode-with-gram.mdx
M	docs/src/content/docs/clients/using-claude-code-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-claude-desktop-with-gram-mcp-server.mdx
M	docs/src/content/docs/clients/using-cline-with-gram-mcp-server.mdx
M	docs/src/content/docs/clients/using-gemini-cli-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-mistral-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-n8n-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-roo-code-with-gram-mcp-server.mdx
M	docs/src/content/docs/examples/adding-ai-chat-to-your-app.mdx
