### PR TITLE
fix: chat title not auto generated

### DIFF
--- a/.changeset/fix-chat-title-auto-generated.md
+++ b/.changeset/fix-chat-title-auto-generated.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Fix chat title not being auto-generated for new chats from the playground by skipping title update when the server returns "New Chat".

--- a/elements/src/hooks/useGramThreadListAdapter.tsx
+++ b/elements/src/hooks/useGramThreadListAdapter.tsx
@@ -318,7 +318,7 @@ export function useGramThreadListAdapter(
             const result = (await response.json()) as { title: string };
             const title = result.title;
 
-            if (title) {
+            if (title && title !== "New Chat") {
               return createAssistantStream((controller) => {
                 controller.appendText(title);
                 controller.close();


### PR DESCRIPTION
The new chats from playground always return "New Chat". This PR fixes it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
