### PR TITLE
chore: ensure elements docs sync workflow runs

### DIFF
--- a/.github/workflows/sync-elements-docs-to-marketing.yaml
+++ b/.github/workflows/sync-elements-docs-to-marketing.yaml
@@ -5,6 +5,10 @@ on:
       - main
     paths:
      - "elements/docs/**"
+  workflow_run:
+    workflows: ["Generate Elements TypeDoc Documentation"]
+    types:
+      - completed
   workflow_dispatch: # Manual trigger for testing
 permissions:
   contents: read
@@ -18,6 +22,8 @@ env:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Run on push/dispatch, or when workflow_run succeeds
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout Gram repo (source)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This will manually trigger the elements doc sync to the gram marketing site anytime the TypeDoc workflow is run. Right now its skipping CI so its not working.