### PR TITLE
chore: pin madprocs version and gitignore port file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scratch/
 /local/keys
 .speakeasy/temp
 mprocs.log
+.madprocs.port
 melange.log
 __debug_bin*
 go.work

--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,7 @@ uv = "0.10.9"
 yq = "4.52.4"
 hk = "1.38.0"
 pkl = "0.31.0"
-"github:speakeasy-api/madprocs" = "latest"
+"github:speakeasy-api/madprocs" = "v0.1.22"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.


### PR DESCRIPTION
## Summary
- Pin madprocs to v0.1.22 instead of `latest` for reproducible builds
- Add `.madprocs.port` to gitignore (local runtime artifact)

## Test plan
- [ ] Verify `mise install` still works
- [ ] Verify madprocs starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
