### PR TITLE
chore: capture runner identity

### DIFF
--- a/.mise-tasks/test/apko-functions.mts
+++ b/.mise-tasks/test/apko-functions.mts
@@ -129,6 +129,10 @@ function containerTester(opts: { image: string; codeBind: string }) {
     const { image, codeBind } = opts;
     const wrapped = String.raw`
 set -e
+export GRAM_FUNCTION_AUTH_SECRET="dGVzdC1rZXktMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM="
+export GRAM_PROJECT_ID="019b0849-297e-7d12-85d8-feceb2bee6ef"
+export GRAM_DEPLOYMENT_ID="019b0849-7c1f-7b5c-8326-da62cb20aabd"
+export GRAM_FUNCTION_ID="019b0849-a74f-7945-9ce1-1f0323b379da"
 gram-runner -init -language $RUNNER_LANGUAGE
 echo ==START==
 ${script}

--- a/functions/internal/attr/conventions.go
+++ b/functions/internal/attr/conventions.go
@@ -10,6 +10,9 @@ import (
 type Key = attribute.Key
 
 const (
+	ServiceNameKey    = semconv.ServiceNameKey
+	ServiceVersionKey = semconv.ServiceVersionKey
+
 	DeviceKey              = semconv.SystemDeviceKey
 	ExceptionStacktraceKey = semconv.ExceptionStacktraceKey
 	ErrorMessageKey        = semconv.ErrorMessageKey
@@ -32,6 +35,14 @@ const (
 	DataDogTraceIDKey = attribute.Key("dd.trace_id")
 	DataDogSpanIDKey  = attribute.Key("dd.span_id")
 )
+
+func ServiceName(v string) attribute.KeyValue { return ServiceNameKey.String(v) }
+func SlogServiceName(v string) slog.Attr      { return slog.String(string(ServiceNameKey), v) }
+
+func ServiceVersion(v string) attribute.KeyValue { return ServiceVersionKey.String(v) }
+func SlogServiceVersion(v string) slog.Attr {
+	return slog.String(string(ServiceVersionKey), v)
+}
 
 func Device(v string) attribute.KeyValue { return DeviceKey.String(v) }
 func SlogDevice(v string) slog.Attr      { return slog.String(string(DeviceKey), v) }

--- a/functions/internal/auth/id.go
+++ b/functions/internal/auth/id.go
@@ -1,0 +1,13 @@
+package auth
+
+import (
+	"github.com/speakeasy-api/gram/functions/internal/svc"
+)
+
+type RunnerIdentity struct {
+	AuthSecret   svc.Secret[[]byte] `json:"-"`
+	Version      string             `json:"version"`
+	ProjectID    string             `json:"project_id"`
+	DeploymentID string             `json:"deployment_id"`
+	FunctionID   string             `json:"function_id"`
+}

--- a/functions/internal/auth/middleware_test.go
+++ b/functions/internal/auth/middleware_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -11,15 +12,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/speakeasy-api/gram/functions/internal/auth"
 	"github.com/speakeasy-api/gram/functions/internal/encryption"
-	"github.com/stretchr/testify/require"
 )
 
 func newEncryptionClient(t *testing.T) *encryption.Client {
 	t.Helper()
 
-	enc, err := encryption.New("dGVzdC1rZXktMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM=")
+	key, err := base64.StdEncoding.DecodeString("dGVzdC1rZXktMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM=")
+	require.NoError(t, err)
+
+	enc, err := encryption.New(key)
 	require.NoError(t, err)
 	return enc
 }

--- a/functions/internal/encryption/encryption.go
+++ b/functions/internal/encryption/encryption.go
@@ -67,11 +67,7 @@ type Client struct {
 	key []byte
 }
 
-func New(base64Key string) (*Client, error) {
-	key, err := base64.StdEncoding.DecodeString(base64Key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode base64 key: %w", err)
-	}
+func New(key []byte) (*Client, error) {
 	if len(key) != 32 {
 		return nil, fmt.Errorf("invalid AES-256 key size: %d bytes", len(key))
 	}

--- a/functions/internal/svc/secret.go
+++ b/functions/internal/svc/secret.go
@@ -1,0 +1,42 @@
+package svc
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Secret[T any] struct {
+	value T
+}
+
+func NewSecret[T any](v T) Secret[T] {
+	return Secret[T]{value: v}
+}
+
+func (s Secret[T]) Reveal() T {
+	return s.value
+}
+
+// String implements fmt.Stringer to prevent secrets from leaking in logs
+func (s Secret[T]) String() string {
+	return "[REDACTED]"
+}
+
+// GoString implements fmt.GoStringer to prevent secrets from leaking in debug output
+func (s Secret[T]) GoString() string {
+	return "Secret{[REDACTED]}"
+}
+
+// MarshalJSON implements json.Marshaler to prevent secrets from leaking in JSON
+func (s Secret[T]) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal("[REDACTED]")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal secret: %w", err)
+	}
+	return data, nil
+}
+
+// MarshalText implements encoding.TextMarshaler to prevent secrets from leaking in text encoding
+func (s Secret[T]) MarshalText() ([]byte, error) {
+	return []byte("[REDACTED]"), nil
+}

--- a/functions/internal/svc/secret_test.go
+++ b/functions/internal/svc/secret_test.go
@@ -1,0 +1,210 @@
+package svc
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecret_String(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret("super-secret-password")
+		result := secret.String()
+		require.Equal(t, "[REDACTED]", result)
+		require.NotContains(t, result, "super-secret-password")
+	})
+
+	t.Run("empty string secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret("")
+		result := secret.String()
+		require.Equal(t, "[REDACTED]", result)
+	})
+}
+
+func TestSecret_GoString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret("super-secret-password")
+		result := secret.GoString()
+		require.Equal(t, "Secret{[REDACTED]}", result)
+		require.NotContains(t, result, "super-secret-password")
+	})
+
+	t.Run("empty string secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret("")
+		result := secret.GoString()
+		require.Equal(t, "Secret{[REDACTED]}", result)
+	})
+}
+
+func TestSecret_Printf(t *testing.T) {
+	t.Parallel()
+
+	secret := NewSecret("my-api-key-12345")
+
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{
+			name:   "percent v",
+			format: "%v",
+		},
+		{
+			name:   "percent s",
+			format: "%s",
+		},
+		{
+			name:   "percent plus v",
+			format: "%+v",
+		},
+		{
+			name:   "percent sharp v",
+			format: "%#v",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := fmt.Sprintf(tt.format, secret)
+			require.NotContains(t, result, "my-api-key-12345")
+			require.Contains(t, result, "[REDACTED]")
+		})
+	}
+}
+
+func TestSecret_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret("super-secret-api-key")
+		data, err := json.Marshal(secret)
+		require.NoError(t, err)
+
+		require.Equal(t, `"[REDACTED]"`, string(data))
+		require.NotContains(t, string(data), "super-secret-api-key")
+	})
+
+	t.Run("empty string secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret("")
+		data, err := json.Marshal(secret)
+		require.NoError(t, err)
+
+		require.Equal(t, `"[REDACTED]"`, string(data))
+	})
+}
+
+func TestSecret_MarshalJSON_InStruct(t *testing.T) {
+	t.Parallel()
+
+	type Config struct {
+		Username string        `json:"username"`
+		Password Secret[string] `json:"password"`
+		APIKey   Secret[string] `json:"api_key"`
+	}
+
+	config := Config{
+		Username: "admin",
+		Password: NewSecret("super-secret-password"),
+		APIKey:   NewSecret("sk-1234567890"),
+	}
+
+	data, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	jsonStr := string(data)
+	require.Contains(t, jsonStr, `"username":"admin"`)
+	require.Contains(t, jsonStr, `"password":"[REDACTED]"`)
+	require.Contains(t, jsonStr, `"api_key":"[REDACTED]"`)
+	require.NotContains(t, jsonStr, "super-secret-password")
+	require.NotContains(t, jsonStr, "sk-1234567890")
+}
+
+func TestSecret_MarshalText(t *testing.T) {
+	t.Parallel()
+
+	secret := NewSecret("text-secret-value")
+
+	data, err := secret.MarshalText()
+	require.NoError(t, err)
+
+	require.Equal(t, []byte("[REDACTED]"), data)
+	require.NotContains(t, string(data), "text-secret-value")
+}
+
+func TestSecret_Reveal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    any
+		expected any
+	}{
+		{
+			name:     "string secret",
+			value:    "my-secret-password",
+			expected: "my-secret-password",
+		},
+		{
+			name:     "int secret",
+			value:    42,
+			expected: 42,
+		},
+		{
+			name:     "struct secret",
+			value:    struct{ Key string }{Key: "value"},
+			expected: struct{ Key string }{Key: "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			secret := NewSecret(tt.value)
+			revealed := secret.Reveal()
+			require.Equal(t, tt.expected, revealed)
+		})
+	}
+}
+
+func TestSecret_DifferentTypes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("int secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret(12345)
+		require.Equal(t, "[REDACTED]", secret.String())
+		require.Equal(t, 12345, secret.Reveal())
+	})
+
+	t.Run("byte slice secret", func(t *testing.T) {
+		t.Parallel()
+		secret := NewSecret([]byte("secret-bytes"))
+		require.Equal(t, "[REDACTED]", secret.String())
+		require.Equal(t, []byte("secret-bytes"), secret.Reveal())
+	})
+
+	t.Run("struct secret", func(t *testing.T) {
+		t.Parallel()
+		type Credentials struct {
+			Username string
+			Password string
+		}
+		creds := Credentials{Username: "admin", Password: "pass123"}
+		secret := NewSecret(creds)
+		require.Equal(t, "[REDACTED]", secret.String())
+		require.Equal(t, creds, secret.Reveal())
+	})
+}


### PR DESCRIPTION
This change refactors the Gram Functions runner to capture relevant information about it into a RunnerIdentity struct that can be passed to various components. It includes the shared secret which can be used for authentication and signing as well as metadata like the project, deployment and function IDs.