### PR TITLE
chore: copy mise.local.toml to new worktrees

### DIFF
--- a/.mise-tasks/git/worknew.sh
+++ b/.mise-tasks/git/worknew.sh
@@ -20,7 +20,7 @@ dest="${usage_dir:?}/_gram_${usage_name:?}"
 git fetch
 git worktree add "${dest}" "${usage_branch:?}"
 
-cp ./mise.local.toml "${dest}"
+[ -f ./mise.local.toml ] && cp ./mise.local.toml "${dest}"
 cd "${dest}"
 mise trust
 git checkout -b "${new_branch}"


### PR DESCRIPTION
This change updates git:worknew mise task to copy the mise.local.toml file into newly created git worktrees. This file contains credentials and settings necessary to run gram locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1446">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
