### PR TITLE
chore: add mise tasks for working local runner

### DIFF
--- a/.mise-tasks/funcs/_access.mts
+++ b/.mise-tasks/funcs/_access.mts
@@ -1,0 +1,41 @@
+import crypto from "node:crypto";
+
+export async function mintV1Bearer(encryptionKey: string): Promise<string> {
+  const keyBytes = Buffer.from(encryptionKey, "base64");
+
+  const payload = JSON.stringify({
+    id: crypto.randomUUID(),
+    exp: Math.trunc((Date.now() + 2 * 60 * 60 * 1000) / 1000),
+  });
+
+  const encoder = new TextEncoder();
+  const plaintext = encoder.encode(payload);
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+
+  // Generate random nonce (12 bytes for GCM)
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+
+  // Encrypt the payload
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce },
+    key,
+    plaintext,
+  );
+
+  // Prepend nonce to ciphertext (matching Go's gcm.Seal behavior)
+  const combined = new Uint8Array(nonce.length + ciphertext.byteLength);
+  combined.set(nonce, 0);
+  combined.set(new Uint8Array(ciphertext), nonce.length);
+
+  // Base64 encode the result
+  const encrypted = Buffer.from(combined).toString("base64");
+
+  return `v01.${encrypted}`;
+}

--- a/.mise-tasks/funcs/mint-v1.mts
+++ b/.mise-tasks/funcs/mint-v1.mts
@@ -1,0 +1,19 @@
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning --experimental-strip-types
+
+//MISE description="Create a V1 Bearer token for calling a Gram Functions runner. Combines well with curl and other CLIs."
+//MISE quiet=true
+//MISE hide=true
+
+//USAGE flag "--key <key>" help="Base64-encoded encryption key."
+
+import { mintV1Bearer } from "./_access.mts";
+import assert from "node:assert";
+
+async function main() {
+  const key = process.env["usage_key"] || process.env["GRAM_ENCRYPTION_KEY"];
+  assert(key, "Usage parameter '--key' is required");
+
+  console.log(await mintV1Bearer(key));
+}
+
+main();

--- a/.mise-tasks/funcs/run.mts
+++ b/.mise-tasks/funcs/run.mts
@@ -1,0 +1,107 @@
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning --experimental-strip-types
+
+//MISE description="Start a local Gram Functions runner for development and testing."
+
+//USAGE flag "--code <file>" help="Path to file containing the function code to run."
+//USAGE flag "--name <name>" default="gf-runner" required=#true help="A name for the runner container instance."
+//USAGE flag "--image <image>" default="gram-runner-nodejs22:dev" required=#true help="The Docker image to use for the runner."
+
+import path from "node:path";
+import { $, chalk, fs } from "zx";
+import { isCancel, confirm } from "@clack/prompts";
+
+const SAMPLE_CODE = `
+export async function handleToolCall(call) {
+  const { name, input } = call;
+  console.log("AAAAH", name)
+
+  if (name !== "greet") {
+    throw new Error(\`Unknown tool: \${name}\`);
+  }
+  return new Response(JSON.stringify({ message: \`Hello, \${input.user}!\` }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+`;
+
+async function run() {
+  const name = process.env["usage_name"] || "gf-runner";
+  const image = process.env["usage_image"] || "gram-runner-nodejs22";
+
+  const imageExists = await $`docker images -q ${image}`.quiet();
+  if (!imageExists.stdout.trim()) {
+    const ans = await confirm({
+      message: `The image "${image}" does not exist. Build it now? (mise run build:functions-local)`,
+    });
+    if (isCancel(ans) || !ans) {
+      console.log(
+        "Aborted. You can build the image manually with: mise run build:functions-local.",
+      );
+      return;
+    }
+
+    console.log(chalk.bold(`Building image "${image}"...`));
+    await $({ stdio: "inherit" })`mise run build:functions-local`;
+  }
+
+  const nameFilter = `name=${name}`;
+  const ps = await $`docker ps -q --filter ${nameFilter}`;
+  if (ps.stdout.trim()) {
+    const ans = await confirm({
+      message: `A container with the name "${name}" is already running. Kill it?`,
+    });
+    if (isCancel(ans) || !ans) {
+      console.log("Aborted.");
+      return;
+    }
+
+    await $`docker rm -f ${name}`;
+  }
+
+  let code = process.env["usage_code"] || null;
+  const tmpDir = await fs.mkdtemp("/tmp/gram-runner-");
+  if (!code) {
+    const tmpFile = `${tmpDir}/functions.js`;
+    await fs.writeFile(tmpFile, SAMPLE_CODE.trim());
+    code = tmpFile;
+  }
+
+  // Zip the function code file
+  const zipPath = path.join(tmpDir, `code.zip`);
+  await $`zip -j ${zipPath} ${code}`;
+
+  console.log(
+    `Starting Gram Functions runner "${name}" using image "${image}"...`,
+  );
+
+  const env = [
+    "--env",
+    `GRAM_SERVER_URL=${process.env["GRAM_SERVER_URL"]}`,
+    "--env",
+    `GRAM_FUNCTION_AUTH_SECRET=${process.env["GRAM_ENCRYPTION_KEY"]}`,
+    "--env",
+    `GRAM_PROJECT_ID=${crypto.randomUUID()}`,
+    "--env",
+    `GRAM_DEPLOYMENT_ID=${crypto.randomUUID()}`,
+    "--env",
+    `GRAM_FUNCTION_ID=${crypto.randomUUID()}`,
+  ];
+
+  await $({
+    stdio: "inherit",
+  })`docker run -d --rm --name ${name} ${env} -p 8888:8888 -v ${zipPath}:/data/code.zip ${image}`;
+
+  console.log(
+    chalk.bold("Example tool call:\n\n") +
+      chalk.blueBright(
+        `
+mise run funcs:tool \\
+  --name greet \\
+  --input '{"user": "world"}'
+\n`.slice(1, -1),
+      ),
+  );
+}
+
+await run();

