### PR TITLE
chore: set license, homepage, repository fields in package.json

### DIFF
--- a/ts-framework/create-function/LICENSE
+++ b/ts-framework/create-function/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Speakeasy Development, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ts-framework/create-function/package.json
+++ b/ts-framework/create-function/package.json
@@ -4,8 +4,14 @@
   "version": "0.1.0",
   "description": "Build AI tools and deploy them to getgram.ai",
   "keywords": [],
+  "homepage": "https://github.com/speakeasy-api/gram",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/speakeasy-api/gram.git",
+    "directory": "ts-framework/create-function"
+  },
   "author": "Georges Haidar <georges@speakeasyapi.dev>",
-  "license": "ISC",
+  "license": "MIT",
   "main": "dist/index.js",
   "bin": {
     "create-function": "dist/main.js"

--- a/ts-framework/functions/LICENSE
+++ b/ts-framework/functions/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Speakeasy Development, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ts-framework/functions/package.json
+++ b/ts-framework/functions/package.json
@@ -6,7 +6,13 @@
   "author": "Georges Haidar <georges@speakeasyapi.dev>",
   "main": "dist/index.js",
   "keywords": [],
-  "license": "ISC",
+  "license": "MIT",
+  "homepage": "https://github.com/speakeasy-api/gram",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/speakeasy-api/gram.git",
+    "directory": "ts-framework/functions"
+  },
   "scripts": {
     "test": "vitest run",
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
This change sets the missing fields in the package.json files for the `ts-framework/create-function` and `ts-framework/functions` packages.