### PR TITLE
mig: add project_allowed_origins table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1078,3 +1078,19 @@ CREATE TABLE IF NOT EXISTS mcp_registries (
 CREATE UNIQUE INDEX IF NOT EXISTS mcp_registries_url_key
 ON mcp_registries (url)
 WHERE deleted IS FALSE;
+
+-- Allowed origins, primarily for for Elements
+CREATE TABLE IF NOT EXISTS project_allowed_origins (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  origin TEXT NOT NULL CHECK (origin <> '' AND CHAR_LENGTH(origin) <= 500),
+  status TEXT NOT NULL DEFAULT 'pending',
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT project_allowed_origins_pkey PRIMARY KEY (id),
+  CONSTRAINT project_allowed_origins_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -483,6 +483,17 @@ type Project struct {
 	Deleted                bool
 }
 
+type ProjectAllowedOrigin struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+	Origin    string
+	Status    string
+	CreatedAt pgtype.Timestamptz
+	UpdatedAt pgtype.Timestamptz
+	DeletedAt pgtype.Timestamptz
+	Deleted   bool
+}
+
 type ProjectToolVariation struct {
 	ID        uuid.UUID
 	ProjectID uuid.UUID

--- a/server/migrations/20251215191551_project_allowed_origins.sql
+++ b/server/migrations/20251215191551_project_allowed_origins.sql
@@ -1,0 +1,14 @@
+-- Create "project_allowed_origins" table
+CREATE TABLE "project_allowed_origins" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "origin" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'pending',
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "project_allowed_origins_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "project_allowed_origins_origin_check" CHECK ((origin <> ''::text) AND (char_length(origin) <= 500))
+);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0z8AEvcPKgU1mD6R4jNVsRHH01pAc6Dp4IZ2Ytf01/s=
+h1:O3460nLsiTfOpaukpviEyko5Yjb8aBmaYQAwNcEyIDU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -79,3 +79,4 @@ h1:0z8AEvcPKgU1mD6R4jNVsRHH01pAc6Dp4IZ2Ytf01/s=
 20251202182959_agent-execution-table.sql h1:q2PyP6iOoBAkQC0pgAFPre5+Amk3Kal7Mc2Twbni0gg=
 20251208165035_static-oauth-proxy-providers.sql h1:zujMl7j65KUuVit7bS6766+uKR83F76NK9eHW8zBT1U=
 20251211215818_add-mcp-registries-table.sql h1:kHtam7hD4LdWVu1bfV94RLc7YKux50obf2O4FNnetGs=
+20251215191551_project_allowed_origins.sql h1:yz7r3hzC4dmYqvBxMkt87IM6+eoZVgf3pHLz+oqPs8E=


### PR DESCRIPTION
Design decisions:
- This is scoped by project (and not something more granular like "elements instance") for ease of configuration. It's not clear why someone would want to allow one origin for one of their elements instances and not another
- The status column allows us to use this table to register URLs we've received requests from, allowing users to one-click-approve