### PR TITLE
chore: disable publishing functions images for dependabot PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -996,7 +996,7 @@ jobs:
 
       - name: "[DEV] Create fly app"
         id: flyCreateDev
-        if: ${{ needs.changes.outputs.functions == 'true' }}
+        if: ${{ needs.changes.outputs.functions == 'true' && github.actor != 'dependabot[bot]' }}
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
@@ -1009,7 +1009,7 @@ jobs:
 
       - name: "[PROD] Create fly app"
         id: flyCreateProd
-        if: ${{ needs.changes.outputs.functions == 'true' }}
+        if: ${{ needs.changes.outputs.functions == 'true' && github.actor != 'dependabot[bot]' }}
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
@@ -1021,11 +1021,11 @@ jobs:
             --force
 
       - name: Set up Docker Buildx
-        if: ${{ needs.changes.outputs.functions == 'true' }}
+        if: ${{ needs.changes.outputs.functions == 'true' && github.actor != 'dependabot[bot]' }}
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Extract Docker metadata
-        if: ${{ needs.changes.outputs.functions == 'true' }}
+        if: ${{ needs.changes.outputs.functions == 'true' && github.actor != 'dependabot[bot]' }}
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
@@ -1040,7 +1040,7 @@ jobs:
             type=sha,format=long,prefix=,suffix=-${{ matrix.runtime }}
 
       - name: Tag images
-        if: ${{ needs.changes.outputs.functions == 'true' }}
+        if: ${{ needs.changes.outputs.functions == 'true' && github.actor != 'dependabot[bot]' }}
         working-directory: functions
         run: |
           set -x
@@ -1054,7 +1054,7 @@ jobs:
           done
 
       - name: "[DEV] Push images"
-        if: ${{ needs.changes.outputs.functions == 'true' }}
+        if: ${{ needs.changes.outputs.functions == 'true' && github.actor != 'dependabot[bot]' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
         run: |
@@ -1063,7 +1063,7 @@ jobs:
           docker push --all-tags "${{ steps.flyCreateDev.outputs.flyAppRegistry }}"
 
       - name: "[PROD] Push images"
-        if: ${{ needs.changes.outputs.functions == 'true' }}
+        if: ${{ needs.changes.outputs.functions == 'true' && github.actor != 'dependabot[bot]' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
         run: |


### PR DESCRIPTION
This change updates the GitHub Actions workflow to skip publishing functions images when the PR is created by dependabot. This is unnecessary for now when checking these PRs since it requires provisioning a bunch of secrets to access the image registry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
