### PR TITLE
fix: sources breadcrumb dead link

### DIFF
--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -3,6 +3,8 @@ import React, { useMemo } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 import { useSlugs } from "./contexts/Sdk";
 import { cn } from "./lib/utils";
+import Billing from "./pages/billing/Billing";
+import Catalog, { CatalogRoot } from "./pages/catalog/Catalog";
 import Deployment from "./pages/deployments/deployment/Deployment";
 import Deployments, { DeploymentsRoot } from "./pages/deployments/Deployments";
 import EnvironmentPage from "./pages/environments/Environment";
@@ -13,6 +15,7 @@ import Home from "./pages/home/Home";
 import Integrations from "./pages/integrations/Integrations";
 import Login from "./pages/login/Login";
 import Register from "./pages/login/Register";
+import Logs from "./pages/logs/Logs";
 import { MCPDetailPage, MCPDetailsRoot } from "./pages/mcp/MCPDetails";
 import { MCPHostedPage } from "./pages/mcp/MCPHostedPage";
 import { MCPOverview, MCPRoot } from "./pages/mcp/MCPOverview";
@@ -24,6 +27,8 @@ import PromptPage from "./pages/prompts/Prompt";
 import Prompts, { PromptsRoot } from "./pages/prompts/Prompts";
 import SDK from "./pages/sdk/SDK";
 import Settings from "./pages/settings/Settings";
+import SourceDetails from "./pages/sources/SourceDetails";
+import { SourcesRoot } from "./pages/sources/Sources";
 import CustomTools, { CustomToolsRoot } from "./pages/toolBuilder/CustomTools";
 import {
   ToolBuilderNew,
@@ -31,11 +36,6 @@ import {
 } from "./pages/toolBuilder/ToolBuilder";
 import ToolsetPage, { ToolsetRoot } from "./pages/toolsets/Toolset";
 import Toolsets, { ToolsetsRoot } from "./pages/toolsets/Toolsets";
-import Billing from "./pages/billing/Billing";
-import Logs from "./pages/logs/Logs";
-import { SourcesRoot, SourcesPage } from "./pages/sources/Sources";
-import SourceDetails from "./pages/sources/SourceDetails";
-import Catalog, { CatalogRoot } from "./pages/catalog/Catalog";
 
 type AppRouteBasic = {
   title: string;
@@ -189,7 +189,7 @@ const ROUTE_STRUCTURE = {
     url: "sources",
     icon: "file-code",
     component: SourcesRoot,
-    indexComponent: SourcesPage,
+    indexComponent: Toolsets,
     subPages: {
       source: {
         title: "Source Details",


### PR DESCRIPTION
Rather than the sources page "index" being a nonexistent half-page, this makes it show the same thing as the toolsets page