### PR TITLE
chore: change default config file to gram.json

### DIFF
--- a/cli/internal/app/stage.go
+++ b/cli/internal/app/stage.go
@@ -47,8 +47,8 @@ YAML/JSON documents.
 		Flags: []cli.Flag{
 			&cli.PathFlag{
 				Name:  "config",
-				Usage: "Path to the deployment file",
-				Value: "config.json",
+				Usage: "Path to the deployment config file",
+				Value: "gram.json",
 			},
 		},
 		Subcommands: []*cli.Command{


### PR DESCRIPTION
This change updates the default config file for `gram stage ...` from `config.json` to `gram.json`.