### PR TITLE
fix: clarify private MCP label to specify project scope

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1058,7 +1058,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
             icon: "lock",
             label: "Private",
             description:
-              "Only users with a Gram API Key can read the tools hosted by this server.",
+              "Only users with a Gram API Key from this project can read the tools hosted by this server.",
           },
         ]}
         selectedValue={isPublic ? "public" : "private"}


### PR DESCRIPTION
## Summary
- Clarify private MCP server label to indicate API key must be from the same project

The previous description "Only users with a Gram API Key can read the tools hosted by this server" was misleading - it implied any Gram API Key would work. In reality, the backend validates that the API key belongs to an organization that owns the project containing the MCP server.

## Test plan
- [ ] Verify label text is updated in MCP settings page
- [ ] Confirm wording is accurate per backend logic in `server/internal/mcp/impl.go:541-562`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
