### PR TITLE
fix: hide featured third-party servers section when empty

### DIFF
--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -243,40 +243,42 @@ export default function Home() {
         </div>
 
         {/* Featured Servers Section */}
-        <div className="mt-10">
-          <Stack
-            direction="horizontal"
-            justify="space-between"
-            align="center"
-            className="mb-4"
-          >
-            <h2 className="text-lg font-semibold">
-              Featured Third-Party Servers
-            </h2>
-            <routes.catalog.Link>
-              <span className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1">
-                Browse all <ArrowRight className="w-4 h-4" />
-              </span>
-            </routes.catalog.Link>
-          </Stack>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {isLoading &&
-              [...Array(6)].map((_, i) => (
-                <Skeleton key={i} className="h-[140px] rounded-xl" />
-              ))}
-            {!isLoading &&
-              featuredServers.map((server) => (
-                <FeaturedServerCard
-                  key={server.registrySpecifier}
-                  server={server}
-                  detailHref={routes.catalog.detail.href(
-                    encodeURIComponent(server.registrySpecifier),
-                  )}
-                  externalMcps={externalMcps}
-                />
-              ))}
+        {(isLoading || featuredServers.length > 0) && (
+          <div className="mt-10">
+            <Stack
+              direction="horizontal"
+              justify="space-between"
+              align="center"
+              className="mb-4"
+            >
+              <h2 className="text-lg font-semibold">
+                Featured Third-Party Servers
+              </h2>
+              <routes.catalog.Link>
+                <span className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1">
+                  Browse all <ArrowRight className="w-4 h-4" />
+                </span>
+              </routes.catalog.Link>
+            </Stack>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {isLoading &&
+                [...Array(6)].map((_, i) => (
+                  <Skeleton key={i} className="h-[140px] rounded-xl" />
+                ))}
+              {!isLoading &&
+                featuredServers.map((server) => (
+                  <FeaturedServerCard
+                    key={server.registrySpecifier}
+                    server={server}
+                    detailHref={routes.catalog.detail.href(
+                      encodeURIComponent(server.registrySpecifier),
+                    )}
+                    externalMcps={externalMcps}
+                  />
+                ))}
+            </div>
           </div>
-        </div>
+        )}
       </Page.Body>
     </Page>
   );


### PR DESCRIPTION
## Summary
- Hide the "Featured Third-Party Servers" section on the home page when no servers are found from the catalog
- Section still shows loading skeletons while data is being fetched
- Prevents empty section with just a heading from displaying

## Test plan
- [ ] Navigate to home page and verify featured servers section shows loading skeletons initially
- [ ] Verify section displays correctly when servers are found
- [ ] Verify section is completely hidden when no matching servers are returned from the catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
