### PR TITLE
mig: add header definitions to schema

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1174,6 +1174,7 @@ CREATE TABLE IF NOT EXISTS external_mcp_tool_definitions (
   oauth_token_endpoint TEXT,
   oauth_registration_endpoint TEXT,
   oauth_scopes_supported TEXT[],
+  header_definitions JSONB,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -227,6 +227,7 @@ type ExternalMcpToolDefinition struct {
 	OauthTokenEndpoint         pgtype.Text
 	OauthRegistrationEndpoint  pgtype.Text
 	OauthScopesSupported       []string
+	HeaderDefinitions          []byte
 	CreatedAt                  pgtype.Timestamptz
 	UpdatedAt                  pgtype.Timestamptz
 	DeletedAt                  pgtype.Timestamptz

--- a/server/migrations/20260127183030_add_header_definitions_for_external_mcp.sql
+++ b/server/migrations/20260127183030_add_header_definitions_for_external_mcp.sql
@@ -1,0 +1,2 @@
+-- Modify "external_mcp_tool_definitions" table
+ALTER TABLE "external_mcp_tool_definitions" ADD COLUMN "header_definitions" jsonb NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:gw4/8gTZ7jMgt/MVxKuitk6K0B87jGwe7UPeCSmCz/s=
+h1:Ah6FwNY+7w3q4GD+RVg4p37x0+s4EanTIw7Z1FM6Z90=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -91,3 +91,4 @@ h1:gw4/8gTZ7jMgt/MVxKuitk6K0B87jGwe7UPeCSmCz/s=
 20260122012039_chat_message_metadata.sql h1:TiP3PZYE3eZ22hE+Dgsxesy5zirwEQz+xNAjsTwGxLg=
 20260122192347_chat-content-raw-columns.sql h1:Y1XDsAX1O+f1hsJWFf3IG6pC33h9mtqWidy7RAm/4NI=
 20260127002212_mcp_env_vars.sql h1:SyyU7ZXDITVxMGsSPCAjuBBNXNgxfm+3DjmV5YDV/FQ=
+20260127183030_add_header_definitions_for_external_mcp.sql h1:zhgPD7ecRzM2VFj67jchsx0TiBLpLD4QoIvgT+7TKSw=


### PR DESCRIPTION
This adds a JSONB blob for storing registry header definitions to ensure gram can properly advertise config exposed by external MCPs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
