### PR TITLE
chore: add telemetry query to list usage by user

### DIFF
--- a/server/internal/telemetry/repo/models.go
+++ b/server/internal/telemetry/repo/models.go
@@ -134,3 +134,35 @@ type MetricsSummaryRow struct {
 	ToolSuccessCounts map[string]uint64 `ch:"tool_success_counts"`
 	ToolFailureCounts map[string]uint64 `ch:"tool_failure_counts"`
 }
+
+// UserSummary represents aggregated usage metrics for a single user from ClickHouse.
+// Used for the searchUsers endpoint, grouping by user_id or external_user_id.
+// The UserID field holds whichever identifier was used for grouping; the caller
+// knows which one it represents based on the group_by parameter.
+type UserSummary struct {
+	UserID string `ch:"user_id"`
+
+	// Activity timestamps
+	FirstSeenUnixNano int64 `ch:"first_seen_unix_nano"`
+	LastSeenUnixNano  int64 `ch:"last_seen_unix_nano"`
+
+	// Chat metrics
+	TotalChats        uint64 `ch:"total_chats"`
+	TotalChatRequests uint64 `ch:"total_chat_requests"`
+
+	// Token metrics
+	TotalInputTokens  int64   `ch:"total_input_tokens"`
+	TotalOutputTokens int64   `ch:"total_output_tokens"`
+	TotalTokens       int64   `ch:"total_tokens"`
+	AvgTokensPerReq   float64 `ch:"avg_tokens_per_request"`
+
+	// Tool call metrics
+	TotalToolCalls  uint64 `ch:"total_tool_calls"`
+	ToolCallSuccess uint64 `ch:"tool_call_success"`
+	ToolCallFailure uint64 `ch:"tool_call_failure"`
+
+	// Tool breakdowns (maps of tool URN -> count)
+	ToolCounts        map[string]uint64 `ch:"tool_counts"`
+	ToolSuccessCounts map[string]uint64 `ch:"tool_success_counts"`
+	ToolFailureCounts map[string]uint64 `ch:"tool_failure_counts"`
+}


### PR DESCRIPTION
This will let us see per user summarised usage of chats so people can get quick insights on amount of tool calls and chats each user has. 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
