### PR TITLE
fix: use GitHub App token for dispatch-release workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1233,9 +1233,17 @@ jobs:
     needs: [docker-build-server]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@b96fde71c0080358ed6e2d162f11c612c92a97d1 # v2.1.4
+        with:
+          app-id: ${{ vars.GRAM_BOT_APP_ID }}
+          private-key: ${{ secrets.GRAM_BOT_PRIVATE_KEY }}
+          owner: speakeasy-api
+          repositories: gram-infra
       - name: Dispatch prepare-release
         env:
-          GH_TOKEN: ${{ secrets.GRAM_INFRA_SPEAKEASYBOT_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh workflow run "Prepare Release" \
             -R speakeasy-api/gram-infra \


### PR DESCRIPTION
## Summary
- Replace expired PAT (`GRAM_INFRA_SPEAKEASYBOT_TOKEN`) with GitHub App token for cross-repo workflow dispatch
- Uses existing `GRAM_BOT_APP_ID` and `GRAM_BOT_PRIVATE_KEY` that other workflows already use
- GitHub Apps are more reliable than PATs as they're org-level and don't expire unexpectedly

Fixes failing run: https://github.com/speakeasy-api/gram/actions/runs/21827288836/job/62976237950

Error was:
```
unable to determine default branch for speakeasy-api/gram-infra: HTTP 401: Bad credentials
```

## Requirement
The `gram-bot` GitHub App must be installed on the `speakeasy-api/gram-infra` repository with `actions:write` permission.

## Test plan
- [ ] Merge to main and verify dispatch-release job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)