### PR TITLE
chore: update action url to correct

### DIFF
--- a/.github/workflows/sync-docs-to-marketing.yaml
+++ b/.github/workflows/sync-docs-to-marketing.yaml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Gram repo (source)
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v4.1.6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Checkout Marketing repo (destination)
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v4.1.6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ env.MARKETING_REPO }}
           ref: ${{ env.BRANCH }}


### PR DESCRIPTION
The pinned checkout url did not work, updated to a working one.

https://github.com/speakeasy-api/gram/actions/runs/18606978380/job/53058268266#step:1:29