### PR TITLE
chore: bump madprocs to v0.1.12

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,7 @@ uv = "0.10.9"
 yq = "4.52.4"
 hk = "1.38.0"
 pkl = "0.31.0"
-"github:speakeasy-api/madprocs" = "v0.1.10"
+"github:speakeasy-api/madprocs" = "v0.1.12"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.


### PR DESCRIPTION
## Summary
- Bumps madprocs from v0.1.10 to v0.1.12
- Fixes WebSocket reconnection loop when switching processes in web UI

## Test plan
- [x] Verified locally that web UI no longer creates multiple WebSocket connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
