### PR TITLE
feat: add provider_type column to oauth_proxy_providers table

### DIFF
--- a/server/migrations/20251205170534_static-oauth-proxy-providers.sql
+++ b/server/migrations/20251205170534_static-oauth-proxy-providers.sql
@@ -1,0 +1,2 @@
+-- Modify "oauth_proxy_providers" table
+ALTER TABLE "oauth_proxy_providers" ADD CONSTRAINT "custom_provider_endpoints" CHECK (((provider_type <> 'custom'::text) AND (authorization_endpoint IS NOT NULL) AND (token_endpoint IS NOT NULL)) OR (provider_type = 'gram'::text)), ADD CONSTRAINT "oauth_proxy_providers_provider_type_check" CHECK (provider_type = ANY (ARRAY['custom'::text, 'gram'::text])), ALTER COLUMN "authorization_endpoint" DROP NOT NULL, ALTER COLUMN "token_endpoint" DROP NOT NULL, ADD COLUMN "provider_type" text NOT NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:AJ7aQqZIcGgewUmN5QncCJkrlkyWmDjEeD0h8+Wli+E=
+h1:mcIUGbEOK92bN1f14QcNi9Yfx8Cc2A/kmvNK9WIdFB4=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -77,3 +77,4 @@ h1:AJ7aQqZIcGgewUmN5QncCJkrlkyWmDjEeD0h8+Wli+E=
 20251126021621_add-auth-input-to-function-resource.sql h1:2vSYx5xIklau99YBK1h/Ipb0dAmR+KUqJlJlwEY5qRc=
 20251128143912_add-instructions-to-mcp-metadata.sql h1:WgeMPuB4wXz1c4mhf4+ZoTwtPfZ0NkTQBTXW3s4L8CE=
 20251202182959_agent-execution-table.sql h1:q2PyP6iOoBAkQC0pgAFPre5+Amk3Kal7Mc2Twbni0gg=
+20251205170534_static-oauth-proxy-providers.sql h1:CWxTw34t4wgtBtq2JPqY9xwr76jwJlUkCJ0Lq/U5kgU=


### PR DESCRIPTION
Allows a "provider_type" to be supplied, which would allow a user to elect to use gram auth for their private MCP server.