### PR TITLE
chore: remove os.Getenv from deployments service

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -563,7 +563,7 @@ func newStartCommand() *cli.Command {
 			integrations.Attach(mux, integrations.NewService(logger, db, sessionManager))
 			templates.Attach(mux, templates.NewService(logger, db, sessionManager, toolsetsSvc))
 			assets.Attach(mux, assets.NewService(logger, db, sessionManager, assetStorage))
-			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalClient, sessionManager, assetStorage, posthogClient))
+			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalClient, sessionManager, assetStorage, posthogClient, siteURL))
 			keys.Attach(mux, keys.NewService(logger, db, sessionManager, c.String("environment")))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, db, sessionManager, chatSessionsManager))
 			environments.Attach(mux, environments.NewService(logger, db, sessionManager, encryptionClient))

--- a/server/internal/agents/setup_test.go
+++ b/server/internal/agents/setup_test.go
@@ -129,7 +129,7 @@ func newTestAgentsService(t *testing.T) (context.Context, *testInstance) {
 
 	// Create supporting services
 	toolsetsSvc := toolsets.NewService(logger, conn, sessionManager, nil)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthogClient)
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthogClient, testenv.DefaultSiteURL(t))
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 
 	return ctx, &testInstance{

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log/slog"
-	"os"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -54,6 +53,7 @@ type Service struct {
 	assetStorage   assets.BlobStore
 	temporal       client.Client
 	posthog        *posthog.Posthog
+	siteURL        *url.URL
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -66,6 +66,7 @@ func NewService(
 	sessions *sessions.Manager,
 	assetStorage assets.BlobStore,
 	posthog *posthog.Posthog,
+	siteURL *url.URL,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("deployments"))
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/deployments")
@@ -83,6 +84,7 @@ func NewService(
 		assetStorage:   assetStorage,
 		temporal:       temporal,
 		posthog:        posthog,
+		siteURL:        siteURL,
 	}
 }
 
@@ -977,7 +979,7 @@ func (s *Service) captureDeploymentProcessedEvent(
 		"functions_asset_count":           len(dep.FunctionsAssets),
 		"openapiv3_asset_count":           len(dep.Openapiv3Assets),
 		"first_deployment_with_functions": firstDeploymentWithFunctions,
-		"logs_url":                        fmt.Sprintf("%s/%s/%s/deployments/%s", os.Getenv("GRAM_SITE_URL"), organizationSlug, projectSlug, dep.ID),
+		"logs_url":                        s.siteURL.JoinPath(organizationSlug, projectSlug, "deployments", dep.ID).String(),
 	}
 
 	if previousDeployment != nil {

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -93,7 +93,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
-	svc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog)
+	svc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t))
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 	packagesSvc := packages.NewService(logger, conn, sessionManager)
 

--- a/server/internal/functions/setup_test.go
+++ b/server/internal/functions/setup_test.go
@@ -103,7 +103,7 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 	ph := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
 	svc := functions.NewService(logger, tracerProvider, conn, enc, tigrisStore)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, ph)
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, ph, testenv.DefaultSiteURL(t))
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 
 	return ctx, &testInstance{

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -2,18 +2,30 @@ package testenv
 
 import (
 	"log/slog"
+	"net/url"
 	"os"
 	"testing"
 
-	"github.com/speakeasy-api/gram/server/internal/encryption"
-	"github.com/speakeasy-api/gram/server/internal/functions"
-	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 	tracernoop "go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
+
+func DefaultSiteURL(t *testing.T) *url.URL {
+	t.Helper()
+	val := conv.Default(os.Getenv("GRAM_SITE_URL"), "https://localhost:5173")
+	parsed, err := url.Parse(val)
+	require.NoError(t, err, "expected default site URL to parse")
+	return parsed
+
+}
 
 func NewFunctionsTestOrchestrator(t *testing.T) functions.Orchestrator {
 	t.Helper()

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -103,7 +103,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	require.NoError(t, worker.Start(), "start temporal worker")
 
 	toolsSvc := tools.NewService(logger, conn, sessionManager)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog)
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t))
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 	packagesSvc := packages.NewService(logger, conn, sessionManager)
 	toolsetsSvc := toolsets.NewService(logger, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient))

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -109,7 +109,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
 	svc := toolsets.NewService(logger, conn, sessionManager, nil)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog)
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t))
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 	packagesSvc := packages.NewService(logger, conn, sessionManager)
 


### PR DESCRIPTION
This change removes the os.Getenv call from the deployments service thereby removing the unwanted dependency on environment variables within the service.