### PR TITLE
chore: allow browser based mcp clients

### DIFF
--- a/server/internal/httputil/utils.go
+++ b/server/internal/httputil/utils.go
@@ -1,0 +1,19 @@
+package httputil
+
+import (
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// IsBrowserPageRequest checks if the request is from a browser by examining the Accept header
+// for HTML content types (text/html or application/xhtml+xml).
+func IsBrowserPageRequest(r *http.Request) bool {
+	for mediaTypeFull := range strings.SplitSeq(r.Header.Get("Accept"), ",") {
+		if mediatype, _, err := mime.ParseMediaType(mediaTypeFull); err == nil &&
+			(mediatype == "text/html" || mediatype == "application/xhtml+xml") {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/middleware/cors.go
+++ b/server/internal/middleware/cors.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"github.com/speakeasy-api/gram/server/internal/httputil"
 	"net/http"
 	"net/url"
 	"slices"
@@ -10,6 +11,7 @@ import (
 var mcpOpenAccessControlRoutes = []string{
 	"/.well-known/oauth-authorization-server/mcp",
 	"/.well-known/oauth-protected-resource/mcp",
+	"/mcp/",
 }
 
 func CORSMiddleware(env string, serverURL string) func(next http.Handler) http.Handler {
@@ -44,9 +46,9 @@ func CORSMiddleware(env string, serverURL string) func(next http.Handler) http.H
 			// These need to be accessible from the browser on any origin
 			if slices.ContainsFunc(mcpOpenAccessControlRoutes, func(route string) bool {
 				return strings.HasPrefix(r.URL.Path, route)
-			}) {
+			}) && !httputil.IsBrowserPageRequest(r) {
 				w.Header().Set("Access-Control-Allow-Origin", "*")
-				w.Header().Set("Access-Control-Allow-Methods", "GET")
+				w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
 				w.Header().Del("Access-Control-Allow-Credentials")
 			}
 


### PR DESCRIPTION
Browser based MCP clients such as as the following attempt to make requests to the actual MCP server via the browser.
- [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) (in Direct Mode)
- [Cloudflare Playground](https://playground.ai.cloudflare.com/)

To support this, you'd more or less have to open up CORs for these MCP routes.


We have a bit of added complications where we have these hosted pages. When in hosted page mode we actually do need a more restrictive CORs policy because you can't have `Access-Control-Allow-Credentials` true when `Access-Control-Allow-Origin` is *