### PR TITLE
fix: add defensive check for undefined currentProject in Auth.tsx

### DIFF
--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -124,8 +124,8 @@ export const ProjectProvider = ({
 
   // Update project state when current project changes
   useEffect(() => {
-    if (!project || project.slug !== currentProject.slug) {
-      setProject(currentProject);
+    if (!project || project.slug !== currentProject?.slug) {
+      setProject(currentProject ?? null);
     }
   }, [currentProject, project]);
 


### PR DESCRIPTION
## Summary
- Adds optional chaining when accessing `currentProject.slug` to prevent TypeError when `organization.projects` is empty
- Fixes race condition where useEffect runs before the early return guard

Fixes AGE-1379

## Test plan
- [ ] Verify app doesn't crash when user has no projects in their organization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
