### PR TITLE
chore: update onboarding to reflect new positioning

### DIFF
--- a/client/dashboard/src/pages/onboarding/Wizard.tsx
+++ b/client/dashboard/src/pages/onboarding/Wizard.tsx
@@ -448,7 +448,7 @@ const InitialChoiceStep = ({
             onDeployChatClick();
           }}
           icon={MessageSquare}
-          title="Deploy Data-Integrated Chat"
+          title="Deploy Chat Connected To Your Data"
           description="Build embeddable chat experiences powered by your data"
         />
       </div>


### PR DESCRIPTION
Adds a branching step at the beginning of onboarding with the following options:
1. Connect to popular MCPs -- Redirects straight to catalog
2. Connect to your data -- Continues to the current onboarding (select openapi or custom code)
3. Deploy Data-Integrated Chat -- Triggers a feature request modal for now. Soon to be replaced with Elements onboarding

<img width="4584" height="2814" alt="CleanShot 2026-01-07 at 11 03 04@2x" src="https://github.com/user-attachments/assets/2560653d-8b04-44c3-a896-b3ae025785bd" />
