### PR TITLE
chore: remove skill folders for unused coding agents

### DIFF
--- a/.cline/skills/vercel-react-best-practices
+++ b/.cline/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.codebuddy/skills/vercel-react-best-practices
+++ b/.codebuddy/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.commandcode/skills/vercel-react-best-practices
+++ b/.commandcode/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.continue/skills/vercel-react-best-practices
+++ b/.continue/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.crush/skills/vercel-react-best-practices
+++ b/.crush/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.factory/skills/vercel-react-best-practices
+++ b/.factory/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.gemini/skills/vercel-react-best-practices
+++ b/.gemini/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.goose/skills/vercel-react-best-practices
+++ b/.goose/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.junie/skills/vercel-react-best-practices
+++ b/.junie/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.kilocode/skills/vercel-react-best-practices
+++ b/.kilocode/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.kiro/skills/vercel-react-best-practices
+++ b/.kiro/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.kode/skills/vercel-react-best-practices
+++ b/.kode/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.mcpjam/skills/vercel-react-best-practices
+++ b/.mcpjam/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.mux/skills/vercel-react-best-practices
+++ b/.mux/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.neovate/skills/vercel-react-best-practices
+++ b/.neovate/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.openhands/skills/vercel-react-best-practices
+++ b/.openhands/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.pi/skills/vercel-react-best-practices
+++ b/.pi/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.pochi/skills/vercel-react-best-practices
+++ b/.pochi/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.qoder/skills/vercel-react-best-practices
+++ b/.qoder/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.qwen/skills/vercel-react-best-practices
+++ b/.qwen/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.roo/skills/vercel-react-best-practices
+++ b/.roo/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.trae/skills/vercel-react-best-practices
+++ b/.trae/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.windsurf/skills/vercel-react-best-practices
+++ b/.windsurf/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.zencoder/skills/vercel-react-best-practices
+++ b/.zencoder/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices


### PR DESCRIPTION
There were skills added for various coding agents that are not being used on the Gram team and were polluting the top level repository view.

We will consider a workflow for supporting other coding agents that plays well with gitignore rules and derives from a common base that is versioned in the gram repo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
