### PR TITLE
chore: query encode cli params [DO NOT MERGE]

### DIFF
--- a/client/dashboard/src/pages/login/components/login-section.tsx
+++ b/client/dashboard/src/pages/login/components/login-section.tsx
@@ -128,7 +128,7 @@ export function LoginSection(props: LoginSectionProps) {
 
   const handleLogin = async () => {
     let href = `${getServerURL()}/rpc/auth.login`;
-    if (redirectTo) href += `?redirect=${redirectTo}`;
+    if (redirectTo) href += `?redirect=${encodeURIComponent(redirectTo)}`;
 
     window.location.href = href;
   };


### PR DESCRIPTION
_temporary test to see why query params are dropped ([DataDog](https://app.datadoghq.com/logs?query=%22Found%20destination%20URL%20in%20state%3A%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZnzfrLB8yE8YgAAABhBWm56ZnJydEFBQ29sZndWR1BRVE5BQUIAAAAkZjE5OWYzN2UtY2NmMC00OTc0LWFkYzYtZWQxOTZlZTM1ZGFmAAABIA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760725994387&to_ts=1760726894387&live=true))._
