### PR TITLE
chore: add source control metadata to telemetry attributes

### DIFF
--- a/server/cmd/gram/root.go
+++ b/server/cmd/gram/root.go
@@ -49,7 +49,10 @@ func newApp() *cli.App {
 				RawLevel:    c.String("log-level"),
 				Pretty:      c.Bool("log-pretty"),
 				DataDogAttr: os.Getenv("DD_SERVICE") != "",
-			}))
+			})).With(
+				attr.SlogDataDogGitCommitSHA(GitSHA),
+				attr.SlogDataDogGitRepoURL("github.com/speakeasy-api/gram"),
+			)
 
 			// Sets `GOMEMLIMIT` to 90% of cgroup's memory limit.
 			_, err := memlimit.SetGoMemLimitWithOpts(memlimit.WithLogger(nil))

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -338,6 +338,7 @@ func newStartCommand() *cli.Command {
 			shutdown, err := o11y.SetupOTelSDK(ctx, logger, o11y.SetupOTelSDKOptions{
 				ServiceName:    serviceName,
 				ServiceVersion: shortGitSHA(),
+				GitSHA:         GitSHA,
 				EnableTracing:  c.Bool("with-otel-tracing"),
 				EnableMetrics:  c.Bool("with-otel-metrics"),
 			})

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -249,6 +249,7 @@ func newWorkerCommand() *cli.Command {
 			shutdown, err = o11y.SetupOTelSDK(ctx, logger, o11y.SetupOTelSDKOptions{
 				ServiceName:    serviceName,
 				ServiceVersion: shortGitSHA(),
+				GitSHA:         GitSHA,
 				EnableTracing:  c.Bool("with-otel-tracing"),
 				EnableMetrics:  c.Bool("with-otel-metrics"),
 			})

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -46,10 +46,12 @@ const (
 	ReasonKey   = attribute.Key("reason")
 	ValueKey    = attribute.Key("value")
 
-	SpanIDKey         = attribute.Key("span.id")
-	TraceIDKey        = attribute.Key("trace.id")
-	DataDogTraceIDKey = attribute.Key("dd.trace_id")
-	DataDogSpanIDKey  = attribute.Key("dd.span_id")
+	SpanIDKey              = attribute.Key("span.id")
+	TraceIDKey             = attribute.Key("trace.id")
+	DataDogGitCommitSHAKey = attribute.Key("git.commit.sha")
+	DataDogGitRepoURLKey   = attribute.Key("git.repository_url")
+	DataDogTraceIDKey      = attribute.Key("dd.trace_id")
+	DataDogSpanIDKey       = attribute.Key("dd.span_id")
 
 	FlyAppNameKey    = attribute.Key("fly.app.name")
 	FlyOrgIDKey      = attribute.Key("fly.org.id")
@@ -279,6 +281,14 @@ func SlogSpanID(v string) slog.Attr      { return slog.String(string(SpanIDKey),
 
 func TraceID(v string) attribute.KeyValue { return TraceIDKey.String(v) }
 func SlogTraceID(v string) slog.Attr      { return slog.String(string(TraceIDKey), v) }
+
+func DataDogGitCommitSHA(v string) attribute.KeyValue { return DataDogGitCommitSHAKey.String(v) }
+func SlogDataDogGitCommitSHA(v string) slog.Attr {
+	return slog.String(string(DataDogGitCommitSHAKey), v)
+}
+
+func DataDogGitRepoURL(v string) attribute.KeyValue { return DataDogGitRepoURLKey.String(v) }
+func SlogDataDogGitRepoURL(v string) slog.Attr      { return slog.String(string(DataDogGitRepoURLKey), v) }
 
 func DataDogTraceID(v string) attribute.KeyValue { return DataDogTraceIDKey.String(v) }
 func SlogDataDogTraceID(v string) slog.Attr {

--- a/server/internal/o11y/setup.go
+++ b/server/internal/o11y/setup.go
@@ -29,6 +29,7 @@ import (
 type SetupOTelSDKOptions struct {
 	ServiceName    string
 	ServiceVersion string
+	GitSHA         string
 	EnableTracing  bool
 	EnableMetrics  bool
 }
@@ -97,6 +98,7 @@ func SetupOTelSDK(ctx context.Context, logger *slog.Logger, options SetupOTelSDK
 		ctx,
 		options.ServiceName,
 		options.ServiceVersion,
+		options.GitSHA,
 		metricExporter,
 		spanExporter,
 		prop,
@@ -127,6 +129,7 @@ func newClueConfig(
 	ctx context.Context,
 	svcName string,
 	svcVersion string,
+	gitSHA string,
 	metricExporter sdkmetric.Exporter,
 	spanExporter sdktrace.SpanExporter,
 	propagators propagation.TextMapPropagator,
@@ -139,6 +142,8 @@ func newClueConfig(
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(svcName),
 			semconv.ServiceVersionKey.String(svcVersion),
+			attr.DataDogGitCommitSHA(gitSHA),
+			attr.DataDogGitRepoURL("github.com/speakeasy-api/gram"),
 		))
 	if err != nil {
 		return nil, fmt.Errorf("create resource: %w", err)


### PR DESCRIPTION
This change adds source control metadata to tracing and logging data to better work with [Datadog Source Code Integration][1]

[1]: https://docs.datadoghq.com/integrations/guide/source-code-integration/