### PR TITLE
chore: support dev against remote docker server

### DIFF
--- a/.mise-tasks/nuke.sh
+++ b/.mise-tasks/nuke.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-docker compose --profile "*" down --volumes --rmi local --remove-orphans
+docker compose --profile "*" down --volumes --remove-orphans
 
 echo ""
 echo "💥 All infra resources destroyed"

--- a/.mise-tasks/start/oteltui.sh
+++ b/.mise-tasks/start/oteltui.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#MISE description="Start otel-tui for viewing OpenTelemetry traces and metrics emitted by Gram"
+#MISE hide=true
+
+set -e
+
+docker compose up -d oteltui
+docker compose attach oteltui

--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U", "${DB_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -40,9 +40,9 @@ services:
         "server",
         "start-dev",
         "--ip",
-        "0.0.0.0",
+        "${TEMPORAL_IP:-0.0.0.0}",
         "--ui-ip",
-        "0.0.0.0",
+        "${TEMPORAL_IP:-0.0.0.0}",
         "--namespace",
         "default",
         "--db-filename",
@@ -58,14 +58,14 @@ services:
 
   oteltui:
     image: ymtdzzz/otel-tui@sha256:67010920b012ee998888cf39a794f32e97ca4b01cd02681f25e8f47c261e305b
-
     stdin_open: true
     tty: true
     ports:
       - "${OTLP_GRPC_PORT}:4317"
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.8.3
+    build:
+      context: ./local/clickhouse
     restart: unless-stopped
     ports:
       - "${CLICKHOUSE_HTTP_PORT}:8123"
@@ -79,11 +79,6 @@ services:
     memswap_limit: 2g
     volumes:
       - clickhouse_data:/var/lib/clickhouse
-      - ./local/clickhouse/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ./local/clickhouse/config.d/limits.xml:/etc/clickhouse-server/config.d/limits.xml
-      - ./local/clickhouse/config.d/ssl.xml:/etc/clickhouse-server/config.d/ssl.xml
-      - ./local/clickhouse/users.d/dev_profile.xml:/etc/clickhouse-server/users.d/dev_profile.xml
-      - ./local/clickhouse/certs:/etc/clickhouse-server/certs:ro
     ulimits:
       nofile:
         soft: 262144
@@ -100,7 +95,7 @@ services:
     volumes:
       - mcp_registry_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U", "mcp_registry"]
+      test: ["CMD-SHELL", "pg_isready -U mcp_registry"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/local/clickhouse/Dockerfile
+++ b/local/clickhouse/Dockerfile
@@ -1,0 +1,5 @@
+FROM clickhouse/clickhouse-server:25.8.3
+
+COPY config.d /etc/clickhouse-server/config.d
+COPY users.d /etc/clickhouse-server/users.d
+COPY certs /etc/clickhouse-server/certs

--- a/mise.toml
+++ b/mise.toml
@@ -62,12 +62,13 @@ GRAM_CLICKHOUSE_GOMIGRATE_URL = "clickhouse://{{env.CLICKHOUSE_HOST}}:{{env.CLIC
 ############################
 ## Temporal configuration ##
 ############################
+TEMPORAL_HOST = "127.0.0.1"
 TEMPORAL_PORT = "7233"
 TEMPORAL_NAMESPACE = "default"
 TEMPORAL_TASK_QUEUE = "main"
 ## When using Temporal Cloud, the following variable should like something like:
 ##     "<namespace>.<account>.tmprl.cloud:7233".
-TEMPORAL_ADDRESS = ":{{env.TEMPORAL_PORT}}"
+TEMPORAL_ADDRESS = "{{env.TEMPORAL_HOST}}:{{env.TEMPORAL_PORT}}"
 
 ###################################
 ## Gram server and worker config ##
@@ -93,8 +94,9 @@ GRAM_ASSETS_BACKEND = "fs"
 GRAM_ASSETS_URI = ".assets"
 ## The following variable is used to encrypt env vars stored in the database.
 GRAM_ENCRYPTION_KEY = "unset"
+GRAM_REDIS_CACHE_HOST = "127.0.0.1"
 GRAM_REDIS_CACHE_PORT = "5445"
-GRAM_REDIS_CACHE_ADDR = "127.0.0.1:{{env.GRAM_REDIS_CACHE_PORT}}"
+GRAM_REDIS_CACHE_ADDR = "{{env.GRAM_REDIS_CACHE_HOST}}:{{env.GRAM_REDIS_CACHE_PORT}}"
 GRAM_REDIS_CACHE_PASSWORD = "xi9XILbY"
 OPENROUTER_DEV_KEY = "unset"
 ## The following two variables are used by Speakeasy staff developing against
@@ -110,8 +112,9 @@ GRAM_SSL_KEY_FILE = "{{config_root}}/local/ssl/keys/local-key.pem"
 ##########################
 ## Observability config ##
 ##########################
+OTLP_GRPC_HOST = "localhost"
 OTLP_GRPC_PORT = "4317"
-OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:{{env.OTLP_GRPC_PORT}}"
+OTEL_EXPORTER_OTLP_ENDPOINT = "http://{{env.OTLP_GRPC_HOST}}:{{env.OTLP_GRPC_PORT}}"
 ## Change these to 0 to disable OpenTelemetry traces and metrics to be emitted.
 GRAM_ENABLE_OTEL_TRACES = 1
 GRAM_ENABLE_OTEL_METRICS = 1
@@ -119,6 +122,7 @@ GRAM_ENABLE_OTEL_METRICS = 1
 ################################
 ## Local development settings ##
 ################################
+JAEGER_WEB_PORT = "16686" 
 GRAM_LOG_PRETTY = 1
 ## DO NOT SET THIS VARIABLE WHEN DEPLOYING TO PRODUCTION.
 GRAM_UNSAFE_LOCAL_ENV_PATH = "{{config_root}}/.local.env.json"

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -14,6 +14,6 @@ procs:
     stop:
       send-keys: ["<C-c>"]
   otel:
-    cmd: ["docker", "compose", "attach", "oteltui"]
+    cmd: ["mise", "run", "start:oteltui"]
     stop:
-      send-keys: ["<C-p>", "<C-q>"]
+      send-keys: ["<C-c>"]


### PR DESCRIPTION
This change updates the local development setup to support running against a remote environment and Docker server. The main enablers for this are:
- Make the hostname of all services configurable via environment variables so that they can be set to the remote server's hostname
- Define a Dockerfile for Clickhouse with config files baked in since local volumes won't work against a remote Docker server.

There was a small adjustment to how we run otel-tui to ensure it can be stopped. When connecting to docker over TCP, detaching from otel-tui was causing a hang (known issue with docker CLI).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
