### PR TITLE
fix: polar not found check using errors.As

### DIFF
--- a/server/internal/thirdparty/polar/client.go
+++ b/server/internal/thirdparty/polar/client.go
@@ -11,10 +11,10 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	polargo "github.com/polarsource/polar-go"
+	"github.com/polarsource/polar-go/models/apierrors"
 	polarComponents "github.com/polarsource/polar-go/models/components"
 	polarOperations "github.com/polarsource/polar-go/models/operations"
 	"github.com/redis/go-redis/v9"
@@ -483,24 +483,13 @@ func (p *Client) getCustomerState(ctx context.Context, orgID string) (*polarComp
 		polarCustomerState = customerState.CustomerState
 	} else {
 		externalCustomerState, err := p.polar.Customers.GetStateExternal(ctx, orgID)
-		notFoundErrors := []string{
-			"resourcenotfound",
-			"not found",
-		}
-		containsNotFoundError := func(err error) bool {
-			for _, notFoundError := range notFoundErrors {
-				if strings.Contains(strings.ToLower(err.Error()), notFoundError) {
-					return true
-				}
-			}
-			return false
-		}
+		var notFound *apierrors.ResourceNotFound
+		isNotFoundError := errors.As(err, &notFound) ||
+			(externalCustomerState != nil &&
+				externalCustomerState.HTTPMeta.Response != nil &&
+				externalCustomerState.HTTPMeta.Response.StatusCode == http.StatusNotFound)
 
-		isNotFoundError := externalCustomerState != nil &&
-			externalCustomerState.HTTPMeta.Response != nil &&
-			externalCustomerState.HTTPMeta.Response.StatusCode == http.StatusNotFound
-
-		if err != nil && !isNotFoundError && !containsNotFoundError(err) {
+		if err != nil && !isNotFoundError {
 			return nil, fmt.Errorf("query polar customer state: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

Polar's API returns `{"error":"","detail":"Not found"}` (empty `error` field) when an org has no customer record. The previous guard used `strings.Contains(err.Error(), "ResourceNotFound")` which failed to match this response, causing `getPeriodUsage` to return a 500 for those orgs.

Switched to `errors.As(err, &*apierrors.ResourceNotFound)` to match on the typed SDK error regardless of field contents.

## Root cause

The SDK's `ResourceNotFound.Error()` JSON-marshals itself, so when Polar returns an empty `error` field the string representation lacks `"ResourceNotFound"` — only the type check is reliable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
