### PR TITLE
chore: ignore deprecations in staticcheck

### DIFF
--- a/functions/.golangci.yaml
+++ b/functions/.golangci.yaml
@@ -73,8 +73,15 @@ linters:
         - org
         - project
     staticcheck:
-      dot-import-whitelist:
-        - goa.design/goa/v3/dsl
+      checks:
+        - "all"
+        - "-ST1000"
+        - "-ST1003"
+        - "-ST1016"
+        - "-SA1019"
+        - "-ST1020"
+        - "-ST1021"
+        - "-ST1022"
     spancheck:
       checks:
         - end

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -74,6 +74,15 @@ linters:
     staticcheck:
       dot-import-whitelist:
         - goa.design/goa/v3/dsl
+      checks:
+        - "all"
+        - "-ST1000"
+        - "-ST1003"
+        - "-ST1016"
+        - "-SA1019"
+        - "-ST1020"
+        - "-ST1021"
+        - "-ST1022"
     spancheck:
       checks:
         - end


### PR DESCRIPTION
`otelhttp.WithRouteTag` was recently marked as deprecated but we need to keep it around since the `(net/http).Request.Pattern` which is what otelhttp middleware now defaults to looking at is not set at the right point in time when a request comes in. The order of middleware wrapping:

```
request
  -> otelhttp.NewHandler <-- request.Pattern is read here as ""
    -> ...
      -> chi.Mux <-- request.Pattern is set here
```