### PR TITLE
fix: auth banner 'Configure now' navigates to authentication tab

### DIFF
--- a/client/dashboard/src/pages/playground/PlaygroundElements.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElements.tsx
@@ -221,7 +221,7 @@ function AuthWarningBanner({
         {missingCount === 1 ? "variable" : "variables"} not configured.{" "}
         <routes.mcp.details.Link
           params={[toolsetSlug]}
-          hash="auth"
+          hash="authentication"
           className="underline hover:text-foreground font-medium"
         >
           Configure now


### PR DESCRIPTION
## Summary
- Fixes the "Configure now" link in the Playground auth warning banner to navigate to the authentication tab instead of the MCP server overview page
- The `hash` prop was incorrectly set to `"auth"` but `MCPDetails.tsx` only recognizes `"authentication"` as a valid tab value

Fixes [AGE-1286](https://linear.app/speakeasy/issue/AGE-1286/bug-auth-not-configured-banner-in-playground-goes-to-homepage-of-mcp)

## Test plan
- [ ] Open Playground with an MCP server that has unconfigured auth variables
- [ ] Click "Configure now" in the warning banner
- [ ] Verify it navigates to the MCP details page with the authentication tab selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
