### PR TITLE
chore: fix atlas ci action pinning

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -280,7 +280,7 @@ jobs:
           fi
 
       - name: Push PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/push@v1.14.1 # 0a618492a098d16d0e1bd7778d6aaa73ba3978b5
+        uses: ariga/atlas-action/migrate/push@418e89b652adbfeecd531cfabbec7c24db17f25c # v1.14.2
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -288,7 +288,7 @@ jobs:
           tag: ${{ steps.tag.outputs.tag }}
 
       - name: Push ClickHouse migrations
-        uses: ariga/atlas-action/migrate/push@v1.14.1 # 0a618492a098d16d0e1bd7778d6aaa73ba3978b5
+        uses: ariga/atlas-action/migrate/push@418e89b652adbfeecd531cfabbec7c24db17f25c # v1.14.2
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse


### PR DESCRIPTION
The atlas actions in GitHub workflow were pinned incorrectly. This change fixes that and ensures lint and push actions point at the same versions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
