### PR TITLE
chore: update git:workinit to try pnpm offline install

### DIFF
--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -36,7 +36,10 @@ for item in "${copy_from_main[@]}"; do
 done
 
 mise trust
-mise run install:pnpm
+if ! mise run install:pnpm --offline; then
+  echo "Offline install failed, falling back to online install..."
+  mise run install:pnpm
+fi
 
 suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 compose_project="gram-infra-${suffix}"

--- a/.mise-tasks/install/pnpm.sh
+++ b/.mise-tasks/install/pnpm.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
+
 #MISE description="Install NPM dependencies"
 #MISE hide=true
 
+#USAGE flag "--offline" help="Install using only the local cache"
+
 set -e
-exec pnpm i
+
+args=()
+if [[ "${usage_offline:-}" == "true" ]]; then
+  args+=(--offline)
+fi
+
+exec pnpm i "${args[@]}"


### PR DESCRIPTION
Try `pnpm install --offline` first to speed up worktree initialization when dependencies are already cached. Falls back to a regular online install if the offline attempt fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
