### PR TITLE
fix: server filter matches similarly-named servers

### DIFF
--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -348,10 +348,14 @@ func (q *Queries) ListToolTraces(ctx context.Context, arg ListToolTracesParams) 
 	havingParts := []string{"((tool_name IS NOT NULL AND tool_name != '') OR startsWith(gram_urn, 'tools:'))"}
 	havingArgs := []any{}
 
-	// URN filter must use HAVING because it's an aggregate function in SELECT
+	// URN filter must use HAVING because gram_urn comes from an aggregate (any()).
+	// This field serves double duty:
+	//   - Server filter dropdown sends a URN prefix like "tools:http:petstore" → use startsWith with ':'
+	//     so it doesn't accidentally match "tools:http:petstore-external:tool1"
+	//   - Search bar sends free-text like "petstore" → fall back to position() substring match
 	if arg.GramURN != "" {
-		havingParts = append(havingParts, "position(gram_urn, ?) > 0")
-		havingArgs = append(havingArgs, arg.GramURN)
+		havingParts = append(havingParts, "(startsWith(gram_urn, concat(?, ':')) OR gram_urn = ? OR (NOT startsWith(?, 'tools:') AND position(gram_urn, ?) > 0))")
+		havingArgs = append(havingArgs, arg.GramURN, arg.GramURN, arg.GramURN, arg.GramURN)
 	}
 
 	// EventSource filter must use HAVING because it's an aggregate function in SELECT


### PR DESCRIPTION
## Summary
- The server filter on the MCP logs page used `position(gram_urn, ?) > 0` (substring match) in the `ListToolTraces` query
- This caused "Fermat Platform" (`tools:http:fermat-platform`) to also match "Fermat Platform (External)" (`tools:http:fermat-platform-external:*`) because the shorter prefix is a substring of the longer one
- Fixed with `startsWith` + `:` delimiter for URN prefixes (e.g. values starting with `tools:`), with fallback to `position()` for free-text search queries from the search bar

Follows up on #1888 which fixed the `ListTelemetryLogs` query — this PR fixes the same class of bug in `ListToolTraces`.

## Test plan
- [x] All 141 telemetry tests pass (including `TestSearchToolCalls_FilterByGramURN` with exact, prefix, and substring cases)
- [ ] Verify: similarly-named servers like "Fermat Platform" vs "Fermat Platform (External)" filter correctly on MCP logs page
- [ ] Verify: free-text search bar still works (substring matching for non-URN queries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)