### PR TITLE
chore: git-ignore SDK docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ junit-report.xml
 !.vscode/extensions.json
 *.code-workspace
 .idea
+/client/sdk/docs
 /server/goa*
 /server/gram
 # Goa generates OpenAPI v2 specs with non-deterministic examples. Nothing consumes them.

--- a/client/sdk/.genignore
+++ b/client/sdk/.genignore
@@ -1,2 +1,0 @@
-# Ignore generated documentation folder
-docs/


### PR DESCRIPTION
This change drops the .genignore rule for docs which didn't seem to be working and instead opts for adding /client/sdk/docs to the .gitignore file. This can be beneficial because `speakeasy` will still generate docs that are available to coding agents as context while not adding noise to source control.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
