### PR TITLE
fix: show 6 featured servers on homepage

### DIFF
--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -29,8 +29,8 @@ const SERVER_WEBSITE_MAP: Record<string, string> = {
   "com.stripe/mcp": "stripe.com",
   "app.linear/linear": "linear.app",
   "io.github.getsentry/sentry-mcp": "sentry.io",
-  "io.github.aws/mcp-proxy-for-aws": "aws.amazon.com",
-  "io.github.grafana/mcp-grafana": "grafana.com",
+  "io.github.github/github-mcp-server": "github.com",
+  "com.notion/mcp": "notion.so",
 };
 
 export function CatalogDetailRoot() {

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -48,8 +48,8 @@ const FEATURED_SERVER_SPECIFIERS = [
   "com.stripe/mcp",
   "app.linear/linear",
   "io.github.getsentry/sentry-mcp",
-  "io.github.aws/mcp-proxy-for-aws",
-  "io.github.grafana/mcp-grafana",
+  "io.github.github/github-mcp-server",
+  "com.notion/mcp",
 ];
 
 export default function Home() {


### PR DESCRIPTION
## Summary

- Replace non-existent AWS and Grafana MCP servers with GitHub and Notion
- Homepage now displays 6 featured servers (2 full rows of 3)

The previous AWS (`io.github.aws/mcp-proxy-for-aws`) and Grafana (`io.github.grafana/mcp-grafana`) specifiers don't exist in the Pulse MCP registry, causing only 4 servers to display. Replaced with official servers that exist:

- `io.github.github/github-mcp-server` - GitHub
- `com.notion/mcp` - Notion

## Test plan

- [x] Verify homepage shows 6 featured server cards
- [x] Verify GitHub and Notion cards display correctly with icons/metadata
- [x] Verify clicking cards navigates to correct detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
