### PR TITLE
feat(cli): always show url during auth

### DIFF
--- a/.changeset/always-show-auth-url.md
+++ b/.changeset/always-show-auth-url.md
@@ -1,5 +1,0 @@
----
-"cli": patch
----
-
-Always print the auth URL to the terminal during login, regardless of whether a browser can be opened.

--- a/.changeset/always-show-auth-url.md
+++ b/.changeset/always-show-auth-url.md
@@ -1,0 +1,5 @@
+---
+"cli": patch
+---
+
+Always print the auth URL to the terminal during login, regardless of whether a browser can be opened.

--- a/.changeset/fuzzy-zoos-warn.md
+++ b/.changeset/fuzzy-zoos-warn.md
@@ -1,0 +1,5 @@
+---
+"cli": minor
+---
+
+show url during auth

--- a/cli/internal/auth/dispatcher.go
+++ b/cli/internal/auth/dispatcher.go
@@ -30,6 +30,8 @@ func (d *Dispatcher) Dispatch(
 		return fmt.Errorf("failed to build auth URL: %w", err)
 	}
 
+	fmt.Printf("\nPlease visit: %s\n\n", authURL)
+
 	if canOpenBrowser() {
 		if err := openBrowser(authURL); err != nil {
 			d.logger.WarnContext(
@@ -37,10 +39,7 @@ func (d *Dispatcher) Dispatch(
 				"failed to open browser, please visit URL manually",
 				slog.String("error", err.Error()),
 			)
-			fmt.Printf("\nPlease visit: %s\n\n", authURL)
 		}
-	} else {
-		fmt.Printf("\nPlease visit: %s\n\n", authURL)
 	}
 
 	return nil

--- a/cli/internal/auth/dispatcher.go
+++ b/cli/internal/auth/dispatcher.go
@@ -19,7 +19,7 @@ func NewDispatcher(logger *slog.Logger) *Dispatcher {
 }
 
 // Dispatch opens the authentication URL in the user's browser,
-// or prints it if the browser cannot be launched.
+// and prints it if the browser cannot be launched.
 func (d *Dispatcher) Dispatch(
 	ctx context.Context,
 	webAppURL string,


### PR DESCRIPTION
I don't always use my default browser and hence this prevents copy pasting step from my default browser.

<img width="1804" height="174" alt="image" src="https://github.com/user-attachments/assets/149fcf85-7a17-465a-929f-2434d2dd414b" />
