### PR TITLE
chore: disable zero:summary task in agent mode

### DIFF
--- a/zero
+++ b/zero
@@ -109,7 +109,7 @@ mise run zero:migrations
 mise db:migrate
 mise clickhouse:migrate
 
-mise zero:summary
+interactive_only mise zero:summary
 
 echo -e "\n✅ All set up!"
 


### PR DESCRIPTION
This change updates the zero script to disable the zero:summary task when running in agent mode. This task fails in agent mode because no docker-compose infra gets spun up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1445">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
