### PR TITLE
fix: resolve LanguageModel type mismatch in elements

### DIFF
--- a/elements/src/components/ui/time-range-picker.tsx
+++ b/elements/src/components/ui/time-range-picker.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { CalendarIcon, ChevronDown, Zap } from "lucide-react";
-import { generateObject } from "ai";
+import { generateObject, LanguageModel } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { z } from "zod";
 
@@ -233,7 +233,7 @@ async function parseWithAI(
         }),
     });
 
-    const model = openRouter.chat(TIME_RANGE_MODEL);
+    const model = openRouter.chat(TIME_RANGE_MODEL) as LanguageModel;
 
     const result = await generateObject({
       model,

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -37,6 +37,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   convertToModelMessages,
   createUIMessageStream,
+  LanguageModel,
   smoothStream,
   stepCountIs,
   streamText,
@@ -374,7 +375,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
         // Stream the response
         const modelToUse = config.languageModel
           ? config.languageModel
-          : openRouterModel!.chat(model);
+          : (openRouterModel!.chat(model) as LanguageModel);
 
         try {
           // This works around AI SDK bug where these fields cause validation failures

--- a/elements/src/hooks/useModel.ts
+++ b/elements/src/hooks/useModel.ts
@@ -26,5 +26,5 @@ export const useModel = (
     },
   });
 
-  return openRouter.chat(model);
+  return openRouter.chat(model) as LanguageModel;
 };


### PR DESCRIPTION
## Summary
- Cast `openRouter.chat()` returns as `LanguageModel` to fix TypeScript compilation errors in the elements package
- Root cause: `@openrouter/ai-sdk-provider` resolves `@ai-sdk/provider@3.0.7` (from another workspace package) while `ai@5.0.90` uses `@ai-sdk/provider@2.0.0` — the types are structurally identical but TypeScript treats them as incompatible
- Affected files: `useModel.ts`, `ElementsProvider.tsx`, `time-range-picker.tsx`

## Test plan
- [x] `pnpm type-check` passes in `elements/`
- [ ] Verify elements build succeeds in CI
- [ ] Verify chat functionality still works (OpenRouter model usage unchanged at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
