### PR TITLE
fix: isolate Redis DBs in mcpmetadata tests to prevent flaky auth

### DIFF
--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -20,6 +21,10 @@ import (
 
 var (
 	infra *testenv.Environment
+	// redisDBCounter assigns each parallel test its own Redis DB to prevent
+	// cache key collisions (e.g. speakeasyUserInfo:1245) between concurrent
+	// calls to PopulateLocalDevDefaultAuthSession during test auth setup.
+	redisDBCounter atomic.Int32
 )
 
 func TestMain(m *testing.M) {
@@ -60,7 +65,8 @@ func newTestMCPMetadataService(t *testing.T) (context.Context, *testInstance) {
 	conn, err := infra.CloneTestDatabase(t, "mcpmetadatatest")
 	require.NoError(t, err)
 
-	redisClient, err := infra.NewRedisClient(t, 0)
+	redisDB := int(redisDBCounter.Add(1) % 16)
+	redisClient, err := infra.NewRedisClient(t, redisDB)
 	require.NoError(t, err)
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)


### PR DESCRIPTION
## Summary
- Fix flaky `server/internal/mcpmetadata` tests that intermittently fail with "unauthorized access" in CI
- All 13+ parallel tests shared Redis DB 0, causing cache key collisions on `speakeasyUserInfo:1245` during concurrent `PopulateLocalDevDefaultAuthSession` calls in auth setup
- Each test now gets its own Redis DB via an atomic counter, fully isolating cache state

## Test plan
- [x] `go vet` passes on the package
- [ ] CI server-test job passes without mcpmetadata failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
