### PR TITLE
feat: search projects on org page

### DIFF
--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -46,9 +46,13 @@ export default function OrgHome() {
           placeholder="Search projects..."
           className="mb-4"
         />
-        {projects.length === 0 ? (
+        {projects.length === 0 && search ? (
           <Type muted className="py-8 text-center">
             No projects matching &ldquo;{search}&rdquo;
+          </Type>
+        ) : projects.length === 0 ? (
+          <Type muted className="py-8 text-center">
+            No projects yet.
           </Type>
         ) : (
           <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">

--- a/client/dashboard/src/pages/org/OrgProjects.tsx
+++ b/client/dashboard/src/pages/org/OrgProjects.tsx
@@ -42,9 +42,13 @@ export default function OrgProjects() {
           placeholder="Search projects..."
           className="mb-4"
         />
-        {projects.length === 0 ? (
+        {projects.length === 0 && search ? (
           <Type muted className="py-8 text-center">
             No projects matching &ldquo;{search}&rdquo;
+          </Type>
+        ) : projects.length === 0 ? (
+          <Type muted className="py-8 text-center">
+            No projects yet.
           </Type>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- Add a search bar above the project list on both the Org Home and Org Projects pages
- Filters projects by name or slug using case-insensitive matching
- Shows an empty state message when no projects match the search query

Closes AGE-1580

## Test plan
- [ ] Navigate to the org home page and verify the search bar appears above the project grid
- [ ] Navigate to the org projects page and verify the search bar appears above the project grid
- [ ] Type a project name and confirm the list filters in real-time
- [ ] Type a project slug and confirm the list filters correctly
- [ ] Search for a non-existent project and confirm the empty state message appears
- [ ] Clear the search and confirm all projects reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
