### PR TITLE
fix(dashboard): fix WebGL onboarding bugs

### DIFF
--- a/client/dashboard/src/components/webgl/ascii-video.tsx
+++ b/client/dashboard/src/components/webgl/ascii-video.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { WebGLVideo } from "./components/webgl-video";
+import { useWebGLStore } from "./store";
 
 export interface AsciiVideoProps {
   videoSrc: string;
@@ -22,6 +23,13 @@ export function AsciiVideo({
   flipX = false,
   flipY = false,
 }: AsciiVideoProps) {
+  const isWebGLAvailable = useWebGLStore((state) => state.isWebGLAvailable);
+
+  // Gracefully skip rendering if WebGL is not available
+  if (!isWebGLAvailable) {
+    return null;
+  }
+
   return (
     <WebGLVideo
       textureUrl={videoSrc}

--- a/client/dashboard/src/components/webgl/canvas.tsx
+++ b/client/dashboard/src/components/webgl/canvas.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { Canvas as R3FCanvas, useThree } from "@react-three/fiber";
 import { EffectComposer } from "@react-three/postprocessing";
 import * as THREE from "three";
-import { useTheme } from "next-themes";
+import { useMoonshineConfig } from "@speakeasy-api/moonshine";
 import { PerspectiveCamera } from "@react-three/drei";
 
 const CanvasManager = ({
@@ -20,7 +20,7 @@ const CanvasManager = ({
 }: {
   containerRef: RefObject<HTMLDivElement | null>;
 }) => {
-  const { resolvedTheme } = useTheme();
+  const { theme: resolvedTheme } = useMoonshineConfig();
   const canvasZIndex = useWebGLStore((state) => state.canvasZIndex);
   const canvasBlendMode = useWebGLStore((state) => state.canvasBlendMode);
   const gl = useThree((state) => state.gl);
@@ -139,11 +139,17 @@ InnerCanvas.displayName = "InnerCanvas";
 export const WebGLCanvas = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasZIndex = useWebGLStore((state) => state.canvasZIndex);
+  const isWebGLAvailable = useWebGLStore((state) => state.isWebGLAvailable);
 
   useScrollUpdate(containerRef);
 
   // Use full viewport height when visible (z-index >= 0), otherwise add padding for scroll
   const heightOffset = canvasZIndex >= 0 ? 1 : 1 + CANVAS_PADDING * 2;
+
+  // Gracefully skip rendering if WebGL is not available
+  if (!isWebGLAvailable) {
+    return null;
+  }
 
   return (
     <div

--- a/client/dashboard/src/components/webgl/components/ascii-effect/index.tsx
+++ b/client/dashboard/src/components/webgl/components/ascii-effect/index.tsx
@@ -273,7 +273,7 @@ class ASCIIEffectImpl extends Effect {
     scrollOffset,
   }: ASCIIEffectProps) {
     super("ASCIIEffect", fragmentShader, {
-      blendFunction: BlendFunction.NORMAL,
+      blendFunction: BlendFunction.SET,
       uniforms: new Map<string, THREE.Uniform<unknown>>([
         ["uFont", new THREE.Uniform(fontTexture)],
         ["uCharSize", new THREE.Uniform(charSize)],

--- a/client/dashboard/src/components/webgl/store.ts
+++ b/client/dashboard/src/components/webgl/store.ts
@@ -1,5 +1,6 @@
 import * as THREE from "three";
 import { create } from "zustand";
+import { getWebGLAvailability } from "./utils/detect-webgl";
 
 interface WebGLElement {
   element: HTMLDivElement;
@@ -15,6 +16,7 @@ interface DraggableWindow {
 }
 
 interface WebGLStore {
+  isWebGLAvailable: boolean;
   heroCanvasReady: boolean;
   elements: WebGLElement[];
   scrollOffset: THREE.Vector2;
@@ -48,6 +50,7 @@ interface WebGLStore {
 }
 
 export const useWebGLStore = create<WebGLStore>((set) => ({
+  isWebGLAvailable: getWebGLAvailability(),
   heroCanvasReady: false,
   elements: [],
   setElements: (elements) =>

--- a/client/dashboard/src/components/webgl/utils/detect-webgl.ts
+++ b/client/dashboard/src/components/webgl/utils/detect-webgl.ts
@@ -1,0 +1,29 @@
+/**
+ * Detects if WebGL is available in the current browser environment.
+ * Returns true if WebGL can be used, false otherwise.
+ */
+export function isWebGLAvailable(): boolean {
+  try {
+    const canvas = document.createElement("canvas");
+    const gl =
+      canvas.getContext("webgl2") ||
+      canvas.getContext("webgl") ||
+      canvas.getContext("experimental-webgl");
+    return gl !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Cached result of WebGL availability check.
+ * Computed once on first access.
+ */
+let cachedResult: boolean | null = null;
+
+export function getWebGLAvailability(): boolean {
+  if (cachedResult === null) {
+    cachedResult = isWebGLAvailable();
+  }
+  return cachedResult;
+}


### PR DESCRIPTION
<img width="1520" height="1642" alt="CleanShot 2025-12-09 at 16 31 52@2x" src="https://github.com/user-attachments/assets/1f4ee05e-0429-4ee7-a2be-41f97443d3a7" />

- Add graceful WebGL fallback for users without graphics acceleration
- Fix ASCII shader effect broken by postprocessing 6.38.0 blend mode changes (use BlendFunction.SET instead of NORMAL)