### PR TITLE
fix: mcp enable button to be distinct

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -446,8 +446,7 @@ export function MCPEnableButton({ toolset }: { toolset: Toolset }) {
   return (
     <>
       <Button
-        variant="secondary"
-        className="bg-foreground hover:bg-foreground/90 text-background hover:text-background"
+        variant="primary"
         onClick={() => setIsServerEnableDialogOpen(true)}
       >
         {toolset.mcpEnabled ? "DISABLE" : "ENABLE"}


### PR DESCRIPTION
it is hard to locate the enable button on first look due to it matching with the background

example image before fix:

<img width="513" height="266" alt="image" src="https://github.com/user-attachments/assets/0061efb0-d03a-482a-bbb3-870a71f9ab1c" />

image after fix:
<img width="685" height="262" alt="image" src="https://github.com/user-attachments/assets/e14ccdb3-dabe-415a-8624-16852eb9f7c5" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
