### PR TITLE
mig(external_mcp): support source names and oauth metadata discovery

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1085,6 +1085,7 @@ CREATE TABLE IF NOT EXISTS external_mcp_attachments (
   registry_id uuid NOT NULL,
   name TEXT NOT NULL CHECK (name <> ''),
   slug TEXT NOT NULL CHECK (slug <> ''),
+  registry_server_specifier TEXT NOT NULL CHECK (registry_server_specifier <> ''),
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -1110,6 +1111,16 @@ CREATE TABLE IF NOT EXISTS external_mcp_tool_definitions (
   tool_urn TEXT NOT NULL CHECK (tool_urn <> ''),
   remote_url TEXT NOT NULL CHECK (remote_url <> ''),
   requires_oauth BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- OAuth metadata
+  -- '2.1' = MCP OAuth with RFC 8414 discovery + dynamic registration
+  -- '2.0' = legacy OAuth 2.0 (no AS discovery, requires static client config)
+  -- 'none' = no OAuth required
+  oauth_version TEXT NOT NULL DEFAULT 'none',
+  oauth_authorization_endpoint TEXT,
+  oauth_token_endpoint TEXT,
+  oauth_registration_endpoint TEXT,
+  oauth_scopes_supported TEXT[],
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -184,27 +184,33 @@ type EnvironmentEntry struct {
 }
 
 type ExternalMcpAttachment struct {
-	ID           uuid.UUID
-	DeploymentID uuid.UUID
-	RegistryID   uuid.UUID
-	Name         string
-	Slug         string
-	CreatedAt    pgtype.Timestamptz
-	UpdatedAt    pgtype.Timestamptz
-	DeletedAt    pgtype.Timestamptz
-	Deleted      bool
-}
-
-type ExternalMcpToolDefinition struct {
 	ID                      uuid.UUID
-	ExternalMcpAttachmentID uuid.UUID
-	ToolUrn                 string
-	RemoteUrl               string
-	RequiresOauth           bool
+	DeploymentID            uuid.UUID
+	RegistryID              uuid.UUID
+	Name                    string
+	Slug                    string
+	RegistryServerSpecifier string
 	CreatedAt               pgtype.Timestamptz
 	UpdatedAt               pgtype.Timestamptz
 	DeletedAt               pgtype.Timestamptz
 	Deleted                 bool
+}
+
+type ExternalMcpToolDefinition struct {
+	ID                         uuid.UUID
+	ExternalMcpAttachmentID    uuid.UUID
+	ToolUrn                    string
+	RemoteUrl                  string
+	RequiresOauth              bool
+	OauthVersion               string
+	OauthAuthorizationEndpoint pgtype.Text
+	OauthTokenEndpoint         pgtype.Text
+	OauthRegistrationEndpoint  pgtype.Text
+	OauthScopesSupported       []string
+	CreatedAt                  pgtype.Timestamptz
+	UpdatedAt                  pgtype.Timestamptz
+	DeletedAt                  pgtype.Timestamptz
+	Deleted                    bool
 }
 
 type ExternalOauthServerMetadatum struct {

--- a/server/migrations/20251219193631_add-registry-server-specifier-and-oauth-metadata.sql
+++ b/server/migrations/20251219193631_add-registry-server-specifier-and-oauth-metadata.sql
@@ -1,0 +1,4 @@
+-- Modify "external_mcp_attachments" table
+ALTER TABLE "external_mcp_attachments" ADD CONSTRAINT "external_mcp_attachments_registry_server_specifier_check" CHECK (registry_server_specifier <> ''::text), ADD COLUMN "registry_server_specifier" text NOT NULL;
+-- Modify "external_mcp_tool_definitions" table
+ALTER TABLE "external_mcp_tool_definitions" ADD COLUMN "oauth_version" text NOT NULL DEFAULT 'none', ADD COLUMN "oauth_authorization_endpoint" text NULL, ADD COLUMN "oauth_token_endpoint" text NULL, ADD COLUMN "oauth_registration_endpoint" text NULL, ADD COLUMN "oauth_scopes_supported" text[] NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:5OBPKwbPfbmTS4WJ5Czy6jDCz5QfQ5HoFE0S5HfRwrs=
+h1:7FbKGgb3xn3/gqQZmdvM93GQG8i3DBIyqCBvoczkO5g=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -81,3 +81,4 @@ h1:5OBPKwbPfbmTS4WJ5Czy6jDCz5QfQ5HoFE0S5HfRwrs=
 20251211215818_add-mcp-registries-table.sql h1:kHtam7hD4LdWVu1bfV94RLc7YKux50obf2O4FNnetGs=
 20251215201744_add-external-mcp-tables.sql h1:sAQggcVLuT+SJYL1doah5Ngc2dWDexn8uFLpIyfh6hA=
 20251215231431_project_allowed_origins.sql h1:UF+S/RzRrq+wZjtVbFmJzEWEdmr9o6ThVDRV8CUQuWs=
+20251219193631_add-registry-server-specifier-and-oauth-metadata.sql h1:4GBkF2ZPHrqtqagYCvMNU3XLTIqxJYhNvDT9wssdjm8=


### PR DESCRIPTION
This updates schema and models to support to new features to be released in subsequent PRs:

* decoupling source name from registry specifier
* discovering and persisting OAuth metadata from external MCP servers in order to support OAuth in external MCPs more seamlessly