### PR TITLE
chore: add claude to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -29,7 +29,7 @@ jobs:
           path-to-document: "https://github.com/speakeasy-api/gram/blob/main/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: "cla-signatures"
-          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cursoragent
+          allowlist: speakeasy-api/*,dependabot[bot],renovate[bot],gram-bot[bot],cursoragent,claude
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Summary
- Adds `claude` to the CLA Assistant allowlist so AI-assisted contributions don't trigger CLA signature requirements

## Test plan
- [ ] Merge this PR
- [ ] Comment `recheck` on any PR where Claude is flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1362">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
