### PR TITLE
chore: capture full git sha as docker build arg

### DIFF
--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -113,7 +113,7 @@ runs:
 
     - name: Set GIT_SHA
       shell: bash
-      run: echo "GIT_SHA=$(echo $GITHUB_SHA | cut -c1-8)" >> $GITHUB_ENV
+      run: echo "GIT_SHA=$(echo $GITHUB_SHA)" >> $GITHUB_ENV
 
     - name: Build and push registry Docker image
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0


### PR DESCRIPTION
This change updates the CI workflow so it provides the full Git commit SHA to docker image builds. The full SHA is needed to power DataDog's source code integration.