### PR TITLE
feat: scannability design with rich view for structured diff summary

### DIFF
--- a/client/dashboard/src/components/auditlogs/structured-diff.tsx
+++ b/client/dashboard/src/components/auditlogs/structured-diff.tsx
@@ -30,16 +30,16 @@ function ChangedFieldRow({
   newValue: unknown;
 }) {
   return (
-    <div className="flex items-center gap-3 border-b border-border/50 px-3 py-2 last:border-b-0">
-      <span className="w-[140px] shrink-0 font-mono text-xs font-medium text-muted-foreground">
+    <div className="flex items-start gap-3 border-b border-border/50 px-3 py-2 last:border-b-0">
+      <span className="w-[140px] shrink-0 pt-0.5 font-mono text-xs font-medium text-muted-foreground">
         {field}
       </span>
-      <div className="flex items-center gap-2">
-        <span className="rounded bg-red-50 px-2 py-0.5 font-mono text-xs text-red-700 line-through dark:bg-red-950 dark:text-red-400">
+      <div className="flex min-w-0 flex-1 flex-wrap items-start gap-2">
+        <span className="max-w-full break-all rounded bg-red-50 px-2 py-0.5 font-mono text-xs text-red-700 line-through dark:bg-red-950 dark:text-red-400">
           {formatValue(oldValue)}
         </span>
-        <span className="text-xs text-muted-foreground">→</span>
-        <span className="rounded bg-emerald-50 px-2 py-0.5 font-mono text-xs text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">
+        <span className="pt-0.5 text-xs text-muted-foreground">→</span>
+        <span className="max-w-full break-all rounded bg-emerald-50 px-2 py-0.5 font-mono text-xs text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">
           {formatValue(newValue)}
         </span>
       </div>

--- a/client/dashboard/src/components/auditlogs/structured-diff.tsx
+++ b/client/dashboard/src/components/auditlogs/structured-diff.tsx
@@ -1,0 +1,114 @@
+import type { AuditLog } from "@gram/client/models/components";
+import { computeChangedFields } from "@/lib/compute-changed-fields";
+import { useMemo, useState, Suspense } from "react";
+import React from "react";
+import { Icon } from "@speakeasy-api/moonshine";
+import { HighlightProvider } from "@/components/diffs/provider";
+
+const StaticDiff = React.lazy(() =>
+  import("@/components/auditlogs/diff").then((mod) => ({
+    default: mod.StaticDiff,
+  })),
+);
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return "(none)";
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return String(value);
+  if (typeof value === "number") return String(value);
+  return JSON.stringify(value);
+}
+
+function ChangedFieldRow({
+  field,
+  oldValue,
+  newValue,
+}: {
+  field: string;
+  oldValue: unknown;
+  newValue: unknown;
+}) {
+  return (
+    <div className="flex items-center gap-3 border-b border-border/50 px-3 py-2 last:border-b-0">
+      <span className="w-[140px] shrink-0 font-mono text-xs font-medium text-muted-foreground">
+        {field}
+      </span>
+      <div className="flex items-center gap-2">
+        <span className="rounded bg-red-50 px-2 py-0.5 font-mono text-xs text-red-700 line-through dark:bg-red-950 dark:text-red-400">
+          {formatValue(oldValue)}
+        </span>
+        <span className="text-xs text-muted-foreground">→</span>
+        <span className="rounded bg-emerald-50 px-2 py-0.5 font-mono text-xs text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">
+          {formatValue(newValue)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function StructuredDiff({ log }: { log: AuditLog }) {
+  const [showRawDiff, setShowRawDiff] = useState(false);
+
+  const changes = useMemo(
+    () => computeChangedFields(log.beforeSnapshot, log.afterSnapshot),
+    [log.beforeSnapshot, log.afterSnapshot],
+  );
+
+  if (showRawDiff) {
+    return (
+      <div className="mt-2">
+        <button
+          type="button"
+          onClick={() => setShowRawDiff(false)}
+          className="mb-2 text-xs text-blue-500 hover:underline"
+        >
+          View structured diff
+        </button>
+        <HighlightProvider>
+          <Suspense
+            fallback={
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Icon name="loader-circle" className="size-4 animate-spin" />
+                <span>Loading diff...</span>
+              </div>
+            }
+          >
+            <StaticDiff log={log} />
+          </Suspense>
+        </HighlightProvider>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2">
+      <div className="flex items-center gap-2 py-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Changed fields
+        </span>
+        <div className="h-px flex-1 bg-border" />
+        <span className="text-[11px] text-muted-foreground">
+          {changes.length} field{changes.length === 1 ? "" : "s"} changed
+        </span>
+      </div>
+      <div className="rounded-md border bg-background">
+        {changes.map((change) => (
+          <ChangedFieldRow
+            key={change.field}
+            field={change.field}
+            oldValue={change.oldValue}
+            newValue={change.newValue}
+          />
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => setShowRawDiff(true)}
+        className="mt-2 text-xs text-blue-500 hover:underline"
+      >
+        View raw diff
+      </button>
+    </div>
+  );
+}

--- a/client/dashboard/src/lib/audit-log-colors.test.ts
+++ b/client/dashboard/src/lib/audit-log-colors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { getActionCategory, getActionColorConfig } from "./audit-log-colors";
+
+describe("getActionCategory", () => {
+  it("categorizes create actions", () => {
+    expect(getActionCategory("mcp:create")).toBe("create");
+    expect(getActionCategory("asset:create")).toBe("create");
+    expect(getActionCategory("project:create")).toBe("create");
+  });
+
+  it("categorizes upload as create", () => {
+    expect(getActionCategory("asset:upload")).toBe("create");
+  });
+
+  it("categorizes update actions", () => {
+    expect(getActionCategory("mcp:update")).toBe("update");
+    expect(getActionCategory("project:update")).toBe("update");
+    expect(getActionCategory("toolset:attach_external_oauth")).toBe("update");
+    expect(getActionCategory("toolset:attach_oauth_proxy")).toBe("update");
+    expect(getActionCategory("mcp_metadata:update")).toBe("update");
+  });
+
+  it("categorizes deploy actions", () => {
+    expect(getActionCategory("deployments:redeploy")).toBe("deploy");
+    expect(getActionCategory("deployments:evolve")).toBe("deploy");
+    expect(getActionCategory("deployments:create")).toBe("deploy");
+  });
+
+  it("categorizes destructive actions", () => {
+    expect(getActionCategory("project:delete")).toBe("destructive");
+    expect(getActionCategory("toolset:delete")).toBe("destructive");
+    expect(getActionCategory("toolset:detach_oauth_proxy")).toBe("destructive");
+    expect(getActionCategory("toolset:detach_external_oauth")).toBe(
+      "destructive",
+    );
+    expect(getActionCategory("api_key:revoke")).toBe("destructive");
+  });
+
+  it("defaults unknown actions to update", () => {
+    expect(getActionCategory("unknown:something")).toBe("update");
+  });
+});
+
+describe("getActionColorConfig", () => {
+  it("returns correct colors for each category", () => {
+    const create = getActionColorConfig("create");
+    expect(create.dot).toBe("bg-emerald-500");
+    expect(create.text).toBe("text-emerald-700");
+    expect(create.bg).toBe("bg-emerald-50");
+
+    const destructive = getActionColorConfig("destructive");
+    expect(destructive.dot).toBe("bg-red-500");
+    expect(destructive.text).toBe("text-red-700");
+    expect(destructive.bg).toBe("bg-red-50");
+  });
+});

--- a/client/dashboard/src/lib/audit-log-colors.ts
+++ b/client/dashboard/src/lib/audit-log-colors.ts
@@ -1,0 +1,55 @@
+export type ActionCategory = "create" | "update" | "deploy" | "destructive";
+
+export function getActionCategory(action: string): ActionCategory {
+  const [resource, verb] = action.split(":");
+
+  if (
+    verb?.includes("delete") ||
+    verb?.includes("detach") ||
+    verb?.includes("revoke") ||
+    verb?.includes("remove")
+  ) {
+    return "destructive";
+  }
+
+  if (resource === "deployments") {
+    return "deploy";
+  }
+
+  if (verb?.includes("create") || verb?.includes("upload")) {
+    return "create";
+  }
+
+  return "update";
+}
+
+const colorConfigs = {
+  create: {
+    dot: "bg-emerald-500",
+    text: "text-emerald-700",
+    bg: "bg-emerald-50",
+  },
+  update: {
+    dot: "bg-yellow-500",
+    text: "text-yellow-700",
+    bg: "bg-yellow-50",
+  },
+  deploy: {
+    dot: "bg-blue-500",
+    text: "text-blue-700",
+    bg: "bg-blue-50",
+  },
+  destructive: {
+    dot: "bg-red-500",
+    text: "text-red-700",
+    bg: "bg-red-50",
+  },
+} as const;
+
+export type ActionColorConfig = (typeof colorConfigs)[ActionCategory];
+
+export function getActionColorConfig(
+  category: ActionCategory,
+): ActionColorConfig {
+  return colorConfigs[category];
+}

--- a/client/dashboard/src/lib/compute-changed-fields.test.ts
+++ b/client/dashboard/src/lib/compute-changed-fields.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { computeChangedFields } from "./compute-changed-fields";
+
+describe("computeChangedFields", () => {
+  it("returns empty array when snapshots are identical", () => {
+    const snapshot = { McpEnabled: true, Name: "test" };
+    expect(computeChangedFields(snapshot, snapshot)).toEqual([]);
+  });
+
+  it("detects a single changed field", () => {
+    const before = { McpEnabled: false, Name: "test" };
+    const after = { McpEnabled: true, Name: "test" };
+    expect(computeChangedFields(before, after)).toEqual([
+      { field: "McpEnabled", oldValue: false, newValue: true },
+    ]);
+  });
+
+  it("detects multiple changed fields", () => {
+    const before = { McpEnabled: false, Description: "old", Name: "test" };
+    const after = { McpEnabled: true, Description: "new", Name: "test" };
+    const result = computeChangedFields(before, after);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      field: "McpEnabled",
+      oldValue: false,
+      newValue: true,
+    });
+    expect(result).toContainEqual({
+      field: "Description",
+      oldValue: "old",
+      newValue: "new",
+    });
+  });
+
+  it("detects added fields", () => {
+    const before = { Name: "test" };
+    const after = { Name: "test", McpEnabled: true };
+    expect(computeChangedFields(before, after)).toEqual([
+      { field: "McpEnabled", oldValue: undefined, newValue: true },
+    ]);
+  });
+
+  it("detects removed fields", () => {
+    const before = { Name: "test", McpEnabled: true };
+    const after = { Name: "test" };
+    expect(computeChangedFields(before, after)).toEqual([
+      { field: "McpEnabled", oldValue: true, newValue: undefined },
+    ]);
+  });
+
+  it("handles null/undefined snapshots", () => {
+    expect(computeChangedFields(null, null)).toEqual([]);
+    expect(computeChangedFields(undefined, undefined)).toEqual([]);
+    expect(computeChangedFields(null, { Name: "test" })).toEqual([
+      { field: "Name", oldValue: undefined, newValue: "test" },
+    ]);
+  });
+
+  it("stringifies complex values for display", () => {
+    const before = { Items: [1, 2] };
+    const after = { Items: [1, 2, 3] };
+    const result = computeChangedFields(before, after);
+    expect(result).toHaveLength(1);
+    expect(result[0].field).toBe("Items");
+  });
+
+  it("sorts results alphabetically by field name", () => {
+    const before = { Zebra: 1, Apple: 1 };
+    const after = { Zebra: 2, Apple: 2 };
+    const result = computeChangedFields(before, after);
+    expect(result[0].field).toBe("Apple");
+    expect(result[1].field).toBe("Zebra");
+  });
+});

--- a/client/dashboard/src/lib/compute-changed-fields.ts
+++ b/client/dashboard/src/lib/compute-changed-fields.ts
@@ -1,0 +1,44 @@
+export type ChangedField = {
+  field: string;
+  oldValue: unknown;
+  newValue: unknown;
+};
+
+export function computeChangedFields(
+  before: unknown,
+  after: unknown,
+): ChangedField[] {
+  const beforeObj =
+    before != null && typeof before === "object"
+      ? (before as Record<string, unknown>)
+      : {};
+  const afterObj =
+    after != null && typeof after === "object"
+      ? (after as Record<string, unknown>)
+      : {};
+
+  const allKeys = new Set([
+    ...Object.keys(beforeObj),
+    ...Object.keys(afterObj),
+  ]);
+
+  const changes: ChangedField[] = [];
+
+  for (const key of allKeys) {
+    const oldVal = beforeObj[key];
+    const newVal = afterObj[key];
+
+    const oldStr = JSON.stringify(oldVal);
+    const newStr = JSON.stringify(newVal);
+
+    if (oldStr !== newStr) {
+      changes.push({
+        field: key,
+        oldValue: oldVal,
+        newValue: newVal,
+      });
+    }
+  }
+
+  return changes.sort((a, b) => a.field.localeCompare(b.field));
+}

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -21,6 +21,7 @@ import {
 import { Icon, Input } from "@speakeasy-api/moonshine";
 import React, {
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -554,9 +555,11 @@ export default function OrgAuditLogs() {
     return `${actor} ${action} ${verb} ${subject}`;
   }, []);
 
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+
   const searchMatchIndices = useMemo(() => {
-    if (!searchQuery) return [];
-    const query = searchQuery.toLowerCase();
+    if (!deferredSearchQuery) return [];
+    const query = deferredSearchQuery.toLowerCase();
     const indices: number[] = [];
     logs.forEach((log, index) => {
       if (getSearchableText(log).toLowerCase().includes(query)) {
@@ -564,7 +567,7 @@ export default function OrgAuditLogs() {
       }
     });
     return indices;
-  }, [searchQuery, logs, getSearchableText]);
+  }, [deferredSearchQuery, logs, getSearchableText]);
 
   const scrollToLog = useCallback((index: number) => {
     const element = logRefs.current.get(index);

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -848,6 +848,53 @@ export default function OrgAuditLogs() {
             {/* Search toolbar */}
             {!isLoading && !error && logs.length > 0 && (
               <div className="flex items-center gap-2 border-b bg-surface/50 p-2">
+                <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+                  {searchQuery ? (
+                    <>
+                      <span className="flex items-center gap-1">
+                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                          N
+                        </kbd>
+                        <span>/</span>
+                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                          ⇧N
+                        </kbd>
+                        <span className="ml-0.5">results</span>
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                          ESC
+                        </kbd>
+                        <span>clear</span>
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <span className="flex items-center gap-1">
+                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                          J
+                        </kbd>
+                        <span>/</span>
+                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                          K
+                        </kbd>
+                        <span className="ml-0.5">navigate</span>
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                          G
+                        </kbd>
+                        <span>first</span>
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                          ⇧G
+                        </kbd>
+                        <span>last</span>
+                      </span>
+                    </>
+                  )}
+                </div>
                 <div className="ml-auto relative">
                   <Icon
                     name="search"
@@ -901,7 +948,7 @@ export default function OrgAuditLogs() {
                     )
                   ) : (
                     <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
-                      <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                      <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm font-mono">
                         /
                       </span>
                     </div>
@@ -1011,49 +1058,6 @@ export default function OrgAuditLogs() {
               </div>
             )}
           </div>
-
-          {/* Footer shortcuts bar */}
-          {logs.length > 0 && (
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <div className="flex items-center gap-4">
-                {searchQuery ? (
-                  <>
-                    <div className="flex items-center gap-1">
-                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">N</kbd>
-                      <span>/</span>
-                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">
-                        {"\u21E7"}N
-                      </kbd>
-                      <span className="ml-1">navigate results</span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">
-                        ESC
-                      </kbd>
-                      <span>clear search</span>
-                    </div>
-                  </>
-                ) : (
-                  <>
-                    <div className="flex items-center gap-1">
-                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">
-                        {"\u2318"}F
-                      </kbd>
-                      <span>or</span>
-                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">/</kbd>
-                      <span>to search</span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">J</kbd>
-                      <span>/</span>
-                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">K</kbd>
-                      <span className="ml-1">navigate logs</span>
-                    </div>
-                  </>
-                )}
-              </div>
-            </div>
-          )}
         </div>
       </Page.Body>
     </Page>

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -323,7 +323,7 @@ function AuditLogRow({
 
   if (showDiff && diffExpanded) {
     return (
-      <div key={log.id}>
+      <div>
         <div
           className={cn(
             "rounded-t-lg border border-b-0",
@@ -341,7 +341,6 @@ function AuditLogRow({
 
   return (
     <div
-      key={log.id}
       className={cn("rounded-none", isOdd ? "bg-muted/30" : "bg-background")}
     >
       {rowContent}

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -18,8 +18,15 @@ import {
   useAuditLogsInfinite,
   useAuditLogFacets,
 } from "@gram/client/react-query";
-import { Icon } from "@speakeasy-api/moonshine";
-import React, { useMemo, useState, type ReactNode } from "react";
+import { Icon, Input } from "@speakeasy-api/moonshine";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { Link } from "react-router";
 import {
   getActionCategory,
@@ -284,14 +291,23 @@ function AuditLogRow({
   orgSlug,
   timestampMode,
   isOdd,
+  isHighlighted,
+  rowRef,
+  highlightMatch,
 }: {
   log: AuditLog;
   orgSlug: string;
   timestampMode: "utc" | "local";
   isOdd: boolean;
+  isHighlighted?: boolean;
+  rowRef?: (el: HTMLDivElement | null) => void;
+  highlightMatch?: (text: string) => React.ReactNode;
 }) {
   const [diffExpanded, setDiffExpanded] = useState(false);
   const showDiff = hasDiff(log);
+
+  const actorLabel = getActorLabel(log);
+  const verbText = renderVerb(log);
 
   const rowContent = (
     <div className="flex items-start gap-3.5 px-4 py-2.5">
@@ -299,9 +315,11 @@ function AuditLogRow({
       <ActionBadge action={log.action} />
       <div className="min-w-0 flex-1 text-sm leading-5">
         <span>
-          <StrongName>{getActorLabel(log)}</StrongName>
+          <StrongName>
+            {highlightMatch ? highlightMatch(actorLabel) : actorLabel}
+          </StrongName>
           <span className="mx-1.5 text-muted-foreground">
-            {renderVerb(log)}
+            {highlightMatch ? highlightMatch(verbText) : verbText}
           </span>
           {renderSubject(log, orgSlug)}
         </span>
@@ -323,7 +341,10 @@ function AuditLogRow({
 
   if (showDiff && diffExpanded) {
     return (
-      <div>
+      <div
+        ref={rowRef}
+        className={cn(isHighlighted && "border-l-4 border-l-foreground")}
+      >
         <div
           className={cn(
             "rounded-t-lg border border-b-0",
@@ -341,7 +362,12 @@ function AuditLogRow({
 
   return (
     <div
-      className={cn("rounded-none", isOdd ? "bg-muted/30" : "bg-background")}
+      ref={rowRef}
+      className={cn(
+        "rounded-none transition-colors",
+        isOdd ? "bg-muted/30" : "bg-background",
+        isHighlighted && "border-l-4 border-l-foreground",
+      )}
     >
       {rowContent}
     </div>
@@ -511,6 +537,215 @@ export default function OrgAuditLogs() {
     selectedAction !== "all" ||
     selectedActor !== "all";
 
+  // --- Search & keyboard navigation state ---
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentLogIndex, setCurrentLogIndex] = useState<number | null>(null);
+  const [currentSearchIndex, setCurrentSearchIndex] = useState(0);
+  const [searchInputFocused, setSearchInputFocused] = useState(false);
+
+  const logsContainerRef = useRef<HTMLDivElement>(null);
+  const logRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+  const getSearchableText = useCallback((log: AuditLog): string => {
+    const actor = getActorLabel(log);
+    const action = formatAuditAction(log.action);
+    const verb = renderVerb(log);
+    const subject = getSubjectLabel(log);
+    return `${actor} ${action} ${verb} ${subject}`;
+  }, []);
+
+  const searchMatchIndices = useMemo(() => {
+    if (!searchQuery) return [];
+    const query = searchQuery.toLowerCase();
+    const indices: number[] = [];
+    logs.forEach((log, index) => {
+      if (getSearchableText(log).toLowerCase().includes(query)) {
+        indices.push(index);
+      }
+    });
+    return indices;
+  }, [searchQuery, logs, getSearchableText]);
+
+  const scrollToLog = useCallback((index: number) => {
+    const element = logRefs.current.get(index);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    setCurrentLogIndex(index);
+  }, []);
+
+  const navigateToResult = useCallback(
+    (direction: "next" | "prev") => {
+      if (searchMatchIndices.length === 0) return;
+
+      let newIndex: number;
+      if (direction === "next") {
+        newIndex = (currentSearchIndex + 1) % searchMatchIndices.length;
+      } else {
+        newIndex =
+          currentSearchIndex === 0
+            ? searchMatchIndices.length - 1
+            : currentSearchIndex - 1;
+      }
+
+      setCurrentSearchIndex(newIndex);
+      const targetIndex = searchMatchIndices[newIndex];
+      if (targetIndex !== undefined) {
+        scrollToLog(targetIndex);
+      }
+    },
+    [currentSearchIndex, searchMatchIndices, scrollToLog],
+  );
+
+  const handleSearchChange = useCallback(
+    (query: string) => {
+      setSearchQuery(query);
+      setCurrentSearchIndex(0);
+
+      if (query) {
+        const q = query.toLowerCase();
+        const firstMatch = logs.findIndex((log) =>
+          getSearchableText(log).toLowerCase().includes(q),
+        );
+        if (firstMatch !== -1) {
+          scrollToLog(firstMatch);
+        }
+      } else {
+        setCurrentLogIndex(null);
+      }
+    },
+    [logs, getSearchableText, scrollToLog],
+  );
+
+  const highlightMatch = useCallback(
+    (text: string): React.ReactNode => {
+      if (!searchQuery) return text;
+
+      const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const parts = text.split(new RegExp(`(${escaped})`, "gi"));
+      return (
+        <>
+          {parts.map((part, i) =>
+            part.toLowerCase() === searchQuery.toLowerCase() ? (
+              <mark
+                key={i}
+                className="bg-yellow-200 dark:bg-yellow-800 text-inherit"
+              >
+                {part}
+              </mark>
+            ) : (
+              part
+            ),
+          )}
+        </>
+      );
+    },
+    [searchQuery],
+  );
+
+  // Keyboard handler
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const logsContainer = logsContainerRef.current;
+      const activeElement = document.activeElement;
+      const isWithinLogsSection = logsContainer?.contains(
+        activeElement as Node,
+      );
+      const isSearchInputFocusedNow = activeElement?.hasAttribute(
+        "data-audit-search-input",
+      );
+
+      if (e.key === "Escape") {
+        if (isWithinLogsSection || isSearchInputFocusedNow) {
+          e.preventDefault();
+          setSearchQuery("");
+          setCurrentLogIndex(null);
+          setCurrentSearchIndex(0);
+          const el = document.activeElement as HTMLElement;
+          if (el && el.tagName === "INPUT") {
+            el.blur();
+          }
+        }
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        if (isWithinLogsSection || isSearchInputFocusedNow) {
+          e.preventDefault();
+          const searchInput = document.querySelector<HTMLInputElement>(
+            "[data-audit-search-input]",
+          );
+          searchInput?.focus();
+        }
+        return;
+      }
+
+      const isInInput =
+        activeElement?.tagName === "INPUT" ||
+        activeElement?.tagName === "TEXTAREA" ||
+        activeElement?.tagName === "SELECT";
+      if (!isInInput) {
+        switch (e.key) {
+          case "/": {
+            e.preventDefault();
+            const searchInput = document.querySelector<HTMLInputElement>(
+              "[data-audit-search-input]",
+            );
+            searchInput?.focus();
+            break;
+          }
+          case "n":
+            if (searchMatchIndices.length > 0) {
+              e.preventDefault();
+              navigateToResult("next");
+            }
+            break;
+          case "N":
+            if (e.shiftKey && searchMatchIndices.length > 0) {
+              e.preventDefault();
+              navigateToResult("prev");
+            }
+            break;
+          case "j":
+            e.preventDefault();
+            if (currentLogIndex !== null && currentLogIndex < logs.length - 1) {
+              scrollToLog(currentLogIndex + 1);
+            } else if (currentLogIndex === null && logs.length > 0) {
+              scrollToLog(0);
+            }
+            break;
+          case "k":
+            e.preventDefault();
+            if (currentLogIndex !== null && currentLogIndex > 0) {
+              scrollToLog(currentLogIndex - 1);
+            }
+            break;
+          case "g":
+            if (!e.shiftKey && !e.ctrlKey && logs.length > 0) {
+              e.preventDefault();
+              scrollToLog(0);
+            }
+            break;
+          case "G":
+            if (e.shiftKey && logs.length > 0) {
+              e.preventDefault();
+              scrollToLog(logs.length - 1);
+            }
+            break;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    currentLogIndex,
+    logs.length,
+    navigateToResult,
+    scrollToLog,
+    searchMatchIndices.length,
+  ]);
+
   return (
     <Page>
       <Page.Header>
@@ -610,54 +845,137 @@ export default function OrgAuditLogs() {
           </div>
 
           <div className="overflow-hidden rounded-lg border bg-background">
-            {isLoading ? (
-              <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
-                <Icon name="loader-circle" className="size-4 animate-spin" />
-                <span>Loading audit logs...</span>
-              </div>
-            ) : error ? (
-              <div className="flex flex-col items-center gap-2 py-12 text-center">
-                <Type className="font-medium">Error loading audit logs</Type>
-                <Type muted small>
-                  {error.message}
-                </Type>
-              </div>
-            ) : logs.length === 0 ? (
-              <div className="flex flex-col items-center gap-2 py-12 text-center">
-                <Type className="font-medium">No audit logs found</Type>
-                <Type muted small>
-                  {selectedProjectSlug === "all" &&
-                  selectedAction === "all" &&
-                  selectedActor === "all"
-                    ? "Activity will appear here as changes are made across your organization."
-                    : "No audit logs match the selected filters."}
-                </Type>
-              </div>
-            ) : (
-              <div>
-                {dateGroups.map((group) => {
-                  let rowIndex = 0;
-                  return (
-                    <React.Fragment key={group.key}>
-                      <DateGroupHeader date={group.date} mode={tsMode} />
-                      {group.logs.map((log) => {
-                        const isOdd = rowIndex % 2 === 1;
-                        rowIndex++;
-                        return (
-                          <AuditLogRow
-                            key={log.id}
-                            log={log}
-                            orgSlug={orgSlug}
-                            timestampMode={tsMode}
-                            isOdd={isOdd}
-                          />
-                        );
-                      })}
-                    </React.Fragment>
-                  );
-                })}
+            {/* Search toolbar */}
+            {!isLoading && !error && logs.length > 0 && (
+              <div className="flex items-center gap-2 border-b bg-surface/50 p-2">
+                <div className="ml-auto relative">
+                  <Icon
+                    name="search"
+                    className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                  />
+                  <Input
+                    data-audit-search-input
+                    type="text"
+                    placeholder="Search audit logs"
+                    value={searchQuery}
+                    onChange={(e) => handleSearchChange(e.target.value)}
+                    onFocus={() => setSearchInputFocused(true)}
+                    onBlur={() => setSearchInputFocused(false)}
+                    className="pl-7 pr-16 w-56 text-xs py-1 rounded-sm"
+                  />
+                  {searchQuery || searchInputFocused ? (
+                    searchMatchIndices.length > 0 ? (
+                      <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+                        <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                          ESC
+                        </span>
+                        <span className="text-[10px] text-muted-foreground mx-0.5">
+                          {currentSearchIndex + 1}/{searchMatchIndices.length}
+                        </span>
+                        <div className="flex items-center">
+                          <button
+                            onClick={() => navigateToResult("prev")}
+                            className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                            title="Previous (Shift+N)"
+                          >
+                            <Icon name="chevron-up" className="size-2.5" />
+                          </button>
+                          <button
+                            onClick={() => navigateToResult("next")}
+                            className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                            title="Next (N)"
+                          >
+                            <Icon name="chevron-down" className="size-2.5" />
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+                        <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                          ESC
+                        </span>
+                        <span className="text-[10px] text-muted-foreground ml-0.5">
+                          0/0
+                        </span>
+                      </div>
+                    )
+                  ) : (
+                    <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
+                      <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                        /
+                      </span>
+                    </div>
+                  )}
+                </div>
               </div>
             )}
+
+            <div
+              ref={logsContainerRef}
+              tabIndex={0}
+              className="focus:outline-none"
+            >
+              {isLoading ? (
+                <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+                  <Icon name="loader-circle" className="size-4 animate-spin" />
+                  <span>Loading audit logs...</span>
+                </div>
+              ) : error ? (
+                <div className="flex flex-col items-center gap-2 py-12 text-center">
+                  <Type className="font-medium">Error loading audit logs</Type>
+                  <Type muted small>
+                    {error.message}
+                  </Type>
+                </div>
+              ) : logs.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-12 text-center">
+                  <Type className="font-medium">No audit logs found</Type>
+                  <Type muted small>
+                    {selectedProjectSlug === "all" &&
+                    selectedAction === "all" &&
+                    selectedActor === "all"
+                      ? "Activity will appear here as changes are made across your organization."
+                      : "No audit logs match the selected filters."}
+                  </Type>
+                </div>
+              ) : (
+                <div>
+                  {(() => {
+                    let flatIndex = 0;
+                    return dateGroups.map((group) => {
+                      let rowIndex = 0;
+                      return (
+                        <React.Fragment key={group.key}>
+                          <DateGroupHeader date={group.date} mode={tsMode} />
+                          {group.logs.map((log) => {
+                            const isOdd = rowIndex % 2 === 1;
+                            rowIndex++;
+                            const idx = flatIndex++;
+                            return (
+                              <AuditLogRow
+                                key={log.id}
+                                log={log}
+                                orgSlug={orgSlug}
+                                timestampMode={tsMode}
+                                isOdd={isOdd}
+                                isHighlighted={idx === currentLogIndex}
+                                rowRef={(el) => {
+                                  if (el) logRefs.current.set(idx, el);
+                                  else logRefs.current.delete(idx);
+                                }}
+                                highlightMatch={
+                                  searchQuery ? highlightMatch : undefined
+                                }
+                              />
+                            );
+                          })}
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              )}
+            </div>
 
             {(logs.length > 0 || isFetchingNextPage) && (
               <div className="flex items-center justify-between border-t bg-muted/20 px-4 py-3">
@@ -693,6 +1011,49 @@ export default function OrgAuditLogs() {
               </div>
             )}
           </div>
+
+          {/* Footer shortcuts bar */}
+          {logs.length > 0 && (
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <div className="flex items-center gap-4">
+                {searchQuery ? (
+                  <>
+                    <div className="flex items-center gap-1">
+                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">N</kbd>
+                      <span>/</span>
+                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">
+                        {"\u21E7"}N
+                      </kbd>
+                      <span className="ml-1">navigate results</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">
+                        ESC
+                      </kbd>
+                      <span>clear search</span>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="flex items-center gap-1">
+                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">
+                        {"\u2318"}F
+                      </kbd>
+                      <span>or</span>
+                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">/</kbd>
+                      <span>to search</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">J</kbd>
+                      <span>/</span>
+                      <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">K</kbd>
+                      <span className="ml-1">navigate logs</span>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       </Page.Body>
     </Page>

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -618,14 +618,10 @@ export default function OrgAuditLogs() {
     return indices;
   }, [deferredSearchQuery, logs, getSearchableText]);
 
-  useEffect(() => {
-    if (
-      searchMatchIndices.length > 0 &&
-      currentSearchIndex >= searchMatchIndices.length
-    ) {
-      setCurrentSearchIndex(0);
-    }
-  }, [searchMatchIndices.length, currentSearchIndex]);
+  const effectiveSearchIndex =
+    searchMatchIndices.length > 0
+      ? Math.min(currentSearchIndex, searchMatchIndices.length - 1)
+      : 0;
 
   const scrollToLog = useCallback((index: number) => {
     const element = logRefs.current.get(index);
@@ -641,12 +637,12 @@ export default function OrgAuditLogs() {
 
       let newIndex: number;
       if (direction === "next") {
-        newIndex = (currentSearchIndex + 1) % searchMatchIndices.length;
+        newIndex = (effectiveSearchIndex + 1) % searchMatchIndices.length;
       } else {
         newIndex =
-          currentSearchIndex === 0
+          effectiveSearchIndex === 0
             ? searchMatchIndices.length - 1
-            : currentSearchIndex - 1;
+            : effectiveSearchIndex - 1;
       }
 
       setCurrentSearchIndex(newIndex);
@@ -655,7 +651,7 @@ export default function OrgAuditLogs() {
         scrollToLog(targetIndex);
       }
     },
-    [currentSearchIndex, searchMatchIndices, scrollToLog],
+    [effectiveSearchIndex, searchMatchIndices, scrollToLog],
   );
 
   const handleSearchChange = useCallback(
@@ -983,7 +979,7 @@ export default function OrgAuditLogs() {
                           ESC
                         </span>
                         <span className="text-[10px] text-muted-foreground mx-0.5">
-                          {currentSearchIndex + 1}/{searchMatchIndices.length}
+                          {effectiveSearchIndex + 1}/{searchMatchIndices.length}
                         </span>
                         <div className="flex items-center">
                           <button

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -311,7 +311,7 @@ function AuditLogRow({
             onClick={() => setDiffExpanded((v) => !v)}
             className="ml-2 text-xs text-blue-500 hover:underline"
           >
-            {diffExpanded ? "Hide diff" : "Show diff"}
+            {diffExpanded ? "Hide diff ▴" : "Show diff ▾"}
           </button>
         )}
       </div>

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -1,6 +1,5 @@
 import { useQueryState } from "nuqs";
 import { Page } from "@/components/page-layout";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -9,14 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { Switch } from "@/components/ui/switch";
@@ -28,15 +19,14 @@ import {
   useAuditLogFacets,
 } from "@gram/client/react-query";
 import { Icon } from "@speakeasy-api/moonshine";
-import React, { Suspense, useMemo, useState, type ReactNode } from "react";
+import React, { useMemo, useState, type ReactNode } from "react";
 import { Link } from "react-router";
-import { HighlightProvider } from "@/components/diffs/provider";
-
-const StaticDiff = React.lazy(() =>
-  import("@/components/auditlogs/diff").then((mod) => ({
-    default: mod.StaticDiff,
-  })),
-);
+import {
+  getActionCategory,
+  getActionColorConfig,
+} from "@/lib/audit-log-colors";
+import { StructuredDiff } from "@/components/auditlogs/structured-diff";
+import { cn } from "@/lib/utils";
 
 type FacetOption = {
   count?: number;
@@ -44,32 +34,36 @@ type FacetOption = {
   value: string;
 };
 
-function getTimestampFormatter(mode: "utc" | "local") {
+function formatTimeOnly(date: Date, mode: "utc" | "local") {
+  return new Intl.DateTimeFormat(undefined, {
+    ...(mode === "utc" ? { timeZone: "UTC" } : {}),
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(date);
+}
+
+function formatDateHeader(date: Date, mode: "utc" | "local") {
   return new Intl.DateTimeFormat(undefined, {
     ...(mode === "utc" ? { timeZone: "UTC" } : {}),
     year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    timeZoneName: "short",
-    hour12: false,
-  });
+    month: "long",
+    day: "numeric",
+  }).format(date);
+}
+
+function getDateKey(date: Date, mode: "utc" | "local") {
+  if (mode === "utc") {
+    return date.toISOString().slice(0, 10);
+  }
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 function StrongName({ children }: { children: ReactNode }) {
   return <strong className="font-semibold text-foreground">{children}</strong>;
-}
-
-function formatTimestamp(date: Date, mode: "utc" | "local") {
-  const formatter = getTimestampFormatter(mode);
-  const parts = formatter.formatToParts(date);
-  const values = Object.fromEntries(
-    parts.map((part) => [part.type, part.value]),
-  );
-
-  return `${values.day}/${values.month}/${values.year} ${values.hour}:${values.minute}:${values.second} ${values.timeZoneName}`;
 }
 
 function getActorLabel(log: AuditLog) {
@@ -84,68 +78,7 @@ function truncateMiddle(value: string, start = 18, end = 16) {
   if (value.length <= start + end + 1) {
     return value;
   }
-
   return `${value.slice(0, start)}...${value.slice(-end)}`;
-}
-
-function renderSubject(log: AuditLog, orgSlug: string) {
-  if (log.subjectType === "deployment" && log.projectSlug) {
-    return (
-      <Link
-        to={`/${orgSlug}/projects/${log.projectSlug}/deployments/${log.subjectId}`}
-        className="text-primary hover:underline"
-      >
-        <StrongName>{log.subjectId}</StrongName>
-      </Link>
-    );
-  }
-
-  if (log.subjectType === "toolset" && log.projectSlug && log.subjectSlug) {
-    return (
-      <Link
-        to={`/${orgSlug}/projects/${log.projectSlug}/mcp/${log.subjectSlug}`}
-        className="text-primary hover:underline"
-      >
-        <StrongName>{log.subjectSlug}</StrongName>
-      </Link>
-    );
-  }
-
-  if (log.subjectType === "project" && log.subjectSlug) {
-    return (
-      <Link
-        to={`/${orgSlug}/projects/${log.subjectSlug}`}
-        className="text-primary hover:underline"
-      >
-        <StrongName>{log.subjectSlug}</StrongName>
-      </Link>
-    );
-  }
-
-  if (log.subjectType === "api_key") {
-    return (
-      <Link
-        to={`/${orgSlug}/api-keys`}
-        className="text-primary hover:underline"
-      >
-        <StrongName>{getSubjectLabel(log)}</StrongName>
-      </Link>
-    );
-  }
-
-  if (log.subjectType === "asset") {
-    const subjectLabel = getSubjectLabel(log);
-
-    return (
-      <SimpleTooltip tooltip={subjectLabel}>
-        <span className="inline-block max-w-[34ch] align-bottom">
-          <StrongName>{truncateMiddle(subjectLabel)}</StrongName>
-        </span>
-      </SimpleTooltip>
-    );
-  }
-
-  return <StrongName>{getSubjectLabel(log)}</StrongName>;
 }
 
 function getResourceLabel(resource: string) {
@@ -177,14 +110,284 @@ function getResourceLabel(resource: string) {
 
 function formatAuditAction(action: string) {
   const [resource, verb] = action.split(":");
-
   if (!resource || !verb) {
     return action;
   }
-
   const resourceLabel = resource === "toolset" ? "mcp" : resource;
-
   return `${resourceLabel}:${verb}`;
+}
+
+function renderSubject(log: AuditLog, orgSlug: string) {
+  const monoClass = "font-mono text-xs text-muted-foreground";
+
+  if (log.subjectType === "deployment" && log.projectSlug) {
+    return (
+      <Link
+        to={`/${orgSlug}/projects/${log.projectSlug}/deployments/${log.subjectId}`}
+        className={cn(monoClass, "hover:underline")}
+      >
+        {log.subjectId}
+      </Link>
+    );
+  }
+
+  if (log.subjectType === "toolset" && log.projectSlug && log.subjectSlug) {
+    return (
+      <Link
+        to={`/${orgSlug}/projects/${log.projectSlug}/mcp/${log.subjectSlug}`}
+        className={cn(monoClass, "hover:underline")}
+      >
+        {log.subjectSlug}
+      </Link>
+    );
+  }
+
+  if (log.subjectType === "project" && log.subjectSlug) {
+    return (
+      <Link
+        to={`/${orgSlug}/projects/${log.subjectSlug}`}
+        className={cn(monoClass, "hover:underline")}
+      >
+        {log.subjectSlug}
+      </Link>
+    );
+  }
+
+  if (log.subjectType === "api_key") {
+    return (
+      <Link
+        to={`/${orgSlug}/api-keys`}
+        className={cn(monoClass, "hover:underline")}
+      >
+        {getSubjectLabel(log)}
+      </Link>
+    );
+  }
+
+  if (log.subjectType === "asset") {
+    const subjectLabel = getSubjectLabel(log);
+    return (
+      <SimpleTooltip tooltip={subjectLabel}>
+        <span
+          className={cn(monoClass, "inline-block max-w-[34ch] align-bottom")}
+        >
+          {truncateMiddle(subjectLabel)}
+        </span>
+      </SimpleTooltip>
+    );
+  }
+
+  return <span className={monoClass}>{getSubjectLabel(log)}</span>;
+}
+
+function renderVerb(log: AuditLog): string {
+  switch (log.action) {
+    case "project:create":
+      return "created project";
+    case "project:update":
+      return "updated project";
+    case "project:delete":
+      return "deleted project";
+    case "environment:create":
+      return "created environment";
+    case "environment:update":
+      return "updated environment";
+    case "environment:delete":
+      return "deleted environment";
+    case "template:create":
+      return "created template";
+    case "template:update":
+      return "updated template";
+    case "template:delete":
+      return "deleted template";
+    case "toolset:create":
+      return "created MCP server";
+    case "toolset:update":
+      return "updated MCP server";
+    case "toolset:delete":
+      return "deleted MCP server";
+    case "toolset:attach_external_oauth":
+      return "attached an external OAuth server to MCP server";
+    case "toolset:detach_external_oauth":
+      return "detached an external OAuth server from MCP server";
+    case "toolset:attach_oauth_proxy":
+      return "attached an OAuth proxy to MCP server";
+    case "toolset:detach_oauth_proxy":
+      return "detached an OAuth proxy from MCP server";
+    case "api_key:create":
+      return "created API key";
+    case "api_key:revoke":
+      return "revoked API key";
+    case "variation:update_global":
+      return "updated a global variation for";
+    case "variation:delete_global":
+      return "deleted a global variation for";
+    case "deployments:create":
+      return "created deployment";
+    case "deployments:evolve":
+      return "created deployment";
+    case "deployments:redeploy":
+      return "redeployed deployment";
+    case "custom_domains:create":
+      return "added custom domain";
+    case "custom_domains:delete":
+      return "deleted custom domain";
+    case "mcp_metadata:update":
+      return "updated MCP metadata for";
+    case "asset:create":
+      return "uploaded asset";
+    default: {
+      const [resource = "activity", verb = "updated"] = log.action.split(":");
+      return `${verb.replace(/_/g, " ")} ${getResourceLabel(resource)}`;
+    }
+  }
+}
+
+function hasDiff(log: AuditLog): boolean {
+  if (log.action.startsWith("deployments:")) {
+    return false;
+  }
+  return log.beforeSnapshot != null || log.afterSnapshot != null;
+}
+
+function ActionBadge({ action }: { action: string }) {
+  const category = getActionCategory(action);
+  const colors = getActionColorConfig(category);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 font-mono text-[11px] font-medium",
+        colors.bg,
+        colors.text,
+      )}
+    >
+      {formatAuditAction(action)}
+    </span>
+  );
+}
+
+function ActionDot({ action }: { action: string }) {
+  const category = getActionCategory(action);
+  const colors = getActionColorConfig(category);
+  return (
+    <span
+      className={cn(
+        "mt-[3px] inline-block size-2 shrink-0 rounded-full",
+        colors.dot,
+      )}
+    />
+  );
+}
+
+function AuditLogRow({
+  log,
+  orgSlug,
+  timestampMode,
+  isOdd,
+}: {
+  log: AuditLog;
+  orgSlug: string;
+  timestampMode: "utc" | "local";
+  isOdd: boolean;
+}) {
+  const [diffExpanded, setDiffExpanded] = useState(false);
+  const showDiff = hasDiff(log);
+
+  const rowContent = (
+    <div className="flex items-start gap-3.5 px-4 py-2.5">
+      <ActionDot action={log.action} />
+      <ActionBadge action={log.action} />
+      <div className="min-w-0 flex-1 text-sm leading-5">
+        <span>
+          <StrongName>{getActorLabel(log)}</StrongName>
+          <span className="mx-1.5 text-muted-foreground">
+            {renderVerb(log)}
+          </span>
+          {renderSubject(log, orgSlug)}
+        </span>
+        {showDiff && (
+          <button
+            type="button"
+            onClick={() => setDiffExpanded((v) => !v)}
+            className="ml-2 text-xs text-blue-500 hover:underline"
+          >
+            {diffExpanded ? "Hide diff" : "Show diff"}
+          </button>
+        )}
+      </div>
+      <span className="shrink-0 font-mono text-xs text-muted-foreground">
+        {formatTimeOnly(log.createdAt, timestampMode)}
+      </span>
+    </div>
+  );
+
+  if (showDiff && diffExpanded) {
+    return (
+      <div key={log.id}>
+        <div
+          className={cn(
+            "rounded-t-lg border border-b-0",
+            isOdd ? "bg-muted/30" : "bg-background",
+          )}
+        >
+          {rowContent}
+        </div>
+        <div className="rounded-b-lg border border-t-0 bg-background px-4 pb-3 pt-2">
+          <StructuredDiff log={log} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      key={log.id}
+      className={cn("rounded-none", isOdd ? "bg-muted/30" : "bg-background")}
+    >
+      {rowContent}
+    </div>
+  );
+}
+
+function DateGroupHeader({
+  date,
+  mode,
+}: {
+  date: Date;
+  mode: "utc" | "local";
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-2">
+      <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {formatDateHeader(date, mode)}
+      </span>
+      <div className="h-px flex-1 bg-border" />
+    </div>
+  );
+}
+
+type DateGroup = {
+  key: string;
+  date: Date;
+  logs: AuditLog[];
+};
+
+function groupLogsByDate(logs: AuditLog[], mode: "utc" | "local"): DateGroup[] {
+  const groups: DateGroup[] = [];
+  const keyMap = new Map<string, DateGroup>();
+
+  for (const log of logs) {
+    const key = getDateKey(log.createdAt, mode);
+    let group = keyMap.get(key);
+    if (!group) {
+      group = { key, date: log.createdAt, logs: [] };
+      groups.push(group);
+      keyMap.set(key, group);
+    }
+    group.logs.push(log);
+  }
+
+  return groups;
 }
 
 function FacetSelect({
@@ -236,186 +439,6 @@ function FacetSelect({
   );
 }
 
-function renderAuditMessage(log: AuditLog, orgSlug: string) {
-  const actor = <StrongName>{getActorLabel(log)}</StrongName>;
-  const subject = renderSubject(log, orgSlug);
-
-  switch (log.action) {
-    case "project:create":
-      return (
-        <>
-          {actor} created project {subject}
-        </>
-      );
-    case "project:update":
-      return (
-        <>
-          {actor} updated project {subject}
-        </>
-      );
-    case "project:delete":
-      return (
-        <>
-          {actor} deleted project {subject}
-        </>
-      );
-    case "environment:create":
-      return (
-        <>
-          {actor} created environment {subject}
-        </>
-      );
-    case "environment:update":
-      return (
-        <>
-          {actor} updated environment {subject}
-        </>
-      );
-    case "environment:delete":
-      return (
-        <>
-          {actor} deleted environment {subject}
-        </>
-      );
-    case "template:create":
-      return (
-        <>
-          {actor} created template {subject}
-        </>
-      );
-    case "template:update":
-      return (
-        <>
-          {actor} updated template {subject}
-        </>
-      );
-    case "template:delete":
-      return (
-        <>
-          {actor} deleted template {subject}
-        </>
-      );
-    case "toolset:create":
-      return (
-        <>
-          {actor} created MCP server {subject}
-        </>
-      );
-    case "toolset:update":
-      return (
-        <>
-          {actor} updated MCP server {subject}
-        </>
-      );
-    case "toolset:delete":
-      return (
-        <>
-          {actor} deleted MCP server {subject}
-        </>
-      );
-    case "toolset:attach_external_oauth":
-      return (
-        <>
-          {actor} attached an external OAuth server to MCP server {subject}
-        </>
-      );
-    case "toolset:detach_external_oauth":
-      return (
-        <>
-          {actor} detached an external OAuth server from MCP server {subject}
-        </>
-      );
-    case "toolset:attach_oauth_proxy":
-      return (
-        <>
-          {actor} attached an OAuth proxy to MCP server {subject}
-        </>
-      );
-    case "toolset:detach_oauth_proxy":
-      return (
-        <>
-          {actor} detached an OAuth proxy from MCP server {subject}
-        </>
-      );
-    case "api_key:create":
-      return (
-        <>
-          {actor} created API key {subject}
-        </>
-      );
-    case "api_key:revoke":
-      return (
-        <>
-          {actor} revoked API key {subject}
-        </>
-      );
-    case "variation:update_global":
-      return (
-        <>
-          {actor} updated a global variation for {subject}
-        </>
-      );
-    case "variation:delete_global":
-      return (
-        <>
-          {actor} deleted a global variation for {subject}
-        </>
-      );
-    case "deployments:create":
-      return (
-        <>
-          {actor} created deployment {subject}
-        </>
-      );
-    case "deployments:evolve":
-      return (
-        <>
-          {actor} created deployment {subject}
-        </>
-      );
-    case "deployments:redeploy":
-      return (
-        <>
-          {actor} redeployed deployment {subject}
-        </>
-      );
-    case "custom_domains:create":
-      return (
-        <>
-          {actor} added custom domain {subject}
-        </>
-      );
-    case "custom_domains:delete":
-      return (
-        <>
-          {actor} deleted custom domain {subject}
-        </>
-      );
-    case "mcp_metadata:update":
-      return (
-        <>
-          {actor} updated MCP metadata for {subject}
-        </>
-      );
-    case "asset:create":
-      return (
-        <>
-          {actor} uploaded asset {subject}
-        </>
-      );
-    default: {
-      const [resource = "activity", verb = "updated"] = log.action.split(":");
-
-      return (
-        <>
-          {actor} {verb.replace(/_/g, " ")} {getResourceLabel(resource)}{" "}
-          {subject}
-        </>
-      );
-    }
-  }
-}
-
 export default function OrgAuditLogs() {
   const organization = useOrganization();
   const { orgSlug } = useSlugs();
@@ -432,6 +455,10 @@ export default function OrgAuditLogs() {
   const [timestampMode, setTimestampMode] = useQueryState("time", {
     defaultValue: "utc",
   });
+
+  const tsMode = (timestampMode === "local" ? "local" : "utc") as
+    | "utc"
+    | "local";
 
   const projects = useMemo(
     () =>
@@ -473,6 +500,11 @@ export default function OrgAuditLogs() {
   const logs = useMemo(
     () => data?.pages.flatMap((page) => page.result.logs) ?? [],
     [data],
+  );
+
+  const dateGroups = useMemo(
+    () => groupLogsByDate(logs, tsMode),
+    [logs, tsMode],
   );
 
   const hasActiveFilters =
@@ -550,7 +582,7 @@ export default function OrgAuditLogs() {
                 <Type
                   small
                   className={
-                    timestampMode === "utc"
+                    tsMode === "utc"
                       ? "text-foreground"
                       : "text-muted-foreground"
                   }
@@ -558,7 +590,7 @@ export default function OrgAuditLogs() {
                   UTC
                 </Type>
                 <Switch
-                  checked={timestampMode === "local"}
+                  checked={tsMode === "local"}
                   onCheckedChange={(checked) => {
                     void setTimestampMode(checked ? "local" : "utc");
                   }}
@@ -567,7 +599,7 @@ export default function OrgAuditLogs() {
                 <Type
                   small
                   className={
-                    timestampMode === "local"
+                    tsMode === "local"
                       ? "text-foreground"
                       : "text-muted-foreground"
                   }
@@ -579,103 +611,54 @@ export default function OrgAuditLogs() {
           </div>
 
           <div className="overflow-hidden rounded-lg border bg-background">
-            <HighlightProvider>
-              <Table>
-                <TableHeader className="bg-muted/30">
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead className="h-11 w-[240px] text-xs uppercase tracking-wide text-muted-foreground">
-                      Timestamp
-                    </TableHead>
-                    <TableHead className="h-11 w-[180px] text-xs uppercase tracking-wide text-muted-foreground">
-                      Project
-                    </TableHead>
-                    <TableHead className="h-11 text-xs uppercase tracking-wide text-muted-foreground">
-                      Event
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {isLoading ? (
-                    <TableRow className="hover:bg-transparent">
-                      <TableCell colSpan={3} className="py-12">
-                        <div className="flex items-center justify-center gap-2 text-muted-foreground">
-                          <Icon
-                            name="loader-circle"
-                            className="size-4 animate-spin"
+            {isLoading ? (
+              <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+                <Icon name="loader-circle" className="size-4 animate-spin" />
+                <span>Loading audit logs...</span>
+              </div>
+            ) : error ? (
+              <div className="flex flex-col items-center gap-2 py-12 text-center">
+                <Type className="font-medium">Error loading audit logs</Type>
+                <Type muted small>
+                  {error.message}
+                </Type>
+              </div>
+            ) : logs.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 py-12 text-center">
+                <Type className="font-medium">No audit logs found</Type>
+                <Type muted small>
+                  {selectedProjectSlug === "all" &&
+                  selectedAction === "all" &&
+                  selectedActor === "all"
+                    ? "Activity will appear here as changes are made across your organization."
+                    : "No audit logs match the selected filters."}
+                </Type>
+              </div>
+            ) : (
+              <div>
+                {dateGroups.map((group) => {
+                  let rowIndex = 0;
+                  return (
+                    <React.Fragment key={group.key}>
+                      <DateGroupHeader date={group.date} mode={tsMode} />
+                      {group.logs.map((log) => {
+                        const isOdd = rowIndex % 2 === 1;
+                        rowIndex++;
+                        return (
+                          <AuditLogRow
+                            key={log.id}
+                            log={log}
+                            orgSlug={orgSlug}
+                            timestampMode={tsMode}
+                            isOdd={isOdd}
                           />
-                          <span>Loading audit logs...</span>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ) : error ? (
-                    <TableRow className="hover:bg-transparent">
-                      <TableCell colSpan={3} className="py-12">
-                        <div className="flex flex-col items-center gap-2 text-center">
-                          <Type className="font-medium">
-                            Error loading audit logs
-                          </Type>
-                          <Type muted small>
-                            {error.message}
-                          </Type>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ) : logs.length === 0 ? (
-                    <TableRow className="hover:bg-transparent">
-                      <TableCell colSpan={3} className="py-12">
-                        <div className="flex flex-col items-center gap-2 text-center">
-                          <Type className="font-medium">
-                            No audit logs found
-                          </Type>
-                          <Type muted small>
-                            {selectedProjectSlug === "all" &&
-                            selectedAction === "all" &&
-                            selectedActor === "all"
-                              ? "Activity will appear here as changes are made across your organization."
-                              : "No audit logs match the selected filters."}
-                          </Type>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    logs.map((log) => {
-                      return (
-                        <TableRow key={log.id}>
-                          <TableCell className="font-mono text-xs text-muted-foreground">
-                            {formatTimestamp(
-                              log.createdAt,
-                              timestampMode === "local" ? "local" : "utc",
-                            )}
-                          </TableCell>
-                          <TableCell className="font-mono text-sm">
-                            {log.projectSlug ? (
-                              <Link
-                                to={`/${orgSlug}/projects/${log.projectSlug}`}
-                                className="text-primary hover:underline"
-                              >
-                                {log.projectSlug}
-                              </Link>
-                            ) : null}
-                          </TableCell>
-                          <TableCell className="whitespace-normal text-sm leading-6">
-                            <div className="flex flex-nowrap items-baseline gap-2">
-                              <Badge
-                                variant="outline"
-                                className="font-mono text-[11px]"
-                              >
-                                {formatAuditAction(log.action)}
-                              </Badge>
-                              <span>{renderAuditMessage(log, orgSlug)}</span>
-                            </div>
-                            {renderDiff(log)}
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })
-                  )}
-                </TableBody>
-              </Table>
-            </HighlightProvider>
+                        );
+                      })}
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+            )}
 
             {(logs.length > 0 || isFetchingNextPage) && (
               <div className="flex items-center justify-between border-t bg-muted/20 px-4 py-3">
@@ -714,51 +697,5 @@ export default function OrgAuditLogs() {
         </div>
       </Page.Body>
     </Page>
-  );
-}
-
-function renderDiff(log: AuditLog) {
-  if (log.action.startsWith("deployments:")) {
-    return null;
-  }
-
-  if (log.beforeSnapshot == null && log.afterSnapshot == null) {
-    return null;
-  }
-
-  return <AuditLogDiff log={log} />;
-}
-
-function AuditLogDiff({ log }: { log: AuditLog }) {
-  const [isVisible, setIsVisible] = useState(false);
-
-  return (
-    <div className="mt-2">
-      <Button
-        className="font-bold"
-        type="button"
-        variant="link"
-        size="sm"
-        onClick={() => setIsVisible((visible) => !visible)}
-        aria-expanded={isVisible}
-      >
-        {isVisible ? "Hide diff" : "Show diff"}
-      </Button>
-
-      {isVisible ? (
-        <div className="mt-2">
-          <Suspense
-            fallback={
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <Icon name="loader-circle" className="size-4 animate-spin" />
-                <span>Loading diff...</span>
-              </div>
-            }
-          >
-            <StaticDiff log={log} />
-          </Suspense>
-        </div>
-      ) : null}
-    </div>
   );
 }

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -188,6 +188,39 @@ function renderSubject(log: AuditLog, orgSlug: string) {
   return <span className={monoClass}>{getSubjectLabel(log)}</span>;
 }
 
+function describeToolsetUpdate(log: AuditLog): string {
+  const before = log.beforeSnapshot as Record<string, unknown> | undefined;
+  const after = log.afterSnapshot as Record<string, unknown> | undefined;
+  if (!before || !after) return "updated MCP server";
+
+  const changed = new Set<string>();
+  for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    if (JSON.stringify(before[key]) !== JSON.stringify(after[key])) {
+      changed.add(key);
+    }
+  }
+
+  if (changed.has("McpIsPublic") && changed.size <= 2) {
+    const isPublic = after["McpIsPublic"];
+    return `changed MCP server visibility to ${isPublic ? "public" : "private"}`;
+  }
+  if (changed.has("McpEnabled") && changed.size <= 2) {
+    const enabled = after["McpEnabled"];
+    return `${enabled ? "enabled" : "disabled"} MCP for server`;
+  }
+  if (changed.has("Name") && changed.size <= 2) {
+    return `renamed MCP server to ${after["Name"]}`;
+  }
+  if (changed.has("ToolSelectionMode") && changed.size <= 2) {
+    return `changed tool selection mode to ${after["ToolSelectionMode"]}`;
+  }
+  if (changed.has("Description") && changed.size <= 2) {
+    return "updated MCP server description";
+  }
+
+  return "updated MCP server";
+}
+
 function renderVerb(log: AuditLog): string {
   switch (log.action) {
     case "project:create":
@@ -211,7 +244,7 @@ function renderVerb(log: AuditLog): string {
     case "toolset:create":
       return "created MCP server";
     case "toolset:update":
-      return "updated MCP server";
+      return describeToolsetUpdate(log);
     case "toolset:delete":
       return "deleted MCP server";
     case "toolset:attach_external_oauth":
@@ -569,6 +602,15 @@ export default function OrgAuditLogs() {
     return indices;
   }, [deferredSearchQuery, logs, getSearchableText]);
 
+  useEffect(() => {
+    if (
+      searchMatchIndices.length > 0 &&
+      currentSearchIndex >= searchMatchIndices.length
+    ) {
+      setCurrentSearchIndex(0);
+    }
+  }, [searchMatchIndices.length, currentSearchIndex]);
+
   const scrollToLog = useCallback((index: number) => {
     const element = logRefs.current.get(index);
     if (element) {
@@ -620,12 +662,17 @@ export default function OrgAuditLogs() {
     [logs, getSearchableText, scrollToLog],
   );
 
+  const searchRegex = useMemo(() => {
+    if (!searchQuery) return null;
+    const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(${escaped})`, "gi");
+  }, [searchQuery]);
+
   const highlightMatch = useCallback(
     (text: string): React.ReactNode => {
-      if (!searchQuery) return text;
+      if (!searchRegex) return text;
 
-      const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const parts = text.split(new RegExp(`(${escaped})`, "gi"));
+      const parts = text.split(searchRegex);
       return (
         <>
           {parts.map((part, i) =>
@@ -643,7 +690,7 @@ export default function OrgAuditLogs() {
         </>
       );
     },
-    [searchQuery],
+    [searchQuery, searchRegex],
   );
 
   // Keyboard handler

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -566,6 +566,17 @@ export default function OrgAuditLogs() {
     [logs, tsMode],
   );
 
+  const logFlatIndices = useMemo(() => {
+    const map = new Map<string, number>();
+    let idx = 0;
+    for (const group of dateGroups) {
+      for (const log of group.logs) {
+        map.set(log.id, idx++);
+      }
+    }
+    return map;
+  }, [dateGroups]);
+
   const hasActiveFilters =
     selectedProjectSlug !== "all" ||
     selectedAction !== "all" ||
@@ -579,6 +590,11 @@ export default function OrgAuditLogs() {
 
   const logsContainerRef = useRef<HTMLDivElement>(null);
   const logRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+  // Reset navigation state when the log list changes (filters, pagination)
+  useEffect(() => {
+    setCurrentLogIndex(null);
+  }, [logs]);
 
   const getSearchableText = useCallback((log: AuditLog): string => {
     const actor = getActorLabel(log);
@@ -1037,39 +1053,31 @@ export default function OrgAuditLogs() {
                 </div>
               ) : (
                 <div>
-                  {(() => {
-                    let flatIndex = 0;
-                    return dateGroups.map((group) => {
-                      let rowIndex = 0;
-                      return (
-                        <React.Fragment key={group.key}>
-                          <DateGroupHeader date={group.date} mode={tsMode} />
-                          {group.logs.map((log) => {
-                            const isOdd = rowIndex % 2 === 1;
-                            rowIndex++;
-                            const idx = flatIndex++;
-                            return (
-                              <AuditLogRow
-                                key={log.id}
-                                log={log}
-                                orgSlug={orgSlug}
-                                timestampMode={tsMode}
-                                isOdd={isOdd}
-                                isHighlighted={idx === currentLogIndex}
-                                rowRef={(el) => {
-                                  if (el) logRefs.current.set(idx, el);
-                                  else logRefs.current.delete(idx);
-                                }}
-                                highlightMatch={
-                                  searchQuery ? highlightMatch : undefined
-                                }
-                              />
-                            );
-                          })}
-                        </React.Fragment>
-                      );
-                    });
-                  })()}
+                  {dateGroups.map((group) => (
+                    <React.Fragment key={group.key}>
+                      <DateGroupHeader date={group.date} mode={tsMode} />
+                      {group.logs.map((log, rowIndex) => {
+                        const idx = logFlatIndices.get(log.id) ?? 0;
+                        return (
+                          <AuditLogRow
+                            key={log.id}
+                            log={log}
+                            orgSlug={orgSlug}
+                            timestampMode={tsMode}
+                            isOdd={rowIndex % 2 === 1}
+                            isHighlighted={idx === currentLogIndex}
+                            rowRef={(el) => {
+                              if (el) logRefs.current.set(idx, el);
+                              else logRefs.current.delete(idx);
+                            }}
+                            highlightMatch={
+                              searchQuery ? highlightMatch : undefined
+                            }
+                          />
+                        );
+                      })}
+                    </React.Fragment>
+                  ))}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

Redesigns the audit logs page for scannability, with a new structured diff viewer and keyboard navigation inspired by the deployment logs table.

## Changes

https://github.com/user-attachments/assets/3d61e9bb-6393-403d-9648-99887d95f35d


**Layout & visual hierarchy**

- Replaces the flat `<Table>` with a date-grouped feed layout
- Adds color-coded action badges using existing brand tokens (create/emerald, update/yellow, deploy/blue, destructive/red)
- Structured event text: bold actor → muted verb → monospace target
- Alternating row backgrounds, time-only per row, date headers per group

**Structured diff viewer**

- Replaces the full-JSON side-by-side diff default with a structured `field: old → new` view
- Only shows fields that actually changed (computed client-side from `beforeSnapshot`/`afterSnapshot`)
- "View raw diff" fallback preserves the existing `@pierre/diffs` JSON viewer for complex cases
- Long values wrap gracefully within the card width

**Search & keyboard navigation** (ported from `LogsTabContent`)

- `⌘F` / `/` to search across actor, action, verb, and subject
- Yellow highlight on matches with `n` / `⇧N` result cycling
- `j` / `k` to move between entries, `g` / `⇧G` to jump first/last
- Focused entry gets a left border indicator with smooth scroll-into-view
- Inline keyboard hints in the search toolbar that swap context between idle and search-active states

## New files

- `client/dashboard/src/lib/audit-log-colors.ts` — action → color category mapping (+ tests)
- `client/dashboard/src/lib/compute-changed-fields.ts` — JSON snapshot diffing utility (+ tests)
- `client/dashboard/src/components/auditlogs/structured-diff.tsx` — structured diff component with raw fallback

## Test plan

- [ ] `pnpm tsc --noEmit` passes (verified locally)
- [ ] 15 unit tests pass (`audit-log-colors`, `compute-changed-fields`)
- [ ] Navigate to `/:orgSlug/audit-logs` and verify date grouping renders
- [ ] Verify color-coded badges for create/update/deploy/destructive actions
- [ ] Click "Show diff ▾" on an update row → verify structured field list
- [ ] Click "View raw diff" → verify the existing `@pierre/diffs` viewer loads
- [ ] Press `⌘F` or `/` → verify search input focuses
- [ ] Type a query → verify yellow highlighting and result counter
- [ ] Press `n` / `⇧N` → verify result cycling
- [ ] Press `j` / `k` / `g` / `⇧G` → verify entry navigation
- [ ] Press `ESC` → verify search clears
- [ ] Verify filters, UTC/Local toggle, and Load more pagination still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
