### PR TITLE
mig: add api_key_id materialized column to telemetry_logs

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260206100103_add-api-key-id-materialized-col.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260206100103_add-api-key-id-materialized-col.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` DROP INDEX `idx_telemetry_logs_mat_api_key_id`;
+ALTER TABLE `telemetry_logs` DROP COLUMN `api_key_id`;

--- a/server/clickhouse/local/golang_migrate/20260206100103_add-api-key-id-materialized-col.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260206100103_add-api-key-id-materialized-col.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `api_key_id` String MATERIALIZED toString(attributes.gram.api_key.id) COMMENT 'API key ID (materialized from attributes.gram.api_key.id).';
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_api_key_id` ((api_key_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:OnncRSwwYKpiWAifyd0a59DW/ETAO1ysr0wSreUqHeg=
+h1:UORNkdnipFmkdBXiTlUajr7H5NPEqvr4bvyUk6VUNIM=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -10,3 +10,4 @@ h1:OnncRSwwYKpiWAifyd0a59DW/ETAO1ysr0wSreUqHeg=
 20260205142724_drop-telemetry-materialized-col-indices.up.sql h1:Gsi7yz/z13YAGfzKuftzFdQSO6mj7l0je7AfnPx+H/Y=
 20260205142751_drop-telemetry-materialized-cols.up.sql h1:gEbtbNCvNv2p2KBqgPNGCNVE7tNQK21BUsm2XVbt5wU=
 20260205142915_add-telemetry-materialized-cols.up.sql h1:OELvwpMsl1noENBrRSOb90/HSOVTIIfjqucLsJUHBd8=
+20260206100103_add-api-key-id-materialized-col.up.sql h1:onLGWT+hY47HKScXjiGFZZnl9/j6QHNao8XPh6Swmdc=

--- a/server/clickhouse/migrations/20260206100100_add-api-key-id-materialized-col.sql
+++ b/server/clickhouse/migrations/20260206100100_add-api-key-id-materialized-col.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `api_key_id` String MATERIALIZED toString(attributes.gram.api_key.id) COMMENT 'API key ID (materialized from attributes.gram.api_key.id).';

--- a/server/clickhouse/migrations/20260206100101_add-api-key-id-index.sql
+++ b/server/clickhouse/migrations/20260206100101_add-api-key-id-index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_api_key_id` ((api_key_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:K/voiF2x2uki3sgCWvl6glPs9K4wMV9OI3BsBHm5pdU=
+h1:YrOxPWRzz1cVsIjme5znmE6sCCqfhP+NSO6DnFIT5fU=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -15,3 +15,5 @@ h1:K/voiF2x2uki3sgCWvl6glPs9K4wMV9OI3BsBHm5pdU=
 20260205142720_drop-telemetry-materialized-col-indices.sql h1:4enC5fre0wRAsHRRw7yjfKm5pC9cQHmwGagfwQ4f/Os=
 20260205142748_drop-telemetry-materialized-cols.sql h1:FNrH/9hOG1kDmqAbsUBsfuCGojU/zYn8xpRnNyHrYKo=
 20260205142913_add-telemetry-materialized-cols.sql h1:bwVf+w7sqps7SBZe7f81LBLmxFQkGJ1K/aCrRZV6UKU=
+20260206100100_add-api-key-id-materialized-col.sql h1:VKiEKZAHeeOeL2bg5WE8eSVmEBYG3Bcup1wiYsjr8eM=
+20260206100101_add-api-key-id-index.sql h1:ZMWlLWRRxEWZumMvR+QBz9C24M5GiWEPcPmgKnj/9Ss=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -109,7 +109,8 @@ CREATE TABLE IF NOT EXISTS telemetry_logs (
     urn String MATERIALIZED toString(attributes.gram.tool.urn) COMMENT 'Tool URN (materialized from attributes.gram.tool.urn).',
     chat_id String MATERIALIZED toString(attributes.gen_ai.conversation.id) COMMENT 'Chat ID (materialized from attributes.gen_ai.conversation.id).',
     user_id String MATERIALIZED toString(attributes.user.id) COMMENT 'User ID (materialized from attributes.user.id).',
-    external_user_id String MATERIALIZED toString(attributes.gram.external_user.id) COMMENT 'External user ID (materialized from attributes.gram.external_user.id).'
+    external_user_id String MATERIALIZED toString(attributes.gram.external_user.id) COMMENT 'External user ID (materialized from attributes.gram.external_user.id).',
+    api_key_id String MATERIALIZED toString(attributes.gram.api_key.id) COMMENT 'API key ID (materialized from attributes.gram.api_key.id).'
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))
 ORDER BY (gram_project_id, time_unix_nano, id)
@@ -133,3 +134,4 @@ CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_urn ON telemetry_logs (urn) TY
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_chat_id ON telemetry_logs (chat_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_user_id ON telemetry_logs (user_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_external_user_id ON telemetry_logs (external_user_id) TYPE bloom_filter(0.01) GRANULARITY 1;
+CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_api_key_id ON telemetry_logs (api_key_id) TYPE bloom_filter(0.01) GRANULARITY 1;


### PR DESCRIPTION
## Summary

- Adds `api_key_id` as a materialized column in ClickHouse `telemetry_logs` table to enable filtering observability metrics by API key
- Column extracts from `attributes.gram.api_key.id` with a bloom filter index for efficient querying
- Adds `APIKeyIDKey` attribute constant and helper functions (`APIKeyID()`, `SlogAPIKeyID()`) for populating telemetry events

## Context

This is a prerequisite for the observability overview page which will allow users to filter metrics by API key. A follow-up PR will add the plumbing to populate the `api_key_id` attribute when creating telemetry events.

## Test plan

- [ ] Migration applies cleanly to ClickHouse
- [ ] New column appears in `telemetry_logs` table
- [ ] Index is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
