### PR TITLE
chore: implement functions.ToolCaller interface

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -498,7 +498,7 @@ func newStartCommand() *cli.Command {
 
 			slackClient := slack_client.NewSlackClient(slack.SlackClientID(c.String("environment")), c.String("slack-client-secret"), db, encryptionClient)
 			baseChatClient := openrouter.NewChatClient(logger, openRouter)
-			chatClient := chat.NewChatClient(logger, tracerProvider, meterProvider, db, openRouter, baseChatClient, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, tcm)
+			chatClient := chat.NewChatClient(logger, tracerProvider, meterProvider, db, openRouter, baseChatClient, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, tcm)
 			mux := goahttp.NewMuxer()
 
 			mux.Use(middleware.CORSMiddleware(c.String("environment"), c.String("server-url")))
@@ -526,10 +526,10 @@ func newStartCommand() *cli.Command {
 			tools.Attach(mux, tools.NewService(logger, db, sessionManager))
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env)
 			oauth.Attach(mux, oauthService)
-			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, billingTracker, tcm))
+			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, billingTracker, tcm))
 			mcpMetadataService := mcpmetadata.NewService(logger, db, sessionManager, serverURL, cache.NewRedisCacheAdapter(redisClient))
 			mcpmetadata.Attach(mux, mcpMetadataService)
