### PR TITLE
fix: prevent showing feedback button when the last message errored

### DIFF
--- a/elements/src/components/assistant-ui/thread.tsx
+++ b/elements/src/components/assistant-ui/thread.tsx
@@ -497,6 +497,14 @@ const ComposerFeedback: FC = () => {
   const { isResolved, feedbackHidden, setResolved, submitFeedback } =
     useChatResolution();
 
+  const lastMessageErrored = useAssistantState(({ thread }) => {
+    const lastMessage = thread.messages[thread.messages.length - 1];
+    return (
+      lastMessage?.role === "assistant" &&
+      lastMessage.status?.type === "incomplete"
+    );
+  });
+
   const handleFeedback = useCallback(
     async (type: "like" | "dislike") => {
       const feedback = type === "like" ? "success" : "failure";
@@ -513,7 +521,7 @@ const ComposerFeedback: FC = () => {
       </ThreadPrimitive.If>
       <ThreadPrimitive.If running={false}>
         <AnimatePresence>
-          {!isResolved && !feedbackHidden && (
+          {!isResolved && !feedbackHidden && !lastMessageErrored && (
             <m.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
in playground, when the last message errors (last message is always assistant message meaning that there was a problem in openrouter), do not show the feedback buttons
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
