### PR TITLE
chore: chore: capture stack trace when recording errors

### DIFF
--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -115,7 +115,7 @@ func (e *ShareableError) LogValue() slog.Value {
 func (e *ShareableError) Log(ctx context.Context, logger *slog.Logger, args ...slog.Attr) *ShareableError {
 	span := trace.SpanFromContext(ctx)
 	span.SetStatus(codes.Error, e.String())
-	span.RecordError(e)
+	span.RecordError(e, trace.WithStackTrace(true))
 
 	var pcs [1]uintptr
 	runtime.Callers(2, pcs[:]) // skip [Callers, Log]


### PR DESCRIPTION
This change updates (*oops.ShareableError).Log so we capture stack traces when recording errors to OpenTelemetry spans.