### PR TITLE
feat: add copy install URL button to MCP cards

### DIFF
--- a/client/dashboard/src/components/mcp/MCPCard.tsx
+++ b/client/dashboard/src/components/mcp/MCPCard.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Type } from "@/components/ui/type";
 import { UpdatedAt } from "@/components/updated-at";
 import { useMcpUrl } from "@/hooks/useToolsetUrl";
@@ -6,8 +6,8 @@ import { cn } from "@/lib/utils";
 import { useRoutes } from "@/routes";
 import { ToolsetEntry } from "@gram/client/models/components";
 import { useLatestDeployment } from "@gram/client/react-query";
-import { Check, Link2 } from "lucide-react";
-import { type MouseEvent, useMemo, useState } from "react";
+import { Link2 } from "lucide-react";
+import { useMemo } from "react";
 import { useCatalogIconMap } from "../sources/Sources";
 import {
   ExternalMCPIllustration,
@@ -121,7 +121,14 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
             {toolset.name}
           </Type>
           <div className="flex items-center gap-1">
-            {installPageUrl && <CopyLinkButton url={installPageUrl} />}
+            {installPageUrl && (
+              <CopyButton
+                text={installPageUrl}
+                size="icon-sm"
+                icon={Link2}
+                tooltip="Copy install page URL"
+              />
+            )}
             <ToolCollectionBadge toolNames={toolset.tools.map((t) => t.name)} />
           </div>
         </div>
@@ -138,28 +145,5 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
         </div>
       </div>
     </div>
-  );
-}
-
-function CopyLinkButton({ url }: { url: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleClick = (e: MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-    navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1000);
-  };
-
-  return (
-    <Button
-      variant="ghost"
-      size="icon-sm"
-      onClick={handleClick}
-      tooltip="Copy install page URL"
-    >
-      {copied ? <Check className="h-4 w-4" /> : <Link2 className="h-4 w-4" />}
-    </Button>
   );
 }

--- a/client/dashboard/src/components/ui/copy-button.tsx
+++ b/client/dashboard/src/components/ui/copy-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, type LucideIcon } from "lucide-react";
 import { useState } from "react";
 
 export const CopyButton = ({
@@ -10,6 +10,7 @@ export const CopyButton = ({
   className,
   tooltip,
   onCopy,
+  icon: Icon = Copy,
 }: {
   text: string;
   size?: "icon" | "icon-sm" | "inline";
@@ -17,6 +18,7 @@ export const CopyButton = ({
   className?: string;
   tooltip?: string;
   onCopy?: () => void; // Extra callback to do something when the code is copied
+  icon?: LucideIcon;
 }) => {
   const [recentlyCopied, setRecentlyCopied] = useState(false);
 
@@ -48,7 +50,7 @@ export const CopyButton = ({
       {recentlyCopied ? (
         <Check className="h-5 w-5" />
       ) : (
-        <Copy className="h-5 w-5" />
+        <Icon className="h-5 w-5" />
       )}
     </Button>
   );


### PR DESCRIPTION
## Summary
- Adds a link icon button to each MCP server card on the `/mcp` page that copies the hosted install page URL to the clipboard
- Always visible (no hover required), shows a checkmark for 1 second after copying
- Uses `Link2` icon from lucide-react and the existing `useMcpUrl` hook's `installPageUrl`

## Test plan
- [x] Navigate to `/mcp` page
- [x] Verify link icon button is visible on each hosted MCP card
- [x] Click the link button — confirm URL is copied to clipboard and icon briefly changes to a checkmark
- [x] Confirm clicking the link button does NOT navigate into the card detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

<img width="904" height="630" alt="CleanShot 2026-03-12 at 14 23 48@2x" src="https://github.com/user-attachments/assets/050e6081-2cbc-4e53-a121-157f76595638" />

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
