### PR TITLE
chore(ci): re-tag functions runner images on PRs without functions changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -936,6 +936,13 @@ jobs:
         if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login == 'dependabot[bot]' }}
         run: echo "No functions changes detected — skipping functions-image (${{ matrix.runtime }})."
 
+      - name: Generate preview tag
+        id: preview
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+        run: |
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-8)
+          echo "tag=pr-${{ github.event.pull_request.number }}-${SHORT_SHA}" >> $GITHUB_OUTPUT
+
       # --- Re-tag path: no functions changes, tag existing main image with PR tags (DEV only) ---
 
       - name: Checkout (re-tag)
@@ -988,7 +995,7 @@ jobs:
           tags: |
             type=ref,event=branch,prefix=,suffix=-${{ matrix.runtime }}
             type=ref,event=tag,prefix=,suffix=-${{ matrix.runtime }}
-            type=ref,event=pr,suffix=-${{ matrix.runtime }}
+            type=raw,value=${{ steps.preview.outputs.tag }},suffix=-${{ matrix.runtime }}
             type=schedule,pattern=nightly,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,format=long,prefix=,suffix=-${{ matrix.runtime }}
@@ -1117,7 +1124,7 @@ jobs:
           tags: |
             type=ref,event=branch,prefix=,suffix=-${{ matrix.runtime }}
             type=ref,event=tag,prefix=,suffix=-${{ matrix.runtime }}
-            type=ref,event=pr,suffix=-${{ matrix.runtime }}
+            type=raw,value=${{ steps.preview.outputs.tag }},suffix=-${{ matrix.runtime }}
             type=schedule,pattern=nightly,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,format=long,prefix=,suffix=-${{ matrix.runtime }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -932,9 +932,86 @@ jobs:
           - runtime: nodejs24
             apko-config: ./images/nodejs24-alpine3.23.yaml
     steps:
-      - name: Skip if no functions changes exist
-        if: ${{ needs.changes.outputs.functions != 'true' }}
+      - name: Skip if no functions changes exist (dependabot)
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login == 'dependabot[bot]' }}
         run: echo "No functions changes detected — skipping functions-image (${{ matrix.runtime }})."
+
+      # --- Re-tag path: no functions changes, tag existing main image with PR tags (DEV only) ---
+
+      - name: Checkout (re-tag)
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Find source SHA from main
+        id: source
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        run: |
+          SOURCE_SHA=$(git merge-base HEAD origin/main)
+          echo "sha_short=${SOURCE_SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "sha_long=$SOURCE_SHA" >> $GITHUB_OUTPUT
+          echo "Source SHA: $SOURCE_SHA (short: ${SOURCE_SHA:0:7})"
+
+      - name: Setup Mise (re-tag)
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Install dependencies (re-tag)
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: "[DEV] Create fly app (re-tag)"
+        id: flyCreateDevRetag
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        shell: bash
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+          FLY_IMAGE: ${{ vars.FLY_IMAGE_DEV }}
+        run: |
+          mise run fly:init-runner \
+            --org ${{ secrets.FLY_ORG_DEV }} \
+            --image $FLY_IMAGE \
+            --force
+
+      - name: Extract Docker metadata (re-tag)
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        id: metaRetag
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: |
+            ${{ steps.flyCreateDevRetag.outputs.flyAppRegistry }}
+          tags: |
+            type=ref,event=branch,prefix=,suffix=-${{ matrix.runtime }}
+            type=ref,event=tag,prefix=,suffix=-${{ matrix.runtime }}
+            type=schedule,pattern=nightly,prefix=,suffix=-${{ matrix.runtime }}
+            type=sha,prefix=,suffix=-${{ matrix.runtime }}
+            type=sha,format=long,prefix=,suffix=-${{ matrix.runtime }}
+
+      - name: "Pull, re-tag, and push (DEV)"
+        if: ${{ needs.changes.outputs.functions != 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+        run: |
+          set -x
+          fly auth docker
+
+          SOURCE_IMAGE="${{ steps.flyCreateDevRetag.outputs.flyAppRegistry }}:sha-${{ steps.source.outputs.sha_short }}-${{ matrix.runtime }}"
+          echo "Pulling source image: $SOURCE_IMAGE"
+          docker pull "$SOURCE_IMAGE"
+
+          TAGS="${{ steps.metaRetag.outputs.tags }}"
+          for TAG in $TAGS; do
+            docker tag "$SOURCE_IMAGE" "$TAG"
+          done
+
+          docker push --all-tags "${{ steps.flyCreateDevRetag.outputs.flyAppRegistry }}"
+
+      # --- Full build path: functions changes detected ---
 
       - name: Checkout
         if: ${{ needs.changes.outputs.functions == 'true' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1000,7 +1000,7 @@ jobs:
           set -x
           fly auth docker
 
-          SOURCE_IMAGE="${{ steps.flyCreateDevRetag.outputs.flyAppRegistry }}:sha-${{ steps.source.outputs.sha_short }}-${{ matrix.runtime }}"
+          SOURCE_IMAGE="${{ steps.flyCreateDevRetag.outputs.flyAppRegistry }}:${{ steps.source.outputs.sha_short }}-${{ matrix.runtime }}"
           echo "Pulling source image: $SOURCE_IMAGE"
           docker pull "$SOURCE_IMAGE"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -988,6 +988,7 @@ jobs:
           tags: |
             type=ref,event=branch,prefix=,suffix=-${{ matrix.runtime }}
             type=ref,event=tag,prefix=,suffix=-${{ matrix.runtime }}
+            type=ref,event=pr,suffix=-${{ matrix.runtime }}
             type=schedule,pattern=nightly,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,format=long,prefix=,suffix=-${{ matrix.runtime }}
@@ -1116,6 +1117,7 @@ jobs:
           tags: |
             type=ref,event=branch,prefix=,suffix=-${{ matrix.runtime }}
             type=ref,event=tag,prefix=,suffix=-${{ matrix.runtime }}
+            type=ref,event=pr,suffix=-${{ matrix.runtime }}
             type=schedule,pattern=nightly,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,format=long,prefix=,suffix=-${{ matrix.runtime }}


### PR DESCRIPTION
## Summary

- When a PR has no changes to the `functions/` directory, the `functions-image` job currently no-ops entirely
- This change adds a "re-tag" path that pulls the image from the merge-base SHA on `main` and re-tags it with the PR's SHA-based image tags
- Only the **DEV** registry is tagged (not PROD)
- Dependabot PRs still skip entirely

### How it works

1. Checkout with full history, find `git merge-base HEAD origin/main`
2. Call `fly:init-runner` (idempotent) to ensure the DEV registry app exists
3. `docker pull` the source image using the merge-base's short SHA tag
4. Re-tag with the PR's metadata tags (branch, SHA, etc.)
5. `docker push --all-tags` to the DEV Fly registry

We could consider re-implementing this before merge using [`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_copy.md) for efficiency (copies manifests directly without pulling layers), but at the cost of another build dependency.

## Test plan

- [ ] Open a PR that does **not** touch `functions/` and verify the re-tag path runs successfully
- [ ] Verify the tagged images appear in the DEV Fly registry
- [ ] Open a PR that **does** touch `functions/` and verify the full build path still works
- [ ] Verify dependabot PRs still skip the job entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
