### PR TITLE
fix: introduce fallback stub for `ToolMetricsClient` in dev and prod

### DIFF
--- a/server/internal/gateway/proxy_test.go
+++ b/server/internal/gateway/proxy_test.go
@@ -70,7 +70,7 @@ func newClickhouseClient(t *testing.T, orgId string) *toolmetrics.Queries {
 
 	tracerProvider := testenv.NewTracerProvider(t)
 
-	ch := toolmetrics.New(testenv.NewLogger(t), tracerProvider, chConn, func(ctx context.Context, log toolmetrics.ToolHTTPRequest) (bool, error) {
+	ch := toolmetrics.New(testenv.NewLogger(t), tracerProvider, chConn, func(context.Context, string) (bool, error) {
 		return true, nil
 	})
 

--- a/server/internal/logs/setup_test.go
+++ b/server/internal/logs/setup_test.go
@@ -74,7 +74,7 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 
 	tracerProvider := testenv.NewTracerProvider(t)
 
-	chClient := toolmetrics.New(logger, tracerProvider, chConn, func(ctx context.Context, log toolmetrics.ToolHTTPRequest) (bool, error) {
+	chClient := toolmetrics.New(logger, tracerProvider, chConn, func(context.Context, string) (bool, error) {
 		return true, nil
 	})
 

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -94,7 +94,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	toolMetrics := toolmetrics.New(logger, tracerProvider, chConn, func(ctx context.Context, log toolmetrics.ToolHTTPRequest) (bool, error) {
+	toolMetrics := toolmetrics.New(logger, tracerProvider, chConn, func(context.Context, string) (bool, error) {
 		return true, nil
 	})
 

--- a/server/internal/thirdparty/toolmetrics/db.go
+++ b/server/internal/thirdparty/toolmetrics/db.go
@@ -20,7 +20,7 @@ type Queries struct {
 	conn       CHTX
 	logger     *slog.Logger
 	tracer     trace.Tracer
-	ShouldFlag func(ctx context.Context, log ToolHTTPRequest) (bool, error)
+	ShouldFlag func(ctx context.Context, orgId string) (bool, error)
 }
 
 // WithConn returns a new Queries instance using the provided connection.
@@ -34,9 +34,9 @@ func (q *Queries) WithConn(conn CHTX) *Queries {
 }
 
 // New creates a new Queries instance with logger and tracer.
-func New(logger *slog.Logger, traceProvider trace.TracerProvider, conn CHTX, shouldFlag func(ctx context.Context, log ToolHTTPRequest) (bool, error)) *Queries {
+func New(logger *slog.Logger, traceProvider trace.TracerProvider, conn CHTX, shouldFlag func(ctx context.Context, orgId string) (bool, error)) *Queries {
 	if shouldFlag == nil {
-		shouldFlag = func(ctx context.Context, log ToolHTTPRequest) (bool, error) {
+		shouldFlag = func(ctx context.Context, orgId string) (bool, error) {
 			return true, nil
 		}
 	}

--- a/server/internal/thirdparty/toolmetrics/models.go
+++ b/server/internal/thirdparty/toolmetrics/models.go
@@ -96,4 +96,6 @@ type ToolMetricsProvider interface {
 	List(ctx context.Context, opts ListToolLogsOptions) (*ListResult, error)
 	// Log tool call request/response
 	Log(context.Context, ToolHTTPRequest) error
+	// ShouldLog returns true if the tool call should be logged
+	ShouldLog(context.Context, string) (bool, error)
 }

--- a/server/internal/thirdparty/toolmetrics/queries.sql.go
+++ b/server/internal/thirdparty/toolmetrics/queries.sql.go
@@ -37,6 +37,10 @@ order by ts
 limit $5
 `
 
+func (q *Queries) ShouldLog(ctx context.Context, orgId string) (bool, error) {
+	return q.ShouldFlag(ctx, orgId)
+}
+
 // List retrieves tool logs based on the provided options.
 func (q *Queries) List(ctx context.Context, opts ListToolLogsOptions) (res *ListResult, err error) {
 	projectID := opts.ProjectID
@@ -133,7 +137,7 @@ func (q *Queries) List(ctx context.Context, opts ListToolLogsOptions) (res *List
 
 // Log inserts a tool HTTP request log entry.
 func (q *Queries) Log(ctx context.Context, log ToolHTTPRequest) (err error) {
-	allow, err := q.ShouldFlag(ctx, log)
+	allow, err := q.ShouldFlag(ctx, log.OrganizationID)
 	if err != nil {
 		q.logger.ErrorContext(ctx, "failed to fetch feature flag", attr.SlogError(err))
 		return nil

--- a/server/internal/thirdparty/toolmetrics/stub.go
+++ b/server/internal/thirdparty/toolmetrics/stub.go
@@ -1,0 +1,19 @@
+package toolmetrics
+
+import (
+	"context"
+)
+
+type StubToolMetricsClient struct{}
+
+func (n *StubToolMetricsClient) List(_ context.Context, _ ListToolLogsOptions) (*ListResult, error) {
+	return nil, nil
+}
+
+func (n *StubToolMetricsClient) Log(_ context.Context, _ ToolHTTPRequest) error {
+	return nil
+}
+
+func (n *StubToolMetricsClient) ShouldLog(_ context.Context, _ string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
- Refactor `ShouldFlag` signatures to accept an organisation ID
- Introduce a fallback stub for `ToolMetricsClient` in dev and prod.