### PR TITLE
chore: add DeletePrincipalGrantByTuple SQLc query

### DIFF
--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -32,6 +32,14 @@ DELETE FROM principal_grants
 WHERE id = @id
   AND organization_id = @organization_id;
 
+-- name: DeletePrincipalGrantByTuple :execrows
+-- Removes a single grant row matching the exact (org, principal, scope, resource) tuple.
+DELETE FROM principal_grants
+WHERE organization_id = @organization_id
+  AND principal_urn = @principal_urn
+  AND scope = @scope
+  AND resource = @resource;
+
 -- name: DeletePrincipalGrantsByPrincipal :execrows
 -- Removes all grants for a specific principal within an org.
 -- Useful when removing a user from an organization.

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -32,6 +32,35 @@ func (q *Queries) DeletePrincipalGrant(ctx context.Context, arg DeletePrincipalG
 	return result.RowsAffected(), nil
 }
 
+const deletePrincipalGrantByTuple = `-- name: DeletePrincipalGrantByTuple :execrows
+DELETE FROM principal_grants
+WHERE organization_id = $1
+  AND principal_urn = $2
+  AND scope = $3
+  AND resource = $4
+`
+
+type DeletePrincipalGrantByTupleParams struct {
+	OrganizationID string
+	PrincipalUrn   urn.Principal
+	Scope          string
+	Resource       string
+}
+
+// Removes a single grant row matching the exact (org, principal, scope, resource) tuple.
+func (q *Queries) DeletePrincipalGrantByTuple(ctx context.Context, arg DeletePrincipalGrantByTupleParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deletePrincipalGrantByTuple,
+		arg.OrganizationID,
+		arg.PrincipalUrn,
+		arg.Scope,
+		arg.Resource,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deletePrincipalGrantsByPrincipal = `-- name: DeletePrincipalGrantsByPrincipal :execrows
 DELETE FROM principal_grants
 WHERE organization_id = $1


### PR DESCRIPTION
## Summary

- Adds `DeletePrincipalGrantByTuple` SQLc query to delete a single grant by its exact `(organization_id, principal_urn, scope, resource)` tuple
- This matches the unique constraint on the `principal_grants` table, enabling precise single-grant removal

Part of AGE-1566.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
