### PR TITLE
chore: move vercel redirects to new folder

### DIFF
--- a/redirects/index.html
+++ b/redirects/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Gram docs</title>
+</head>
+
+<body>
+    <p>Redirecting...</p>
+</body>
+
+</html>

--- a/redirects/vercel.json
+++ b/redirects/vercel.json
@@ -1,0 +1,14 @@
+{
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "https://www.speakeasy.com/docs/gram/introduction",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "destination": "https://www.speakeasy.com/docs/gram/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
This change starts the migration of the vercel redirects configuration from docs/ to redirects/ so that we may use the docs/ folder for project documentation in the future.