### PR TITLE
fix: ensure proxied keys are correctly formatted as headers

### DIFF
--- a/server/internal/gateway/security.go
+++ b/server/internal/gateway/security.go
@@ -172,9 +172,10 @@ func processSecurity(
 	}
 
 	for key, value := range env.SystemEnv.All() {
-		canonicalKey := http.CanonicalHeaderKey(key)
+		headerKey := toolconfig.ToHTTPHeader(key)
+		canonicalKey := http.CanonicalHeaderKey(headerKey)
 		if _, alreadyProcessed := securityHeadersProcessed[canonicalKey]; !alreadyProcessed {
-			req.Header.Set(key, value)
+			req.Header.Set(headerKey, value)
 		}
 	}
 


### PR DESCRIPTION
Currently sending headers set in attached environments that _aren't_ specified by the underlying source as `_` delimited instead of `-` delimited . This addresses that isseu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
