### PR TITLE
fix: add retry logic to GCR docker login

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -117,11 +117,23 @@ jobs:
           service_account: "speakeasy-registry-ga-ci@linen-analyst-344721.iam.gserviceaccount.com"
       - name: Login to GCR
         if: ${{ needs.changes.outputs.server == 'true' }}
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: gcr.io/linen-analyst-344721
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+        env:
+          GCR_TOKEN: ${{ steps.auth.outputs.access_token }}
+        run: |
+          max_attempts=3
+          for ((i=1; i<=max_attempts; i++)); do
+            echo "Docker login attempt $i/$max_attempts..."
+            if docker login -u oauth2accesstoken --password-stdin gcr.io/linen-analyst-344721 <<< "$GCR_TOKEN"; then
+              echo "Login successful"
+              exit 0
+            fi
+            if [ $i -lt $max_attempts ]; then
+              echo "Login failed, waiting 5s before retry..."
+              sleep 5
+            fi
+          done
+          echo "All login attempts failed"
+          exit 1
       - name: Build and Push Registry image to GCR
         id: build
         if: ${{ needs.changes.outputs.server == 'true' }}
@@ -497,11 +509,23 @@ jobs:
           service_account: "speakeasy-registry-ga-ci@linen-analyst-344721.iam.gserviceaccount.com"
       - name: Login to GCR
         if: env.SHOULD_BUILD_DOCKER == 'true'
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: gcr.io/linen-analyst-344721
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+        env:
+          GCR_TOKEN: ${{ steps.auth.outputs.access_token }}
+        run: |
+          max_attempts=3
+          for ((i=1; i<=max_attempts; i++)); do
+            echo "Docker login attempt $i/$max_attempts..."
+            if docker login -u oauth2accesstoken --password-stdin gcr.io/linen-analyst-344721 <<< "$GCR_TOKEN"; then
+              echo "Login successful"
+              exit 0
+            fi
+            if [ $i -lt $max_attempts ]; then
+              echo "Login failed, waiting 5s before retry..."
+              sleep 5
+            fi
+          done
+          echo "All login attempts failed"
+          exit 1
       - name: Build and Push Registry image to GCR
         id: build
         if: env.SHOULD_BUILD_DOCKER == 'true'


### PR DESCRIPTION
## Summary
- Replace `docker/login-action` with custom bash script for GCR authentication
- Add retry logic (3 attempts, 5s delay) to handle transient network errors
- Use `--password-stdin` for secure token handling

## Test plan
- [ ] Verify PR workflow runs successfully with GCR login
- [ ] Confirm retry logging appears in workflow output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1398">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
