### PR TITLE
chore: create a db replica user, make sure my image is tagged in a very specific way

### DIFF
--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -40,6 +40,19 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
+    - name: Generate preview tag
+      id: preview-tag
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          echo "tag=pr-${{ github.event.pull_request.number }}-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "enabled=true" >> $GITHUB_OUTPUT
+        else
+          echo "tag=" >> $GITHUB_OUTPUT
+          echo "enabled=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Extract Docker metadata
       id: meta
       uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -49,6 +62,7 @@ runs:
           type=ref,event=branch
           type=ref,event=tag
           type=ref,event=pr
+          type=raw,value=${{ steps.preview-tag.outputs.tag }},enable=${{ steps.preview-tag.outputs.enabled }}
           type=schedule,pattern=nightly
           type=sha
           type=sha,format=long


### PR DESCRIPTION
 * This change is done to make it easier to safely create preview environments for Gram.
  * The change ensures we create an explicit image tag that we can configure argocd to use for a `ApplicationSet` configuration -- whilst we've got one similar with the implicit `type=ref,event=pr` I find it easier to grok when we have an explicit one.