### PR TITLE
fix: remove duplicate clickhouse port mapping

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -70,7 +70,6 @@ services:
     ports:
       - "${CLICKHOUSE_HTTP_PORT}:8123"
       - "${CLICKHOUSE_NATIVE_PORT}:9440"
-      - "${CLICKHOUSE_HTTP_PORT}:8123"
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: gram


### PR DESCRIPTION
## Summary
- Removed duplicate `${CLICKHOUSE_HTTP_PORT}:8123` port mapping in the clickhouse service (compose.yml line 73 was identical to line 71)
- This caused Docker Compose validation to fail: `services.clickhouse.ports array items[0,2] must be unique`
- Broke `./zero` setup for all developers

## Test plan
- [x] Verified `compose.yml` passes Docker Compose validation
- [ ] Run `./zero` to confirm local dev environment starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
