### PR TITLE
fix: add pulse values to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -155,7 +155,8 @@ GRAM_FUNCTIONS_LOCAL_RUNNER_ROOT = "{{config_root}}/local/functions"
 ## discoverable by the Gram application.
 LOCAL_MCP_REGISTRY_PORT = "9847"
 LOCAL_MCP_REGISTRY_URL = "http://localhost:{{env.LOCAL_MCP_REGISTRY_PORT}}"
-
+PULSE_REGISTRY_TENANT = "unset"
+PULSE_REGISTRY_KEY = "unset"
 
 ##############
 ## Elements ##


### PR DESCRIPTION
These were missing but they are required for running the application