### PR TITLE
fix: hardcoded orgslug in mcp logs

### DIFF
--- a/client/dashboard/src/pages/mcp/BuiltInMCPDetailPage.tsx
+++ b/client/dashboard/src/pages/mcp/BuiltInMCPDetailPage.tsx
@@ -69,10 +69,10 @@ const TAB_TRIGGER_CLASS = cn(
 
 export function BuiltInMCPDetailPage() {
   const { builtInSlug } = useParams();
-  const { projectSlug } = useSlugs();
+  const { orgSlug, projectSlug } = useSlugs();
   const [activeTab, setActiveTab] = useState("overview");
 
-  const mcpUrl = `${getServerURL()}/mcp/speakeasy-team-mcp-logs`;
+  const mcpUrl = `${getServerURL()}/mcp/${orgSlug}-mcp-logs`;
 
   const configJson = `{
   "mcpServers": {


### PR DESCRIPTION
otherwise the following error occurs

<img width="1136" height="126" alt="image" src="https://github.com/user-attachments/assets/6cbe0248-610d-4135-bc8b-6a7c6abcfd20" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
