### PR TITLE
chore: sync docs from Marketing Site

### DIFF
--- a/docs/src/content/docs/api-clients/using-anthropic-api-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/api-clients/using-anthropic-api-with-gram-mcp-servers.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-Anthropic's [Messages API](https://docs.anthropic.com/en/api/messages) supports remote MCP servers through their MCP connector feature. This allows you to give Claude models direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](/gram-quickstart).
+Anthropic's [Messages API](https://docs.anthropic.com/en/api/messages) supports remote MCP servers through their MCP connector feature. This allows you to give Claude models direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](gram-quickstart).
 
 This guide will show you how to connect Anthropic's API to a Gram-hosted MCP server using an example [Push Advisor API](https://github.com/ritza-co/gram-examples/blob/main/push-advisor-api/openapi.yaml). You'll learn how to create an MCP server from an OpenAPI document, set up the connection, configure authentication, and use natural language to query the example API.
 
@@ -22,7 +22,7 @@ You'll need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram MCP server configured, you can skip to [connecting Anthropic API to your Gram-hosted MCP server](#connecting-anthropic-api-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out our [introduction to Gram](/introduction).
+If you already have a Gram MCP server configured, you can skip to [connecting Anthropic API to your Gram-hosted MCP server](#connecting-anthropic-api-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out our [introduction to Gram](introduction).
 
 ### Setting up a Gram project
 
@@ -75,7 +75,7 @@ Scroll down to the **MCP Config** section and note your MCP server URL. For this
 
 `https://app.getgram.ai/mcp/canipushtoprod`
 
-For authenticated servers, you'll need an API key. [Generate an API key](/concepts/api-keys) in the **Settings** tab.
+For authenticated servers, you'll need an API key. [Generate an API key](concepts/api-keys) in the **Settings** tab.
 
 ## Connecting Anthropic API to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/api-clients/using-langchain-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/api-clients/using-langchain-with-gram-mcp-servers.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-[LangChain](https://www.langchain.com/) and [LangGraph](https://www.langchain.com/langgraph) support MCP servers through the `langchain-mcp-adapters` library, which allows you to give your LangChain agents and LangGraph workflows direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](/gram-quickstart).
+[LangChain](https://www.langchain.com/) and [LangGraph](https://www.langchain.com/langgraph) support MCP servers through the `langchain-mcp-adapters` library, which allows you to give your LangChain agents and LangGraph workflows direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](gram-quickstart).
 
 This guide demonstrates how to connect LangChain to a Gram-hosted MCP server using an example [Push Advisor API](https://github.com/ritza-co/gram-examples/blob/main/push-advisor-api/openapi.yaml). You'll learn how to create an MCP server from an OpenAPI document, set up the connection, configure authentication, and use natural language to query the example API.
 
@@ -22,7 +22,7 @@ You'll need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram MCP server configured, you can skip to [connecting LangChain to your Gram-hosted MCP server](#connecting-langchain-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and to creating a Gram-hosted MCP server, check out our [introduction to Gram](/introduction).
+If you already have a Gram MCP server configured, you can skip to [connecting LangChain to your Gram-hosted MCP server](#connecting-langchain-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and to creating a Gram-hosted MCP server, check out our [introduction to Gram](introduction).
 
 ### Setting up a new Gram project
 
@@ -34,7 +34,7 @@ Follow the steps to configure a toolset and publish an MCP server. At the end of
 
 For this guide, we'll use the public server URL `https://app.getgram.ai/mcp/canipushtoprod`
 
-For authenticated servers, you'll need an API key. [Generate an API key](/concepts/api-keys) in the **Settings** tab.
+For authenticated servers, you'll need an API key. [Generate an API key](concepts/api-keys) in the **Settings** tab.
 
 ## Connecting LangChain to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/api-clients/using-openai-agents-sdk-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/api-clients/using-openai-agents-sdk-with-gram-mcp-servers.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 The OpenAI [Agents SDK](https://openai.github.io/openai-agents-python/) is a production-ready framework for building agentic AI applications. The Agents SDK provides advanced features like persistent sessions, agent handoffs, guardrails, and comprehensive tracing for complex workflows.
 
-When combined with [Gram-hosted MCP servers](/gram-quickstart), the Agents SDK enables you to build sophisticated agents that can interact with your APIs, databases, and other services through natural language conversations with persistent context.
+When combined with [Gram-hosted MCP servers](gram-quickstart), the Agents SDK enables you to build sophisticated agents that can interact with your APIs, databases, and other services through natural language conversations with persistent context.
 
 This guide shows you how to connect the OpenAI Agents SDK to a Gram-hosted MCP server using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
@@ -17,18 +17,18 @@ You'll learn how to set up the connection, configure agents with MCP tools, and 
 
 OpenAI provides three main approaches for integrating with MCP servers:
 
-- **The [Responses API](/api-clients/using-openai-api-with-gram-mcp-servers):** An API with a simple request-response pattern, ideal for basic tool calling and quick integrations.
+- **The [Responses API](api-clients/using-openai-api-with-gram-mcp-servers):** An API with a simple request-response pattern, ideal for basic tool calling and quick integrations.
 - **The Agents SDK (this guide):** An advanced agent framework with sessions, handoffs, and persistent context that is perfect for complex conversational workflows.
-- **[ChatGPT Connectors](/clients/using-chatgpt-connectors-with-gram):** Connectors offer direct ChatGPT integration to end users via a web UI.
+- **[ChatGPT Connectors](clients/using-chatgpt-connectors-with-gram):** Connectors offer direct ChatGPT integration to end users via a web UI.
 
-If you're unsure which approach fits your needs, start with the [Responses API guide](/api-clients/using-openai-api-with-gram-mcp-servers) for simpler implementations or try [ChatGPT Connectors](/clients/using-chatgpt-connectors-with-gram) for a web UI solution.
+If you're unsure which approach fits your needs, start with the [Responses API guide](api-clients/using-openai-api-with-gram-mcp-servers) for simpler implementations or try [ChatGPT Connectors](clients/using-chatgpt-connectors-with-gram) for a web UI solution.
 
 ## Prerequisites
 
 To follow this tutorial, you need:
 
 - A [Gram account](https://app.getgram.ai)
-- A [Taskmaster MCP server](/examples/creating-taskmaster-mcp-server) set up and configured
+- A [Taskmaster MCP server](examples/creating-taskmaster-mcp-server) set up and configured
 - An [OpenAI API key](https://platform.openai.com/api-keys)
 - A Python environment set up on your machine
 
@@ -36,7 +36,7 @@ To follow this tutorial, you need:
 
 Before connecting the OpenAI Agents SDK to a Taskmaster MCP server, you first need to create one. 
 
-Follow the guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server), which walks you through:
+Follow the guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server), which walks you through:
 
 - Setting up a Gram project with the Taskmaster OpenAPI document
 - Getting a Taskmaster API key from your instance
@@ -66,7 +66,7 @@ export GRAM_KEY=your-gram-api-key  # Optional: only needed for private MCP serve
 ```
 
 :::note[Code Examples]
-Throughout this guide, replace `your-taskmaster-slug` with your actual MCP server URL and update the header names to match your server configuration from the guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server).
+Throughout this guide, replace `your-taskmaster-slug` with your actual MCP server URL and update the header names to match your server configuration from the guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server).
 :::
 
 ### Basic connection (public server)

--- a/docs/src/content/docs/api-clients/using-openai-api-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/api-clients/using-openai-api-with-gram-mcp-servers.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-The OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses) supports remote MCP servers through its MCP tool feature. This allows you to give GPT models direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](/gram-quickstart).
+The OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses) supports remote MCP servers through its MCP tool feature. This allows you to give GPT models direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](gram-quickstart).
 
 This guide shows you how to connect the OpenAI Responses API to a Gram-hosted MCP server using an example [Push Advisor API](https://github.com/ritza-co/gram-examples/blob/main/push-advisor-api/openapi.yaml). You'll learn how to create an MCP server from an OpenAPI document, set up the connection, configure authentication, and use natural language to query the example API.
 
@@ -16,10 +16,10 @@ Find the full code and OpenAPI document in the [Push Advisor API repository](htt
 OpenAI provides three main approaches for integrating with MCP servers:
 
 - **The Responses API (this guide):** An API with a simple request-response pattern, ideal for basic tool calling and quick integrations.
-- **The [Agents SDK](/api-clients/using-openai-agents-sdk-with-gram-mcp-servers):** An advanced agent framework with sessions, handoffs, and persistent context that is perfect for complex conversational workflows.
-- **[ChatGPT Connectors](/clients/using-chatgpt-connectors-with-gram):** Connectors offer direct ChatGPT integration to end users via a web UI.
+- **The [Agents SDK](api-clients/using-openai-agents-sdk-with-gram-mcp-servers):** An advanced agent framework with sessions, handoffs, and persistent context that is perfect for complex conversational workflows.
+- **[ChatGPT Connectors](clients/using-chatgpt-connectors-with-gram):** Connectors offer direct ChatGPT integration to end users via a web UI.
 
-If you need more advanced features like persistent conversations or complex workflows, consider the [Agents SDK guide](/api-clients/using-openai-agents-sdk-with-gram-mcp-servers), or try [ChatGPT Connectors](/clients/using-chatgpt-connectors-with-gram) for a web UI solution.
+If you need more advanced features like persistent conversations or complex workflows, consider the [Agents SDK guide](api-clients/using-openai-agents-sdk-with-gram-mcp-servers), or try [ChatGPT Connectors](clients/using-chatgpt-connectors-with-gram) for a web UI solution.
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ You'll need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram MCP server configured, you can skip to [connecting the Responses API to your Gram-hosted MCP server](#connecting-the-responses-api-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out our [introduction to Gram](/introduction).
+If you already have a Gram MCP server configured, you can skip to [connecting the Responses API to your Gram-hosted MCP server](#connecting-the-responses-api-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out our [introduction to Gram](introduction).
 
 ### Setting up a Gram project
 
@@ -84,7 +84,7 @@ Scroll down to the **MCP Config** section and note your MCP server URL. For this
 
 `https://app.getgram.ai/mcp/canipushtoprod`
 
-For authenticated servers, you'll need an API key. [Generate an API key](/concepts/api-keys) in the **Settings** tab.
+For authenticated servers, you'll need an API key. [Generate an API key](concepts/api-keys) in the **Settings** tab.
 
 ## Connecting the Responses API to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/api-clients/using-pydantic-ai-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/api-clients/using-pydantic-ai-with-gram-mcp-servers.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-[Pydantic AI](https://ai.pydantic.dev/) supports MCP servers through the `pydantic-ai-mcp-client` library. This allows you to give your Pydantic AI agents direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](/gram-quickstart).
+[Pydantic AI](https://ai.pydantic.dev/) supports MCP servers through the `pydantic-ai-mcp-client` library. This allows you to give your Pydantic AI agents direct access to your tools and infrastructure by connecting to [Gram-hosted MCP servers](gram-quickstart).
 
 This guide shows you how to connect Pydantic AI to a Gram-hosted MCP server using an example [Push Advisor API](https://github.com/ritza-co/gram-examples/blob/main/push-advisor-api/openapi.yaml). You'll learn how to create an MCP server from an OpenAPI document, set up the connection, configure authentication, and use natural language to query the example API.
 
@@ -26,7 +26,7 @@ If you already have a Gram-hosted MCP server configured, you can skip to [connec
 
 For this guide, we'll use the public server URL `https://app.getgram.ai/mcp/canipushtoprod`.
 
-For authenticated servers, you'll need an API key. [Generate an API key](/concepts/api-keys) in the **Settings** tab. For an in-depth guide to how Gram works and to creating a Gram-hosted MCP server, check out our [introduction to Gram](/introduction).
+For authenticated servers, you'll need an API key. [Generate an API key](concepts/api-keys) in the **Settings** tab. For an in-depth guide to how Gram works and to creating a Gram-hosted MCP server, check out our [introduction to Gram](introduction).
 
 ## Connecting Pydantic AI to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/api-clients/using-vercel-ai-sdk-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/api-clients/using-vercel-ai-sdk-with-gram-mcp-servers.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-The [Vercel AI SDK](https://ai-sdk.dev/) supports remote MCP servers through its experimental MCP client feature. This allows you to give AI models direct access to your tools and APIs by connecting to [Gram-hosted MCP servers](/gram-quickstart).
+The [Vercel AI SDK](https://ai-sdk.dev/) supports remote MCP servers through its experimental MCP client feature. This allows you to give AI models direct access to your tools and APIs by connecting to [Gram-hosted MCP servers](gram-quickstart).
 
 This guide shows you how to connect the Vercel AI SDK to a Gram-hosted MCP server using an example [Push Advisor API](https://github.com/ritza-co/gram-examples/blob/main/push-advisor-api/openapi.yaml). You'll learn how to create an MCP server from an OpenAPI document, set up the connection, configure authentication, and use natural language to query the example API.
 
@@ -22,7 +22,7 @@ You'll need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram MCP server configured, you can skip to [connecting the Vercel AI SDK to your Gram-hosted MCP server](#connecting-the-vercel-ai-sdk-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and to creating a Gram-hosted MCP server, check out our [introduction to Gram](/introduction).
+If you already have a Gram MCP server configured, you can skip to [connecting the Vercel AI SDK to your Gram-hosted MCP server](#connecting-the-vercel-ai-sdk-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and to creating a Gram-hosted MCP server, check out our [introduction to Gram](introduction).
 
 ### Setting up a new Gram project
 
@@ -34,7 +34,7 @@ Follow the steps to configure a toolset and publish an MCP server. At the end of
 
 For this guide, we'll use the public server URL `https://app.getgram.ai/mcp/canipushtoprod`.
 
-For authenticated servers, you'll need an API key. [Generate an API key](/concepts/api-keys) in the **Settings** tab.
+For authenticated servers, you'll need an API key. [Generate an API key](concepts/api-keys) in the **Settings** tab.
 
 ## Connecting the Vercel AI SDK to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/build-mcp/advanced-tool-curation.md
+++ b/docs/src/content/docs/build-mcp/advanced-tool-curation.md
@@ -11,9 +11,9 @@ Tool curation involves thinking like an agent-UX designer. It requires understan
 
 ## Understanding tools and toolsets
 
-**[Tools](/concepts/tool-definitions)** are individual callable API actions. When uploading an OpenAPI document to Gram, each operation becomes a tool definition — a single endpoint that an agent can invoke. For example, a CRM API might generate tools like `search_users`, `create_deal`, and `list_pipelines`.
+**[Tools](concepts/tool-definitions)** are individual callable API actions. When uploading an OpenAPI document to Gram, each operation becomes a tool definition — a single endpoint that an agent can invoke. For example, a CRM API might generate tools like `search_users`, `create_deal`, and `list_pipelines`.
 
-**[Toolsets](/concepts/toolsets)** are curated bundles of tools organized around specific use cases or workflows. Rather than giving an agent access to every available tool, select only the ones needed to accomplish particular tasks. Think of toolsets as specialized toolkits — bring only the necessary tools for each job.
+**[Toolsets](concepts/toolsets)** are curated bundles of tools organized around specific use cases or workflows. Rather than giving an agent access to every available tool, select only the ones needed to accomplish particular tasks. Think of toolsets as specialized toolkits — bring only the necessary tools for each job.
 
 ## The tool curation challenge
 

--- a/docs/src/content/docs/build-mcp/create-default-toolset.md
+++ b/docs/src/content/docs/build-mcp/create-default-toolset.md
@@ -9,7 +9,7 @@ Gram uses your API as the starting point for the creation of your MCP server. A 
 
 This toolset is created via an uploaded OpenAPI document.
 
-The default toolset will likely contain too many tools for an LLM to use effectively in production. Before launching the MCP server, [a custom toolset will be curated](/) to contain only the tools that are relevant to the intended use case.
+The default toolset will likely contain too many tools for an LLM to use effectively in production. Before launching the MCP server, [a custom toolset will be curated]() to contain only the tools that are relevant to the intended use case.
 
 ## Generating tools from OpenAPI
 
@@ -26,7 +26,7 @@ To upload an OpenAPI document:
 
 ![Validating tool definitions](/img/guides/build-mcp/01-upload-openapi-document-done.png)
 
-Gram will parse the uploaded OpenAPI document and generate [tool definitions](/concepts/tool-definitions) for each endpoint method.
+Gram will parse the uploaded OpenAPI document and generate [tool definitions](concepts/tool-definitions) for each endpoint method.
 
 ## How it works
 
@@ -34,4 +34,4 @@ Gram does not make use of the entire OpenAPI document, therefore the document do
 
 In particular, Gram will pull out the URL paths, HTTP methods, request schemas, and operation descriptions.
 
-Most OpenAPI documents, do not contain detailed, contextual descriptions. That's okay. Context can be added via [prompts](/build-mcp/writing-prompts) in the Gram or added to the OpenAPI document with the `x-gram` extension](/concepts/openapi#using-the-x-gram-extension) to help LLM agents understand and use your tools correctly.
+Most OpenAPI documents, do not contain detailed, contextual descriptions. That's okay. Context can be added via [prompts](build-mcp/writing-prompts) in the Gram or added to the OpenAPI document with the `x-gram` extension](concepts/openapi#using-the-x-gram-extension) to help LLM agents understand and use your tools correctly.

--- a/docs/src/content/docs/build-mcp/custom-toolsets.md
+++ b/docs/src/content/docs/build-mcp/custom-toolsets.md
@@ -29,7 +29,7 @@ To create a toolset:
 ## Best practices for curating toolsets
 
 :::tip[The art of tool curation]
-If you want to go deeper in this topic, see [the art of tool curation](/build-mcp/advanced-tool-curation).
+If you want to go deeper in this topic, see [the art of tool curation](build-mcp/advanced-tool-curation).
 :::
 
 - **Design workflow-first** - Group tools by agent tasks, not API structure. Create "Deal Creation" or "Deal Management" toolsets rather than mixing all CRUD operations together.

--- a/docs/src/content/docs/clients/using-chatgpt-developer-mode-with-gram.mdx
+++ b/docs/src/content/docs/clients/using-chatgpt-developer-mode-with-gram.mdx
@@ -11,11 +11,11 @@ The new Developer Mode in [ChatGPT](https://chatgpt.com/) lets you wire external
 Developer Mode is currently only available on Plus and Pro plans. It is not available on Free or Business plans. You can read more about Developer Mode in the [OpenAI documentation](https://platform.openai.com/docs/guides/developer-mode).
 :::
 
-When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers hosted on [Gram](/gram-quickstart), you can give ChatGPT access to your APIs and tools in just a few minutes.
+When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers hosted on [Gram](gram-quickstart), you can give ChatGPT access to your APIs and tools in just a few minutes.
 
 ![Screenshot showing Acme To-Do in ChatGPT preview](/img/guides/chatgpt/acme-todo-in-chatgpt-preview.png)
 
-This guide walks you through connecting ChatGPT to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using the example Acme To-Do API. You'll learn to set up the connection, configure the custom connector, and test it with natural language prompts for managing your to-dos.
+This guide walks you through connecting ChatGPT to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using the example Acme To-Do API. You'll learn to set up the connection, configure the custom connector, and test it with natural language prompts for managing your to-dos.
 
 We'll use the Acme To-Do API as our example. It's a simple Python Flask REST API for managing to-do list items. You can find the complete OpenAPI document here: [`acmetodo.yaml`](https://github.com/ritza-co/acme-todo/blob/main/acmetodo.yaml).
 
@@ -29,7 +29,7 @@ To follow this tutorial, you need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram-hosted MCP server configured, skip to the section on [connecting ChatGPT to your Gram-hosted MCP server](#connecting-chatgpt-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](/blog/gram-concepts).
+If you already have a Gram-hosted MCP server configured, skip to the section on [connecting ChatGPT to your Gram-hosted MCP server](#connecting-chatgpt-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts).
 
 ## Setting up a Gram project
 
@@ -77,7 +77,7 @@ By default, the server URL is set by the OpenAPI document. The `acmetodo.yaml` O
 If you use your own API, set the server URL to the URL of your deployment. You can either edit the OpenAPI document and skip the step below, or set the server URL in the environment variables.
 :::
 
-[Environments](/concepts/environments) store API keys and configurations separate from your toolset logic.
+[Environments](concepts/environments) store API keys and configurations separate from your toolset logic.
 
 In the **Environments** tab, click the **Default** environment. Click the three-dot menu in the top-right corner of the environment card and then click **Fill for Toolset**. Select the **Acmetodo** toolset and click **Fill Variables** to automatically populate the required variables.
 

--- a/docs/src/content/docs/clients/using-claude-code-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-claude-code-with-gram-mcp-servers.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, Claude Code becomes even more useful. Using MCP servers, you can give Claude access to your tools and infrastructure, allowing it to work with your APIs, databases, and other services.
 
-This guide shows you how to connect Claude Code to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Claude Code to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Claude Code.
 
@@ -38,7 +38,7 @@ If installation is successful, you'll see Claude Code's available commands and o
 
 ## Creating an MCP server
 
-Before connecting Claude Code to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server).
+Before connecting Claude Code to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server).
 
 ## Connecting Claude Code to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/clients/using-claude-desktop-with-gram-mcp-server.mdx
+++ b/docs/src/content/docs/clients/using-claude-desktop-with-gram-mcp-server.mdx
@@ -9,7 +9,7 @@ Claude Desktop is Anthropic's standalone AI assistant application that supports 
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, Claude Desktop becomes even more powerful. Using MCP servers, you can give Claude access to your tools and infrastructure, allowing it to work with your APIs, databases, and other services.
 
-This guide shows you how to connect Claude Desktop to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Claude Desktop to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Claude Desktop.
 
@@ -24,7 +24,7 @@ To follow this tutorial, you need:
 
 ## Creating an MCP server
 
-Before connecting Claude Desktop to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server).
+Before connecting Claude Desktop to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server).
 
 Once your Taskmaster MCP server is ready, there are two ways you can connect it to Claude Desktop:
 

--- a/docs/src/content/docs/clients/using-cline-with-gram-mcp-server.mdx
+++ b/docs/src/content/docs/clients/using-cline-with-gram-mcp-server.mdx
@@ -9,7 +9,7 @@ Cline is a [VS Code extension](https://marketplace.visualstudio.com/items?itemNa
 
 When paired with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, you can connect Cline to your APIs, databases, and infrastructure services, granting it contextual access to your tools and data.
 
-This guide shows you how to connect Cline to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Cline to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Cline.
 
@@ -26,7 +26,7 @@ To follow this tutorial, you need:
 
 ## Creating an MCP server
 
-Before connecting Cline to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server).
+Before connecting Cline to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server).
 
 ## Connecting Cline to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/clients/using-gemini-cli-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-gemini-cli-with-gram-mcp-servers.mdx
@@ -11,7 +11,7 @@ sidebar:
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, Gemini CLI becomes even more useful. Using MCP servers, you can give Gemini access to your tools and infrastructure, allowing it to work with your APIs, databases, and other services through built-in MCP support.
 
-This guide shows you how to connect Gemini CLI to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Gemini CLI to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Gemini CLI.
 
@@ -57,7 +57,7 @@ When you first run `gemini`, you're prompted to authenticate. Sign in with your 
 
 ## Creating an MCP server
 
-Before connecting Gemini CLI to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server).
+Before connecting Gemini CLI to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server).
 
 ## Connecting Gemini CLI to your Gram-hosted MCP server
 

--- a/docs/src/content/docs/clients/using-mistral-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-mistral-with-gram-mcp-servers.mdx
@@ -7,11 +7,11 @@ sidebar:
 
 [Mistral AI](https://mistral.ai/) recently introduced [MCP connectors and memories in Le Chat](https://mistral.ai/news/le-chat-mcp-connectors-memories), making it incredibly easy to enhance Mistral's capabilities with external tools and data sources. This means you can integrate your existing applications directly into Mistral's chat interface.
 
-When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers hosted on [Gram](/gram-quickstart), you can give Mistral access to your APIs and tools in just a few minutes. 
+When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers hosted on [Gram](gram-quickstart), you can give Mistral access to your APIs and tools in just a few minutes. 
 
 ![Screenshot showing Acme Todo in Mistral preview](/img/guides/mistral/acme-todo-in-mistral-preview.png)
 
-This guide will walk you through connecting Mistral to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using the example Acme Todo API. You'll learn how to set up the connection, configure the custom connector, and test it with natural language prompts to manage your todos.
+This guide will walk you through connecting Mistral to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using the example Acme Todo API. You'll learn how to set up the connection, configure the custom connector, and test it with natural language prompts to manage your todos.
 
 We'll use the Acme Todo API as our example, it's a simple Python Flask REST API for managing todo items. You can find the complete OpenAPI specification here: [`acmetodo.yaml`](https://github.com/ritza-co/acme-todo/blob/main/acmetodo.yaml).
 
@@ -25,7 +25,7 @@ You'll need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram-hosted MCP server configured, you can skip to [connecting Mistral to your Gram-hosted MCP server](#connecting-mistral-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](/blog/gram-concepts).
+If you already have a Gram-hosted MCP server configured, you can skip to [connecting Mistral to your Gram-hosted MCP server](#connecting-mistral-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on creating a Gram-hosted MCP server, check out the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts).
 
 ### Setting up a Gram project
 
@@ -73,7 +73,7 @@ By default, the server URL is set by the OpenAPI document. The `acme-todo` opena
 If you are using your own MCP server, you will need to set the server URL to the URL of your MCP server. You can either edit the OpenAPI document and skip the step below, or set the server URL in the environment variables.
 :::
 
-[Environments](/concepts/environments) store API keys and configuration separate from your toolset logic.
+[Environments](concepts/environments) store API keys and configuration separate from your toolset logic.
 
 In the **Environments** tab, click the "Default" environment. Click the three dots in the top right corner of the environment card and then **Fill for Toolset**. Select the **Acme Todo** toolset and click **Fill Variables** to automatically populate the required variables.
 
@@ -107,7 +107,7 @@ Mistral supports a **Custom Connector** that you can configure to connect to you
 
    ![Screenshot showing the Mistral Add Custom Connector dialog](/img/guides/mistral/adding-custom-connector.png)
 
-   - For Authentication, select **API Token Authentication** and add your [Gram API key](/concepts/api-keys).
+   - For Authentication, select **API Token Authentication** and add your [Gram API key](concepts/api-keys).
    
    ![Screenshot showing the Mistral Add Custom Connector dialog with API Token Authentication selected](/img/guides/mistral/mistral-auth-connector.png)
 

--- a/docs/src/content/docs/clients/using-n8n-with-gram-mcp-servers.mdx
+++ b/docs/src/content/docs/clients/using-n8n-with-gram-mcp-servers.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 When combined with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, n8n can leverage AI agents that have access to your tools and infrastructure, enabling intelligent automation workflows that can interact with your APIs, databases, and other services.
 
-This guide will show you how to connect n8n to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using the example Push Advisor API from the [Gram concepts guide](/blog/gram-concepts). You'll learn how to set up the connection, test it, and use natural language to perform vibe checks before running automated deployments.
+This guide will show you how to connect n8n to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using the example Push Advisor API from the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts). You'll learn how to set up the connection, test it, and use natural language to perform vibe checks before running automated deployments.
 
 Find the full code and OpenAPI document in the [Push Advisor API repository](https://github.com/ritza-co/gram-examples/tree/main/push-advisor-api).
 
@@ -23,7 +23,7 @@ To follow this tutorial, you need:
 
 ## Creating a Gram MCP server
 
-If you already have a Gram MCP server configured, you can skip to [connecting n8n to your Gram-hosted MCP server](#connecting-n8n-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on how to create a Gram-hosted MCP server, check out the [Gram concepts guide](/blog/gram-concepts).
+If you already have a Gram MCP server configured, you can skip to [connecting n8n to your Gram-hosted MCP server](#connecting-n8n-to-your-gram-hosted-mcp-server). For an in-depth guide to how Gram works and more details on how to create a Gram-hosted MCP server, check out the [Gram concepts guide](https://www.speakeasy.com/mcp/core-concepts).
 
 ### Setting up a Gram project
 
@@ -63,7 +63,7 @@ Click **Toolsets** in the sidebar to view the Push Advisor toolset.
 
 ### Configuring environment variables
 
-[Environments](/concepts/environments) store API keys and configuration separate from your toolset logic.
+[Environments](concepts/environments) store API keys and configuration separate from your toolset logic.
 
 In the **Environments** tab, click the **Default** environment. Click **Edit** and then **Fill for Toolset**. Select the **Push Advisor** toolset and click **Fill Variables** to automatically populate the required variables.
 
@@ -105,7 +105,7 @@ The configuration will look something like this:
 
 Use the **Authenticated Server** configuration if you want to use the MCP server in a private environment.
 
-You'll need an API key to use an authenticated server. [Generate an API key](/concepts/api-keys) in the **Settings** tab and copy it to the `GRAM_KEY` environment variable in place of `<your-key-here>`.
+You'll need an API key to use an authenticated server. [Generate an API key](concepts/api-keys) in the **Settings** tab and copy it to the `GRAM_KEY` environment variable in place of `<your-key-here>`.
 
 The authenticated server configuration looks something like this:
 

--- a/docs/src/content/docs/clients/using-roo-code-with-gram-mcp-server.mdx
+++ b/docs/src/content/docs/clients/using-roo-code-with-gram-mcp-server.mdx
@@ -9,7 +9,7 @@ Roo Code is a [VS Code extension](https://marketplace.visualstudio.com/items?ite
 
 When paired with [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, you can connect Roo Code to your APIs, databases, and infrastructure services, granting it contextual access to your tools and data.
 
-This guide shows you how to connect Roo Code to a [Gram-hosted MCP server](/blog/the-easiest-way-to-host-mcp-servers) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
+This guide shows you how to connect Roo Code to a [Gram-hosted MCP server](https://www.speakeasy.com/blog/release-gram-beta) using Taskmaster, a full-stack CRUD application for task and project management. Taskmaster includes a web UI for managing projects and tasks, a built-in HTTP API, OAuth 2.0 authentication, and a Neon PostgreSQL database for storing data. Try the [demo app](https://taskmaster-speakeasyapi.vercel.app/) to see it in action.
 
 You'll learn how to set up the connection, test it, and use natural language to manage tasks, projects, and workflows through Roo Code.
 
@@ -26,7 +26,7 @@ To follow this tutorial, you need:
 
 ## Creating an MCP server
 
-Before connecting Roo Code to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server).
+Before connecting Roo Code to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server).
 
 ## Connecting Roo Code to your Gram-hosted MCP server
 
@@ -40,7 +40,7 @@ To add a server to Roo Code, click the **Server** icon at the top right of the R
 
 Click **Edit Global MCP** to open Roo Code's global MCP server `mcp_settings.json` file.
 
-Add your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server) guide.
+Add your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server) guide.
 
 - If you're using a **Pass-through Authentication**, add the following to the `mcp_settings.json` file:
 

--- a/docs/src/content/docs/clients/using-your-ide-with-gram-mcp-server.mdx
+++ b/docs/src/content/docs/clients/using-your-ide-with-gram-mcp-server.mdx
@@ -18,11 +18,11 @@ Find the full code and OpenAPI document in the [Taskmaster repository](https://g
 To follow this guide, you need:
 
 - A [Gram account](https://app.getgram.ai)
-- An MCP client (This guide covers Cursor, VS Code with Copilot, Windsurf, and Amp. For Claude Desktop, see the [dedicated Claude Desktop guide](/clients/using-claude-desktop-with-gram-mcp-server).)
+- An MCP client (This guide covers Cursor, VS Code with Copilot, Windsurf, and Amp. For Claude Desktop, see the [dedicated Claude Desktop guide](clients/using-claude-desktop-with-gram-mcp-server).)
 
 ## Creating an MCP server
 
-Before connecting your IDE to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server).
+Before connecting your IDE to a Taskmaster MCP server, you first need to create one. Follow our guide to [creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server).
 
 Once your Taskmaster MCP server is ready, you can connect it to your IDE. The following sections show you how to add the MCP server configuration to the most popular IDE-based MCP clients.
 
@@ -43,7 +43,7 @@ In Cursor, navigate to **Settings -> Cursor Settings** and open **Tools & Integr
 
 ### 2. Add the MCP server configuration
 
-Cursor's global MCP configuration file will open. Add your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server) guide.
+Cursor's global MCP configuration file will open. Add your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server) guide.
 
 For a public server, the configuration looks like this:
 
@@ -105,7 +105,7 @@ Open the VS Code command palette with `Ctrl/Cmd + Shift + P` and search for `Add
 
 ![Screenshot showing the VS Code Add HTTP MCP Server dialog](/img/guides/mcp-installing-ide/vscode-add-http-server.png)
 
-Paste in the URL of your Taskmaster MCP server from the [Creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server) guide and enter the server name.
+Paste in the URL of your Taskmaster MCP server from the [Creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server) guide and enter the server name.
 
 ![Screenshot showing pasting the MCP server URL](/img/guides/mcp-installing-ide/vscode-paste-mcp-url.png)
 
@@ -168,7 +168,7 @@ Under the **Plugins (MCP Servers)** section, click **Manage plugins** to access 
 
 ### 2. Add the MCP server configuration
 
-In the `mcp_config.json` file that opens, replace the contents with your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server) guide:
+In the `mcp_config.json` file that opens, replace the contents with your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server) guide:
 
 ```json
 {
@@ -268,7 +268,7 @@ The location of the Amp CLI configuration file varies by operating system:
 
 ### 2. Add the MCP server configuration
 
-Add the `amp.mcpServers` setting with your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](/examples/creating-taskmaster-mcp-server) guide to the configuration file.
+Add the `amp.mcpServers` setting with your Taskmaster MCP server configuration from the [Creating a Taskmaster MCP server](examples/creating-taskmaster-mcp-server) guide to the configuration file.
 
 For a public server, the configuration will look like this:
 

--- a/docs/src/content/docs/command-line/use.md
+++ b/docs/src/content/docs/command-line/use.md
@@ -5,13 +5,13 @@ description: How to use the Gram CLI for deployments
 
 ## About
 
-The Gram CLI helps you manage [Deployments](/concepts/deployments) without leaving the command line.
+The Gram CLI helps you manage [Deployments](concepts/deployments) without leaving the command line.
 
-It can also integrate with CI/CD pipelines. See our [Deploy from GitHub Actions](/examples/deploy-from-github-actions) guide.
+It can also integrate with CI/CD pipelines. See our [Deploy from GitHub Actions](examples/deploy-from-github-actions) guide.
 
 ## Authentication
 
-Create and save a [Producer key](/concepts/api-keys#producer-keys) from your Gram dashboard.
+Create and save a [Producer key](concepts/api-keys#producer-keys) from your Gram dashboard.
 
 Expose this key as an environment variable called `$GRAM_API_KEY`.
 

--- a/docs/src/content/docs/concepts/deployments.md
+++ b/docs/src/content/docs/concepts/deployments.md
@@ -19,7 +19,7 @@ A project's deployment history can be accessed from the "Deployments" page:
 
 A Deployment is created whenever you upload a new asset, or update an existing
 one. Once the deployment process is finished, tool definitions generated from
-it can be used in [Toolsets](/build-mcp/custom-toolsets) and Custom Tools. If a
+it can be used in [Toolsets](build-mcp/custom-toolsets) and Custom Tools. If a
 Deployment includes updates to existing assets, any dependent tool definitions,
 toolsets, custom tools, and MCP servers are updated automatically.
 

--- a/docs/src/content/docs/concepts/openapi.md
+++ b/docs/src/content/docs/concepts/openapi.md
@@ -61,10 +61,10 @@ paths:
 
 Without the `x-gram` extension, the generated tool would be named `ecommerce_e_commerce_v1_product`, and have the description `"Get a product by its ID"`, resulting in a poor quality tool. The `x-gram` extension allows you to customize a tool's name and description without altering the original information in the OpenAPI document.
 
-The `x-gram` extension also supports [response filtering](/build-mcp/response-filtering) through the `responseFilterType` property, which helps LLMs process API responses more effectively.
+The `x-gram` extension also supports [response filtering](build-mcp/response-filtering) through the `responseFilterType` property, which helps LLMs process API responses more effectively.
 
 
-Using the `x-gram` extension is optional. With Gram's [tool variations](/concepts/tool-variations) feature, you can modify a tool's name and description when curating tools into toolsets. However, it might be worth using the `x-gram` extension to make your OpenAPI document clean, descriptive, and LLM-ready before bringing it into Gram, so your team doesn't need to fix tool names and descriptions later.
+Using the `x-gram` extension is optional. With Gram's [tool variations](concepts/tool-variations) feature, you can modify a tool's name and description when curating tools into toolsets. However, it might be worth using the `x-gram` extension to make your OpenAPI document clean, descriptive, and LLM-ready before bringing it into Gram, so your team doesn't need to fix tool names and descriptions later.
 
 ## Limitations of OpenAPI 3.0.x
 

--- a/docs/src/content/docs/concepts/tool-definitions.md
+++ b/docs/src/content/docs/concepts/tool-definitions.md
@@ -5,10 +5,10 @@ sidebar:
   order: 0
 ---
 
-When you upload an [OpenAPI document](/concepts/openapi) or enable an integration in Gram, Gram creates a deployment and begins processing it. During this stage, every operation defined in the OpenAPI document is automatically converted into a corresponding tool definition.
+When you upload an [OpenAPI document](concepts/openapi) or enable an integration in Gram, Gram creates a deployment and begins processing it. During this stage, every operation defined in the OpenAPI document is automatically converted into a corresponding tool definition.
 
 ![Generating tools](/img/concepts/tool-definitions/tools-generation.png)
 
 Tool definitions contain both the metadata needed to describe a tool to an LLM and the configuration Gram uses to construct the corresponding HTTP request to your API or a third-party integration.
 
-When creating toolsets, you select the relevant tool definitions to include and invoke them using the Gram Playground, SDK, or MCP server. To build and proxy the HTTP request to the appropriate endpoint, Gram combines the tool definition with the selected [environment](/concepts/environments) (which defaults to `Default Env`).
+When creating toolsets, you select the relevant tool definitions to include and invoke them using the Gram Playground, SDK, or MCP server. To build and proxy the HTTP request to the appropriate endpoint, Gram combines the tool definition with the selected [environment](concepts/environments) (which defaults to `Default Env`).

--- a/docs/src/content/docs/concepts/tool-variations.md
+++ b/docs/src/content/docs/concepts/tool-variations.md
@@ -11,7 +11,7 @@ Improving tool descriptions is a form of prompt engineering, and it's a critical
 
 Gram provides two ways to improve a tool's description:
 
-- [Editing the OpenAPI document](/concepts/openapi#using-the-x-gram-extension) and adding the `x-gram` extension to the endpoint to override or enrich the tool's metadata.
+- [Editing the OpenAPI document](concepts/openapi#using-the-x-gram-extension) and adding the `x-gram` extension to the endpoint to override or enrich the tool's metadata.
 - Using the Gram Playground to directly edit a tool's name and description. This feature is called **Tool variations**.
 
 Under the **Tools** tab for a toolset, you can edit the name and description of a tool.

--- a/docs/src/content/docs/concepts/toolsets.md
+++ b/docs/src/content/docs/concepts/toolsets.md
@@ -25,7 +25,7 @@ When creating a toolset, start by identifying the specific task you want an LLM 
 
 To ensure your toolsets are LLM-friendly:
 
-- Refine tool names and descriptions using Gram's [tool-variations](/concepts/tool-variations) feature to improve clarity and usability for the LLM.
+- Refine tool names and descriptions using Gram's [tool-variations](concepts/tool-variations) feature to improve clarity and usability for the LLM.
 - Keep toolsets focused by including only what's needed for the task. Avoid unrelated tools that may confuse the agent.
 
 ## Experimenting with toolsets

--- a/docs/src/content/docs/examples/adding-ai-chat-to-your-app.mdx
+++ b/docs/src/content/docs/examples/adding-ai-chat-to-your-app.mdx
@@ -15,7 +15,7 @@ If you have any kind of SaaS application, you're probably used to your users usi
 
 This guide shows you how to add a chat interface to an existing application. You can give your users natural language interaction, while your current backend, security model, and business logic remain unchanged.
 
-<video width="600" controls style="display: block; margin: 0 auto;">
+<video width="600" controls={true} muted={true}>
   <source src="/videos/taskboard-show-tasks.mp4" type="video/mp4" />
     Your browser does not support the video tag.
 </video>
@@ -178,7 +178,7 @@ If you're using Gram for the first time:
 3. Upload the OpenAPI document (`public/swagger.json`).
 4. Name the API (for example, "TaskBoard"), toolset, and server slug (for example, "taskboard-demo").
 
-<video width="600" controls style="display: block; margin: 0 auto;">
+<video width="600" controls={true} muted={true}>
   <source src="/videos/taskboard-mcp-create.mp4" type="video/mp4" />
     Your browser does not support the video tag.
 </video>
@@ -831,7 +831,7 @@ You should see:
 2. **Automatic TaskBoard updates** when the agent performs actions
 3. **Only your tasks** are visible and editable (user permissions respected)
 
-<video width="600" controls style="display: block; margin: 0 auto;">
+<video width="600" controls={true} muted={true}>
   <source src="/videos/taskboard-new-task.mp4" type="video/mp4" />
     Your browser does not support the video tag.
 </video>

--- a/docs/src/content/docs/examples/creating-taskmaster-mcp-server.mdx
+++ b/docs/src/content/docs/examples/creating-taskmaster-mcp-server.mdx
@@ -88,7 +88,7 @@ Before configuring environment variables, create an API key:
 
 ## Configuring environment variables
 
-[Environments](/concepts/environments) store API keys and configuration separately from your toolset logic.
+[Environments](concepts/environments) store API keys and configuration separately from your toolset logic.
 
 In the **Environments** tab, click the **Default** environment. Click the three-dot menu in the top-right corner of the environment card, and in the dropdown, click **Fill for Toolset**. Select the **Taskmaster** toolset and click **Fill Variables** to automatically populate the required variables.
 
@@ -180,10 +180,10 @@ Before connecting to external clients, test your setup by using the **Gram Playg
 
 Your Taskmaster MCP server is now ready to use with any MCP client. You can connect it to:
 
-- [Claude Code](/clients/using-claude-code-with-gram-mcp-servers)
-- [Claude Desktop](/clients/using-claude-desktop-with-gram-mcp-server)  
-- [Your IDE](/clients/using-your-ide-with-gram-mcp-server)
-- [Cline](/clients/using-cline-with-gram-mcp-server)
+- [Claude Code](clients/using-claude-code-with-gram-mcp-servers)
+- [Claude Desktop](clients/using-claude-desktop-with-gram-mcp-server)  
+- [Your IDE](clients/using-your-ide-with-gram-mcp-server)
+- [Cline](clients/using-cline-with-gram-mcp-server)
 - Any other MCP-compatible client
 
 

--- a/docs/src/content/docs/examples/deploy-from-github-actions.md
+++ b/docs/src/content/docs/examples/deploy-from-github-actions.md
@@ -15,7 +15,7 @@ This allows you to deploy changes automatically whenever you push to your reposi
 
 Before setting up GitHub Actions deployment, ensure you have:
 
-- A Gram [Producer key](/concepts/api-keys#producer-keys)
+- A Gram [Producer key](concepts/api-keys#producer-keys)
 - A repository with your OpenAPI specification or toolset configuration
 
 ## Setup

--- a/docs/src/content/docs/examples/oauth-external-server.md
+++ b/docs/src/content/docs/examples/oauth-external-server.md
@@ -279,7 +279,7 @@ function handleLogin(request, corsHeaders) {
 
 ## Defining OAuth in the OpenAPI document
 
-Next, we'll document our OAuth configuration in the OpenAPI document, you can read more about how Gram uses the OpenAPI document [here](/concepts/openapi).
+Next, we'll document our OAuth configuration in the OpenAPI document, you can read more about how Gram uses the OpenAPI document [here](concepts/openapi).
 
 ```yaml
 openapi: 3.1.0
@@ -363,7 +363,7 @@ The metadata format is standardized across OAuth providers. Most providers offer
 
 Finally, let's test everything in the Gram playground.
 
-After [uploading our OpenAPI document](/build-mcp/create-default-toolset) and creating a toolset, we'll go to the playground to test it. When we ask the AI agent to get deployment history, it will automatically detect that OAuth authentication is required:
+After [uploading our OpenAPI document](build-mcp/create-default-toolset) and creating a toolset, we'll go to the playground to test it. When we ask the AI agent to get deployment history, it will automatically detect that OAuth authentication is required:
 
 ![Gram Playground Testing](/img/guides/oauth-external-server/gram-playground-testing.png)
 

--- a/docs/src/content/docs/guides.md
+++ b/docs/src/content/docs/guides.md
@@ -9,10 +9,10 @@ Here you'll find detailed guides on how to quickly get connected to your Gram MC
 
 Specifically we provide detailed instructions on:
 
-* Connecting with GUI MCP Clients such as [Using Claude Desktop with Gram-hosted MCP servers](/clients/using-claude-desktop-with-gram-mcp-server).
-* Connecting with CLI tools such as [Using Claude Code with Gram-hosted MCP servers](/clients/using-claude-code-with-gram-mcp-servers).
-* Using MCP programmatically through APIs such as [Using OpenAI API with Gram-hosted MCP servers](/api-clients/using-openai-api-with-gram-mcp-servers).
-* Building example applications like [Add AI chat to an existing app](/examples/adding-ai-chat-to-your-app).
+* Connecting with GUI MCP Clients such as [Using Claude Desktop with Gram-hosted MCP servers](clients/using-claude-desktop-with-gram-mcp-server).
+* Connecting with CLI tools such as [Using Claude Code with Gram-hosted MCP servers](clients/using-claude-code-with-gram-mcp-servers).
+* Using MCP programmatically through APIs such as [Using OpenAI API with Gram-hosted MCP servers](api-clients/using-openai-api-with-gram-mcp-servers).
+* Building example applications like [Add AI chat to an existing app](examples/adding-ai-chat-to-your-app).
 
 See the full list in the sidebar. Is there something you want added? Feel free to [open an issue](https://github.com/speakeasy-api/gram-docs/issues)!
 

--- a/docs/src/content/docs/host-mcp/deploy-mcp-server.md
+++ b/docs/src/content/docs/host-mcp/deploy-mcp-server.md
@@ -63,7 +63,7 @@ Under the **MCP Installation** section, you can see the MCP server installation 
 
 Your MCP server is now live. Here are some next steps to consider:
 
-- **Iterate on tool descriptions:** Refine tool definitions and use [tool variations](/concepts/tool-variations) to help LLMs better understand and invoke them accurately.
+- **Iterate on tool descriptions:** Refine tool definitions and use [tool variations](concepts/tool-variations) to help LLMs better understand and invoke them accurately.
 - **Create custom toolsets:** Group tools by task to design structured, step-by-step workflows tailored to specific use cases.
 - **Integrate with frameworks:** Use the Gram Python or TypeScript SDK to build agentic workflows. On the **Playground** page, you can select a ready-to-use code snippet in [Python](https://pypi.org/project/gram-ai/) or [JavaScript](https://www.npmjs.com/package/@gram-ai/sdk).
 

--- a/docs/src/content/docs/host-mcp/public-private-servers.md
+++ b/docs/src/content/docs/host-mcp/public-private-servers.md
@@ -21,7 +21,7 @@ Public servers are the easiest way to use Gram and are typically what you'd use 
 
 ![Example of a Gram-hosted MCP documentation page showing available tools and endpoints](/img/guides/gram-example-public-docs.png)
 
-Public servers also support [MCP Managed OAuth](/build-mcp/adding-oauth) for simplified authentication.
+Public servers also support [MCP Managed OAuth](build-mcp/adding-oauth) for simplified authentication.
 
 ## Private Servers
 
@@ -60,7 +60,7 @@ Pass-through authentication can be used with both public and private Gram server
 
 ## Managed Authentication
 
-Managed authentication lets you store API credentials centrally in Gram [environments](/concepts/environments), so users only need a Gram API key to access your server. This is perfect for demos, trials, or team scenarios where you want to provide easy access without exposing your actual API keys.
+Managed authentication lets you store API credentials centrally in Gram [environments](concepts/environments), so users only need a Gram API key to access your server. This is perfect for demos, trials, or team scenarios where you want to provide easy access without exposing your actual API keys.
 
 For example, you could give potential customers a temporary Gram API key to test your service. They get instant access to your tools without needing to sign up for your API or handle sensitive credentials directly. All the actual API keys and configuration stay securely stored in your Gram environment.
 
@@ -87,6 +87,6 @@ For example, you could give potential customers a temporary Gram API key to test
 
 The `Gram-Environment` header specifies which Gram environment to link - you can use different environments for development, staging, or production configurations.
 
-Before using managed authentication, use the [Playground](/build-mcp/test-toolsets#_top) to ensure your environment is properly configured with all required API keys. The Playground will automatically prompt you to create any missing keys with the correct names.
+Before using managed authentication, use the [Playground](build-mcp/test-toolsets#_top) to ensure your environment is properly configured with all required API keys. The Playground will automatically prompt you to create any missing keys with the correct names.
 
 You can also mix managed and pass-through authentication, using Gram environments for some credentials while letting users provide others directly.

--- a/docs/src/content/docs/host-mcp/publish-gram-server-mcp-registry.md
+++ b/docs/src/content/docs/host-mcp/publish-gram-server-mcp-registry.md
@@ -28,7 +28,7 @@ Future versions of Gram will automate this publishing process. These instruction
 To follow the tutorial, you need:
 
 - **A [Gram Pro or Enterprise account](https://www.speakeasy.com/pricing?product=mcp):** You need a custom domain to publish your MCP server to the registry.
-- **A Gram-hosted MCP server:** If you don't have one, learn to create one in our [quickstart guide](/gram-quickstart).
+- **A Gram-hosted MCP server:** If you don't have one, learn to create one in our [quickstart guide](gram-quickstart).
 - **Domain management access for a custom domain:** You need to create a DNS TXT record.
 - **A GitHub repository:** This is where you need to store your MCP server source code.
 
@@ -253,4 +253,4 @@ You have now published your Gram MCP server on the official MCP Registry, making
 To maintain and further improve your MCP server, you can:
 
 - Automate publishing with [GitHub Actions workflows](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md)
-- Refine tool definitions and use [tool variations](/concepts/tool-variations) to help LLMs better understand and invoke them accurately
+- Refine tool definitions and use [tool variations](concepts/tool-variations) to help LLMs better understand and invoke them accurately

--- a/docs/src/content/docs/introduction.md
+++ b/docs/src/content/docs/introduction.md
@@ -43,7 +43,7 @@ Existing REST APIs are a starting point, but to create a functional MCP server, 
 2. **Add Context** - A user reading an API reference is coming in with some implicit context about the relevant business domain. The same is not true of an LLM examining a list of tools on an MCP server. It is up to the MCP server maintainer to make sure the server provides the LLM with the context it needs. Adding rich tool descriptions, prompts, and examples, greatly improves the performance of the MCP server. Focus on the _when_ and _why_ of the tool. Gram gives you the ability to add additional context to your tools.
 3. **Define Custom Tools** - REST APIs are resource-oriented: create a company, update the contact field, etc. MCP servers work best when they're workflow-based: "summarize recent channel activity". Gram gives you the ability to distribute custom tools that wrap multiple API endpoints and additional steps as a single tool.
 
-Gram makes tool creation & curation easy. [Tools](/concepts/tool-definitions) are bootstrapped by pulling API paths, input schemas, security schemes, and descriptions out of OpenAPI documents. Once an API is uploaded to the Gram platform the day 0 workflow looks like this:
+Gram makes tool creation & curation easy. [Tools](concepts/tool-definitions) are bootstrapped by pulling API paths, input schemas, security schemes, and descriptions out of OpenAPI documents. Once an API is uploaded to the Gram platform the day 0 workflow looks like this:
 
 * Remove unnecessary tools from your toolset
 * Combine tools into use case specific toolsets.
@@ -69,7 +69,7 @@ Currently, MCP servers are mostly **local** (hosted by API consumers), which cre
 
 Once tools have been curated, the MCP server is ready to deploy. Every toolset automatically comes with an MCP server hosted at a Gram managed URL. Custom domains can be linked to create a branded, 1st party MCP server at `mcp.{{your-domain}}.com/{{server-name}}`
 
-Gram provides completely [managed hosting of MCP servers](/gram-quickstart) or self-hosted.
+Gram provides completely [managed hosting of MCP servers](gram-quickstart) or self-hosted.
 
 ## LLM-Friendly Docs
 
@@ -85,11 +85,11 @@ Finally, you can copy the contents of any page as markdown by pressing â€œCmd+Câ
 
 ## Further Reading
 
-- [Quickstart](/gram-quickstart)
-- [Creating your first toolset](/build-mcp/create-default-toolset)
-- [Curating custom toolsets](/build-mcp/custom-toolsets)
-- [Deploying an MCP server](/host-mcp/deploy-mcp-server)
-- [OpenAPI concepts](/concepts/openapi)
-- [Tool definitions](/concepts/tool-definitions)
-- [Toolsets](/concepts/toolsets)
-- [Environment variables](/concepts/environments)
+- [Quickstart](gram-quickstart)
+- [Creating your first toolset](build-mcp/create-default-toolset)
+- [Curating custom toolsets](build-mcp/custom-toolsets)
+- [Deploying an MCP server](host-mcp/deploy-mcp-server)
+- [OpenAPI concepts](concepts/openapi)
+- [Tool definitions](concepts/tool-definitions)
+- [Toolsets](concepts/toolsets)
+- [Environment variables](concepts/environments)


### PR DESCRIPTION
### Sync from Marketing Site

**Source commit:** `20c7770595a37c4314e80cb2603bffc882878a9e`

**Grouped file changes:**
#### `docs/src/`
M	docs/src/content/docs/api-clients/using-anthropic-api-with-gram-mcp-servers.mdx
M	docs/src/content/docs/api-clients/using-langchain-with-gram-mcp-servers.mdx
M	docs/src/content/docs/api-clients/using-openai-agents-sdk-with-gram-mcp-servers.mdx
M	docs/src/content/docs/api-clients/using-openai-api-with-gram-mcp-servers.mdx
M	docs/src/content/docs/api-clients/using-pydantic-ai-with-gram-mcp-servers.mdx
M	docs/src/content/docs/api-clients/using-vercel-ai-sdk-with-gram-mcp-servers.mdx
M	docs/src/content/docs/build-mcp/advanced-tool-curation.md
M	docs/src/content/docs/build-mcp/create-default-toolset.md
M	docs/src/content/docs/build-mcp/custom-toolsets.md
M	docs/src/content/docs/clients/using-chatgpt-developer-mode-with-gram.mdx
M	docs/src/content/docs/clients/using-claude-code-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-claude-desktop-with-gram-mcp-server.mdx
M	docs/src/content/docs/clients/using-cline-with-gram-mcp-server.mdx
M	docs/src/content/docs/clients/using-gemini-cli-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-mistral-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-n8n-with-gram-mcp-servers.mdx
M	docs/src/content/docs/clients/using-roo-code-with-gram-mcp-server.mdx
M	docs/src/content/docs/clients/using-your-ide-with-gram-mcp-server.mdx
M	docs/src/content/docs/command-line/use.md
M	docs/src/content/docs/concepts/deployments.md
M	docs/src/content/docs/concepts/openapi.md
M	docs/src/content/docs/concepts/tool-definitions.md
M	docs/src/content/docs/concepts/tool-variations.md
M	docs/src/content/docs/concepts/toolsets.md
M	docs/src/content/docs/examples/adding-ai-chat-to-your-app.mdx
M	docs/src/content/docs/examples/creating-taskmaster-mcp-server.mdx
M	docs/src/content/docs/examples/deploy-from-github-actions.md
M	docs/src/content/docs/examples/oauth-external-server.md
M	docs/src/content/docs/guides.md
M	docs/src/content/docs/host-mcp/deploy-mcp-server.md
M	docs/src/content/docs/host-mcp/public-private-servers.md
M	docs/src/content/docs/host-mcp/publish-gram-server-mcp-registry.md
M	docs/src/content/docs/introduction.md
