### PR TITLE
chore: add support links to user dropdown menu

### DIFF
--- a/.changeset/friendly-bottles-flow.md
+++ b/.changeset/friendly-bottles-flow.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add support links to user dropdown menu (Get Support, Chat with Team, Bug or Feature Request)

--- a/client/dashboard/src/components/top-header.tsx
+++ b/client/dashboard/src/components/top-header.tsx
@@ -203,16 +203,12 @@ export function TopHeader() {
                     Get Support
                   </a>
                 </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() => {
-                    if (window.Pylon) {
-                      window.Pylon("show");
-                    }
-                  }}
-                >
-                  <MessageCircleIcon className="mr-2 h-4 w-4" />
-                  Chat with Team
-                </DropdownMenuItem>
+                {window.Pylon && (
+                  <DropdownMenuItem onClick={() => window.Pylon("show")}>
+                    <MessageCircleIcon className="mr-2 h-4 w-4" />
+                    Chat with Team
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem asChild>
                   <a
                     href="https://github.com/speakeasy-api/gram/issues/new"


### PR DESCRIPTION
## Summary
- Adds three new support-related menu items to the user dropdown in the dashboard header
- **Get Support** → Opens email client for gram@speakeasy.com
- **Chat with Team** → Opens Pylon chat widget (already integrated in the app)
- **Bug or Feature Request** → Links to GitHub issues page

<img width="496" height="638" alt="CleanShot 2026-02-01 at 20 52 10@2x" src="https://github.com/user-attachments/assets/f1510f83-c967-4efd-8a07-246cd1f0cda8" />

## Test plan
- [x] Open dashboard and click user avatar in top-right
- [x] Verify "Get Support" opens email composer with gram@speakeasy.com
- [x] Verify "Chat with Team" opens Pylon chat widget
- [x] Verify "Bug or Feature Request" opens GitHub issues in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1436">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
