### PR TITLE
chore: deployments with multiple function assets

### DIFF
--- a/server/internal/deployments/queries.sql
+++ b/server/internal/deployments/queries.sql
@@ -579,8 +579,7 @@ FROM deployments_functions df
 INNER JOIN deployments d ON df.deployment_id = d.id
 WHERE 
   d.project_id = @project_id
-  AND df.deployment_id = @deployment_id
-LIMIT 1;
+  AND df.deployment_id = @deployment_id;
 
 -- name: GetFunctionCredentialsBatch :many
 SELECT DISTINCT ON (function_id)

--- a/server/internal/deployments/repo/queries.sql.go
+++ b/server/internal/deployments/repo/queries.sql.go
@@ -962,7 +962,6 @@ INNER JOIN deployments d ON df.deployment_id = d.id
 WHERE 
   d.project_id = $1
   AND df.deployment_id = $2
-LIMIT 1
 `
 
 type GetDeploymentFunctionsParams struct {


### PR DESCRIPTION
For deployments that had multiple function assets attached the actual functions are currently not working other than for the first asset. This is because we are only deploying a fly app for that first asset.