### PR TITLE
feat: add toolset_slug materialized column to ClickHouse

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260317141706_add-toolset-slug-materialized-col.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260317141706_add-toolset-slug-materialized-col.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` DROP INDEX `idx_telemetry_logs_mat_toolset_slug`;
+ALTER TABLE `telemetry_logs` DROP COLUMN `toolset_slug`;

--- a/server/clickhouse/local/golang_migrate/20260317141706_add-toolset-slug-materialized-col.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260317141706_add-toolset-slug-materialized-col.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `toolset_slug` String MATERIALIZED toString(attributes.gram.toolset.slug) COMMENT 'Toolset slug (materialized from attributes.gram.toolset.slug).';
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_toolset_slug` ((toolset_slug)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:V3hnbL8BE2R5LgltzMRfJCyVZRHqOMhnXG58Ee3aP5A=
+h1:LbtnE9SLkhHeSDxa5O9tB/z6FqvzmmUe0cJJRYBQb94=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -23,3 +23,4 @@ h1:V3hnbL8BE2R5LgltzMRfJCyVZRHqOMhnXG58Ee3aP5A=
 20260226021049_exclude-uuid-urns-from-trace-summaries-mv.up.sql h1:csrm4iWyxmLe9mJEZP965zGkmaq2Ub9mwLdX7gGTpMg=
 20260226021105_add-tool-event-source-cols.up.sql h1:7PSYOXvC/BDETPvcx1okvs/UhhW5Xkhl5Vmb4ORfZ24=
 20260312103223_fix-mv-chat-id-consistency.up.sql h1:k3UBif7E2UdGpZCACyncsA2N6SE39LLhkFLilFf2cSQ=
+20260317141706_add-toolset-slug-materialized-col.up.sql h1:778pwTDG4f/5PCdBTr0z4G5Pye8AAVAe9EUCRArY3/w=

--- a/server/clickhouse/migrations/20260317141703_add-toolset-slug-materialized-col.sql
+++ b/server/clickhouse/migrations/20260317141703_add-toolset-slug-materialized-col.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `toolset_slug` String MATERIALIZED toString(attributes.gram.toolset.slug) COMMENT 'Toolset slug (materialized from attributes.gram.toolset.slug).';
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_toolset_slug` ((toolset_slug)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:HVWN/V+UmOiu7urupwGTsFyvRcLDF0LwW5xwzYmK9YE=
+h1:PK/2o540JDE4fCatu2Mi7EsFEEEAk+5j8MemwfIzK1Q=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -28,3 +28,4 @@ h1:HVWN/V+UmOiu7urupwGTsFyvRcLDF0LwW5xwzYmK9YE=
 20260226021045_exclude-uuid-urns-from-trace-summaries-mv.sql h1:5Cg0Wd/3f5hKtvjV7wB/itsDP07LPzjQzxOGRa36jKo=
 20260226021100_add-tool-event-source-cols.sql h1:2wEI67ZeRw/n+huRlbd51FfGZ5bCvr3AzBNzDcPUQl0=
 20260312103219_fix-mv-chat-id-consistency.sql h1:zQ6kNeH47NUINVxQ4BnDp2gDbwAoZUkaROXlDHqZZTY=
+20260317141703_add-toolset-slug-materialized-col.sql h1:2Zsgy6UACkwVOXhTGLckHM0JsuyTMtkDc/LWQAddKqs=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -49,7 +49,8 @@ CREATE TABLE IF NOT EXISTS telemetry_logs (
     evaluation_score_label String MATERIALIZED toString(attributes.gen_ai.evaluation.score.label) COMMENT 'Evaluation result label (success, failure, partial, abandoned).',
     tool_name String MATERIALIZED toString(attributes.gram.tool.name) COMMENT 'Tool name (materialized from attributes.gram.tool.name).',
     tool_source String MATERIALIZED toString(attributes.gram.tool_call.source) COMMENT 'Tool call source (materialized from attributes.gram.tool_call.source).',
-    event_source String MATERIALIZED toString(attributes.gram.event.source) COMMENT 'Event source (materialized from attributes.gram.event.source).'
+    event_source String MATERIALIZED toString(attributes.gram.event.source) COMMENT 'Event source (materialized from attributes.gram.event.source).',
+    toolset_slug String MATERIALIZED toString(attributes.gram.toolset.slug) COMMENT 'Toolset slug (materialized from attributes.gram.toolset.slug).'
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))
 ORDER BY (gram_project_id, time_unix_nano, id)
@@ -78,6 +79,7 @@ CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_evaluation_score_label ON tele
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_tool_name ON telemetry_logs (tool_name) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_tool_source ON telemetry_logs (tool_source) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_event_source ON telemetry_logs (event_source) TYPE bloom_filter(0.01) GRANULARITY 1;
+CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_toolset_slug ON telemetry_logs (toolset_slug) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 CREATE TABLE IF NOT EXISTS trace_summaries (
     -- Key cols

--- a/server/internal/telemetry/repo/materialized_columns_gen.go
+++ b/server/internal/telemetry/repo/materialized_columns_gen.go
@@ -18,4 +18,5 @@ var materializedColumns = map[string]string{
 	"gram.tool.name":                "tool_name",
 	"gram.tool_call.source":         "tool_source",
 	"gram.event.source":             "event_source",
+	"gram.toolset.slug":             "toolset_slug",
 }


### PR DESCRIPTION
## Summary
- Adds a `toolset_slug` materialized column to the `telemetry_logs` ClickHouse table, extracted from `attributes.gram.toolset.slug`.
- Adds a bloom filter index for efficient filtering by toolset slug.
- Regenerates `materialized_columns_gen.go` to include the new column mapping.

## Context
Companion to #1903 which records the toolset slug in telemetry attributes. This PR makes it a queryable/filterable field in the dashboard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
