### PR TITLE
fix: sources breadcrumbs expose unnecessary sources page

### DIFF
--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -78,14 +78,19 @@ function PageHeaderBreadcrumbs({
   };
 
   // Build breadcrumb elements from URL segments
-  const visibleElements = location.pathname
+  const allSegments = location.pathname
     .split("/")
-    .filter(Boolean) // Remove empty strings
-    .slice(2) // Remove the two leading elements (org slug and project slug)
-    .filter((segment) => !skipSegments.includes(segment)) // Skip specified segments
-    .map((segment, index, segments) => {
-      const url = "/" + segments.slice(0, index + 1).join("/");
-      const isCurrentPage = location.pathname.endsWith(url);
+    .filter(Boolean)
+    .slice(2);
+
+  const visibleElements = allSegments
+    .map((segment, index) => {
+      const url = "/" + allSegments.slice(0, index + 1).join("/");
+      const isCurrentPage = index === allSegments.length - 1;
+
+      if (skipSegments.includes(segment)) {
+        return null;
+      }
 
       let display = segment;
       if (allSubstitutions[segment]) {
@@ -99,7 +104,8 @@ function PageHeaderBreadcrumbs({
         display,
         isCurrentPage,
       };
-    });
+    })
+    .filter((elem): elem is NonNullable<typeof elem> => elem !== null);
 
   visibleElements.unshift({
     url: "/",


### PR DESCRIPTION
## Summary

Fixes the breadcrumb navigation bug on source detail pages where:
- Clicking "Sources" in the breadcrumbs linked to a broken route
- The source name breadcrumb was incorrectly marked as a link (not current page)

**Root cause:** The breadcrumb component was filtering out `skipSegments` before building URLs, causing incorrect paths like `/sources/my-api` instead of `/sources/http/my-api`.

**Fix:** Separate URL building from display filtering - URLs are now built from the full path segments, while only the display is affected by `skipSegments`.

Closes AGE-1048

## Test plan

- [x] Navigate to a source detail page (e.g., `/sources/http/my-api-slug`)
- [x] Verify "Sources" breadcrumb links to `/sources` (the index page)
- [x] Verify the source name is shown as current page (not a link)
- [ ] Test with external MCP sources (`/sources/externalmcp/...`)
- [x] Test with function sources (`/sources/function/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)