### PR TITLE
chore: add tracing around registry client HTTP calls

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -574,7 +574,7 @@ func newStartCommand() *cli.Command {
 			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, billingTracker, tcm, productFeatures, serverURL))
 			mcpMetadataService := mcpmetadata.NewService(logger, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient))
 			mcpmetadata.Attach(mux, mcpMetadataService)
-			externalmcp.Attach(mux, externalmcp.NewService(logger, db, sessionManager))
+			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager))
 			mcp.Attach(mux, mcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, posthogClient, serverURL, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, oauthService, billingTracker, billingRepo, tcm, productFeatures, ragService, temporalClient), mcpMetadataService)
 			chat.Attach(mux, chat.NewService(logger, db, sessionManager, chatSessionsManager, openRouter, &background.FallbackModelUsageTracker{Temporal: temporalClient}))
 			if slackClient.Enabled() {

--- a/server/internal/background/activities/process_deployment.go
+++ b/server/internal/background/activities/process_deployment.go
@@ -79,7 +79,7 @@ func NewProcessDeployment(
 		projects:       projectsRepo.New(db),
 		billingRepo:    billingRepo,
 		externalmcp:    externalmcpRepo.New(db),
-		registryClient: externalmcp.NewRegistryClient(logger),
+		registryClient: externalmcp.NewRegistryClient(logger, tracerProvider),
 	}
 }
 

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -76,7 +76,7 @@ func NewService(
 		db:             db,
 		repo:           repo.New(db),
 		externalmcp:    externalmcpRepo.New(db),
-		registryClient: externalmcp.NewRegistryClient(logger),
+		registryClient: externalmcp.NewRegistryClient(logger, tracerProvider),
 		auth:           auth.New(logger, db, sessions),
 		assets:         assetsRepo.New(db),
 		packages:       packagesRepo.New(db),

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
@@ -37,16 +36,16 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
 	logger = logger.With(attr.SlogComponent("externalmcp"))
 
 	return &Service{
-		tracer:         otel.Tracer("github.com/speakeasy-api/gram/server/internal/externalmcp"),
+		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/externalmcp"),
 		logger:         logger,
 		db:             db,
 		repo:           repo.New(db),
 		auth:           auth.New(logger, db, sessions),
-		registryClient: NewRegistryClient(logger),
+		registryClient: NewRegistryClient(logger, tracerProvider),
 	}
 }
 

--- a/server/internal/externalmcp/registryclient_test.go
+++ b/server/internal/externalmcp/registryclient_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger)
+	client := NewRegistryClient(logger, testenv.NewTracerProvider(t))
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
@@ -86,7 +87,7 @@ func TestGetServerDetails_OnlySSE(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger)
+	client := NewRegistryClient(logger, testenv.NewTracerProvider(t))
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
@@ -132,7 +133,7 @@ func TestGetServerDetails_PrefersStreamableHTTPOverSSE(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger)
+	client := NewRegistryClient(logger, testenv.NewTracerProvider(t))
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),


### PR DESCRIPTION
This change adds tracing spans to the external MCP registry client HTTP requests. This will allow us to better understand what aspects of adding an external MCP server in a deployment are taking the longest.