### PR TITLE
feat: copy .mise-tasks/local into new git worktrees

### DIFF
--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -28,6 +28,7 @@ copy_from_main=(
   ./.vscode
   ./.cursor
   ./.claude
+  ./.mise-tasks
 )
 
 for item in "${copy_from_main[@]}"; do


### PR DESCRIPTION
## Summary
- Adds `.mise-tasks/local` to the list of paths copied from main when running `git:workinit`, so local mise tasks are available in new worktrees.

## Test plan
- [ ] Run `mise git:workinit` and verify `.mise-tasks/local` is copied into the new worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
