### PR TITLE
fix: allow all headers for chat sessions routes

### DIFF
--- a/server/internal/middleware/chat_session_cors.go
+++ b/server/internal/middleware/chat_session_cors.go
@@ -28,7 +28,6 @@ func chatSessionsCORS(chatSessionsManager *chatsessions.Manager) func(next http.
 				if requestedHeaders := r.Header.Get("Access-Control-Request-Headers"); requestedHeaders != "" {
 					w.Header().Set("Access-Control-Allow-Headers", requestedHeaders)
 				}
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}


### PR DESCRIPTION
For chat sessions enabled routes, users need to be able to attach arbitrary headers, e.g. `MY_COMPANY_API_KEY` which will get forwarded to their tools. This issue just came up because previously the mcp requests for chat were coming from the customer's backend