### PR TITLE
chore: move location of tool metrics from thirdparty to telemetry folder

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -24,7 +24,7 @@ import (
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
 	"github.com/speakeasy-api/gram/server/internal/inv"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/superfly/fly-go/tokens"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"

--- a/server/internal/agents/agents.go
+++ b/server/internal/agents/agents.go
@@ -29,7 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )

--- a/server/internal/chat/client.go
+++ b/server/internal/chat/client.go
@@ -30,7 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
 )
 

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/templates"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"

--- a/server/internal/gateway/proxy_test.go
+++ b/server/internal/gateway/proxy_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 

--- a/server/internal/gateway/resources.go
+++ b/server/internal/gateway/resources.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/server/internal/gateway/security.go
+++ b/server/internal/gateway/security.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
 func processSecurity(

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"

--- a/server/internal/logs/impl.go
+++ b/server/internal/logs/impl.go
@@ -16,7 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"

--- a/server/internal/logs/listLogs_test.go
+++ b/server/internal/logs/listLogs_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/gen/logs"
-	"github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -193,7 +193,7 @@ func TestListLogs_TimeRangeFilter(t *testing.T) {
 		id, err := fromTimeV7(baseTime.Add(time.Duration(i) * time.Minute))
 		require.NoError(t, err)
 
-		err = ti.chClient.Log(ctx, toolmetrics.ToolHTTPRequest{
+		err = ti.chClient.Log(ctx, telemetry.ToolHTTPRequest{
 			ID:                id.String(),
 			Ts:                baseTime.Add(time.Duration(i) * time.Minute),
 			OrganizationID:    orgID,
@@ -201,7 +201,7 @@ func TestListLogs_TimeRangeFilter(t *testing.T) {
 			DeploymentID:      deploymentID,
 			ToolID:            toolID,
 			ToolURN:           "urn:tool:test",
-			ToolType:          toolmetrics.ToolTypeHTTP,
+			ToolType:          telemetry.ToolTypeHTTP,
 			TraceID:           id.String()[:32],
 			SpanID:            id.String()[:16],
 			HTTPMethod:        "GET",
@@ -324,7 +324,7 @@ func TestListLogs_VerifyLogFields(t *testing.T) {
 	baseTime := time.Unix(id.Time().UnixTime()).
 		UTC().Add(-10 * time.Minute)
 
-	err = ti.chClient.Log(ctx, toolmetrics.ToolHTTPRequest{
+	err = ti.chClient.Log(ctx, telemetry.ToolHTTPRequest{
 		ID:                id.String(),
 		Ts:                baseTime,
 		OrganizationID:    orgID,
@@ -332,7 +332,7 @@ func TestListLogs_VerifyLogFields(t *testing.T) {
 		DeploymentID:      deploymentID,
 		ToolID:            toolID,
 		ToolURN:           toolURN,
-		ToolType:          toolmetrics.ToolTypeHTTP,
+		ToolType:          telemetry.ToolTypeHTTP,
 		TraceID:           traceID,
 		SpanID:            spanID,
 		HTTPMethod:        "POST",
@@ -408,7 +408,7 @@ func insertTestLogs(t *testing.T, ctx context.Context, ti *testInstance, project
 		id, err := fromTimeV7(baseTime.Add(time.Duration(i) * time.Minute))
 		require.NoError(t, err)
 
-		err = ti.chClient.Log(ctx, toolmetrics.ToolHTTPRequest{
+		err = ti.chClient.Log(ctx, telemetry.ToolHTTPRequest{
 			ID:                id.String(),
 			Ts:                baseTime.Add(time.Duration(i) * time.Minute),
 			OrganizationID:    orgID,
@@ -416,7 +416,7 @@ func insertTestLogs(t *testing.T, ctx context.Context, ti *testInstance, project
 			DeploymentID:      deploymentID,
 			ToolID:            toolID,
 			ToolURN:           "urn:tool:test",
-			ToolType:          toolmetrics.ToolTypeHTTP,
+			ToolType:          telemetry.ToolTypeHTTP,
 			TraceID:           id.String()[:32],
 			SpanID:            id.String()[:16],
 			HTTPMethod:        "GET",

--- a/server/internal/logs/setup_test.go
+++ b/server/internal/logs/setup_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	logsvc "github.com/speakeasy-api/gram/server/internal/logs"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
-	"github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
 var (
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 type testInstance struct {
 	service        *logsvc.Service
 	conn           *pgxpool.Pool
-	chClient       *toolmetrics.Queries
+	chClient       *telemetry.Queries
 	sessionManager *sessions.Manager
 }
 
@@ -74,7 +74,7 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 
 	tracerProvider := testenv.NewTracerProvider(t)
 
-	chClient := toolmetrics.New(logger, tracerProvider, chConn, func(context.Context, string) (bool, error) {
+	chClient := telemetry.New(logger, tracerProvider, chConn, func(context.Context, string) (bool, error) {
 		return true, nil
 	})
 

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/rag"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -25,7 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -29,7 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/rag"
-	tm "github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
 	temporal_client "go.temporal.io/sdk/client"
 )

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
-	"github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
 
@@ -104,7 +104,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	toolMetrics := toolmetrics.New(logger, tracerProvider, chConn, func(context.Context, string) (bool, error) {
+	toolMetrics := telemetry.New(logger, tracerProvider, chConn, func(context.Context, string) (bool, error) {
 		return true, nil
 	})
 

--- a/server/internal/telemetry/db.go
+++ b/server/internal/telemetry/db.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 import (
 	"context"
@@ -41,7 +41,7 @@ func New(logger *slog.Logger, traceProvider trace.TracerProvider, conn CHTX, sho
 		}
 	}
 
-	tracer := traceProvider.Tracer("github.com/speakeasy-api/gram/server/internal/thirdparty/toolmetrics")
+	tracer := traceProvider.Tracer("github.com/speakeasy-api/gram/server/internal/telemetry")
 
 	return &Queries{
 		conn:       conn,

--- a/server/internal/telemetry/logging.go
+++ b/server/internal/telemetry/logging.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 import (
 	"context"

--- a/server/internal/telemetry/models.go
+++ b/server/internal/telemetry/models.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 import (
 	"context"

--- a/server/internal/telemetry/pageable.go
+++ b/server/internal/telemetry/pageable.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 type Pagination struct {
 	PerPage    int           `json:"per_page" validate:"required,gte=1,lte=100"`

--- a/server/internal/telemetry/queries.sql.go
+++ b/server/internal/telemetry/queries.sql.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 import (
 	"context"

--- a/server/internal/telemetry/queries_test.go
+++ b/server/internal/telemetry/queries_test.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 import (
 	"strings"

--- a/server/internal/telemetry/roundtripper.go
+++ b/server/internal/telemetry/roundtripper.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 import (
 	"fmt"

--- a/server/internal/telemetry/stub.go
+++ b/server/internal/telemetry/stub.go
@@ -1,4 +1,4 @@
-package toolmetrics
+package telemetry
 
 import (
 	"context"


### PR DESCRIPTION
it felt a bit odd to me that the tool metrics logic lived under the `thirdparty` folder. As a new-comer it wasn't obvious this lived here, and this folder does seem dedicated to third party tooling (polar, slack, etc).

This PR moves it to a dedicated `telemetry` folder. I considered having it in `o11y` but I felt that folder should be dedicated to the actual server logging tooling (slog, metrics, etc).

I'm doing this in preparation of work to start fetching function logs from clickhouse to our dashboard.