### PR TITLE
fix: raise local ClickHouse memory and concurrency limits

### DIFF
--- a/local/clickhouse/config.d/limits.xml
+++ b/local/clickhouse/config.d/limits.xml
@@ -2,7 +2,7 @@
 <!-- Server-level limits for low-memory development -->
 <clickhouse>
     <!-- Hard total server memory cap (bytes) -->
-    <max_server_memory_usage>1073741824</max_server_memory_usage> <!-- 1 GB -->
+    <max_server_memory_usage>0</max_server_memory_usage> <!-- 0 = auto (90% of container RAM) -->
 
     <!-- Reduce cache sizes relative to available RAM -->
     <cache_size_to_ram_max_ratio>0.20</cache_size_to_ram_max_ratio>

--- a/local/clickhouse/users.d/dev_profile.xml
+++ b/local/clickhouse/users.d/dev_profile.xml
@@ -7,14 +7,14 @@
             <log_query_threads>0</log_query_threads>
 
             <!-- Limit concurrent queries per user -->
-            <max_concurrent_queries_for_user>2</max_concurrent_queries_for_user>
+            <max_concurrent_queries_for_user>30</max_concurrent_queries_for_user>
 
             <!-- Limit concurrent queries for all users combined -->
-            <max_concurrent_queries_for_all_users>4</max_concurrent_queries_for_all_users>
+            <max_concurrent_queries_for_all_users>30</max_concurrent_queries_for_all_users>
 
-            <!-- Memory limits per query and per user -->
-            <max_memory_usage>536870912</max_memory_usage>
-            <max_memory_usage_for_user>1073741824</max_memory_usage_for_user>
+            <!-- Memory limits per query and per user (0 = unlimited, bounded by server cap) -->
+            <max_memory_usage>0</max_memory_usage>
+            <max_memory_usage_for_user>0</max_memory_usage_for_user>
         </default>
     </profiles>
 </clickhouse>


### PR DESCRIPTION
## Summary

I found that when testing our telemetry logs locally some tool call logs were not showing up. I believe this to be a resource issue due to the generation of materliazed clickhouse views. After I changed these params the logs were working as expected.

- Raises local ClickHouse memory and concurrency limits that were causing telemetry inserts to be silently dropped
- The `JSON` column type used by `telemetry_logs` is memory-intensive, and concurrent inserts triggering materialized views would exceed the 1 GB server memory cap — ClickHouse silently discards data while returning success to the client

## Changes

| Setting | Before | After | File |
|---|---|---|---|
| `max_server_memory_usage` | 1 GB | 0 (auto, 90% of container RAM) | `config.d/limits.xml` |
| `max_memory_usage` (per query) | 512 MB | 0 (bounded by server cap) | `users.d/dev_profile.xml` |
| `max_memory_usage_for_user` | 1 GB | 0 (bounded by server cap) | `users.d/dev_profile.xml` |
| `max_concurrent_queries_for_user` | 2 | 30 | `users.d/dev_profile.xml` |
| `max_concurrent_queries_for_all_users` | 4 | 30 | `users.d/dev_profile.xml` |

After applying, rebuild the ClickHouse container: `docker compose build clickhouse && docker compose up -d clickhouse`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
