### PR TITLE
chore: create manual chunks for lucide and 3rd party deps

### DIFF
--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -23,6 +23,24 @@ export default defineConfig({
   build: {
     target: "es2022",
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "lucide-react": ["lucide-react"],
+          moonshine: ["@speakeasy-api/moonshine"],
+          externals: [
+            "posthog-js",
+            "react",
+            "react-dom",
+            "react-error-boundary",
+            "react-router",
+            "sonner",
+            "vaul",
+            "zod",
+          ],
+        },
+      },
+    },
   },
   esbuild: {
     target: "es2022",


### PR DESCRIPTION
This change defines manual chunks in the dashboard's vite configuration to group moonshine components in one chunk, lucide icons together in another chunk and several 3rd party dependencies that rarely change together in another chunk.