--- a/.mise-tasks/funcs/tool.mts
+++ b/.mise-tasks/funcs/tool.mts
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning --experimental-strip-types
+
+//MISE description="Call a tool on a local Gram Functions runner."
+//MISE quiet=true
+
+//USAGE flag "--url <url>" default="http://localhost:8888" help="The base URL of the local Gram Functions runner."
+//USAGE flag "--name <name>" required=#true help="The name of the tool to call."
+//USAGE flag "--input <json>" help="The JSON input to send to the tool."
+//USAGE flag "--env <json>" help="A JSON object of environment variables to use with the tool call."
+
+import assert from "node:assert";
+import { Writable } from "node:stream";
+import { $ } from "zx";
+
+async function run() {
+  const url = process.env["usage_url"];
+  const name = process.env["usage_name"];
+  const input = process.env["usage_input"]
+    ? JSON.parse(process.env["usage_input"])
+    : void 0;
+  const envVars = process.env["usage_env"]
+    ? JSON.parse(process.env["usage_env"])
+    : void 0;
+
+  assert(url, "--url argument is required.");
+  assert(name, "--name argument is required.");
+
+  const token = await $`mise funcs:mint-v1`.text();
+
+  const res = await fetch(`${url}/tool-call`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token.trim()}`,
+    },
+    body: JSON.stringify({ name, input, env: envVars }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`Status ${res.status}:\n${text}`);
+    process.exit(1);
+  }
+
+  if (!res.body) {
+    console.log("<No response body>");
+    return;
+  }
+
+  await res.body.pipeTo(Writable.toWeb(process.stdout));
+}
+
+run();


### PR DESCRIPTION
This change adds mise tasks for starting a Gram Functions runner locally and calling tools against it.

The two new tasks are:

- `mise run funcs:run` - starts a runner in the background
- `mise run funcs:tool` - calls a tool against the local runner

Example:

```
$ mise run funcs:run
$ mise run funcs:tool --name greet --input '{"user": "mate"}'
```

The `funcs:run` task can also be used to start a runner with an image pulled down from a remote registry:

```
docker pull registry.fly.io/example-1234:main-nodejs
mise run funcs:run --image registry.fly.io/example-1234:main-nodejs
mise run funcs:tool --name greet --input '{"user": "mate"}'
```