### PR TITLE
chore: remove incorrect urn in analyze segment

### DIFF
--- a/server/internal/background/activities/chat_resolutions/analyze_segment.go
+++ b/server/internal/background/activities/chat_resolutions/analyze_segment.go
@@ -177,7 +177,7 @@ func (a *AnalyzeSegment) Do(ctx context.Context, args AnalyzeSegmentArgs) error 
 		Timestamp: time.Now(),
 		ToolInfo: telemetry.ToolInfo{
 			ID:             "",
-			URN:            "agents:chat:resolution",
+			URN:            "",
 			Name:           "chat_resolution",
 			ProjectID:      args.ProjectID.String(),
 			DeploymentID:   "",


### PR DESCRIPTION
This shouldn't be using a URN. 

It might look weird to pass a ToolInfo to the createlog event when this is not a tool. It won't be a problem soon because we will be able to get rid of this ToolInfo param and just let create logs accept attributes. The reason we have it now is that we are writing to specific columns that require types to be known (which we'll replace with materialized columns instead).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
