### PR TITLE
chore: add atlas migration troubleshooting to claude md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ Contains the main application code for the Gram server:
 
 </commands>
 
+### Atlas Migration Troubleshooting
+
+- **"migration file X was added out of order" error**: Rename the migration file to have a timestamp after the latest existing migration (e.g., `20260129_foo.sql` → `20260203000001_foo.sql`), then run `mise db:hash` to regenerate `atlas.sum`.
+
 ## Mise CLI
 
 The `mise` tasks listed in this guide should be used where building, testing or linting is needed. The commands can take arguments directly and don't need a `--` separator. For example, to run the server in development mode, use:


### PR DESCRIPTION
## Summary
- Documents how to fix "migration file added out of order" Atlas errors
- Adds `mise db:hash` command to regenerate checksums after renaming migrations

## Context
When working on feature branches, migrations can end up with timestamps older than migrations already merged to main. This causes Atlas to reject the migration with a "non-linear" error.

## Test plan
- [x] Verified fix works by renaming `20260129231659_team-invites.sql` → `20260203000001_team-invites.sql`
- [x] Ran `mise db:hash` and `./zero` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
