### PR TITLE
fix: expose all telemetry tools to insights AI assistant

### DIFF
--- a/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
+++ b/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
@@ -396,9 +396,19 @@ export default function ObservabilityOverview() {
     }
   }, []);
 
-  // Copilot config - filters to metrics-related tools
+  // Telemetry tools available to the AI assistant on the overview page.
+  // These correspond to operationIds in server/design/telemetry/design.go.
   const metricsToolFilter = useCallback(
-    ({ toolName }: { toolName: string }) => toolName.includes("metrics"),
+    ({ toolName }: { toolName: string }) =>
+      [
+        "search_logs",
+        "search_tool_calls",
+        "search_chats",
+        "search_users",
+        "get_project_metrics_summary",
+        "get_user_metrics_summary",
+        "get_observability_overview",
+      ].some((tool) => toolName.includes(tool)),
     [],
   );
   const mcpConfig = useObservabilityMcpConfig({


### PR DESCRIPTION
Fixes: https://linear.app/speakeasy/issue/AGE-1376/bug-insights-ai-popout-missing-tools-access-messages

## Summary

The AI assistant on the observability overview page was only seeing 2 tools (`get_user_metrics_summary` and `get_project_metrics_summary`) because the filter used `toolName.includes("metrics")`. This expands the allowlist to include all 7 relevant telemetry endpoints defined in `server/design/telemetry/design.go`.

### Tools now available
- `search_logs`
- `search_tool_calls`
- `search_chats`
- `search_users`
- `get_project_metrics_summary`
- `get_user_metrics_summary`
- `get_observability_overview`

### Tools intentionally excluded
- `capture_event` — write operation, not useful for querying
- `list_filter_options` — internal UI helper, not useful for the assistant

## Approach: hardcoded allowlist

We considered several alternatives before landing on a simple hardcoded list:

1. **Tag-based filtering via `_meta`** — Propagate OpenAPI tags (e.g. `"telemetry"`) through MCP `_meta` and filter on the frontend. This auto-updates when new endpoints are added, but the default becomes opt-out (new tools are exposed unless explicitly excluded), which is unsafe.

2. **Opt-in annotation in Goa design** — Add a `Meta("x-gram-ai-visible", "true")` extension to each endpoint. Safe default (new tools hidden), but adds complexity to the design layer for a concern that's really about the dashboard.

3. **MCP `ToolAnnotations` extension** — Add an `ai_visible_hint` boolean to the existing annotation system. Follows MCP patterns but requires a DB migration for a simple filtering need.

The hardcoded list is the simplest approach that's safe by default — new telemetry endpoints won't be exposed to the assistant unless someone explicitly adds them here.

## Intentionally unchanged

The existing logs pages retain the tools they already have, as metrics isn't relevant for those pages.

## Test plan
- [x] Verify the insights page AI assistant sees all 7 telemetry tools
- [x] Verify `capture_event` and `list_filter_options` are not available
- [x] Verify the Logs and Chat Logs pages retain their existing tool filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
