### PR TITLE
feat(dashboard): smart command palette with live search

### DIFF
--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -153,6 +153,7 @@ const RouteProvider = () => {
         icon: "home",
         onSelect: () => routes.home.goTo(),
         group: "Navigation",
+        keywords: ["dashboard", "overview"],
       },
       {
         id: "go-sources",
@@ -160,6 +161,7 @@ const RouteProvider = () => {
         icon: "file-code",
         onSelect: () => routes.sources.goTo(),
         group: "Navigation",
+        keywords: ["openapi", "functions", "api"],
       },
       {
         id: "go-mcp-servers",
@@ -167,6 +169,7 @@ const RouteProvider = () => {
         icon: "network",
         onSelect: () => routes.mcp.goTo(),
         group: "Navigation",
+        keywords: ["toolsets", "tools", "servers"],
       },
       {
         id: "go-playground",
@@ -174,6 +177,7 @@ const RouteProvider = () => {
         icon: "message-square",
         onSelect: () => routes.playground.goTo(),
         group: "Navigation",
+        keywords: ["chat", "test", "try"],
       },
       {
         id: "go-insights",
@@ -181,6 +185,7 @@ const RouteProvider = () => {
         icon: "layout-dashboard",
         onSelect: () => routes.observability.goTo(),
         group: "Navigation",
+        keywords: ["analytics", "observability", "metrics"],
       },
     ];
 

--- a/client/dashboard/src/components/command-palette/CommandPalette.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPalette.tsx
@@ -7,12 +7,62 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { useCommandPalette } from "@/contexts/CommandPalette";
+import { sourceTypeToUrnKind, type SourceType } from "@/lib/sources";
+import { useRoutes } from "@/routes";
+import {
+  useLatestDeployment,
+  useListAssets,
+} from "@gram/client/react-query/index.js";
 import { Icon, IconName, Badge } from "@speakeasy-api/moonshine";
+import { Plus, Upload, MessageSquare } from "lucide-react";
+import { useMemo } from "react";
+import { useToolsets } from "@/pages/toolsets/Toolsets";
+
+interface SourceItem {
+  name: string;
+  slug: string;
+  type: SourceType;
+}
+
+function useSources(): SourceItem[] {
+  const { data: deploymentResult } = useLatestDeployment();
+  const { data: assets } = useListAssets();
+
+  return useMemo(() => {
+    const deployment = deploymentResult?.deployment;
+    if (!deployment) return [];
+
+    const openApiSources: SourceItem[] = assets
+      ? deployment.openapiv3Assets
+          .filter((da) => assets.assets.some((a) => a.id === da.assetId))
+          .map((da) => ({ name: da.name, slug: da.slug, type: "openapi" }))
+      : [];
+
+    const functionSources: SourceItem[] = assets
+      ? (deployment.functionsAssets ?? [])
+          .filter((da) => assets.assets.some((a) => a.id === da.assetId))
+          .map((da) => ({ name: da.name, slug: da.slug, type: "function" }))
+      : [];
+
+    const externalMcpSources: SourceItem[] = (
+      deployment.externalMcps ?? []
+    ).map((em) => ({
+      name: em.name,
+      slug: em.slug,
+      type: "externalmcp",
+    }));
+
+    return [...openApiSources, ...functionSources, ...externalMcpSources];
+  }, [deploymentResult, assets]);
+}
 
 export function CommandPalette() {
   const { isOpen, close, actions, contextBadge } = useCommandPalette();
+  const routes = useRoutes();
+  const toolsets = useToolsets();
+  const sources = useSources();
 
-  // Group actions by their group property
+  // Group context-registered actions by their group property
   const groupedActions = actions.reduce(
     (acc, action) => {
       const group = action.group || "Actions";
@@ -49,22 +99,29 @@ export function CommandPalette() {
       <CommandInput placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
+
+        {/* Context-registered action groups (Navigation, Tool Actions, etc.) */}
         {sortedGroups.map(([groupName, groupActions]) => (
           <CommandGroup key={groupName} heading={groupName}>
             {groupActions.map((action) => (
               <CommandItem
                 key={action.id}
                 onSelect={() => handleSelect(action)}
-                className="flex items-center justify-between"
+                keywords={action.keywords}
               >
-                <div className="flex items-center gap-2">
-                  {action.icon && (
-                    <Icon name={action.icon as IconName} className="size-4" />
-                  )}
+                {action.icon && (
+                  <Icon name={action.icon as IconName} className="size-4" />
+                )}
+                <div className="flex flex-col">
                   <span>{action.label}</span>
+                  {action.description && (
+                    <span className="text-xs text-muted-foreground">
+                      {action.description}
+                    </span>
+                  )}
                 </div>
                 {action.shortcut && (
-                  <span className="text-xs text-muted-foreground">
+                  <span className="ml-auto text-xs text-muted-foreground">
                     {action.shortcut}
                   </span>
                 )}
@@ -72,6 +129,93 @@ export function CommandPalette() {
             ))}
           </CommandGroup>
         ))}
+
+        {/* MCP Servers — live from useToolsets() */}
+        {toolsets.length > 0 && (
+          <CommandGroup heading="MCP Servers">
+            {toolsets.map((toolset) => (
+              <CommandItem
+                key={`mcp-${toolset.slug}`}
+                onSelect={() => {
+                  routes.mcp.details.goTo(toolset.slug);
+                  close();
+                }}
+                keywords={[toolset.slug, "mcp", "server", "toolset"]}
+              >
+                <Icon name="network" className="size-4" />
+                <div className="flex flex-col">
+                  <span>{toolset.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {toolset.slug}
+                    {toolset.tools.length > 0 &&
+                      ` · ${toolset.tools.length} tools`}
+                  </span>
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {/* Sources — live from deployment data */}
+        {sources.length > 0 && (
+          <CommandGroup heading="Sources">
+            {sources.map((source) => (
+              <CommandItem
+                key={`source-${source.type}-${source.slug}`}
+                onSelect={() => {
+                  routes.sources.source.goTo(
+                    sourceTypeToUrnKind(source.type),
+                    source.slug,
+                  );
+                  close();
+                }}
+                keywords={[source.slug, source.type, "source"]}
+              >
+                <Icon name="file-code" className="size-4" />
+                <div className="flex flex-col">
+                  <span>{source.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {source.slug} · {source.type}
+                  </span>
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {/* Quick Actions */}
+        <CommandGroup heading="Quick Actions">
+          <CommandItem
+            onSelect={() => {
+              routes.sources.addOpenAPI.goTo();
+              close();
+            }}
+            keywords={["upload", "openapi", "spec", "api"]}
+          >
+            <Upload className="size-4" />
+            <span>Upload OpenAPI</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() => {
+              routes.sources.addFromCatalog.goTo();
+              close();
+            }}
+            keywords={["add", "source", "catalog", "third-party", "mcp"]}
+          >
+            <Plus className="size-4" />
+            <span>Add source from catalog</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() => {
+              routes.playground.goTo();
+              close();
+            }}
+            keywords={["chat", "test", "try", "playground"]}
+          >
+            <MessageSquare className="size-4" />
+            <span>Open Playground</span>
+          </CommandItem>
+        </CommandGroup>
       </CommandList>
     </CommandDialog>
   );

--- a/client/dashboard/src/contexts/CommandPalette.tsx
+++ b/client/dashboard/src/contexts/CommandPalette.tsx
@@ -15,6 +15,8 @@ export interface CommandAction {
   shortcut?: string;
   onSelect: () => void;
   group?: string;
+  keywords?: string[];
+  description?: string;
 }
 
 interface CommandPaletteContextType {


### PR DESCRIPTION
## Summary

- Extend `CommandAction` with `keywords` and `description` fields for richer fuzzy matching and subtitle text
- Rewrite `CommandPalette` to fetch live MCP servers (via `useToolsets()`) and sources (via deployment data) directly, rendering them as searchable groups
- Add "Quick Actions" group with shortcuts for uploading OpenAPI specs, adding catalog sources, and opening the playground
- Add keyword hints to existing navigation actions (e.g., typing "tools" surfaces "Go to MCP Servers")

## Test plan

- [ ] Open cmd+k and verify Navigation, MCP Servers, Sources, and Quick Actions groups render
- [ ] Type an MCP server name — verify it appears and navigates on select
- [ ] Type a source name — verify it appears and navigates to source detail
- [ ] Verify existing contextual actions (e.g., tool selection in ToolList) still appear
- [ ] Run `cd client/dashboard && npx tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
