### PR TITLE
fix: remove synctest from oauth tests to fix Redis incompatibility

### DIFF
--- a/server/internal/oauth/setup_test.go
+++ b/server/internal/oauth/setup_test.go
@@ -2,6 +2,8 @@ package oauth_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"log"
 	"log/slog"
 	"net/url"
@@ -113,6 +115,35 @@ func (e *tokenTestEnv) issueToken(
 	require.NoError(t, err)
 
 	return token, client.ClientID, client.ClientSecret
+}
+
+// expireTokenInCache modifies an existing token's ExpiresAt to be in the past,
+// simulating an expired downstream token without using synctest.
+func (e *tokenTestEnv) expireTokenInCache(
+	t *testing.T,
+	ctx context.Context,
+	toolsetID uuid.UUID,
+	accessToken string,
+	expiresAt time.Time,
+) {
+	t.Helper()
+
+	// Compute the cache key using the hashed access token
+	hash := sha256.Sum256([]byte(accessToken))
+	accessTokenHash := base64.RawURLEncoding.EncodeToString(hash[:])
+	cacheKey := oauth.TokenCacheKey(toolsetID, accessTokenHash) + ":"
+
+	// Get the current token from cache
+	var token oauth.Token
+	err := e.cacheAdapter.Get(ctx, cacheKey, &token)
+	require.NoError(t, err, "failed to get token from cache")
+
+	// Modify the expiry
+	token.ExpiresAt = expiresAt
+
+	// Update the token in cache
+	err = e.cacheAdapter.Update(ctx, cacheKey, token)
+	require.NoError(t, err, "failed to update token in cache")
 }
 
 // oauthServiceTestEnv wraps a full oauth.Service whose internal TokenService

--- a/server/internal/oauth/token_service_test.go
+++ b/server/internal/oauth/token_service_test.go
@@ -2,7 +2,6 @@ package oauth_test
 
 import (
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -141,32 +140,29 @@ func TestExchangeRefreshToken_InvalidRefreshToken(t *testing.T) {
 
 func TestExchangeRefreshToken_ExpiredDownstreamToken(t *testing.T) {
 	t.Parallel()
+	ctx := t.Context()
+	env := newTokenTestEnv(t)
+	toolsetID := uuid.New()
+	upstreamExpiry := time.Now().Add(365 * 24 * time.Hour)
 
-	synctest.Test(t, func(t *testing.T) {
-		ctx := t.Context()
-		env := newTokenTestEnv(t) // Redis client created inside the bubble
-		toolsetID := uuid.New()
-		upstreamExpiry := time.Now().Add(365 * 24 * time.Hour)
+	token, clientID, clientSecret := env.issueToken(t, ctx, toolsetID,
+		"upstream-access", "upstream-refresh", &upstreamExpiry, []string{"api_key"})
 
-		token, clientID, clientSecret := env.issueToken(t, ctx, toolsetID,
-			"upstream-access", "upstream-refresh", &upstreamExpiry, []string{"api_key"})
+	// Directly expire the token in cache to simulate 31 days passing
+	env.expireTokenInCache(t, ctx, toolsetID, token.AccessToken, time.Now().Add(-1*time.Hour))
 
-		// Sleep past the 30-day default token expiration
-		time.Sleep(31 * 24 * time.Hour)
+	_, err := env.tokenService.ValidateAccessToken(ctx, toolsetID, token.AccessToken)
+	require.ErrorIs(t, err, oauth.ErrExpiredAccessToken)
 
-		_, err := env.tokenService.ValidateAccessToken(ctx, toolsetID, token.AccessToken)
-		require.ErrorIs(t, err, oauth.ErrExpiredAccessToken)
-
-		// Refresh token should still work (24h grace period on cache TTL)
-		newToken, err := env.tokenService.ExchangeRefreshToken(ctx, &oauth.TokenRequest{
-			GrantType:    "refresh_token",
-			RefreshToken: token.RefreshToken,
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-		}, testMCPURL, toolsetID)
-		require.NoError(t, err)
-		require.NotEqual(t, token.AccessToken, newToken.AccessToken)
-	})
+	// Refresh token should still work (24h grace period on cache TTL)
+	newToken, err := env.tokenService.ExchangeRefreshToken(ctx, &oauth.TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: token.RefreshToken,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}, testMCPURL, toolsetID)
+	require.NoError(t, err)
+	require.NotEqual(t, token.AccessToken, newToken.AccessToken)
 }
 
 func TestExchangeRefreshToken_ExpiredUpstreamSecrets(t *testing.T) {


### PR DESCRIPTION
## Summary

- Rewrote `TestExchangeRefreshToken_ExpiredDownstreamToken` to not use Go's `testing/synctest`
- Added `expireTokenInCache` helper to directly modify token expiry in cache

## Problem

The `server-test` CI check was failing due to 14 tests in `server/internal/oauth` failing with:
```
fatal error: send on synctest channel from outside bubble
```

`synctest.Test()` creates an isolated "bubble" that's incompatible with real Redis connections - the Redis client spawns background goroutines for connection pooling that exist outside the synctest bubble.

## Solution

Instead of using synctest to simulate 31 days passing, the test now directly stores a modified token with a past `ExpiresAt` to simulate an already-expired token.

## Testing

All 14 oauth tests now pass:
- `TestRefreshProxyToken_*` (7 tests)
- `TestExchangeRefreshToken_*` (6 tests)
- `TestCreateTokenResponse_IncludesRefreshToken`

Fixes: https://linear.app/speakeasy/issue/AGE-1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
