### PR TITLE
fix: add a dashboard environment variable for gram auth to be nice

### DIFF
--- a/cli/internal/app/auth.go
+++ b/cli/internal/app/auth.go
@@ -122,7 +122,7 @@ func newAuthCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:    "dashboard-url",
 				Usage:   "URL of the Gram dashboard for authentication",
-				EnvVars: []string{"GRAM_DASHBOARD_URL"},
+				EnvVars: []string{"GRAM_SITE_URL"},
 			},
 		},
 		Subcommands: []*cli.Command{

--- a/mise.toml
+++ b/mise.toml
@@ -77,7 +77,6 @@ GRAM_WORKER_CONTROL_ADDRESS = ":8082"
 GRAM_ENVIRONMENT = "local"
 GRAM_SERVER_URL = "https://localhost:8080"
 GRAM_SITE_URL = "https://localhost:5173"
-GRAM_DASHBOARD_URL = "{{env.GRAM_SITE_URL}}"
 GRAM_ASSETS_BACKEND = "fs"
 GRAM_ASSETS_URI = ".assets"
 ## The following variable is used to encrypt env vars stored in the database.


### PR DESCRIPTION
`gram auth` took some finagling to get working on my machine. This adds the `GRAM_DASHBOARD_URL` to the `mise env` config so that we're able to run gram auth with fewer weird things happening
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
