### PR TITLE
fix: skip atlas login if already authenticated

### DIFF
--- a/.mise-tasks/clickhouse/migrate.sh
+++ b/.mise-tasks/clickhouse/migrate.sh
@@ -31,7 +31,7 @@ else
     args+=("--dry-run")
   fi
 
-  atlas login
+  atlas whoami &>/dev/null || atlas login
 
   exec atlas migrate apply \
     --dir file://clickhouse/migrations \


### PR DESCRIPTION
Change `atlas login` to `atlas whoami &>/dev/null || atlas login` so login is only attempted when not already authenticated

`atlas login` unconditionally attempts an OAuth browser flow on every run of `mise clickhouse:migrate`, returning a 403 Forbidden when the flow can't complete (e.g. in agent/CI contexts or when a network proxy intercepts the request). Since credentials may already be stored, there's no need to reauthenticate.