### PR TITLE
chore: loosen restrictions on class names

### DIFF
--- a/ts-framework/functions/src/build/mcp.ts
+++ b/ts-framework/functions/src/build/mcp.ts
@@ -82,8 +82,14 @@ async function buildFunctionsManifest(options: {
   const server = await import(entrypoint).then((mod) => {
     const exportsym = options.serverExport ?? "server";
     const serverExport = mod[exportsym];
+    if (typeof serverExport === "undefined") {
+      throw new Error(
+        `Export "${exportsym}" in entrypoint "${entrypoint}" is undefined`,
+      );
+    }
+
     const klass = serverExport?.constructor?.name;
-    if (klass !== "McpServer") {
+    if (klass !== "McpServer" && klass !== "Server") {
       throw new Error(
         `Export "${exportsym}" does not appear to be an instance of McpServer`,
       );


### PR DESCRIPTION
This change allows us to support MCP SDKs imports
that orginate from:

```
"@modelcontextprotocol/sdk/server/mcp.js"
```

where the export is called `Server`.

Previously, we only supported the export path

```
"@modelcontextprotocol/sdk/server/index.js"

```

where the export is called `McpServer`.

This new pattern has the unfortunate quality of
perhaps being overly permissive. We could imagine
exports called `Server` not matching our preferred types. We could consider different identity checks here if we are concerned about this loose typing.