### PR TITLE
fix: explicilty resolve the custom domain

### DIFF
--- a/.changeset/fresh-eels-worry.md
+++ b/.changeset/fresh-eels-worry.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+Add correct resolution of custom domains for private MCP servers in install pages


### PR DESCRIPTION
We explicitly query against the domain configured
for a given toolset so we don't have to fuss with
trying to infer it from the session

docs(changeset): Add correct resolution of custom domains for private MCP servers in install pages