### PR TITLE
fix: respect generated server instructions character limit

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -548,7 +548,7 @@ Best practices:
 DO: Focus on cross-feature relationships (how tools work together, required sequences), document operational patterns and workflows, be explicit about constraints and limitations, keep it short like a quick-reference card.
 DO NOT: Duplicate individual tool descriptions, include marketing claims, try to change model personality, write lengthy prose.
 
-Keep the total output under 2000 characters.
+Keep the total output under ${INSTRUCTIONS_SOFT_LIMIT} characters.
 
 Server details:
 ${JSON.stringify({ name: toolset.name, tools: tools.map((t) => ({ name: t.name, description: t.description })) }, null, 2)}


### PR DESCRIPTION
When generating server instructions with AI, it is crossing 2000 character limit when they are many tools.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
