### PR TITLE
chore: remove org id restriction on reaper

### DIFF
--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -541,18 +541,6 @@ func (f *FlyRunner) reap(ctx context.Context, logger *slog.Logger, appsRepo *rep
 		return fmt.Errorf("get existing app name: %w", err)
 	}
 
-	enabled, err := appsRepo.IsReapingEnabledForProject(ctx, repo.IsReapingEnabledForProjectParams{
-		ProjectID:       req.ProjectID,
-		OrganizationIds: []string{"5ad61845-b72e-4f0d-9dde-e0bdcf98e374", "5a25158b-24dc-4d49-b03d-e85acfbea59c"},
-	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("check reaping enabled for project: %w", err)
-	}
-	if !enabled {
-		logger.InfoContext(ctx, "reaping is not enabled for project")
-		return nil
-	}
-
 	logger = logger.With(
 		attr.SlogFlyAppName(app.AppName),
 		attr.SlogFlyOrgSlug(app.FlyOrgSlug),

--- a/server/internal/functions/queries.sql
+++ b/server/internal/functions/queries.sql
@@ -145,10 +145,3 @@ WHERE
   AND reaped_at IS NULL
 ORDER BY created_at DESC
 LIMIT 1;
-
--- name: IsReapingEnabledForProject :one
-SELECT true AS enabled
-FROM projects
-WHERE
-  id = @project_id
-  AND organization_id = ANY(@organization_ids);

--- a/server/internal/functions/repo/queries.sql.go
+++ b/server/internal/functions/repo/queries.sql.go
@@ -329,26 +329,6 @@ func (q *Queries) InitFlyApp(ctx context.Context, arg InitFlyAppParams) (uuid.UU
 	return id, err
 }
 
-const isReapingEnabledForProject = `-- name: IsReapingEnabledForProject :one
-SELECT true AS enabled
-FROM projects
-WHERE
-  id = $1
-  AND organization_id = ANY($2)
-`
-
-type IsReapingEnabledForProjectParams struct {
-	ProjectID       uuid.UUID
-	OrganizationIds []string
-}
-
-func (q *Queries) IsReapingEnabledForProject(ctx context.Context, arg IsReapingEnabledForProjectParams) (bool, error) {
-	row := q.db.QueryRow(ctx, isReapingEnabledForProject, arg.ProjectID, arg.OrganizationIds)
-	var enabled bool
-	err := row.Scan(&enabled)
-	return enabled, err
-}
-
 const markFlyAppReaped = `-- name: MarkFlyAppReaped :exec
 UPDATE fly_apps SET
   reap_error = $1,


### PR DESCRIPTION
This change lifts the restriction that made the reaper only consider a couple of Gram organizations. It will now run for all orgs.