### PR TITLE
chore: use pre-installed temporal cli for tests

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -25,6 +25,7 @@ yq = "4.52.4"
 hk = "1.38.0"
 pkl = "0.31.0"
 "github:speakeasy-api/madprocs" = "0.1.22"
+"github:temporalio/cli" = "1.6.1"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.

--- a/server/internal/testenv/temporal.go
+++ b/server/internal/testenv/temporal.go
@@ -26,7 +26,8 @@ func NewTemporalDevServer(t *testing.T, ctx context.Context) (*testsuite.DevServ
 
 	for range 5 {
 		temporal, err = testsuite.StartDevServer(ctx, testsuite.DevServerOptions{
-			LogLevel: "error",
+			LogLevel:     "error",
+			ExistingPath: "temporal",
 			ClientOptions: &client.Options{
 				Namespace: fmt.Sprintf("test_%s", nextRandom()),
 				Logger:    logger,


### PR DESCRIPTION
This change updates the test environment to use a pre-installed Temporal CLI which greatly speeds up the test setup time. Previously, every test was triggering a download of the CLI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
