### PR TITLE
fix: replace paid atlas txtar checks with nolint directive

### DIFF
--- a/server/migrations/20260202185119_chat_resolution_table.sql
+++ b/server/migrations/20260202185119_chat_resolution_table.sql
@@ -1,11 +1,4 @@
--- atlas:txtar
-
--- checks/destructive.sql --
--- Verify columns are empty before dropping (DS103).
-SELECT NOT EXISTS (SELECT 1 FROM chats WHERE resolution IS NOT NULL) AS chats_resolution_empty;
-SELECT NOT EXISTS (SELECT 1 FROM chats WHERE resolution_notes IS NOT NULL) AS chats_resolution_notes_empty;
-
--- migration.sql --
+-- atlas:nolint DS103
 -- Modify "chats" table
 -- Columns moved to the new chat_resolutions table below.
 ALTER TABLE "chats" DROP COLUMN "resolution", DROP COLUMN "resolution_notes";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TYgtei6fTQXQw36JRXiYTnOpPYUoz3pcRYbaeK3ajUM=
+h1:QDql9g7uQSqWUkcxiP2YlVt59CMaC0c+LuirvtbNnHQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -95,7 +95,7 @@ h1:TYgtei6fTQXQw36JRXiYTnOpPYUoz3pcRYbaeK3ajUM=
 20260129164323_install_redirect.sql h1:QK9StZ1pz4N+oRPcNYFeOx8AVt2tQBRJC+NRKJSeWOk=
 20260129194537_api-key-last-accessed.sql h1:2ggrS/lKJnBS6HSll9akkQg9SZSYy03W839YxU46+mU=
 20260129231659_team-invites.sql h1:wiU38rRgiHfTCKmO+XF40Vv7Y5eZfuuKSxAqIfGKgdc=
-20260202185119_chat_resolution_table.sql h1:MgA57rYkPmw9Ls0gYhJIfvqUJf7skN+S6AJbRuo4VVg=
-20260202191147_store-user-access-tokens.sql h1:EPCrGhvPPv96s27kfR6eElUCAhcU8qE25nR+qXg6Rn4=
-20260202212612_chat_message_seq.sql h1:t1ZVSRF6fHqiZ+gm5M9GezoHXRFP5ntPuLH+L1FeU64=
-20260202230735_add-mcp-metadata-title-text.sql h1:CuQu/HO7oU6ygPih/JQMddVvnk56cLQohfmKSyh+xqs=
+20260202185119_chat_resolution_table.sql h1:yQpDPNFKRG24dCkp3gf+Gx/b8MevRBTnq3FW/cdszXM=
+20260202191147_store-user-access-tokens.sql h1:w6xawh64CrzDewwAAoHbPDIKfuz5lbXNFpJGsJFvwBU=
+20260202212612_chat_message_seq.sql h1:A4W0ScDOEj6ykCD5hXZ6d37PNWUiTjR0QRpJXeX+TIg=
+20260202230735_add-mcp-metadata-title-text.sql h1:yXUfvgiVMTA6lOT1TLC4nCHhjQXAyBe7O2KypnNnEkA=


### PR DESCRIPTION
## Summary
- Replace `atlas:txtar` destructive check directives with `atlas:nolint DS103` in the chat resolution migration
- The `txtar` checks require paid Atlas features, which prevents OSS contributors from running `./zero` locally
- Uses the same `nolint` pattern already established in `20260202212612_chat_message_seq.sql`

## Test plan
- [ ] Verify `./zero` runs successfully without paid Atlas license
- [ ] Verify migration applies cleanly with `mise db:migrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1466">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
