### PR TITLE
feat: add refresh_token grant support to OAuth proxy

### DIFF
--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -421,6 +421,7 @@ func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) error {
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		CodeVerifier: r.FormValue("code_verifier"),
+		RefreshToken: r.FormValue("refresh_token"),
 	}
 
 	var token *Token
@@ -428,6 +429,8 @@ func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) error {
 	switch req.GrantType {
 	case "authorization_code":
 		token, err = s.tokenService.ExchangeAuthorizationCode(ctx, req, fullMCPURL, toolset.ID)
+	case "refresh_token":
+		token, err = s.tokenService.ExchangeRefreshToken(ctx, req, fullMCPURL, toolset.ID)
 	default:
 		return oops.E(oops.CodeBadRequest, nil, "unsupported grant type: %s", req.GrantType).Log(ctx, s.logger)
 	}

--- a/server/internal/oauth/storage.go
+++ b/server/internal/oauth/storage.go
@@ -53,6 +53,7 @@ var _ cache.CacheableObject[Token] = (*Token)(nil)
 type Token struct {
 	ToolsetID       uuid.UUID        `json:"-"`
 	AccessToken     string           `json:"access_token"`
+	RefreshToken    string           `json:"-"`
 	TokenType       string           `json:"token_type"`
 	Scope           string           `json:"scope,omitempty"`
 	CreatedAt       time.Time        `json:"created_at"`
@@ -64,11 +65,18 @@ func TokenCacheKey(toolsetID uuid.UUID, token string) string {
 	return "oauthToken:" + toolsetID.String() + ":" + token
 }
 
+func RefreshTokenCacheKey(toolsetID uuid.UUID, refreshTokenHash string) string {
+	return "oauthRefreshToken:" + toolsetID.String() + ":" + refreshTokenHash
+}
+
 func (t Token) CacheKey() string {
 	return TokenCacheKey(t.ToolsetID, t.AccessToken)
 }
 
 func (t Token) AdditionalCacheKeys() []string {
+	if t.RefreshToken != "" {
+		return []string{RefreshTokenCacheKey(t.ToolsetID, t.RefreshToken)}
+	}
 	return []string{}
 }
 

--- a/server/internal/oauth/token_service.go
+++ b/server/internal/oauth/token_service.go
@@ -69,10 +69,16 @@ func (ts *TokenService) ExchangeAuthorizationCode(ctx context.Context, req *Toke
 		return nil, fmt.Errorf("failed to generate access token: %w", err)
 	}
 
+	refreshToken, err := ts.generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate refresh token: %w", err)
+	}
+
 	// Create token response
 	token := &Token{
 		ToolsetID:       toolsetId,
 		AccessToken:     accessToken,
+		RefreshToken:    refreshToken,
 		TokenType:       "Bearer",
 		Scope:           grant.Scope,
 		ExternalSecrets: grant.ExternalSecrets,
@@ -85,6 +91,80 @@ func (ts *TokenService) ExchangeAuthorizationCode(ctx context.Context, req *Toke
 	}
 
 	return token, nil
+}
+
+// ExchangeRefreshToken exchanges a refresh token for a new access/refresh token pair (rotation).
+func (ts *TokenService) ExchangeRefreshToken(ctx context.Context, req *TokenRequest, mcpURL string, toolsetID uuid.UUID) (*Token, error) {
+	if req.ClientID == "" {
+		return nil, fmt.Errorf("client_id is required")
+	}
+	if req.RefreshToken == "" {
+		return nil, fmt.Errorf("refresh_token is required")
+	}
+
+	_, err := ts.clientRegistration.ValidateClientCredentials(ctx, mcpURL, req.ClientID, req.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("invalid client credentials: %w", err)
+	}
+
+	// Look up existing token by refresh token hash
+	refreshHash := sha256.Sum256([]byte(req.RefreshToken))
+	refreshTokenHash := base64.RawURLEncoding.EncodeToString(refreshHash[:])
+	oldToken, err := ts.tokenStorage.Get(ctx, RefreshTokenCacheKey(toolsetID, refreshTokenHash))
+	if err != nil {
+		return nil, fmt.Errorf("invalid refresh token: %w", err)
+	}
+
+	// Check if the token has expired
+	if time.Now().After(oldToken.ExpiresAt) {
+		return nil, fmt.Errorf("refresh token has expired")
+	}
+
+	// Decrypt external secrets and check expiration
+	for i, externalSecret := range oldToken.ExternalSecrets {
+		decrypted, err := ts.enc.Decrypt(externalSecret.Token)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt token secret: %w", err)
+		}
+		oldToken.ExternalSecrets[i].Token = decrypted
+		if externalSecret.ExpiresAt != nil && externalSecret.ExpiresAt.Before(time.Now()) {
+			return nil, fmt.Errorf("underlying credentials have expired")
+		}
+	}
+
+	// Delete old token (removes both access + refresh cache keys).
+	// The retrieved token already has hashed AccessToken and RefreshToken from storage,
+	// so CacheKey() and AdditionalCacheKeys() compute the correct keys.
+	if err := ts.deleteToken(ctx, oldToken); err != nil {
+		ts.logger.ErrorContext(ctx, "failed to delete old token during refresh", attr.SlogError(err))
+	}
+
+	// Generate new access token + new refresh token (rotation)
+	newAccessToken, err := ts.generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate access token: %w", err)
+	}
+	newRefreshToken, err := ts.generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate refresh token: %w", err)
+	}
+
+	newToken := &Token{
+		ToolsetID:       toolsetID,
+		AccessToken:     newAccessToken,
+		RefreshToken:    newRefreshToken,
+		TokenType:       "Bearer",
+		Scope:           oldToken.Scope,
+		ExternalSecrets: oldToken.ExternalSecrets,
+		CreatedAt:       time.Now(),
+		ExpiresAt:       time.Now().Add(ts.accessTokenExpiration),
+	}
+
+	if err := ts.storeToken(ctx, *newToken); err != nil {
+		return nil, fmt.Errorf("failed to store new token: %w", err)
+	}
+
+	return newToken, nil
 }
 
 var (
@@ -156,10 +236,11 @@ func (ts *TokenService) CreateTokenResponse(token *Token) *TokenResponse {
 	expiresIn := max(int(time.Until(token.ExpiresAt).Seconds()), 0)
 
 	return &TokenResponse{
-		AccessToken: token.AccessToken,
-		TokenType:   token.TokenType,
-		ExpiresIn:   expiresIn,
-		Scope:       token.Scope,
+		AccessToken:  token.AccessToken,
+		TokenType:    token.TokenType,
+		ExpiresIn:    expiresIn,
+		Scope:        token.Scope,
+		RefreshToken: token.RefreshToken,
 	}
 }
 
@@ -198,6 +279,12 @@ func (ts *TokenService) storeToken(ctx context.Context, token Token) error {
 	// hash access token on storage
 	hash := sha256.Sum256([]byte(token.AccessToken))
 	token.AccessToken = base64.RawURLEncoding.EncodeToString(hash[:])
+
+	// hash refresh token on storage
+	if token.RefreshToken != "" {
+		refreshHash := sha256.Sum256([]byte(token.RefreshToken))
+		token.RefreshToken = base64.RawURLEncoding.EncodeToString(refreshHash[:])
+	}
 
 	if err := ts.tokenStorage.Store(ctx, token); err != nil {
 		return fmt.Errorf("failed to store token: %w", err)

--- a/server/internal/oauth/types.go
+++ b/server/internal/oauth/types.go
@@ -41,13 +41,15 @@ type TokenRequest struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	CodeVerifier string `json:"code_verifier"`
+	RefreshToken string `json:"refresh_token"`
 }
 
 type TokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
-	Scope       string `json:"scope,omitempty"`
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
 // OAuthProxyProviderType represents the type of OAuth provider.

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -88,7 +88,7 @@ func ResolveOAuthServerMetadataFromToolset(
 				TokenEndpoint:                 baseURL + "/oauth/" + mcpSlug + "/token",
 				RegistrationEndpoint:          baseURL + "/oauth/" + mcpSlug + "/register",
 				ResponseTypesSupported:        []string{"code"},
-				GrantTypesSupported:           []string{"authorization_code"},
+				GrantTypesSupported:           []string{"authorization_code", "refresh_token"},
 				CodeChallengeMethodsSupported: []string{"plain", "S256"},
 			},
 			Raw:      nil,


### PR DESCRIPTION
## Summary
- Adds `refresh_token` grant type to the OAuth proxy token endpoint (`/oauth/{mcpSlug}/token`)
- MCP clients can exchange a refresh token for a new access/refresh token pair (token rotation)
- Updates well-known metadata to advertise `refresh_token` grant support alongside `authorization_code`

Fixes [AGE-1402](https://linear.app/speakeasy/issue/AGE-1402/bug-external-oauth-mcp-servers-log-users-out-no-token-refresh)

## Changes
- **token_service.go**: Generate refresh tokens in `ExchangeAuthorizationCode`, add `ExchangeRefreshToken` method with full token rotation (old token deleted, new pair issued)
- **storage.go**: Add `RefreshToken` field to `Token` struct, `RefreshTokenCacheKey` helper, `AdditionalCacheKeys` returns refresh token key for dual-key lookup
- **types.go**: Add `RefreshToken` to `TokenRequest` and `TokenResponse`
- **impl.go**: Extract `refresh_token` from form values, add `case "refresh_token"` to `handleToken`
- **wellknown.go**: Advertise `["authorization_code", "refresh_token"]` in `GrantTypesSupported`

## Test plan
- [ ] Existing tests pass
- [ ] Exchange an auth code → response includes `refresh_token`
- [ ] `POST grant_type=refresh_token&refresh_token=...&client_id=...` returns new token pair
- [ ] Old refresh token is invalidated after use (rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
