### PR TITLE
docs: RBAC access package design examples (DO NOT MERGE)

### DIFF
--- a/server/internal/access/access_design_example.go
+++ b/server/internal/access/access_design_example.go
@@ -1,0 +1,242 @@
+// Package access provides the access control API for Gram's RBAC system.
+//
+// THIS FILE IS A DESIGN EXAMPLE — it is not meant to compile. It demonstrates
+// the intended public API surface, handler integration patterns, and the
+// middleware enforcement model. Delete before implementation begins.
+//
+// Design principles:
+//   - Grants are resolved ONCE per request by the middleware and stored in context.
+//   - Handlers call access.Can / access.Filter for authorization decisions.
+//   - The middleware verifies that at least one check was performed (safety net).
+//   - The API is intentionally small: Can, Filter, and Check are the only
+//     public functions that handlers need.
+//
+// Inspiration:
+//   - SpiceDB:   client.CheckPermission(ctx, &pb.CheckPermissionRequest{Resource, Permission, Subject})
+//   - Clerk:     claims.HasPermission("org:billing:read")
+//   - Ory Keto:  client.PermissionApi.CheckPermission(ctx).Namespace(...).Object(...).Relation(...).Execute()
+//
+// Our model is simpler than all three because we don't have hierarchical
+// relationships or external stores. The entire grant set fits in a single
+// Postgres query per request.
+package access
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync/atomic"
+)
+
+// ---------------------------------------------------------------------------
+// Scopes — typed constants mirroring DB slugs
+// ---------------------------------------------------------------------------
+
+type Scope string
+
+const (
+	ScopeOrgRead    Scope = "org:read"
+	ScopeOrgAdmin   Scope = "org:admin"
+	ScopeBuildRead  Scope = "build:read"
+	ScopeBuildWrite Scope = "build:write"
+	ScopeMCPRead    Scope = "mcp:read"
+	ScopeMCPWrite   Scope = "mcp:write"
+	ScopeMCPConnect Scope = "mcp:connect"
+)
+
+// ---------------------------------------------------------------------------
+// Grants — resolved once per request, stored in context
+// ---------------------------------------------------------------------------
+
+// Grants holds the complete set of permissions for the current principal.
+// It is resolved by the middleware before the handler runs, and is analogous
+// to Clerk's SessionClaims — one object per request, read-only during the
+// handler's lifetime.
+type Grants struct {
+	orgID    string
+	userID   string
+	roleSlug string
+	rows     []grantRow // from DB or synthetic (API key / bypass)
+	checked  atomic.Bool
+}
+
+// grantRow is a single row from principal_grants (or a synthetic equivalent).
+type grantRow struct {
+	Scope     Scope
+	Resources []string // nil = unrestricted; non-nil = allowlist
+}
+
+// ---------------------------------------------------------------------------
+// Check — a single (scope, resource) tuple
+// ---------------------------------------------------------------------------
+
+// Check creates a permission check for a specific scope and resource.
+// Use empty string for resourceID on org-scoped checks.
+func Check(scope Scope, resourceID string) check {
+	return check{scope: scope, resourceID: resourceID}
+}
+
+type check struct {
+	scope      Scope
+	resourceID string
+}
+
+// ---------------------------------------------------------------------------
+// Can — the primary authorization function
+// ---------------------------------------------------------------------------
+
+// Can verifies that the current principal holds ALL of the specified permissions.
+// Returns nil if all checks pass, or a 403 error if any check fails.
+//
+// This is the function handlers call for point-access checks. It marks the
+// request as "checked" for the safety-net middleware.
+//
+// Usage:
+//
+//	// Single check
+//	if err := access.Can(ctx, access.Check(access.ScopeBuildRead, projectID)); err != nil {
+//	    return nil, err
+//	}
+//
+//	// Multiple checks (ALL must pass)
+//	if err := access.Can(ctx,
+//	    access.Check(access.ScopeBuildWrite, projectID),
+//	    access.Check(access.ScopeMCPWrite, mcpID),
+//	); err != nil {
+//	    return nil, err
+//	}
+func Can(ctx context.Context, checks ...check) error {
+	g := GrantsFromContext(ctx)
+	if g == nil {
+		return ErrNoGrants
+	}
+	g.checked.Store(true)
+
+	for _, c := range checks {
+		if !g.hasAccess(c.scope, c.resourceID) {
+			return Denied(c.scope, c.resourceID)
+		}
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Filter — for list endpoints
+// ---------------------------------------------------------------------------
+
+// Filter returns the set of resource IDs the principal is allowed to access
+// for the given scope.
+//
+//   - nil slice:      unrestricted (user can access all resources)
+//   - non-nil slice:  allowlist (handler adds WHERE id = ANY($filter))
+//   - error:          no access at all (handler returns 403)
+//
+// This marks the request as "checked" for the safety-net middleware.
+//
+// Usage:
+//
+//	filter, err := access.Filter(ctx, access.ScopeBuildRead)
+//	if err != nil {
+//	    return nil, err // 403
+//	}
+//	// filter is nil (unrestricted) or []string (allowlist)
+//	projects, err := s.repo.ListProjects(ctx, orgID, filter)
+func Filter(ctx context.Context, scope Scope) ([]string, error) {
+	g := GrantsFromContext(ctx)
+	if g == nil {
+		return nil, ErrNoGrants
+	}
+	g.checked.Store(true)
+
+	return g.resourceFilter(scope)
+}
+
+// ---------------------------------------------------------------------------
+// Internal grant evaluation (not exported)
+// ---------------------------------------------------------------------------
+
+// hasAccess implements the core check algorithm:
+//  1. Find all grant rows matching scope.
+//  2. If ANY row has nil resources (unrestricted) -> true.
+//  3. Otherwise, check if resourceID is in the union of all resource arrays.
+func (g *Grants) hasAccess(scope Scope, resourceID string) bool {
+	for _, row := range g.rows {
+		if row.Scope != scope {
+			continue
+		}
+
+		// Unrestricted grant (resources = NULL in DB) → immediate allow.
+		// This is why grants are additive: if ANY row is unrestricted,
+		// it doesn't matter what other rows say.
+		if row.Resources == nil {
+			return true
+		}
+
+		// Scoped grant (resources = [...] in DB) → check if the target
+		// resource is in this row's allowlist.
+		if slices.Contains(row.Resources, resourceID) {
+			return true
+		}
+	}
+
+	// No matching row granted access — either no rows for this scope at all,
+	// or rows existed but the resource wasn't in any allowlist.
+	return false
+}
+
+// resourceFilter implements the filter algorithm for list endpoints:
+//  1. Find all grant rows matching scope. No rows -> error.
+//  2. If ANY row is unrestricted -> nil (all resources).
+//  3. Otherwise -> union of all resource arrays.
+func (g *Grants) resourceFilter(scope Scope) ([]string, error) {
+	var (
+		found     bool
+		resources []string
+	)
+	for _, row := range g.rows {
+		if row.Scope != scope {
+			continue
+		}
+		found = true
+		if row.Resources == nil {
+			return nil, nil // unrestricted
+		}
+		resources = append(resources, row.Resources...)
+	}
+	if !found {
+		return nil, Denied(scope, "")
+	}
+	return resources, nil
+}
+
+// ---------------------------------------------------------------------------
+// Context helpers
+// ---------------------------------------------------------------------------
+
+type contextKey struct{}
+
+func GrantsToContext(ctx context.Context, g *Grants) context.Context {
+	return context.WithValue(ctx, contextKey{}, g)
+}
+
+func GrantsFromContext(ctx context.Context) *Grants {
+	g, _ := ctx.Value(contextKey{}).(*Grants)
+	return g
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+var ErrNoGrants = fmt.Errorf("access: no grants in context")
+
+// Denied returns a 403-style error. In the real implementation this would
+// return an oops.ShareableError with CodeForbidden. For now it's a plain error
+// so the design example tests can run.
+func Denied(scope Scope, resourceID string) error {
+	if resourceID == "" {
+		return fmt.Errorf("access denied: missing scope %s", scope)
+	}
+	return fmt.Errorf("access denied: scope %s on resource %s", scope, resourceID)
+}

--- a/server/internal/access/check_walkthrough_test.go
+++ b/server/internal/access/check_walkthrough_test.go
@@ -1,0 +1,610 @@
+package access
+
+// ===========================================================================
+// CHECK ALGORITHM WALKTHROUGH WITH IN-MEMORY DB
+//
+// This file is a runnable test suite that demonstrates exactly how the check
+// algorithm works against realistic data. It builds an in-memory representation
+// of the principal_grants table, resolves Grants the same way the middleware
+// would, and then runs Can / Filter checks with step-by-step commentary.
+//
+// Run with: go test -v -run TestWalkthrough ./server/internal/access/
+// ===========================================================================
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory DB: mirrors the principal_grants Postgres table
+// ---------------------------------------------------------------------------
+
+// principalGrantRow mirrors one row of the principal_grants table.
+//
+// CREATE TABLE principal_grants (
+//
+//	id              UUID PRIMARY KEY,
+//	organization_id UUID NOT NULL,
+//	principal_type  TEXT NOT NULL CHECK (principal_type IN ('user', 'role')),
+//	principal_id    TEXT NOT NULL,  -- user UUID or role slug
+//	scope_slug      TEXT NOT NULL,
+//	resources       TEXT[],         -- NULL = unrestricted; ARRAY = allowlist
+//	UNIQUE (organization_id, principal_type, principal_id, scope_slug)
+//
+// );
+type principalGrantRow struct {
+	OrganizationID string
+	PrincipalType  string // "user" or "role"
+	PrincipalID    string // user UUID or role slug
+	ScopeSlug      Scope
+	Resources      []string // nil = unrestricted
+}
+
+// memDB is the in-memory principal_grants table.
+type memDB struct {
+	rows []principalGrantRow
+}
+
+func newMemDB() *memDB {
+	return &memDB{}
+}
+
+// insert adds a grant row. Mirrors INSERT INTO principal_grants.
+func (db *memDB) insert(orgID, principalType, principalID string, scope Scope, resources []string) {
+	db.rows = append(db.rows, principalGrantRow{
+		OrganizationID: orgID,
+		PrincipalType:  principalType,
+		PrincipalID:    principalID,
+		ScopeSlug:      scope,
+		Resources:      resources,
+	})
+}
+
+// queryForPrincipal mirrors the SQL query the middleware runs once per request:
+//
+//	SELECT scope_slug, resources FROM principal_grants
+//	WHERE organization_id = $org
+//	  AND (
+//	    (principal_type = 'role' AND principal_id = $role_slug)
+//	    OR
+//	    (principal_type = 'user' AND principal_id = $user_id)
+//	  )
+//
+// Returns the matching rows as grantRow values for the Grants object.
+func (db *memDB) queryForPrincipal(orgID, roleSlug, userID string) []grantRow {
+	var result []grantRow
+	for _, row := range db.rows {
+		if row.OrganizationID != orgID {
+			continue
+		}
+		roleMatch := row.PrincipalType == "role" && row.PrincipalID == roleSlug
+		userMatch := row.PrincipalType == "user" && row.PrincipalID == userID
+		if !roleMatch && !userMatch {
+			continue
+		}
+		result = append(result, grantRow{
+			Scope:     row.ScopeSlug,
+			Resources: row.Resources,
+		})
+	}
+	return result
+}
+
+// resolveGrants simulates what the middleware does: query DB, build Grants.
+func (db *memDB) resolveGrants(orgID, roleSlug, userID string) *Grants {
+	return &Grants{
+		orgID:    orgID,
+		userID:   userID,
+		roleSlug: roleSlug,
+		rows:     db.queryForPrincipal(orgID, roleSlug, userID),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustCan(t *testing.T, ctx context.Context, checks ...check) {
+	t.Helper()
+	if err := Can(ctx, checks...); err != nil {
+		t.Fatalf("expected ALLOW, got DENY: %v", err)
+	}
+}
+
+func mustDeny(t *testing.T, ctx context.Context, checks ...check) {
+	t.Helper()
+	if err := Can(ctx, checks...); err == nil {
+		t.Fatalf("expected DENY, got ALLOW")
+	}
+}
+
+func mustFilter(t *testing.T, ctx context.Context, scope Scope) []string {
+	t.Helper()
+	result, err := Filter(ctx, scope)
+	if err != nil {
+		t.Fatalf("expected filter result, got error: %v", err)
+	}
+	return result
+}
+
+func mustFilterDeny(t *testing.T, ctx context.Context, scope Scope) {
+	t.Helper()
+	_, err := Filter(ctx, scope)
+	if err == nil {
+		t.Fatal("expected filter DENY, got allow")
+	}
+}
+
+func ctxWithGrants(grants *Grants) context.Context {
+	return GrantsToContext(context.Background(), grants)
+}
+
+// ===========================================================================
+// THE DATABASE: a realistic org with multiple users, roles, and resources
+// ===========================================================================
+
+func seedTestDB() *memDB {
+	db := newMemDB()
+	org := "org-acme"
+
+	// -----------------------------------------------------------------
+	// DEFAULT ROLE GRANTS (seeded at org creation — all unrestricted)
+	// These are the rows every org gets when it's created.
+	// -----------------------------------------------------------------
+
+	// admin role: all 7 scopes, unrestricted
+	for _, scope := range []Scope{ScopeOrgRead, ScopeOrgAdmin, ScopeBuildRead, ScopeBuildWrite, ScopeMCPRead, ScopeMCPWrite, ScopeMCPConnect} {
+		db.insert(org, "role", "admin", scope, nil) // nil = unrestricted
+	}
+
+	// member role: 4 scopes, unrestricted
+	for _, scope := range []Scope{ScopeOrgRead, ScopeBuildRead, ScopeMCPRead, ScopeMCPConnect} {
+		db.insert(org, "role", "member", scope, nil)
+	}
+
+	// -----------------------------------------------------------------
+	// USER-LEVEL GRANTS (set by admins for specific users)
+	// -----------------------------------------------------------------
+
+	// Bob the contractor: can ONLY connect to mcp-payments. No role grants.
+	db.insert(org, "user", "bob", ScopeMCPConnect, []string{"mcp-payments"})
+
+	// Grace the contractor: build:read on proj-xyz only.
+	db.insert(org, "user", "grace", ScopeBuildRead, []string{"proj-xyz"})
+
+	// Jack: build:read on proj-a and proj-b only.
+	db.insert(org, "user", "jack", ScopeBuildRead, []string{"proj-a", "proj-b"})
+	// Jack also gets mcp:connect on mcp-internal only.
+	db.insert(org, "user", "jack", ScopeMCPConnect, []string{"mcp-internal"})
+
+	// Irene (member role + extra user grant): her user grant is NARROWER
+	// than her role grant, but grants are additive — role wins.
+	db.insert(org, "user", "irene", ScopeBuildRead, []string{"proj-a"})
+
+	return db
+}
+
+// ===========================================================================
+// SCENARIO 1: Alice — a regular admin
+//
+//	Role: admin
+//	User grants: none
+//	Expected: can do everything, unrestricted
+// ===========================================================================
+
+func TestWalkthroughAliceAdmin(t *testing.T) {
+	db := seedTestDB()
+
+	// Middleware resolves grants for Alice (admin role, no user-level grants).
+	// DB query returns all 7 role rows, each with resources = nil.
+	grants := db.resolveGrants("org-acme", "admin", "alice")
+	ctx := ctxWithGrants(grants)
+
+	printGrants(t, "Alice (admin)", grants)
+
+	// Alice can read any project — unrestricted build:read from admin role
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-xyz"))
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-abc"))
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-brand-new")) // even a project created 5 seconds ago
+
+	// Alice can write to any project
+	mustCan(t, ctx, Check(ScopeBuildWrite, "proj-xyz"))
+
+	// Alice can manage the org
+	mustCan(t, ctx, Check(ScopeOrgAdmin, ""))
+
+	// Alice can connect to any MCP
+	mustCan(t, ctx, Check(ScopeMCPConnect, "mcp-payments"))
+	mustCan(t, ctx, Check(ScopeMCPConnect, "mcp-analytics"))
+
+	// Alice can do multi-scope operations (e.g., publish toolset)
+	mustCan(t, ctx,
+		Check(ScopeBuildWrite, "proj-xyz"),
+		Check(ScopeMCPWrite, "mcp-payments"),
+	)
+
+	// Filter: Alice sees all projects (unrestricted)
+	filter := mustFilter(t, ctx, ScopeBuildRead)
+	if filter != nil {
+		t.Fatalf("expected nil (unrestricted), got %v", filter)
+	}
+}
+
+// ===========================================================================
+// SCENARIO 2: Dave — a regular member
+//
+//	Role: member
+//	User grants: none
+//	Expected: read everything, connect to MCPs, but NO write access
+// ===========================================================================
+
+func TestWalkthroughDaveMember(t *testing.T) {
+	db := seedTestDB()
+
+	grants := db.resolveGrants("org-acme", "member", "dave")
+	ctx := ctxWithGrants(grants)
+
+	printGrants(t, "Dave (member)", grants)
+
+	// Dave can read any project — unrestricted build:read from member role
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-xyz"))
+
+	// Dave CANNOT write — member role doesn't have build:write
+	mustDeny(t, ctx, Check(ScopeBuildWrite, "proj-xyz"))
+
+	// Dave CANNOT admin the org
+	mustDeny(t, ctx, Check(ScopeOrgAdmin, ""))
+
+	// Dave CAN connect to any MCP — member role has mcp:connect unrestricted
+	mustCan(t, ctx, Check(ScopeMCPConnect, "mcp-payments"))
+
+	// Dave CANNOT write MCP config
+	mustDeny(t, ctx, Check(ScopeMCPWrite, "mcp-payments"))
+
+	// Filter: Dave sees all projects (unrestricted build:read from role)
+	filter := mustFilter(t, ctx, ScopeBuildRead)
+	if filter != nil {
+		t.Fatalf("expected nil (unrestricted), got %v", filter)
+	}
+
+	// Filter: Dave gets DENIED for build:write (no write scope at all)
+	mustFilterDeny(t, ctx, ScopeBuildWrite)
+}
+
+// ===========================================================================
+// SCENARIO 3: Bob — contractor with single MCP access, no role
+//
+//	Role: (none — or a role with zero default grants, e.g., "contractor")
+//	User grants: mcp:connect on ["mcp-payments"]
+//	Expected: can only connect to mcp-payments, nothing else
+// ===========================================================================
+
+func TestWalkthroughBobContractor(t *testing.T) {
+	db := seedTestDB()
+
+	// Bob has no role grants (role "contractor" has no default grants).
+	// Only user-level: mcp:connect on ["mcp-payments"].
+	grants := db.resolveGrants("org-acme", "contractor", "bob")
+	ctx := ctxWithGrants(grants)
+
+	printGrants(t, "Bob (contractor)", grants)
+
+	// Bob CAN connect to mcp-payments
+	mustCan(t, ctx, Check(ScopeMCPConnect, "mcp-payments"))
+
+	// Bob CANNOT connect to mcp-analytics (not in his allowlist)
+	mustDeny(t, ctx, Check(ScopeMCPConnect, "mcp-analytics"))
+
+	// Bob CANNOT read projects (no build:read grant at all)
+	mustDeny(t, ctx, Check(ScopeBuildRead, "proj-xyz"))
+
+	// Bob CANNOT list projects (no build:read → Filter returns error)
+	mustFilterDeny(t, ctx, ScopeBuildRead)
+
+	// Bob CANNOT read the org
+	mustDeny(t, ctx, Check(ScopeOrgRead, ""))
+
+	// KEY POINT: Bob has mcp:connect on mcp-payments, but NO build:read.
+	// The MCP server might "belong to" a project, but there is NO implicit
+	// hierarchy. Bob can call tools on mcp-payments but cannot see the
+	// project that contains it. (Invariant 1)
+}
+
+// ===========================================================================
+// SCENARIO 4: Grace — contractor with one project
+//
+//	Role: (none)
+//	User grants: build:read on ["proj-xyz"]
+//	Expected: can read proj-xyz, denied on everything else
+// ===========================================================================
+
+func TestWalkthroughGraceContractor(t *testing.T) {
+	db := seedTestDB()
+
+	grants := db.resolveGrants("org-acme", "contractor", "grace")
+	ctx := ctxWithGrants(grants)
+
+	printGrants(t, "Grace (contractor)", grants)
+
+	// Grace CAN read proj-xyz
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-xyz"))
+
+	// Grace CANNOT read proj-abc (not in her allowlist)
+	mustDeny(t, ctx, Check(ScopeBuildRead, "proj-abc"))
+
+	// Filter: Grace's list is restricted to ["proj-xyz"]
+	filter := mustFilter(t, ctx, ScopeBuildRead)
+	if len(filter) != 1 || filter[0] != "proj-xyz" {
+		t.Fatalf("expected [proj-xyz], got %v", filter)
+	}
+
+	// Grace CANNOT write (no build:write grant)
+	mustDeny(t, ctx, Check(ScopeBuildWrite, "proj-xyz"))
+
+	// Grace CANNOT connect to MCPs (no mcp:connect grant)
+	mustDeny(t, ctx, Check(ScopeMCPConnect, "mcp-payments"))
+}
+
+// ===========================================================================
+// SCENARIO 5: Jack — contractor with scoped access to multiple resources
+//
+//	Role: (none)
+//	User grants:
+//	  - build:read on ["proj-a", "proj-b"]
+//	  - mcp:connect on ["mcp-internal"]
+//	Expected: can read 2 projects, connect to 1 MCP, nothing else
+// ===========================================================================
+
+func TestWalkthroughJackContractor(t *testing.T) {
+	db := seedTestDB()
+
+	grants := db.resolveGrants("org-acme", "contractor", "jack")
+	ctx := ctxWithGrants(grants)
+
+	printGrants(t, "Jack (contractor)", grants)
+
+	// Jack CAN read proj-a and proj-b
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-a"))
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-b"))
+
+	// Jack CANNOT read proj-c (not in allowlist)
+	mustDeny(t, ctx, Check(ScopeBuildRead, "proj-c"))
+
+	// Jack CAN connect to mcp-internal
+	mustCan(t, ctx, Check(ScopeMCPConnect, "mcp-internal"))
+
+	// Jack CANNOT connect to mcp-payments (not in allowlist)
+	mustDeny(t, ctx, Check(ScopeMCPConnect, "mcp-payments"))
+
+	// Filter for build:read: returns ["proj-a", "proj-b"]
+	filter := mustFilter(t, ctx, ScopeBuildRead)
+	if len(filter) != 2 {
+		t.Fatalf("expected 2 projects, got %v", filter)
+	}
+
+	// Filter for mcp:connect: returns ["mcp-internal"]
+	mcpFilter := mustFilter(t, ctx, ScopeMCPConnect)
+	if len(mcpFilter) != 1 || mcpFilter[0] != "mcp-internal" {
+		t.Fatalf("expected [mcp-internal], got %v", mcpFilter)
+	}
+
+	// Filter for build:write: DENIED (no grant at all)
+	mustFilterDeny(t, ctx, ScopeBuildWrite)
+}
+
+// ===========================================================================
+// SCENARIO 6: Irene — member role + narrower user grant (additive model)
+//
+//	Role: member (unrestricted build:read, org:read, mcp:read, mcp:connect)
+//	User grants: build:read on ["proj-a"]
+//	Expected: the user grant does NOT restrict her. Role's unrestricted
+//	          build:read wins. She can read ALL projects.
+//
+//	This is the most important scenario for understanding the additive model.
+// ===========================================================================
+
+func TestWalkthroughIreneAdditiveModel(t *testing.T) {
+	db := seedTestDB()
+
+	// Irene is a "member" AND has user-level build:read on ["proj-a"].
+	// The resolver picks up BOTH the role grant and the user grant.
+	grants := db.resolveGrants("org-acme", "member", "irene")
+	ctx := ctxWithGrants(grants)
+
+	printGrants(t, "Irene (member + user grant)", grants)
+
+	// The resolved rows for build:read are:
+	//   row 1: (role, member, build:read, nil)       ← unrestricted (from role)
+	//   row 2: (user, irene,  build:read, [proj-a])  ← scoped (from user grant)
+	//
+	// hasAccess("build:read", "proj-b") iterates:
+	//   row 1: scope matches, resources is nil → return true (UNRESTRICTED WINS)
+	//   (row 2 is never even checked)
+
+	// Irene CAN read proj-b — the unrestricted role grant dominates
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-b"))
+
+	// Irene CAN read proj-a too (obviously)
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-a"))
+
+	// Irene CAN read proj-brand-new — unrestricted means ALL projects
+	mustCan(t, ctx, Check(ScopeBuildRead, "proj-brand-new"))
+
+	// Filter: unrestricted (nil), not ["proj-a"]
+	filter := mustFilter(t, ctx, ScopeBuildRead)
+	if filter != nil {
+		t.Fatalf("expected nil (unrestricted), got %v — user grant should NOT restrict below role", filter)
+	}
+
+	// KEY POINT: Adding a user-level grant NEVER restricts access.
+	// To restrict Irene to proj-a only, you would need to change her role
+	// to one that doesn't have unrestricted build:read (e.g., "contractor").
+}
+
+// ===========================================================================
+// SCENARIO 7: UpdateToolset field-level gating
+//
+//	This simulates the handler logic for UpdateToolset, showing how different
+//	users get different levels of access within the SAME endpoint.
+// ===========================================================================
+
+func TestWalkthroughUpdateToolsetFieldGating(t *testing.T) {
+	db := seedTestDB()
+	org := "org-acme"
+
+	// Give Eve build:write on proj-xyz but NO mcp:write
+	db.insert(org, "user", "eve", ScopeBuildRead, []string{"proj-xyz"})
+	db.insert(org, "user", "eve", ScopeBuildWrite, []string{"proj-xyz"})
+
+	// Give Frank build:write AND mcp:write on proj-xyz / mcp-payments
+	db.insert(org, "user", "frank-dev", ScopeBuildRead, []string{"proj-xyz"})
+	db.insert(org, "user", "frank-dev", ScopeBuildWrite, []string{"proj-xyz"})
+	db.insert(org, "user", "frank-dev", ScopeMCPWrite, []string{"mcp-payments"})
+
+	// --- Eve: can update green fields, not red fields ---
+	eveGrants := db.resolveGrants(org, "contractor", "eve")
+	eveCtx := ctxWithGrants(eveGrants)
+
+	printGrants(t, "Eve (contractor + build:write)", eveGrants)
+
+	// Step 1: build:write check (gates green fields) — ALLOW
+	mustCan(t, eveCtx, Check(ScopeBuildWrite, "proj-xyz"))
+
+	// Step 2: mcp:write check (gates red fields) — DENY
+	// This is what happens when Eve tries to set mcp_enabled=true
+	mustDeny(t, eveCtx, Check(ScopeMCPWrite, "mcp-payments"))
+
+	// So: Eve can update name, description, tools, templates (green)
+	// but NOT mcp_enabled, mcp_slug, mcp_is_public (red).
+
+	// --- Frank: can update everything ---
+	frankGrants := db.resolveGrants(org, "contractor", "frank-dev")
+	frankCtx := ctxWithGrants(frankGrants)
+
+	printGrants(t, "Frank (contractor + build:write + mcp:write)", frankGrants)
+
+	// Step 1: build:write — ALLOW
+	mustCan(t, frankCtx, Check(ScopeBuildWrite, "proj-xyz"))
+
+	// Step 2: mcp:write — ALLOW
+	mustCan(t, frankCtx, Check(ScopeMCPWrite, "mcp-payments"))
+
+	// Frank can update all fields — green AND red.
+
+	// --- Alice (admin): can update everything (unrestricted) ---
+	aliceGrants := db.resolveGrants(org, "admin", "alice")
+	aliceCtx := ctxWithGrants(aliceGrants)
+
+	mustCan(t, aliceCtx, Check(ScopeBuildWrite, "proj-xyz"))
+	mustCan(t, aliceCtx, Check(ScopeMCPWrite, "mcp-payments"))
+}
+
+// ===========================================================================
+// SCENARIO 8: API key (legacy scope translation)
+//
+//	API keys bypass the principal_grants table entirely. The middleware
+//	translates legacy scopes to synthetic grant rows.
+// ===========================================================================
+
+func TestWalkthroughAPIKeyLegacy(t *testing.T) {
+	// Simulate what the resolver does for API keys.
+	// No DB query — purely in-code translation.
+
+	legacyMap := map[string][]Scope{
+		"producer": {ScopeOrgRead, ScopeBuildRead, ScopeBuildWrite, ScopeMCPRead, ScopeMCPWrite, ScopeMCPConnect},
+		"consumer": {ScopeOrgRead, ScopeBuildRead, ScopeMCPRead, ScopeMCPConnect},
+		"chat":     {ScopeMCPRead, ScopeMCPConnect},
+	}
+
+	buildSyntheticGrants := func(legacyScopes []string) *Grants {
+		g := &Grants{}
+		for _, ls := range legacyScopes {
+			for _, scope := range legacyMap[ls] {
+				g.rows = append(g.rows, grantRow{Scope: scope, Resources: nil}) // all unrestricted
+			}
+		}
+		return g
+	}
+
+	// --- Producer key ---
+	producerGrants := buildSyntheticGrants([]string{"producer"})
+	producerCtx := ctxWithGrants(producerGrants)
+
+	printGrants(t, "API key (producer)", producerGrants)
+
+	mustCan(t, producerCtx, Check(ScopeBuildWrite, "proj-xyz"))     // can write
+	mustCan(t, producerCtx, Check(ScopeMCPConnect, "mcp-payments")) // can connect
+	mustDeny(t, producerCtx, Check(ScopeOrgAdmin, ""))              // CANNOT admin (intentional)
+
+	// --- Consumer key ---
+	consumerGrants := buildSyntheticGrants([]string{"consumer"})
+	consumerCtx := ctxWithGrants(consumerGrants)
+
+	mustCan(t, consumerCtx, Check(ScopeBuildRead, "proj-xyz"))      // can read
+	mustCan(t, consumerCtx, Check(ScopeMCPConnect, "mcp-payments")) // can connect
+	mustDeny(t, consumerCtx, Check(ScopeBuildWrite, "proj-xyz"))    // CANNOT write
+	mustDeny(t, consumerCtx, Check(ScopeMCPWrite, "mcp-payments"))  // CANNOT write MCP
+
+	// --- Chat key ---
+	chatGrants := buildSyntheticGrants([]string{"chat"})
+	chatCtx := ctxWithGrants(chatGrants)
+
+	mustCan(t, chatCtx, Check(ScopeMCPConnect, "mcp-payments")) // can connect
+	mustDeny(t, chatCtx, Check(ScopeBuildRead, "proj-xyz"))     // CANNOT read projects
+	mustDeny(t, chatCtx, Check(ScopeOrgRead, ""))               // CANNOT read org
+}
+
+// ===========================================================================
+// SCENARIO 9: New project — no seeding needed
+//
+//	When a new project is created, users with unrestricted build:read
+//	can access it immediately. No rows need to be inserted.
+//	Users with scoped grants do NOT get access automatically.
+// ===========================================================================
+
+func TestWalkthroughNewProjectNoSeeding(t *testing.T) {
+	db := seedTestDB()
+
+	brandNewProjectID := "proj-created-5-seconds-ago"
+
+	// Dave (member) — unrestricted build:read from role
+	daveGrants := db.resolveGrants("org-acme", "member", "dave")
+	daveCtx := ctxWithGrants(daveGrants)
+
+	// Dave CAN read the new project — no grant insertion needed
+	mustCan(t, daveCtx, Check(ScopeBuildRead, brandNewProjectID))
+
+	// Jack (contractor) — scoped build:read on [proj-a, proj-b]
+	jackGrants := db.resolveGrants("org-acme", "contractor", "jack")
+	jackCtx := ctxWithGrants(jackGrants)
+
+	// Jack CANNOT read the new project — it's not in his allowlist
+	mustDeny(t, jackCtx, Check(ScopeBuildRead, brandNewProjectID))
+
+	// An admin would need to add brandNewProjectID to Jack's allowlist
+	// via UPDATE principal_grants SET resources = array_append(resources, 'proj-created-5-seconds-ago')
+}
+
+// ===========================================================================
+// Helper: print resolved grants for debugging
+// ===========================================================================
+
+func printGrants(t *testing.T, label string, g *Grants) {
+	t.Helper()
+	t.Logf("=== Resolved grants for %s ===", label)
+	if len(g.rows) == 0 {
+		t.Logf("  (no grants)")
+		return
+	}
+	for _, row := range g.rows {
+		if row.Resources == nil {
+			t.Logf("  %-15s  resources: NULL (unrestricted)", row.Scope)
+		} else {
+			t.Logf("  %-15s  resources: [%s]", row.Scope, strings.Join(row.Resources, ", "))
+		}
+	}
+	_ = fmt.Sprintf("") // suppress unused import
+}

--- a/server/internal/access/handler_examples_test.go
+++ b/server/internal/access/handler_examples_test.go
@@ -1,0 +1,563 @@
+// Package access — handler integration examples.
+//
+// THIS FILE IS A DESIGN EXAMPLE — it shows how handlers at various levels of
+// complexity would integrate with the access package. It is meant to be read
+// during RFC review, not to compile.
+//
+// Each example maps to a real handler pattern found in the codebase and shows
+// the before/after diff.
+package access_test
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/access"
+)
+
+// ===========================================================================
+// EXAMPLE 1: Simple read — GetProject
+// ===========================================================================
+//
+// Before (current code, server/internal/projects/impl.go:76):
+//
+//	func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload) (*gen.GetProjectResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//	    // ... query project ...
+//	}
+//
+// After:
+//
+//	func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload) (*gen.GetProjectResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    // NEW: RBAC check — build:read on this project
+//	    if err := access.Can(ctx, access.Check(access.ScopeBuildRead, projectID)); err != nil {
+//	        return nil, err
+//	    }
+//
+//	    // ... query project (unchanged) ...
+//	}
+//
+// Notes:
+//   - One line added. The middleware already resolved Grants into context.
+//   - projectID comes from resolving payload.Slug -> DB row -> ID.
+//     Alternatively, middleware could pass it from authCtx.ProjectID.
+//   - If the user doesn't have build:read for this project, they get 403.
+
+func ExampleCan_simpleRead() {
+	ctx := context.Background()
+	projectID := "proj-abc-123"
+
+	// This is the entire RBAC integration for a simple read endpoint.
+	if err := access.Can(ctx, access.Check(access.ScopeBuildRead, projectID)); err != nil {
+		// returns 403 — handler stops here
+		_ = err
+		return
+	}
+	// ... handler continues with query logic ...
+}
+
+// ===========================================================================
+// EXAMPLE 2: Simple write — CreateDeployment
+// ===========================================================================
+//
+// Before:
+//
+//	func (s *Service) CreateDeployment(ctx context.Context, payload *gen.CreateDeploymentPayload) (*gen.CreateDeploymentResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ProjectID == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//	    // ... create deployment ...
+//	}
+//
+// After:
+//
+//	func (s *Service) CreateDeployment(ctx context.Context, payload *gen.CreateDeploymentPayload) (*gen.CreateDeploymentResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ProjectID == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    // NEW: RBAC check — build:write on the project
+//	    if err := access.Can(ctx, access.Check(access.ScopeBuildWrite, authCtx.ProjectID.String())); err != nil {
+//	        return nil, err
+//	    }
+//
+//	    // ... create deployment (unchanged) ...
+//	}
+//
+// Notes:
+//   - For "create" endpoints, the resource being created doesn't exist yet.
+//     We check against the PARENT resource (the project).
+//   - authCtx.ProjectID is already available from the project_slug security
+//     scheme, so no extra DB lookup is needed.
+
+func ExampleCan_simpleWrite() {
+	ctx := context.Background()
+	projectID := "proj-abc-123"
+
+	if err := access.Can(ctx, access.Check(access.ScopeBuildWrite, projectID)); err != nil {
+		_ = err
+		return
+	}
+	// ... create the deployment ...
+}
+
+// ===========================================================================
+// EXAMPLE 3: Org-level admin — CreateKey
+// ===========================================================================
+//
+// Before:
+//
+//	func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) (*gen.CreateKeyResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//	    // ... create API key ...
+//	}
+//
+// After:
+//
+//	func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) (*gen.CreateKeyResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    // NEW: RBAC check — org:admin (no resource ID for org-scoped checks)
+//	    if err := access.Can(ctx, access.Check(access.ScopeOrgAdmin, "")); err != nil {
+//	        return nil, err
+//	    }
+//
+//	    // ... create API key (unchanged) ...
+//	}
+//
+// Notes:
+//   - Org-scoped checks use empty string for resourceID.
+//   - org:admin is never resource-scoped (there's only one org per request).
+
+func ExampleCan_orgAdmin() {
+	ctx := context.Background()
+
+	// Org-level check — no resource ID needed
+	if err := access.Can(ctx, access.Check(access.ScopeOrgAdmin, "")); err != nil {
+		_ = err
+		return
+	}
+}
+
+// ===========================================================================
+// EXAMPLE 4: List endpoint with resource filtering — ListProjects
+// ===========================================================================
+//
+// Before (server/internal/projects/impl.go:166):
+//
+//	func (s *Service) ListProjects(ctx context.Context, payload *gen.ListProjectsPayload) (*gen.ListProjectsResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.SessionID == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//	    // ... org membership check ...
+//	    projects, err := s.repo.ListProjectsByOrganization(ctx, payload.OrganizationID)
+//	    // ... map and return ...
+//	}
+//
+// After:
+//
+//	func (s *Service) ListProjects(ctx context.Context, payload *gen.ListProjectsPayload) (*gen.ListProjectsResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    // NEW: RBAC filter — returns nil (unrestricted) or []string (allowlist)
+//	    filter, err := access.Filter(ctx, access.ScopeBuildRead)
+//	    if err != nil {
+//	        return nil, err // 403 — user has no build:read at all
+//	    }
+//
+//	    // Pass filter to query — nil means no WHERE clause, []string means WHERE id = ANY($filter)
+//	    projects, err := s.repo.ListProjectsByOrganization(ctx, payload.OrganizationID, filter)
+//	    // ... map and return (unchanged) ...
+//	}
+//
+// The SQLc query changes to:
+//
+//	-- name: ListProjectsByOrganization :many
+//	SELECT * FROM projects
+//	WHERE organization_id = $1
+//	  AND deleted_at IS NULL
+//	  AND ($2::text[] IS NULL OR id::text = ANY($2))
+//	ORDER BY created_at DESC;
+//
+// Notes:
+//   - Filter replaces the old org-membership check for list endpoints.
+//   - Pagination works correctly because the DB applies the filter.
+//   - If the user is unrestricted (role grant with NULL resources), filter
+//     returns nil, and the query returns everything — no performance penalty.
+
+func ExampleFilter_listProjects() {
+	ctx := context.Background()
+
+	filter, err := access.Filter(ctx, access.ScopeBuildRead)
+	if err != nil {
+		// 403 — no access at all
+		_ = err
+		return
+	}
+	// filter is nil (unrestricted) or []string{"proj-a", "proj-b"} (allowlist)
+	_ = filter
+	// Pass to: s.repo.ListProjectsByOrganization(ctx, orgID, filter)
+}
+
+// ===========================================================================
+// EXAMPLE 5: Field-level gating — UpdateToolset (THE KEY EXAMPLE)
+// ===========================================================================
+//
+// This is the critical use case from the images. UpdateToolset has fields that
+// require different permission levels:
+//
+//   GREEN fields (build:write on project):
+//     - name, description, default_environment_slug
+//     - prompt_template_names, tool_urns, resource_urns
+//     - tool_selection_mode
+//
+//   RED fields (mcp:write on mcp resource):
+//     - mcp_enabled, mcp_slug, mcp_is_public, custom_domain_id
+//
+// A user with build:write but NOT mcp:write can update the green fields
+// but NOT the red ones — in a SINGLE endpoint.
+//
+// Before (server/internal/toolsets/impl.go:201):
+//
+//	func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetPayload) (*types.Toolset, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ProjectID == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//	    // ... all fields updated without permission checks ...
+//	}
+//
+// After:
+//
+//	func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetPayload) (*types.Toolset, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ProjectID == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    projectID := authCtx.ProjectID.String()
+//
+//	    // STEP 1: Every UpdateToolset call requires build:write on the project.
+//	    // This gates the "green" fields (name, description, tools, etc).
+//	    if err := access.Can(ctx, access.Check(access.ScopeBuildWrite, projectID)); err != nil {
+//	        return nil, err
+//	    }
+//
+//	    // STEP 2: If any MCP-related field is being modified, ALSO require
+//	    // mcp:write on the MCP resource. This gates the "red" fields.
+//	    if hasMCPFields(payload) {
+//	        mcpID := existingToolset.McpSlug.String // resolved after fetching existing toolset
+//	        if err := access.Can(ctx, access.Check(access.ScopeMCPWrite, mcpID)); err != nil {
+//	            return nil, err
+//	        }
+//	    }
+//
+//	    // ... rest of handler (unchanged) ...
+//	}
+//
+// The helper:
+//
+//	func hasMCPFields(p *gen.UpdateToolsetPayload) bool {
+//	    return p.McpEnabled != nil || p.McpSlug != nil || p.McpIsPublic != nil || p.CustomDomainID != nil
+//	}
+//
+// KEY INSIGHT: This is why we need handler-level checks, not middleware-only.
+// Middleware sees one endpoint (toolsets.updateToolset) and can only check one
+// scope. But the handler knows which fields are being modified and can check
+// different scopes for different field groups.
+
+func ExampleCan_fieldLevelGating() {
+	ctx := context.Background()
+	projectID := "proj-abc-123"
+	mcpID := "mcp-payments"
+
+	// Always required — gates the "green" fields
+	if err := access.Can(ctx, access.Check(access.ScopeBuildWrite, projectID)); err != nil {
+		_ = err
+		return
+	}
+
+	// Conditionally required — only if MCP fields are present in payload
+	mcpFieldsPresent := true // payload.McpEnabled != nil || payload.McpSlug != nil || ...
+	if mcpFieldsPresent {
+		if err := access.Can(ctx, access.Check(access.ScopeMCPWrite, mcpID)); err != nil {
+			_ = err
+			return
+		}
+	}
+}
+
+// ===========================================================================
+// EXAMPLE 6: Multi-scope check in one call — PublishToolset
+// ===========================================================================
+//
+// PublishToolset needs BOTH build:write (to modify the toolset) AND mcp:write
+// (to affect the MCP server). Both must pass.
+//
+//	func (s *Service) PublishToolset(ctx context.Context, payload *gen.PublishToolsetPayload) (*types.Toolset, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ProjectID == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    // Both scopes required — if either fails, the whole call is denied.
+//	    if err := access.Can(ctx,
+//	        access.Check(access.ScopeBuildWrite, authCtx.ProjectID.String()),
+//	        access.Check(access.ScopeMCPWrite, mcpID),
+//	    ); err != nil {
+//	        return nil, err
+//	    }
+//
+//	    // ... publish logic ...
+//	}
+
+func ExampleCan_multiScope() {
+	ctx := context.Background()
+	projectID := "proj-abc-123"
+	mcpID := "mcp-payments"
+
+	// Both must pass — single Can call with multiple checks
+	if err := access.Can(ctx,
+		access.Check(access.ScopeBuildWrite, projectID),
+		access.Check(access.ScopeMCPWrite, mcpID),
+	); err != nil {
+		_ = err
+		return
+	}
+}
+
+// ===========================================================================
+// EXAMPLE 7: MCP tool invocation — instances service
+// ===========================================================================
+//
+// The instances service handles MCP RPC calls (tools/call, prompts/get, etc).
+// These require mcp:connect on the specific MCP server.
+//
+//	func (s *Service) HandleRPC(ctx context.Context, payload *gen.HandleRPCPayload) (*gen.HandleRPCResult, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    mcpID := resolveMCPID(ctx, payload) // from request routing
+//
+//	    if err := access.Can(ctx, access.Check(access.ScopeMCPConnect, mcpID)); err != nil {
+//	        return nil, err
+//	    }
+//
+//	    // ... dispatch RPC to MCP server ...
+//	}
+//
+// Note: mcp:connect is independent of build:read. A contractor with
+// mcp:connect on "mcp-payments" but no build:read cannot see the project
+// that contains the MCP server. Invariant 1: no implicit hierarchy.
+
+func ExampleCan_mcpConnect() {
+	ctx := context.Background()
+	mcpID := "mcp-payments"
+
+	if err := access.Can(ctx, access.Check(access.ScopeMCPConnect, mcpID)); err != nil {
+		_ = err
+		return
+	}
+}
+
+// ===========================================================================
+// EXAMPLE 8: Middleware — enforcement + safety net
+// ===========================================================================
+//
+// The middleware is a Goa endpoint middleware (same pattern as MapErrors and
+// TraceMethods). It wraps every endpoint with grant resolution and post-check
+// verification.
+//
+//	func Enforce(resolver *Resolver) func(goa.Endpoint) goa.Endpoint {
+//	    return func(next goa.Endpoint) goa.Endpoint {
+//	        return func(ctx context.Context, req any) (any, error) {
+//	            svc, _ := ctx.Value(goa.ServiceKey).(string)
+//	            method, _ := ctx.Value(goa.MethodKey).(string)
+//
+//	            // Check exemptions first
+//	            if reason, exempt := Exemptions[svc]; exempt {
+//	                _ = reason // logged at startup
+//	                return next(ctx, req)
+//	            }
+//
+//	            // Resolve grants from DB/cache (or synthetic for API keys/bypass)
+//	            authCtx, _ := contextvalues.GetAuthContext(ctx)
+//	            grants, err := resolver.Resolve(ctx, authCtx)
+//	            if err != nil {
+//	                return nil, err
+//	            }
+//
+//	            // Inject grants into context for handlers to use
+//	            ctx = GrantsToContext(ctx, grants)
+//
+//	            // Call the handler
+//	            result, err := next(ctx, req)
+//
+//	            // SAFETY NET: verify at least one check was performed
+//	            if !grants.checked.Load() {
+//	                // In dev: panic("handler %s.%s did not perform any access check")
+//	                // In prod: log warning
+//	                logger.WarnContext(ctx, "handler did not perform access check",
+//	                    slog.String("service", svc),
+//	                    slog.String("method", method),
+//	                )
+//	            }
+//
+//	            return result, err
+//	        }
+//	    }
+//	}
+//
+// Wiring in Attach (server/internal/toolsets/impl.go):
+//
+//	func Attach(mux goahttp.Muxer, service *Service) {
+//	    endpoints := gen.NewEndpoints(service)
+//	    endpoints.Use(middleware.MapErrors())
+//	    endpoints.Use(middleware.TraceMethods(service.tracer))
+//	    endpoints.Use(access.Enforce(service.resolver))  // <-- NEW
+//	    srv.Mount(mux, srv.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, nil, nil))
+//	}
+
+// ===========================================================================
+// EXAMPLE 9: Resolver — how grants are built for different auth types
+// ===========================================================================
+//
+// The Resolver produces Grants differently depending on how the user authenticated:
+//
+//	type Resolver struct {
+//	    repo  *repo.Queries
+//	    cache cache.Cache
+//	}
+//
+//	func (r *Resolver) Resolve(ctx context.Context, authCtx *contextvalues.AuthContext) (*Grants, error) {
+//	    // 1. Chat session / function token → bypass (always allow)
+//	    if authCtx.AccountType == "chat_session" || authCtx.AccountType == "function" {
+//	        return bypassGrants(), nil
+//	    }
+//
+//	    // 2. API key → translate legacy scopes, no DB query
+//	    if authCtx.APIKeyID != "" {
+//	        return syntheticGrantsFromAPIKey(authCtx.APIKeyScopes), nil
+//	    }
+//
+//	    // 3. Session user → query DB (with cache)
+//	    cacheKey := fmt.Sprintf("rbac:%s:%s", authCtx.UserID, authCtx.ActiveOrganizationID)
+//	    if cached, ok := r.cache.Get(ctx, cacheKey); ok {
+//	        return cached.(*Grants), nil
+//	    }
+//
+//	    rows, err := r.repo.GetPrincipalGrants(ctx, repo.GetPrincipalGrantsParams{
+//	        OrganizationID: authCtx.ActiveOrganizationID,
+//	        RoleSlug:       authCtx.RoleSlug, // from org_user_relationships.workos_role_slug
+//	        UserID:         authCtx.UserID,
+//	    })
+//	    if err != nil {
+//	        return nil, fmt.Errorf("resolve grants: %w", err)
+//	    }
+//
+//	    grants := buildGrants(authCtx, rows)
+//	    r.cache.Set(ctx, cacheKey, grants, 5*time.Minute)
+//	    return grants, nil
+//	}
+//
+// Legacy API key translation (static map, no DB):
+//
+//	var legacyAPIKeyMap = map[string][]Scope{
+//	    "producer": {ScopeOrgRead, ScopeBuildRead, ScopeBuildWrite, ScopeMCPRead, ScopeMCPWrite, ScopeMCPConnect},
+//	    "consumer": {ScopeOrgRead, ScopeBuildRead, ScopeMCPRead, ScopeMCPConnect},
+//	    "chat":     {ScopeMCPRead, ScopeMCPConnect},
+//	}
+//
+//	func syntheticGrantsFromAPIKey(legacyScopes []string) *Grants {
+//	    g := &Grants{}
+//	    for _, ls := range legacyScopes {
+//	        for _, scope := range legacyAPIKeyMap[ls] {
+//	            g.rows = append(g.rows, grantRow{Scope: scope, Resources: nil}) // unrestricted
+//	        }
+//	    }
+//	    return g
+//	}
+
+// ===========================================================================
+// EXAMPLE 10: Complete before/after for UpdateToolset with full context
+// ===========================================================================
+//
+// This is the most complex example — showing the complete handler with all
+// the access checks inline, matching the real codebase structure.
+//
+//	func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetPayload) (*types.Toolset, error) {
+//	    authCtx, ok := contextvalues.GetAuthContext(ctx)
+//	    if !ok || authCtx == nil || authCtx.ProjectID == nil {
+//	        return nil, oops.C(oops.CodeUnauthorized)
+//	    }
+//
+//	    logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogToolsetSlug(string(payload.Slug)))
+//
+//	    // ---------------------------------------------------------------
+//	    // RBAC: build:write is always required (gates green fields)
+//	    // ---------------------------------------------------------------
+//	    if err := access.Can(ctx, access.Check(access.ScopeBuildWrite, authCtx.ProjectID.String())); err != nil {
+//	        return nil, err
+//	    }
+//
+//	    dbtx, err := s.db.Begin(ctx)
+//	    if err != nil {
+//	        return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, logger)
+//	    }
+//	    defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+//
+//	    tr := s.repo.WithTx(dbtx)
+//
+//	    existingToolset, err := tr.GetToolset(ctx, repo.GetToolsetParams{
+//	        Slug:      conv.ToLower(payload.Slug),
+//	        ProjectID: *authCtx.ProjectID,
+//	    })
+//	    if err != nil {
+//	        return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+//	    }
+//
+//	    // ---------------------------------------------------------------
+//	    // RBAC: if any MCP field is being changed, require mcp:write
+//	    // ---------------------------------------------------------------
+//	    if payload.McpEnabled != nil || payload.McpSlug != nil || payload.McpIsPublic != nil || payload.CustomDomainID != nil {
+//	        mcpID := existingToolset.McpSlug.String
+//	        if err := access.Can(ctx, access.Check(access.ScopeMCPWrite, mcpID)); err != nil {
+//	            return nil, err
+//	        }
+//	    }
+//
+//	    // ... build updateParams from existing + payload fields (unchanged) ...
+//	    // ... validate, update, commit (unchanged) ...
+//
+//	    return toolsetDetails, nil
+//	}
+//
+// Why this works:
+//   - A member with build:write but NOT mcp:write can update name, description,
+//     tools, templates, etc. — all the "green" fields.
+//   - If they try to set mcp_enabled=true, the second check kicks in and
+//     returns 403.
+//   - An admin with both build:write AND mcp:write can update everything.
+//   - The safety-net middleware sees that at least one Can() call was made
+//     (the first one), so it doesn't panic/warn.


### PR DESCRIPTION
## Summary

Reference implementation and test walkthrough for the in-house RBAC system designed in [RFC: Gram RBAC — Scope & Permission Design](https://www.notion.so/speakeasyapi/RFC-Gram-RBAC-Scope-Permission-Design-319726c497cc8177b7e9dea65a91ff10).

**This PR is not intended to merge.** It serves as a reference for the actual implementation.

## Files

- **`access_design_example.go`** — Package API surface: `Can()`, `Filter()`, `Check()`, `Grants` type, `hasAccess`/`resourceFilter` algorithms, context helpers, error types
- **`handler_examples_test.go`** — 10 handler examples showing before/after patterns for real codebase handlers (simple read, write, org admin, list filtering, field-level gating, multi-scope, MCP connect, middleware shape, resolver, complete UpdateToolset)
- **`check_walkthrough_test.go`** — 9 runnable test scenarios with in-memory DB mirroring `principal_grants` schema, covering admin, member, contractor, additive model, field-level gating, API keys, and new-project auto-access

## Key design decisions captured

- 3 public functions only: `access.Can(ctx, checks...)`, `access.Filter(ctx, scope)`, `access.Check(scope, resourceID)`
- All grants resolved upfront per request (not per-scope)
- Subject comes from context (no explicit parameter)
- Creation endpoints check against parent scope with empty resource ID
- Field-level gating via sequential `Can()` calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
