### PR TITLE
feat: add Gram functions composition

### DIFF
--- a/.changeset/eleven-jars-teach.md
+++ b/.changeset/eleven-jars-teach.md
@@ -68,7 +68,7 @@ import { trainGram } from './train'
 import { flightGram } from './flight'
 
 const travelGram = new Gram()
-  .append(trainGram)
-  .append(flightGram);
+  .extend(trainGram)
+  .extend(flightGram);
 
 ```

--- a/ts-framework/functions/README.md
+++ b/ts-framework/functions/README.md
@@ -80,7 +80,7 @@ export default gram;
 
 ### Composing Gram Instances
 
-You can compose multiple Gram instances together using the `append()` method,
+You can compose multiple Gram instances together using the `extend()` method,
 similar to Hono's route groups pattern. This is useful for organizing tools by
 domain or functionality:
 
@@ -119,15 +119,15 @@ const stringTools = new Gram()
   });
 
 // Combine both
-const gram = mathTools.append(stringTools);
+const gram = mathTools.extend(stringTools);
 
 export default gram;
 ```
 
-The `append()` method:
+The `extend()` method:
 
 - **Merges tools**: All tools from both instances are combined
-- **Override behavior**: If tool names collide, the appended instance's tools
+- **Override behavior**: If tool names collide, the extended instance's tools
   override the original's
 - **Preserves context**: Each tool maintains its original Gram instance's
   execution context (environment variables and lax validation settings)

--- a/ts-framework/functions/src/framework.test.ts
+++ b/ts-framework/functions/src/framework.test.ts
@@ -337,7 +337,7 @@ test("appends one Gram to another", () => {
     },
   });
 
-  const merged = g1.append(g2);
+  const merged = g1.extend(g2);
 
   expect(merged.manifest()).toEqual({
     version: "0.0.0",
@@ -432,8 +432,8 @@ describe("with fake timers", () => {
   });
 });
 
