### PR TITLE
mig: add flyio reap tracking

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -430,6 +430,7 @@ CREATE TABLE IF NOT EXISTS fly_apps (
   status TEXT NOT NULL, -- pending, ready, failed
   
   reaped_at timestamptz, -- when we deleted an app and its resources on fly.io
+  reap_error TEXT, -- error message if reaping failed
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -441,7 +442,8 @@ CREATE TABLE IF NOT EXISTS fly_apps (
   CONSTRAINT fly_apps_access_id_fkey FOREIGN KEY (access_id) REFERENCES functions_access (id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS fly_apps_project_deployment_function_key ON fly_apps (project_id, deployment_id, function_id, status);
+CREATE UNIQUE INDEX IF NOT EXISTS fly_apps_project_deployment_function_active_key ON fly_apps (project_id, deployment_id, function_id) WHERE reaped_at IS NULL;
+CREATE INDEX IF NOT EXISTS fly_apps_reaper_idx ON fly_apps (project_id, created_at DESC) WHERE status = 'ready' AND reaped_at IS NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS fly_apps_seq_key ON fly_apps (seq DESC);
 CREATE INDEX IF NOT EXISTS fly_apps_access_id_idx ON fly_apps (access_id DESC);
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -198,6 +198,7 @@ type FlyApp struct {
 	PrimaryRegion string
 	Status        string
 	ReapedAt      pgtype.Timestamptz
+	ReapError     pgtype.Text
 	CreatedAt     pgtype.Timestamptz
 	UpdatedAt     pgtype.Timestamptz
 }

--- a/server/migrations/20251111180235_fly-apps-reap-state.sql
+++ b/server/migrations/20251111180235_fly-apps-reap-state.sql
@@ -1,0 +1,10 @@
+-- atlas:txmode none
+
+-- Drop index "fly_apps_project_deployment_function_key" from table: "fly_apps"
+DROP INDEX CONCURRENTLY "fly_apps_project_deployment_function_key";
+-- Modify "fly_apps" table
+ALTER TABLE "fly_apps" ADD COLUMN "reap_error" text NULL;
+-- Create index "fly_apps_project_deployment_function_active_key" to table: "fly_apps"
+CREATE UNIQUE INDEX CONCURRENTLY "fly_apps_project_deployment_function_active_key" ON "fly_apps" ("project_id", "deployment_id", "function_id") WHERE (reaped_at IS NULL);
+-- Create index "fly_apps_reaper_idx" to table: "fly_apps"
+CREATE INDEX CONCURRENTLY "fly_apps_reaper_idx" ON "fly_apps" ("project_id", "created_at" DESC) WHERE ((status = 'ready'::text) AND (reaped_at IS NULL));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:wogdDQltJwCokZjsdCSpOhzcsGWHVCLvKNJJNhRKxuE=
+h1:Qm7TluoIHDgRPjohVd9rnZiUJZci3BU+Kp9X/ZLqV1s=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -66,3 +66,4 @@ h1:wogdDQltJwCokZjsdCSpOhzcsGWHVCLvKNJJNhRKxuE=
 20251105184547_add-organization-features-table.sql h1:1OTlrIlL1jagd9BRvB1hO3B7c+1XRMvHhw1GSGKPPWA=
 20251110195659_add-pgvector-extension.sql h1:JWfchfuTbSewGzYrDlymV5RiwYvaFcC2tvKBjdulhNI=
 20251111165847_add-toolset-embedding-migration.sql h1:1cuNc8gF7U8EKK7agVmvP3FdS6+U36oSwVc8G6yyzHg=
+20251111180235_fly-apps-reap-state.sql h1:7ml5z97oDOZwEf26Lc57uA/SA7Q7dOktOmaxv1IZ9Ck=


### PR DESCRIPTION
This migrations updates the fly_apps table to help identify apps to reap and track an any errors encountered during the reaping process.