### PR TITLE
mig: add agent execution table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1042,6 +1042,7 @@ USING GIN (tags);
 CREATE TABLE IF NOT EXISTS agent_executions (
   id TEXT NOT NULL,
   project_id UUID NOT NULL,
+  deployment_id UUID,
   status TEXT NOT NULL,
   started_at TIMESTAMPTZ NOT NULL,
   completed_at TIMESTAMPTZ,
@@ -1049,7 +1050,8 @@ CREATE TABLE IF NOT EXISTS agent_executions (
   deleted BOOLEAN NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
 
   CONSTRAINT agent_executions_pkey PRIMARY KEY (id),
-  CONSTRAINT agent_executions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE SET NULL
+  CONSTRAINT agent_executions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE SET NULL,
+  CONSTRAINT agent_executions_deployment_id_fkey FOREIGN KEY (deployment_id) REFERENCES deployments (id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS agent_executions_project_id_started_at_idx

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -14,13 +14,14 @@ import (
 )
 
 type AgentExecution struct {
-	ID          string
-	ProjectID   uuid.UUID
-	Status      string
-	StartedAt   pgtype.Timestamptz
-	CompletedAt pgtype.Timestamptz
-	DeletedAt   pgtype.Timestamptz
-	Deleted     bool
+	ID           string
+	ProjectID    uuid.UUID
+	DeploymentID uuid.NullUUID
+	Status       string
+	StartedAt    pgtype.Timestamptz
+	CompletedAt  pgtype.Timestamptz
+	DeletedAt    pgtype.Timestamptz
+	Deleted      bool
 }
 
 type ApiKey struct {

--- a/server/migrations/20251202182959_agent-execution-table.sql
+++ b/server/migrations/20251202182959_agent-execution-table.sql
@@ -2,12 +2,14 @@
 CREATE TABLE "agent_executions" (
   "id" text NOT NULL,
   "project_id" uuid NOT NULL,
+  "deployment_id" uuid NULL,
   "status" text NOT NULL,
   "started_at" timestamptz NOT NULL,
   "completed_at" timestamptz NULL,
   "deleted_at" timestamptz NULL,
   "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
   PRIMARY KEY ("id"),
+  CONSTRAINT "agent_executions_deployment_id_fkey" FOREIGN KEY ("deployment_id") REFERENCES "deployments" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
   CONSTRAINT "agent_executions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE SET NULL
 );
 -- Create index "agent_executions_project_id_started_at_idx" to table: "agent_executions"

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:2jR2IAegdRQp5Uw6D/0Vz/VBB2l+tO2Ask4IbxatbJg=
+h1:AJ7aQqZIcGgewUmN5QncCJkrlkyWmDjEeD0h8+Wli+E=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -76,4 +76,4 @@ h1:2jR2IAegdRQp5Uw6D/0Vz/VBB2l+tO2Ask4IbxatbJg=
 20251120023036_toolset-environments-table.sql h1:8vdWnH+WhsSHhLG7LBfwSi/ACebjsKI6JpyYggOfQS8=
 20251126021621_add-auth-input-to-function-resource.sql h1:2vSYx5xIklau99YBK1h/Ipb0dAmR+KUqJlJlwEY5qRc=
 20251128143912_add-instructions-to-mcp-metadata.sql h1:WgeMPuB4wXz1c4mhf4+ZoTwtPfZ0NkTQBTXW3s4L8CE=
-20251202014303_basic-agent-execution-table.sql h1:G/58lqj5p/Jvy7dOBxGumAFgbYuEQqARFSOzJ2YrEIE=
+20251202182959_agent-execution-table.sql h1:q2PyP6iOoBAkQC0pgAFPre5+Amk3Kal7Mc2Twbni0gg=


### PR DESCRIPTION
A very basic table that allows to track agent execution for the purpose of visualization/pagination in a dashboard tab.

The goal is not to materialize a bunch of data about the specific execution. That is currently held in temporal and would be retrieved via API upon clicking into an agent run.

This will just efficiently power a very basic list view of agent runs by timestamp. More data could eventually be materialized onto this table, but for now it should stay very limited.