### PR TITLE
fix(dashboard): sort project dropdown alphabetically

### DIFF
--- a/client/dashboard/src/components/top-header.tsx
+++ b/client/dashboard/src/components/top-header.tsx
@@ -122,23 +122,25 @@ export function TopHeader() {
                 <CommandList className="max-h-[250px] !p-1">
                   <CommandEmpty>No projects found.</CommandEmpty>
                   <CommandGroup heading="Projects">
-                    {organization.projects.map((p) => (
-                      <CommandItem
-                        key={p.id}
-                        value={p.slug}
-                        onSelect={() => handleProjectSelect(p.slug)}
-                        className="flex items-center gap-2 cursor-pointer"
-                      >
-                        <ProjectAvatar
-                          project={p}
-                          className="h-5 w-5 rounded shrink-0"
-                        />
-                        <span className="flex-1 truncate">{p.slug}</span>
-                        {p.id === project.id && (
-                          <CheckIcon className="w-4 h-4 shrink-0" />
-                        )}
-                      </CommandItem>
-                    ))}
+                    {[...organization.projects]
+                      .sort((a, b) => a.slug.localeCompare(b.slug))
+                      .map((p) => (
+                        <CommandItem
+                          key={p.id}
+                          value={p.slug}
+                          onSelect={() => handleProjectSelect(p.slug)}
+                          className="flex items-center gap-2 cursor-pointer"
+                        >
+                          <ProjectAvatar
+                            project={p}
+                            className="h-5 w-5 rounded shrink-0"
+                          />
+                          <span className="flex-1 truncate">{p.slug}</span>
+                          {p.id === project.id && (
+                            <CheckIcon className="w-4 h-4 shrink-0" />
+                          )}
+                        </CommandItem>
+                      ))}
                   </CommandGroup>
                 </CommandList>
               </Command>


### PR DESCRIPTION
## Summary
- Sort projects alphabetically by slug in the project switcher dropdown
- Uses `localeCompare()` for proper string comparison

## Test plan
- [ ] Open the project dropdown in the top header
- [ ] Verify projects are now listed in alphabetical order

Fixes https://linear.app/speakeasy/issue/AGE-1443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
