### PR TITLE
Language maturity page updates

### DIFF
--- a/client/sdk/README.md
+++ b/client/sdk/README.md
@@ -11,9 +11,6 @@ Developer-friendly & type-safe Typescript SDK specifically catered to leverage _
 
 <br /><br />
 
-> [!IMPORTANT]
-> This SDK is not yet ready for production use. To complete setup please follow the steps outlined in your [workspace](https://app.speakeasy.com/org/speakeasy-self/speakeasy-self). Delete this section before > publishing to a package manager.
-
 <!-- Start Summary [summary] -->
 ## Summary
 
@@ -37,17 +34,12 @@ Gram API Description: Gram is the tools platform for AI agents
   * [Custom HTTP Client](#custom-http-client)
   * [Debugging](#debugging)
 * [Development](#development)
-  * [Maturity](#maturity)
   * [Contributions](#contributions)
 
 <!-- End Table of Contents [toc] -->
 
 <!-- Start SDK Installation [installation] -->
 ## SDK Installation
-
-> [!TIP]
-> To finish publishing your SDK to npm and others you must [run your first generation action](https://www.speakeasy.com/docs/github-setup#step-by-step-guide).
-
 
 The SDK can be installed with either [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/), [bun](https://bun.sh/) or [yarn](https://classic.yarnpkg.com/en/) package managers.
 
@@ -458,11 +450,6 @@ popular asynchronous state management library.
 To learn about this feature and how to get started, check
 [REACT_QUERY.md](./REACT_QUERY.md).
 
-> [!WARNING]
->
-> This feature is currently in **preview** and is subject to breaking changes
-> within the current major version of the SDK as we gather user feedback on it.
-
 <details>
 
 <summary>Available React hooks</summary>
@@ -851,12 +838,6 @@ You can also enable a default debug logger by setting an environment variable `G
 <!-- Placeholder for Future Speakeasy SDK Sections -->
 
 # Development
-
-## Maturity
-
-This SDK is in beta, and there may be breaking changes between versions without a major version update. Therefore, we recommend pinning usage
-to a specific package version. This way, you can install the same version each time without breaking changes unless you are intentionally
-looking for the latest version.
 
 ## Contributions
 


### PR DESCRIPTION
Removes "bad vibes" messaging from the SDK README to improve the perceived maturity and readiness of the SDK.

The original Linear issue GEN-2473 referenced an external Speakeasy documentation page. While that page is outside this codebase, similar negative messaging was identified within `client/sdk/README.md`. This PR addresses those local instances by removing warnings about the SDK not being production-ready, features being in preview, and the overall beta status. Note that this README is auto-generated, so these changes may be overwritten on the next SDK generation.

---
Linear Issue: [GEN-2473](https://linear.app/speakeasy/issue/GEN-2473/feat-updates-to-language-maturity-page-to-remove-bad-vibes)

<p><a href="https://cursor.com/background-agent?bcId=bc-fce9eb0c-f255-49c2-b59d-cd801560dfe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fce9eb0c-f255-49c2-b59d-cd801560dfe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

