### PR TITLE
mig: add audience column to oauth_proxy_servers

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -566,6 +566,7 @@ CREATE TABLE IF NOT EXISTS oauth_proxy_servers (
   project_id uuid NOT NULL,
 
   slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 100),
+  audience TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -508,6 +508,7 @@ type OauthProxyServer struct {
 	ID        uuid.UUID
 	ProjectID uuid.UUID
 	Slug      string
+	Audience  pgtype.Text
 	CreatedAt pgtype.Timestamptz
 	UpdatedAt pgtype.Timestamptz
 	DeletedAt pgtype.Timestamptz

--- a/server/internal/oauth/repo/models.go
+++ b/server/internal/oauth/repo/models.go
@@ -61,6 +61,7 @@ type OauthProxyServer struct {
 	ID        uuid.UUID
 	ProjectID uuid.UUID
 	Slug      string
+	Audience  pgtype.Text
 	CreatedAt pgtype.Timestamptz
 	UpdatedAt pgtype.Timestamptz
 	DeletedAt pgtype.Timestamptz

--- a/server/internal/oauth/repo/queries.sql.go
+++ b/server/internal/oauth/repo/queries.sql.go
@@ -208,7 +208,7 @@ func (q *Queries) GetExternalOAuthServerMetadata(ctx context.Context, arg GetExt
 }
 
 const getOAuthProxyServer = `-- name: GetOAuthProxyServer :one
-SELECT id, project_id, slug, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, slug, audience, created_at, updated_at, deleted_at, deleted
 FROM oauth_proxy_servers s
 WHERE s.project_id = $1 AND s.id = $2 AND s.deleted IS FALSE
 `
@@ -225,6 +225,7 @@ func (q *Queries) GetOAuthProxyServer(ctx context.Context, arg GetOAuthProxyServ
 		&i.ID,
 		&i.ProjectID,
 		&i.Slug,
+		&i.Audience,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -591,7 +592,7 @@ INSERT INTO oauth_proxy_servers (
     $2
 ) ON CONFLICT (project_id, slug) WHERE deleted IS FALSE DO UPDATE SET
     updated_at = clock_timestamp()
-RETURNING id, project_id, slug, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, slug, audience, created_at, updated_at, deleted_at, deleted
 `
 
 type UpsertOAuthProxyServerParams struct {
@@ -607,6 +608,7 @@ func (q *Queries) UpsertOAuthProxyServer(ctx context.Context, arg UpsertOAuthPro
 		&i.ID,
 		&i.ProjectID,
 		&i.Slug,
+		&i.Audience,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260218000001_oauth-proxy-server-audience.sql
+++ b/server/migrations/20260218000001_oauth-proxy-server-audience.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oauth_proxy_servers ADD COLUMN audience TEXT;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Edqi50yehGQ3Z+4643tr+qYBPeY0Ir/upsg+522vXIo=
+h1:GptIDIRsk/M6xg9xV4w3BS1uEQXvJHzDH1WYIctfOAg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -105,3 +105,4 @@ h1:Edqi50yehGQ3Z+4643tr+qYBPeY0Ir/upsg+522vXIo=
 20260205195141_chat_res_user_feedback.sql h1:WnMMCCfsRKRWLGKUkHBjsfxKzdaA12l2U4QnDvazR6w=
 20260205195200_tools-add-annotations-column.sql h1:ENgMYtaQrroMmVLTiyG2UubPcc+1aY9PodrXIz1Ajow=
 20260210042235_add-annotations-to-external-mcp-tools.sql h1:hYxDhF69ey4vm3pW2+niUmPI3nL/BjaCiA+sER2T3BA=
+20260218000001_oauth-proxy-server-audience.sql h1:2bnirfFCHHKh3gtEOigHlT1bPYORon/j4FyjAejgeUI=


### PR DESCRIPTION
## Summary
- Adds nullable `audience TEXT` column to `oauth_proxy_servers` table
- Used by the feature PR to store the audience parameter for upstream OAuth providers (e.g. Auth0)

## Test plan
- [ ] Migration applies cleanly
- [ ] Rollback is safe (nullable column, no data dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
