### PR TITLE
fix: improve functions `dev` script

### DIFF
--- a/ts-framework/create-function/gram-template-gram/package.json
+++ b/ts-framework/create-function/gram-template-gram/package.json
@@ -19,7 +19,7 @@
     "node": ">=22.18.0"
   },
   "scripts": {
-    "dev": "mcp-inspector nodemon -q --watch src --exec node ./src/server.ts",
+    "dev": "mcp-inspector --transport stdio nodemon -q --watch src --exec node --experimental-strip-types ./src/server.ts",
     "lint": "tsc --noEmit",
     "_:build": "gf build",
     "push": "gf push",

--- a/ts-framework/create-function/gram-template-mcp/package.json
+++ b/ts-framework/create-function/gram-template-mcp/package.json
@@ -19,7 +19,7 @@
     "node": ">=22.18.0"
   },
   "scripts": {
-    "dev": "mcp-inspector nodemon -q --watch src --exec node ./src/server.ts",
+    "dev": "mcp-inspector --transport stdio nodemon -q --watch src --exec node --experimental-strip-types ./src/server.ts",
     "_:build": "gf build",
     "push": "gf push",
     "prebuild": "tsc -p tsconfig.json",


### PR DESCRIPTION
Solves two issues with the `pnpm dev` command in functions:
- Now mcp-inspector is invoked with `--transport stdio`, resulting in the correct option being selected in the UI
- We add `--experimental-strip-types` for wider node version compatibility 