### PR TITLE
fix: repair syntax error in json template

### DIFF
--- a/server/internal/mcpmetadata/cursor_snippet.json.tmpl
+++ b/server/internal/mcpmetadata/cursor_snippet.json.tmpl
@@ -2,6 +2,8 @@
   "url": "{{ .MCPURL }}"{{- if (gt (len .SecurityInputs) 0) }},
   "headers": {
     {{- range $i, $input := .SecurityInputs }}{{- if $i }},{{ end }}
-    "{{ $input.SystemName | asHTTPHeader }}": "${{ "{" }}{{ $input.DisplayName | asPosixName }}{{ "}" }}"{{- end }}
+    "{{ $input.SystemName | asHTTPHeader }}": "${{ "{" }}{{ $input.DisplayName | asPosixName }}{{ "}" }}"
+    {{- end }}
   }
+  {{- end }}
 }


### PR DESCRIPTION
Was testing against a stale server - accidentally missed some `end` markers