### PR TITLE
fix: resolve CORS error on install page for custom domains

### DIFF
--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -783,7 +783,7 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 		VSCodeInstallLink: safeVsCodeURL,
 		OrganizationName:  organization.Name,
 		SiteURL:           s.siteURL.String(),
-		ScriptURL:         s.serverURL.String() + "/mcp/install-page-" + s.installPageScriptHash + ".js",
+		ScriptURL:         "/mcp/install-page-" + s.installPageScriptHash + ".js",
 		LogoAssetURL:      logoAssetURL,
 		DocsURL:           docsURL,
 		DocsText:          docsText,


### PR DESCRIPTION
## Summary

- When an MCP server has a custom domain (e.g. `chat.speakeasy.com`), the install page's `<script type="module">` tag was loading JS from an absolute URL pointing to `app.getgram.ai`, causing a CORS error since the `Access-Control-Allow-Origin` header didn't match the custom domain origin
- Changed the script URL from absolute (`s.serverURL + "/mcp/install-page-{hash}.js"`) to relative (`"/mcp/install-page-{hash}.js"`), so the script loads from the same origin as the page — no cross-origin request, no CORS issue

## Test plan

- [ ] Visit `https://chat.speakeasy.com/mcp/speakeasy-team-nktsz/install` and confirm the install page loads without CORS errors
- [ ] Visit `https://app.getgram.ai/mcp/speakeasy-team-nktsz/install` and confirm it still works as before
- [ ] Check browser console for any remaining CORS or script loading errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
