### PR TITLE
fix: restart Temporal during setup to clear SQLite locks

### DIFF
--- a/.mise-tasks/zero/cleanup.sh
+++ b/.mise-tasks/zero/cleanup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+#MISE description="Restart Temporal to clear SQLite locks"
+#MISE hide=true
+
+set -e
+
+# Restart Temporal container to clear any SQLite locks from previous runs
+# The health check doesn't catch SQLite lock issues, so we restart unconditionally
+if docker compose ps gram-temporal --status running -q 2>/dev/null | grep -q .; then
+    echo "Restarting Temporal container..."
+    docker compose restart gram-temporal
+    until docker compose exec gram-temporal temporal operator cluster health 2>/dev/null; do
+        echo "Waiting for Temporal to be healthy..."
+        sleep 2
+    done
+fi

--- a/zero
+++ b/zero
@@ -106,6 +106,10 @@ mise run build:internal-sdk
 echo -e "\n⏳ Updating VS Code and Cursor editor settings"
 mise run install:vscode
 
+echo -e "\n⏳ Cleaning up stale processes and Temporal state"
+interactive_only mise run zero:cleanup
+echo "✅ Cleaned up stale state"
+
 echo -e "\n⏳ Starting infra"
 interactive_only mise infra:start
 


### PR DESCRIPTION
## Summary
- Adds a `zero:cleanup` mise task that restarts the Temporal container during `./zero` setup
- Fixes seed failures caused by stale SQLite locks in Temporal's database
- The health check doesn't detect SQLite lock issues, so we restart unconditionally

## Test plan
- [ ] Run `./zero` on a fresh clone
- [ ] Run `./zero` after switching branches to verify Temporal restarts correctly
- [ ] Run `mise seed` after setup completes to verify seeding works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
