### PR TITLE
chore: revert version bump to atlas action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -212,7 +212,7 @@ jobs:
           cloud-token: ${{ secrets.ATLAS_TOKEN }}
 
       - name: Lint PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/lint@v1.13.14
+        uses: ariga/atlas-action/migrate/lint@v1.14.2
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -223,7 +223,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Lint ClickHouse migrations
-        uses: ariga/atlas-action/migrate/lint@v1.13.14
+        uses: ariga/atlas-action/migrate/lint@v1.14.2
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
@@ -280,7 +280,7 @@ jobs:
           fi
 
       - name: Push PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/push@v1.13.14
+        uses: ariga/atlas-action/migrate/push@v1.14.2
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -288,7 +288,7 @@ jobs:
           tag: ${{ steps.tag.outputs.tag }}
 
       - name: Push ClickHouse migrations
-        uses: ariga/atlas-action/migrate/push@v1.13.14
+        uses: ariga/atlas-action/migrate/push@v1.14.2
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse


### PR DESCRIPTION
This change reverts a recent update to atlas action in pr.yaml workflow because it was causing build failures:

```
Run ariga/atlas-action/migrate/push@418e89b652adbfeecd531cfabbec7c24db17f25c
/home/runner/_work/_actions/ariga/atlas-action/418e89b652adbfeecd531cfabbec7c24db17f25c/shim/dist/actions/index.js:27
      throw new Error(`Invalid version: ${version}`);
            ^

Error: Invalid version: 418e89b652adbfeecd531cfabbec7c24db17f25c
    at run (/home/runner/_work/_actions/ariga/atlas-action/418e89b652adbfeecd531cfabbec7c24db17f25c/shim/dist/actions/index.js:27:13)
    at Object.<anonymous> (/home/runner/_work/_actions/ariga/atlas-action/418e89b652adbfeecd531cfabbec7c24db17f25c/migrate/push/index.js:1:35)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Module._load (node:internal/modules/cjs/loader:1091:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
