### PR TITLE
fix: elements mise setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -161,8 +161,8 @@ PULSE_REGISTRY_KEY = "unset"
 ## Elements ##
 ## Used for local development only
 ## Storybook runs internally on 6007, but the protocol sniffing proxy serves on 6006
-ELEMENTS_STORYBOOK_PORT = "6007"
-VITE_GRAM_ELEMENTS_STORYBOOK_URL = "https://localhost:6006"
+ELEMENTS_STORYBOOK_PORT = "6006"
+VITE_GRAM_ELEMENTS_STORYBOOK_URL = "https://localhost:{{env.ELEMENTS_STORYBOOK_PORT}}"
 
 #########################
 ## Polar configuration ##


### PR DESCRIPTION
The mise file specified the wrong port for Elements
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
