### PR TITLE
mig: scope user oauth tokens to toolset

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1279,7 +1279,7 @@ WHERE deleted IS FALSE;
 CREATE TABLE IF NOT EXISTS user_oauth_tokens (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
 
-  -- Scoping: per user, per org, per OAuth server (RFC recommendation)
+  -- Scoping: per user, per org, per toolset
   user_id TEXT NOT NULL,
   organization_id TEXT NOT NULL,
   project_id uuid NOT NULL,
@@ -1287,7 +1287,6 @@ CREATE TABLE IF NOT EXISTS user_oauth_tokens (
   toolset_id uuid NOT NULL,  -- FK to toolsets
 
   -- OAuth 2.1 server issuer URL (from AS metadata, e.g., "https://accounts.google.com")
-  -- This allows token reuse across MCP servers sharing the same OAuth provider
   oauth_server_issuer TEXT NOT NULL CHECK (oauth_server_issuer <> '' AND CHAR_LENGTH(oauth_server_issuer) <= 500),
 
   -- Token data (encrypted at rest via application layer)
@@ -1315,7 +1314,7 @@ CREATE TABLE IF NOT EXISTS user_oauth_tokens (
 
 -- Unique constraint: one token per user per org per OAuth issuer
 CREATE UNIQUE INDEX IF NOT EXISTS user_oauth_tokens_user_org_issuer_key
-ON user_oauth_tokens (user_id, organization_id, oauth_server_issuer)
+ON user_oauth_tokens (user_id, organization_id, toolset_id)
 WHERE deleted IS FALSE;
 
 -- Team invites for organization member management

--- a/server/migrations/20260203225638_index-user-tokens-by-toolset-id.sql
+++ b/server/migrations/20260203225638_index-user-tokens-by-toolset-id.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Drop index "user_oauth_tokens_user_org_issuer_key" from table: "user_oauth_tokens"
+DROP INDEX CONCURRENTLY "user_oauth_tokens_user_org_issuer_key";
+-- Create index "user_oauth_tokens_user_org_issuer_key" to table: "user_oauth_tokens"
+CREATE UNIQUE INDEX CONCURRENTLY "user_oauth_tokens_user_org_issuer_key" ON "user_oauth_tokens" ("user_id", "organization_id", "toolset_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QDql9g7uQSqWUkcxiP2YlVt59CMaC0c+LuirvtbNnHQ=
+h1:fR7N/ubPA/5ZjpWOJKokGq1Wd0kBYn5IZmgYFTaYm6M=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -99,3 +99,4 @@ h1:QDql9g7uQSqWUkcxiP2YlVt59CMaC0c+LuirvtbNnHQ=
 20260202191147_store-user-access-tokens.sql h1:w6xawh64CrzDewwAAoHbPDIKfuz5lbXNFpJGsJFvwBU=
 20260202212612_chat_message_seq.sql h1:A4W0ScDOEj6ykCD5hXZ6d37PNWUiTjR0QRpJXeX+TIg=
 20260202230735_add-mcp-metadata-title-text.sql h1:yXUfvgiVMTA6lOT1TLC4nCHhjQXAyBe7O2KypnNnEkA=
+20260203225638_index-user-tokens-by-toolset-id.sql h1:q/sTybbrDaFLntwK2HxCtCIfmvLm++N7XLOlVW05DWE=


### PR DESCRIPTION
This migration indexes user OAuth tokens by `toolset_id` instead of Issuer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1478">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
