### PR TITLE
chore: allow posthog to maintain a state of feature flags

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -252,6 +252,12 @@ func newStartCommand() *cli.Command {
 			Required: false,
 		},
 		&cli.StringFlag{
+			Name:     "posthog-personal-api-key",
+			Usage:    "The posthog personal API key for local feature flag evaluation",
+			EnvVars:  []string{"POSTHOG_PERSONAL_API_KEY"},
+			Required: false,
+		},
+		&cli.StringFlag{
 			Name:     "polar-api-key",
 			Usage:    "The polar API key",
 			EnvVars:  []string{"POLAR_API_KEY"},
@@ -387,7 +393,7 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to create pylon client: %w", err)
 			}
 
-			posthogClient := posthog.New(ctx, logger, c.String("posthog-api-key"), c.String("posthog-endpoint"))
+			posthogClient := posthog.New(ctx, logger, c.String("posthog-api-key"), c.String("posthog-endpoint"), c.String("posthog-personal-api-key"))
 			var features feature.Provider = posthogClient
 			if c.String("environment") == "local" {
 				features = newLocalFeatureFlags(ctx, logger, c.String("local-feature-flags-csv"))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -161,6 +161,12 @@ func newWorkerCommand() *cli.Command {
 			Required: false,
 		},
 		&cli.StringFlag{
+			Name:     "posthog-personal-api-key",
+			Usage:    "The posthog personal API key for local feature flag evaluation",
+			EnvVars:  []string{"POSTHOG_PERSONAL_API_KEY"},
+			Required: false,
+		},
+		&cli.StringFlag{
 			Name:     "local-feature-flags-csv",
 			Usage:    "Path to a CSV file containing local feature flags. Format: distinct_id,flag,enabled (with header row).",
 			EnvVars:  []string{"GRAM_LOCAL_FEATURE_FLAGS_CSV"},
@@ -300,7 +306,7 @@ func newWorkerCommand() *cli.Command {
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
-			posthogClient := posthog.New(ctx, logger, c.String("posthog-api-key"), c.String("posthog-endpoint"))
+			posthogClient := posthog.New(ctx, logger, c.String("posthog-api-key"), c.String("posthog-endpoint"), c.String("posthog-personal-api-key"))
 			var features feature.Provider = posthogClient
 			if c.String("environment") == "local" {
 				features = newLocalFeatureFlags(ctx, logger, c.String("local-feature-flags-csv"))

--- a/server/internal/auth/sessions/localdev.go
+++ b/server/internal/auth/sessions/localdev.go
@@ -78,7 +78,7 @@ func NewUnsafeManager(logger *slog.Logger, db *pgxpool.Pool, redisClient *redis.
 		return nil, fmt.Errorf("failed to create fake pylon: %w", err)
 	}
 
-	fakePosthog := posthog.New(context.Background(), logger, "test-posthog-key", "test-posthog-host")
+	fakePosthog := posthog.New(context.Background(), logger, "test-posthog-key", "test-posthog-host", "")
 
 	return &Manager{
 		logger:                 logger.With(attr.SlogComponent("sessions")),

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -287,7 +287,7 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 	pylon, err := pylon.NewPylon(logger, "")
 	require.NoError(t, err)
 
-	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host")
+	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -89,7 +89,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 
 	enc := testenv.NewEncryptionClient(t)
 	env := environments.NewEnvironmentEntries(logger, conn, enc)
-	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host")
+	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
 	guardianPolicy := guardian.NewDefaultPolicy()
 	oauthService := oauth.NewService(logger, tracerProvider, meterProvider, conn, serverURL, cacheAdapter, enc, env)


### PR DESCRIPTION
So one solution to the concern around feature flags making an API call everytime one is checked. If you add a posthog personal API key their SDK creates a poller to maintain the feature flag state. Not as nice as some other products with SSE, but it's what they've got. We already have a personal API key available in our GCP environment so it's just a matter of plumbing it through.

https://github.com/PostHog/posthog-go/blob/master/posthog.go#L157

The alternative to this I think is we don't do this and we just read through cache feature flags ourselves

