### PR TITLE
chore: setup more dependabot groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       - "/.github/workflows/composite/build-push"
     schedule:
       interval: "weekly"
+    groups:
+      artifacts:
+        patterns:
+          - "actions/download-artifact"
+          - "actions/upload-artifact"
   - package-ecosystem: "gomod"
     directories:
       - "/"
@@ -35,6 +40,9 @@ updates:
       redis:
         patterns:
           - "github.com/redis/go-redis/*"
+      aws:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2/*"
   - package-ecosystem: "docker"
     directory: "/server"
     schedule:


### PR DESCRIPTION
group aws sdk package updates together and github's actions/upload-artifact and actions/download-artifact together.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
