### PR TITLE
chore: add gram-bot to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: 'https://github.com/speakeasy-api/gram/blob/main/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla-signatures'
-          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot]
+          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot]
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Summary
- Adds `gram-bot[bot]` to the CLA Assistant allowlist
- Prevents automated PRs from gram-bot from being blocked by CLA signature requirements

## Test plan
- [x] Verify the allowlist syntax matches existing bot entries (`dependabot[bot]`, `renovate[bot]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)