### PR TITLE
feat: track toolset slug and MCP URL in telemetry attributes

### DIFF
--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -437,6 +437,7 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 			}
 		}
 
+		attrRecorder.RecordToolsetSlug(toolsetSlug)
 		logParams := tm.LogParams{
 			Timestamp: time.Now(),
 			ToolInfo: tm.ToolInfo{

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -175,6 +175,8 @@ func handleResourcesRead(
 			logAttrs[attr.APIKeyIDKey] = payload.apiKeyID
 		}
 
+		logAttrs.RecordToolsetSlug(payload.toolset)
+		logAttrs.RecordMCPURL(mcpURL)
 		params := tm.LogParams{
 			Timestamp: time.Now(),
 			ToolInfo: tm.ToolInfo{

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -287,6 +287,8 @@ func handleToolsCall(
 		if payload.apiKeyID != "" {
 			logAttrs[attr.APIKeyIDKey] = payload.apiKeyID
 		}
+		logAttrs.RecordToolsetSlug(payload.toolset)
+		logAttrs.RecordMCPURL(mcpURL)
 		params := tm.LogParams{
 			Timestamp: time.Now(),
 			ToolInfo: tm.ToolInfo{

--- a/server/internal/telemetry/attribute_recorder.go
+++ b/server/internal/telemetry/attribute_recorder.go
@@ -127,6 +127,18 @@ func (h HTTPLogAttributes) RecordResponseBodyContent(body []byte) {
 	h[attr.GenAIToolCallResultKey] = truncateBody(body)
 }
 
+func (h HTTPLogAttributes) RecordToolsetSlug(slug string) {
+	if slug != "" {
+		h[attr.ToolsetSlugKey] = slug
+	}
+}
+
+func (h HTTPLogAttributes) RecordMCPURL(url string) {
+	if url != "" {
+		h[attr.McpURLKey] = url
+	}
+}
+
 func truncateBody(body []byte) string {
 	if len(body) <= maxBodyContentBytes {
 		return string(body)


### PR DESCRIPTION
## Summary

We have a bug that occurs when there are 2 separate MCPs sharing the same source. When we try to filter per server on insights it doesn't work because we don't have the MCP URL or toolset slug in our telemetry logs.

This PR starts tracking toolset slug and mcp URL in our telemetry logs.

Changes:

- Adds `RecordToolsetSlug()` and `RecordMCPURL()` methods to `HTTPLogAttributes`, following the existing recorder pattern used for status codes, request bodies, etc.
- Records the MCP server name (toolset slug) and MCP URL as telemetry attributes on tool call and resource read logs across MCP and instance call sites.

## Approach
Rather than threading new parameters through gateway method signatures (`Do`, `ReadResource`, etc.) or adding fields to `ToolInfo`, the toolset slug and MCP URL are recorded directly into the attributes map at the call sites that have this context. This keeps the gateway API stable and follows the established pattern for telemetry metadata.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
