### PR TITLE
fix: remove npm token env

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,6 @@ jobs:
           publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Prune PNPM store
         run: pnpm store prune


### PR DESCRIPTION
# What

We do not need to attach the NPM_TOKEN to the env for this step - i dont think it's harming anything as is, but it's superfluous given we rely on Trusted Publishing