### PR TITLE
fix: use custom domain URL in playground MCP config

### DIFF
--- a/client/dashboard/src/pages/playground/PlaygroundElements.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElements.tsx
@@ -7,7 +7,7 @@ import {
 import { Type } from "@/components/ui/type";
 import { useProject, useSession } from "@/contexts/Auth";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
-import { useInternalMcpUrl } from "@/hooks/useToolsetUrl";
+import { useMcpUrl } from "@/hooks/useToolsetUrl";
 import type { Toolset } from "@/lib/toolTypes";
 import { getServerURL } from "@/lib/utils";
 import { useRoutes } from "@/routes";
@@ -68,8 +68,8 @@ export function PlaygroundElements({
     { enabled: !!toolsetSlug },
   );
 
-  // Get MCP URL from toolset (always uses Gram domain, not custom domains)
-  const mcpUrl = useInternalMcpUrl(toolset);
+  // Get MCP URL from toolset (uses custom domain if configured)
+  const { url: mcpUrl } = useMcpUrl(toolset);
 
   // Get environments and MCP metadata for auth status check
   const { data: environmentsData } = useListEnvironments();


### PR DESCRIPTION
## Summary
- Fix playground MCP config to use custom domain URL when configured
- Previously the playground always used `app.getgram.ai/mcp/{slug}`, which broke MCPs using custom domains
- Switch from `useInternalMcpUrl` to `useMcpUrl` hook which respects custom domain configuration

## Test plan
- [ ] Load a playground for an MCP server with a custom domain configured
- [ ] Verify the MCP connection works correctly using the custom domain URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
