### PR TITLE
feat: land on most recently used project

### DIFF
--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -101,7 +101,12 @@ export const ProjectProvider = ({
   const { projectSlug } = useSlugs();
   const [project, setProject] = useState<ProjectEntry | null>(null);
 
-  const defaultProject = organization.projects[0];
+  // Fall back to the user's most recently used project, then to the first project
+  const preferredSlug = localStorage.getItem(PREFERRED_PROJECT_KEY);
+  const preferredProject = preferredSlug
+    ? organization.projects.find((p) => p.slug === preferredSlug)
+    : undefined;
+  const defaultProject = preferredProject ?? organization.projects[0];
 
   const currentProject =
     organization.projects.find((p) => p.slug === projectSlug) ?? defaultProject;
@@ -268,6 +273,19 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
     // On an org-level page or bare URL with no project context — that's fine,
     // unless we're at the root "/" with no org slug either
     if (!orgSlug || orgSlug !== session.organization.slug) {
+      // If the user has a preferred project, redirect to it instead of org home
+      const preferredSlug = localStorage.getItem(PREFERRED_PROJECT_KEY);
+      const preferredProject = preferredSlug
+        ? session.organization.projects.find((p) => p.slug === preferredSlug)
+        : undefined;
+      if (preferredProject) {
+        return (
+          <Navigate
+            to={`/${session.organization.slug}/projects/${preferredProject.slug}`}
+            replace
+          />
+        );
+      }
       // Redirect to org home
       return <Navigate to={`/${session.organization.slug}`} replace />;
     }


### PR DESCRIPTION
## Summary
- When returning to the app at the root URL (`/`), redirect to the user's last-visited project instead of the org home page
- Uses the existing `preferredProject` localStorage key that was already being written on every project visit
- Also uses the preferred project as the default fallback in `ProjectProvider` (instead of always picking `projects[0]`)
- Validates the stored slug against the user's current project list, falling back gracefully if the project no longer exists

Closes AGE-1582

## Test plan
- [ ] Open the app, visit a specific project (e.g. "my-project")
- [ ] Navigate away or close the tab, then reopen the app at the root URL `/`
- [ ] Verify you land on "my-project" instead of the org home
- [ ] Delete the `preferredProject` key from localStorage, reload at `/` — should fall back to org home
- [ ] Visit `/:orgSlug` directly — should still show the org home page (no forced redirect)
- [ ] Switch orgs — verify the preferred project is validated against the new org's project list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
