### PR TITLE
mig: increase api_keys name length limit from 40 to 255 characters

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -214,7 +214,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
   project_id uuid,
   created_by_user_id TEXT NOT NULL,
 
-  name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 40),
+  name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 255),
   key_prefix TEXT NOT NULL,
   key_hash TEXT NOT NULL,
   scopes TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],

--- a/server/migrations/20260302094057_increase-api-key-name-length.sql
+++ b/server/migrations/20260302094057_increase-api-key-name-length.sql
@@ -1,0 +1,3 @@
+-- Increase API key name length limit from 40 to 255 characters to support URL-based names
+ALTER TABLE api_keys DROP CONSTRAINT IF EXISTS api_keys_name_check;
+ALTER TABLE api_keys ADD CONSTRAINT api_keys_name_check CHECK (name <> '' AND CHAR_LENGTH(name) <= 255);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:IQPXNJRQXeZF/biiQJxJwCpgcgj3RLq6y6GcIh+8hgg=
+h1:UVwed9twWmHrhafiwN/C7ymj2XTYdnt5itmybU70Z04=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -108,5 +108,6 @@ h1:IQPXNJRQXeZF/biiQJxJwCpgcgj3RLq6y6GcIh+8hgg=
 20260218000001_oauth-proxy-server-audience.sql h1:2bnirfFCHHKh3gtEOigHlT1bPYORon/j4FyjAejgeUI=
 20260227194055_add-workos-identity-fields.sql h1:f9mTAnu8rIlwzGGhxu2+r2Pnngh4IbxBQrn9tBcsugc=
 20260227224912_add-slack-apps-tables.sql h1:7gBj1mNj0I2mqDoqG55pi1HnAyloA9kMoF5fOdJ6F08=
-20260303144420_deployment-tags.sql h1:+4b/+iiEGBsOu7PZv5doW83CeiGLB6sTanGTXeSWwJU=
-20260305144932_add-workos-org-id.sql h1:KNcwC34iHLPViXsZrVK5ugIwGs1WZXs0sbUoYc8tNBE=
+20260302094057_increase-api-key-name-length.sql h1:9WlT0llugUeRtG/VMTeQjPc8nFi1LEjNWIKCgrUtn1A=
+20260303144420_deployment-tags.sql h1:7RTc0h4AqiOxgnsD6J5/D51+ef82MyJOHIyBe5jP2Lo=
+20260305144932_add-workos-org-id.sql h1:bdIMjzNVbFY8IAvADZ/rDxeim/ZQy2S3b2Q45p0Bs2M=


### PR DESCRIPTION
## Summary

Fixes AGE-1417: API key creation fails with a 500 error when the name is a URL.

- Increased `api_keys.name` column length limit from 40 to 255 characters
- Added migration to update the CHECK constraint

## Linear Issue

https://linear.app/speakeasy/issue/AGE-1417/bug-api-key-creation-fails-when-name-is-a-url

## Test Plan

- [ ] Create an API key with a URL as the name (e.g., `https://github.com/org/repo`)
- [ ] Verify key is created successfully
- [ ] Verify existing API keys still work

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
