### PR TITLE
fix(elements): correct tool call status rendering for duplicate names

### DIFF
--- a/elements/src/components/assistant-ui/tool-fallback.tsx
+++ b/elements/src/components/assistant-ui/tool-fallback.tsx
@@ -29,7 +29,7 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
   const message = useAssistantState(({ message }) => message)
   const toolParts = message.parts.filter((part) => part.type === 'tool-call')
   const matchingMessagePartIndex = toolParts.findIndex(
-    (part) => part.toolName === toolName
+    (part) => part.toolCallId === toolCallId
   )
 
   const handleApproveOnce = () => {


### PR DESCRIPTION
## Summary

- Fixes bug where resolution status of subsequent tool calls altered the visual rendering of earlier tool calls with the same name
- Changed `findIndex` predicate from matching `toolName` to matching `toolCallId` in `tool-fallback.tsx`

## Root Cause

When multiple tool calls share the same name (e.g., calling `search` twice), `findIndex` was returning index `0` for all of them, causing incorrect border styling.

## Test Plan

- [ ] Run Storybook (`cd elements && pnpm dev`) and verify tool calls with duplicate names render correctly
- [ ] Each tool call should show its own border status independent of others

Fixes [AGE-1270](https://linear.app/speakeasy/issue/AGE-1270)

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1424">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
