### PR TITLE
feat: ts framework support for oauth inputs

### DIFF
--- a/ts-framework/functions/src/framework.ts
+++ b/ts-framework/functions/src/framework.ts
@@ -214,7 +214,10 @@ export class Gram<
   #lax: boolean;
   #inputEnv?: Record<string, string | undefined> | undefined;
   #envSchema?: EnvSchema;
-  #oauthVariable?: string;
+  #authInput?: {
+    type: "oauth2";
+    variable: string;
+  };
 
   constructor(opts?: {
     /**
@@ -248,7 +251,12 @@ export class Gram<
     this.#lax = Boolean(opts?.lax);
     this.#inputEnv = opts?.env;
     this.#envSchema = opts?.envSchema;
-    this.#oauthVariable = opts?.authInput?.oauthVariable;
+    this.#authInput = opts?.authInput
+      ? {
+          type: "oauth2",
+          variable: opts.authInput.oauthVariable,
+        }
+      : undefined;
   }
 
   protected get tools() {
@@ -408,11 +416,8 @@ export class Gram<
         );
       }
 
-      if (this.#oauthVariable != null) {
-        result.authInput = {
-          type: "oauth2",
-          variable: this.#oauthVariable,
-        };
+      if (this.#authInput != null) {
+        result.authInput = this.#authInput;
       }
 
       return result;


### PR DESCRIPTION
Adds support to the Functions TS framework for "oauth inputs"
Also fixes an issue where envSchema descriptions weren't being processed 

A user can now write:
```
envSchema: {
    GOOGLE_ACCESS_TOKEN: z.string().describe("Google OAuth2 access token"),
  },
  authInput: {
    oauthVariable: "GOOGLE_ACCESS_TOKEN",
  },
})
```
Which results in the oauth token being piped into that variable during function execution

It must be added to envSchema so that the types work for `ctx.env`