### PR TITLE
fix: add wait strategies to test Redis container startup

### DIFF
--- a/server/internal/testenv/redis.go
+++ b/server/internal/testenv/redis.go
@@ -11,12 +11,21 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/testcontainers/testcontainers-go"
 	tcr "github.com/testcontainers/testcontainers-go/modules/redis"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 type RedisClientFunc func(t *testing.T, db int) (*redis.Client, error)
 
 func NewTestRedis(ctx context.Context) (*tcr.RedisContainer, RedisClientFunc, error) {
-	container, err := tcr.Run(ctx, "redis:6.2-alpine", testcontainers.WithLogger(NewTestcontainersLogger()))
+	container, err := tcr.Run(
+		ctx,
+		"redis:6.2-alpine",
+		testcontainers.WithLogger(NewTestcontainersLogger()),
+		testcontainers.WithAdditionalWaitStrategy(
+			wait.ForLog("Ready to accept connections"),
+			wait.ForListeningPort("6379/tcp"),
+		),
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to start redis container: %w", err)
 	}


### PR DESCRIPTION
The Redis testcontainer could be used before it was fully ready to accept connections, causing flaky test failures. Add explicit wait strategies for the log message and listening port.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
