### PR TITLE
feat: add explanatory language to environment configuration tab

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -691,11 +691,14 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
         </Button>
       </div>
       <p className="text-sm text-muted-foreground">
-        Add arbitrary key-value pairs that are passed to the backend when users
-        connect to this server. Use them for API keys, configuration options, or
-        any custom data your backend needs. Click the state button to cycle
-        between User Provided (set at runtime), System (set here), and Omitted
-        (not included).
+        Environments store key-value pairs that are passed to the backend when
+        users connect. They can be shared across multiple MCP servers, so you
+        only need to configure common values like API keys once.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Add variables for API keys, configuration options, or any custom data
+        your backend needs. Use the state button to set each variable as User
+        Provided (set at runtime), System (set here), or Omitted (not included).
       </p>
 
       {/* All Variables Section */}
@@ -750,8 +753,9 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
               No environment variables configured yet.
             </p>
             <p className="text-sm text-muted-foreground mb-4">
-              Add key-value pairs to pass API keys, configuration options, or
-              any custom data to your backend.
+              Add key-value pairs to pass API keys, configuration, or any custom
+              data to your backend. Environments can be shared across multiple
+              MCP servers.
             </p>
             <Button onClick={() => setIsAddingNew(true)} variant="secondary">
               <Button.LeftIcon>


### PR DESCRIPTION
## Summary
- Updated the environment configuration tab description to explain that users can add arbitrary key-value pairs passed to the backend
- Added explanatory copy to the empty state so first-time users understand the feature's purpose
- Retained existing state-button usage instructions

Closes AGE-1369

## Test plan
- [x] Verify the description text renders correctly on the environment config tab when variables exist
- [x] Verify the empty state shows the new explanatory copy when no variables are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
