### PR TITLE
feat: create gram functions framework and scaffolder

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,8 +8,15 @@
     }
   ],
   "fixed": [],
-  "linked": [],
-  "ignore": [],
+  "linked": [
+    [
+      "@gram-ai/functions",
+      "@gram-ai/create-function"
+    ]
+  ],
+  "ignore": [
+    "gram-template-*"
+  ],
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",

--- a/.changeset/light-loops-shout.md
+++ b/.changeset/light-loops-shout.md
@@ -1,0 +1,32 @@
+---
+"@gram-ai/create-function": minor
+"@gram-ai/functions": minor
+---
+
+Introducing a new framework that simplifies writing and bundling Gram Functions.
+The simplest "Hello, World!" Gram Function with this framework looks like this:
+
+```typescript
+import { Gram } from "@gram-ai/functions";
+import * as z from "zod/mini";
+
+const gram = new Gram().tool({
+  name: "greet",
+  description: "Greet someone special",
+  inputSchema: { name: z.string() },
+  async execute(ctx, input) {
+    return ctx.json({ message: `Hello, ${input.name}!` });
+  },
+});
+
+export default gram;
+```
+
+In addition to the new framework, we introduce a project scaffolder that users
+can run to quickly set up a new Gram Functions project with all necessary
+boilerplate and configuration. When it is published, it will be available
+through:
+
+```
+pnpm create @gram-ai/function
+```

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -11,3 +11,6 @@ client:
 
 functions:
   - 'functions/**'
+
+tsframework:
+  - 'ts-framework/**'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,6 +26,7 @@ jobs:
       server: ${{ steps.gates.outputs.server }}
       client: ${{ steps.gates.outputs.client }}
       functions: ${{ steps.gates.outputs.functions }}
