### PR TITLE
feat: add claude opus 4.6 to openrouter model list

### DIFF
--- a/elements/src/lib/models.ts
+++ b/elements/src/lib/models.ts
@@ -1,6 +1,7 @@
 // List of openrouter models available to the user
 // This list should be updated to match the model whitelist on the backend side.
 export const MODELS = [
+  'anthropic/claude-opus-4.6',
   'anthropic/claude-sonnet-4.5',
   'anthropic/claude-haiku-4.5',
   'anthropic/claude-sonnet-4',

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -35,6 +35,7 @@ var ErrGenerationNotFound = errors.New("generation not found")
 // Just a general allowlist for models we allow to proxy through us for playground usage, chat, or agentic usecases
 // This list can stay sufficiently robust, we should just need to allow list a model before it goes through us
 var allowList = map[string]bool{
+	"anthropic/claude-opus-4.6":     true,
 	"anthropic/claude-sonnet-4.5":   true,
 	"anthropic/claude-haiku-4.5":    true,
 	"anthropic/claude-sonnet-4":     true,


### PR DESCRIPTION
Adds anthropic/claude-opus-4.6 to both frontend model picker and backend allowlist, positioned at top of list.

https://claude.ai/code/session_01GgyRxJAuNZu7y9JBsSuvUD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