-describe("append", () => {
-  test("appends tools from another Gram instance", async () => {
+describe("extend", () => {
+  test("extends tools from another Gram instance", async () => {
     const original = new Gram().tool({
       name: "echo",
       description: "Echoes the input",
@@ -452,13 +452,13 @@ describe("append", () => {
       },
     });
 
-    const appended = original.append(other);
+    const extended =original.extend(other);
 
     // Verify that g1 is mutated (not copied)
-    expect(appended).toBe(original);
+    expect(extended).toBe(original);
 
     // Should be able to call tools from both instances
-    const res1 = await appended.handleToolCall({
+    const res1 = await extended.handleToolCall({
       name: "echo",
       input: { message: "Hello!" },
     });
@@ -466,7 +466,7 @@ describe("append", () => {
     const data1 = await res1.json();
     expect(data1).toEqual({ echoed: "Hello!" });
 
-    const res2 = await appended.handleToolCall({
+    const res2 = await extended.handleToolCall({
       name: "add",
       input: { a: 1, b: 2 },
     });
@@ -494,9 +494,9 @@ describe("append", () => {
       },
     });
 
-    const appended = g1.append(g2);
+    const extended =g1.extend(g2);
 
-    const response = await appended.handleToolCall({
+    const response = await extended.handleToolCall({
       name: "greet",
       input: {},
     });
@@ -523,10 +523,10 @@ describe("append", () => {
       },
     });
 
-    const appended = original.append(other);
+    const extended =original.extend(other);
 
     // Should use g1's lax setting (true), so invalid input should pass
-    const response = await appended.handleToolCall({
+    const response = await extended.handleToolCall({
       name: "echo",
       input: { message: 123 } as any, // Invalid type but lax mode
     });
@@ -534,7 +534,7 @@ describe("append", () => {
 
     // Should use g2's lax setting (false), so invalid input should fail
     try {
-      await appended.handleToolCall({
+      await extended.handleToolCall({
         name: "add",
         input: { a: "not a number", b: 2 } as any, // Invalid type, strict mode
       });
@@ -572,16 +572,16 @@ describe("append", () => {
       },
     });
 
-    const appended = original.append(other);
+    const extended =original.extend(other);
 
     // g1's tool should still access G1_VAR
-    const res1 = await appended.handleToolCall({ name: "getG1Var", input: {} });
+    const res1 = await extended.handleToolCall({ name: "getG1Var", input: {} });
     expect(res1.status).toBe(200);
     const data1 = await res1.json();
     expect(data1).toEqual({ value: "value from g1" });
 
     // g2's tool should still access G2_VAR (not G1_VAR) even when called through merged
-    const res2 = await appended.handleToolCall({ name: "getG2Var", input: {} });
+    const res2 = await extended.handleToolCall({ name: "getG2Var", input: {} });
     expect(res2.status).toBe(200);
     const data2 = await res2.json();
     expect(data2).toEqual({ value: "value from g2" });
@@ -612,16 +612,16 @@ describe("append", () => {
       },
     });
 
-    const appended = original.append(firstOther).append(secondOther);
+    const extended =original.extend(firstOther).extend(secondOther);
 
     // Should have all three tools
-    const res1 = await appended.handleToolCall({ name: "tool1", input: {} });
+    const res1 = await extended.handleToolCall({ name: "tool1", input: {} });
     expect((await res1.json()).from).toBe("g1");
 
-    const res2 = await appended.handleToolCall({ name: "tool2", input: {} });
+    const res2 = await extended.handleToolCall({ name: "tool2", input: {} });
     expect((await res2.json()).from).toBe("g2");
 
-    const res3 = await appended.handleToolCall({ name: "tool3", input: {} });
+    const res3 = await extended.handleToolCall({ name: "tool3", input: {} });
     expect((await res3.json()).from).toBe("g3");
   });
 });

--- a/ts-framework/functions/src/framework.ts
+++ b/ts-framework/functions/src/framework.ts
@@ -284,11 +284,11 @@ export class Gram<
   }
 
   /**
-   * Appends another Gram instance's tools and environment schema to this one.
+   * Extends this Gram instance with another Gram instance's tools and environment schema.
    * Similar to Hono's route groups. Returns a new Gram instance with merged
    * tools and environment schemas.
    */
-  append<
+  extend<
     OtherTools extends {
       [k: string]: ToolDefinition<any, any, any, Response>;
     },


### PR DESCRIPTION
## Summary

Gram instances are now composable. This allows some similarity to Hono's grouping pattern, making it possible to split and organize Gram Functions code bases more than before. For example, before:

```typescript
const gram = new Gram({
  envSchema: {
    TRAIN_API_KEY: z.string().describe("API key for the train service"),
    FLIGHT_API_KEY: z.string().describe("API key for the flight service"),
  },
})
  .tool({
    name: "train_book",
    description: "Books a train ticket",
  })
  .tool({
    name: "train_status",
    description: "Gets the status of a train",
  })
  .tool({
    name: "flight_book",
    description: "Books a flight ticket",
  })
  .tool({
    name: "flight_status",
    description: "Gets the status of a flight",
  });
```

And now, with composibility:

```typescript
// train.ts
const trainGram = new Gram({
  envSchema: {
    TRAIN_API_KEY: z.string().describe("API key for the train service"),
  },
})
  .tool({
    name: "train_book",
    description: "Books a train ticket",
  })
  .tool({
    name: "train_status",
    description: "Gets the status of a train",
  });
})

// flight.ts
const flightGram = new Gram({
  envSchema: {
    FLIGHT_API_KEY: z.string().describe("API key for the flight service"),
  },
})
  .tool({
    name: "flight_book",
    description: "Books a flight ticket",
  })
  .tool({
    name: "flight_status",
    description: "Gets the status of a flight",
  });

// index.ts
import { trainGram } from './train'
import { flightGram } from './flight'

const travelGram = new Gram()
  .extend(trainGram)
  .extend(flightGram);

```