### PR TITLE
chore: add event source to telemetry attributes

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -109,6 +109,7 @@ const (
 	EnvironmentIDKey               = attribute.Key("gram.environment.id")
 	EnvironmentSlugKey             = attribute.Key("gram.environment.slug")
 	EnvVarNameKey                  = attribute.Key("gram.envvar.name")
+	EventSourceKey                 = attribute.Key("gram.event.source")
 	ErrorIDKey                     = attribute.Key("gram.error.id")
 	FilterExpressionKey            = attribute.Key("gram.filter.src")
 	FlyAppInternalIDKey            = attribute.Key("gram.fly.app_id")
@@ -516,6 +517,9 @@ func SlogEnvironmentSlug(v string) slog.Attr      { return slog.String(string(En
 
 func EnvVarName(v string) attribute.KeyValue { return EnvVarNameKey.String(v) }
 func SlogEnvVarName(v string) slog.Attr      { return slog.String(string(EnvVarNameKey), v) }
+
+func EventSource(v string) attribute.KeyValue { return EventSourceKey.String(v) }
+func SlogEventSource(v string) slog.Attr      { return slog.String(string(EventSourceKey), v) }
 
 func ErrorID(v string) attribute.KeyValue { return ErrorIDKey.String(v) }
 func SlogErrorID(v string) slog.Attr      { return slog.String(string(ErrorIDKey), v) }

--- a/server/internal/background/activities/chat_resolutions/analyze_segment.go
+++ b/server/internal/background/activities/chat_resolutions/analyze_segment.go
@@ -175,6 +175,7 @@ func (a *AnalyzeSegment) Do(ctx context.Context, args AnalyzeSegmentArgs) error 
 	}
 
 	attrs := map[attr.Key]any{
+		attr.EventSourceKey:                string(telemetry.EventSourceEvaluation),
 		attr.GenAIEvaluationNameKey:        "chat_resolution",
 		attr.GenAIEvaluationScoreLabelKey:  result.Resolution,
 		attr.GenAIEvaluationScoreValueKey:  score,

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1256,6 +1256,7 @@ func (r *responseCaptor) emitGenAITelemetry(toolCallsJSON []byte) {
 	// but remain in the attributes JSON. Resource attributes are auto-partitioned
 	// based on telemetry.ResourceAttributeKeys.
 	attrs := map[attr.Key]any{
+		attr.EventSourceKey: string(telemetry.EventSourceChatCompletion),
 		attr.ResourceURNKey: "agents:chat:completion",
 		attr.LogBodyKey: fmt.Sprintf("LLM chat completion: model=%s, input_tokens=%d, output_tokens=%d",
 			r.model, r.usage.PromptTokens, r.usage.CompletionTokens),

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -416,6 +416,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 			FunctionExecutionTime: functionsExecutionTime,
 		})
 
+		attrRecorder[attr.EventSourceKey] = string(tm.EventSourceToolCall)
 		attrRecorder.RecordStatusCode(interceptor.statusCode)
 		attrRecorder.RecordRequestBody(requestNumBytes)
 		attrRecorder.RecordResponseBody(outputNumBytes)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -904,7 +904,7 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "resources/list":
 		return handleResourcesList(ctx, s.logger, s.db, payload, req, &s.toolsetCache)
 	case "resources/read":
-		return handleResourcesRead(ctx, s.logger, s.db, payload, req, s.toolProxy, s.env, s.billingTracker, s.billingRepository, s.telemetryService, s.features)
+		return handleResourcesRead(ctx, s.logger, s.db, payload, req, s.toolProxy, s.env, s.billingTracker, s.billingRepository, s.telemetryService)
 	default:
 		return nil, &rpcError{
 			ID:      req.ID,

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -26,7 +26,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
@@ -59,8 +58,7 @@ func handleResourcesRead(
 	env toolconfig.EnvironmentLoader,
 	billingTracker billing.Tracker,
 	billingRepository billing.Repository,
-	telemSvc *tm.Service,
-	featuresClient *productfeatures.Client) (json.RawMessage, error) {
+	telemSvc *tm.Service) (json.RawMessage, error) {
 	var params resourceReadParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "failed to parse get resource request").Log(ctx, logger)
@@ -162,6 +160,7 @@ func handleResourcesRead(
 			FunctionExecutionTime: functionsExecutionTime,
 		})
 
+		logAttrs[attr.EventSourceKey] = string(tm.EventSourceResourceRead)
 		logAttrs.RecordStatusCode(rw.statusCode)
 		logAttrs.RecordRequestBody(requestBytes)
 		logAttrs.RecordResponseBody(outputBytes)

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -253,13 +253,14 @@ func handleToolsCall(
 			FunctionExecutionTime: functionsExecutionTime,
 		})
 
+		logAttrs[attr.EventSourceKey] = string(tm.EventSourceToolCall)
 		logAttrs.RecordStatusCode(rw.statusCode)
 		logAttrs.RecordRequestBody(requestBytes)
 		logAttrs.RecordResponseBody(outputBytes)
 		logAttrs.RecordTraceContext(ctx)
 		logAttrs.RecordRequestBodyContent(requestBodyBytes)
 		logAttrs.RecordResponseBodyContent(rw.body.Bytes())
-		
+
 		if payload.chatID != "" {
 			logAttrs[attr.GenAIConversationIDKey] = payload.chatID
 		}

--- a/server/internal/telemetry/telemetry.go
+++ b/server/internal/telemetry/telemetry.go
@@ -6,6 +6,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
 
+// EventSource identifies the type of event that generated a telemetry log.
+type EventSource string
+
+const (
+	EventSourceToolCall       EventSource = "tool_call"
+	EventSourceChatCompletion EventSource = "chat_completion"
+	EventSourceEvaluation     EventSource = "evaluation"
+	EventSourceResourceRead   EventSource = "resource_read"
+)
+
 // PosthogClient defines the interface for capturing events in PostHog.
 type PosthogClient interface {
 	CaptureEvent(ctx context.Context, eventName string, distinctID string, eventProperties map[string]any) error


### PR DESCRIPTION
## Summary
- Introduces `gram.event.source` attribute (`EventSourceKey`) to identify what type of event generated each telemetry log
- Adds `EventSource` type with constants: `tool_call`, `chat_completion`, `evaluation`, `resource_read`
- Sets the event source at all 5 `CreateLog` call sites (MCP tool call, MCP resource read, chat completion, chat resolution evaluation, direct tool call)
- Removes unused `featuresClient` parameter from `handleResourcesRead`

Closes AGE-1315

## Test plan
- [x] `mise build:server` passes
- [x] `mise lint:server` passes
- [x] `go test ./server/internal/telemetry/...` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
