### PR TITLE
chore: use pgvector as dev database in mise db:rewind

### DIFF
--- a/.mise-tasks/db/rewind.mts
+++ b/.mise-tasks/db/rewind.mts
@@ -65,7 +65,13 @@ async function main() {
   const targetId = target.split("_")[0];
   console.log(`Rewinding to migration ID ${chalk.cyanBright(targetId)}`);
 
-  await $`atlas migrate down --to-version ${targetId} --url "$GRAM_DATABASE_URL" --dev-url "docker://postgres/17/dev?search_path=public"`;
+  const proc =
+    await $`atlas migrate down --to-version ${targetId} --url "$GRAM_DATABASE_URL" --dev-url "docker://pgvector/pgvector/pg17/dev?search_path=public"`.nothrow();
+  if (proc.exitCode !== 0) {
+    console.error(chalk.redBright("Failed to rewind migrations:"));
+    console.error(proc.stderr);
+    process.exit(1);
+  }
 
   console.log("Done.\n");
 


### PR DESCRIPTION
This change updates `mise db:rewind` task to use the pgvector docker image as the reference dev database when working through rewinding migrations.