+      tsframework: ${{ steps.gates.outputs.tsframework }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
@@ -56,6 +57,13 @@ jobs:
             echo "Functions jobs will run."
           else
             echo "Functions jobs will be skipped."
+          fi
+
+          if [[ "${{ steps.filter.outputs.tsframework }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" ]]; then
+            echo "tsframework=true" >> $GITHUB_OUTPUT
+            echo "TypeScript framework jobs will run."
+          else
+            echo "TypeScript framework jobs will be skipped."
           fi
 
   docker-build-server:
@@ -698,4 +706,55 @@ jobs:
 
       - name: Prune PNPM store
         if: ${{ needs.changes.outputs.functions == 'true' && success() }}
+        run: pnpm store prune
+
+  ts-framework-test:
+    runs-on: ubicloud-standard-4
+    needs: [changes]
+    steps:
+      - name: Skip if no ts framework changes exist
+        if: ${{ needs.changes.outputs.tsframework != 'true' }}
+        run: echo "No TypeScript framework changes detected — skipping ts-framework-test."
+
+      - name: Checkout
+        if: ${{ needs.changes.outputs.tsframework == 'true' }}
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
+
+      - name: Setup Mise
+        if: ${{ needs.changes.outputs.tsframework == 'true' }}
+        uses: jdx/mise-action@e3d7b8d67a7958d1207f6ed871e83b1ea780e7b0 # v3.3.1
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Prepare GitHub Actions environment
+        if: ${{ needs.changes.outputs.tsframework == 'true' }}
+        run: mise run github
+
+      - name: Cache PNPM
+        if: ${{ needs.changes.outputs.tsframework == 'true' }}
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          key: ${{ env.GH_CACHE_PNPM_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_PNPM_KEY }}
+            ${{ env.GH_CACHE_PNPM_KEY_PARTIAL }}
+          path: |
+            ${{ env.PNPM_STORE_PATH }}
+      
+      - name: Install dependencies
+        if: ${{ needs.changes.outputs.tsframework == 'true' }}
+        run: pnpm install --frozen-lockfile
+      
+      - name: Test TypeScript framework
+        if: ${{ needs.changes.outputs.tsframework == 'true' }}
+        run: pnpm --filter "./ts-framework/**" test
+
+      - name: Build TypeScript framework
+        if: ${{ needs.changes.outputs.tsframework == 'true' }}
+        run: pnpm --filter "./ts-framework/**" build
+
+      - name: Prune PNPM store
+        if: ${{ needs.changes.outputs.tsframework == 'true' && success() }}
         run: pnpm store prune

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,11 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: ubicloud-standard-4
+    # We have setup NPM trusted publishing which requires running the release
+    # workflow on GitHub-hosted runners. It can running on ubicloud or any other
+    # self-hosted runners that we manage.
+    # https://docs.npmjs.com/trusted-publishers
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
@@ -53,7 +57,6 @@ jobs:
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          NPM_TOKEN: "not-set" # intentionally not set for now
 
       - name: Prune PNPM store
         run: pnpm store prune

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ gram.code-workspace
 .local.env.json
 /server/cmd/local
 /local/cmd
-
+dist/
 **/.claude/settings.local.json
 .vercel
 cover.*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,7 +305,7 @@ importers:
         version: 8.2.8(@aws-sdk/credential-provider-web-identity@3.883.0)(astro@5.14.1(@azure/identity@4.11.1)(@types/node@24.5.2)(@vercel/functions@2.2.13(@aws-sdk/credential-provider-web-identity@3.883.0))(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)(typescript@5.9.2)(yaml@2.8.1))(react@19.1.1)(rollup@4.50.2)
       '@tailwindcss/vite':
         specifier: ^4.1.7
-        version: 4.1.13(vite@6.3.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
+        version: 4.1.13(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@types/react':
         specifier: ^19.1.6
         version: 19.1.13
@@ -375,6 +375,94 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jiti@2.5.1)(lightningcss@1.30.1)(msw@2.11.3(@types/node@22.18.6)(typescript@5.9.2))(yaml@2.8.1)
 
   server: {}
+
+  ts-framework/create-function:
+    dependencies:
+      '@bomb.sh/args':
+        specifier: ^0.3.1
+        version: 0.3.1
+      '@clack/prompts':
+        specifier: ^1.0.0-alpha.6
+        version: 1.0.0-alpha.6
+      zx:
+        specifier: 8.8.4-lite
+        version: 8.8.4-lite
+    devDependencies:
+      '@gram-ai/functions':
+        specifier: workspace:^
+        version: link:../functions
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.19.1
+        version: 1.19.1
+      '@types/node':
+        specifier: 22.x
+        version: 22.18.6
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+
+  ts-framework/create-function/gram-template-gram:
+    dependencies:
+      '@gram-ai/functions':
+        specifier: 'workspace:'
+        version: link:../../functions
+      zod:
+        specifier: ^4
+        version: 4.1.12
+    devDependencies:
+      '@types/node':
+        specifier: 22.x
+        version: 22.18.6
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+
+  ts-framework/create-function/gram-template-mcp:
+    dependencies:
+      '@gram-ai/functions':
+        specifier: 'workspace:'
+        version: link:../../functions
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.19.1
+        version: 1.19.1
+      zod:
+        specifier: ^3
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 22.x
+        version: 22.18.6
+      typescript:
+        specifier: ^5
+        version: 5.8.3
+
+  ts-framework/functions:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.19.1
+        version: 1.19.1
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
+      esbuild:
+        specifier: ^0.25.10
+        version: 0.25.10
+      zod:
+        specifier: ^4
+        version: 4.1.12
+    devDependencies:
+      '@types/archiver':
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(msw@2.11.3(@types/node@24.5.2)(typescript@5.9.2))(yaml@2.8.1)
 
 packages:
 
@@ -761,6 +849,9 @@ packages:
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
+  '@bomb.sh/args@0.3.1':
+    resolution: {integrity: sha512-CwxKrfgcorUPP6KfYD59aRdBYWBTsfsxT+GmoLVnKo5Tmyoqbpo0UNcjngRMyU+6tiPbd18RuIYxhgAn44wU/Q==}
+
   '@bundled-es-modules/cookie@2.0.1':
     resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
 
@@ -824,6 +915,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.0.0-alpha.6':
+    resolution: {integrity: sha512-eG5P45+oShFG17u9I1DJzLkXYB1hpUgTLi32EfsMjSHLEqJUR8BOBCVFkdbUX2g08eh/HCi6UxNGpPhaac1LAA==}
+
+  '@clack/prompts@1.0.0-alpha.6':
+    resolution: {integrity: sha512-75NCtYOgDHVBE2nLdKPTDYOaESxO0GLAKC7INREp5VbS988Xua1u+588VaGlcvXiLc/kSwc25Cd+4PeTSpY6QQ==}
 
   '@code-hike/lighter@1.0.1':
     resolution: {integrity: sha512-mccvcsk5UTScRrE02oBz1/qzckyhD8YE3VQlQv++2bSVVZgNuCUX8MpokSCi5OmfRAAxbj6kmNiqq1Um8eXPrw==}
@@ -1224,78 +1321,92 @@ packages:
     resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.3':
     resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.3':
     resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.3':
     resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.3':
     resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
     resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.3':
     resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.4':
     resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.4':
     resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.4':
     resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.4':
     resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.4':
     resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.4':
     resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.4':
     resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.4':
     resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
@@ -1434,6 +1545,10 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@modelcontextprotocol/sdk@1.19.1':
+    resolution: {integrity: sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ==}
+    engines: {node: '>=18'}
 
   '@mswjs/interceptors@0.39.7':
     resolution: {integrity: sha512-sURvQbbKsq5f8INV54YJgJEdk8oxBanqkTiXXd33rKmofFCwZLhLRszPduMZ9TA9b8/1CHc/IJmOlBHJk2Q5AQ==}
@@ -2171,56 +2286,67 @@ packages:
     resolution: {integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.2':
     resolution: {integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.2':
     resolution: {integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.50.2':
     resolution: {integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.50.2':
     resolution: {integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.2':
     resolution: {integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.2':
     resolution: {integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.2':
     resolution: {integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.2':
     resolution: {integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.2':
     resolution: {integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.50.2':
     resolution: {integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.2':
     resolution: {integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==}
@@ -2542,24 +2668,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
     resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
     resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.13':
     resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.13':
     resolution: {integrity: sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==}
@@ -2624,6 +2754,9 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@types/archiver@6.0.3':
+    resolution: {integrity: sha512-a6wUll6k3zX6qs5KlxIggs1P1JcYJaTCx2gnlr+f0S1yd2DoaEwoIK10HmBaLnZwWneBz+JBm0dwcZu0zECBcQ==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2722,6 +2855,9 @@ packages:
 
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
@@ -2985,6 +3121,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -3070,6 +3210,14 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -3142,6 +3290,9 @@ packages:
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -3243,6 +3394,10 @@ packages:
   blob-to-buffer@1.2.9:
     resolution: {integrity: sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==}
 
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -3271,11 +3426,18 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   buildcheck@0.0.6:
     resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
@@ -3285,12 +3447,20 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -3444,6 +3614,10 @@ packages:
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -3451,11 +3625,23 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -3471,12 +3657,25 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+
   countries-list@3.1.1:
     resolution: {integrity: sha512-nPklKJ5qtmY5MdBKw1NiBAoyx5Sa7p2yPpljZyQ7gyCN1m+eMFs9I6CT37Mxt8zvR5L3VzD3DJBE4WQzX3WF4A==}
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -3614,6 +3813,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -3729,6 +3932,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -3903,6 +4110,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-source-plus@0.1.12:
     resolution: {integrity: sha512-98wOULBKdZV9BnI2OY0wCb4VCoQmyRyESDtKPYR4l9D8hEXbfLdk0ue6va1zlYW1wqhcJHm2w9kJtUtsl9ZB9A==}
 
@@ -3920,6 +4131,18 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -3927,6 +4150,16 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
 
   expressive-code@0.41.3:
     resolution: {integrity: sha512-YLnD62jfgBZYrXIPQcJ0a51Afv9h8VlWqEGK9uU2T5nL/5rb8SnA86+7+mgCZe5D34Tff5RNEA5hjNVJYHzrFg==}
@@ -4011,6 +4244,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
+    engines: {node: '>= 0.8'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -4061,6 +4298,10 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   framer-motion@11.18.2:
     resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
     peerDependencies:
@@ -4088,6 +4329,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -4353,6 +4598,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -4437,6 +4686,10 @@ packages:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -4503,6 +4756,9 @@ packages:
   is-primitive@3.0.1:
     resolution: {integrity: sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==}
     engines: {node: '>=0.10.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -4642,6 +4898,10 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -4678,24 +4938,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -4877,6 +5141,14 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -4997,8 +5269,16 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mimic-fn@2.1.0:
@@ -5011,6 +5291,10 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -5114,6 +5398,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -5188,6 +5476,10 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
@@ -5316,6 +5608,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -5336,6 +5632,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5362,6 +5661,10 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
@@ -5502,6 +5805,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -5527,6 +5834,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -5544,6 +5855,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -5552,6 +5867,14 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.1:
+    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -5666,6 +5989,13 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -5808,6 +6138,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -5863,6 +6197,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
@@ -5872,6 +6214,9 @@ packages:
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.32.6:
     resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
@@ -5891,6 +6236,22 @@ packages:
 
   shiki@3.13.0:
     resolution: {integrity: sha512-aZW4l8Og16CokuCLf8CF8kq+KK2yOygapU5m3+hoGw0Mdosc6fPitjM+ujYarppj5ZIKGyPDPP1vqmQhr+5/0g==}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -6000,6 +6361,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@astrojs/starlight': '>=0.32.0'
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -6204,6 +6569,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
@@ -6265,6 +6634,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typesafe-path@0.2.2:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
@@ -6359,6 +6732,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unstorage@1.17.1:
     resolution: {integrity: sha512-KKGwRTT0iVBCErKemkJCLs7JdxNVfqTPc/85ae1XES0+bsHbc/sFBfVi5kJp156cc51BHinIH2l3k0EZ24vOBQ==}
@@ -6477,6 +6854,10 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
@@ -6865,6 +7246,10 @@ packages:
   yoga-wasm-web@0.3.3:
     resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
+
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
@@ -6879,6 +7264,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.12:
+    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -6886,6 +7274,10 @@ packages:
     resolution: {integrity: sha512-qvsKBnvWHstHKCluKPlEgI/D3+mdiQyMoSSeFR8IX/aXzWIas5A297KxKgPJhuPXdrR6ma0Jzx43+GQ/8sqbrw==}
     engines: {node: '>= 12.17.0'}
     hasBin: true
+
+  zx@8.8.4-lite:
+    resolution: {integrity: sha512-NaH101NH/XG5jP2cWvr/AFyd7EE1mQ6ZvqBzvJ4ceXwxfmchhPX4RjudB3MXa/+thcxR6xB9znZUiX2u/Tq+AA==}
+    engines: {node: '>= 12.17.0'}
 
 snapshots:
 
@@ -7912,6 +8304,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@bomb.sh/args@0.3.1': {}
+
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:
       cookie: 0.7.2
@@ -8071,6 +8465,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@1.0.0-alpha.6':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.0.0-alpha.6':
+    dependencies:
+      '@clack/core': 1.0.0-alpha.6
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@code-hike/lighter@1.0.1':
     dependencies:
@@ -8307,7 +8712,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8329,7 +8734,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -8578,6 +8983,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.18.6
 
+  '@inquirer/confirm@5.1.18(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.2.2(@types/node@24.5.2)
+      '@inquirer/type': 3.0.8(@types/node@24.5.2)
+    optionalDependencies:
+      '@types/node': 24.5.2
+    optional: true
+
   '@inquirer/core@10.2.2(@types/node@22.18.6)':
     dependencies:
       '@inquirer/ansi': 1.0.0
@@ -8590,6 +9003,20 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 22.18.6
+
+  '@inquirer/core@10.2.2(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/ansi': 1.0.0
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@24.5.2)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.5.2
+    optional: true
 
   '@inquirer/external-editor@1.0.1(@types/node@24.5.2)':
     dependencies:
@@ -8610,6 +9037,11 @@ snapshots:
   '@inquirer/type@3.0.8(@types/node@22.18.6)':
     optionalDependencies:
       '@types/node': 22.18.6
+
+  '@inquirer/type@3.0.8(@types/node@24.5.2)':
+    optionalDependencies:
+      '@types/node': 24.5.2
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -8635,7 +9067,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
@@ -8722,6 +9154,23 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.0.0
       vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.19.1':
+    dependencies:
+      ajv: 6.12.6
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.1.0
+      express-rate-limit: 7.5.1(express@5.1.0)
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -10030,13 +10479,6 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@6.3.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
-    dependencies:
-      '@tailwindcss/node': 4.1.13
-      '@tailwindcss/oxide': 4.1.13
-      tailwindcss: 4.1.13
-      vite: 6.3.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
-
   '@tailwindcss/vite@4.1.13(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.13
@@ -10062,6 +10504,10 @@ snapshots:
   '@tootallnate/once@2.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@types/archiver@6.0.3':
+    dependencies:
+      '@types/readdir-glob': 1.1.5
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -10112,12 +10558,12 @@ snapshots:
 
   '@types/fontkit@2.0.8':
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@types/hast@3.0.4':
     dependencies:
@@ -10129,7 +10575,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@types/long@4.0.2': {}
 
@@ -10169,16 +10615,20 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/readdir-glob@1.1.5':
+    dependencies:
+      '@types/node': 22.18.6
+
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@types/statuses@2.0.6': {}
 
@@ -10247,7 +10697,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.35.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -10259,7 +10709,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.35.0(jiti@2.5.1)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -10372,7 +10822,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -10388,7 +10838,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -10537,6 +10987,15 @@ snapshots:
       msw: 2.11.3(@types/node@22.18.6)(typescript@5.9.2)
       vite: 7.1.6(@types/node@22.18.6)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
+  '@vitest/mocker@3.2.4(msw@2.11.3(@types/node@24.5.2)(typescript@5.9.2))(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      msw: 2.11.3(@types/node@24.5.2)(typescript@5.9.2)
+      vite: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -10619,6 +11078,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -10695,6 +11159,28 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   arg@5.0.2: {}
 
@@ -10865,6 +11351,8 @@ snapshots:
 
   async-sema@3.1.1: {}
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
   axios@1.11.0(debug@4.4.1):
@@ -10958,6 +11446,20 @@ snapshots:
 
   blob-to-buffer@1.2.9: {}
 
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.1
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   bowser@2.12.1: {}
@@ -10998,9 +11500,16 @@ snapshots:
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
+  buffer-crc32@1.0.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -11012,12 +11521,19 @@ snapshots:
     dependencies:
       run-applescript: 7.0.0
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -11153,13 +11669,29 @@ snapshots:
 
   common-ancestor-path@1.0.1: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   concat-map@0.0.1: {}
 
   consola@3.4.2: {}
 
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.2: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -11169,6 +11701,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   countries-list@3.1.1: {}
 
   cpu-features@0.0.10:
@@ -11176,6 +11713,13 @@ snapshots:
       buildcheck: 0.0.6
       nan: 2.23.0
     optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-fetch@3.2.0:
     dependencies:
@@ -11288,6 +11832,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
@@ -11391,6 +11937,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -11661,6 +12209,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-source-plus@0.1.12:
     dependencies:
       ofetch: 1.4.1
@@ -11677,9 +12227,53 @@ snapshots:
     dependencies:
       bare-events: 2.7.0
 
+  events@3.3.0: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expand-template@2.0.3: {}
 
   expect-type@1.2.2: {}
+
+  express-rate-limit@7.5.1(express@5.1.0):
+    dependencies:
+      express: 5.1.0
+
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   expressive-code@0.41.3:
     dependencies:
@@ -11757,6 +12351,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -11823,6 +12428,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded@0.2.0: {}
+
   framer-motion@11.18.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       motion-dom: 11.18.1
@@ -11840,6 +12447,8 @@ snapshots:
     optionalDependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -12307,6 +12916,14 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -12409,6 +13026,8 @@ snapshots:
 
   ip-address@10.0.1: {}
 
+  ipaddr.js@1.9.1: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-alphabetical@2.0.1: {}
@@ -12453,6 +13072,8 @@ snapshots:
       isobject: 3.0.1
 
   is-primitive@3.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -12592,6 +13213,10 @@ snapshots:
   kleur@4.1.5: {}
 
   klona@2.0.6: {}
+
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
 
   levn@0.4.1:
     dependencies:
@@ -12920,6 +13545,10 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
@@ -13203,9 +13832,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -13214,6 +13849,10 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
+
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.2
 
   minimatch@9.0.5:
     dependencies:
@@ -13285,6 +13924,33 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.11.3(@types/node@24.5.2)(typescript@5.9.2):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@inquirer/confirm': 5.1.18(@types/node@24.5.2)
+      '@mswjs/interceptors': 0.39.7
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.6
+      graphql: 16.11.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 4.41.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   muggle-string@0.4.1: {}
 
   mute-stream@0.0.8: {}
@@ -13301,6 +13967,8 @@ snapshots:
   napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   neotraverse@0.6.18: {}
 
@@ -13354,6 +14022,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  object-inspect@1.13.4: {}
 
   ofetch@1.4.1:
     dependencies:
@@ -13523,6 +14193,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -13538,6 +14210,8 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  path-to-regexp@8.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -13551,6 +14225,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@4.0.1: {}
+
+  pkce-challenge@5.0.0: {}
 
   postcss-nested@6.2.0(postcss@8.5.6):
     dependencies:
@@ -13636,6 +14312,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process@0.11.10: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -13671,13 +14349,18 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       long: 5.3.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
 
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -13702,11 +14385,24 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.1:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.7.0
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -13831,6 +14527,18 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.6
 
   readdirp@4.1.2: {}
 
@@ -14078,6 +14786,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.50.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.0.0: {}
 
   run-async@2.4.1: {}
@@ -14130,6 +14848,31 @@ snapshots:
 
   semver@7.7.2: {}
 
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.1: {}
 
   set-value@4.1.0:
@@ -14138,6 +14881,8 @@ snapshots:
       is-primitive: 3.0.1
 
   setimmediate@1.0.5: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.32.6:
     dependencies:
@@ -14200,6 +14945,34 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -14218,7 +14991,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14331,6 +15104,8 @@ snapshots:
     dependencies:
       '@astrojs/starlight': 0.34.8(astro@5.14.1(@azure/identity@4.11.1)(@types/node@24.5.2)(@vercel/functions@2.2.13(@aws-sdk/credential-provider-web-identity@3.883.0))(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)(typescript@5.9.2)(yaml@2.8.1))
       picomatch: 4.0.3
+
+  statuses@2.0.1: {}
 
   statuses@2.0.2: {}
 
@@ -14561,6 +15336,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.16
@@ -14606,6 +15383,12 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
 
   typesafe-path@0.2.2: {}
 
@@ -14740,6 +15523,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   unstorage@1.17.1(@azure/identity@4.11.1)(@vercel/functions@2.2.13(@aws-sdk/credential-provider-web-identity@3.883.0)):
     dependencies:
       anymatch: 3.1.3
@@ -14795,6 +15580,8 @@ snapshots:
 
   uuid@9.0.1: {}
 
+  vary@1.1.2: {}
+
   vaul@1.1.2(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -14826,6 +15613,27 @@ snapshots:
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.6(@types/node@22.18.6)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14900,7 +15708,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.2
       magic-string: 0.30.19
       pathe: 2.0.3
@@ -14917,6 +15725,48 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.18.6
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(msw@2.11.3(@types/node@24.5.2)(typescript@5.9.2))(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.11.3(@types/node@24.5.2)(typescript@5.9.2))(vite@7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.6(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.5.2
     transitivePeerDependencies:
       - jiti
       - less
@@ -15169,6 +16019,12 @@ snapshots:
 
   yoga-wasm-web@0.3.3: {}
 
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
+
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
@@ -15180,6 +16036,10 @@ snapshots:
 
   zod@3.25.76: {}
 
+  zod@4.1.12: {}
+
   zwitch@2.0.4: {}
 
   zx@8.8.1: {}
+
+  zx@8.8.4-lite: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,16 +1,18 @@
 packages:
   - client/*
   - sdks/*
+  - ts-framework/*
+  - ts-framework/create-function/gram-template-*
   - server
   - cli
   - functions
   - docs
 
 catalog:
-  "@ai-sdk/openai": ^1.3.4
-  "@tanstack/react-query": ^5.89.0
-  "@types/react": ^19.1.13
-  "@types/react-dom": ^19.1.9
+  '@ai-sdk/openai': ^1.3.4
+  '@tanstack/react-query': ^5.89.0
+  '@types/react': ^19.1.13
+  '@types/react-dom': ^19.1.9
   ai: ^4.0.52
   typescript: 5.9.2
 

--- a/ts-framework/create-function/.gitignore
+++ b/ts-framework/create-function/.gitignore
@@ -1,0 +1,28 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+*.tsbuildinfo
+dist
+!/src/bin

--- a/ts-framework/create-function/gram-template-gram/.gitignore
+++ b/ts-framework/create-function/gram-template-gram/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.env
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+*.tsbuildinfo

--- a/ts-framework/create-function/gram-template-gram/CONTRIBUTING.md
+++ b/ts-framework/create-function/gram-template-gram/CONTRIBUTING.md
@@ -1,0 +1,399 @@
+# Project Contribution Guide
+
+- This is a Node.js project using TypeScript to build [Gram](https://gram.ai) Functions.
+- The codebase assumes Node.js v22 or later is in use and TypeScript v5.9 or later is required.
+- When working in this codebase prefer using the Web APIs and Node.js standard library where possible instead of third-party libraries.
+
+## Project Structure
+
+- `src/` - Contains the source TypeScript code for the Gram Functions.
+- `dist/` - Output directory for the built code (generated after running `npm run build`).
+- `package.json` - Defines project metadata, dependencies, and scripts.
+- `tsconfig.json` - TypeScript configuration file.
+
+## `package.json` scripts
+
+- `build` - Bundles the Gram Functions code into a zip file for deployment and places it in the `dist/` directory.
+- `lint` - Runs the TypeScript compiler in `noEmit` mode to check for type errors.
+
+<details open>
+<summary><strong>Guide: Using `@gram-ai/functions`</strong></summary>
+
+## Core Concepts
+
+### The Gram Instance
+
+The `Gram` class is the main entry point for defining tools. You create an instance and chain `.tool()` calls to register multiple tools:
+
+```typescript
+import { Gram } from "@gram-ai/functions";
+import * as z from "zod/mini";
+
+const g = new Gram()
+  .tool({
+    name: "add",
+    description: "Add two numbers",
+    inputSchema: { a: z.number(), b: z.number() },
+    async execute(ctx, input) {
+      return ctx.json({ sum: input.a + input.b });
+    },
+  })
+  .tool({
+    name: "multiply",
+    description: "Multiply two numbers",
+    inputSchema: { a: z.number(), b: z.number() },
+    async execute(ctx, input) {
+      return ctx.json({ product: input.a * input.b });
+    },
+  });
+
+export const handleToolCall = g.handleToolCall;
+```
+
+### Tool Definition
+
+Each tool requires:
+
+- **name**: A unique identifier for the tool
+- **description** (optional): Human-readable description of what the tool does
+- **inputSchema**: A Zod schema object defining the expected input parameters
+- **variables** (optional): Environment variables the tool needs
+- **execute**: An async function that implements the tool logic
+
+### Tool Context
+
+The `execute` function receives a `ctx` (context) object with helper methods:
+
+#### `ctx.json(data)`
+
+Returns a JSON response:
+
+```typescript
+async execute(ctx, input) {
+  return ctx.json({ result: "success", value: 42 });
+}
+```
+
+#### `ctx.text(data)`
+
+Returns a plain text response:
+
+```typescript
+async execute(ctx, input) {
+  return ctx.text("Operation completed successfully");
+}
+```
+
+#### `ctx.html(data)`
+
+Returns an HTML response:
+
+```typescript
+async execute(ctx, input) {
+  return ctx.html("<h1>Hello, World!</h1>");
+}
+```
+
+#### `ctx.fail(data, options?)`
+
+Throws an error response (never returns):
+
+```typescript
+async execute(ctx, input) {
+  if (!input.value) {
+    ctx.fail({ error: "value is required" }, { status: 400 });
+  }
+  // ...
+}
+```
+
+#### `ctx.signal`
+
+An `AbortSignal` for handling cancellation:
+
+```typescript
+async execute(ctx, input) {
+  const response = await fetch(input.url, { signal: ctx.signal });
+  return ctx.json(await response.json());
+}
+```
+
+#### `ctx.vars`
+
+Access to environment variables defined in the tool's `variables` property:
+
+```typescript
+.tool({
+  name: "api_call",
+  inputSchema: { endpoint: z.string() },
+  variables: {
+    API_KEY: { description: "API key for authentication" }
+  },
+  async execute(ctx, input) {
+    const apiKey = ctx.vars.API_KEY;
+    // Use apiKey...
+  },
+})
+```
+
+## Input Validation
+
+Input schemas are defined using [Zod](https://zod.dev/):
+
+```typescript
+import * as z from "zod/mini";
+
+.tool({
+  name: "create_user",
+  inputSchema: {
+    email: z.string().check(z.email()),
+    age: z.number().check(z.min(18)),
+    name: z.optional(z.string()),
+  },
+  async execute(ctx, input) {
+    // input is fully typed based on the schema
+    return ctx.json({ userId: "123" });
+  },
+})
+```
+
+### Lax Mode
+
+By default, the framework strictly validates input. You can enable lax mode to allow unvalidated input to pass through:
+
+```typescript
+const g = new Gram({ lax: true });
+```
+
+## Environment Variables
+
+### Runtime Environment
+
+Pass environment variables are read from `process.env` by default, but you can override them when creating the `Gram` instance:
+
+```typescript
+const g = new Gram({
+  env: {
+    API_KEY: "secret-key",
+    BASE_URL: "https://api.example.com",
+  },
+});
+```
+
+If not provided, the framework falls back to `process.env`.
+
+### Tool Variables
+
+Declare which environment variables a tool needs:
+
+```typescript
+.tool({
+  name: "weather",
+  inputSchema: { city: z.string() },
+  variables: {
+    WEATHER_API_KEY: {
+      description: "API key for weather service"
+    }
+  },
+  async execute(ctx, input) {
+    const apiKey = ctx.vars.WEATHER_API_KEY;
+    // Make API call...
+  },
+})
+```
+
+## Response Types
+
+The framework supports multiple response types. All response methods return Web API `Response` objects.
+
+### JSON Response
+
+```typescript
+return ctx.json({
+  status: "success",
+  data: { id: 123, name: "Example" },
+});
+```
+
+### Text Response
+
+```typescript
+return ctx.text("Plain text response");
+```
+
+### HTML Response
+
+```typescript
+return ctx.html(`
+  <!DOCTYPE html>
+  <html>
+    <body><h1>Hello</h1></body>
+  </html>
+`);
+```
+
+### Custom Response
+
+You can also return a plain `Response` object:
+
+```typescript
+return new Response(data, {
+  status: 200,
+  headers: {
+    "Content-Type": "application/xml",
+    "X-Custom-Header": "value",
+  },
+});
+```
+
+## Error Handling
+
+### Using `ctx.fail()`
+
+Use `ctx.fail()` to throw error responses:
+
+```typescript
+async execute(ctx, input) {
+  if (!input.userId) {
+    ctx.fail(
+      { error: "userId is required" },
+      { status: 400 }
+    );
+  }
+
+  const user = await fetchUser(input.userId);
+  if (!user) {
+    ctx.fail(
+      { error: "User not found" },
+      { status: 404 }
+    );
+  }
+
+  return ctx.json({ user });
+}
+```
+
+Errors automatically include a stack trace in the response.
+
+### Using `assert()`
+
+The `assert` function provides a convenient way to validate conditions and throw error responses:
+
+```typescript
+import { assert } from "@gram-ai/functions";
+
+async execute(ctx, input) {
+  assert(input.userId, { error: "userId is required" }, { status: 400 });
+
+  const user = await fetchUser(input.userId);
+  assert(user, { error: "User not found" }, { status: 404 });
+
+  return ctx.json({ user });
+}
+```
+
+The `assert` function throws a `Response` object when the condition is false. The framework catches all thrown values, and if any happen to be a `Response` instance, they will be returned to the client.
+
+Key points about `assert`:
+
+- First parameter is the condition to check
+- Second parameter is the error data (must include an `error` field)
+- Third parameter is optional and can specify the status code (defaults to 500)
+- Automatically includes a stack trace in the response
+- Uses TypeScript's assertion type to narrow types when the assertion passes
+
+## Manifest Generation
+
+Generate a manifest of all registered tools:
+
+```typescript
+const g = new Gram()
+  .tool({
+    /* ... */
+  })
+  .tool({
+    /* ... */
+  });
+
+const manifest = g.manifest();
+// {
+//   version: "0.0.0",
+//   tools: [
+//     {
+//       name: "tool1",
+//       description: "...",
+//       inputSchema: "...", // JSON Schema string
+//       variables: { ... }
+//     },
+//     ...
+//   ]
+// }
+```
+
+## Handling Tool Calls
+
+Export the `handleToolCall` method to process incoming requests:
+
+```typescript
+const g = new Gram()
+  .tool({
+    /* ... */
+  })
+  .tool({
+    /* ... */
+  });
+
+export const handleToolCall = g.handleToolCall;
+```
+
+You can also call tools programmatically:
+
+```typescript
+const response = await g.handleToolCall({
+  name: "add",
+  input: { a: 5, b: 3 },
+});
+
+const data = await response.json();
+console.log(data); // { sum: 8 }
+```
+
+With abort signal support:
+
+```typescript
+const controller = new AbortController();
+
+const responsePromise = g.handleToolCall(
+  { name: "longRunning", input: {} },
+  { signal: controller.signal },
+);
+
+// Cancel after 5 seconds
+setTimeout(() => controller.abort(), 5000);
+```
+
+## Type Safety
+
+The framework provides full TypeScript type inference:
+
+```typescript
+const g = new Gram().tool({
+  name: "greet",
+  inputSchema: { name: z.string() },
+  async execute(ctx, input) {
+    // input.name is typed as string
+    return ctx.json({ message: `Hello, ${input.name}` });
+  },
+});
+
+// Type-safe tool calls
+const response = await g.handleToolCall({
+  name: "greet", // Only "greet" is valid
+  input: { name: "World" }, // input is typed correctly
+});
+
+// Response type is inferred
+const data = await response.json(); // { message: string }
+```
+
+</details>

--- a/ts-framework/create-function/gram-template-gram/package.json
+++ b/ts-framework/create-function/gram-template-gram/package.json
@@ -1,0 +1,35 @@
+{
+  "type": "module",
+  "name": "gram-template-gram",
+  "version": "0.0.0",
+  "author": "",
+  "description": "",
+  "private": true,
+  "keywords": [
+    "mcp",
+    "getgram.ai"
+  ],
+  "license": "ISC",
+  "main": "dist/functions.js",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "engine": {
+    "node": ">=22.18.0"
+  },
+  "scripts": {
+    "lint": "tsc --noEmit",
+    "build": "node ./src/build.ts",
+    "prebuild": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@gram-ai/functions": "workspace:",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "22.x"
+  }
+}

--- a/ts-framework/create-function/gram-template-gram/src/build.ts
+++ b/ts-framework/create-function/gram-template-gram/src/build.ts
@@ -1,0 +1,14 @@
+import { buildFunctions } from "@gram-ai/functions/build";
+import { join } from "path";
+
+async function build() {
+  await buildFunctions({
+    outDir: "dist",
+    entrypoint: join(import.meta.dirname, "functions.ts"),
+    export: "default",
+  });
+}
+
+if (import.meta.main) {
+  await build();
+}

--- a/ts-framework/create-function/gram-template-gram/src/functions.ts
+++ b/ts-framework/create-function/gram-template-gram/src/functions.ts
@@ -1,0 +1,13 @@
+import { Gram } from "@gram-ai/functions";
+import * as z from "zod/mini";
+
+const gram = new Gram().tool({
+  name: "greet",
+  description: "Greet someone special",
+  inputSchema: { name: z.string() },
+  async execute(ctx, input) {
+    return ctx.json({ message: `Hello, ${input.name}!` });
+  },
+});
+
+export default gram;

--- a/ts-framework/create-function/gram-template-gram/tsconfig.json
+++ b/ts-framework/create-function/gram-template-gram/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "include": ["src"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+
+    "module": "nodenext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "types": ["node"],
+    "resolveJsonModule": true,
+
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    "noUncheckedIndexedAccess": true,
+
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true
+  }
+}

--- a/ts-framework/create-function/gram-template-mcp/.gitignore
+++ b/ts-framework/create-function/gram-template-mcp/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.env
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+*.tsbuildinfo

--- a/ts-framework/create-function/gram-template-mcp/package.json
+++ b/ts-framework/create-function/gram-template-mcp/package.json
@@ -1,0 +1,35 @@
+{
+  "type": "module",
+  "name": "gram-template-mcp",
+  "version": "0.0.0",
+  "author": "",
+  "description": "",
+  "private": true,
+  "keywords": [
+    "mcp",
+    "getgram.ai"
+  ],
+  "license": "ISC",
+  "main": "dist/functions.js",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "engine": {
+    "node": ">=22.18.0"
+  },
+  "scripts": {
+    "build": "node ./src/build.ts",
+    "prebuild": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@gram-ai/functions": "workspace:",
+    "@modelcontextprotocol/sdk": "^1.19.1",
+    "zod": "^3"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "22.x"
+  }
+}

--- a/ts-framework/create-function/gram-template-mcp/src/build.ts
+++ b/ts-framework/create-function/gram-template-mcp/src/build.ts
@@ -1,0 +1,14 @@
+import { buildMCPServer } from "@gram-ai/functions/build";
+
+async function build() {
+  await buildMCPServer({
+    outDir: "dist",
+    functionEntrypoint: "./src/functions.ts",
+    serverExport: "server",
+    serverEntrypoint: "./src/mcp.ts",
+  });
+}
+
+if (import.meta.main) {
+  await build();
+}

--- a/ts-framework/create-function/gram-template-mcp/src/functions.ts
+++ b/ts-framework/create-function/gram-template-mcp/src/functions.ts
@@ -1,0 +1,28 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { server } from "./mcp.js";
+
+const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+
+await server.connect(serverTransport);
+
+const client = new Client({ name: "gram-functions", version: "0.0.0" });
+await client.connect(clientTransport);
+
+export async function handleToolCall(call: {
+  name: string;
+  input?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+}): Promise<Response> {
+  const response = await client.callTool({
+    name: call.name,
+    arguments: call.input,
+    _meta: call._meta,
+  });
+
+  const body = JSON.stringify(response);
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json; mcp=tools_call" },
+  });
+}

--- a/ts-framework/create-function/gram-template-mcp/src/mcp.ts
+++ b/ts-framework/create-function/gram-template-mcp/src/mcp.ts
@@ -1,0 +1,22 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export const server = new McpServer({
+  name: "demo-server",
+  version: "1.0.0",
+});
+
+server.registerTool(
+  "add",
+  {
+    title: "Addition Tool",
+    description: "Add two numbers",
+    inputSchema: { a: z.number(), b: z.number() },
+  },
+  async ({ a, b }) => {
+    const output = { result: a + b };
+    return {
+      content: [{ type: "text", text: JSON.stringify(output) }],
+    };
+  },
+);

--- a/ts-framework/create-function/gram-template-mcp/tsconfig.json
+++ b/ts-framework/create-function/gram-template-mcp/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "include": ["src"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+
+    "module": "nodenext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "types": ["node"],
+    "resolveJsonModule": true,
+
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    "noUncheckedIndexedAccess": true,
+
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true
+  }
+}

--- a/ts-framework/create-function/package.json
+++ b/ts-framework/create-function/package.json
@@ -1,0 +1,42 @@
+{
+  "type": "module",
+  "name": "@gram-ai/create-function",
+  "version": "0.0.0",
+  "description": "Build AI tools and deploy them to getgram.ai",
+  "keywords": [],
+  "author": "Georges Haidar <georges@speakeasyapi.dev>",
+  "license": "ISC",
+  "main": "dist/index.js",
+  "bin": {
+    "create-function": "dist/main.js"
+  },
+  "scripts": {
+    "build": "tsc --noEmit false",
+    "prepublishOnly": "npm run build"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "src",
+    "dist",
+    "gram-template-*/**"
+  ],
+  "packageManager": "pnpm@10.18.2",
+  "dependencies": {
+    "@bomb.sh/args": "^0.3.1",
+    "@clack/prompts": "^1.0.0-alpha.6",
+    "zx": "8.8.4-lite"
+  },
+  "devDependencies": {
+    "@gram-ai/functions": "workspace:^",
+    "@modelcontextprotocol/sdk": "^1.19.1",
+    "@types/node": "22.x",
+    "prettier": "^3.6.2",
+    "typescript": "catalog:",
+    "zod": "^3.25.76"
+  }
+}

--- a/ts-framework/create-function/src/main.ts
+++ b/ts-framework/create-function/src/main.ts
@@ -1,0 +1,189 @@
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import { join, resolve } from "node:path";
+import process from "node:process";
+import { $ } from "zx";
+import { isCancel, log, taskLog } from "@clack/prompts";
+import { parse } from "@bomb.sh/args";
+import pkg from "../package.json" with { type: "json" };
+
+import {
+  confirmOrClack,
+  selectOrClack,
+  textOrClack,
+  yn,
+} from "./prompts/helpers.ts";
+
+const packageNameRE = /^(@?[a-z0-9-_]+\/)?[a-z0-9-_]+$/;
+
+const knownPackageManagers = new Set(["npm", "yarn", "pnpm", "bun", "deno"]);
+
+async function init(argv: string[]): Promise<void> {
+  let packageManager = "npm";
+  let detectedPM = process.env["npm_config_user_agent"]?.split("/")[0] || "";
+  if (knownPackageManagers.has(detectedPM)) {
+    packageManager = detectedPM;
+  }
+
+  const args = parse(argv, {
+    alias: { y: "yes" },
+    string: ["template", "name", "dir", "git", "install"],
+    boolean: ["yes"],
+  });
+
+  const template = await selectOrClack<string>({
+    message: "Pick a framework",
+    options: [
+      {
+        value: "gram",
+        label: "Gram",
+        hint: "Simple framework focused on getting you up and runnning with minimal code.",
+      },
+      {
+        value: "mcp",
+        label: "MCP",
+        hint: "Use the official @modelcontextprotocol/sdk package to build an MCP server and deploy it to Gram.",
+      },
+    ],
+  })(args.template);
+  if (isCancel(template)) {
+    log.info("Operation cancelled.");
+    return;
+  }
+
+  const nameArg = args.name?.trim();
+  const name = await textOrClack({
+    message: "What do you want to call your project?",
+    defaultValue: "gram-mcp-server",
+    validate: (value) => {
+      if (packageNameRE.test(value || "")) {
+        return undefined;
+      }
+      return [
+        "Package names can be scoped or unscoped and must only contain alphanumeric characters, dashes and underscores.",
+        "Examples:",
+        "my-mcp-server",
+        "@fancy-org/mcp-server",
+      ].join(" ");
+    },
+  })(nameArg);
+  if (isCancel(name)) {
+    log.info("Operation cancelled.");
+    return;
+  }
+
+  const rootDir = name.split("/").pop()?.trim() || "gram-func";
+  const dirArg = args.dir?.trim();
+  let dir = await textOrClack({
+    message: "Where do you want to create it?",
+    initialValue: rootDir,
+    defaultValue: rootDir,
+    validate: (value) => {
+      const trimmed = value?.trim() || "";
+      if (trimmed.length === 0) {
+        return "Directory name cannot be empty.";
+      }
+
+      if (existsSync(trimmed)) {
+        return `Directory ${trimmed} already exists. Please choose a different name.`;
+      }
+
+      return undefined;
+    },
+  })(dirArg);
+  if (isCancel(dir)) {
+    log.info("Operation cancelled.");
+    return;
+  }
+  dir = dir.trim();
+
+  const initGit = await confirmOrClack({
+    message: "Initialize a git repository?",
+  })(args.yes || yn(args.git ?? false));
+  if (isCancel(initGit)) {
+    log.info("Operation cancelled.");
+    return;
+  }
+
+  const installDeps = await confirmOrClack({
+    message: `Install dependencies with ${packageManager}?`,
+  })(args.yes || yn(args.install ?? false));
+  if (isCancel(installDeps)) {
+    log.info("Operation cancelled.");
+    return;
+  }
+
+  const tlog = taskLog({
+    title: "Setting up project",
+  });
+
+  tlog.message("Scaffolding");
+  const dirname = import.meta.dirname;
+  const templateDir = resolve(join(dirname, "..", `gram-template-${template}`));
+  await fs.cp(templateDir, dir, {
+    recursive: true,
+    filter: (src) =>
+      !src.includes("node_modules") &&
+      !src.includes(".git") &&
+      !src.includes("dist"),
+  });
+
+  let gramFuncsVersion = pkg.devDependencies["@gram-ai/functions"];
+  if (gramFuncsVersion == null || gramFuncsVersion.startsWith("workspace:")) {
+    // This templating package and `@gram-ai/functions` are versioned in
+    // lockstep so we can just use the matching version.
+    gramFuncsVersion = `^${pkg.version}`;
+  }
+  if (
+    yn(process.env["GRAM_DEV"]) &&
+    existsSync(resolve(dirname, "..", "..", "functions"))
+  ) {
+    // For local development, use the local version of `@gram-ai/functions`
+    // if it exists.
+    const localPkgPath = resolve(dirname, "..", "..", "functions");
+    gramFuncsVersion = `file:${localPkgPath}`;
+    tlog.message(`Using local @gram-ai/functions from ${localPkgPath}`);
+  }
+
+  tlog.message("Updating package.json");
+  const pkgPath = await fs.readFile(join(dir, "package.json"), "utf-8");
+  const dstPkg = JSON.parse(pkgPath);
+  dstPkg.name = name;
+  const deps = dstPkg.dependencies;
+  if (deps?.["@gram-ai/functions"] != null) {
+    deps["@gram-ai/functions"] = gramFuncsVersion;
+  }
+
+  await fs.writeFile(
+    join(dir, "package.json"),
+    JSON.stringify(dstPkg, null, 2),
+  );
+
+  const contributingPath = join(dir, "CONTRIBUTING.md");
+  if (existsSync(contributingPath)) {
+    tlog.message("Creating symlinks for CONTRIBUTING.md");
+    await fs.symlink("CONTRIBUTING.md", join(dir, "AGENTS.md"));
+    await fs.symlink("CONTRIBUTING.md", join(dir, "CLAUDE.md"));
+  }
+
+  if (initGit) {
+    tlog.message("Initializing git repository");
+    await $`git init ${dir}`;
+  }
+
+  if (installDeps) {
+    tlog.message(`Installing dependencies with ${packageManager}`);
+    await $`cd ${dir} && ${packageManager} install`;
+  }
+
+  tlog.success(
+    `All done! Run \`cd ${dir} && ${packageManager} run build\` to build your first Gram Function.`,
+  );
+}
+
+try {
+  await init(process.argv);
+} catch (err) {
+  log.error(`Unexpected error: ${err}`);
+  process.exit(1);
+}

--- a/ts-framework/create-function/src/prompts/helpers.ts
+++ b/ts-framework/create-function/src/prompts/helpers.ts
@@ -1,0 +1,33 @@
+import {
+  confirm,
+  select,
+  text,
+  type ConfirmOptions,
+  type SelectOptions,
+  type TextOptions,
+} from "@clack/prompts";
+
+const y = new Set(["y", "yes", "true", "t", "1"]);
+export function yn(value: boolean | string | undefined): boolean {
+  if (value == null) return false;
+  if (typeof value === "boolean") return value;
+  return y.has(value.toLowerCase());
+}
+
+export function textOrClack(
+  options: TextOptions,
+): (value: string | undefined) => Promise<string | symbol> {
+  return async (value: string | undefined) => value || text(options);
+}
+
+export function selectOrClack<T>(
+  options: SelectOptions<T>,
+): (value: T | undefined) => Promise<T | symbol> {
+  return async (value: T | undefined) => value || select(options);
+}
+
+export function confirmOrClack(
+  options: ConfirmOptions,
+): (value: boolean | undefined) => Promise<boolean | symbol> {
+  return async (value: boolean | undefined) => value || confirm(options);
+}

--- a/ts-framework/create-function/tsconfig.json
+++ b/ts-framework/create-function/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "include": ["src"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "dist",
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+
+    "module": "nodenext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "types": ["node"],
+    "resolveJsonModule": true,
+
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    "noUncheckedIndexedAccess": true,
+
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true
+  }
+}

--- a/ts-framework/functions/README.md
+++ b/ts-framework/functions/README.md
@@ -1,0 +1,424 @@
+# Gram Functions for TypeScript
+
+Gram Functions are small pieces of code that represent LLM tools. They are
+deployed to [Gram](https://getgram.ai) and are then exposed to LLMs via MCP
+servers.
+
+This library provides a small framework for authoring Gram Functions in
+TypeScript. The "Hello, World!" example is:
+
+```typescript
+import { Gram } from "@gram-ai/functions";
+import * as z from "zod/mini";
+
+const g = new Gram().tool({
+  name: "greet",
+  description: "Greet someone special",
+  inputSchema: { name: z.string() },
+  async execute(ctx, input) {
+    return ctx.json({ message: `Hello, ${input.name}!` });
+  },
+});
+
+export const handleToolCall = g.handleToolCall;
+```
+
+## Quickstart
+
+You can use one of the following command to scaffold a new Gram Function project quickly:
+
+```
+pnpm create @gram-ai/function@latest --template gram
+
+## Or one of the following:
+# bun create @gram-ai/function@latest --template gram
+# npm create @gram-ai/function@latest -- --template gram
+```
+
+## Installation
+
+Use one of the following commands to add the package to your project:
+
+```
+pnpm add @gram-ai/functions
+
+## Or one of the following:
+# bun add @gram-ai/functions
+# npm add @gram-ai/functions
+```
+
+## Core Concepts
+
+### The Gram Instance
+
+The `Gram` class is the main entry point for defining tools. You create an instance and chain `.tool()` calls to register multiple tools:
+
+```typescript
+import { Gram } from "@gram-ai/functions";
+import * as z from "zod/mini";
+
+const g = new Gram()
+  .tool({
+    name: "add",
+    description: "Add two numbers",
+    inputSchema: { a: z.number(), b: z.number() },
+    async execute(ctx, input) {
+      return ctx.json({ sum: input.a + input.b });
+    },
+  })
+  .tool({
+    name: "multiply",
+    description: "Multiply two numbers",
+    inputSchema: { a: z.number(), b: z.number() },
+    async execute(ctx, input) {
+      return ctx.json({ product: input.a * input.b });
+    },
+  });
+
+export const handleToolCall = g.handleToolCall;
+```
+
+### Tool Definition
+
+Each tool requires:
+
+- **name**: A unique identifier for the tool
+- **description** (optional): Human-readable description of what the tool does
+- **inputSchema**: A Zod schema object defining the expected input parameters
+- **variables** (optional): Environment variables the tool needs
+- **execute**: An async function that implements the tool logic
+
+### Tool Context
+
+The `execute` function receives a `ctx` (context) object with helper methods:
+
+#### `ctx.json(data)`
+
+Returns a JSON response:
+
+```typescript
+async execute(ctx, input) {
+  return ctx.json({ result: "success", value: 42 });
+}
+```
+
+#### `ctx.text(data)`
+
+Returns a plain text response:
+
+```typescript
+async execute(ctx, input) {
+  return ctx.text("Operation completed successfully");
+}
+```
+
+#### `ctx.html(data)`
+
+Returns an HTML response:
+
+```typescript
+async execute(ctx, input) {
+  return ctx.html("<h1>Hello, World!</h1>");
+}
+```
+
+#### `ctx.fail(data, options?)`
+
+Throws an error response (never returns):
+
+```typescript
+async execute(ctx, input) {
+  if (!input.value) {
+    ctx.fail({ error: "value is required" }, { status: 400 });
+  }
+  // ...
+}
+```
+
+#### `ctx.signal`
+
+An `AbortSignal` for handling cancellation:
+
+```typescript
+async execute(ctx, input) {
+  const response = await fetch(input.url, { signal: ctx.signal });
+  return ctx.json(await response.json());
+}
+```
+
+#### `ctx.vars`
+
+Access to environment variables defined in the tool's `variables` property:
+
+```typescript
+.tool({
+  name: "api_call",
+  inputSchema: { endpoint: z.string() },
+  variables: {
+    API_KEY: { description: "API key for authentication" }
+  },
+  async execute(ctx, input) {
+    const apiKey = ctx.vars.API_KEY;
+    // Use apiKey...
+  },
+})
+```
+
+## Input Validation
+
+Input schemas are defined using [Zod](https://zod.dev/):
+
+```typescript
+import * as z from "zod/mini";
+
+.tool({
+  name: "create_user",
+  inputSchema: {
+    email: z.string().check(z.email()),
+    age: z.number().check(z.min(18)),
+    name: z.optional(z.string()),
+  },
+  async execute(ctx, input) {
+    // input is fully typed based on the schema
+    return ctx.json({ userId: "123" });
+  },
+})
+```
+
+### Lax Mode
+
+By default, the framework strictly validates input. You can enable lax mode to allow unvalidated input to pass through:
+
+```typescript
+const g = new Gram({ lax: true });
+```
+
+## Environment Variables
+
+### Runtime Environment
+
+Pass environment variables are read from `process.env` by default, but you can override them when creating the `Gram` instance:
+
+```typescript
+const g = new Gram({
+  env: {
+    API_KEY: "secret-key",
+    BASE_URL: "https://api.example.com",
+  },
+});
+```
+
+If not provided, the framework falls back to `process.env`.
+
+### Tool Variables
+
+Declare which environment variables a tool needs:
+
+```typescript
+.tool({
+  name: "weather",
+  inputSchema: { city: z.string() },
+  variables: {
+    WEATHER_API_KEY: {
+      description: "API key for weather service"
+    }
+  },
+  async execute(ctx, input) {
+    const apiKey = ctx.vars.WEATHER_API_KEY;
+    // Make API call...
+  },
+})
+```
+
+## Response Types
+
+The framework supports multiple response types. All response methods return Web API `Response` objects.
+
+### JSON Response
+
+```typescript
+return ctx.json({
+  status: "success",
+  data: { id: 123, name: "Example" },
+});
+```
+
+### Text Response
+
+```typescript
+return ctx.text("Plain text response");
+```
+
+### HTML Response
+
+```typescript
+return ctx.html(`
+  <!DOCTYPE html>
+  <html>
+    <body><h1>Hello</h1></body>
+  </html>
+`);
+```
+
+### Custom Response
+
+You can also return a plain `Response` object:
+
+```typescript
+return new Response(data, {
+  status: 200,
+  headers: {
+    "Content-Type": "application/xml",
+    "X-Custom-Header": "value",
+  },
+});
+```
+
+## Error Handling
+
+### Using `ctx.fail()`
+
+Use `ctx.fail()` to throw error responses:
+
+```typescript
+async execute(ctx, input) {
+  if (!input.userId) {
+    ctx.fail(
+      { error: "userId is required" },
+      { status: 400 }
+    );
+  }
+
+  const user = await fetchUser(input.userId);
+  if (!user) {
+    ctx.fail(
+      { error: "User not found" },
+      { status: 404 }
+    );
+  }
+
+  return ctx.json({ user });
+}
+```
+
+Errors automatically include a stack trace in the response.
+
+### Using `assert()`
+
+The `assert` function provides a convenient way to validate conditions and throw error responses:
+
+```typescript
+import { assert } from "@gram-ai/functions";
+
+async execute(ctx, input) {
+  assert(input.userId, { error: "userId is required" }, { status: 400 });
+
+  const user = await fetchUser(input.userId);
+  assert(user, { error: "User not found" }, { status: 404 });
+
+  return ctx.json({ user });
+}
+```
+
+The `assert` function throws a `Response` object when the condition is false. The framework catches all thrown values, and if any happen to be a `Response` instance, they will be returned to the client.
+
+Key points about `assert`:
+- First parameter is the condition to check
+- Second parameter is the error data (must include an `error` field)
+- Third parameter is optional and can specify the status code (defaults to 500)
+- Automatically includes a stack trace in the response
+- Uses TypeScript's assertion type to narrow types when the assertion passes
+
+## Manifest Generation
+
+Generate a manifest of all registered tools:
+
+```typescript
+const g = new Gram()
+  .tool({
+    /* ... */
+  })
+  .tool({
+    /* ... */
+  });
+
+const manifest = g.manifest();
+// {
+//   version: "0.0.0",
+//   tools: [
+//     {
+//       name: "tool1",
+//       description: "...",
+//       inputSchema: "...", // JSON Schema string
+//       variables: { ... }
+//     },
+//     ...
+//   ]
+// }
+```
+
+## Handling Tool Calls
+
+Export the `handleToolCall` method to process incoming requests:
+
+```typescript
+const g = new Gram()
+  .tool({
+    /* ... */
+  })
+  .tool({
+    /* ... */
+  });
+
+export const handleToolCall = g.handleToolCall;
+```
+
+You can also call tools programmatically:
+
+```typescript
+const response = await g.handleToolCall({
+  name: "add",
+  input: { a: 5, b: 3 },
+});
+
+const data = await response.json();
+console.log(data); // { sum: 8 }
+```
+
+With abort signal support:
+
+```typescript
+const controller = new AbortController();
+
+const responsePromise = g.handleToolCall(
+  { name: "longRunning", input: {} },
+  { signal: controller.signal },
+);
+
+// Cancel after 5 seconds
+setTimeout(() => controller.abort(), 5000);
+```
+
+## Type Safety
+
+The framework provides full TypeScript type inference:
+
+```typescript
+const g = new Gram().tool({
+  name: "greet",
+  inputSchema: { name: z.string() },
+  async execute(ctx, input) {
+    // input.name is typed as string
+    return ctx.json({ message: `Hello, ${input.name}` });
+  },
+});
+
+// Type-safe tool calls
+const response = await g.handleToolCall({
+  name: "greet", // Only "greet" is valid
+  input: { name: "World" }, // input is typed correctly
+});
+
+// Response type is inferred
+const data = await response.json(); // { message: string }
+```

--- a/ts-framework/functions/package.json
+++ b/ts-framework/functions/package.json
@@ -1,0 +1,50 @@
+{
+  "type": "module",
+  "name": "@gram-ai/functions",
+  "version": "0.0.0",
+  "description": "",
+  "author": "Georges Haidar <georges@speakeasyapi.dev>",
+  "main": "dist/index.js",
+  "keywords": [],
+  "license": "ISC",
+  "scripts": {
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "packageManager": "pnpm@10.18.2",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./build": {
+      "import": "./dist/build/index.js",
+      "types": "./dist/build/index.d.ts"
+    }
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": "^1.19.1",
+    "zod": "^4"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "archiver": "^7.0.1",
+    "esbuild": "^0.25.10"
+  },
+  "devDependencies": {
+    "@types/archiver": "^6.0.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/ts-framework/functions/src/build/gram.ts
+++ b/ts-framework/functions/src/build/gram.ts
@@ -1,0 +1,89 @@
+import { mkdir, open, stat, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import esbuild from "esbuild";
+import { Gram } from "../framework.ts";
+import archiver from "archiver";
+
+export async function buildFunctions(options: {
+  entrypoint: string;
+  export: string;
+  outDir: string;
+  cwd?: string;
+}) {
+  const cwd = options.cwd ?? process.cwd();
+  const entrypoint = resolve(cwd, options.entrypoint);
+  const gram = await import(entrypoint).then((mod) => {
+    const exportsym = options.export ?? "gram";
+    const gramExport = mod[exportsym];
+    if (!(gramExport instanceof Gram)) {
+      throw new Error(
+        `Export "${exportsym}" does not appear to be an instance of Gram`,
+      );
+    }
+
+    if (
+      exportsym !== "default" &&
+      typeof mod["handleToolCall"] !== "function"
+    ) {
+      throw new Error(
+        `Either make the Gram instance the default export or export a "handleToolCall" function in ${entrypoint}.`,
+      );
+    }
+
+    return gramExport;
+  });
+
+  const manifest = gram.manifest();
+
+  await mkdir(options.outDir, { recursive: true });
+  const outFile = resolve(options.outDir, "manifest.json");
+  await writeFile(outFile, JSON.stringify(manifest, null, 2));
+
+  await bundleFunction({
+    entrypoint,
+    outFile: resolve(options.outDir, "functions.js"),
+  });
+
+  const archive = archiver("zip", { zlib: { level: 9 } });
+  const { promise, resolve: res, reject: rej } = Promise.withResolvers<void>();
+  archive.on("error", rej);
+  archive.on("close", res);
+
+  const output = await open(resolve(options.outDir, "gram.zip"), "w");
+  archive.pipe(output.createWriteStream());
+  archive.file(join(options.outDir, "manifest.json"), {
+    name: "manifest.json",
+  });
+  archive.file(join(options.outDir, "functions.js"), { name: "functions.js" });
+  await archive.finalize();
+  await promise;
+  await output.close();
+
+  const zipstats = await stat(join(options.outDir, "gram.zip"));
+  return {
+    files: [{ path: join(options.outDir, "gram.zip"), size: zipstats.size }],
+  };
+}
+
+async function bundleFunction(options: {
+  entrypoint: string;
+  outFile: string;
+}): Promise<Array<{ path: string; hash: string }>> {
+  const res = await esbuild.build({
+    entryPoints: [options.entrypoint],
+    outfile: options.outFile,
+    bundle: true,
+    treeShaking: true,
+    minify: true,
+    platform: "node",
+    target: ["node22"],
+    format: "esm",
+  });
+
+  return (
+    res.outputFiles?.map((f) => ({
+      path: f.path,
+      hash: f.hash,
+    })) || []
+  );
+}

--- a/ts-framework/functions/src/build/index.ts
+++ b/ts-framework/functions/src/build/index.ts
@@ -1,0 +1,2 @@
+export { buildFunctions } from "./gram.ts";
+export { buildMCPServer } from "./mcp.ts";

--- a/ts-framework/functions/src/build/mcp.ts
+++ b/ts-framework/functions/src/build/mcp.ts
@@ -1,0 +1,128 @@
+import { writeFile, open, stat, mkdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import esbuild from "esbuild";
+import archiver from "archiver";
+
+export type BuildMCPServerResult = {
+  files: Array<{ path: string; size: number }>;
+};
+
+export async function buildMCPServer(options: {
+  serverEntrypoint: string;
+  serverExport: string;
+  functionEntrypoint: string;
+  outDir: string;
+}): Promise<BuildMCPServerResult> {
+  await mkdir(options.outDir, { recursive: true });
+
+  const manifest = await buildFunctionsManifest({
+    entrypoint: options.serverEntrypoint,
+    serverExport: options.serverExport,
+  });
+  await writeFile(
+    join(options.outDir, "manifest.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+
+  await bundleFunction({
+    entrypoint: options.functionEntrypoint,
+    outFile: join(options.outDir, "functions.js"),
+  });
+
+  const archive = archiver("zip", { zlib: { level: 9 } });
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  archive.on("error", reject);
+  archive.on("close", resolve);
+
+  const output = await open(join(options.outDir, "gram.zip"), "w");
+  archive.pipe(output.createWriteStream());
+  archive.file(join(options.outDir, "manifest.json"), {
+    name: "manifest.json",
+  });
+  archive.file(join(options.outDir, "functions.js"), { name: "functions.js" });
+  await archive.finalize();
+  await promise;
+  await output.close();
+
+  const zipstats = await stat(join(options.outDir, "gram.zip"));
+  return {
+    files: [{ path: join(options.outDir, "gram.zip"), size: zipstats.size }],
+  };
+}
+
+async function buildFunctionsManifest(options: {
+  entrypoint: string;
+  serverExport?: string;
+  cwd?: string;
+}): Promise<{
+  version: string;
+  tools: Array<{
+    name: string;
+    description?: string | undefined;
+    inputSchema: unknown;
+  }>;
+}> {
+  const cwd = options.cwd ?? process.cwd();
+  const entrypoint = resolve(cwd, options.entrypoint);
+
+  const { InMemoryTransport } = await import(
+    "@modelcontextprotocol/sdk/inMemory.js"
+  );
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+
+  const server = await import(entrypoint).then((mod) => {
+    const exportsym = options.serverExport ?? "server";
+    const serverExport = mod[exportsym];
+    const klass = serverExport?.constructor?.name;
+    if (klass !== "McpServer") {
+      throw new Error(
+        `Export "${exportsym}" does not appear to be an instance of McpServer`,
+      );
+    }
+
+    return serverExport;
+  });
+
+  const mcpClient = new Client({
+    name: "@gram-ai/functions",
+    version: "0.0.0",
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await mcpClient.connect(clientTransport);
+
+  const res = await mcpClient.listTools();
+  const tools = res.tools.map((tool) => {
+    return {
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    };
+  });
+
+  return { version: "0.0.0", tools };
+}
+
+async function bundleFunction(options: {
+  entrypoint: string;
+  outFile: string;
+}): Promise<Array<{ path: string; hash: string }>> {
+  const res = await esbuild.build({
+    entryPoints: [options.entrypoint],
+    outfile: options.outFile,
+    bundle: true,
+    treeShaking: true,
+    minify: true,
+    platform: "node",
+    target: ["node22"],
+    format: "esm",
+  });
+
+  return (
+    res.outputFiles?.map((f) => ({
+      path: f.path,
+      hash: f.hash,
+    })) || []
+  );
+}

--- a/ts-framework/functions/src/framework.test.ts
+++ b/ts-framework/functions/src/framework.test.ts
@@ -1,0 +1,385 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod/mini";
+import {
+  Gram,
+  assert,
+  type JSONResponse,
+  type TextResponse,
+  type ToolSignature,
+} from "./framework.ts";
+
+test("static types", () => {
+  const g = new Gram()
+    .tool({
+      name: "echo",
+      description: "Echoes the input",
+      inputSchema: { message: z.string() },
+      async execute(ctx, input) {
+        return ctx.json({ echoed: input.message });
+      },
+    })
+    .tool({
+      name: "add",
+      description: "Add two numbers",
+      inputSchema: { a: z.number(), b: z.number() },
+      async execute(ctx, input) {
+        return ctx.json({ sum: input.a + input.b });
+      },
+    })
+    .tool({
+      name: "shout",
+      description: "Shouts the input",
+      inputSchema: {},
+      variables: { MESSAGE: { description: "The message to shout" } },
+      async execute(ctx) {
+        return ctx.text(ctx.vars["MESSAGE"]?.toUpperCase() + "!!!");
+      },
+    });
+
+  type G = typeof g extends Gram<infer TTools> ? TTools : never;
+  const val: any = null;
+  const all = [
+    val as ToolSignature<G["echo"]>,
+    val as ToolSignature<G["add"]>,
+    val as ToolSignature<G["shout"]>,
+  ] as const;
+
+  all satisfies readonly [
+    ["echo", { message: string }, string, JSONResponse<{ echoed: string }>],
+    ["add", { a: number; b: number }, string, JSONResponse<{ sum: number }>],
+    ["shout", {}, string, TextResponse<string>],
+  ];
+});
+
+test("calls one registered tool", async () => {
+  const g = new Gram().tool({
+    name: "echo",
+    description: "Echoes the input",
+    inputSchema: { message: z.string() },
+    async execute(ctx, input) {
+      return ctx.json({ echoed: input.message });
+    },
+  });
+
+  const response = await g.handleToolCall({
+    name: "echo",
+    input: { message: "Hello, world!" },
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Content-Type")).toBe("application/json");
+
+  const data = await response.json();
+  expect(data).toEqual({ echoed: "Hello, world!" });
+});
+
+test("calls many registered tools", async () => {
+  const g = new Gram()
+    .tool({
+      name: "echo",
+      description: "Echoes the input",
+      inputSchema: { message: z.string() },
+      async execute(ctx, input) {
+        return ctx.json({ echoed: input.message });
+      },
+    })
+    .tool({
+      name: "add",
+      description: "Add two numbers",
+      inputSchema: { a: z.number(), b: z.number() },
+      async execute(ctx, input) {
+        return ctx.json({ sum: input.a + input.b });
+      },
+    });
+
+  const res1 = await g.handleToolCall({
+    name: "echo",
+    input: { message: "Hello, world!" },
+  });
+  expect(res1.status).toBe(200);
+  expect(res1.headers.get("Content-Type")).toBe("application/json");
+
+  let data1 = await res1.json();
+  expect(data1).toEqual({ echoed: "Hello, world!" });
+  data1 satisfies { echoed: string };
+
+  const res2 = await g.handleToolCall({
+    name: "add",
+    input: { a: 1, b: 2 },
+  });
+  expect(res2.status).toBe(200);
+  expect(res2.headers.get("Content-Type")).toBe("application/json");
+
+  const data2 = await res2.json();
+  expect(data2).toEqual({ sum: 3 });
+  data2 satisfies { sum: number };
+});
+
+test("throws on unrecognized tool", async () => {
+  const g = new Gram()
+    .tool({
+      name: "echo",
+      description: "Echoes the input",
+      inputSchema: { message: z.string() },
+      async execute(ctx, input) {
+        return ctx.json({ echoed: input.message });
+      },
+    })
+    .tool({
+      name: "add",
+      description: "Add two numbers",
+      inputSchema: { a: z.number(), b: z.number() },
+      async execute(ctx, input) {
+        return ctx.json({ sum: input.a + input.b });
+      },
+    });
+
+  await expect(
+    // Make it look like we have this tool for TypeScript. We just want to
+    // test that the right error is thrown at runtime.
+    (g as any).handleToolCall({
+      name: "fail",
+      input: { value: "unreachable" },
+    }),
+  ).rejects.toThrow("Tool not found: fail");
+});
+
+test("supports environment variables", async () => {
+  const g = new Gram({ env: { GREETING: "Hello!" } }).tool({
+    name: "echo",
+    description: "Echoes the input",
+    inputSchema: {},
+    variables: { GREETING: { description: "The message to echo" } },
+    async execute(ctx) {
+      return ctx.json({ echoed: ctx.vars["GREETING"] || "fail" });
+    },
+  });
+
+  const response = await g.handleToolCall({
+    name: "echo",
+    input: {},
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Content-Type")).toBe("application/json");
+
+  const data = await response.json();
+  expect(data).toEqual({ echoed: "Hello!" });
+});
+
+test("supports text tools", async () => {
+  const g = new Gram()
+    .tool({
+      name: "add",
+      description: "Add two numbers",
+      inputSchema: { a: z.number(), b: z.number() },
+      async execute(ctx, input) {
+        return ctx.json({ sum: input.a + input.b });
+      },
+    })
+    .tool({
+      name: "shout",
+      description: "Shouts the input",
+      inputSchema: { message: z.string() },
+      async execute(ctx, input) {
+        return ctx.text(input.message.toUpperCase() + "!!!");
+      },
+    });
+
+  // Call two tools to verify that there are no side effects between calls.
+  let response: Response = await g.handleToolCall({
+    name: "add",
+    input: { a: 1, b: 2 },
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Content-Type")).toBe("application/json");
+  let data: unknown = await response.json();
+  expect(data).toEqual({ sum: 3 });
+
+  response = await g.handleToolCall({
+    name: "shout",
+    input: { message: "hello" },
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Content-Type")).toBe("text/plain;charset=UTF-8");
+
+  data = await response.text();
+  expect(data).toBe("HELLO!!!");
+});
+
+test("supports html tools", async () => {
+  const g = new Gram().tool({
+    name: "shout",
+    description: "Shouts the input",
+    inputSchema: { message: z.string() },
+    async execute(ctx, input) {
+      return ctx.html(`<h1>${input.message.toUpperCase()}!!!</h1>`);
+    },
+  });
+
+  const response = await g.handleToolCall({
+    name: "shout",
+    input: { message: "hello" },
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Content-Type")).toBe("text/html");
+
+  const data = await response.text();
+  expect(data).toBe("<h1>HELLO!!!</h1>");
+});
+
+test("supports plain Response values", async () => {
+  const g = new Gram().tool({
+    name: "shout",
+    description: "Shouts the input",
+    inputSchema: { message: z.string() },
+    async execute(_ctx, input) {
+      return new Response(input.message.toUpperCase() + "!!!", {
+        status: 200,
+        headers: {
+          "Content-Type": "text/plain;charset=UTF-8",
+        },
+      });
+    },
+  });
+
+  const response = await g.handleToolCall({
+    name: "shout",
+    input: { message: "hello" },
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Content-Type")).toBe("text/plain;charset=UTF-8");
+
+  const data = await response.text();
+  expect(data).toBe("HELLO!!!");
+});
+
+test("generates a manifest", () => {
+  const g = new Gram()
+    .tool({
+      name: "echo",
+      inputSchema: { message: z.string() },
+      async execute(ctx, input) {
+        return ctx.json({ echoed: input.message });
+      },
+    })
+    .tool({
+      name: "add",
+      description: "Add two numbers",
+      inputSchema: { a: z.number(), b: z.number() },
+      async execute(ctx, input) {
+        return ctx.json({ sum: input.a + input.b });
+      },
+    })
+    .tool({
+      name: "shout",
+      description: "Shouts the input",
+      inputSchema: {},
+      variables: { MESSAGE: { description: "The message to shout" } },
+      async execute(ctx) {
+        return ctx.text(ctx.vars["MESSAGE"]?.toUpperCase() + "!!!");
+      },
+    });
+
+  expect(g.manifest()).toEqual({
+    version: "0.0.0",
+    tools: [
+      {
+        name: "echo",
+        inputSchema: expect.stringContaining("message"),
+      },
+      {
+        name: "add",
+        description: "Add two numbers",
+        inputSchema: expect.stringContaining(`"required":["a","b"]`),
+      },
+      {
+        name: "shout",
+        description: "Shouts the input",
+        inputSchema: expect.any(String),
+        variables: {
+          MESSAGE: { description: "The message to shout" },
+        },
+      },
+    ],
+  });
+});
+
+test("assert throws response with default status 500", () => {
+  expect(() => {
+    assert(false, { error: "Something went wrong" });
+  }).toThrow(Response);
+
+  try {
+    assert(false, { error: "Something went wrong" });
+  } catch (err) {
+    expect(err).toBeInstanceOf(Response);
+    const response = err as Response;
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+  }
+});
+
+test("assert throws response with custom status", async () => {
+  try {
+    assert(false, { error: "Bad request" }, { status: 400 });
+  } catch (err) {
+    expect(err).toBeInstanceOf(Response);
+    const response = err as Response;
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+
+    const data = await response.json();
+    expect(data).toMatchObject({ error: "Bad request" });
+    expect(data).toHaveProperty("stack");
+  }
+});
+
+test("assert does not throw when condition is true", () => {
+  expect(() => {
+    assert(true, { error: "This should not throw" });
+  }).not.toThrow();
+});
+
+describe("with fake timers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("propagates abort signal", async () => {
+    const g = new Gram().tool({
+      name: "waiter",
+      description: "Waits for a signal",
+      inputSchema: {},
+      async execute(ctx) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        ctx.signal.addEventListener("abort", () => {
+          resolve();
+        });
+        await promise;
+        return ctx.json({ done: ctx.signal.aborted });
+      },
+    });
+
+    const controller = new AbortController();
+    const callPromise = g.handleToolCall(
+      {
+        name: "waiter",
+        input: {},
+      },
+      { signal: controller.signal },
+    );
+
+    // Abort after the tool execution has started
+    setTimeout(() => controller.abort(), 1000);
+    vi.runAllTimers();
+
+    const response = await callPromise;
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+
+    const data = await response.json();
+    expect(data).toEqual({ done: true });
+  });
+});

--- a/ts-framework/functions/src/framework.ts
+++ b/ts-framework/functions/src/framework.ts
@@ -1,0 +1,246 @@
+import type * as z from "zod";
+import * as zm from "zod/mini";
+
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
+type VarDef = { description?: string };
+
+export class ResponseError extends Error {
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ResponseError";
+  }
+}
+
+export type ToolDefinition<
+  TName extends string,
+  TInputSchema extends z.core.$ZodShape,
+  Vars extends string,
+  Result extends Response,
+> = {
+  name: TName;
+  description?: string;
+  inputSchema: TInputSchema;
+  variables?: Record<string, VarDef>;
+  execute: (
+    ctx: ToolContext<Record<Vars, string | undefined>>,
+    input: z.infer<z.ZodObject<TInputSchema>>,
+  ) => Promise<Result>;
+};
+
+export type ToolSignature<T> =
+  T extends ToolDefinition<
+    infer Name,
+    infer InputSchema,
+    infer Vars,
+    infer Result
+  >
+    ? [Name, z.infer<z.ZodObject<InputSchema>>, Vars, Result]
+    : never;
+
+type InferInput<T> = ToolSignature<T>[1];
+
+type InferResult<T> = ToolSignature<T>[3];
+
+export type Manifest = {
+  version: string;
+  tools: Array<{
+    name: string;
+    description?: string;
+    inputSchema: string;
+    variables?: Record<string, VarDef>;
+  }>;
+};
+
+export function assert<V extends { error: string; stack?: never }>(
+  cond: boolean,
+  data: V,
+  options?: { status?: number },
+): asserts cond {
+  if (!cond) {
+    throw new Response(
+      JSON.stringify({ ...data, stack: new ResponseError().stack }),
+      {
+        status: options?.status || 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  }
+}
+
+class ToolContext<
+  Vars extends Record<string, string | undefined> = Record<
+    string,
+    string | undefined
+  >,
+> {
+  #keys: Set<string>;
+  #env: Record<string, string | undefined>;
+  readonly signal: AbortSignal;
+  constructor(
+    signal: AbortSignal,
+    vardef: Record<keyof Vars, VarDef>,
+    env?: Record<string, string | undefined>,
+  ) {
+    this.signal = signal;
+    this.#keys = new Set(Object.keys(vardef));
+    this.#env = env || {};
+  }
+
+  get vars(): Vars {
+    const result: Record<string, string> = {};
+    for (const key of this.#keys) {
+      if (Object.hasOwn(this.#env, key) && this.#env[key] != null) {
+        result[key] = this.#env[key] || "";
+      }
+    }
+    return result as Vars;
+  }
+
+  fail<V extends { error: string; stack?: never }>(
+    data: V,
+    options?: { status?: number },
+  ): never {
+    assert(false, data, options);
+  }
+
+  json<V>(data: V): JSONResponse<V> {
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }) as JSONResponse<V>;
+  }
+  text<V extends string>(data: V): TextResponse<V> {
+    return new Response(data, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain;charset=UTF-8",
+      },
+    }) as TextResponse<V>;
+  }
+  html(data: string): TextResponse<string> {
+    return new Response(data, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html",
+      },
+    }) as TextResponse<string>;
+  }
+}
+
+export interface JSONResponse<T> extends Response {
+  json(): Promise<T>;
+}
+
+export interface TextResponse<T extends string> extends Response {
+  text(): Promise<T>;
+}
+
+export class Gram<
+  TTools extends {
+    [k: string]: ToolDefinition<any, any, string, Response>;
+  } = {},
+> {
+  private tools: Map<string, ToolDefinition<any, any, string, Response>>;
+  private lax: boolean;
+  private env: Record<string, string | undefined> | undefined;
+
+  constructor(opts?: { lax?: boolean; env?: Record<string, string> }) {
+    this.tools = new Map();
+    this.lax = Boolean(opts?.lax);
+    this.env = opts?.env;
+  }
+
+  tool<
+    TName extends string,
+    TInputSchema extends z.core.$ZodShape,
+    TVariables extends string,
+    Res extends Response,
+  >(
+    definition: ToolDefinition<TName, TInputSchema, TVariables, Res>,
+  ): Gram<
+    Prettify<
+      TTools & {
+        [k in TName]: ToolDefinition<TName, TInputSchema, TVariables, Res>;
+      }
+    >
+  > {
+    this.tools.set(definition.name, definition as any);
+    return this as any;
+  }
+
+  async handleToolCall<TName extends keyof TTools & string>(
+    request: {
+      name: TName;
+      input: InferInput<TTools[TName]>;
+    },
+    options?: { signal?: AbortSignal },
+  ): Promise<InferResult<TTools[TName]>> {
+    const tool = this.tools.get(request.name);
+    if (!tool) {
+      throw new Error(`Tool not found: ${request.name}`);
+    }
+
+    const ctx = new ToolContext(
+      options?.signal || new AbortController().signal,
+      tool.variables || {},
+      this.env || process.env,
+    );
+
+    const schema = zm.object(tool.inputSchema);
+    const vres = schema.safeParse(request.input);
+    let validatedInput: Record<string, unknown> = {};
+    if (vres.success) {
+      validatedInput = vres.data;
+    } else if (
+      this.lax &&
+      typeof request.input === "object" &&
+      request.input !== null
+    ) {
+      validatedInput = request.input as Record<string, unknown>;
+    } else {
+      ctx.fail(
+        { error: vres.error.message, issues: vres.error.issues },
+        { status: 400 },
+      );
+    }
+
+    return (await tool.execute(ctx, validatedInput)) as InferResult<
+      TTools[TName]
+    >;
+  }
+
+  manifest(): Manifest {
+    const tools = Array.from(this.tools.values()).map((tool) => {
+      const schema = zm.object(tool.inputSchema);
+      const inputSchema = zm.toJSONSchema(schema);
+      const result: {
+        name: string;
+        description?: string;
+        inputSchema: string;
+        variables?: Record<string, VarDef>;
+      } = {
+        name: tool.name,
+        inputSchema: JSON.stringify(inputSchema),
+      };
+      if (tool.description != null) {
+        result.description = tool.description;
+      }
+      if (tool.variables != null && Object.keys(tool.variables).length > 0) {
+        result.variables = tool.variables;
+      }
+      return result;
+    });
+
+    return {
+      version: "0.0.0",
+      tools,
+    };
+  }
+}

--- a/ts-framework/functions/src/index.ts
+++ b/ts-framework/functions/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./framework.js";

--- a/ts-framework/functions/tsconfig.json
+++ b/ts-framework/functions/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "include": ["src"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "rewriteRelativeImportExtensions": true,
+
+    "module": "nodenext",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "types": ["node"],
+    "resolveJsonModule": true,
+
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
This change introduces a new framework that simplifies writing and bundling Gram Functions. The simplest "Hello, World!" Gram Function with this framework looks like this:

```typescript
import { Gram } from "@gram-ai/functions";
import * as z from "zod/mini";

const gram = new Gram().tool({
  name: "greet",
  description: "Greet someone special",
  inputSchema: { name: z.string() },
  async execute(ctx, input) {
    return ctx.json({ message: `Hello, ${input.name}!` });
  },
});

export default gram;
```

In addition to the new framework, we introduce a project scaffolder that users can run to quickly set up a new Gram Functions project with all necessary boilerplate and configuration. When it is published, it will be available through:

```
pnpm create @gram-ai/function
```