### PR TITLE
fix: add empty states to insights page

### DIFF
--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -98,7 +98,7 @@ When the user asks about "current period", "selected period", "this timeframe", 
 
   const contextValue = useMemo(
     () => ({ isExpanded, setIsExpanded }),
-    [isExpanded, setIsExpanded],
+    [isExpanded],
   );
 
   return (

--- a/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
+++ b/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
@@ -97,6 +97,12 @@ function NoDataOverlay() {
   );
 }
 
+interface SetupRequiredModalProps {
+  open: boolean;
+  onClose: () => void;
+  onNavigateToElements: () => void;
+}
+
 /**
  * Modal shown when there's no data at all across any period,
  * prompting the user to set up Elements
@@ -105,11 +111,7 @@ function SetupRequiredModal({
   open,
   onClose,
   onNavigateToElements,
-}: {
-  open: boolean;
-  onClose: () => void;
-  onNavigateToElements: () => void;
-}) {
+}: SetupRequiredModalProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <Dialog.Content className="sm:max-w-md">
@@ -728,20 +730,17 @@ function ObservabilityContent({
   const { isExpanded: isInsightsOpen, setIsExpanded } = useInsightsState();
   const [showSetupModal, setShowSetupModal] = useState(false);
 
-  // Check for total empty state (no data at all across any period)
-  const hasAnyData = useMemo(() => {
-    if (!data) return false;
+  // Check data availability for empty states
+  const { hasAnyData, currentWindowHasData } = useMemo(() => {
+    if (!data) return { hasAnyData: false, currentWindowHasData: false };
     // Check current period, comparison period, and time series
     const currentHasData = hasSummaryData(data.summary);
     const comparisonHasData = hasSummaryData(data.comparison);
     const timeSeriesHasData = hasTimeSeriesData(data.timeSeries ?? []);
-    return currentHasData || comparisonHasData || timeSeriesHasData;
-  }, [data]);
-
-  // Check if current time window has data
-  const currentWindowHasData = useMemo(() => {
-    if (!data) return false;
-    return hasTimeSeriesData(data.timeSeries ?? []);
+    return {
+      hasAnyData: currentHasData || comparisonHasData || timeSeriesHasData,
+      currentWindowHasData: timeSeriesHasData,
+    };
   }, [data]);
 
   // Show setup modal when data loads and there's no data at all


### PR DESCRIPTION
## Summary

- Add empty state handling for the Insights page when there's no telemetry data
- Show "No data for selected time range" overlay on charts when current time window has no data
- Show setup modal with link to Elements page when there's no data at all across any period

## Changes

- **NoDataOverlay**: New overlay component displayed on time series charts when no data exists for the selected time range
- **SetupRequiredModal**: Modal prompting users to set up Elements when no telemetry data exists
- **InsightsContext**: Exposed `setIsExpanded` to allow closing the sidebar from within modal handlers
- Fixed sidebar remaining open when clicking modal buttons by properly propagating close handlers


<img width="3520" height="2394" alt="CleanShot 2026-02-12 at 14 02 18@2x" src="https://github.com/user-attachments/assets/1e62ca38-0d6f-4fd0-9c6b-fd75c3a4c331" />
<img width="3520" height="2394" alt="CleanShot 2026-02-12 at 14 02 09@2x" src="https://github.com/user-attachments/assets/a085d5d3-0d53-40b6-a006-da165f4d9e3a" />

## Test plan

- [ ] Navigate to Insights page with no telemetry data - verify setup modal appears
- [ ] Click "Set Up Elements" - verify sidebar closes and navigates to /elements
- [ ] Click "Maybe Later" - verify modal and sidebar both close
- [ ] Select a time range with no data - verify "No data" overlay appears on charts
- [ ] Select a time range with data - verify charts display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
