### PR TITLE
chore: press enter key to skip workos

### DIFF
--- a/.mise-tasks/zero/workos.mts
+++ b/.mise-tasks/zero/workos.mts
@@ -21,10 +21,10 @@ async function run() {
     "💬 If you don't have WorkOS access, skip this step and the mock IDP will use a hardcoded test user instead.",
   );
 
-  const answer = await question("💬 Do you want to configure WorkOS? [y/N] ", {
-    choices: ["y", "N"],
-  });
-  if (answer.toLowerCase() !== "y") {
+  const clientId = await question(
+    "💬 Paste your WorkOS Client ID or press enter to skip: ",
+  );
+  if (!clientId) {
     console.log("⏭️  Skipping WorkOS setup. Mock IDP will run in mock mode.");
     process.exit(0);
   }
@@ -36,12 +36,6 @@ async function run() {
   );
   console.log(`\thttp://${host}:${port}/v1/speakeasy_provider/oidc/callback`);
   console.log();
-
-  const clientId = await question("💬 Paste your WorkOS Client ID: ");
-  if (!clientId) {
-    console.log("❌ Client ID is required.");
-    process.exit(1);
-  }
 
   const clientSecret = await question("💬 Paste your WorkOS Client Secret: ");
   if (!clientSecret) {


### PR DESCRIPTION
all other questions in `./zero` can be skipped by pressing the enter key.
this helps prevent the y/n question for workos token
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/1993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
