### PR TITLE
chore: add tigris onboarding to `zero:fly`

### DIFF
--- a/.mise-tasks/zero/fly.mts
+++ b/.mise-tasks/zero/fly.mts
@@ -49,7 +49,7 @@ async function run() {
     `
 👀 To deploy Gram Functions to Fly.io, you'll need:
     🎈 A Fly.io account (https://fly.io)
-    🎈 A Fly.io organization-scoped token (https://fly.io/tokens/create)
+    🎈 A Fly.io organization-scoped token (https://fly.io/tokens/create or \`fly tokens create org --name <name>\`)
     🎈 A Fly.io app hosting the the Gram Functions runner images
     🐅 A Tigris bucket associated with the Fly.io organization
     🐅 A Tigris access key and secret with permissions to access the bucket (https://console.tigris.dev)


### PR DESCRIPTION
This change updates the `zero:fly` mise task to include onboarding steps for Tigris. It also makes the script retain any existing config values so it can be run with `--restart` without losing prior setup.