### PR TITLE
fix(elements): change elements to eagerly load 

### DIFF
--- a/.changeset/quiet-hairs-occur.md
+++ b/.changeset/quiet-hairs-occur.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Change elements to eagerly load (do not wait for MCP tools discovery)

--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -177,7 +177,7 @@ const ThreadWelcome: FC = () => {
 }
 
 const ThreadSuggestions: FC = () => {
-  const { config, isLoadingMCPTools } = useElements()
+  const { config } = useElements()
   const r = useRadius()
   const d = useDensity()
   const suggestions = config.welcome?.suggestions ?? []
@@ -214,12 +214,7 @@ const ThreadSuggestions: FC = () => {
             !isStandalone && 'nth-[n+3]:hidden @md:nth-[n+3]:block'
           )}
         >
-          <ThreadPrimitive.Suggestion
-            disabled={isLoadingMCPTools}
-            prompt={suggestion.action}
-            send
-            asChild
-          >
+          <ThreadPrimitive.Suggestion prompt={suggestion.action} send asChild>
             <Button
               variant="ghost"
               className={cn(
@@ -254,7 +249,6 @@ const Composer: FC = () => {
     attachments: true,
   }
   const components = config.components ?? {}
-  const { isLoadingMCPTools } = useElements()
 
   if (components.Composer) {
     return <components.Composer />
@@ -287,7 +281,6 @@ const Composer: FC = () => {
           )}
           rows={1}
           autoFocus
-          disabled={isLoadingMCPTools}
           aria-label="Message input"
         />
         <ComposerAction />

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -96,9 +96,6 @@ const ElementsProviderWithApproval = ({
     environment: config.environment ?? {},
   })
 
-  // Show loading if we don't have tools yet or they're actively loading
-  const isLoadingMCPTools = !mcpTools || mcpToolsLoading
-
   // Store approval helpers in ref so they can be used in async contexts
   const approvalHelpersRef = useRef<ApprovalHelpers>({
     requestApproval: toolApproval.requestApproval,
@@ -242,7 +239,6 @@ const ElementsProviderWithApproval = ({
           isOpen: isOpen ?? false,
           setIsOpen,
           plugins,
-          isLoadingMCPTools,
         }}
       >
         {children}

--- a/elements/src/types/index.ts
+++ b/elements/src/types/index.ts
@@ -689,10 +689,4 @@ export type ElementsContextType = {
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
   plugins: Plugin[]
-
-  /**
-   * Indicates if the process of discovering MCP tools is still ongoing.
-   * TODO: failure state
-   */
-  isLoadingMCPTools: boolean
 }


### PR DESCRIPTION
# What

Currently the Elements chat will prevent the user sending a message if the MCP tools haven't been discovered yet - we can let this happen in the background instead.