### PR TITLE
fix: apply toolsToInclude filter outside query to fix stale tools on navigation

### DIFF
--- a/.changeset/fix-stale-tools-navigation.md
+++ b/.changeset/fix-stale-tools-navigation.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Fix stale toolsToInclude when client-side navigating between pages

--- a/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
+++ b/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
@@ -1,15 +1,13 @@
 import { useSession } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
 import { getServerURL } from "@/lib/utils";
-import type { ElementsConfig } from "@gram-ai/elements";
+import type { ElementsConfig, ToolsFilter } from "@gram-ai/elements";
 import { chatSessionsCreate } from "@gram/client/funcs/chatSessionsCreate";
 import { useGramContext, useListToolsets } from "@gram/client/react-query";
 import { useCallback, useMemo } from "react";
 
-type ToolFilter = (params: { toolName: string }) => boolean;
-
 interface ObservabilityMcpConfigOptions {
-  toolsToInclude: ToolFilter;
+  toolsToInclude: ToolsFilter;
 }
 
 /**

--- a/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
@@ -128,16 +128,16 @@ export default function ChatLogs() {
   const [offset, setOffset] = useState(0);
   const limit = 50;
 
-  // Copilot config - includes both chat and logs tools for comprehensive analysis
-  const observabilityToolFilter = useCallback(
-    ({ toolName }: { toolName: string }) => {
-      const name = toolName.toLowerCase();
-      return name.includes("chat") || name.includes("logs");
-    },
-    [],
-  );
+  // Copilot config - whitelist of tools for chat session analysis
   const mcpConfig = useObservabilityMcpConfig({
-    toolsToInclude: observabilityToolFilter,
+    toolsToInclude: [
+      "gram_search_logs",
+      "gram_search_chats",
+      "gram_get_deployment_logs",
+      "gram_load_chat",
+      "gram_list_chats_with_resolutions",
+      "gram_list_chats",
+    ],
   });
 
   // Parse URL params

--- a/elements/src/index.ts
+++ b/elements/src/index.ts
@@ -63,6 +63,7 @@ export type {
   ThemeConfig,
   ToolMentionsConfig,
   ToolsConfig,
+  ToolsFilter,
   UnifiedSessionAuthConfig,
   Variant,
   VARIANTS,


### PR DESCRIPTION
## Summary
- Fix stale `toolsToInclude` when client-side navigating between insights, logs, and chat sessions pages
- Move tools filtering from inside `queryFn` to a `useMemo` so it re-runs when `toolsToInclude` changes
- Use static whitelist for chat sessions page tools instead of dynamic filter

## Test plan
- [ ] Navigate to insights page and open AI chat - verify metrics tools are available
- [ ] Client-side navigate to chat sessions page and open AI chat - verify correct tools: `gram_search_logs`, `gram_search_chats`, `gram_get_deployment_logs`, `gram_load_chat`, `gram_list_chats_with_resolutions`, `gram_list_chats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)