### PR TITLE
chore: switch metrics queries to read from metrics_summaries MV

### DIFF
--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -688,7 +688,7 @@ func (q *Queries) getOverviewSummaryMV(arg GetOverviewSummaryParams) squirrel.Se
 		From("metrics_summaries").
 		Where("gram_project_id = ?", arg.GramProjectID).
 		Where("time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeStart).
-		Where("time_bucket <= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeEnd)
+		Where("time_bucket < toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeEnd)
 }
 
 // getOverviewSummaryRaw builds a query against the raw telemetry_logs table (used when filters are applied).


### PR DESCRIPTION
## Summary
- Switches `GetMetricsSummary` and `GetOverviewSummary` queries to read from the pre-aggregated `metrics_summaries` materialized view instead of raw `telemetry_logs`
- Stacked on #1579 (schema + MV + backfill)

## Test plan
- [ ] `go test ./server/internal/telemetry/...` passes with both schema and query changes
- [ ] Verify metrics dashboard returns correct data in local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
