### PR TITLE
chore: add client commands to claude md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,18 @@ Contains the main application code for the Gram server:
 
 </commands>
 
+### client/dashboard
+
+The main frontend application lives in `client/dashboard/` (not `client/` directly).
+
+<commands>
+
+- `cd client/dashboard && npx tsc --noEmit`: Type-check the dashboard
+- `cd client/dashboard && pnpm build`: Build the dashboard
+- `cd client/dashboard && pnpm dev`: Run dev server
+
+</commands>
+
 ### Atlas Migration Troubleshooting
 
 - **"migration file X was added out of order" error**: Rename the migration file to have a timestamp after the latest existing migration (e.g., `20260129_foo.sql` → `20260203000001_foo.sql`), then run `mise db:hash` to regenerate `atlas.sum`.


### PR DESCRIPTION
## Summary
- Adds frontend type-check, build, and dev commands for `client/dashboard/`
- Clarifies that the dashboard lives in `client/dashboard/`, not `client/` directly

## Test plan
- [x] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
