### PR TITLE
fix: use the custom domain  as the mcp url

### DIFF
--- a/.changeset/late-adults-divide.md
+++ b/.changeset/late-adults-divide.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+Correctly use the custom domain on install pages

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -312,7 +312,7 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 		toolNames = append(toolNames, baseTool.Name)
 	}
 
-	MCPURL, err := resolveMCPURLFromContext(ctx, s.serverURL.String(), mcpSlug, toolset.McpIsPublic)
+	MCPURL, err := resolveMCPURLFromContext(ctx, s.serverURL.String(), mcpSlug)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "resolved bad url").Log(ctx, s.logger)
 	}
@@ -368,7 +368,7 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 	return nil
 }
 
-func resolveMCPURLFromContext(ctx context.Context, serverUrl string, mcpSlug string, serverIsPublic bool) (string, error) {
+func resolveMCPURLFromContext(ctx context.Context, serverUrl string, mcpSlug string) (string, error) {
 	customDomainCtx := customdomains.FromContext(ctx)
 	baseURL := serverUrl + "/mcp"
 	if customDomainCtx != nil {


### PR DESCRIPTION
This logic was _totally_ errant in that it would only use custom domains for private servers, but I think we should always use a custom domain if one is available.