### PR TITLE
chore: replace all bare http.Client usages

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -67,6 +67,21 @@ linters:
         linters:
           - exhaustruct
           - gosec
+      # The guardian package is the only package that is allowed to access
+      # http.Client directly since it constructs the safe HTTP clients
+      # that are used throughout the codebase. This is tracked by GG002.
+      - path: internal/guardian/policy\.go
+        linters:
+          - forbidigo
+        text: GG002
+      # The gateway package contains an HTTP reverse proxy that needs finer
+      # grained control over the HTTP client it uses, so we allow direct use of
+      # http.Client there as well. It is manually decorating the client with
+      # SSRF protection from the guardian module and OTel instrumentation.
+      - path: internal/gateway/proxy\.go
+        linters:
+          - forbidigo
+        text: GG002
   settings:
     gosec:
       excludes:
@@ -85,7 +100,10 @@ linters:
       forbid:
         - pattern: ^os\.Getenv$
           pkg: ^os$
-          msg: "Direct environment variable access is forbidden because it makes testing harder. Access to environment variables is only allowed in the cmd/."
+          msg: "GG001: Direct environment variable access is forbidden because it makes testing harder. Access to environment variables is only allowed in the cmd/."
+        - pattern: ^http\.Client$
+          pkg: ^net/http$
+          msg: "GG002: Use `(*github.com/speakeasy-api/gram/server/internal/guardian.Policy).Client(...)` (or .PooledClient(...)) and the HTTPClient from the same package."
         - pattern: ^otel\.Tracer$
           pkg: ^go\.opentelemetry\.io/otel$
           msg: "GG003: pass a trace.TracerProvider to functions instead of using otel.Tracer directly."

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -45,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/must"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -68,6 +69,26 @@ func loadConfigFromFile(c *cli.Context, flags []cli.Flag) error {
 		cfgLoader = altsrc.InitInputSourceWithContext(flags, altsrc.NewTomlSourceFromFlagFunc("config-file"))
 	}
 	return cfgLoader(c)
