### PR TITLE
fix: nullable runner version

### DIFF
--- a/server/internal/background/activities/deploy_function_runners.go
+++ b/server/internal/background/activities/deploy_function_runners.go
@@ -251,9 +251,5 @@ func (d *DeployFunctionRunners) resolveRunnerVersion(
 		return d.defaultVersion
 	}
 
-	if !pinned.Valid {
-		return d.defaultVersion
-	}
-
-	return conv.Default(functions.RunnerVersion(pinned.String), d.defaultVersion)
+	return conv.Default(functions.RunnerVersion(pinned), d.defaultVersion)
 }

--- a/server/internal/functions/queries.sql
+++ b/server/internal/functions/queries.sql
@@ -40,7 +40,8 @@ function_preference AS (
 )
 SELECT COALESCE(
     (SELECT v FROM function_preference),
-    (SELECT v FROM project_preference)
+    (SELECT v FROM project_preference),
+    ''
 )::text as runner_version;
 
 -- name: InitFlyApp :one

--- a/server/internal/functions/repo/queries.sql.go
+++ b/server/internal/functions/repo/queries.sql.go
@@ -131,7 +131,8 @@ function_preference AS (
 )
 SELECT COALESCE(
     (SELECT v FROM function_preference),
-    (SELECT v FROM project_preference)
+    (SELECT v FROM project_preference),
+    ''
 )::text as runner_version
 `
 


### PR DESCRIPTION
Fixes `gram.component=deploy-function-runner error.message="can't scan into dest[0] (col: runner_version): cannot scan NULL into *string" `