### PR TITLE
fix: use correct API URL for elements on dev environment

### DIFF
--- a/client/dashboard/src/pages/logs/Logs.tsx
+++ b/client/dashboard/src/pages/logs/Logs.tsx
@@ -397,6 +397,7 @@ const useGramMcpConfig = () => {
         toolsToInclude,
       },
       api: {
+        url: getServerURL(),
         sessionFn: getSession,
       },
       environment: {

--- a/client/dashboard/src/pages/metrics/Metrics.tsx
+++ b/client/dashboard/src/pages/metrics/Metrics.tsx
@@ -242,6 +242,7 @@ const useGramMcpConfig = () => {
         toolsToInclude,
       },
       api: {
+        url: getServerURL(),
         sessionFn: getSession,
       },
       environment: {


### PR DESCRIPTION
## Summary
- Logs and metrics pages were missing `api.url` in their `ElementsConfig`, causing `getApiUrl()` in elements to fall back to the hardcoded `https://app.getgram.ai` default instead of using the current origin
- Added `url: getServerURL()` to the `api` config in both pages, matching what playground and elements pages already do

## Test plan
- [ ] Deploy to dev and verify the logs page chat makes requests to `dev.getgram.ai/chat/completions` instead of `app.getgram.ai`
- [ ] Verify metrics page chat also uses the correct dev URL
- [ ] Verify production (`app.getgram.ai`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
