### PR TITLE
feat: Slack app manifest scope and toolset filtering fixes

### DIFF
--- a/client/dashboard/src/pages/slackapp/slackManifest.ts
+++ b/client/dashboard/src/pages/slackapp/slackManifest.ts
@@ -10,6 +10,7 @@ export const BOT_SCOPES = [
   "users:read",
   "channels:history",
   "channels:read",
+  "reactions:write",
 ];
 
 export const BOT_EVENTS = ["app_mention", "message.im"];

--- a/server/internal/background/activities/get_slack_project_context.go
+++ b/server/internal/background/activities/get_slack_project_context.go
@@ -59,9 +59,9 @@ func (s *GetSlackProjectContext) Do(ctx context.Context, event types.SlackEvent)
 		return nil, oops.E(oops.CodeUnexpected, err, "error getting app auth info").Log(ctx, s.logger)
 	}
 
-	toolsets, err := s.toolsetRepo.ListToolsetsByProject(ctx, authInfo.ProjectID)
+	toolsets, err := s.toolsetRepo.ListToolsetsBySlackAppID(ctx, gramAppID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error getting asset").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "error listing toolsets for slack app").Log(ctx, s.logger)
 	}
 
 	projects, err := s.projectRepo.ListProjectsByOrganization(ctx, authInfo.OrganizationID)

--- a/server/internal/toolsets/queries.sql
+++ b/server/internal/toolsets/queries.sql
@@ -208,6 +208,14 @@ WHERE tp.toolset_id = @toolset_id
   AND tp.project_id = @project_id
 ORDER BY tp.prompt_name;
 
+-- name: ListToolsetsBySlackAppID :many
+SELECT t.*
+FROM toolsets t
+JOIN slack_app_toolsets sat ON t.id = sat.toolset_id
+WHERE sat.slack_app_id = @slack_app_id
+  AND t.deleted IS FALSE
+ORDER BY t.created_at DESC;
+
 -- name: GetToolsetsByToolURN :many
 SELECT
     t.*,

--- a/server/internal/toolsets/repo/queries.sql.go
+++ b/server/internal/toolsets/repo/queries.sql.go
@@ -815,6 +815,54 @@ func (q *Queries) ListEnabledToolsetsByOrganization(ctx context.Context, organiz
 	return items, nil
 }
 
+const listToolsetsBySlackAppID = `-- name: ListToolsetsBySlackAppID :many
+SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.created_at, t.updated_at, t.deleted_at, t.deleted
+FROM toolsets t
+JOIN slack_app_toolsets sat ON t.id = sat.toolset_id
+WHERE sat.slack_app_id = $1
+  AND t.deleted IS FALSE
+ORDER BY t.created_at DESC
+`
+
+func (q *Queries) ListToolsetsBySlackAppID(ctx context.Context, slackAppID uuid.UUID) ([]Toolset, error) {
+	rows, err := q.db.Query(ctx, listToolsetsBySlackAppID, slackAppID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Toolset
+	for rows.Next() {
+		var i Toolset
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.ProjectID,
+			&i.Name,
+			&i.Slug,
+			&i.Description,
+			&i.DefaultEnvironmentSlug,
+			&i.McpSlug,
+			&i.McpIsPublic,
+			&i.McpEnabled,
+			&i.ToolSelectionMode,
+			&i.CustomDomainID,
+			&i.ExternalOauthServerID,
+			&i.OauthProxyServerID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listToolsetsByProject = `-- name: ListToolsetsByProject :many
 SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets


### PR DESCRIPTION
## Summary
- Add `reactions:write` bot scope to the Slack app manifest so the bot can add emoji reactions to messages
- Fix `GetSlackProjectContext` to query only the toolsets configured for the specific Slack app (via `slack_app_toolsets` join table) instead of all project toolsets, fixing wrong default toolset selection and crashes on empty toolsets

## Test plan
- [ ] Verify new Slack apps provisioned via the manifest deep link include `reactions:write` in their bot scopes
- [ ] Verify the Slack bot only sees its configured toolsets, not all project toolsets
- [ ] Verify the correct default toolset is selected when a user messages the bot without specifying one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
