### PR TITLE
fix: update README to mention TypeScript MCP server Framework

### DIFF
--- a/ts-framework/functions/README.md
+++ b/ts-framework/functions/README.md
@@ -1,6 +1,6 @@
 # TypeScript MCP server Framework
 
-This library provides a lightweight framework for building MCP servers in
+This library provides a lightweight framework for building MCP compliant agentic tools in
 TypeScript using Gram Functions.
 
 Gram Functions are small pieces of code that represent LLM tools. They are


### PR DESCRIPTION
Updated README to reflect new framework name and description.