### PR TITLE
chore: reorder clickhouse migrations to be linear

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260226021049_exclude-uuid-urns-from-trace-summaries-mv.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260226021049_exclude-uuid-urns-from-trace-summaries-mv.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create "trace_summaries_mv" view
+DROP VIEW `trace_summaries_mv`;
+-- reverse: drop "trace_summaries_mv" view
+CREATE MATERIALIZED VIEW `trace_summaries_mv` TO `trace_summaries` AS SELECT trace_id, gram_project_id, any(gram_deployment_id) AS gram_deployment_id, any(gram_function_id) AS gram_function_id, any(gram_urn) AS gram_urn, min(time_unix_nano) AS start_time_unix_nano, toUInt64(count(*)) AS log_count, anyIfState(toInt32OrNull(toString(attributes.http.response.status_code)), toString(attributes.http.response.status_code) != '') AS http_status_code FROM telemetry_logs WHERE (trace_id IS NOT NULL) AND (trace_id != '') GROUP BY trace_id, gram_project_id;

--- a/server/clickhouse/local/golang_migrate/20260226021049_exclude-uuid-urns-from-trace-summaries-mv.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260226021049_exclude-uuid-urns-from-trace-summaries-mv.up.sql
@@ -1,0 +1,4 @@
+-- drop "trace_summaries_mv" view
+DROP VIEW `trace_summaries_mv`;
+-- create "trace_summaries_mv" view
+CREATE MATERIALIZED VIEW `trace_summaries_mv` TO `trace_summaries` AS SELECT trace_id, gram_project_id, any(gram_deployment_id) AS gram_deployment_id, any(gram_function_id) AS gram_function_id, any(gram_urn) AS gram_urn, min(time_unix_nano) AS start_time_unix_nano, toUInt64(count(*)) AS log_count, anyIfState(toInt32OrNull(toString(attributes.http.response.status_code)), toString(attributes.http.response.status_code) != '') AS http_status_code FROM telemetry_logs WHERE (trace_id IS NOT NULL) AND (trace_id != '') AND (NOT startsWith(telemetry_logs.gram_urn, 'urn:uuid:')) GROUP BY trace_id, gram_project_id;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:RiTOc1IT2dF/39rrLcvyFR1KLzFKwKbv7ZIENL2UWqY=
+h1:DQXf78IEmYUXBwHOcEyCWyJfYqZQJ0Zj3hPUqq3wGi8=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -20,3 +20,4 @@ h1:RiTOc1IT2dF/39rrLcvyFR1KLzFKwKbv7ZIENL2UWqY=
 20260218153315_drop-http-requests-raw-table.up.sql h1:MocFAXxujpVVe5sD+Zukvt/uViG/3O4EoKve2h9BT7M=
 20260224141502_drop-telemetry-tool-logs-indices.up.sql h1:OyRD8E6Fqzq2qvf2qI8xD9L6H+f6a9DnEf3WD10IG28=
 20260224141534_drop-telemetry-tool-logs-table.up.sql h1:Ha55865WR8eewciESJitB5VZcEjZTdI+xip68t4OsB4=
+20260226021049_exclude-uuid-urns-from-trace-summaries-mv.up.sql h1:csrm4iWyxmLe9mJEZP965zGkmaq2Ub9mwLdX7gGTpMg=

--- a/server/clickhouse/migrations/20260226021045_exclude-uuid-urns-from-trace-summaries-mv.sql
+++ b/server/clickhouse/migrations/20260226021045_exclude-uuid-urns-from-trace-summaries-mv.sql
@@ -1,5 +1,4 @@
--- Recreate trace_summaries_mv to exclude chat completion logs (urn:uuid:...) at insert time.
--- This prevents the non-deterministic any(gram_urn) from picking a urn:uuid: value
--- for traces that also contain tool call logs.
-DROP VIEW IF EXISTS trace_summaries_mv;
+-- Drop "trace_summaries_mv" view
+DROP VIEW `trace_summaries_mv`;
+-- Create "trace_summaries_mv" view
 CREATE MATERIALIZED VIEW `trace_summaries_mv` TO `trace_summaries` AS SELECT trace_id, gram_project_id, any(gram_deployment_id) AS gram_deployment_id, any(gram_function_id) AS gram_function_id, any(gram_urn) AS gram_urn, min(time_unix_nano) AS start_time_unix_nano, toUInt64(count(*)) AS log_count, anyIfState(toInt32OrNull(toString(attributes.http.response.status_code)), toString(attributes.http.response.status_code) != '') AS http_status_code FROM telemetry_logs WHERE (trace_id IS NOT NULL) AND (trace_id != '') AND (NOT startsWith(telemetry_logs.gram_urn, 'urn:uuid:')) GROUP BY trace_id, gram_project_id;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vfr8PAGdzSGw7gTxjS1F3Qmr83ouSsDmUkHNNPs8nyk=
+h1:TuyC6Wvu8439RTzHcoR6ISmwYM+ptYPRgM6SnS92DHI=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -23,6 +23,6 @@ h1:vfr8PAGdzSGw7gTxjS1F3Qmr83ouSsDmUkHNNPs8nyk=
 20260212181036_add-metrics-summaries-mv.sql h1:/+UesqwZ8s2mU9PcweEapcCyHMz8BgQwq6BU5D0BIwc=
 20260218145823_drop-http-requests-indices.sql h1:uBjSJXWXv/JlKSpNhpZ/16JCIB5g6Z2h3oAV3byoQng=
 20260218153311_drop-http-requests-raw-table.sql h1:9QBbHi9mALdsTkvwDq4zNdSREbkJKdeqp00yEGYDPtk=
-20260222230000_exclude-uuid-urns-from-trace-summaries-mv.sql h1:l4hOs5whg6aJv2hy82rJwpL0zKLBJLguiBssjnbhSl0=
-20260224141459_drop-telemetry-tool-logs-indices.sql h1:eBBxi6CrvqFtYcwn1f6Ng2zCILGRqCW6dxy7q6q202Y=
-20260224141530_drop-telemetry-tool-logs-table.sql h1:1pBAxx62LYUNWBQbRbaB4m96cVByjpzcRZRYL4ONG+Y=
+20260224141459_drop-telemetry-tool-logs-indices.sql h1:N7awTLVuFQEU/C2Pis3SFkuM1lie1oc7Fvqp7nTOLDg=
+20260224141530_drop-telemetry-tool-logs-table.sql h1:5W+Oag/bm1vdl9YUHm/gAoIuWaUB4RoeN/UAJpfNQi8=
+20260226021045_exclude-uuid-urns-from-trace-summaries-mv.sql h1:5Cg0Wd/3f5hKtvjV7wB/itsDP07LPzjQzxOGRa36jKo=


### PR DESCRIPTION
https://github.com/speakeasy-api/gram/commit/3cae542655070ecab9b5a725e6afd15196d14182#diff-a4bdebf319fbb13401eed381c1f32a4ae3d025adc2690182bec771c1bcb7af1e

Recent merge suffered from migration race conditions. This commit reorders clickhouse migrations such that this migration will occur last and migrations will succeed.

There is _some_ risk as the previous version seems to have been modified from the auto-generated version. But careful analysis indicates the only differences are a missing comment and a missing `IF EXISTS` clause. Possible the `IF EXISTS` clause just there for some local database surgery reasons because state in my local database and clickhouse cloud databases suggest this should succeed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
