### PR TITLE
fix: chat history ordering and scroll

### DIFF
--- a/client/dashboard/src/pages/playground/PlaygroundElements.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElements.tsx
@@ -6,11 +6,11 @@ import {
 } from "@/components/ui/popover";
 import { Type } from "@/components/ui/type";
 import { useProject, useSession } from "@/contexts/Auth";
-import { useRoutes } from "@/routes";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
 import { useInternalMcpUrl } from "@/hooks/useToolsetUrl";
-import { getServerURL } from "@/lib/utils";
 import type { Toolset } from "@/lib/toolTypes";
+import { getServerURL } from "@/lib/utils";
+import { useRoutes } from "@/routes";
 import {
   Chat,
   ChatHistory,
@@ -183,7 +183,7 @@ export function PlaygroundElements({
             </PopoverTrigger>
             <PopoverContent
               align="start"
-              className="w-72 p-0 max-h-96 overflow-hidden"
+              className="w-72 p-0 max-h-96 overflow-y-scroll"
             >
               <ChatHistory className="h-full max-h-96 overflow-y-auto" />
             </PopoverContent>

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -73,59 +73,62 @@ VALUES (
 );
 
 -- name: ListAllChats :many
-SELECT 
+SELECT
     c.*,
     (
         COALESCE(
             (SELECT COUNT(*) FROM chat_messages WHERE chat_id = c.id),
             0
         )
-    )::integer as num_messages 
+    )::integer as num_messages
     , (
         COALESCE(
             (SELECT SUM(total_tokens) FROM chat_messages WHERE chat_id = c.id),
             0
         )
     )::integer as total_tokens
-FROM chats c 
-WHERE c.project_id = @project_id;
+FROM chats c
+WHERE c.project_id = @project_id
+ORDER BY c.updated_at DESC;
 
 -- name: ListChatsForExternalUser :many
-SELECT 
+SELECT
     c.*,
     (
         COALESCE(
             (SELECT COUNT(*) FROM chat_messages WHERE chat_id = c.id),
             0
         )
-    )::integer as num_messages 
+    )::integer as num_messages
     , (
         COALESCE(
             (SELECT SUM(total_tokens) FROM chat_messages WHERE chat_id = c.id),
             0
         )
     )::integer as total_tokens
-FROM chats c 
-WHERE c.project_id = @project_id AND c.external_user_id = @external_user_id;
+FROM chats c
+WHERE c.project_id = @project_id AND c.external_user_id = @external_user_id
+ORDER BY c.updated_at DESC;
 
 
 -- name: ListChatsForUser :many
-SELECT 
+SELECT
     c.*,
     (
         COALESCE(
             (SELECT COUNT(*) FROM chat_messages WHERE chat_id = c.id),
             0
         )
-    )::integer as num_messages 
+    )::integer as num_messages
     , (
         COALESCE(
             (SELECT SUM(total_tokens) FROM chat_messages WHERE chat_id = c.id),
             0
         )
     )::integer as total_tokens
-FROM chats c 
-WHERE c.project_id = @project_id AND c.user_id = @user_id;
+FROM chats c
+WHERE c.project_id = @project_id AND c.user_id = @user_id
+ORDER BY c.updated_at DESC;
 
 -- name: GetChat :one
 SELECT * FROM chats WHERE id = @id;

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -212,22 +212,23 @@ func (q *Queries) InsertChatResolutionMessage(ctx context.Context, arg InsertCha
 }
 
 const listAllChats = `-- name: ListAllChats :many
-SELECT 
+SELECT
     c.id, c.project_id, c.organization_id, c.user_id, c.external_user_id, c.title, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         COALESCE(
             (SELECT COUNT(*) FROM chat_messages WHERE chat_id = c.id),
             0
         )
-    )::integer as num_messages 
+    )::integer as num_messages
     , (
         COALESCE(
             (SELECT SUM(total_tokens) FROM chat_messages WHERE chat_id = c.id),
             0
         )
     )::integer as total_tokens
-FROM chats c 
+FROM chats c
 WHERE c.project_id = $1
+ORDER BY c.updated_at DESC
 `
 
 type ListAllChatsRow struct {
@@ -373,22 +374,23 @@ func (q *Queries) ListChatResolutions(ctx context.Context, chatID uuid.UUID) ([]
 }
 
 const listChatsForExternalUser = `-- name: ListChatsForExternalUser :many
-SELECT 
+SELECT
     c.id, c.project_id, c.organization_id, c.user_id, c.external_user_id, c.title, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         COALESCE(
             (SELECT COUNT(*) FROM chat_messages WHERE chat_id = c.id),
             0
         )
-    )::integer as num_messages 
+    )::integer as num_messages
     , (
         COALESCE(
             (SELECT SUM(total_tokens) FROM chat_messages WHERE chat_id = c.id),
             0
         )
     )::integer as total_tokens
-FROM chats c 
+FROM chats c
 WHERE c.project_id = $1 AND c.external_user_id = $2
+ORDER BY c.updated_at DESC
 `
 
 type ListChatsForExternalUserParams struct {
@@ -445,22 +447,23 @@ func (q *Queries) ListChatsForExternalUser(ctx context.Context, arg ListChatsFor
 }
 
 const listChatsForUser = `-- name: ListChatsForUser :many
-SELECT 
+SELECT
     c.id, c.project_id, c.organization_id, c.user_id, c.external_user_id, c.title, c.created_at, c.updated_at, c.deleted_at, c.deleted,
     (
         COALESCE(
             (SELECT COUNT(*) FROM chat_messages WHERE chat_id = c.id),
             0
         )
-    )::integer as num_messages 
+    )::integer as num_messages
     , (
         COALESCE(
             (SELECT SUM(total_tokens) FROM chat_messages WHERE chat_id = c.id),
             0
         )
     )::integer as total_tokens
-FROM chats c 
+FROM chats c
 WHERE c.project_id = $1 AND c.user_id = $2
+ORDER BY c.updated_at DESC
 `
 
 type ListChatsForUserParams struct {


### PR DESCRIPTION
2 issues:
- Chat history was sorted in the reverse order by default
- Chat history in playground wasn't scrollable

<img width="790" height="1046" alt="CleanShot 2026-02-03 at 15 31 29@2x" src="https://github.com/user-attachments/assets/dc39516f-3f2b-436c-b7b1-953552450cc9" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1479">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
