### PR TITLE
chore: add hk hook for running speakeasy generator

### DIFF
--- a/.mise-tasks/gen/sdk.sh
+++ b/.mise-tasks/gen/sdk.sh
@@ -1,5 +1,37 @@
 #!/usr/bin/env bash
+
 #MISE description="Generate SDK from OpenAPI spec"
 
+#USAGE flag "-c --check" help="Check if the Gram-Internal OpenAPI output is up-to-date"
+
 set -e
-exec speakeasy run
+
+generate() {
+  speakeasy run
+}
+
+check_inputs() {
+  workflow=".speakeasy/workflow.yaml"
+  source_key=".sources.Gram-Internal"
+  schema=$(yq "${source_key}.inputs[0].location" "$workflow")
+  output=$(yq "${source_key}.output" "$workflow")
+  readarray -t overlays < <(yq -r "${source_key}.overlays[].location" "$workflow")
+
+  args=(--schema "$schema")
+  for overlay in "${overlays[@]}"; do
+    args+=(--overlay "$overlay")
+  done
+  result=$(speakeasy overlay apply "${args[@]}")
+
+  if ! diff -q <(echo "$result") "$output" >/dev/null 2>&1; then
+    echo "Gram-Internal OpenAPI spec is out of date. Run 'mise gen:sdk' to regenerate." >&2
+    exit 1
+  fi
+  echo "Gram-Internal OpenAPI spec is up to date."
+}
+
+if [[ "${usage_check:-}" == "true" ]]; then
+  check_inputs
+else
+  generate
+fi

--- a/hk.pkl
+++ b/hk.pkl
@@ -21,6 +21,11 @@ local linters = new Mapping<String, Step> {
     glob = "**/*.go"
     fix = "mise run -q go:fix {{files}}"
   }
+  ["speakeasy"] {
+    glob = List("overlays/**/*.yaml", "server/gen/http/openapi3.yaml")
+    check = "mise run -q gen:sdk --check"
+    fix = "mise run -q gen:sdk"
+  }
 }
 
 hooks {


### PR DESCRIPTION
This change updates hk configuration to add a hook for generating the Gram internal SDK if its inputs have changed. This helps developers avoid forgetting to regenerate the SDK after making changes to the Goa design files or overlay files.

We implemented a faster check mode to the `gen:sdk` task as part of this change that is invoked with `mise run gen:sdk --check`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
