### PR TITLE
chore: update calendly link for support calls

### DIFF
--- a/client/dashboard/src/components/project-menu.tsx
+++ b/client/dashboard/src/components/project-menu.tsx
@@ -218,7 +218,7 @@ export function ProjectMenu() {
           </SimpleTooltip>
           <NavButton
             title="Contact us"
-            href="https://calendly.com/d/crtj-3tk-wpd/demo-with-speakeasy"
+            href="https://calendly.com/d/ctgg-5dv-3kw/intro-to-gram-call"
             Icon={(props) => (
               <Icon
                 name="message-circle"

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -891,7 +891,7 @@ function OAuthTabModal({
       toolset_slug: toolsetSlug,
     });
     window.open(
-      "https://calendly.com/d/crtj-3tk-wpd/demo-with-speakeasy",
+      "https://calendly.com/d/ctgg-5dv-3kw/intro-to-gram-call",
       "_blank",
     );
   };


### PR DESCRIPTION
## Summary
- Updated Calendly link from the old demo URL to the new "Intro to Gram" call URL
- Changed in 2 locations:
  - MCP OAuth integration request flow (MCPDetails.tsx)
  - Contact us navigation button (project-menu.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)