### PR TITLE
fix: ensure all private servers show private server install instructions

### DIFF
--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -579,11 +579,11 @@ func (s *Service) loadToolsetFromContextAndSlug(ctx context.Context, mcpSlug str
 // resolveSecurityMode determines the security mode based on toolset configuration
 // Prefers oauth > gram > public
 func (s *Service) resolveSecurityMode(toolset *toolsets_repo.Toolset) securityMode {
-	if toolset.OauthProxyServerID.Valid || toolset.ExternalOauthServerID.Valid {
-		return securityModeOAuth
-	}
-
 	if toolset.McpIsPublic {
+		if toolset.OauthProxyServerID.Valid || toolset.ExternalOauthServerID.Valid {
+			return securityModeOAuth
+		}
+
 		return securityModePublic
 	}
 


### PR DESCRIPTION
Private servers, whether Gram OAuth or just API Key, should always show the private installation snippet.

## Before 🙅‍♂️

<img width="3302" height="2146" alt="CleanShot 2025-12-16 at 12 33 16@2x" src="https://github.com/user-attachments/assets/097f7c81-43bd-428a-92cf-15e3e7f76259" />

## After 👍

<img width="3302" height="2146" alt="CleanShot 2025-12-16 at 12 34 29@2x" src="https://github.com/user-attachments/assets/701566be-6d51-434b-b3d2-ee96f5a06390" />