### PR TITLE
chore: trust mkcert root CA as part of zero:tls

### DIFF
--- a/.mise-tasks/zero/tls.sh
+++ b/.mise-tasks/zero/tls.sh
@@ -116,6 +116,13 @@ gen_keypair() {
   mkcert \
     -cert-file "$CERT_PATH" -key-file "$KEY_PATH" "$hostname"
 
+  root_ca="$(mkcert -CAROOT)/rootCA.pem"
+  if [ ! -f "$root_ca" ]; then
+    echo "WARN: root CA not found at $root_ca" >&2
+  else
+    mise set --file mise.local.toml NODE_EXTRA_CA_CERTS="$root_ca"
+  fi
+
   echo "  cert => $CERT_PATH"
   echo "  key  => $KEY_PATH"
 }


### PR DESCRIPTION
This change updates the zero:tls task to ensure `NODE_EXTRA_CA_CERTS` is set to include the mkcert root CA certificate. This is because Node.js does not use the system root store.

https://github.com/FiloSottile/mkcert?tab=readme-ov-file#using-the-root-with-nodejs