### PR TITLE
mig: add slack_apps and slack_app_toolsets tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -885,6 +885,47 @@ CREATE TABLE IF NOT EXISTS slack_app_connections (
   CONSTRAINT slack_auth_connections_organization_id_project_id_key UNIQUE (organization_id, project_id)
 );
 
+CREATE TABLE IF NOT EXISTS slack_apps (
+  -- Column order optimized for alignment (PG110)
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  slack_team_name TEXT,
+  slack_bot_user_id TEXT,
+  slack_client_secret TEXT,
+  slack_signing_secret TEXT,
+  slack_team_id TEXT,
+  organization_id TEXT NOT NULL,
+  slack_bot_token TEXT,
+  slack_client_id TEXT,
+  system_prompt TEXT,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'unconfigured',
+  icon_asset_id uuid,
+  project_id uuid NOT NULL,
+  id uuid PRIMARY KEY DEFAULT generate_uuidv7(),
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT slack_apps_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS slack_apps_project_name_key
+  ON slack_apps (project_id, name) WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS slack_apps_slack_team_id_key
+  ON slack_apps (slack_team_id) WHERE deleted IS FALSE AND slack_team_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS slack_app_toolsets (
+  id uuid PRIMARY KEY DEFAULT generate_uuidv7(),
+  slack_app_id uuid NOT NULL,
+  toolset_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT slack_app_toolsets_slack_app_id_fkey FOREIGN KEY (slack_app_id) REFERENCES slack_apps (id) ON DELETE CASCADE,
+  CONSTRAINT slack_app_toolsets_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE CASCADE,
+  CONSTRAINT slack_app_toolsets_slack_app_id_toolset_id_key UNIQUE (slack_app_id, toolset_id)
+);
+
 CREATE TABLE IF NOT EXISTS tool_variations_groups (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -643,6 +643,27 @@ type PromptTemplate struct {
 	Deleted       bool
 }
 
+type SlackApp struct {
+	CreatedAt          pgtype.Timestamptz
+	DeletedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
+	SlackTeamName      pgtype.Text
+	SlackBotUserID     pgtype.Text
+	SlackClientSecret  pgtype.Text
+	SlackSigningSecret pgtype.Text
+	SlackTeamID        pgtype.Text
+	OrganizationID     string
+	SlackBotToken      pgtype.Text
+	SlackClientID      pgtype.Text
+	SystemPrompt       pgtype.Text
+	Name               string
+	Status             string
+	IconAssetID        uuid.NullUUID
+	ProjectID          uuid.UUID
+	ID                 uuid.UUID
+	Deleted            bool
+}
+
 type SlackAppConnection struct {
 	SlackTeamID        string
 	OrganizationID     string
@@ -652,6 +673,13 @@ type SlackAppConnection struct {
 	DefaultToolsetSlug pgtype.Text
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
+}
+
+type SlackAppToolset struct {
+	ID         uuid.UUID
+	SlackAppID uuid.UUID
+	ToolsetID  uuid.UUID
+	CreatedAt  pgtype.Timestamptz
 }
 
 type SourceEnvironment struct {

--- a/server/migrations/20260227224912_add-slack-apps-tables.sql
+++ b/server/migrations/20260227224912_add-slack-apps-tables.sql
@@ -1,0 +1,38 @@
+-- Create "slack_apps" table
+CREATE TABLE "slack_apps" (
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "slack_team_name" text NULL,
+  "slack_bot_user_id" text NULL,
+  "slack_client_secret" text NULL,
+  "slack_signing_secret" text NULL,
+  "slack_team_id" text NULL,
+  "organization_id" text NOT NULL,
+  "slack_bot_token" text NULL,
+  "slack_client_id" text NULL,
+  "system_prompt" text NULL,
+  "name" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'unconfigured',
+  "icon_asset_id" uuid NULL,
+  "project_id" uuid NOT NULL,
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "slack_apps_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "slack_apps_project_name_key" to table: "slack_apps"
+CREATE UNIQUE INDEX "slack_apps_project_name_key" ON "slack_apps" ("project_id", "name") WHERE (deleted IS FALSE);
+-- Create index "slack_apps_slack_team_id_key" to table: "slack_apps"
+CREATE UNIQUE INDEX "slack_apps_slack_team_id_key" ON "slack_apps" ("slack_team_id") WHERE ((deleted IS FALSE) AND (slack_team_id IS NOT NULL));
+-- Create "slack_app_toolsets" table
+CREATE TABLE "slack_app_toolsets" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "slack_app_id" uuid NOT NULL,
+  "toolset_id" uuid NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "slack_app_toolsets_slack_app_id_toolset_id_key" UNIQUE ("slack_app_id", "toolset_id"),
+  CONSTRAINT "slack_app_toolsets_slack_app_id_fkey" FOREIGN KEY ("slack_app_id") REFERENCES "slack_apps" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "slack_app_toolsets_toolset_id_fkey" FOREIGN KEY ("toolset_id") REFERENCES "toolsets" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fXNPaTtjytfiPx+3PRp+4PG4miZAZsMZ/Lgp3ENuyB8=
+h1:bG9gTfVWEJ7s203zzs1MfAHyAK2eFTnWCNpldUCYhDI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -107,3 +107,4 @@ h1:fXNPaTtjytfiPx+3PRp+4PG4miZAZsMZ/Lgp3ENuyB8=
 20260210042235_add-annotations-to-external-mcp-tools.sql h1:hYxDhF69ey4vm3pW2+niUmPI3nL/BjaCiA+sER2T3BA=
 20260218000001_oauth-proxy-server-audience.sql h1:2bnirfFCHHKh3gtEOigHlT1bPYORon/j4FyjAejgeUI=
 20260227194055_add-workos-identity-fields.sql h1:f9mTAnu8rIlwzGGhxu2+r2Pnngh4IbxBQrn9tBcsugc=
+20260227224912_add-slack-apps-tables.sql h1:7gBj1mNj0I2mqDoqG55pi1HnAyloA9kMoF5fOdJ6F08=


### PR DESCRIPTION
## Summary
- Adds `slack_apps` table for dynamic Slack app management with per-app credentials, system prompt, icon, and two-state lifecycle (unconfigured/active)
- Adds `slack_app_toolsets` join table linking Slack apps to toolsets
- Column order optimized for PostgreSQL alignment (PG110)

## Test plan
- [ ] Migration applies cleanly against production schema
- [ ] `mise db:diff` produces empty diff after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
