### PR TITLE
fix: correctly expire cookies on log out

### DIFF
--- a/server/design/security/gram_session.go
+++ b/server/design/security/gram_session.go
@@ -29,10 +29,10 @@ var WriteSessionCookie = func() {
 var DeleteSessionCookie = func() {
 	Cookie(fmt.Sprintf("session_cookie:%s", auth.SessionCookie), String, func() {
 	})
+	// NOTE: We set max age to -1 to rather than 0 because go's Set-Cookie treats 0 as unset
 	CookieMaxAge(-1)
 	CookieSecure()
 	CookieHTTPOnly()
-	CookiePath("/")
 }
 
 var SessionHeader = func() {

--- a/server/gen/http/auth/server/encode_decode.go
+++ b/server/gen/http/auth/server/encode_decode.go
@@ -604,8 +604,7 @@ func EncodeLogoutResponse(encoder func(context.Context, http.ResponseWriter) goa
 		http.SetCookie(w, &http.Cookie{
 			Name:     "gram_session",
 			Value:    sessionCookie,
-			MaxAge:   0,
-			Path:     "/",
+			MaxAge:   -1,
 			Secure:   true,
 			HttpOnly: true,
 		})

--- a/server/internal/middleware/session.go
+++ b/server/internal/middleware/session.go
@@ -13,18 +13,6 @@ func SessionMiddleware(next http.Handler) http.Handler {
 			ctx := contextvalues.SetSessionTokenInContext(r.Context(), cookie.Value)
 			r = r.WithContext(ctx)
 		}
-		// TODO: Remove after 11/14/25 (this is only required while we have lingering cookies)
-		if r.URL.Path == "/rpc/auth.info" {
-			http.SetCookie(w, &http.Cookie{
-				Name:     "gram_session",
-				Value:    "",
-				Path:     "/rpc",
-				MaxAge:   -1,
-				HttpOnly: true,
-				Secure:   true,
-				SameSite: http.SameSiteStrictMode,
-			})
-		}
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Here, we make a couple changes that will improve our cookie behaviors.

First, we were previously passing `MaxAge: 0` to `http.SetCookie` (via goa). `SetCookie` treats this value as equivalent to unset and so won't actually expire the cookie. We bypass this by setting MaxAge to -1.

We also remove the `Path` specifier from the DeleteCookie logic. The idea here is that browers will delete all cookies that match all of the attributes you specify, but the match need not match _all_ of the cookies attributes. This lets us ensure that we remove the extraneous cookies that are stored at `/rpc` without disrupting the system and achieves the correct behavior with the new cookies.

@ryan-timothy-albert fyi