### PR TITLE
chore: remove caching directives from mise tasks

### DIFF
--- a/.mise-tasks/build/cli.sh
+++ b/.mise-tasks/build/cli.sh
@@ -2,8 +2,6 @@
 
 #MISE description="Build the gram cli"
 #MISE dir="{{ config_root }}/cli"
-#MISE sources=["go.mod", "go.sum", "**/*.go"]
-#MISE outputs={ auto = true }
 #MISE depends=["go:tidy"]
 
 #USAGE flag "--readonly" help="Build with -mod=readonly"

--- a/.mise-tasks/build/internal-sdk.sh
+++ b/.mise-tasks/build/internal-sdk.sh
@@ -2,8 +2,6 @@
 
 #MISE description="Build the internal SDK that powers the dashboard"
 #MISE dir="{{ config_root }}/client/sdk"
-#MISE sources=["package.json", "pnpm-lock.yaml", "client/sdk/package.json", "client/sdk/src/**/*.ts"]
-#MISE outputs=["client/sdk/esm/**/*"]
 #MISE depends=["install:pnpm"]
 
 #USAGE flag "--readonly" help="Build with --frozen-lockfile"

--- a/.mise-tasks/build/server.sh
+++ b/.mise-tasks/build/server.sh
@@ -2,8 +2,6 @@
 
 #MISE description="Build the gram server"
 #MISE dir="{{ config_root }}/server"
-#MISE sources=["go.mod", "go.sum", "**/*.go"]
-#MISE outputs={ auto = true }
 #MISE depends=["go:tidy"]
 
 #USAGE flag "--readonly" help="Build with -mod=readonly"

--- a/.mise-tasks/gen/goa-server.sh
+++ b/.mise-tasks/gen/goa-server.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 #MISE dir="{{ config_root }}/server"
 #MISE description="Generate from Goa design files"
-#MISE sources=["server/design/**/*.go"]
-#MISE outputs=["server/gen/**/*"]
 
 set -e
 exec goa gen github.com/speakeasy-api/gram/server/design

--- a/.mise-tasks/gen/sdk.sh
+++ b/.mise-tasks/gen/sdk.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 #MISE description="Generate SDK from OpenAPI spec"
-#MISE sources=["server/gen/http/openapi3.yaml", "overlays/goa.yaml"]
-#MISE outputs=["client/sdk/**/*"]
 
 set -e
 exec speakeasy run

--- a/.mise-tasks/gen/sqlc-server.sh
+++ b/.mise-tasks/gen/sqlc-server.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 #MISE dir="{{ config_root }}/server"
 #MISE description="Generate from SQLC files"
-#MISE sources=["**/*.sql","database/sqlc.yaml"]
-#MISE outputs=["internal/**/{db.go,models.go,queries.sql.go,query.sql.go}"]
 
 set -e
 exec sqlc generate -f ./database/sqlc.yaml

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #MISE description="Start up databases, caches and so on"
-#MISE sources=["/dev/null"]
 
 profile=()
 if [[ "$GRAM_ENABLE_OTEL_TRACES" == "1" || "$GRAM_ENABLE_OTEL_METRICS" == "1" ]]; then

--- a/.mise-tasks/infra/stop.sh
+++ b/.mise-tasks/infra/stop.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #MISE description="Stop all docker compose services"
-#MISE sources=["/dev/null"]
 
 set -e
 

--- a/.mise-tasks/lint/cli.sh
+++ b/.mise-tasks/lint/cli.sh
@@ -2,8 +2,6 @@
 
 #MISE description="Run golangci-lint on the CLI codebase"
 #MISE dir="{{ config_root }}/cli"
-#MISE sources=["server/**/*.go", ".golangci.yml"]
-#MISE outputs=["server/**/*.go"]
 
 #USAGE flag "--long" help="Enable more detailed reporting"
 

--- a/.mise-tasks/lint/client.sh
+++ b/.mise-tasks/lint/client.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 #MISE description="Run linting on all client projects using pnpm"
-#MISE sources=["client/**/*.ts", "client/**/*.tsx", "client/**/*.js", "client/**/*.jsx"]
-#MISE outputs=["client/**/*.ts", "client/**/*.tsx", "client/**/*.js", "client/**/*.jsx"]
 
 set -e
 

--- a/.mise-tasks/lint/functions.sh
+++ b/.mise-tasks/lint/functions.sh
@@ -2,8 +2,6 @@
 
 #MISE description="Run golangci-lint on the server codebase"
 #MISE dir="{{ config_root }}/functions"
-#MISE sources=["functions/**/*.go", ".golangci.yml"]
-#MISE outputs=["functions/**/*.go", ".golangci.yml"]
 
 #USAGE flag "--long" help="Enable more detailed reporting"
 

--- a/.mise-tasks/lint/server.sh
+++ b/.mise-tasks/lint/server.sh
@@ -2,8 +2,6 @@
 
 #MISE description="Run golangci-lint on the server codebase"
 #MISE dir="{{ config_root }}/server"
-#MISE sources=["server/**/*.go", ".golangci.yml"]
-#MISE outputs=["server/**/*.go", ".golangci.yml"]
 
 #USAGE flag "--long" help="Enable more detailed reporting"
 

--- a/.mise-tasks/start/worker.sh
+++ b/.mise-tasks/start/worker.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #MISE dir="{{ config_root }}/server"
 #MISE description="Start up the Temporal worker"
-#MISE sources=["server/**/*.go"]
 
 GIT_SHA=$(git rev-parse HEAD)
 go run -ldflags="-X github.com/speakeasy-api/gram/server/cmd/gram.GitSHA=${GIT_SHA} -X goa.design/clue/health.Version=${GIT_SHA}" main.go worker

--- a/.mise-tasks/test/cli.sh
+++ b/.mise-tasks/test/cli.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #MISE dir="{{ config_root }}/cli"
 #MISE description="Test the cli"
-#MISE sources=["cli/**/*.go"]
 
 if [ $# -eq 0 ]; then
   set -- "-tags=inv.debug" "./..."

--- a/.mise-tasks/test/server.sh
+++ b/.mise-tasks/test/server.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #MISE dir="{{ config_root }}/server"
 #MISE description="Test the server with optional coverage generation"
-#MISE sources=["server/**/*.go"]
 
 # Check if flags are provided
 cover=false


### PR DESCRIPTION
This change removes `#MISE sources` and `#MISE outputs` directives from all mise tasks as it's caching semantics often caused false positives and tasks, such `infra:start`, would be skipped when they shouldn't have.