### PR TITLE
fix: prevent ClickHouse SQL injection in ListHooksTraces

### DIFF
--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -1488,6 +1488,9 @@ func (q *Queries) ListHooksTraces(ctx context.Context, arg ListHooksTracesParams
 
 	// Apply arbitrary attribute filters
 	for _, filter := range arg.Filters {
+		if !validJSONPath.MatchString(filter.Path) {
+			continue // skip invalid paths to prevent SQL injection
+		}
 		materializedCol, isMaterialized := materializedColumns[filter.Path]
 		var columnRef string
 		if isMaterialized {


### PR DESCRIPTION
## Summary

- `ListHooksTraces` in `server/internal/telemetry/repo/queries.sql.go` constructs ClickHouse queries using `filter.Path` via `fmt.Sprintf` without input validation, allowing SQL injection
- The sibling function `ListTelemetryLogs` (line 254) already validates paths against `validJSONPath` regex — this was simply missing from `ListHooksTraces`
- A malicious `filter.Path` like `x') OR '1'='1` would be interpolated directly into `has(JSONExtractKeys(attributes), '...')` and `toString(attributes.\`...\`)` clauses
- Added the same `validJSONPath.MatchString(filter.Path)` check to skip invalid paths

## Test plan

- [x] `go build ./server/internal/telemetry/...` compiles cleanly
- [ ] Verify hook traces listing still works with valid attribute filters
- [ ] Confirm malicious filter paths are silently skipped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
