### PR TITLE
feat: pass external_user_id to all PostHog events

### DIFF
--- a/server/internal/thirdparty/posthog/posthog.go
+++ b/server/internal/thirdparty/posthog/posthog.go
@@ -127,6 +127,9 @@ func (p *Posthog) CaptureEvent(ctx context.Context, eventName string, distinctID
 		if authCtx.Email != nil {
 			properties.Set("email", *authCtx.Email)
 		}
+		if authCtx.ExternalUserID != "" {
+			properties.Set("external_user_id", authCtx.ExternalUserID)
+		}
 	}
 
 	// Add custom event properties


### PR DESCRIPTION
## Summary
- Adds `external_user_id` from the auth context to PostHog's auto-enrichment in `CaptureEvent`
- Previously only the telemetry `CaptureEvent` API endpoint included this field — now all PostHog events (`model_usage`, `tool_call`, `prompt_call`, etc.) include the customer-provided user identifier when present
- Field is only set when non-empty (populated from chat session JWTs)

## Test plan
- [x] Verify server builds cleanly
- [ ] Confirm PostHog events from Elements chat sessions include `external_user_id`
- [x] Verify events without an external user ID are unaffected (no empty string sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
