### PR TITLE
chore: hide prefixed URL when it overcrowds the UI

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -478,7 +478,12 @@ export function MCPDetails({ toolset }: { toolset: Toolset }) {
         <Block label="Custom Slug" error={mcpSlugError} className="p-0">
           <BlockInner>
             <Stack direction="horizontal" align="center">
-              <Type muted mono variant="small">
+              <Type
+                muted
+                mono
+                variant="small"
+                className="hidden @lg/main:block"
+              >
                 {toolset.mcpSlug && customServerURL
                   ? `${customServerURL}/mcp/`
                   : `${getServerURL()}/mcp/`}


### PR DESCRIPTION
Introduces a container query to hide the full URL in the custom slug. I don't love solutions that hide info on smaller screens but in the name of practicality and making this interface at least somewhat usable feels like a somewhat reasonable compromise.

# before
<img width="586" height="273" alt="image" src="https://github.com/user-attachments/assets/2cfa846f-b7b6-4aae-9bd4-de7d65107b1b" />

# after
<img width="579" height="204" alt="image" src="https://github.com/user-attachments/assets/0e032623-5ba6-43ad-a9ec-edbad80745be" />


