### PR TITLE
chore: do not require changeset for migration PRs

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -45,8 +45,8 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{ github.event.pull_request.title }}" =~ ^chore(\([a-zA-Z0-9_-]+\))?: ]]; then
-            echo "Skipping changesets-lint job for chore PR."
+          if [[ "${{ github.event.pull_request.title }}" =~ ^(chore|mig)(\([a-zA-Z0-9_-]+\))?: ]]; then
+            echo "Skipping changesets-lint job for chore/mig PR."
             exit 0
           fi
 


### PR DESCRIPTION
This change updates the hygiene workflow to stop requiring a changeset for migration PRs. Typically, these don't contain user facing changes and subsequent PRs that make use of the migrations will have appropriate release notes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1454">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