-			mcp.Attach(mux, mcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, env, posthogClient, serverURL, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, oauthService, billingTracker, billingRepo, tcm), mcpMetadataService)
+			mcp.Attach(mux, mcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, env, posthogClient, serverURL, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, oauthService, billingTracker, billingRepo, tcm), mcpMetadataService)
 			chat.Attach(mux, chat.NewService(logger, db, sessionManager, openRouter))
 			if slackClient.Enabled() {
 				slack.Attach(mux, slack.NewService(logger, db, sessionManager, encryptionClient, redisClient, slackClient, temporalClient, slack.Configurations{

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -354,7 +354,7 @@ func newWorkerCommand() *cli.Command {
 
 			slackClient := slack_client.NewSlackClient(slack.SlackClientID(c.String("environment")), c.String("slack-client-secret"), db, encryptionClient)
 			baseChatClient := openrouter.NewChatClient(logger, openRouter)
-			chatClient := chat.NewChatClient(logger, tracerProvider, meterProvider, db, openRouter, baseChatClient, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, tcm)
+			chatClient := chat.NewChatClient(logger, tracerProvider, meterProvider, db, openRouter, baseChatClient, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, tcm)
 
 			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, redisClient, posthogClient, c)
 			if err != nil {

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -91,6 +91,7 @@ const (
 	ErrorIDKey                     = attribute.Key("gram.error.id")
 	FilterExpressionKey            = attribute.Key("gram.filter.src")
 	FlyAppInternalIDKey            = attribute.Key("gram.fly.app_id")
+	FunctionsBackendKey            = attribute.Key("gram.functions.backend")
 	FunctionsManifestVersionKey    = attribute.Key("gram.functions.manifest_version")
 	FunctionsRunnerImageKey        = attribute.Key("gram.functions.runner_image")
 	FunctionsRunnerVersionKey      = attribute.Key("gram.functions.runner_version")
@@ -400,6 +401,9 @@ func SlogFilterExpression(v string) slog.Attr      { return slog.String(string(F
 
 func FlyAppInternalID(v string) attribute.KeyValue { return FlyAppInternalIDKey.String(v) }
 func SlogFlyAppInternalID(v string) slog.Attr      { return slog.String(string(FlyAppInternalIDKey), v) }
+
+func FunctionsBackend(v string) attribute.KeyValue { return FunctionsBackendKey.String(v) }
+func SlogFunctionsBackend(v string) slog.Attr      { return slog.String(string(FunctionsBackendKey), v) }
 
 func FunctionsManifestVersion(v string) attribute.KeyValue {
 	return FunctionsManifestVersionKey.String(v)

--- a/server/internal/chat/client.go
+++ b/server/internal/chat/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	env_repo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -54,6 +55,7 @@ func NewChatClient(logger *slog.Logger,
 	enc *encryption.Client,
 	cacheImpl cache.Cache,
 	guardianPolicy *guardian.Policy,
+	funcCaller functions.ToolCaller,
 	tcm tm.ToolMetricsProvider,
 ) *ChatClient {
 	return &ChatClient{
@@ -71,6 +73,7 @@ func NewChatClient(logger *slog.Logger,
 			enc,
 			cacheImpl,
 			guardianPolicy,
+			funcCaller,
 			tcm,
 		),
 		toolsetCache: cache.NewTypedObjectCache[mv.ToolsetTools](logger.With(attr.SlogCacheNamespace("toolset")), cacheImpl, cache.SuffixNone),

--- a/server/internal/functions/deploy.go
+++ b/server/internal/functions/deploy.go
@@ -22,7 +22,7 @@ type Deployer interface {
 }
 
 type ToolCaller interface {
-	CallTool(context.Context, RunnerToolCallRequest) (*http.Response, error)
+	ToolCall(context.Context, RunnerToolCallRequest) (*http.Request, error)
 }
 
 type RunnerImageRequest struct {
@@ -75,12 +75,16 @@ type RunnerAsset struct {
 type RunnerToolCallRequest struct {
 	InvocationID uuid.UUID
 
-	ProjectID    uuid.UUID
-	DeploymentID uuid.UUID
-	FunctionsID  uuid.UUID
+	OrganizationID    string
+	OrganizationSlug  string
+	ProjectID         uuid.UUID
+	ProjectSlug       string
+	DeploymentID      uuid.UUID
+	FunctionsID       uuid.UUID
+	FunctionsAccessID uuid.UUID
 
-	URN         urn.Tool
-	Name        string
-	Input       json.RawMessage
-	Environment map[string]string
+	ToolURN         urn.Tool
+	ToolName        string
+	ToolInput       json.RawMessage
+	ToolEnvironment map[string]string
 }

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -129,8 +130,89 @@ func NewFlyRunner(
 	}
 }
 
-func (f *FlyRunner) CallTool(context.Context, RunnerToolCallRequest) (*http.Response, error) {
-	return nil, oops.Permanent(errors.New("not implemented"))
+func (f *FlyRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (httpreq *http.Request, err error) {
+	logger := f.logger.With(
+		attr.SlogFunctionsBackend("flyio"),
+		attr.SlogProjectID(req.ProjectID.String()),
+		attr.SlogDeploymentID(req.DeploymentID.String()),
+		attr.SlogDeploymentFunctionsID(req.FunctionsID.String()),
+		attr.SlogToolURN(req.ToolURN.String()),
+		attr.SlogToolName(req.ToolName),
+	)
+
+	if err := inv.Check(
+		"flyio tool call",
+		"organization id cannot be empty", req.OrganizationID != "",
+		"organization slug cannot be empty", req.OrganizationSlug != "",
+		"project id cannot be nil", req.ProjectID != uuid.Nil,
+		"deployment id cannot be nil", req.DeploymentID != uuid.Nil,
+		"functions id cannot be nil", req.FunctionsID != uuid.Nil,
+		"tool urn cannot be empty", !req.ToolURN.IsZero(),
+		"tool name cannot be empty", req.ToolName != "",
+	); err != nil {
+		return nil, oops.E(oops.CodeInvariantViolation, err, "malformed tool call request").Log(ctx, logger)
+	}
+
+	funcsRepo := repo.New(f.db)
+	row, err := funcsRepo.GetFlyAppAccess(ctx, repo.GetFlyAppAccessParams{
+		ProjectID:    req.ProjectID,
+		DeploymentID: req.DeploymentID,
+		FunctionID:   req.FunctionsID,
+		AccessID:     req.FunctionsAccessID,
+	})
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, oops.E(oops.CodeNotFound, err, "no function runner available to serve tool call").Log(ctx, logger)
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch function runner").Log(ctx, logger)
+	}
+
+	format := row.BearerFormat.String
+	sec := row.EncryptionKey.Reveal()
+	if format == "" || len(sec) == 0 {
+		return nil, oops.E(oops.CodeInvariantViolation, nil, "function runner does not have credentials to make tool call").Log(ctx, logger)
+	}
+
+	unsealedAuthKey, err := f.encryption.Decrypt(string(sec))
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to access credentials for function tool call").Log(ctx, logger)
+	}
+	enc, err := encryption.NewWithBytes([]byte(unsealedAuthKey))
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create encryption client for function tool call").Log(ctx, logger)
+	}
+
+	endpoint, err := url.JoinPath(row.AppUrl, "/tool-call")
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to parse function tool url").Log(ctx, logger)
+	}
+
+	token, err := TokenV1(enc, TokenRequestV1{
+		ID:  req.InvocationID.String(),
+		Exp: time.Now().Add(10 * time.Minute).Unix(),
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create bearer token for function tool call").Log(ctx, logger)
+	}
+
+	payload, err := json.Marshal(CallToolPayload{
+		ToolName:    req.ToolName,
+		Input:       req.ToolInput,
+		Environment: req.ToolEnvironment,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal function tool payload").Log(ctx, logger)
+	}
+
+	httpreq, err = http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to create function tool request").Log(ctx, logger)
+	}
+
+	httpreq.Header.Set("Authorization", "Bearer "+token)
+	httpreq.Header.Set("Content-Type", "application/json")
+
+	return httpreq, nil
 }
 
 func (f *FlyRunner) Deploy(ctx context.Context, req RunnerDeployRequest) (res *RunnerDeployResult, err error) {

--- a/server/internal/functions/deploy_local.go
+++ b/server/internal/functions/deploy_local.go
@@ -27,7 +27,7 @@ func NewLocalRunner(codeRoot *os.Root) *LocalRunner {
 	}
 }
 
-func (l *LocalRunner) CallTool(ctx context.Context, call RunnerToolCallRequest) (*http.Response, error) {
+func (l *LocalRunner) ToolCall(ctx context.Context, call RunnerToolCallRequest) (*http.Request, error) {
 	return nil, oops.Permanent(errors.New("not implemented"))
 }
 

--- a/server/internal/functions/queries.sql
+++ b/server/internal/functions/queries.sql
@@ -1,3 +1,27 @@
+-- name: GetFlyAppAccess :one
+SELECT
+    fa.fly_org_id
+  , fa.fly_org_slug
+  , fa.app_name
+  , fa.app_url
+  , fa.runner_version
+  , access.id AS access_id
+  , access.encryption_key
+  , access.bearer_format
+FROM fly_apps fa
+LEFT JOIN functions_access access
+  ON access.id = fa.access_id
+  AND access.deleted IS FALSE
+WHERE
+  fa.project_id = @project_id
+  AND fa.deployment_id = @deployment_id
+  AND fa.function_id = @function_id
+  AND fa.status = 'ready'
+  AND fa.reaped_at IS NULL
+  AND fa.access_id = @access_id
+ORDER BY fa.seq DESC NULLS LAST
+LIMIT 1;
+
 -- name: GetFunctionsRunnerVersion :one
 WITH project_preference AS (
   SELECT p.functions_runner_version as v

--- a/server/internal/gateway/models.go
+++ b/server/internal/gateway/models.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
-	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -100,13 +99,11 @@ var DisableResponseFiltering = &ResponseFilter{
 
 // FunctionToolCallPlan describes a serverless function that can be invoked as a tool.
 type FunctionToolCallPlan struct {
-	FunctionID   string      `json:"function_id" yaml:"function_id"`
-	ServerURL    string      `json:"server_url" yaml:"server_url"`
-	Runtime      string      `json:"runtime" yaml:"runtime"`
-	BearerFormat string      `json:"bearer_format" yaml:"bearer_format"`
-	AuthSecret   conv.Secret `json:"auth_secret" yaml:"auth_secret"`
-	InputSchema  []byte      `json:"input_schema" yaml:"input_schema"`
-	Variables    []string    `json:"variables" yaml:"variables"`
+	FunctionID        string   `json:"function_id" yaml:"function_id"`
+	FunctionsAccessID string   `json:"functions_access_id" yaml:"functions_access_id"`
+	Runtime           string   `json:"runtime" yaml:"runtime"`
+	InputSchema       []byte   `json:"input_schema" yaml:"input_schema"`
+	Variables         []string `json:"variables" yaml:"variables"`
 }
 
 type ToolKind string

--- a/server/internal/gateway/proxy_test.go
+++ b/server/internal/gateway/proxy_test.go
@@ -18,10 +18,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
+
+var funcs functions.ToolCaller
 
 func newTestToolDescriptor() *ToolDescriptor {
 	return &ToolDescriptor{
@@ -280,6 +283,7 @@ func TestToolProxy_Do_PathParams(t *testing.T) {
 				enc,
 				nil, // no cache needed for this test
 				policy,
+				funcs,
 				chClient,
 			)
 
@@ -408,6 +412,7 @@ func TestToolProxy_Do_HeaderParams(t *testing.T) {
 				enc,
 				nil, // no cache needed for this test
 				policy,
+				funcs,
 				chClient,
 			)
 
@@ -757,6 +762,7 @@ func TestToolProxy_Do_QueryParams(t *testing.T) {
 				enc,
 				nil, // no cache needed for this test
 				policy,
+				funcs,
 				chClient,
 			)
 
@@ -976,6 +982,7 @@ func TestToolProxy_Do_Body(t *testing.T) {
 				enc,
 				nil, // no cache needed for this test
 				policy,
+				funcs,
 				chClient,
 			)
 
@@ -1315,6 +1322,7 @@ func TestToolProxy_Do_StringifiedJSONBody(t *testing.T) {
 				enc,
 				nil,
 				policy,
+				funcs,
 				chClient,
 			)
 

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	environments_repo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
@@ -68,6 +69,7 @@ func NewService(
 	enc *encryption.Client,
 	cacheImpl cache.Cache,
 	guardianPolicy *guardian.Policy,
+	funcCaller functions.ToolCaller,
 	tracking billing.Tracker,
 	tcm tm.ToolMetricsProvider,
 ) *Service {
@@ -92,6 +94,7 @@ func NewService(
 			enc,
 			cacheImpl,
 			guardianPolicy,
+			funcCaller,
 			tcm,
 		),
 		toolsetCache: cache.NewTypedObjectCache[mv.ToolsetTools](logger.With(attr.SlogCacheNamespace("toolset")), cacheImpl, cache.SuffixNone),

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -35,6 +35,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
@@ -97,6 +98,7 @@ func NewService(
 	enc *encryption.Client,
 	cacheImpl cache.Cache,
 	guardianPolicy *guardian.Policy,
+	funcCaller functions.ToolCaller,
 	oauthService *oauth.Service,
 	billingTracker billing.Tracker,
 	billingRepository billing.Repository,
@@ -127,6 +129,7 @@ func NewService(
 			enc,
 			cacheImpl,
 			guardianPolicy,
+			funcCaller,
 			tcm,
 		),
 		oauthService:      oauthService,

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/environments"
+	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/oauth"
@@ -26,6 +27,7 @@ import (
 
 var (
 	infra *testenv.Environment
+	funcs functions.ToolCaller
 )
 
 func TestMain(m *testing.M) {
@@ -96,7 +98,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 		return true, nil
 	})
 
-	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, env, posthog, serverURL, enc, cacheAdapter, guardianPolicy, oauthService, billingStub, billingStub, toolMetrics)
+	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, env, posthog, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, toolMetrics)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/tools/queries.sql
+++ b/server/internal/tools/queries.sql
@@ -255,27 +255,18 @@ SELECT
   , tool.input_schema
   , tool.variables
   , access.id AS access_id
-  , access.encryption_key
-  , access.bearer_format
-  , apps.id as fly_app_internal_id
-  , apps.app_name as fly_app_name
-  , apps.app_url as fly_app_url
-  , apps.runner_version as fly_runner_version
 FROM deployment dep
 INNER JOIN function_tool_definitions tool
   ON tool.deployment_id = dep.id
   AND tool.tool_urn = @urn
   AND tool.project_id = @project_id
   AND tool.deleted IS FALSE
-LEFT JOIN fly_apps apps
-  ON apps.project_id = @project_id
-  AND apps.deployment_id = tool.deployment_id
-  AND apps.function_id = tool.function_id
-  AND apps.status = 'ready'
 LEFT JOIN functions_access access
-  ON access.id = apps.access_id
+  ON access.project_id = @project_id
+  AND access.deployment_id = dep.id
+  AND access.function_id = tool.function_id
   AND access.deleted IS FALSE
-ORDER BY apps.seq DESC NULLS LAST
+ORDER BY access.seq DESC NULLS LAST
 LIMIT 1;
 
 -- name: GetFunctionToolDefinitionByID :one

--- a/server/internal/urn/runners.go
+++ b/server/internal/urn/runners.go
@@ -70,6 +70,10 @@ func newFunctionRunnerFromString(value string) (FunctionRunner, error) {
 	return t, nil
 }
 
+func (u FunctionRunner) IsZero() bool {
+	return u.Kind == "" && u.Tenancy == "" && u.Name == ""
+}
+
 func (u FunctionRunner) String() string {
 	return "gfr" + delimiter + string(u.Kind) + delimiter + u.Tenancy + delimiter + u.Name
 }

--- a/server/internal/urn/tools.go
+++ b/server/internal/urn/tools.go
@@ -64,6 +64,10 @@ func ParseTool(value string) (Tool, error) {
 	return t, nil
 }
 
+func (u Tool) IsZero() bool {
+	return u.Kind == "" && u.Source == "" && u.Name == ""
+}
+
 func (u Tool) String() string {
 	return "tools" + delimiter + string(u.Kind) + delimiter + u.Source + delimiter + u.Name
 }


### PR DESCRIPTION
This change updates the flyio orchestrator to implement the `functions.ToolCaller` interface and then updates the gateway proxy to build requests through that interface. Previously the function tool call planning coupled directly to flyio which was a temporary measure to get things working. Now, working through the interface, the gateway has no knowledge of the underlying orchestrator and allows for swappability and easier testing.