+}
+
+func newGuardianPolicy(c *cli.Context, tracerProvider trace.TracerProvider) (policy *guardian.Policy, err error) {
+	// In local development, allow loopback addresses for internal tool-to-tool communication
+	if c.String("environment") == "local" {
+		policy, err = guardian.NewUnsafePolicy(tracerProvider, []string{}) // Allow all traffic for local development
+		if err != nil {
+			return nil, fmt.Errorf("failed to create unsafe http guardian policy: %w", err)
+		}
+	} else {
+		policy = guardian.NewDefaultPolicy(tracerProvider)
+	}
+	if s := c.StringSlice("disallowed-cidr-blocks"); s != nil {
+		policy, err = guardian.NewUnsafePolicy(tracerProvider, s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create unsafe http guardian policy: %w", err)
+		}
+	}
+
+	return policy, nil
 }
 
 func newClickhouseClient(ctx context.Context, logger *slog.Logger, c *cli.Context) (clickhouse.Conn, func(context.Context) error, error) {
@@ -377,6 +398,7 @@ func newBillingProvider(
 	ctx context.Context,
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
+	guardianPolicy *guardian.Policy,
 	redisClient *redis.Client,
 	posthogClient *posthog.Posthog,
 	c *cli.Context,
@@ -395,7 +417,7 @@ func newBillingProvider(
 		}
 		polarAPIKey := c.String("polar-api-key")
 		polarsdk := polargo.New(polargo.WithSecurity(polarAPIKey), polargo.WithTimeout(30*time.Second)) // Shouldn't take this long, but just in case
-		pclient := polar.NewClient(polarsdk, polarAPIKey, logger, tracerProvider, redisClient, catalog, c.String("polar-webhook-secret"))
+		pclient := polar.NewClient(guardianPolicy, polarsdk, polarAPIKey, logger, tracerProvider, redisClient, catalog, c.String("polar-webhook-secret"))
 		tracker := tracking.New(pclient, posthogClient, logger)
 		return pclient, tracker, nil
 	case c.String("environment") == "local":
@@ -407,12 +429,12 @@ func newBillingProvider(
 	}
 }
 
-func newAccessRoleProvider(ctx context.Context, logger *slog.Logger, c *cli.Context) (access.RoleProvider, error) {
+func newAccessRoleProvider(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, c *cli.Context) (access.RoleProvider, error) {
 	apiKey := c.String("workos-api-key")
 
 	switch {
 	case apiKey != "" && apiKey != "unset":
-		return workos.NewClient(apiKey), nil
+		return workos.NewClient(guardianPolicy, apiKey), nil
 	case c.String("environment") == "local":
 		logger.WarnContext(ctx, "using stub access role provider: WorkOS not configured")
 		return workos.NewStubClient(), nil
@@ -421,7 +443,7 @@ func newAccessRoleProvider(ctx context.Context, logger *slog.Logger, c *cli.Cont
 	}
 }
 
-func newWorkOSClient(c *cli.Context) (client *workos.Client, workosAvailable bool, err error) {
+func newWorkOSClient(guardianPolicy *guardian.Policy, c *cli.Context) (client *workos.Client, workosAvailable bool, err error) {
 	env := c.String("environment")
 	apiKey := c.String("workos-api-key")
 
@@ -430,7 +452,7 @@ func newWorkOSClient(c *cli.Context) (client *workos.Client, workosAvailable boo
 		return nil, false, errors.New("WorkOS API key not provided")
 	}
 
-	return workos.NewClient(apiKey), haveAPIKey, nil
+	return workos.NewClient(guardianPolicy, apiKey), haveAPIKey, nil
 }
 
 func newTigrisStore(ctx context.Context, c *cli.Context, logger *slog.Logger) (*assets.TigrisStore, func(context.Context) error, error) {
@@ -496,6 +518,7 @@ func newFunctionOrchestrator(
 	c *cli.Context,
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	assetStore assets.BlobStore,
 	tigrisStore *assets.TigrisStore,
@@ -520,7 +543,7 @@ func newFunctionOrchestrator(
 			return nil, nilShutdown, fmt.Errorf("parse server url for local functions provider: %w", err)
 		}
 
-		return functions.NewLocalRunner(logger, codeRootDir, serverURL, assetStore), nilShutdown, nil
+		return functions.NewLocalRunner(logger, tracerProvider, codeRootDir, serverURL, assetStore), nilShutdown, nil
 	case "flyio":
 		surl := c.String("server-url")
 		tokenstr := c.String("functions-flyio-api-token")
@@ -553,6 +576,7 @@ func newFunctionOrchestrator(
 		return functions.NewFlyRunner(
 			logger,
 			tracerProvider,
+			guardianPolicy,
 			serverURL,
 			db,
 			assetStore,
@@ -580,7 +604,7 @@ type mcpRegistryClientOptions struct {
 	cacheImpl     cache.Cache
 }
 
-func newMCPRegistryClient(logger *slog.Logger, tracerProvider trace.TracerProvider, opts mcpRegistryClientOptions) (*externalmcp.RegistryClient, error) {
+func newMCPRegistryClient(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, opts mcpRegistryClientOptions) (*externalmcp.RegistryClient, error) {
 	pulseURL, err := url.Parse("https://api.pulsemcp.com")
 	if err != nil {
 		return nil, fmt.Errorf("parse pulse registry url: %w", err)
@@ -588,7 +612,7 @@ func newMCPRegistryClient(logger *slog.Logger, tracerProvider trace.TracerProvid
 
 	backend := externalmcp.NewPulseBackend(pulseURL, opts.pulseTenantID, opts.pulseAPIKey)
 
-	return externalmcp.NewRegistryClient(logger, tracerProvider, backend, opts.cacheImpl), nil
+	return externalmcp.NewRegistryClient(logger, tracerProvider, guardianPolicy, backend, opts.cacheImpl), nil
 }
 
 func newFeatureChecker(logger *slog.Logger, pf *productfeatures.Client, feat productfeatures.Feature) telemetry.FeatureChecker {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -45,7 +45,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
-	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
 	"github.com/speakeasy-api/gram/server/internal/instances"
 	"github.com/speakeasy-api/gram/server/internal/integrations"
@@ -399,6 +398,11 @@ func newStartCommand() *cli.Command {
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
+			guardianPolicy, err := newGuardianPolicy(c, tracerProvider)
+			if err != nil {
+				return err
+			}
+
 			db, err := newDBClient(ctx, logger, meterProvider, c.String("database-url"), dbClientOptions{
 				enableUnsafeLogging: c.Bool("unsafe-db-log"),
 			})
@@ -451,12 +455,12 @@ func newStartCommand() *cli.Command {
 				featureFlags = newLocalFeatureFlags(ctx, logger, c.String("local-feature-flags-csv"))
 			}
 
-			workosClient, workosAvailable, err := newWorkOSClient(c)
+			workosClient, workosAvailable, err := newWorkOSClient(guardianPolicy, c)
 			if err != nil {
 				return fmt.Errorf("failed to create WorkOS client: %w", err)
 			}
 
-			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, redisClient, posthogClient, c)
+			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}
@@ -464,6 +468,7 @@ func newStartCommand() *cli.Command {
 			sessionManager := sessions.NewManager(
 				logger,
 				tracerProvider,
+				guardianPolicy,
 				db,
 				redisClient,
 				cache.SuffixNone,
@@ -515,6 +520,8 @@ func newStartCommand() *cli.Command {
 			} else {
 				openRouter = openrouter.New(
 					logger,
+					tracerProvider,
+					guardianPolicy,
 					db,
 					c.String("environment"),
 					c.String("openrouter-provisioning-key"),
@@ -559,38 +566,20 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to parse site url: %w", err)
 			}
 
-			// In local development, allow loopback addresses for internal tool-to-tool communication
-			var guardianPolicy *guardian.Policy
-			if c.String("environment") == "local" {
-				guardianPolicy, err = guardian.NewUnsafePolicy([]string{}) // Allow all traffic for local development
-				if err != nil {
-					return fmt.Errorf("failed to create unsafe http guardian policy: %w", err)
-				}
-			} else {
-				guardianPolicy = guardian.NewDefaultPolicy()
-			}
-			blockedCIDRs := c.StringSlice("disallowed-cidr-blocks")
-			if blockedCIDRs != nil {
-				guardianPolicy, err = guardian.NewUnsafePolicy(blockedCIDRs)
-				if err != nil {
-					return fmt.Errorf("failed to create unsafe http guardian policy: %w", err)
-				}
-			}
-
 			tigrisStore, shutdown, err := newTigrisStore(ctx, c, logger)
 			if err != nil {
 				return fmt.Errorf("failed to create tigris asset store: %w", err)
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
-			functionsOrchestrator, shutdown, err := newFunctionOrchestrator(c, logger, tracerProvider, db, assetStorage, tigrisStore, encryptionClient)
+			functionsOrchestrator, shutdown, err := newFunctionOrchestrator(c, logger, tracerProvider, guardianPolicy, db, assetStorage, tigrisStore, encryptionClient)
 			if err != nil {
 				return fmt.Errorf("failed to create functions orchestrator: %w", err)
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 			runnerVersion := functions.RunnerVersion(conv.Default(strings.TrimPrefix(c.String("functions-runner-version"), "sha-"), GitSHA))
 
-			slackClient := slack_client.NewSlackClient("", "", db, encryptionClient)
+			slackClient := slack_client.NewSlackClient(guardianPolicy, "", "", db, encryptionClient)
 
 			logsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureLogs)
 			toolIOLogsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureToolIOLogs)
@@ -609,6 +598,7 @@ func newStartCommand() *cli.Command {
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,
+				guardianPolicy,
 				openRouter,
 				chat.NewChatMessageCaptureStrategy(logger, db, assetStorage),
 				chat.NewDefaultUsageTrackingStrategy(db, logger, openRouter, billingTracker, &background.FallbackModelUsageTracker{TemporalEnv: temporalEnv}),
@@ -618,7 +608,7 @@ func newStartCommand() *cli.Command {
 			)
 
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, completionsClient)
-			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, mcpRegistryClientOptions{
+			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, guardianPolicy, mcpRegistryClientOptions{
 				pulseTenantID: c.String("pulse-registry-tenant"),
 				pulseAPIKey:   conv.NewSecret([]byte(c.String("pulse-registry-api-key"))),
 				cacheImpl:     cache.NewRedisCacheAdapter(redisClient),
@@ -629,7 +619,7 @@ func newStartCommand() *cli.Command {
 
 			authorizer := auth.New(logger, db, sessionManager, accessManager)
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager)
-			externalOAuthService := oauth.NewExternalOAuthService(logger, db, cache.NewRedisCacheAdapter(redisClient), authorizer, encryptionClient, externalMcpOAuthConfig)
+			externalOAuthService := oauth.NewExternalOAuthService(logger, guardianPolicy, db, cache.NewRedisCacheAdapter(redisClient), authorizer, encryptionClient, externalMcpOAuthConfig)
 
 			platformSvc := platformtoolsruntime.NewService(logger, db, telemSvc)
 
@@ -669,7 +659,7 @@ func newStartCommand() *cli.Command {
 
 			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), accessManager)
 			mcpMetadataService := mcpmetadata.NewService(logger, tracerProvider, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient), accessManager)
-			roleClient, err := newAccessRoleProvider(ctx, logger, c)
+			roleClient, err := newAccessRoleProvider(ctx, logger, guardianPolicy, c)
 			if err != nil {
 				return fmt.Errorf("failed to create access role provider: %w", err)
 			}
@@ -730,7 +720,7 @@ func newStartCommand() *cli.Command {
 			toolsets.Attach(mux, toolsetsSvc)
 			integrations.Attach(mux, integrations.NewService(logger, tracerProvider, db, sessionManager, accessManager))
 			templates.Attach(mux, templates.NewService(logger, tracerProvider, db, sessionManager, toolsetsSvc, accessManager))
-			assets.Attach(mux, assets.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, assetStorage, c.String("jwt-signing-key"), accessManager))
+			assets.Attach(mux, assets.NewService(logger, tracerProvider, guardianPolicy, db, sessionManager, chatSessionsManager, assetStorage, c.String("jwt-signing-key"), accessManager))
 			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, accessManager))
 			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), accessManager))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, accessManager))
@@ -780,6 +770,7 @@ func newStartCommand() *cli.Command {
 				})
 				group.Go(func() {
 					temporalWorker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, &background.WorkerOptions{
+						GuardianPolicy:      guardianPolicy,
 						DB:                  db,
 						EncryptionClient:    encryptionClient,
 						FeatureProvider:     featureFlags,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
-	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcpclient"
@@ -327,6 +326,11 @@ func newWorkerCommand() *cli.Command {
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
+			guardianPolicy, err := newGuardianPolicy(c, tracerProvider)
+			if err != nil {
+				return err
+			}
+
 			db, err := newDBClient(ctx, logger, meterProvider, c.String("database-url"), dbClientOptions{
 				enableUnsafeLogging: c.Bool("unsafe-db-log"),
 			})
@@ -398,7 +402,7 @@ func newWorkerCommand() *cli.Command {
 
 			productFeatures := productfeatures.NewClient(logger, tracerProvider, db, redisClient)
 
-			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, redisClient, posthogClient, c)
+			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}
@@ -407,25 +411,7 @@ func newWorkerCommand() *cli.Command {
 			if c.String("environment") == "local" {
 				openRouter = openrouter.NewDevelopment(c.String("openrouter-dev-key"))
 			} else {
-				openRouter = openrouter.New(logger, db, c.String("environment"), c.String("openrouter-provisioning-key"), &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}, productFeatures, billingTracker)
-			}
-
-			// In local development, allow loopback addresses for internal tool-to-tool communication
-			var guardianPolicy *guardian.Policy
-			if c.String("environment") == "local" {
-				guardianPolicy, err = guardian.NewUnsafePolicy([]string{}) // Allow all traffic for local development
-				if err != nil {
-					return fmt.Errorf("failed to create unsafe http guardian policy: %w", err)
-				}
-			} else {
-				guardianPolicy = guardian.NewDefaultPolicy()
-			}
-			if s := c.StringSlice("disallowed-cidr-blocks"); s != nil {
-				var err error
-				guardianPolicy, err = guardian.NewUnsafePolicy(s)
-				if err != nil {
-					return fmt.Errorf("failed to create unsafe http guardian policy: %w", err)
-				}
+				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}, productFeatures, billingTracker)
 			}
 
 			tigrisStore, shutdown, err := newTigrisStore(ctx, c, logger)
@@ -434,7 +420,7 @@ func newWorkerCommand() *cli.Command {
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
-			functionsOrchestrator, shutdown, err := newFunctionOrchestrator(c, logger, tracerProvider, db, assetStorage, tigrisStore, encryptionClient)
+			functionsOrchestrator, shutdown, err := newFunctionOrchestrator(c, logger, tracerProvider, guardianPolicy, db, assetStorage, tigrisStore, encryptionClient)
 			if err != nil {
 				return fmt.Errorf("failed to create functions orchestrator: %w", err)
 			}
@@ -442,7 +428,7 @@ func newWorkerCommand() *cli.Command {
 
 			runnerVersion := functions.RunnerVersion(conv.Default(strings.TrimPrefix(c.String("functions-runner-version"), "sha-"), GitSHA))
 
-			slackClient := slack_client.NewSlackClient("", "", db, encryptionClient)
+			slackClient := slack_client.NewSlackClient(guardianPolicy, "", "", db, encryptionClient)
 
 			logsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureLogs)
 			toolIOLogsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureToolIOLogs)
@@ -467,6 +453,7 @@ func newWorkerCommand() *cli.Command {
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,
+				guardianPolicy,
 				openRouter,
 				chat.NewChatMessageCaptureStrategy(logger, db, assetStorage),
 				chat.NewDefaultUsageTrackingStrategy(db, logger, openRouter, billingTracker, &background.FallbackModelUsageTracker{TemporalEnv: temporalEnv}),
@@ -476,7 +463,7 @@ func newWorkerCommand() *cli.Command {
 			)
 
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, completionsClient)
-			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, mcpRegistryClientOptions{
+			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, guardianPolicy, mcpRegistryClientOptions{
 				pulseTenantID: c.String("pulse-registry-tenant"),
 				pulseAPIKey:   conv.NewSecret([]byte(c.String("pulse-registry-api-key"))),
 				cacheImpl:     cache.NewRedisCacheAdapter(redisClient),
@@ -495,7 +482,7 @@ func newWorkerCommand() *cli.Command {
 				return fmt.Errorf("failed to create pylon client: %w", err)
 			}
 
-			sessionManager := sessions.NewManager(logger, tracerProvider, db, redisClient, cache.SuffixNone, c.String("speakeasy-server-address"), c.String("speakeasy-secret-key"), pylonClient, posthogClient, billingRepo, nil)
+			sessionManager := sessions.NewManager(logger, tracerProvider, guardianPolicy, db, redisClient, cache.SuffixNone, c.String("speakeasy-server-address"), c.String("speakeasy-secret-key"), pylonClient, posthogClient, billingRepo, nil)
 
 			chatSessionsManager := chatsessions.NewManager(logger, redisClient, c.String("jwt-signing-key"))
 
@@ -540,6 +527,7 @@ func newWorkerCommand() *cli.Command {
 			 */
 
 			temporalWorker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, &background.WorkerOptions{
+				GuardianPolicy:      guardianPolicy,
 				DB:                  db,
 				EncryptionClient:    encryptionClient,
 				FeatureProvider:     featureFlags,

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -55,6 +56,8 @@ func newTestAccessService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -64,7 +67,7 @@ func newTestAccessService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -34,6 +34,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -51,12 +52,13 @@ const (
 )
 
 type Service struct {
-	tracer    trace.Tracer
-	logger    *slog.Logger
-	db        *pgxpool.Pool
-	auth      *auth.Auth
-	storage   BlobStore
-	jwtSecret string
+	tracer         trace.Tracer
+	logger         *slog.Logger
+	guardianPolicy *guardian.Policy
+	db             *pgxpool.Pool
+	auth           *auth.Auth
+	storage        BlobStore
+	jwtSecret      string
 
 	chatSessions *chatsessions.Manager
 	projects     *projectsRepo.Queries
@@ -66,19 +68,20 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, chatSessions *chatsessions.Manager, storage BlobStore, jwtSecret string, accessLoader auth.AccessLoader) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, db *pgxpool.Pool, sessions *sessions.Manager, chatSessions *chatsessions.Manager, storage BlobStore, jwtSecret string, accessLoader auth.AccessLoader) *Service {
 	logger = logger.With(attr.SlogComponent("assets"))
 
 	return &Service{
-		tracer:       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/assets"),
-		logger:       logger,
-		db:           db,
-		auth:         auth.New(logger, db, sessions, accessLoader),
-		storage:      storage,
-		jwtSecret:    jwtSecret,
-		chatSessions: chatSessions,
-		projects:     projectsRepo.New(db),
-		repo:         repo.New(db),
+		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/assets"),
+		logger:         logger,
+		guardianPolicy: guardianPolicy,
+		db:             db,
+		auth:           auth.New(logger, db, sessions, accessLoader),
+		storage:        storage,
+		jwtSecret:      jwtSecret,
+		chatSessions:   chatSessions,
+		projects:       projectsRepo.New(db),
+		repo:           repo.New(db),
 	}
 }
 
@@ -800,9 +803,8 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create request: %w", err), "error fetching URL")
 	}
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	client := s.guardianPolicy.Client()
+	client.Timeout = 30 * time.Second
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, fmt.Errorf("fetch url: %w", err), "error fetching URL")

--- a/server/internal/assets/setup_test.go
+++ b/server/internal/assets/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -60,6 +61,8 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -69,7 +72,7 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 
@@ -77,7 +80,7 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
-	svc := assets.NewService(logger, tracerProvider, conn, sessionManager, chatSessionsManager, storage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
+	svc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, storage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	repository := repo.New(conn)
 
 	return ctx, &testInstance{

--- a/server/internal/audit/setup_test.go
+++ b/server/internal/audit/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -52,6 +53,8 @@ func newTestAuditService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -60,7 +63,7 @@ func newTestAuditService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -4,19 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"time"
 
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -33,7 +31,7 @@ type Manager struct {
 	userInfoCache          cache.TypedCacheObject[CachedUserInfo]
 	speakeasyServerAddress string
 	speakeasySecretKey     string
-	speakeasyClient        *http.Client
+	speakeasyClient        *guardian.HTTPClient
 	orgRepo                *orgRepo.Queries
 	userRepo               *userRepo.Queries
 	pylon                  *pylon.Pylon
@@ -45,6 +43,7 @@ type Manager struct {
 func NewManager(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	redisClient *redis.Client,
 	suffix cache.Suffix,
@@ -56,13 +55,8 @@ func NewManager(
 	workos *workos.Client,
 ) *Manager {
 	logger = logger.With(attr.SlogComponent("sessions"))
-	speakeasyClient := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: otelhttp.NewTransport(
-			cleanhttp.DefaultPooledTransport(),
-			otelhttp.WithTracerProvider(tracerProvider),
-		),
-	}
+	speakeasyClient := guardianPolicy.PooledClient()
+	speakeasyClient.Timeout = 10 * time.Second
 
 	return &Manager{
 		logger:                 logger.With(attr.SlogComponent("sessions")),

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -277,6 +278,8 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "authtest")
 	require.NoError(t, err)
@@ -295,7 +298,7 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient, nil)
+	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient, nil)
 
 	authConfigs := auth.AuthConfigurations{
 		SpeakeasyServerAddress: mockServer.URL,

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -61,6 +62,7 @@ func NewActivities(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	encryption *encryption.Client,
 	features feature.Provider,
@@ -93,7 +95,7 @@ func NewActivities(
 		getAllOrganizations:           activities.NewGetAllOrganizations(logger, db),
 		getSlackProjectContext:        activities.NewSlackProjectContextActivity(logger, db, slackClient),
 		postSlackMessage:              activities.NewPostSlackMessageActivity(logger, slackClient),
-		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, db, features, assetStorage, billingRepo, mcpRegistryClient),
+		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, guardianPolicy, db, features, assetStorage, billingRepo, mcpRegistryClient),
 		provisionFunctionsAccess:      activities.NewProvisionFunctionsAccess(logger, db, encryption),
 		deployFunctionRunners:         activities.NewDeployFunctionRunners(logger, db, functionsDeployer, functionsVersion, encryption),
 		reapFlyApps:                   activities.NewReapFlyApps(logger, meterProvider, db, functionsDeployer, 3),

--- a/server/internal/background/activities/process_deployment.go
+++ b/server/internal/background/activities/process_deployment.go
@@ -29,6 +29,7 @@ import (
 	externalmcpRepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -42,6 +43,7 @@ type ProcessDeployment struct {
 	logger         *slog.Logger
 	tracer         trace.Tracer
 	tracerProvider trace.TracerProvider
+	guardianPolicy *guardian.Policy
 	metrics        *metrics
 	db             *pgxpool.Pool
 	features       feature.Provider
@@ -60,6 +62,7 @@ func NewProcessDeployment(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	features feature.Provider,
 	assetStorage assets.BlobStore,
@@ -71,6 +74,7 @@ func NewProcessDeployment(
 		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities"),
 		tracerProvider: tracerProvider,
 		metrics:        newMetrics(newMeter(meterProvider), logger),
+		guardianPolicy: guardianPolicy,
 		db:             db,
 		features:       features,
 		repo:           repo.New(db),
@@ -429,7 +433,7 @@ func (p *ProcessDeployment) doExternalMCPs(
 
 	for _, mcp := range externalMCPs {
 		pool.Go(func() error {
-			processor := externalmcp.NewToolExtractor(p.logger, p.db, p.registryClient)
+			processor := externalmcp.NewToolExtractor(p.logger, p.guardianPolicy, p.db, p.registryClient)
 
 			return processor.Do(ctx, externalmcp.ToolExtractorTask{
 				OrgSlug:      orgSlug,

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -34,6 +35,7 @@ import (
 )
 
 type WorkerOptions struct {
+	GuardianPolicy      *guardian.Policy
 	DB                  *pgxpool.Pool
 	EncryptionClient    *encryption.Client
 	FeatureProvider     feature.Provider
@@ -56,6 +58,7 @@ type WorkerOptions struct {
 }
 
 func ForDeploymentProcessing(
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	f feature.Provider,
 	assetStorage assets.BlobStore,
@@ -65,6 +68,7 @@ func ForDeploymentProcessing(
 ) *WorkerOptions {
 	return &WorkerOptions{
 		DB:                  db,
+		GuardianPolicy:      guardianPolicy,
 		EncryptionClient:    enc,
 		FeatureProvider:     f,
 		AssetStorage:        assetStorage,
@@ -94,6 +98,7 @@ func NewTemporalWorker(
 	options ...*WorkerOptions,
 ) worker.Worker {
 	opts := &WorkerOptions{
+		GuardianPolicy:      nil,
 		DB:                  nil,
 		EncryptionClient:    nil,
 		FeatureProvider:     nil,
@@ -117,6 +122,7 @@ func NewTemporalWorker(
 
 	for _, o := range options {
 		opts = &WorkerOptions{
+			GuardianPolicy:      conv.Default(o.GuardianPolicy, opts.GuardianPolicy),
 			DB:                  conv.Default(o.DB, opts.DB),
 			EncryptionClient:    conv.Default(o.EncryptionClient, opts.EncryptionClient),
 			FeatureProvider:     conv.Default(o.FeatureProvider, opts.FeatureProvider),
@@ -151,6 +157,7 @@ func NewTemporalWorker(
 		logger,
 		tracerProvider,
 		meterProvider,
+		opts.GuardianPolicy,
 		opts.DB,
 		opts.EncryptionClient,
 		opts.FeatureProvider,

--- a/server/internal/chat/client.go
+++ b/server/internal/chat/client.go
@@ -6,12 +6,15 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
-func NewBaseChatClient(logger *slog.Logger,
+func NewBaseChatClient(
+	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	openRouter openrouter.Provisioner,
 	temporalEnv *temporal.Environment,
@@ -42,6 +45,7 @@ func NewBaseChatClient(logger *slog.Logger,
 	// Create UnifiedClient with strategies (after telemSvc is available)
 	return openrouter.NewUnifiedClient(
 		logger,
+		guardianPolicy,
 		openRouter,
 		messageCaptureStrategy,
 		usageTrackingStrategy,

--- a/server/internal/customdomains/setup_test.go
+++ b/server/internal/customdomains/setup_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	cdrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -68,6 +69,8 @@ func newTestCustomDomainsService(t *testing.T) (context.Context, *serviceTestIns
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "service_testdb")
 	require.NoError(t, err)
@@ -76,7 +79,7 @@ func newTestCustomDomainsService(t *testing.T) (context.Context, *serviceTestIns
 	require.NoError(t, err)
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
 	temporal := &stubTemporalClient{}

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
@@ -71,6 +72,8 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -82,7 +85,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	f := &feature.InMemory{}
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -93,7 +96,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 
@@ -102,7 +105,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
 	svc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
-	assetsSvc := assets.NewService(logger, tracerProvider, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 
 	return ctx, &testInstance{

--- a/server/internal/environments/setup_test.go
+++ b/server/internal/environments/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/environments"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -59,6 +60,8 @@ func newTestEnvironmentService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -68,7 +71,7 @@ func newTestEnvironmentService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/externalmcp/mcpclient.go
+++ b/server/internal/externalmcp/mcpclient.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
 // AuthRejectedError is returned when an MCP server rejects authentication (401 or 403).
@@ -37,15 +37,16 @@ type ClientOptions struct {
 
 // Client represents an active connection to an external MCP server.
 type Client struct {
-	logger    *slog.Logger
-	remoteURL string
-	session   *mcp.ClientSession
-	authRT    *authRoundTripper
+	logger         *slog.Logger
+	guardianPolicy *guardian.Policy
+	remoteURL      string
+	session        *mcp.ClientSession
+	authRT         *authRoundTripper
 }
 
 // NewClient creates a new client connection to an external MCP server.
 // This performs the MCP protocol initialization internally.
-func NewClient(ctx context.Context, logger *slog.Logger, remoteURL string, transportType types.TransportType, opts *ClientOptions) (*Client, error) {
+func NewClient(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, remoteURL string, transportType types.TransportType, opts *ClientOptions) (*Client, error) {
 	if opts == nil {
 		opts = &ClientOptions{
 			Authorization: "",
@@ -55,19 +56,17 @@ func NewClient(ctx context.Context, logger *slog.Logger, remoteURL string, trans
 
 	logger.InfoContext(ctx, "connecting to external MCP server", attr.SlogURL(remoteURL))
 
+	httpClient := guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
+	trasnport := httpClient.Transport
 	authRT := &authRoundTripper{
-		base:            http.DefaultTransport,
+		base:            trasnport,
 		authorization:   opts.Authorization,
 		headers:         opts.Headers,
 		authRejected:    false,
 		statusCode:      0,
 		wwwAuthenticate: "",
 	}
-
-	retryClient := retryablehttp.NewClient()
-	retryClient.HTTPClient.Transport = authRT
-
-	httpClient := retryClient.StandardClient()
+	httpClient.Transport = authRT
 
 	client := mcp.NewClient(&mcp.Implementation{
 		Name:       "gram-server",
@@ -111,10 +110,11 @@ func NewClient(ctx context.Context, logger *slog.Logger, remoteURL string, trans
 	logger.InfoContext(ctx, "connected to external MCP server")
 
 	return &Client{
-		logger:    logger,
-		remoteURL: remoteURL,
-		session:   session,
-		authRT:    authRT,
+		logger:         logger,
+		guardianPolicy: guardianPolicy,
+		remoteURL:      remoteURL,
+		session:        session,
+		authRT:         authRT,
 	}, nil
 }
 

--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
@@ -102,7 +102,7 @@ type protectedResourceMetadata struct {
 // DiscoverOAuthMetadata discovers OAuth configuration for an external MCP server.
 // It parses the WWW-Authenticate header and fetches metadata from discovered URLs.
 // If no metadata URLs are in the header, it probes standard well-known locations.
-func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, wwwAuthenticate string, remoteURL string) (*OAuthDiscoveryResult, error) {
+func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, wwwAuthenticate string, remoteURL string) (*OAuthDiscoveryResult, error) {
 	// Parse the WWW-Authenticate header
 	params := parseWWWAuthenticate(wwwAuthenticate)
 
@@ -111,7 +111,7 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, wwwAuthenti
 
 	// Strategy 1: Check for auth_server_metadata in header (direct AS metadata URL)
 	if asURL, ok := params["auth_server_metadata"]; ok && asURL != "" {
-		meta, err := fetchJSON[authServerMetadata](ctx, logger, asURL)
+		meta, err := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
 		if err == nil && meta != nil {
 			authServerMeta = meta
 		}
@@ -119,13 +119,13 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, wwwAuthenti
 
 	// Strategy 2: Check for resource_metadata in header (Protected Resource metadata)
 	if rmURL, ok := params["resource_metadata"]; ok && rmURL != "" {
-		meta, err := fetchJSON[protectedResourceMetadata](ctx, logger, rmURL)
+		meta, err := fetchJSON[protectedResourceMetadata](ctx, logger, guardianPolicy, rmURL)
 		if err == nil && meta != nil {
 			resourceMeta = meta
 			// Follow the chain to get AS metadata
 			if len(meta.AuthorizationServers) > 0 {
 				asURL := buildWellKnownURL(meta.AuthorizationServers[0])
-				asMeta, err := fetchJSON[authServerMetadata](ctx, logger, asURL)
+				asMeta, err := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
 				if err == nil && asMeta != nil {
 					authServerMeta = asMeta
 				}
@@ -139,13 +139,13 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, wwwAuthenti
 		if err == nil {
 			// Try OAuth Protected Resource metadata first
 			prURL := origin + "/.well-known/oauth-protected-resource"
-			meta, err := fetchJSON[protectedResourceMetadata](ctx, logger, prURL)
+			meta, err := fetchJSON[protectedResourceMetadata](ctx, logger, guardianPolicy, prURL)
 			if err == nil && meta != nil {
 				resourceMeta = meta
 				// Follow the chain
 				if len(meta.AuthorizationServers) > 0 {
 					asURL := buildWellKnownURL(meta.AuthorizationServers[0])
-					asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, asURL)
+					asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
 					if asMeta != nil {
 						authServerMeta = asMeta
 					}
@@ -155,7 +155,7 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, wwwAuthenti
 			// Try OAuth Authorization Server metadata directly
 			if authServerMeta == nil {
 				asURL := origin + "/.well-known/oauth-authorization-server"
-				asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, asURL)
+				asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
 				if asMeta != nil {
 					authServerMeta = asMeta
 				}
@@ -236,7 +236,7 @@ func buildWellKnownURL(baseURL string) string {
 }
 
 // fetchJSON fetches JSON from a URL and decodes it into the target.
-func fetchJSON[T any](ctx context.Context, logger *slog.Logger, url string) (*T, error) {
+func fetchJSON[T any](ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, url string) (*T, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -246,7 +246,7 @@ func fetchJSON[T any](ctx context.Context, logger *slog.Logger, url string) (*T,
 	}
 	req.Header.Set("Accept", "application/json")
 
-	client := retryablehttp.NewClient().StandardClient()
+	client := guardianPolicy.Client(guardian.WithDefaultRetryConfig())
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch: %w", err)

--- a/server/internal/externalmcp/process.go
+++ b/server/internal/externalmcp/process.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/deployments/events"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -27,10 +28,12 @@ type ToolExtractor struct {
 	db             *pgxpool.Pool
 	registryClient *RegistryClient
 	repo           *repo.Queries
+	guardianPolicy *guardian.Policy
 }
 
 func NewToolExtractor(
 	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	registryClient *RegistryClient,
 ) *ToolExtractor {
@@ -39,6 +42,7 @@ func NewToolExtractor(
 		db:             db,
 		registryClient: registryClient,
 		repo:           repo.New(db),
+		guardianPolicy: guardianPolicy,
 	}
 }
 
@@ -106,14 +110,14 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 
 	var requiresOAuth bool
 	var oauthDiscovery *OAuthDiscoveryResult
-	mcpClient, err := NewClient(ctx, internalLogger, serverDetails.RemoteURL, serverDetails.TransportType, nil)
+	mcpClient, err := NewClient(ctx, internalLogger, te.guardianPolicy, serverDetails.RemoteURL, serverDetails.TransportType, nil)
 	if authErr := (*AuthRejectedError)(nil); errors.As(err, &authErr) {
 		logger.InfoContext(ctx, fmt.Sprintf("[%s] external MCP server rejected auth, attempting OAuth discovery", task.MCP.Name),
 			attr.SlogURL(serverDetails.RemoteURL),
 			attr.SlogHTTPResponseStatusCode(authErr.StatusCode),
 		)
 
-		oauthDiscovery, err = DiscoverOAuthMetadata(ctx, internalLogger, authErr.WWWAuthenticate, serverDetails.RemoteURL)
+		oauthDiscovery, err = DiscoverOAuthMetadata(ctx, internalLogger, te.guardianPolicy, authErr.WWWAuthenticate, serverDetails.RemoteURL)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "[%s] error discovering OAuth metadata", task.MCP.Name).Log(ctx, logger)
 		}

--- a/server/internal/externalmcp/proxytoolexecutor.go
+++ b/server/internal/externalmcp/proxytoolexecutor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	externalmcptypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -53,8 +54,9 @@ type HeaderDefinition struct {
 // external tool name. Actual execution happens elsewhere using the returned
 // URN to get a plan and create a client.
 type ProxyToolExecutor struct {
-	logger  *slog.Logger
-	entries []ProxyToolEntry
+	logger         *slog.Logger
+	guardianPolicy *guardian.Policy
+	entries        []ProxyToolEntry
 }
 
 // HasEntries returns true if this executor has any proxy tool entries.
@@ -151,7 +153,7 @@ func (e *ProxyToolExecutor) listToolsForEntry(
 
 	headers := BuildHeaders(systemEnv, userConfig, plan.HeaderDefinitions, tokenForHeaders)
 
-	client, err := NewClient(ctx, e.logger, plan.RemoteURL, plan.TransportType, &ClientOptions{
+	client, err := NewClient(ctx, e.logger, e.guardianPolicy, plan.RemoteURL, plan.TransportType, &ClientOptions{
 		Authorization: "",
 		Headers:       headers,
 	})
@@ -165,7 +167,7 @@ func (e *ProxyToolExecutor) listToolsForEntry(
 
 // BuildProxyToolExecutor creates a ProxyToolExecutor from a list of tools.
 // Filters internally to only include external MCP tools with Type "proxy".
-func BuildProxyToolExecutor(logger *slog.Logger, tools []*types.Tool) *ProxyToolExecutor {
+func BuildProxyToolExecutor(logger *slog.Logger, guardianPolicy *guardian.Policy, tools []*types.Tool) *ProxyToolExecutor {
 	var entries []ProxyToolEntry
 
 	for _, tool := range tools {
@@ -189,7 +191,8 @@ func BuildProxyToolExecutor(logger *slog.Logger, tools []*types.Tool) *ProxyTool
 	}
 
 	return &ProxyToolExecutor{
-		logger:  logger,
-		entries: entries,
+		logger:         logger,
+		guardianPolicy: guardianPolicy,
+		entries:        entries,
 	}
 }

--- a/server/internal/externalmcp/registryclient.go
+++ b/server/internal/externalmcp/registryclient.go
@@ -12,14 +12,13 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/go-retryablehttp"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	externalmcptypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
@@ -31,7 +30,7 @@ type RegistryBackend interface {
 
 // RegistryClient handles communication with external MCP registries.
 type RegistryClient struct {
-	httpClient   *http.Client
+	httpClient   *guardian.HTTPClient
 	logger       *slog.Logger
 	backend      RegistryBackend
 	listCache    *cache.TypedCacheObject[CachedListServersResponse]
@@ -40,14 +39,9 @@ type RegistryClient struct {
 
 // NewRegistryClient creates a new registry client. The cacheImpl parameter is
 // optional — pass nil to disable caching.
-func NewRegistryClient(logger *slog.Logger, tracerProvider trace.TracerProvider, backend RegistryBackend, cacheImpl cache.Cache) *RegistryClient {
+func NewRegistryClient(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, backend RegistryBackend, cacheImpl cache.Cache) *RegistryClient {
 	rc := &RegistryClient{
-		httpClient: &http.Client{
-			Transport: otelhttp.NewTransport(
-				retryablehttp.NewClient().StandardClient().Transport,
-				otelhttp.WithTracerProvider(tracerProvider),
-			),
-		},
+		httpClient:   guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig()),
 		logger:       logger.With(attr.SlogComponent("mcp_registry_client")),
 		backend:      backend,
 		listCache:    nil,

--- a/server/internal/externalmcp/registryclient_test.go
+++ b/server/internal/externalmcp/registryclient_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	tracernoop "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
 type PassthroughBackend struct{}
@@ -32,6 +33,9 @@ func TestListServers_FiltersDeletedServers(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := slog.New(slog.DiscardHandler)
+	tracerProvider := tracernoop.NewTracerProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := listResponse{
@@ -82,7 +86,7 @@ func TestListServers_FiltersDeletedServers(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger, tracernoop.NewTracerProvider(), &PassthroughBackend{}, nil)
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, nil)
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
@@ -101,6 +105,9 @@ func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := slog.New(slog.DiscardHandler)
+	tracerProvider := tracernoop.NewTracerProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -124,7 +131,7 @@ func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger, tracernoop.NewTracerProvider(), &PassthroughBackend{}, nil)
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, nil)
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
@@ -146,6 +153,9 @@ func TestGetServerDetails_OnlySSE(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := slog.New(slog.DiscardHandler)
+	tracerProvider := tracernoop.NewTracerProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -169,7 +179,7 @@ func TestGetServerDetails_OnlySSE(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger, tracernoop.NewTracerProvider(), &PassthroughBackend{}, nil)
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, nil)
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
@@ -191,6 +201,9 @@ func TestGetServerDetails_PrefersStreamableHTTPOverSSE(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := slog.New(slog.DiscardHandler)
+	tracerProvider := tracernoop.NewTracerProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -215,7 +228,7 @@ func TestGetServerDetails_PrefersStreamableHTTPOverSSE(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger, tracernoop.NewTracerProvider(), &PassthroughBackend{}, nil)
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, nil)
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
@@ -237,6 +250,9 @@ func TestGetServerDetails_SelectedRemotesFiltersToSSE(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := slog.New(slog.DiscardHandler)
+	tracerProvider := tracernoop.NewTracerProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -262,7 +278,7 @@ func TestGetServerDetails_SelectedRemotesFiltersToSSE(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger, tracernoop.NewTracerProvider(), &PassthroughBackend{}, nil)
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, nil)
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),
@@ -285,6 +301,9 @@ func TestGetServerDetails_SelectedRemotesStillPrefersStreamableHTTP(t *testing.T
 	t.Parallel()
 	ctx := context.Background()
 	logger := slog.New(slog.DiscardHandler)
+	tracerProvider := tracernoop.NewTracerProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -310,7 +329,7 @@ func TestGetServerDetails_SelectedRemotesStillPrefersStreamableHTTP(t *testing.T
 	}))
 	defer server.Close()
 
-	client := NewRegistryClient(logger, tracernoop.NewTracerProvider(), &PassthroughBackend{}, nil)
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, nil)
 	client.httpClient = server.Client()
 	registry := Registry{
 		ID:  uuid.New(),

--- a/server/internal/externalmcp/setup_test.go
+++ b/server/internal/externalmcp/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -58,6 +59,8 @@ func newTestExternalMCPService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -66,7 +69,7 @@ func newTestExternalMCPService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -18,14 +18,12 @@ import (
 
 	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/google/uuid"
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	slogmulti "github.com/samber/slog-multi"
 	"github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/fly-go/tokens"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
@@ -34,6 +32,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/deployments/events"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/functions/repo"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -68,7 +67,7 @@ type FlyRunner struct {
 	client          *fly.Client
 	tokens          *tokens.Tokens
 	machinesAPIBase string
-	machinesClient  *http.Client
+	machinesClient  *guardian.HTTPClient
 	defaultOrg      string
 	defaultRegion   string
 	imgSelector     ImageSelector
@@ -84,6 +83,7 @@ var _ interface {
 func NewFlyRunner(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
+	guardianPolicy *guardian.Policy,
 	serverURL *url.URL,
 	db *pgxpool.Pool,
 	assetStorage assets.BlobStore,
@@ -96,12 +96,7 @@ func NewFlyRunner(
 
 	flyAPIBase := conv.Default(o.FlyAPIURL, defaultFlyBaseURL)
 	machinesAPIBase := conv.Default(o.FlyMachinesBaseURL, defaultFlyMachinesURL)
-	machinesClient := &http.Client{
-		Transport: otelhttp.NewTransport(
-			retryablehttp.NewClient().StandardClient().Transport,
-			otelhttp.WithTracerProvider(tracerProvider),
-		),
-	}
+	machinesClient := guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
 
 	c := fly.NewClientFromOptions(fly.ClientOptions{
 		BaseURL: flyAPIBase,
@@ -109,12 +104,9 @@ func NewFlyRunner(
 		Name:    o.ServiceName,
 		Version: o.ServiceVersion,
 		Transport: &fly.Transport{
-			UnderlyingTransport: otelhttp.NewTransport(
-				retryablehttp.NewClient().StandardClient().Transport,
-				otelhttp.WithTracerProvider(tracerProvider),
-			),
-			UserAgent: ua,
-			Tokens:    o.FlyTokens,
+			UnderlyingTransport: guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig()).Transport,
+			UserAgent:           ua,
+			Tokens:              o.FlyTokens,
 		},
 		Logger: &flyLogger{
 			logger:      logger.With(attr.SlogComponent("flyio_client")),

--- a/server/internal/functions/deploy_local.go
+++ b/server/internal/functions/deploy_local.go
@@ -22,11 +22,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
+	"github.com/speakeasy-api/gram/server/internal/must"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -52,7 +55,7 @@ type LocalRunner struct {
 	codeRootDir    string
 	serverURL      *url.URL
 	assetStore     assets.BlobStore
-	httpClient     *http.Client
+	httpClient     *guardian.HTTPClient
 	proxyServerURL string
 
 	proxyOnce  sync.Once
@@ -64,13 +67,17 @@ type LocalRunner struct {
 
 var _ Orchestrator = (*LocalRunner)(nil)
 
-func NewLocalRunner(logger *slog.Logger, codeRootDir string, serverURL *url.URL, assetStore assets.BlobStore) *LocalRunner {
+func NewLocalRunner(logger *slog.Logger, tracerProvider trace.TracerProvider, codeRootDir string, serverURL *url.URL, assetStore assets.BlobStore) *LocalRunner {
+	policy := must.Value(guardian.NewUnsafePolicy(tracerProvider, []string{}))
+	httpClient := policy.PooledClient()
+	httpClient.Timeout = 30 * time.Second
+
 	return &LocalRunner{
 		logger:         logger.With(attr.SlogComponent("local-functions-orchestrator")),
 		codeRootDir:    filepath.Clean(codeRootDir),
 		serverURL:      serverURL,
 		assetStore:     assetStore,
-		httpClient:     &http.Client{Timeout: 30 * time.Second},
+		httpClient:     httpClient,
 		proxyServerURL: "",
 		proxyOnce:      sync.Once{},
 		proxyErr:       nil,
@@ -675,7 +682,7 @@ func localRuntimeLanguage(runtime Runtime) (string, error) {
 	}
 }
 
-func waitForLocalRunner(ctx context.Context, client *http.Client, healthURL string) error {
+func waitForLocalRunner(ctx context.Context, client *guardian.HTTPClient, healthURL string) error {
 	deadline := time.Now().Add(localRunnerHealthTimeout)
 	for time.Now().Before(deadline) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)

--- a/server/internal/functions/deploy_local_test.go
+++ b/server/internal/functions/deploy_local_test.go
@@ -19,12 +19,16 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	tracernoop "go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestLocalRunner_ToolCallAndReadResource(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+	tracerProvider := tracernoop.NewTracerProvider()
+
 	root, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -35,7 +39,7 @@ func TestLocalRunner_ToolCallAndReadResource(t *testing.T) {
 	require.NoError(t, err)
 
 	codeRoot := t.TempDir()
-	runner := NewLocalRunner(slog.New(slog.DiscardHandler), codeRoot, serverURL, assetStore)
+	runner := NewLocalRunner(logger, tracerProvider, codeRoot, serverURL, assetStore)
 
 	archive := buildLocalRunnerArchive(t, `
 export async function handleToolCall({ name, input }) {

--- a/server/internal/functions/setup_test.go
+++ b/server/internal/functions/setup_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -72,6 +73,8 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -86,7 +89,7 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -97,7 +100,7 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 
@@ -107,7 +110,7 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 
 	svc := functions.NewService(logger, tracerProvider, conn, enc, tigrisStore)
 	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, ph, testenv.DefaultSiteURL(t), mcpRegistryClient, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
-	assetsSvc := assets.NewService(logger, tracerProvider, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -703,7 +703,7 @@ func (tp *ToolProxy) doHTTP(
 		}
 	}
 
-	shouldContinue := processSecurity(ctx, logger, req, w, &responseStatusCode, descriptor, plan, tp.cache, env, serverURL, attrRecorder)
+	shouldContinue := processSecurity(ctx, logger, tp.policy, req, w, &responseStatusCode, descriptor, plan, tp.cache, env, serverURL, attrRecorder)
 	if !shouldContinue {
 		return nil
 	}
@@ -790,7 +790,7 @@ func (tp *ToolProxy) doExternalMCP(
 	}
 
 	// Connect to the external MCP server
-	client, err := externalmcp.NewClient(ctx, logger, plan.RemoteURL, plan.TransportType, opts)
+	client, err := externalmcp.NewClient(ctx, logger, tp.policy, plan.RemoteURL, plan.TransportType, opts)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to connect to external MCP server").Log(ctx, logger)
 	}

--- a/server/internal/gateway/proxy_test.go
+++ b/server/internal/gateway/proxy_test.go
@@ -216,7 +216,7 @@ func TestToolProxy_Do_PathParams(t *testing.T) {
 			tracerProvider := testenv.NewTracerProvider(t)
 			meterProvider := testenv.NewMeterProvider(t)
 			enc := testenv.NewEncryptionClient(t)
-			policy, err := guardian.NewUnsafePolicy([]string{})
+			policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 			require.NoError(t, err)
 
 			tool := newTestToolDescriptor()
@@ -346,7 +346,7 @@ func TestToolProxy_Do_HeaderParams(t *testing.T) {
 			tracerProvider := testenv.NewTracerProvider(t)
 			meterProvider := testenv.NewMeterProvider(t)
 			enc := testenv.NewEncryptionClient(t)
-			policy, err := guardian.NewUnsafePolicy([]string{})
+			policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 			require.NoError(t, err)
 
 			tool := newTestToolDescriptor()
@@ -707,7 +707,7 @@ func TestToolProxy_Do_QueryParams(t *testing.T) {
 			tracerProvider := testenv.NewTracerProvider(t)
 			meterProvider := testenv.NewMeterProvider(t)
 			enc := testenv.NewEncryptionClient(t)
-			policy, err := guardian.NewUnsafePolicy([]string{})
+			policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 			require.NoError(t, err)
 
 			tool := newTestToolDescriptor()
@@ -917,7 +917,7 @@ func TestToolProxy_Do_Body(t *testing.T) {
 			tracerProvider := testenv.NewTracerProvider(t)
 			meterProvider := testenv.NewMeterProvider(t)
 			enc := testenv.NewEncryptionClient(t)
-			policy, err := guardian.NewUnsafePolicy([]string{})
+			policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 			require.NoError(t, err)
 
 			// Create tool configuration
@@ -1284,7 +1284,7 @@ func TestToolProxy_Do_StringifiedJSONBody(t *testing.T) {
 			tracerProvider := testenv.NewTracerProvider(t)
 			meterProvider := testenv.NewMeterProvider(t)
 			enc := testenv.NewEncryptionClient(t)
-			policy, err := guardian.NewUnsafePolicy([]string{})
+			policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 			require.NoError(t, err)
 
 			tool := newTestToolDescriptor()
@@ -1368,7 +1368,7 @@ func TestResourceProxy_ReadResource(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	// Create resource descriptor
@@ -1509,7 +1509,7 @@ func TestToolProxy_Do_FunctionMetricsTrailers(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -1593,7 +1593,7 @@ func TestToolProxy_Do_PlatformTool_UsesWrappedBodyPayload(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	descriptor := newTestToolDescriptor()
@@ -1665,7 +1665,7 @@ func TestToolProxy_Do_PlatformTool_PreservesRawBodyFieldPayload(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	descriptor := newTestToolDescriptor()
@@ -1735,7 +1735,7 @@ func TestToolProxy_Do_HTTPTool_UserConfigVariablesSent(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -1829,7 +1829,7 @@ func TestToolProxy_Do_HTTPTool_UserConfigNotInPlanNotSent(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -1934,7 +1934,7 @@ func TestToolProxy_Do_FunctionTool_UserConfigNotInPlanNotSent(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2030,7 +2030,7 @@ func TestToolProxy_Do_HTTPTool_SystemEnvSentWhenInPlan(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2125,7 +2125,7 @@ func TestToolProxy_Do_HTTPTool_SystemEnvKeysConvertedToHTTPHeaders(t *testing.T)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2226,7 +2226,7 @@ func TestToolProxy_Do_FunctionTool_SystemEnvSentWhenInPlan(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2324,7 +2324,7 @@ func TestToolProxy_Do_HTTPTool_UserConfigPrefersOverSystemEnv(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2438,7 +2438,7 @@ func TestToolProxy_Do_FunctionTool_UserConfigPrefersOverSystemEnv(t *testing.T) 
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2553,7 +2553,7 @@ func TestToolProxy_Do_FunctionTool_AuthInputSentWhenInUserConfig(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2665,7 +2665,7 @@ func TestToolProxy_Do_FunctionTool_AuthInputNotSentWhenNotInUserConfig(t *testin
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2777,7 +2777,7 @@ func TestToolProxy_Do_FunctionTool_AuthInputPrefersUserConfigOverSystemEnv(t *te
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -2892,7 +2892,7 @@ func TestToolProxy_Do_FunctionTool_AuthInputSentWithRegularVariables(t *testing.
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()
@@ -3011,7 +3011,7 @@ func TestToolProxy_Do_FunctionTool_AuthInputNilNotSent(t *testing.T) {
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
-	policy, err := guardian.NewUnsafePolicy([]string{})
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
 	tool := newTestToolDescriptor()

--- a/server/internal/gateway/security.go
+++ b/server/internal/gateway/security.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
@@ -24,6 +25,7 @@ import (
 func processSecurity(
 	ctx context.Context,
 	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
 	req *http.Request,
 	w http.ResponseWriter,
 	responseStatusCodeCapture *int,
@@ -145,7 +147,7 @@ func processSecurity(
 						}
 					}
 				case "client_credentials":
-					token, err := processClientCredentials(ctx, logger, req, cacheImpl, tool, plan.SecurityScopes, security, mergedEnv, serverURL)
+					token, err := processClientCredentials(ctx, logger, guardianPolicy, req, cacheImpl, tool, plan.SecurityScopes, security, mergedEnv, serverURL)
 					if err != nil {
 						logger.ErrorContext(ctx, "could not process client credentials", attr.SlogError(err))
 						if strings.Contains(err.Error(), "failed to make client credentials token request") {
@@ -245,7 +247,7 @@ type clientCredentialsTokenResponseCamelCase struct {
 	ExpiresIn   int    `json:"expiresIn"`
 }
 
-func processClientCredentials(ctx context.Context, logger *slog.Logger, req *http.Request, cacheImpl cache.Cache, tool *ToolDescriptor, planScopes map[string][]string, security *HTTPToolSecurity, mergedEnv *toolconfig.CaseInsensitiveEnv, serverURL string) (string, error) {
+func processClientCredentials(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, req *http.Request, cacheImpl cache.Cache, tool *ToolDescriptor, planScopes map[string][]string, security *HTTPToolSecurity, mergedEnv *toolconfig.CaseInsensitiveEnv, serverURL string) (string, error) {
 	// To discuss, currently we are taking the approach of exact scope match for reused tokens
 	// We could look into enabling a prefix match feature for caches where we return multiple entries matching the projectID, clientID, tokenURL and then check scopes against all returned values
 	// We would want to make sure any underlying cache implementation supports this feature
@@ -327,13 +329,8 @@ func processClientCredentials(ctx context.Context, logger *slog.Logger, req *htt
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	// Make the token request
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: otelhttp.NewTransport(
-			http.DefaultTransport,
-			otelhttp.WithPropagators(propagation.TraceContext{}),
-		),
-	}
+	client := guardianPolicy.Client(guardian.WithOTelHTTPOptions(otelhttp.WithPropagators(propagation.TraceContext{})))
+	client.Timeout = 10 * time.Second
 	resp, err := client.Do(tokenReq)
 	if err != nil {
 		return "", fmt.Errorf("failed to make client credentials token request: %w", err)
@@ -429,7 +426,7 @@ func parseClientCredentialsTokenResponse(body []byte) (string, int, error) {
 	return accessToken, expiresIn, nil
 }
 
-func retryTokenRequestWithBasicAuth(ctx context.Context, client *http.Client, tokenURL, clientID, clientSecret string, requestedScopes []string) (*http.Response, error) {
+func retryTokenRequestWithBasicAuth(ctx context.Context, client *guardian.HTTPClient, tokenURL, clientID, clientSecret string, requestedScopes []string) (*http.Response, error) {
 	values := url.Values{}
 	values.Set("grant_type", "client_credentials")
 	if len(requestedScopes) > 0 {

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -1,3 +1,23 @@
+// Package guardian provides HTTP client construction with network security
+// policy enforcement, OpenTelemetry instrumentation, and optional retry logic.
+//
+// It addresses three concerns:
+//
+//   - SSRF prevention: outbound connections are checked at the dialer level
+//     against a configurable blocklist of CIDR ranges (all RFC-defined private
+//     and reserved ranges by default). Because the check runs inside
+//     [net.Dialer.ControlContext] after DNS resolution, it cannot be bypassed
+//     by DNS rebinding.
+//
+//   - Safe HTTP transports: [net/http.DefaultTransport] and
+//     [net/http.DefaultClient] are package-level globals that any code can
+//     mutate at runtime, making their behaviour unpredictable. Policy.Client
+//     and Policy.PooledClient avoid this by constructing fresh, isolated
+//     transports for every call via [github.com/hashicorp/go-cleanhttp].
+//
+//   - Observability: every returned [http.Client] has its transport wrapped
+//     with [go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp] so
+//     all outbound HTTP calls are traced without per-call-site boilerplate.
 package guardian
 
 import (
@@ -9,7 +29,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-retryablehttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/trace"
 )
+
+type HTTPClient = http.Client
 
 var (
 	ErrBadHost   = fmt.Errorf("bad host")
@@ -52,14 +77,79 @@ var defaultBlockedCIDRBlocks = []*net.IPNet{
 	mustParseCIDR("2001:20::/28"),  /* ORCHIDv2 - RFC7343 */
 }
 
+type RetryConfig struct {
+	WaitMin     time.Duration // Minimum time to wait
+	WaitMax     time.Duration // Maximum time to wait
+	MaxAttempts int           // Maximum number of retries
+
+	// CheckRetry specifies the policy for handling retries, and is called
+	// after each request. The default policy is [retryablehttp.DefaultRetryPolicy].
+	CheckRetry retryablehttp.CheckRetry
+
+	// Backoff specifies the policy for how long to wait between retries
+	Backoff retryablehttp.Backoff
+
+	// ErrorHandler specifies the custom error handler to use, if any
+	ErrorHandler retryablehttp.ErrorHandler
+
+	// PrepareRetry can prepare the request for retry operation, for example re-sign it
+	PrepareRetry retryablehttp.PrepareRetry
+}
+
+// DefaultRetryConfig returns a [RetryConfig] populated with the defaults from
+// [github.com/hashicorp/go-retryablehttp]. Use it as a starting point when
+// only a few fields need to be overridden.
+func DefaultRetryConfig() *RetryConfig {
+	return &RetryConfig{
+		WaitMin:      1 * time.Second,
+		WaitMax:      30 * time.Second,
+		MaxAttempts:  4,
+		CheckRetry:   retryablehttp.DefaultRetryPolicy,
+		Backoff:      retryablehttp.DefaultBackoff,
+		ErrorHandler: nil,
+		PrepareRetry: nil,
+	}
+}
+
+type htttpClientOptions struct {
+	otelHTTPOptions []otelhttp.Option
+	retryConfig     *RetryConfig
+}
+
+// WithOTelHTTPOptions appends additional [otelhttp.Option] values to the
+// OpenTelemetry transport instrumentation. Use this to configure trace
+// propagation, filters, or span name formatters on a per-client basis.
+func WithOTelHTTPOptions(options ...otelhttp.Option) func(*htttpClientOptions) {
+	return func(o *htttpClientOptions) {
+		o.otelHTTPOptions = options
+	}
+}
+
+// WithDefaultRetryConfig enables retry behaviour using the defaults from
+// [DefaultRetryConfig].
+func WithDefaultRetryConfig() func(*htttpClientOptions) {
+	return func(o *htttpClientOptions) {
+		o.retryConfig = DefaultRetryConfig()
+	}
+}
+
+// WithRetryConfig enables retry behaviour using the provided [RetryConfig].
+func WithRetryConfig(config *RetryConfig) func(*htttpClientOptions) {
+	return func(o *htttpClientOptions) {
+		o.retryConfig = config
+	}
+}
+
 type Policy struct {
+	tracerProvider    trace.TracerProvider
 	blockedCIDRBlocks []*net.IPNet
 }
 
 // NewDefaultPolicy creates a new Policy that blocks common private and reserved
 // IP ranges.
-func NewDefaultPolicy() *Policy {
+func NewDefaultPolicy(tracerProvider trace.TracerProvider) *Policy {
 	return &Policy{
+		tracerProvider:    tracerProvider,
 		blockedCIDRBlocks: defaultBlockedCIDRBlocks,
 	}
 }
@@ -68,7 +158,7 @@ func NewDefaultPolicy() *Policy {
 // It returns an error if any of the CIDR blocks cannot be parsed.
 // Use NewDefaultPolicy for a safe default that blocks common private and
 // reserved IP ranges.
-func NewUnsafePolicy(disallowedCIDRBlocks []string) (*Policy, error) {
+func NewUnsafePolicy(tracerProvider trace.TracerProvider, disallowedCIDRBlocks []string) (*Policy, error) {
 	var disallowedBlocks []*net.IPNet
 	for _, cidr := range disallowedCIDRBlocks {
 		block, err := parseCIDR(cidr)
@@ -78,23 +168,69 @@ func NewUnsafePolicy(disallowedCIDRBlocks []string) (*Policy, error) {
 		disallowedBlocks = append(disallowedBlocks, block)
 	}
 
-	return &Policy{blockedCIDRBlocks: disallowedBlocks}, nil
+	return &Policy{
+		tracerProvider:    tracerProvider,
+		blockedCIDRBlocks: disallowedBlocks,
+	}, nil
 }
 
-func (p *Policy) PooledClient() *http.Client {
-	t := cleanhttp.DefaultPooledTransport()
-	t.DialContext = p.Dialer().DialContext
-
-	return &http.Client{Transport: t}
+// PooledClient returns an [http.Client] backed by a pooled transport that
+// keeps idle connections alive for reuse. It is appropriate for long-lived
+// clients that make repeated requests to the same host(s). Do not use it for
+// short-lived or one-off requests as idle connections hold open file
+// descriptors until they time out.
+func (p *Policy) PooledClient(options ...func(*htttpClientOptions)) *HTTPClient {
+	return p.clientWithBaseTransport(cleanhttp.DefaultPooledTransport(), options...)
 }
 
-func (p *Policy) Client() *http.Client {
-	t := cleanhttp.DefaultTransport()
-	t.DialContext = p.Dialer().DialContext
-
-	return &http.Client{Transport: t}
+// Client returns an [http.Client] that opens a new connection for every
+// request (keepalives disabled). Because connections are never held idle,
+// the client cannot leak file descriptors, making it safe for short-lived
+// or one-off requests where connection reuse is unnecessary.
+func (p *Policy) Client(options ...func(*htttpClientOptions)) *HTTPClient {
+	return p.clientWithBaseTransport(cleanhttp.DefaultTransport(), options...)
 }
 
+func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...func(*htttpClientOptions)) *HTTPClient {
+	var opts htttpClientOptions
+	for _, option := range options {
+		option(&opts)
+	}
+
+	transport.DialContext = p.Dialer().DialContext
+
+	otelOpts := []otelhttp.Option{otelhttp.WithTracerProvider(p.tracerProvider)}
+	otelOpts = append(otelOpts, opts.otelHTTPOptions...)
+	otelTransport := otelhttp.NewTransport(transport, otelOpts...)
+
+	if opts.retryConfig == nil {
+		return &http.Client{Transport: otelTransport}
+	}
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.HTTPClient = &http.Client{
+		Transport: otelTransport,
+	}
+
+	retryClient.RetryWaitMin = opts.retryConfig.WaitMin
+	retryClient.RetryWaitMax = opts.retryConfig.WaitMax
+	retryClient.RetryMax = opts.retryConfig.MaxAttempts
+	retryClient.CheckRetry = opts.retryConfig.CheckRetry
+	retryClient.Backoff = opts.retryConfig.Backoff
+	retryClient.ErrorHandler = opts.retryConfig.ErrorHandler
+	retryClient.PrepareRetry = opts.retryConfig.PrepareRetry
+
+	return retryClient.StandardClient()
+}
+
+// Dialer returns a [net.Dialer] that enforces the policy's CIDR blocklist via
+// [net.Dialer.ControlContext]. The check runs after DNS resolution on the
+// raw IP address, so it cannot be bypassed by hostnames that resolve to
+// blocked ranges. If the resolved IP falls within a blocked CIDR block the
+// dial fails with [ErrBlockedIP]; malformed addresses fail with [ErrBadHost].
+//
+// Client and PooledClient use this dialer internally. Use Dialer directly only
+// when you need to build a custom [http.Transport].
 func (p *Policy) Dialer() *net.Dialer {
 	return &net.Dialer{
 		Timeout:   30 * time.Second,

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/speakeasy-api/gram/server/internal/dns"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -114,6 +115,7 @@ func DefaultRetryConfig() *RetryConfig {
 type htttpClientOptions struct {
 	otelHTTPOptions []otelhttp.Option
 	retryConfig     *RetryConfig
+	resolver        *net.Resolver
 }
 
 // WithOTelHTTPOptions appends additional [otelhttp.Option] values to the
@@ -137,6 +139,12 @@ func WithDefaultRetryConfig() func(*htttpClientOptions) {
 func WithRetryConfig(config *RetryConfig) func(*htttpClientOptions) {
 	return func(o *htttpClientOptions) {
 		o.retryConfig = config
+	}
+}
+
+func WithResolver(resolver *net.Resolver) func(*htttpClientOptions) {
+	return func(o *htttpClientOptions) {
+		o.resolver = resolver
 	}
 }
 
@@ -197,7 +205,11 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 		option(&opts)
 	}
 
-	transport.DialContext = p.Dialer().DialContext
+	dialOpts := []func(*dialerOptions){}
+	if opts.resolver != nil {
+		dialOpts = append(dialOpts, WithDialerResolver(opts.resolver))
+	}
+	transport.DialContext = p.Dialer(dialOpts...).DialContext
 
 	otelOpts := []otelhttp.Option{otelhttp.WithTracerProvider(p.tracerProvider)}
 	otelOpts = append(otelOpts, opts.otelHTTPOptions...)
@@ -223,6 +235,16 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 	return retryClient.StandardClient()
 }
 
+type dialerOptions struct {
+	resolver *net.Resolver
+}
+
+func WithDialerResolver(resolver *net.Resolver) func(*dialerOptions) {
+	return func(o *dialerOptions) {
+		o.resolver = resolver
+	}
+}
+
 // Dialer returns a [net.Dialer] that enforces the policy's CIDR blocklist via
 // [net.Dialer.ControlContext]. The check runs after DNS resolution on the
 // raw IP address, so it cannot be bypassed by hostnames that resolve to
@@ -231,11 +253,22 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 //
 // Client and PooledClient use this dialer internally. Use Dialer directly only
 // when you need to build a custom [http.Transport].
-func (p *Policy) Dialer() *net.Dialer {
+func (p *Policy) Dialer(options ...func(*dialerOptions)) *net.Dialer {
+	var opts dialerOptions
+	for _, option := range options {
+		option(&opts)
+	}
+
+	resolver := opts.resolver
+	if resolver == nil {
+		resolver = dns.NewNetResolver().Resolver()
+	}
+
 	return &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 		DualStack: true,
+		Resolver:  resolver,
 		ControlContext: func(ctx context.Context, network string, address string, conn syscall.RawConn) error {
 			host, _, err := net.SplitHostPort(address)
 			if err != nil {

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 func TestNewUnsafePolicy(t *testing.T) {
@@ -50,7 +52,7 @@ func TestNewUnsafePolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			policy, err := guardian.NewUnsafePolicy(tt.cidrBlocks)
+			policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), tt.cidrBlocks)
 			if tt.expectError {
 				require.Error(t, err)
 				require.Nil(t, policy)
@@ -64,7 +66,7 @@ func TestNewUnsafePolicy(t *testing.T) {
 
 func TestPolicy_Dialer(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 
 	require.NotNil(t, dialer)
@@ -75,7 +77,7 @@ func TestPolicy_Dialer(t *testing.T) {
 
 func TestPolicy_DialerControlContext(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 
 	ctx := t.Context()
@@ -128,7 +130,7 @@ func TestPolicy_DialerControlContext(t *testing.T) {
 
 func TestPolicy_DialerControlContext_CustomPolicy(t *testing.T) {
 	t.Parallel()
-	policy, err := guardian.NewUnsafePolicy([]string{"8.8.8.0/24"})
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{"8.8.8.0/24"})
 	require.NoError(t, err)
 
 	dialer := policy.Dialer()
@@ -142,35 +144,33 @@ func TestPolicy_DialerControlContext_CustomPolicy(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPolicy_Client(t *testing.T) {
+func TestPolicy_ClientWrapsTransportWithOtel(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	client := policy.Client()
 
 	require.NotNil(t, client)
 	require.NotNil(t, client.Transport)
 
-	transport, ok := client.Transport.(*http.Transport)
+	_, ok := client.Transport.(*otelhttp.Transport)
 	require.True(t, ok)
-	require.NotNil(t, transport.DialContext)
 }
 
-func TestPolicy_PooledClient(t *testing.T) {
+func TestPolicy_PooledClientWrapsTransportWithOtel(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	client := policy.PooledClient()
 
 	require.NotNil(t, client)
 	require.NotNil(t, client.Transport)
 
-	transport, ok := client.Transport.(*http.Transport)
+	_, ok := client.Transport.(*otelhttp.Transport)
 	require.True(t, ok)
-	require.NotNil(t, transport.DialContext)
 }
 
 func TestDefaultPolicyBlocksPrivateIPs(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 	ctx := t.Context()
 
@@ -192,7 +192,7 @@ func TestDefaultPolicyBlocksPrivateIPs(t *testing.T) {
 
 func TestPolicy_DialerIPBlocking(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 	ctx := t.Context()
 
@@ -216,7 +216,7 @@ func TestPolicy_DialerIPBlocking(t *testing.T) {
 
 func TestPolicy_DialerEdgeCases(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 	ctx := t.Context()
 
@@ -262,7 +262,7 @@ func TestPolicy_DialerEdgeCases(t *testing.T) {
 
 func TestPolicy_DialerContext(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
@@ -290,7 +290,7 @@ func TestPolicy_HTTPClientWithCustomPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a custom policy that blocks the test server's IP
-	customPolicy, err := guardian.NewUnsafePolicy([]string{host + "/32"})
+	customPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{host + "/32"})
 	require.NoError(t, err)
 
 	// Test that the custom policy blocks the server
@@ -322,7 +322,7 @@ func TestPolicy_PooledHTTPClientWithFakeNetwork(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a custom policy that allows the test server but blocks private IPs
-	policy, err := guardian.NewUnsafePolicy([]string{
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{
 		"192.168.0.0/16", // Block private IPs
 		"10.0.0.0/8",     // Block private IPs
 		"172.16.0.0/12",  // Block private IPs
@@ -358,7 +358,7 @@ func TestPolicy_PooledHTTPClientWithFakeNetwork(t *testing.T) {
 
 func TestPolicy_IPv4MappedIPv6Addresses(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 	ctx := t.Context()
 
@@ -440,7 +440,7 @@ func TestPolicy_IPv4MappedIPv6Addresses(t *testing.T) {
 
 func TestPolicy_IPv6VariationsBlocking(t *testing.T) {
 	t.Parallel()
-	policy := guardian.NewDefaultPolicy()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
 	dialer := policy.Dialer()
 	ctx := t.Context()
 

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -61,6 +62,8 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := noop.NewTracerProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -70,7 +73,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/keys/setup_test.go
+++ b/server/internal/keys/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/keys"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -60,6 +61,8 @@ func newTestKeysService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -69,7 +72,7 @@ func newTestKeysService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 	ctx = withDefaultOrgAdminGrant(t, ctx, conn)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -68,6 +68,7 @@ type Service struct {
 	logger              *slog.Logger
 	tracer              trace.Tracer
 	metrics             *metrics
+	guardianPolicy      *guardian.Policy
 	db                  *pgxpool.Pool
 	authRepo            *auth_repo.Queries
 	toolsetsRepo        *toolsets_repo.Queries
@@ -148,6 +149,7 @@ func NewService(
 		logger:          logger,
 		tracer:          tracer,
 		metrics:         newMetrics(meter, logger),
+		guardianPolicy:  guardianPolicy,
 		db:              db,
 		authRepo:        auth_repo.New(db),
 		toolsetsRepo:    toolsets_repo.New(db),
@@ -851,9 +853,9 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "notifications/initialized", "notifications/cancelled":
 		return nil, nil
 	case "tools/list":
-		return handleToolsList(ctx, s.logger, s.db, s.env, payload, req, s.posthog, &s.toolsetCache, s.vectorToolStore, s.temporal)
+		return handleToolsList(ctx, s.logger, s.guardianPolicy, s.db, s.env, payload, req, s.posthog, &s.toolsetCache, s.vectorToolStore, s.temporal)
 	case "tools/call":
-		return handleToolsCall(ctx, s.logger, s.metrics, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo)
+		return handleToolsCall(ctx, s.logger, s.metrics, s.guardianPolicy, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo)
 	case "prompts/list":
 		return handlePromptsList(ctx, s.logger, s.db, payload, req, &s.toolsetCache)
 	case "prompts/get":
@@ -1012,6 +1014,7 @@ func (s *Service) HandleToolsList(
 	result, err := handleToolsList(
 		ctx,
 		s.logger,
+		s.guardianPolicy,
 		s.db,
 		s.env,
 		payload,
@@ -1080,6 +1083,7 @@ func (s *Service) HandleToolsCall(
 		ctx,
 		s.logger,
 		s.metrics,
+		s.guardianPolicy,
 		s.db,
 		s.env,
 		payload,

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -28,6 +28,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	mcpmetadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -57,6 +58,7 @@ func handleToolsCall(
 	ctx context.Context,
 	logger *slog.Logger,
 	metrics *metrics,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	env toolconfig.EnvironmentLoader,
 	payload *mcpInputs,
@@ -117,7 +119,7 @@ func handleToolsCall(
 		return nil, oops.E(oops.CodeUnexpected, err, "invalid toolset ID").Log(ctx, logger)
 	}
 
-	executor := externalmcp.BuildProxyToolExecutor(logger, toolset.Tools)
+	executor := externalmcp.BuildProxyToolExecutor(logger, guardianPolicy, toolset.Tools)
 
 	var plan *gateway.ToolCallPlan
 	var toolURN urn.Tool

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/rag"
@@ -41,6 +42,7 @@ type toolListEntry struct {
 func handleToolsList(
 	ctx context.Context,
 	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	env toolconfig.EnvironmentLoader,
 	payload *mcpInputs,
@@ -85,7 +87,7 @@ func handleToolsList(
 	case ToolModeStatic:
 		fallthrough
 	default:
-		tools, err = buildToolListEntries(ctx, logger, db, env, payload, toolset)
+		tools, err = buildToolListEntries(ctx, logger, guardianPolicy, db, env, payload, toolset)
 		if err != nil {
 			return nil, err
 		}
@@ -109,6 +111,7 @@ func handleToolsList(
 func buildToolListEntries(
 	ctx context.Context,
 	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	envLoader toolconfig.EnvironmentLoader,
 	payload *mcpInputs,
@@ -134,7 +137,7 @@ func buildToolListEntries(
 
 	var tools []*toolListEntry
 
-	executor := externalmcp.BuildProxyToolExecutor(logger, toolset.Tools)
+	executor := externalmcp.BuildProxyToolExecutor(logger, guardianPolicy, toolset.Tools)
 	if executor.HasEntries() {
 		resolve := func(ctx context.Context, toolURN urn.Tool, projectID uuid.UUID) (*externalmcp.ToolCallPlan, error) {
 			plan, err := toolsetHelpers.GetToolCallPlanByURN(ctx, toolURN, projectID)

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -82,6 +82,8 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := noop.NewMeterProvider()
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "mcptest")
 	require.NoError(t, err)
@@ -91,7 +93,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-test"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
@@ -106,11 +108,10 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	env := environments.NewEnvironmentEntries(logger, conn, enc, mcpMetadataRepo)
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
-	guardianPolicy := guardian.NewDefaultPolicy()
 	oauthService := oauth.NewService(logger, tracerProvider, meterProvider, conn, serverURL, cacheAdapter, enc, env, sessionManager)
 	billingStub := billing.NewStubClient(logger, tracerProvider)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
-	chatClient := openrouter.NewUnifiedClient(logger, devProvisioner, nil, nil, nil, nil, nil)
+	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, nil, nil, nil, nil, nil)
 	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
 	chatSessions := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 	featClient := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)

--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -62,6 +63,8 @@ func newTestMCPMetadataService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "mcpmetadatatest")
 	require.NoError(t, err)
@@ -72,7 +75,7 @@ func newTestMCPMetadataService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-test"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	goahttp "goa.design/goa/v3/http"
@@ -36,6 +35,7 @@ import (
 	deployments_repo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	externalmcp_repo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oauth/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
@@ -118,7 +118,7 @@ type ExternalOAuthService struct {
 	allowedRedirectHosts []string
 	auth                 *auth.Auth
 	enc                  *encryption.Client
-	httpClient           *http.Client
+	httpClient           *guardian.HTTPClient
 	successPageTmpl      *template.Template
 	successScriptHash    string
 	successScriptData    []byte
@@ -139,6 +139,7 @@ func (s *ExternalOAuthService) isAllowedRedirectHost(host string) bool {
 // NewExternalOAuthService creates a new ExternalOAuthService
 func NewExternalOAuthService(
 	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
 	cacheImpl cache.Cache,
 	auth *auth.Auth,
@@ -171,7 +172,7 @@ func NewExternalOAuthService(
 		allowedRedirectHosts: cfg.AllowedRedirectHosts,
 		auth:                 auth,
 		enc:                  enc,
-		httpClient:           retryablehttp.NewClient().StandardClient(),
+		httpClient:           guardianPolicy.Client(guardian.WithDefaultRetryConfig()),
 		successPageTmpl:      successPageTmpl,
 		successScriptHash:    scriptHashStr,
 		successScriptData:    externalOAuthSuccessScriptData,

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/organizations"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -78,6 +79,8 @@ func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) 
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -86,7 +89,7 @@ func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) 
 	require.NoError(t, err)
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -125,6 +128,8 @@ func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstan
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -133,7 +138,7 @@ func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstan
 	require.NoError(t, err)
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)

--- a/server/internal/packages/setup_test.go
+++ b/server/internal/packages/setup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -59,6 +60,8 @@ func newTestPackagesService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -68,7 +71,7 @@ func newTestPackagesService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/productfeatures/setup_test.go
+++ b/server/internal/productfeatures/setup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -54,6 +55,8 @@ func newTestProductFeaturesService(t *testing.T) (context.Context, *testInstance
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -63,7 +66,7 @@ func newTestProductFeaturesService(t *testing.T) (context.Context, *testInstance
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/projects/setup_test.go
+++ b/server/internal/projects/setup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/projects"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -68,6 +69,8 @@ func newTestProjectsService(t *testing.T, enableRBAC bool) (context.Context, *te
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -77,7 +80,7 @@ func newTestProjectsService(t *testing.T, enableRBAC bool) (context.Context, *te
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)

--- a/server/internal/resources/setup_test.go
+++ b/server/internal/resources/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/resources"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -57,6 +58,8 @@ func newTestResourcesService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -66,7 +69,7 @@ func newTestResourcesService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
@@ -69,6 +70,8 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -78,7 +81,7 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-test"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), billingClient)
 
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 

--- a/server/internal/templates/setup_test.go
+++ b/server/internal/templates/setup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/templates"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -59,6 +60,8 @@ func newTestTemplateService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -68,7 +71,7 @@ func newTestTemplateService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 

--- a/server/internal/testenv/auth.go
+++ b/server/internal/testenv/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 
 	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -19,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -28,7 +30,7 @@ import (
 // NewTestManager creates a sessions.Manager backed by a mock IDP httptest.Server.
 // This replaces the old NewUnsafeManager pattern - tests now exercise the real
 // auth code path (Speakeasy IDP HTTP calls) against a local mock.
-func NewTestManager(t *testing.T, logger *slog.Logger, db *pgxpool.Pool, redisClient *redis.Client, suffix cache.Suffix, billingRepo billing.Repository) *sessions.Manager {
+func NewTestManager(t *testing.T, logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, db *pgxpool.Pool, redisClient *redis.Client, suffix cache.Suffix, billingRepo billing.Repository) *sessions.Manager {
 	t.Helper()
 
 	cfg := mockidp.NewConfig()
@@ -42,7 +44,8 @@ func NewTestManager(t *testing.T, logger *slog.Logger, db *pgxpool.Pool, redisCl
 
 	return sessions.NewManager(
 		logger,
-		NewTracerProvider(t),
+		tracerProvider,
+		guardianPolicy,
 		db,
 		redisClient,
 		suffix,

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
@@ -34,7 +35,7 @@ func NewFunctionsTestOrchestrator(t *testing.T, assetStore assets.BlobStore) fun
 	t.Helper()
 
 	codeRoot := t.TempDir()
-	return functions.NewLocalRunner(NewLogger(t), codeRoot, DefaultSiteURL(t), assetStore)
+	return functions.NewLocalRunner(NewLogger(t), NewTracerProvider(t), codeRoot, DefaultSiteURL(t), assetStore)
 }
 
 func NewEncryptionClient(t *testing.T) *encryption.Client {
@@ -83,9 +84,13 @@ func NewMCPRegistryClient(t *testing.T, logger *slog.Logger, tracerProvider trac
 	pulseURL, err := url.Parse("https://api.pulsemcp.com")
 	require.NoError(t, err, "expected pulse URL to parse")
 
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err, "expected guardian policy to initialize without error")
+
 	client := externalmcp.NewRegistryClient(
 		NewLogger(t),
 		tracerProvider,
+		guardianPolicy,
 		externalmcp.NewPulseBackend(pulseURL, "test-tenant-id", conv.NewSecret([]byte("test-api-key"))),
 		nil,
 	)

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -13,11 +13,12 @@ import (
 	"slices"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -100,19 +101,21 @@ type OpenRouter struct {
 	logger          *slog.Logger
 	repo            *repo.Queries
 	orgRepo         *orgRepo.Queries
-	orClient        *http.Client
+	orClient        *guardian.HTTPClient
 	refresher       KeyRefresher
 	featureClient   *productfeatures.Client
 }
 
-func New(logger *slog.Logger, db *pgxpool.Pool, env string, provisioningKey string, refresher KeyRefresher, featureClient *productfeatures.Client, tracking billing.Tracker) *OpenRouter {
+func New(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, db *pgxpool.Pool, env string, provisioningKey string, refresher KeyRefresher, featureClient *productfeatures.Client, tracking billing.Tracker) *OpenRouter {
+	orClient := guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
+
 	return &OpenRouter{
 		provisioningKey: provisioningKey,
 		env:             env,
 		logger:          logger.With(attr.SlogComponent("openrouter")),
 		repo:            repo.New(db),
 		orgRepo:         orgRepo.New(db),
-		orClient:        retryablehttp.NewClient().StandardClient(),
+		orClient:        orClient,
 		refresher:       refresher,
 		featureClient:   featureClient,
 	}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -12,13 +12,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/go-cleanhttp"
 	"go.opentelemetry.io/otel/trace"
 
 	or_base "github.com/OpenRouterTeam/go-sdk"
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	or_operations "github.com/OpenRouterTeam/go-sdk/models/operations"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
@@ -46,7 +46,7 @@ const (
 // It applies pluggable strategies for message capture and usage tracking.
 type ChatClient struct {
 	logger                 *slog.Logger
-	httpClient             *http.Client
+	httpClient             *guardian.HTTPClient
 	provisioner            Provisioner
 	messageCaptureStrategy MessageCaptureStrategy
 	usageTrackingStrategy  UsageTrackingStrategy
@@ -58,6 +58,7 @@ type ChatClient struct {
 // NewUnifiedClient creates a new UnifiedClient with the given strategies.
 func NewUnifiedClient(
 	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
 	provisioner Provisioner,
 	captureStrategy MessageCaptureStrategy,
 	trackingStrategy UsageTrackingStrategy,
@@ -67,7 +68,7 @@ func NewUnifiedClient(
 ) *ChatClient {
 	return &ChatClient{
 		logger:                 logger.With(attr.SlogComponent("openrouter_completions")),
-		httpClient:             cleanhttp.DefaultPooledClient(),
+		httpClient:             guardianPolicy.PooledClient(),
 		provisioner:            provisioner,
 		messageCaptureStrategy: captureStrategy,
 		usageTrackingStrategy:  trackingStrategy,

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -15,7 +15,9 @@ import (
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -200,9 +202,14 @@ func TestChatClient_GetCompletion(t *testing.T) {
 	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryLogger := &mockTelemetryLogger{}
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	// Create client
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		provisioner,
 		captureStrategy,
 		trackingStrategy,
@@ -319,9 +326,14 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryLogger := &mockTelemetryLogger{}
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	// Create client
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		provisioner,
 		captureStrategy,
 		trackingStrategy,
@@ -430,9 +442,14 @@ func TestChatClient_GetCompletion_WithToolCalls(t *testing.T) {
 	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	// Create client
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		provisioner,
 		captureStrategy,
 		trackingStrategy,
@@ -528,9 +545,14 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 			resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 			telemetryService := &mockTelemetryLogger{}
 
+			tracerProvider := testenv.NewTracerProvider(t)
+			guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+			require.NoError(t, err)
+
 			// Create client
 			client := NewUnifiedClient(
 				slog.Default(),
+				guardianPolicy,
 				provisioner,
 				captureStrategy,
 				trackingStrategy,
@@ -552,7 +574,7 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 			}
 
 			// Call GetCompletion
-			_, err := client.GetCompletion(context.Background(), req)
+			_, err = client.GetCompletion(context.Background(), req)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
@@ -595,9 +617,14 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	// Create client
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		provisioner,
 		captureStrategy,
 		trackingStrategy,
@@ -758,9 +785,14 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 	server := newMockServer(t)
 	defer server.Close()
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	titleGenerator := &trackingTitleGenerator{}
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		&mockMessageCaptureStrategy{},
 		&mockUsageTrackingStrategy{},
@@ -780,7 +812,7 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 		APIKeyID:    "",
 	}
 
-	_, err := client.GetCompletion(context.Background(), req)
+	_, err = client.GetCompletion(context.Background(), req)
 	require.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond)
@@ -799,10 +831,15 @@ func TestChatClient_TitleGeneration_ScheduledPerCompletionWithValidChatID(t *tes
 	server := newMockServer(t)
 	defer server.Close()
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	titleGenerator := &trackingTitleGenerator{}
 	tracker := newTrackingCaptureStrategy()
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		tracker,
 		&mockUsageTrackingStrategy{},
@@ -829,7 +866,7 @@ func TestChatClient_TitleGeneration_ScheduledPerCompletionWithValidChatID(t *tes
 	}
 
 	// One completion with nil ChatID (simulating title-gen activity's internal call)
-	_, err := client.GetCompletion(context.Background(), CompletionRequest{
+	_, err = client.GetCompletion(context.Background(), CompletionRequest{
 		OrgID:       "test-org",
 		ProjectID:   projectID.String(),
 		Messages:    []or.Message{CreateMessageUser("Generate title")},
@@ -861,9 +898,14 @@ func TestChatClient_ReloadChat_NoDuplicateMessages(t *testing.T) {
 	server := newMockServer(t)
 	defer server.Close()
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	tracker := newTrackingCaptureStrategy()
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		tracker,
 		&mockUsageTrackingStrategy{},
@@ -885,7 +927,7 @@ func TestChatClient_ReloadChat_NoDuplicateMessages(t *testing.T) {
 		UsageSource: billing.ModelUsageSourcePlayground,
 		APIKeyID:    "key-1",
 	}
-	_, err := client.GetCompletion(context.Background(), req1)
+	_, err = client.GetCompletion(context.Background(), req1)
 	require.NoError(t, err)
 
 	// After round 1: DB should have [user(StartOrResumeChat), assistant(CaptureMessage)]
@@ -986,9 +1028,14 @@ func TestChatClient_GetCompletion_WithJSONSchema(t *testing.T) {
 	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	// Create client
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		provisioner,
 		captureStrategy,
 		trackingStrategy,
@@ -1096,9 +1143,14 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
 	// Create client
 	client := NewUnifiedClient(
 		slog.Default(),
+		guardianPolicy,
 		provisioner,
 		captureStrategy,
 		trackingStrategy,

--- a/server/internal/thirdparty/polar/client.go
+++ b/server/internal/thirdparty/polar/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
 type Catalog struct {
@@ -65,7 +66,7 @@ type Client struct {
 	logger             *slog.Logger
 	tracer             trace.Tracer
 	polar              *polargo.Polar
-	httpClient         *http.Client
+	httpClient         *guardian.HTTPClient
 	bearerToken        string
 	catalog            *Catalog
 	customerStateCache cache.TypedCacheObject[PolarCustomerState]
@@ -77,12 +78,15 @@ type Client struct {
 var _ billing.Tracker = (*Client)(nil)
 var _ billing.Repository = (*Client)(nil)
 
-func NewClient(polarClient *polargo.Polar, bearerToken string, logger *slog.Logger, tracerProvider trace.TracerProvider, redisClient *redis.Client, catalog *Catalog, webhookSecret string) *Client {
+func NewClient(guardianPolicy *guardian.Policy, polarClient *polargo.Polar, bearerToken string, logger *slog.Logger, tracerProvider trace.TracerProvider, redisClient *redis.Client, catalog *Catalog, webhookSecret string) *Client {
+	client := guardianPolicy.PooledClient()
+	client.Timeout = 30 * time.Second
+
 	return &Client{
 		logger:             logger.With(attr.SlogComponent("polar_usage")),
 		tracer:             tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/thirdparty/polar"),
 		polar:              polarClient,
-		httpClient:         &http.Client{Timeout: 30 * time.Second},
+		httpClient:         client,
 		bearerToken:        bearerToken,
 		catalog:            catalog,
 		customerStateCache: cache.NewTypedObjectCache[PolarCustomerState](logger.With(attr.SlogCacheNamespace("polar-customer-state")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),

--- a/server/internal/thirdparty/slack/client/client.go
+++ b/server/internal/thirdparty/slack/client/client.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/slack/repo"
 )
 
@@ -22,18 +22,18 @@ const slackServer = "https://slack.com/api"
 type SlackClient struct {
 	clientID     string
 	clientSecret string
-	client       *http.Client
+	client       *guardian.HTTPClient
 	enc          *encryption.Client
 	repo         *repo.Queries
 	enabled      bool
 }
 
-func NewSlackClient(clientID, clientSecret string, db *pgxpool.Pool, enc *encryption.Client) *SlackClient {
+func NewSlackClient(guardianPolicy *guardian.Policy, clientID, clientSecret string, db *pgxpool.Pool, enc *encryption.Client) *SlackClient {
 	enabled := clientID != "" && clientSecret != ""
 	return &SlackClient{
 		clientID:     clientID,
 		clientSecret: clientSecret,
-		client:       cleanhttp.DefaultPooledClient(),
+		client:       guardianPolicy.PooledClient(),
 		enc:          enc,
 		repo:         repo.New(db),
 		enabled:      enabled,

--- a/server/internal/thirdparty/workos/client.go
+++ b/server/internal/thirdparty/workos/client.go
@@ -11,11 +11,11 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"github.com/workos/workos-go/v6/pkg/organizations"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
 	"github.com/workos/workos-go/v6/pkg/workos_errors"
 
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
@@ -55,7 +55,7 @@ func wrapSDKError(err error, context string) error {
 type Client struct {
 	apiKey     string
 	endpoint   string // base URL for raw HTTP calls; defaults to workosBaseURL
-	httpClient *http.Client
+	httpClient *guardian.HTTPClient
 	orgs       *organizations.Client
 	um         *usermanagement.Client
 }
@@ -66,10 +66,10 @@ type ClientOpts struct {
 	// Endpoint overrides the WorkOS base URL for both raw HTTP and SDK calls.
 	Endpoint string
 	// HTTPClient overrides the default retryable HTTP client.
-	HTTPClient *http.Client
+	HTTPClient *guardian.HTTPClient
 }
 
-func NewClient(apiKey string, opts ...ClientOpts) *Client {
+func NewClient(guardianPolicy *guardian.Policy, apiKey string, opts ...ClientOpts) *Client {
 	var opt ClientOpts
 	if len(opts) > 0 {
 		opt = opts[0]
@@ -82,9 +82,9 @@ func NewClient(apiKey string, opts ...ClientOpts) *Client {
 
 	httpClient := opt.HTTPClient
 	if httpClient == nil {
-		rc := retryablehttp.NewClient()
-		rc.HTTPClient.Timeout = 10 * time.Second
-		httpClient = rc.StandardClient()
+		retryCfg := guardian.DefaultRetryConfig()
+		retryCfg.WaitMax = 10 * time.Second
+		httpClient = guardianPolicy.PooledClient(guardian.WithRetryConfig(retryCfg))
 	}
 
 	um := usermanagement.NewClient(apiKey)

--- a/server/internal/thirdparty/workos/client_test.go
+++ b/server/internal/thirdparty/workos/client_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/workos/workos-go/v6/pkg/roles"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
 
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
@@ -455,7 +457,11 @@ func newTestClient(t *testing.T, fake *fakeWorkOS) (*workos.Client, *fakeWorkOS)
 	srv := httptest.NewServer(fake)
 	t.Cleanup(srv.Close)
 
-	client := workos.NewClient("test-api-key", workos.ClientOpts{
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	client := workos.NewClient(guardianPolicy, "test-api-key", workos.ClientOpts{
 		Endpoint:   srv.URL,
 		HTTPClient: &http.Client{Timeout: 10 * time.Second},
 	})

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/templates"
@@ -80,6 +81,8 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -90,7 +93,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 
@@ -103,7 +106,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	f := &feature.InMemory{}
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -111,7 +114,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 
 	toolsSvc := tools.NewService(logger, tracerProvider, conn, sessionManager, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
-	assetsSvc := assets.NewService(logger, tracerProvider, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient), access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	templatesSvc := templates.NewService(logger, tracerProvider, conn, sessionManager, toolsetsSvc, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
@@ -81,6 +82,8 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -95,7 +98,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	f := &feature.InMemory{}
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -108,7 +111,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 
@@ -116,7 +119,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 
 	svc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
-	assetsSvc := assets.NewService(logger, tracerProvider, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}))
 
 	return ctx, &testInstance{

--- a/server/internal/variations/setup_test.go
+++ b/server/internal/variations/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/variations"
@@ -57,6 +58,8 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -66,7 +69,7 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 


### PR DESCRIPTION
This change removes all usages of bare `http.Client`s in favour of a safer variant from the guardian package. This is further enforced by an update to the forbidigo linter.

There are five main benefits to the new http client:

- Automatic SSRF protection that covers redirects
- No reliance on unsafe `net/http.DefaultClient` and net/http.DefaultTransport` which can be modified at runtime by malicious code
- Instrumentation with otelhttp
- Built-in configurable retries
- Pooled and unpooled variants via `github.com/hashicorp/go-cleanhttp` or `github.com/hashicorp/go-retryablehttp` (if retries enabled)
- Uses internal `dns` package to configure net.Resolver