### PR TITLE
mig: add materialized columns for chat resolution

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260206114443_add-materialized-column-for-chat-evalutation-score.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260206114443_add-materialized-column-for-chat-evalutation-score.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` DROP COLUMN `evaluation_score_label`;

--- a/server/clickhouse/local/golang_migrate/20260206114443_add-materialized-column-for-chat-evalutation-score.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260206114443_add-materialized-column-for-chat-evalutation-score.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `evaluation_score_label` String MATERIALIZED toString(attributes.gen_ai.evaluation.score.label) COMMENT 'Evaluation result label (success, failure, partial, abandoned).';

--- a/server/clickhouse/local/golang_migrate/20260206114500_add-index-for-chat-evaluation-score.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260206114500_add-index-for-chat-evaluation-score.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` DROP INDEX `idx_telemetry_logs_mat_evaluation_score_label`;

--- a/server/clickhouse/local/golang_migrate/20260206114500_add-index-for-chat-evaluation-score.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260206114500_add-index-for-chat-evaluation-score.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_evaluation_score_label` ((evaluation_score_label)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:UORNkdnipFmkdBXiTlUajr7H5NPEqvr4bvyUk6VUNIM=
+h1:ttLi6zwpUOCORMS4iuQbVUUy59kEAwNuT9QDYIzfNMQ=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -11,3 +11,5 @@ h1:UORNkdnipFmkdBXiTlUajr7H5NPEqvr4bvyUk6VUNIM=
 20260205142751_drop-telemetry-materialized-cols.up.sql h1:gEbtbNCvNv2p2KBqgPNGCNVE7tNQK21BUsm2XVbt5wU=
 20260205142915_add-telemetry-materialized-cols.up.sql h1:OELvwpMsl1noENBrRSOb90/HSOVTIIfjqucLsJUHBd8=
 20260206100103_add-api-key-id-materialized-col.up.sql h1:onLGWT+hY47HKScXjiGFZZnl9/j6QHNao8XPh6Swmdc=
+20260206114443_add-materialized-column-for-chat-evalutation-score.up.sql h1:VSEr6KPOlda/TXDaZAC3GMQfEEIB4E0+27zpBa/TM5k=
+20260206114500_add-index-for-chat-evaluation-score.up.sql h1:Xq6AZLk613h4Fjyb7SJPXdaFwYJTFSeDgj+H9dx/hfs=

--- a/server/clickhouse/migrations/20260206114440_add-materialized-column-for-chat-evalutation-score.sql
+++ b/server/clickhouse/migrations/20260206114440_add-materialized-column-for-chat-evalutation-score.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `evaluation_score_label` String MATERIALIZED toString(attributes.gen_ai.evaluation.score.label) COMMENT 'Evaluation result label (success, failure, partial, abandoned).';

--- a/server/clickhouse/migrations/20260206114457_add-index-for-chat-evaluation-score.sql
+++ b/server/clickhouse/migrations/20260206114457_add-index-for-chat-evaluation-score.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_evaluation_score_label` ((evaluation_score_label)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:YrOxPWRzz1cVsIjme5znmE6sCCqfhP+NSO6DnFIT5fU=
+h1:eygsY9xGG3Sx1/su1WR7KE639BJ4w9NgF4YYn3/jl7w=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -17,3 +17,5 @@ h1:YrOxPWRzz1cVsIjme5znmE6sCCqfhP+NSO6DnFIT5fU=
 20260205142913_add-telemetry-materialized-cols.sql h1:bwVf+w7sqps7SBZe7f81LBLmxFQkGJ1K/aCrRZV6UKU=
 20260206100100_add-api-key-id-materialized-col.sql h1:VKiEKZAHeeOeL2bg5WE8eSVmEBYG3Bcup1wiYsjr8eM=
 20260206100101_add-api-key-id-index.sql h1:ZMWlLWRRxEWZumMvR+QBz9C24M5GiWEPcPmgKnj/9Ss=
+20260206114440_add-materialized-column-for-chat-evalutation-score.sql h1:X4FmPMmmQ0pFWsZaq27EO1M6y5s8QrMcu9F5ObgJZ5c=
+20260206114457_add-index-for-chat-evaluation-score.sql h1:BTFxw3hZzyvQm5eMpSU3jOf5Uy7V7blne1AEElwPRvk=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -110,7 +110,8 @@ CREATE TABLE IF NOT EXISTS telemetry_logs (
     chat_id String MATERIALIZED toString(attributes.gen_ai.conversation.id) COMMENT 'Chat ID (materialized from attributes.gen_ai.conversation.id).',
     user_id String MATERIALIZED toString(attributes.user.id) COMMENT 'User ID (materialized from attributes.user.id).',
     external_user_id String MATERIALIZED toString(attributes.gram.external_user.id) COMMENT 'External user ID (materialized from attributes.gram.external_user.id).',
-    api_key_id String MATERIALIZED toString(attributes.gram.api_key.id) COMMENT 'API key ID (materialized from attributes.gram.api_key.id).'
+    api_key_id String MATERIALIZED toString(attributes.gram.api_key.id) COMMENT 'API key ID (materialized from attributes.gram.api_key.id).',
+    evaluation_score_label String MATERIALIZED toString(attributes.gen_ai.evaluation.score.label) COMMENT 'Evaluation result label (success, failure, partial, abandoned).'
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))
 ORDER BY (gram_project_id, time_unix_nano, id)
@@ -135,3 +136,4 @@ CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_chat_id ON telemetry_logs (cha
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_user_id ON telemetry_logs (user_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_external_user_id ON telemetry_logs (external_user_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_api_key_id ON telemetry_logs (api_key_id) TYPE bloom_filter(0.01) GRANULARITY 1;
+CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_evaluation_score_label ON telemetry_logs (evaluation_score_label) TYPE bloom_filter(0.01) GRANULARITY 1;


### PR DESCRIPTION
We're going to want to start filtering table for chat resolution so adding this here. 

We're following [OTEL conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/) for column naming, hence the score label.

I left out the duration and score number as this are less likely attributes we'll use in query filters.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
