### PR TITLE
mig: add webmcp_enabled column to mcp_metadata

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1017,6 +1017,7 @@ CREATE TABLE IF NOT EXISTS mcp_metadata (
   header_display_names JSONB NOT NULL DEFAULT '{}'::JSONB, -- DEPRECATED: use mcp_environment_configs table instead
   default_environment_id UUID, -- Informs mcp_environment_configs which environment to load from by default
   installation_override_url TEXT, -- URL to redirect to instead of the default installation page
+  webmcp_enabled BOOLEAN NOT NULL DEFAULT false, -- Whether to register tools with the WebMCP browser API on the install page
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -452,6 +452,7 @@ type McpMetadatum struct {
 	HeaderDisplayNames        []byte
 	DefaultEnvironmentID      uuid.NullUUID
 	InstallationOverrideUrl   pgtype.Text
+	WebmcpEnabled             bool
 	CreatedAt                 pgtype.Timestamptz
 	UpdatedAt                 pgtype.Timestamptz
 }

--- a/server/migrations/20260225000001_add_webmcp_enabled.sql
+++ b/server/migrations/20260225000001_add_webmcp_enabled.sql
@@ -1,0 +1,4 @@
+-- Add webmcp_enabled column to mcp_metadata table.
+-- When enabled, the install page injects a WebMCP script that registers
+-- tools with navigator.modelContext for browsing agent discovery.
+ALTER TABLE mcp_metadata ADD COLUMN webmcp_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GptIDIRsk/M6xg9xV4w3BS1uEQXvJHzDH1WYIctfOAg=
+h1:WeCs0tEvT8xLClOn9n8C7HNZH7BcB5RKoOCsWye05UA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -106,3 +106,4 @@ h1:GptIDIRsk/M6xg9xV4w3BS1uEQXvJHzDH1WYIctfOAg=
 20260205195200_tools-add-annotations-column.sql h1:ENgMYtaQrroMmVLTiyG2UubPcc+1aY9PodrXIz1Ajow=
 20260210042235_add-annotations-to-external-mcp-tools.sql h1:hYxDhF69ey4vm3pW2+niUmPI3nL/BjaCiA+sER2T3BA=
 20260218000001_oauth-proxy-server-audience.sql h1:2bnirfFCHHKh3gtEOigHlT1bPYORon/j4FyjAejgeUI=
+20260225000001_add_webmcp_enabled.sql h1:HucZNFB6bHroau2oNvVeVmtdfmprXxWeCOZFNYPbK/g=


### PR DESCRIPTION
## Summary

- Adds `webmcp_enabled BOOLEAN NOT NULL DEFAULT false` column to `mcp_metadata` table
- Backwards-compatible: existing rows default to `false`, no code changes required

## Test plan

- [x] `mise db:hash` regenerates atlas.sum cleanly
- [x] Migration lint passes (Atlas)
- [ ] Staging: verify migration applies without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
