### PR TITLE
chore: mark code as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Generated files - exclude from language stats and diffs
+client/sdk/** linguist-generated
+server/gen/** linguist-generated
+server/internal/**/*.sql.go linguist-generated


### PR DESCRIPTION
@adaam2 told me about this thing last night -- adding before I forget

https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

Didn't mark some sqlc artifacts that tend (eg. models.go) that I tend to find a little more helpful to review when they change but open to be more honest about what we might mark