### PR TITLE
chore: treat mcp registry client as a dependency

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - exhaustive
     - exhaustruct
     - exptostd
+    - forbidigo
     - forcetypeassert
     - gochecksumtype
     - gocritic
@@ -56,11 +57,20 @@ linters:
       - path: internal/billing/stub\.go
         linters:
           - musttag
+      - path: _test\.go|internal/testenv/|cmd/
+        linters:
+          - forbidigo
       - path: _test\.go
         linters:
           - exhaustruct
           - gosec
   settings:
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: ^os\.Getenv$
+          pkg: ^os$
+          msg: "Direct environment variable access is forbidden because it makes testing harder. Access to environment variables is only allowed in the cmd/."
     sloglint:
       no-mixed-args: true
       attr-only: true

--- a/server/cmd/gram/flags_pulsemcp.go
+++ b/server/cmd/gram/flags_pulsemcp.go
@@ -1,0 +1,18 @@
+package gram
+
+import "github.com/urfave/cli/v2"
+
+var pulseMCPFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:     "pulse-registry-tenant",
+		Usage:    "The tenant ID used to communicate with the Pulse MCP registry",
+		EnvVars:  []string{"PULSE_REGISTRY_TENANT"},
+		Required: true,
+	},
+	&cli.StringFlag{
+		Name:     "pulse-registry-api-key",
+		Usage:    "The API key used to communicate with the Pulse MCP registry",
+		EnvVars:  []string{"PULSE_REGISTRY_KEY"},
+		Required: true,
+	},
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -331,8 +331,8 @@ func newStartCommand() *cli.Command {
 	}
 
 	flags = append(flags, clickHouseFlags...)
-
 	flags = append(flags, functionsFlags...)
+	flags = append(flags, pulseMCPFlags...)
 
 	return &cli.Command{
 		Name:  "start",
@@ -537,6 +537,13 @@ func newStartCommand() *cli.Command {
 
 			chatClient := chat.NewChatClient(logger, tracerProvider, meterProvider, db, openRouter, baseChatClient, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator)
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, baseChatClient)
+			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, mcpRegistryClientOptions{
+				pulseTenantID: c.String("pulse-registry-tenant"),
+				pulseAPIKey:   conv.NewSecret([]byte(c.String("pulse-registry-api-key"))),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create mcp registry client: %w", err)
+			}
 
 			mux := goahttp.NewMuxer()
 			mux.Use(middleware.CORSMiddleware(c.String("environment"), c.String("server-url"), chatSessionsManager))
@@ -563,7 +570,7 @@ func newStartCommand() *cli.Command {
 			integrations.Attach(mux, integrations.NewService(logger, db, sessionManager))
 			templates.Attach(mux, templates.NewService(logger, db, sessionManager, toolsetsSvc))
 			assets.Attach(mux, assets.NewService(logger, db, sessionManager, assetStorage))
-			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalClient, sessionManager, assetStorage, posthogClient, siteURL))
+			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalClient, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient))
 			keys.Attach(mux, keys.NewService(logger, db, sessionManager, c.String("environment")))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, db, sessionManager, chatSessionsManager))
 			environments.Attach(mux, environments.NewService(logger, db, sessionManager, encryptionClient))
@@ -574,7 +581,7 @@ func newStartCommand() *cli.Command {
 			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, billingTracker, tcm, productFeatures, serverURL))
 			mcpMetadataService := mcpmetadata.NewService(logger, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient))
 			mcpmetadata.Attach(mux, mcpMetadataService)
