### PR TITLE
fix: typo GRAM_SITE_URL instead of dashboard url

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -4,7 +4,7 @@
 
 1. Setup environment
    - `export GRAM_API_URL=https://localhost:8080`
-   - `export GRAM_DASHBOARD_URL=https://localhost:5173`
+   - `export GRAM_SITE_URL=https://localhost:5173`
    - `export GRAM_ORG=organization-123`
    - `export GRAM_PROJECT=default`
    - `export GRAM_API_KEY=<API-KEY>`


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
