### PR TITLE
fix: move overflow-y scroll to wrapper div for API keys table

### DIFF
--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -320,36 +320,37 @@ export default function Settings() {
             className="w-64"
           />
         </Stack>
-        <Table
-          columns={apiKeyColumns}
-          data={filteredKeys}
-          rowKey={(row) => row.id}
-          className="max-h-[500px] overflow-y-auto"
-          noResultsMessage={
-            <Stack
-              gap={2}
-              className="h-full p-4 bg-background"
-              align="center"
-              justify="center"
-            >
-              <Type variant="body">
-                {apiKeySearch ? "No matching API keys" : "No API keys yet"}
-              </Type>
-              {!apiKeySearch && (
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => setIsCreateDialogOpen(true)}
-                >
-                  <Button.LeftIcon>
-                    <Icon name="key-round" className="h-4 w-4" />
-                  </Button.LeftIcon>
-                  <Button.Text>Create Key</Button.Text>
-                </Button>
-              )}
-            </Stack>
-          }
-        />
+        <div className="max-h-[500px] overflow-y-auto rounded-lg border border-border">
+          <Table
+            columns={apiKeyColumns}
+            data={filteredKeys}
+            rowKey={(row) => row.id}
+            noResultsMessage={
+              <Stack
+                gap={2}
+                className="h-full p-4 bg-background"
+                align="center"
+                justify="center"
+              >
+                <Type variant="body">
+                  {apiKeySearch ? "No matching API keys" : "No API keys yet"}
+                </Type>
+                {!apiKeySearch && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setIsCreateDialogOpen(true)}
+                  >
+                    <Button.LeftIcon>
+                      <Icon name="key-round" className="h-4 w-4" />
+                    </Button.LeftIcon>
+                    <Button.Text>Create Key</Button.Text>
+                  </Button>
+                )}
+              </Stack>
+            }
+          />
+        </div>
 
         <Dialog
           open={isCreateDialogOpen}


### PR DESCRIPTION
## Summary
- Moved `max-h-[500px] overflow-y-auto` from the `<Table>` className to a wrapper `<div>` so vertical scrolling actually works for orgs with many API keys
- CSS `overflow` is ignored on `<table>` elements, so the previous approach never enabled scrolling

## Test plan
- [ ] Navigate to Settings page with an org that has many API keys
- [ ] Verify the table scrolls vertically when keys exceed the 500px max height
- [ ] Verify the search bar still filters keys by name
- [ ] Verify the table displays correctly with few/no keys

Closes AGE-1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
