### PR TITLE
fix: unset GRAM_API_URL in viteprod build env

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: "chore: version packages"
-          publish: pnpm changeset publish
+          publish: mise exec --env viteprod -- pnpm changeset publish
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/mise.viteprod.toml
+++ b/mise.viteprod.toml
@@ -2,8 +2,13 @@
 ## Gram dashboard with Vite for production.
 
 [env]
-## Both the Gram server and dashboard (client) are accesses on https://app.getgram.ai.
+## Both the Gram server and dashboard (client) are accessed on
+## https://app.getgram.ai.
 GRAM_SERVER_URL = false
+## GRAM_API_URL is used primarily during local development. That may change in
+## the future when we create separate builds per environment but until then we
+## should unset it so it is not baked into bundles built with vite.
+GRAM_API_URL = false
 ## Not needed for production builds, but can be useful for local development.
 GRAM_SSL_CERT_FILE = false
 GRAM_SSL_KEY_FILE = false


### PR DESCRIPTION
This change updates the mise.viteprod.toml configuration to unset the GRAM_API_URL environment variable during production builds. This ensures we do not bake in a bad value via Vite's define plugin, which could lead to incorrect API endpoint usage in publish packages like `@gram-ai/elements`.