### PR TITLE
chore: fix CLA link

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,7 +26,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/speakeasyapi/gram/blob/main/CLA.md' # e.g. a CLA or a DCO document
+          path-to-document: 'https://github.com/speakeasy-api/gram/blob/main/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla-signatures'
           allowlist: speakeasy-api/*,dependabot[bot],renovate[bot]


### PR DESCRIPTION
This change fixes a typo in the CLA link that is posted on pull requests by new contributors.