### PR TITLE
feat(cli): prevent opening default browser after push

### DIFF
--- a/cli/internal/app/push.go
+++ b/cli/internal/app/push.go
@@ -239,6 +239,11 @@ NOTE: Names and slugs must be unique across all sources.`[1:],
 				Usage: "Skip polling for deployment completion and return immediately",
 				Value: false,
 			},
+			&cli.BoolFlag{
+				Name:  "no-open",
+				Usage: "Do not open the dashboard in the browser after deployment",
+				Value: false,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			ctx, cancel := signal.NotifyContext(c.Context, os.Interrupt, syscall.SIGTERM)
@@ -279,12 +284,16 @@ NOTE: Names and slugs must be unique across all sources.`[1:],
 			case "completed":
 				logger.InfoContext(ctx, "Deployment succeeded", slogID, slog.String("logs_url", logsURL))
 				fmt.Printf("\nView deployment: %s\n", logsURL)
-				openDeploymentURL(logger, ctx, logsURL)
+				if !c.Bool("no-open") {
+					openDeploymentURL(logger, ctx, logsURL)
+				}
 				return nil
 			case "failed":
 				logger.ErrorContext(ctx, "Deployment failed", slogID, slog.String("logs_url", logsURL))
 				fmt.Printf("\nView deployment logs: %s\n", logsURL)
-				openDeploymentURL(logger, ctx, logsURL)
+				if !c.Bool("no-open") {
+					openDeploymentURL(logger, ctx, logsURL)
+				}
 				return fmt.Errorf("deployment failed")
 			default:
 				logger.InfoContext(


### PR DESCRIPTION
add a `--no-open`  to the push command so that it does not open the default browser
(i have gram logged into another browser other than default)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
