### PR TITLE
chore: add a utility to bypass cached data

### DIFF
--- a/server/internal/cache/cache.go
+++ b/server/internal/cache/cache.go
@@ -49,6 +49,10 @@ func (d *TypedCacheObject[T]) fullKey(key string) string {
 	return key + ":" + d.keySuffix
 }
 
+func (d *TypedCacheObject[T]) SkipCache() TypedCacheObject[T] {
+	return TypedCacheObject[T]{logger: d.logger, cache: NoopCache, keySuffix: d.keySuffix}
+}
+
 func (d *TypedCacheObject[T]) Delete(ctx context.Context, obj T) error {
 	if d.cache == nil {
 		return nil

--- a/server/internal/cache/noop.go
+++ b/server/internal/cache/noop.go
@@ -1,0 +1,48 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var NoopCache = &noopCache{}
+
+type noopCache struct{}
+
+var _ Cache = (*noopCache)(nil)
+
+// Delete implements [Cache].
+func (s *noopCache) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+// DeleteByPrefix implements [Cache].
+func (s *noopCache) DeleteByPrefix(ctx context.Context, prefix string) error {
+	return nil
+}
+
+// Get implements [Cache].
+func (s *noopCache) Get(ctx context.Context, key string, value any) error {
+	return errors.New("no cache entry for key")
+}
+
+// ListAppend implements [Cache].
+func (s *noopCache) ListAppend(ctx context.Context, key string, value any, ttl time.Duration) error {
+	return nil
+}
+
+// ListRange implements [Cache].
+func (s *noopCache) ListRange(ctx context.Context, key string, start int64, stop int64, value any) error {
+	return nil
+}
+
+// Set implements [Cache].
+func (s *noopCache) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
+	return nil
+}
+
+// Update implements [Cache].
+func (s *noopCache) Update(ctx context.Context, key string, value any) error {
+	return nil
+}


### PR DESCRIPTION
This change adds a utility method to `TypedCacheObject[T]` that is used to force fresh data to be fetched, bypassing any caches. Due to the OOP nature of this type and that it is passed as an argument to various functions instead of passing an underlying cache interface, this change was necessary for some upcoming code paths that need to generate audit logs with a true point in time representation of subjects.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
