### PR TITLE
chore: allow elements storybook to run with SSL

### DIFF
--- a/.mise-tasks/start/dashboard.sh
+++ b/.mise-tasks/start/dashboard.sh
@@ -3,4 +3,4 @@
 
 set -e
 
-exec pnpm dev
+exec pnpm --filter ./client/dashboard dev

--- a/.mise-tasks/start/elements.sh
+++ b/.mise-tasks/start/elements.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#MISE description="Start up the Gram Dashboard dev server"
+
+#USAGE flag "--ssl-key <file>" env="GRAM_SSL_KEY_FILE" help="Path to the SSL key file for HTTPS"
+#USAGE flag "--ssl-cert <file>" env="GRAM_SSL_CERT_FILE" help="Path to the SSL certificate file for HTTPS"
+
+set -e
+
+ssl_key=${usage_ssl_key:-}
+ssl_cert=${usage_ssl_cert:-}
+
+args=()
+if [ -n "$ssl_key" ] && [ -n "$ssl_cert" ]; then
+    args+=("--https")
+    args+=("--ssl-key" "$ssl_key")
+    args+=("--ssl-cert" "$ssl_cert")
+fi
+
+exec pnpm --filter ./elements storybook "${args[@]}"

--- a/elements/.storybook/main.ts
+++ b/elements/.storybook/main.ts
@@ -3,6 +3,14 @@ import type { StorybookConfig } from '@storybook/react-vite'
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['@storybook/addon-docs'],
+  viteFinal: (config) => {
+    config.server = {
+      ...config.server,
+      allowedHosts: ['localhost', '127.0.0.1', 'devbox'],
+    }
+
+    return config
+  },
   framework: {
     name: '@storybook/react-vite',
     options: {

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -9,3 +9,7 @@ procs:
     cmd: ["mise", "run", "start:dashboard"]
     stop:
       send-keys: ["<C-c>"]
+  elements:
+    cmd: ["mise", "run", "start:elements"]
+    stop:
+      send-keys: ["<C-c>"]


### PR DESCRIPTION
This change updates the storybook dev server for Elements to:

- Accept SSL key and certificate file paths via existing environment variables and enable HTTPS for the dev server.
- Allow hosts other than localhost including 'devbox' and 127.0.0.1 for better compatibility in various dev environments.
- Run as part of `./zero` (and `mise start` underneath)