### PR TITLE
fix: confusing prompt name error messages

### DIFF
--- a/client/dashboard/src/lib/constants.ts
+++ b/client/dashboard/src/lib/constants.ts
@@ -1,6 +1,6 @@
 export const TOOL_NAME_PATTERN = "^[a-zA-Z]+(?:[_][a-zA-Z0-9]+)*$";
 export const TOOL_NAME_REGEX = new RegExp(TOOL_NAME_PATTERN);
-export const PROMPT_NAME_PATTERN = "^[a-z0-9_-]{1,128}$";
+export const PROMPT_NAME_PATTERN = "^[a-z0-9_-]{1,40}$";
 export const PROMPT_NAME_REGEX = new RegExp(PROMPT_NAME_PATTERN);
 export const PROMPT_ARG_PATTERN = "^[a-zA-Z]+(?:[_][a-zA-Z0-9]+)*$";
 export const PROMPT_ARG_REGEX = new RegExp(PROMPT_ARG_PATTERN);

--- a/client/dashboard/src/pages/prompts/PromptEditor.tsx
+++ b/client/dashboard/src/pages/prompts/PromptEditor.tsx
@@ -136,7 +136,7 @@ export function PromptEditor({
                 name="name"
                 pattern={PROMPT_NAME_PATTERN}
                 placeholder="my-prompt-name"
-                title="Only lowercase letters, numbers, hyphens, and underscores (max 128 characters)"
+                title="Only lowercase letters, numbers, hyphens, and underscores (max 40 characters)"
                 required
               />
             </div>
@@ -244,7 +244,9 @@ export function PromptEditor({
         <div className="pt-6">
           {error ? (
             <div className="bg-red-50 border border-red-200 rounded-md p-3 mb-4">
-              <p className="text-red-700 text-sm">{error.message}</p>
+              <p className="text-red-700 text-sm">
+                {formatPromptError(error.message)}
+              </p>
             </div>
           ) : null}
           <Button type="submit" disabled={isPending} size="md">
@@ -292,6 +294,16 @@ export function PromptEditor({
       </aside>
     </div>
   );
+}
+
+function formatPromptError(message: string): string {
+  if (message.includes("name") && message.includes("match")) {
+    return "Prompt name can only contain lowercase letters, numbers, hyphens, and underscores.";
+  }
+  if (message.includes("name") && message.includes("length")) {
+    return "Prompt name must be 40 characters or fewer.";
+  }
+  return message;
 }
 
 const ArgumentEntry = ({


### PR DESCRIPTION
body.name seems confusing as it can also mean the prompt body - updated it to show a more useful error message


| Before | After |
|--------|--------|
| <img width="732" height="634" alt="image" src="https://github.com/user-attachments/assets/60742de7-e1cf-4ab7-88e2-56bfe63dd37c" /> |<img width="881" height="627" alt="image" src="https://github.com/user-attachments/assets/46c92a3f-260a-4434-92df-7749b6e2da92" /> | 


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
