### PR TITLE
fix(dashboard): prevent duplicate Datadog RUM initialization

### DIFF
--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -70,6 +70,11 @@ export const TelemetryProvider = (props: { children: ReactNode }) => {
   );
 
   useEffect(() => {
+    // Guard against duplicate initialization (can happen in React StrictMode or component remounts)
+    if (datadogRum.getInitConfiguration()) {
+      return;
+    }
+
     if (getServerURL().includes("getgram.ai")) {
       datadogRum.init({
         applicationId: "93afb64a-dd15-490c-a749-51b4c5c5a171",


### PR DESCRIPTION
## Summary

- Fix for the Datadog Browser SDK warning: "SDK is loaded more than once. This is unsupported and might have unexpected behavior."

## Root Cause

The `TelemetryProvider` component in `client/dashboard/src/contexts/Telemetry.tsx` calls `datadogRum.init()` inside a `useEffect` hook with an empty dependency array. This causes duplicate initialization in two scenarios:

1. **React StrictMode** (enabled in development via `main.tsx`): Effects intentionally run twice to help catch bugs
2. **Component remounts**: If `TelemetryProvider` ever remounts, `init()` would be called again

## Fix

Added a guard using `datadogRum.getInitConfiguration()` which returns `undefined` if the SDK hasn't been initialized, or the configuration object if already initialized. The `init()` call is now skipped if the SDK is already configured.

```typescript
useEffect(() => {
  // Guard against duplicate initialization
  if (datadogRum.getInitConfiguration()) {
    return;
  }
  // ... rest of init logic
}, []);
```

## Test plan

- [ ] Verify the warning no longer appears in browser console on page load
- [ ] Verify Datadog RUM still tracks sessions, errors, and user interactions correctly
- [ ] Check Datadog dashboard to confirm events are being captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1378">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
