### PR TITLE
chore: fix clickhouse schema state

### DIFF
--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -24,7 +24,6 @@ create table if not exists http_requests_raw
     response_headers    Map(String, String) CODEC (ZSTD),
     response_body_bytes Int64
 ) engine = MergeTree
-      PARTITION BY toDate(ts)
       ORDER BY (toUInt128(project_id), ts)
       TTL ts + toIntervalDay(60)
       SETTINGS index_granularity = 8192


### PR DESCRIPTION
Right now our live tables do not reflect this partition. The initial base migration did not include it. Therefore, migrations are totally stuck.

You cannot add a partition after a clickhouse table exists so this completely blocks us from doing any forward migration. We could delete all the tables if we really wanted to add this migration. But either way would like to get the schema to a consistent state first.