### PR TITLE
chore: log warning instead of error on skipped operations

### DIFF
--- a/server/internal/openapi/extract_speakeasy.go
+++ b/server/internal/openapi/extract_speakeasy.go
@@ -263,14 +263,14 @@ func (p *ToolExtractor) doSpeakeasy(
 					if task.OnOperationSkipped != nil {
 						task.OnOperationSkipped(err)
 					}
-					_ = oops.E(
-						oops.CodeUnexpected,
-						err,
-						"%s: %s: skipped operation due to error: %s",
-						docInfo.Name,
-						item.opID,
-						err.Error(),
-					).Log(ctx, logger)
+					logger.WarnContext(ctx,
+						fmt.Sprintf(
+							"%s: %s: skipped operation due to error: %s",
+							docInfo.Name,
+							item.opID,
+							err.Error(),
+						),
+					)
 
 					resultChan <- operationResult{
 						def:              nil,


### PR DESCRIPTION
This change updates the OpenAPI processor to log at warning level when skipping operations instead of at error level. This adjustment reflects the non-critical nature of skipped operations and reduces the alert noise we were encountering.