### PR TITLE
chore: add -y/--yes flag to skip interactive prompt

### DIFF
--- a/zero
+++ b/zero
@@ -4,10 +4,15 @@ set -e
 
 # Parse command line arguments
 agent_mode=false
+auto_yes=false
 for arg in "$@"; do
     case $arg in
         --agent)
             agent_mode=true
+            shift
+            ;;
+        -y|--yes)
+            auto_yes=true
             shift
             ;;
     esac
@@ -113,7 +118,9 @@ interactive_only mise zero:summary
 
 echo -e "\n✅ All set up!"
 
-if ! $agent_mode; then
+if $auto_yes; then
+    exec mise run start
+elif ! $agent_mode; then
     echo "Want me to start the server and dashboard (\`mise run start\`)?"
     echo -n "[y/N] "
     read -r answer


### PR DESCRIPTION
## Summary

Adds a `-y` / `--yes` flag to the `zero` setup script that automatically starts the server and dashboard after setup completes, skipping the interactive confirmation prompt.

## Changes

- Added `-y|--yes` argument parsing alongside the existing `--agent` flag
- When `--yes` is passed, the script runs `mise run start` immediately after setup instead of prompting
- The existing interactive prompt and `--agent` behavior are unchanged

## Why

The interactive "Want me to start the server?" prompt at the end of `./zero` is useful for first-time setup, but for developers who know they want to start the server, it adds an unnecessary manual step. `./zero --yes` lets you run the full setup-and-start flow non-interactively without needing the full `--agent` mode (which also skips Docker checks, API key setup, etc.).

---

This PR was written using [Vibe Kanban](https://vibekanban.com)