### PR TITLE
Age 940 sqlc instructions

### DIFF
--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -319,6 +319,7 @@ type McpMetadatum struct {
 	ProjectID                uuid.UUID
 	ExternalDocumentationUrl pgtype.Text
 	LogoID                   uuid.NullUUID
+	Instructions             pgtype.Text
 	CreatedAt                pgtype.Timestamptz
 	UpdatedAt                pgtype.Timestamptz
 }

--- a/server/internal/mcpmetadata/queries.sql
+++ b/server/internal/mcpmetadata/queries.sql
@@ -4,6 +4,7 @@ SELECT id,
        project_id,
        external_documentation_url,
        logo_id,
+       instructions,
        created_at,
        updated_at
 FROM mcp_metadata
@@ -16,17 +17,20 @@ INSERT INTO mcp_metadata (
     toolset_id,
     project_id,
     external_documentation_url,
-    logo_id
-) VALUES (@toolset_id, @project_id, @external_documentation_url, @logo_id)
+    logo_id,
+    instructions
+) VALUES (@toolset_id, @project_id, @external_documentation_url, @logo_id, @instructions)
 ON CONFLICT (toolset_id)
 DO UPDATE SET project_id = EXCLUDED.project_id,
               external_documentation_url = EXCLUDED.external_documentation_url,
               logo_id = EXCLUDED.logo_id,
+              instructions = EXCLUDED.instructions,
               updated_at = clock_timestamp()
 RETURNING id,
           toolset_id,
           project_id,
           external_documentation_url,
           logo_id,
+          instructions,
           created_at,
           updated_at;

--- a/server/internal/mcpmetadata/repo/models.go
+++ b/server/internal/mcpmetadata/repo/models.go
@@ -15,6 +15,7 @@ type McpMetadatum struct {
 	ProjectID                uuid.UUID
 	ExternalDocumentationUrl pgtype.Text
 	LogoID                   uuid.NullUUID
+	Instructions             pgtype.Text
 	CreatedAt                pgtype.Timestamptz
 	UpdatedAt                pgtype.Timestamptz
 }

--- a/server/internal/mcpmetadata/repo/queries.sql.go
+++ b/server/internal/mcpmetadata/repo/queries.sql.go
@@ -18,6 +18,7 @@ SELECT id,
        project_id,
        external_documentation_url,
        logo_id,
+       instructions,
        created_at,
        updated_at
 FROM mcp_metadata
@@ -35,6 +36,7 @@ func (q *Queries) GetMetadataForToolset(ctx context.Context, toolsetID uuid.UUID
 		&i.ProjectID,
 		&i.ExternalDocumentationUrl,
 		&i.LogoID,
+		&i.Instructions,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -46,18 +48,21 @@ INSERT INTO mcp_metadata (
     toolset_id,
     project_id,
     external_documentation_url,
-    logo_id
-) VALUES ($1, $2, $3, $4)
+    logo_id,
+    instructions
+) VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (toolset_id)
 DO UPDATE SET project_id = EXCLUDED.project_id,
               external_documentation_url = EXCLUDED.external_documentation_url,
               logo_id = EXCLUDED.logo_id,
+              instructions = EXCLUDED.instructions,
               updated_at = clock_timestamp()
 RETURNING id,
           toolset_id,
           project_id,
           external_documentation_url,
           logo_id,
+          instructions,
           created_at,
           updated_at
 `
@@ -67,6 +72,7 @@ type UpsertMetadataParams struct {
 	ProjectID                uuid.UUID
 	ExternalDocumentationUrl pgtype.Text
 	LogoID                   uuid.NullUUID
+	Instructions             pgtype.Text
 }
 
 func (q *Queries) UpsertMetadata(ctx context.Context, arg UpsertMetadataParams) (McpMetadatum, error) {
@@ -75,6 +81,7 @@ func (q *Queries) UpsertMetadata(ctx context.Context, arg UpsertMetadataParams) 
 		arg.ProjectID,
 		arg.ExternalDocumentationUrl,
 		arg.LogoID,
+		arg.Instructions,
 	)
 	var i McpMetadatum
 	err := row.Scan(
@@ -83,6 +90,7 @@ func (q *Queries) UpsertMetadata(ctx context.Context, arg UpsertMetadataParams) 
 		&i.ProjectID,
 		&i.ExternalDocumentationUrl,
 		&i.LogoID,
+		&i.Instructions,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)


### PR DESCRIPTION

## What

Update SQL queries and regenerate SQLc code to handle the `instructions` field.

## Why

Builds on PR #940. Now that the `instructions` column exists in the schema, we need to update the SQL queries to read/write it and regenerate the Go types.

## Changes

- Updated `GetMetadataForToolset` query to SELECT `instructions`
- Updated `UpsertMetadata` query to INSERT/UPDATE `instructions`
- Regenerated SQLc code:
  - Added `Instructions pgtype.Text` to `McpMetadatum` struct
  - Updated query functions

## Dependencies

- Depends on PR #940 being merged first