### PR TITLE
chore: run db:reset task in database container

### DIFF
--- a/.mise-tasks/db/reset.sh
+++ b/.mise-tasks/db/reset.sh
@@ -6,7 +6,7 @@ set -e
 
 echo "Dropping and recreating public schema..."
 
-psql "${GRAM_DATABASE_URL//&search_path=public/}" \
+docker compose exec -T gram-db psql -U "${DB_USER}" -d "${DB_NAME}" \
   -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
 echo "Schema reset. Running migrations..."


### PR DESCRIPTION
This change updates the `db:reset` task to execute with the database container instead of the host machine. Previously the task relied on development machines have `psql` installed and configured, which is not guaranteed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