-			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager))
+			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient))
 			mcp.Attach(mux, mcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, posthogClient, serverURL, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, oauthService, billingTracker, billingRepo, tcm, productFeatures, ragService, temporalClient), mcpMetadataService)
 			chat.Attach(mux, chat.NewService(logger, db, sessionManager, chatSessionsManager, openRouter, &background.FallbackModelUsageTracker{Temporal: temporalClient}))
 			if slackClient.Enabled() {
@@ -634,6 +641,7 @@ func newStartCommand() *cli.Command {
 						FunctionsVersion:     runnerVersion,
 						RagService:           ragService,
 						AgentsService:        agentsWorkerSvc,
+						MCPRegistryClient:    mcpRegistryClient,
 					})
 					if err := temporalWorker.Run(workerInterruptCh); err != nil {
 						logger.ErrorContext(ctx, "temporal worker failed", attr.SlogError(err))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -225,8 +225,8 @@ func newWorkerCommand() *cli.Command {
 	}
 
 	flags = append(flags, clickHouseFlags...)
-
 	flags = append(flags, functionsFlags...)
+	flags = append(flags, pulseMCPFlags...)
 
 	return &cli.Command{
 		Name:  "worker",
@@ -382,6 +382,13 @@ func newWorkerCommand() *cli.Command {
 			baseChatClient := openrouter.NewChatClient(logger, openRouter)
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, baseChatClient)
 			chatClient := chat.NewChatClient(logger, tracerProvider, meterProvider, db, openRouter, baseChatClient, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator)
+			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, mcpRegistryClientOptions{
+				pulseTenantID: c.String("pulse-registry-tenant"),
+				pulseAPIKey:   conv.NewSecret([]byte(c.String("pulse-registry-api-key"))),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create mcp registry client: %w", err)
+			}
 
 			// Create agents service for the worker
 			agentsService := agents.NewService(
@@ -417,6 +424,7 @@ func newWorkerCommand() *cli.Command {
 				FunctionsVersion:     runnerVersion,
 				RagService:           ragService,
 				AgentsService:        agentsService,
+				MCPRegistryClient:    mcpRegistryClient,
 			})
 
 			return temporalWorker.Run(worker.InterruptCh())

--- a/server/internal/agents/setup_test.go
+++ b/server/internal/agents/setup_test.go
@@ -82,11 +82,12 @@ func newTestAgentsService(t *testing.T) (context.Context, *testInstance) {
 
 	enc := testenv.NewEncryptionClient(t)
 	funcs := testenv.NewFunctionsTestOrchestrator(t)
+	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
 
 	f := &feature.InMemory{}
 
 	temporal, devserver := infra.NewTemporalClient(t)
-	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs))
+	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 		temporal.Close()
@@ -129,7 +130,7 @@ func newTestAgentsService(t *testing.T) (context.Context, *testInstance) {
 
 	// Create supporting services
 	toolsetsSvc := toolsets.NewService(logger, conn, sessionManager, nil)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthogClient, testenv.DefaultSiteURL(t))
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthogClient, testenv.DefaultSiteURL(t), mcpRegistryClient)
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 
 	return ctx, &testInstance{

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
@@ -73,6 +74,7 @@ func NewActivities(
 	functionsVersion functions.RunnerVersion,
 	ragService *rag.ToolsetVectorStore,
 	agentsService *agents.Service,
+	mcpRegistryClient *externalmcp.RegistryClient,
 	temporalClient client.Client,
 ) *Activities {
 	return &Activities{
@@ -84,7 +86,7 @@ func NewActivities(
 		getAllOrganizations:           activities.NewGetAllOrganizations(logger, db),
 		getSlackProjectContext:        activities.NewSlackProjectContextActivity(logger, db, slackClient),
 		postSlackMessage:              activities.NewPostSlackMessageActivity(logger, slackClient),
-		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, db, features, assetStorage, billingRepo),
+		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, db, features, assetStorage, billingRepo, mcpRegistryClient),
 		provisionFunctionsAccess:      activities.NewProvisionFunctionsAccess(logger, db, encryption),
 		deployFunctionRunners:         activities.NewDeployFunctionRunners(logger, db, functionsDeployer, functionsVersion, encryption),
 		reapFlyApps:                   activities.NewReapFlyApps(logger, meterProvider, db, functionsDeployer, 3),

--- a/server/internal/background/activities/process_deployment.go
+++ b/server/internal/background/activities/process_deployment.go
@@ -63,6 +63,7 @@ func NewProcessDeployment(
 	features feature.Provider,
 	assetStorage assets.BlobStore,
 	billingRepo billing.Repository,
+	registryClient *externalmcp.RegistryClient,
 ) *ProcessDeployment {
 	return &ProcessDeployment{
 		logger:         logger,
@@ -79,7 +80,7 @@ func NewProcessDeployment(
 		projects:       projectsRepo.New(db),
 		billingRepo:    billingRepo,
 		externalmcp:    externalmcpRepo.New(db),
-		registryClient: externalmcp.NewRegistryClient(logger, tracerProvider),
+		registryClient: registryClient,
 	}
 }
 

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
@@ -50,6 +51,7 @@ type WorkerOptions struct {
 	FunctionsVersion     functions.RunnerVersion
 	RagService           *rag.ToolsetVectorStore
 	AgentsService        *agents.Service
+	MCPRegistryClient    *externalmcp.RegistryClient
 }
 
 func ForDeploymentProcessing(
@@ -58,6 +60,7 @@ func ForDeploymentProcessing(
 	assetStorage assets.BlobStore,
 	enc *encryption.Client,
 	deployer functions.Deployer,
+	mcpRegistryClient *externalmcp.RegistryClient,
 ) *WorkerOptions {
 	return &WorkerOptions{
 		DB:                   db,
@@ -66,6 +69,7 @@ func ForDeploymentProcessing(
 		AssetStorage:         assetStorage,
 		FunctionsDeployer:    deployer,
 		FunctionsVersion:     "local", // Test deployers don't use baked versions
+		MCPRegistryClient:    mcpRegistryClient,
 		SlackClient:          nil,
 		ChatClient:           nil,
 		OpenRouterChatClient: nil,
@@ -107,6 +111,7 @@ func NewTemporalWorker(
 		FunctionsVersion:     "",
 		RagService:           nil,
 		AgentsService:        nil,
+		MCPRegistryClient:    nil,
 	}
 
 	for _, o := range options {
@@ -129,6 +134,7 @@ func NewTemporalWorker(
 			FunctionsVersion:     conv.Default(o.FunctionsVersion, opts.FunctionsVersion),
 			RagService:           conv.Default(o.RagService, opts.RagService),
 			AgentsService:        conv.Default(o.AgentsService, opts.AgentsService),
+			MCPRegistryClient:    conv.Default(o.MCPRegistryClient, opts.MCPRegistryClient),
 		}
 	}
 
@@ -160,6 +166,7 @@ func NewTemporalWorker(
 		opts.FunctionsVersion,
 		opts.RagService,
 		opts.AgentsService,
+		opts.MCPRegistryClient,
 		client,
 	)
 

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -67,6 +67,7 @@ func NewService(
 	assetStorage assets.BlobStore,
 	posthog *posthog.Posthog,
 	siteURL *url.URL,
+	mcpRegistryClient *externalmcp.RegistryClient,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("deployments"))
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/deployments")
@@ -77,7 +78,6 @@ func NewService(
 		db:             db,
 		repo:           repo.New(db),
 		externalmcp:    externalmcpRepo.New(db),
-		registryClient: externalmcp.NewRegistryClient(logger, tracerProvider),
 		auth:           auth.New(logger, db, sessions),
 		assets:         assetsRepo.New(db),
 		packages:       packagesRepo.New(db),
@@ -85,6 +85,7 @@ func NewService(
 		temporal:       temporal,
 		posthog:        posthog,
 		siteURL:        siteURL,
+		registryClient: mcpRegistryClient,
 	}
 }
 

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -69,11 +69,12 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 
 	enc := testenv.NewEncryptionClient(t)
 	funcs := testenv.NewFunctionsTestOrchestrator(t)
+	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
 
 	f := &feature.InMemory{}
 
 	temporal, devserver := infra.NewTemporalClient(t)
-	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs))
+	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 		temporal.Close()
@@ -93,7 +94,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
-	svc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t))
+	svc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient)
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 	packagesSvc := packages.NewService(logger, conn, sessionManager)
 

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -36,7 +36,7 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, registryClient *RegistryClient) *Service {
 	logger = logger.With(attr.SlogComponent("externalmcp"))
 
 	return &Service{
@@ -45,7 +45,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		db:             db,
 		repo:           repo.New(db),
 		auth:           auth.New(logger, db, sessions),
-		registryClient: NewRegistryClient(logger, tracerProvider),
+		registryClient: registryClient,
 	}
 }
 

--- a/server/internal/externalmcp/pulse.go
+++ b/server/internal/externalmcp/pulse.go
@@ -1,0 +1,33 @@
+package externalmcp
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+type PulseBackend struct {
+	registryURL *url.URL
+	tenantID    string
+	apiKey      conv.Secret
+}
+
+func NewPulseBackend(registryURL *url.URL, tenantID string, api conv.Secret) *PulseBackend {
+	return &PulseBackend{
+		registryURL: registryURL,
+		tenantID:    tenantID,
+		apiKey:      api,
+	}
+}
+
+func (p *PulseBackend) Match(req *http.Request) bool {
+	return req.URL.Scheme == p.registryURL.Scheme && req.URL.Host == p.registryURL.Host
+}
+
+func (p *PulseBackend) Authorize(req *http.Request) error {
+	req.Header.Set("X-Tenant-ID", p.tenantID)
+	req.Header.Set("X-API-Key", string(p.apiKey.Reveal()))
+
+	return nil
+}

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
@@ -69,4 +70,20 @@ func NewMeterProvider(t *testing.T) metric.MeterProvider {
 	t.Helper()
 
 	return metricnoop.NewMeterProvider()
+}
+
+func NewMCPRegistryClient(t *testing.T, logger *slog.Logger, tracerProvider trace.TracerProvider) *externalmcp.RegistryClient {
+	t.Helper()
+
+	pulseURL, err := url.Parse("https://api.pulsemcp.com")
+	require.NoError(t, err, "expected pulse URL to parse")
+
+	client := externalmcp.NewRegistryClient(
+		NewLogger(t),
+		tracerProvider,
+		externalmcp.NewPulseBackend(pulseURL, "test-tenant-id", conv.NewSecret([]byte("test-api-key"))),
+	)
+	require.NoError(t, err, "expected mcp registry client to initialize without error")
+
+	return client
 }

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -90,11 +90,12 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 
 	enc := testenv.NewEncryptionClient(t)
 	funcs := testenv.NewFunctionsTestOrchestrator(t)
+	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
 
 	f := &feature.InMemory{}
 
 	temporal, devserver := infra.NewTemporalClient(t)
-	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs))
+	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 		temporal.Close()
@@ -103,7 +104,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	require.NoError(t, worker.Start(), "start temporal worker")
 
 	toolsSvc := tools.NewService(logger, conn, sessionManager)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t))
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient)
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 	packagesSvc := packages.NewService(logger, conn, sessionManager)
 	toolsetsSvc := toolsets.NewService(logger, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient))

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -84,11 +84,12 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 
 	enc := testenv.NewEncryptionClient(t)
 	funcs := testenv.NewFunctionsTestOrchestrator(t)
+	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
 
 	f := &feature.InMemory{}
 
 	temporal, devserver := infra.NewTemporalClient(t)
-	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs))
+	worker := background.NewTemporalWorker(temporal, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 		temporal.Close()
@@ -109,7 +110,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
 	svc := toolsets.NewService(logger, conn, sessionManager, nil)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t))
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporal, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient)
 	assetsSvc := assets.NewService(logger, conn, sessionManager, assetStorage)
 	packagesSvc := packages.NewService(logger, conn, sessionManager)
 


### PR DESCRIPTION
This change refactors various services in the server to take MCP registry client as a dependency. Crucially, the construction of the registry client is moved to the command line initialization code. This includes accessing environment variables relating to PulseMCP - the original motivation for this change.