### PR TITLE
chore: set default ttl to 30 days

### DIFF
--- a/server/clickhouse/migrations/20251106194508_set-default-ttl-30-days.sql
+++ b/server/clickhouse/migrations/20251106194508_set-default-ttl-30-days.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `http_requests_raw` MODIFY TTL ts + toIntervalDay(30);

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:kgWh7H/SDPaMTcv4dInHfy5/66Tum0gX+TroTAj2JpE=
+h1:R6RyZoTDStHr/yQjwRSr/HHyCZ8Q6x4yzrRee/INr3g=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
+20251106194508_set-default-ttl-30-days.sql h1:veC6yHSEfqhXJBVWCIXuOldWcQfd611qPW7ozjzg8Ww=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -25,7 +25,7 @@ create table if not exists http_requests_raw
     response_body_bytes Int64
 ) engine = MergeTree
       ORDER BY (toUInt128(project_id), ts)
-      TTL ts + toIntervalDay(60)
+      TTL ts + toIntervalDay(30)
       SETTINGS index_granularity = 8192
       COMMENT 'Stores raw HTTP tool call requests and responses';
 


### PR DESCRIPTION
This is the max we document right now. You can get into function based ttls, for example on account type. But we aren't going to do that right now