### PR TITLE
mig: add scopes and principal_grants tables for RBAC

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1142,6 +1142,7 @@ CREATE TABLE IF NOT EXISTS organization_user_relationships (
   organization_id TEXT NOT NULL,
   user_id TEXT NOT NULL,
   workos_membership_id TEXT,
+  workos_role_slug TEXT NOT NULL DEFAULT 'member',
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -1487,3 +1488,36 @@ CREATE TABLE IF NOT EXISTS hooks_server_name_overrides (
 );
 
 CREATE INDEX IF NOT EXISTS hooks_server_name_overrides_project_id_display_name_idx ON hooks_server_name_overrides(project_id, display_name);
+
+-- RBAC: scope vocabulary (reference data, seeded at app startup)
+CREATE TABLE IF NOT EXISTS scopes (
+  slug TEXT NOT NULL,
+
+  CONSTRAINT scopes_pkey PRIMARY KEY (slug)
+);
+
+-- RBAC: principal grants
+-- One row per (org, principal, scope).
+-- resources = NULL   -> unrestricted: principal has this scope for all resources in the org.
+-- resources = ARRAY  -> allowlist: principal has this scope only for the listed resource IDs.
+-- The UNIQUE constraint guarantees at most one row per (org, principal, scope),
+-- so NULL (unrestricted) and ARRAY (allowlist) are mutually exclusive by construction.
+CREATE TABLE IF NOT EXISTS principal_grants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id TEXT NOT NULL,
+  principal_type TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  scope_slug TEXT NOT NULL,
+  resources TEXT[],
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT principal_grants_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT principal_grants_scope_slug_fkey FOREIGN KEY (scope_slug) REFERENCES scopes (slug) ON DELETE RESTRICT,
+  CONSTRAINT principal_grants_principal_type_check CHECK (principal_type IN ('user', 'role')),
+  CONSTRAINT principal_grants_resources_check CHECK (resources IS NULL OR array_length(resources, 1) BETWEEN 1 AND 200),
+  CONSTRAINT principal_grants_organization_id_principal_type_principal_id_scope_slug_key UNIQUE (organization_id, principal_type, principal_id, scope_slug)
+);
+
+CREATE INDEX IF NOT EXISTS principal_grants_resources_idx ON principal_grants USING GIN (resources);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -582,6 +582,7 @@ type OrganizationUserRelationship struct {
 	OrganizationID     string
 	UserID             string
 	WorkosMembershipID pgtype.Text
+	WorkosRoleSlug     string
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz
@@ -620,6 +621,17 @@ type PackageVersion struct {
 	UpdatedAt    pgtype.Timestamptz
 	DeletedAt    pgtype.Timestamptz
 	Deleted      bool
+}
+
+type PrincipalGrant struct {
+	ID             uuid.UUID
+	OrganizationID string
+	PrincipalType  string
+	PrincipalID    string
+	ScopeSlug      string
+	Resources      []string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
 }
 
 type Project struct {
@@ -670,6 +682,10 @@ type PromptTemplate struct {
 	UpdatedAt     pgtype.Timestamptz
 	DeletedAt     pgtype.Timestamptz
 	Deleted       bool
+}
+
+type Scope struct {
+	Slug string
 }
 
 type SlackApp struct {

--- a/server/internal/organizations/repo/models.go
+++ b/server/internal/organizations/repo/models.go
@@ -25,6 +25,7 @@ type OrganizationUserRelationship struct {
 	OrganizationID     string
 	UserID             string
 	WorkosMembershipID pgtype.Text
+	WorkosRoleSlug     string
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -105,7 +105,7 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 }
 
 const listOrganizationUsers = `-- name: ListOrganizationUsers :many
-SELECT id, organization_id, user_id, workos_membership_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, user_id, workos_membership_id, workos_role_slug, created_at, updated_at, deleted_at, deleted
 FROM organization_user_relationships
 WHERE organization_id = $1
   AND deleted_at IS NULL
@@ -125,6 +125,7 @@ func (q *Queries) ListOrganizationUsers(ctx context.Context, organizationID stri
 			&i.OrganizationID,
 			&i.UserID,
 			&i.WorkosMembershipID,
+			&i.WorkosRoleSlug,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -216,7 +217,7 @@ INSERT INTO organization_user_relationships (
 )
 ON CONFLICT (organization_id, user_id) DO UPDATE SET
     updated_at = clock_timestamp()
-RETURNING id, organization_id, user_id, workos_membership_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, user_id, workos_membership_id, workos_role_slug, created_at, updated_at, deleted_at, deleted
 `
 
 type UpsertOrganizationUserRelationshipParams struct {
@@ -232,6 +233,7 @@ func (q *Queries) UpsertOrganizationUserRelationship(ctx context.Context, arg Up
 		&i.OrganizationID,
 		&i.UserID,
 		&i.WorkosMembershipID,
+		&i.WorkosRoleSlug,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260312161357_add-rbac-scopes-and-principal-grants.sql
+++ b/server/migrations/20260312161357_add-rbac-scopes-and-principal-grants.sql
@@ -1,0 +1,26 @@
+-- Modify "organization_user_relationships" table
+ALTER TABLE "organization_user_relationships" ADD COLUMN "workos_role_slug" text NOT NULL DEFAULT 'member';
+-- Create "scopes" table
+CREATE TABLE "scopes" (
+  "slug" text NOT NULL,
+  PRIMARY KEY ("slug")
+);
+-- Create "principal_grants" table
+CREATE TABLE "principal_grants" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "organization_id" text NOT NULL,
+  "principal_type" text NOT NULL,
+  "principal_id" text NOT NULL,
+  "scope_slug" text NOT NULL,
+  "resources" text[] NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "principal_grants_organization_id_principal_type_principal_id_sc" UNIQUE ("organization_id", "principal_type", "principal_id", "scope_slug"),
+  CONSTRAINT "principal_grants_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "principal_grants_scope_slug_fkey" FOREIGN KEY ("scope_slug") REFERENCES "scopes" ("slug") ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT "principal_grants_principal_type_check" CHECK (principal_type = ANY (ARRAY['user'::text, 'role'::text])),
+  CONSTRAINT "principal_grants_resources_check" CHECK ((resources IS NULL) OR ((array_length(resources, 1) >= 1) AND (array_length(resources, 1) <= 200)))
+);
+-- Create index "principal_grants_resources_idx" to table: "principal_grants"
+CREATE INDEX "principal_grants_resources_idx" ON "principal_grants" USING gin ("resources");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:T6X8ONK6hd7UuxyxKz3p+JjEuv3cZSZXTKgvxdT6uHA=
+h1:gk8B2xK9m4NFEHPCE/86R2MaxwMjZYXoZ0Uzm/O1ZkU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -114,3 +114,4 @@ h1:T6X8ONK6hd7UuxyxKz3p+JjEuv3cZSZXTKgvxdT6uHA=
 20260306123333_add-selected-remotes-column.sql h1:rxIWPKJv8Skpp6GPr4sTKWVL2SmVh3w5S4Un0CWMK38=
 20260310212348_slack_app_registrations.sql h1:RqVogi5e4YZLe9b14dNKrtzxag0YGZL7FlB1Rn/PwcY=
 20260311194019_hooks_server_display_names.sql h1:W3W8A7k5bclXWIVCnKFy8FmqMQUD732OyaThBdQC/Gw=
+20260312161357_add-rbac-scopes-and-principal-grants.sql h1:pSBdlSQrNZmmfPDjOK59K1PRoEmRwEgNs+abdGrBeUc=


### PR DESCRIPTION
## Summary

- Adds `workos_role_slug` column (TEXT NOT NULL DEFAULT 'member') to `organization_user_relationships` to track WorkOS role assignments
- Creates `scopes` reference table (slug-only PK) for RBAC scope vocabulary
- Creates `principal_grants` table for fine-grained permission grants per (org, principal_type, principal_id, scope_slug)
  - TEXT[] `resources` column for optional resource-level allowlists (capped at 200 via CHECK)
  - GIN index on `resources` for array containment queries
  - FK to `organization_metadata` (CASCADE) and `scopes` (RESTRICT)

Scope seed data will be inserted at app startup (not in the migration).

Ref: [AGE-1563](https://linear.app/speakeasy/issue/AGE-1563)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
