### PR TITLE
feat: $(echo 'PWNED') add feature

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@ client/sdk/** linguist-generated
 server/gen/** linguist-generated
 server/internal/**/*.sql.go linguist-generated
 openrouter/** linguist-generated
+
+hey


### PR DESCRIPTION
## Script injection PoC for hygiene.yaml

Demonstrates that `github.event.pull_request.title` is interpolated directly into `run:` shell commands in `.github/workflows/hygiene.yaml`, allowing command substitution via `$(...)` in PR titles.

### The vulnerability

The workflow does:
```yaml
run: |
  if [[ "${{ github.event.pull_request.title }}" =~ ^(chore|fix|feat|mig)... ]]; then
```

Because `${{ }}` is textual substitution before bash parsing, a PR title containing `$(cmd)` executes `cmd` on the CI runner.

### Fix

Pass the title through an environment variable instead:
```yaml
env:
  PR_TITLE: ${{ github.event.pull_request.title }}
run: |
  if [[ "$PR_TITLE" =~ ... ]]; then
```

Environment variables are not subject to shell expansion in the script template.

### Impact

Low — the `pull_request` trigger does not expose repo secrets for fork PRs, and collaborators already have direct access. Still worth fixing as a hygiene issue.