### PR TITLE
chore: enforce RBAC for toolsets domain

### DIFF
--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -221,22 +221,36 @@ func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPay
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
-		return nil, err
-	}
-
 	toolsets, err := s.repo.ListToolsetsByProject(ctx, *authCtx.ProjectID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to list toolsets").Log(ctx, s.logger)
 	}
 
-	result := make([]*types.ToolsetEntry, len(toolsets))
-	for i, toolset := range toolsets {
+	toolsetIDs := make([]string, len(toolsets))
+	for i, ts := range toolsets {
+		toolsetIDs[i] = ts.ID.String()
+	}
+
+	allowedIDs, err := s.access.Filter(ctx, access.ScopeMCPRead, toolsetIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	allowedSet := make(map[string]struct{}, len(allowedIDs))
+	for _, id := range allowedIDs {
+		allowedSet[id] = struct{}{}
+	}
+
+	result := make([]*types.ToolsetEntry, 0, len(allowedIDs))
+	for _, toolset := range toolsets {
+		if _, ok := allowedSet[toolset.ID.String()]; !ok {
+			continue
+		}
 		toolsetDetails, err := mv.DescribeToolsetEntry(ctx, s.logger, s.db, mv.ProjectID(toolset.ProjectID), mv.ToolsetSlug(toolset.Slug))
 		if err != nil {
 			return nil, err
 		}
-		result[i] = toolsetDetails
+		result = append(result, toolsetDetails)
 	}
 
 	return &gen.ListToolsetsResult{
@@ -279,10 +293,6 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
-		return nil, err
-	}
-
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogToolsetSlug(string(payload.Slug)))
 
 	dbtx, err := s.db.Begin(ctx)
@@ -301,6 +311,10 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: existingToolset.ID.String()}); err != nil {
+		return nil, err
 	}
 	existingView, err := mv.DescribeToolset(ctx, logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(existingToolset.Slug), new(s.toolsetCache.SkipCache()))
 	if err != nil {
@@ -514,10 +528,6 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 		return oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
-		return err
-	}
-
 	logger := s.logger
 
 	dbtx, err := s.db.Begin(ctx)
@@ -527,6 +537,21 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	tr := s.repo.WithTx(dbtx)
+
+	toDelete, err := tr.GetToolset(ctx, repo.GetToolsetParams{
+		Slug:      conv.ToLower(payload.Slug),
+		ProjectID: *authCtx.ProjectID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "failed to get toolset").Log(ctx, logger)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: toDelete.ID.String()}); err != nil {
+		return err
+	}
 
 	deleted, err := tr.DeleteToolset(ctx, repo.DeleteToolsetParams{
 		Slug:      conv.ToLower(payload.Slug),
@@ -565,11 +590,16 @@ func (s *Service) GetToolset(ctx context.Context, payload *gen.GetToolsetPayload
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+	toolset, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), &s.toolsetCache)
+	if err != nil {
 		return nil, err
 	}
 
-	return mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), &s.toolsetCache)
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPRead, ResourceID: toolset.ID}); err != nil {
+		return nil, err
+	}
+
+	return toolset, nil
 }
 
 func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPayload) (*types.Toolset, error) {
@@ -757,10 +787,6 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
-		return nil, err
-	}
-
 	if authCtx.AccountType == "free" {
 		return nil, oops.E(oops.CodeForbidden, nil, "free accounts cannot add external OAuth servers").Log(ctx, s.logger)
 	}
@@ -775,6 +801,10 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 
 	existingToolset, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
 	if err != nil {
+		return nil, err
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: existingToolset.ID}); err != nil {
 		return nil, err
 	}
 
@@ -853,10 +883,6 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
-		return nil, err
-	}
-
 	logger := s.logger
 
 	dbtx, err := s.db.Begin(ctx)
@@ -877,6 +903,10 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get toolset").Log(ctx, logger)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: existingToolset.ID.String()}); err != nil {
+		return nil, err
 	}
 
 	var externalServerID *string
@@ -984,10 +1014,6 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
-		return nil, err
-	}
-
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error accessing OAuth proxy servers").Log(ctx, s.logger)
@@ -996,6 +1022,10 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
 	if err != nil {
+		return nil, err
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: toolsetDetails.ID}); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -22,6 +22,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/toolsets/server"
 	gen "github.com/speakeasy-api/gram/server/gen/toolsets"
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
@@ -62,6 +63,7 @@ type Service struct {
 	repo            *repo.Queries
 	environmentRepo *environmentsRepo.Queries
 	auth            *auth.Auth
+	access          *access.Manager
 	toolsets        *Toolsets
 	domainsRepo     *domainsRepo.Queries
 	usageRepo       *usageRepo.Queries
@@ -72,7 +74,7 @@ type Service struct {
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, cacheAdapter cache.Cache, accessLoader auth.AccessLoader) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, cacheAdapter cache.Cache, accessManager *access.Manager) *Service {
 	logger = logger.With(attr.SlogComponent("toolsets"))
 
 	return &Service{
@@ -80,7 +82,8 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		logger:          logger,
 		db:              db,
 		repo:            repo.New(db),
-		auth:            auth.New(logger, db, sessions, accessLoader),
+		auth:            auth.New(logger, db, sessions, accessManager),
+		access:          accessManager,
 		environmentRepo: environmentsRepo.New(db),
 		toolsets:        NewToolsets(db),
 		domainsRepo:     domainsRepo.New(db),
@@ -109,6 +112,10 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil || authCtx.OrganizationSlug == "" {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logger := s.logger
@@ -214,6 +221,10 @@ func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPay
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	toolsets, err := s.repo.ListToolsetsByProject(ctx, *authCtx.ProjectID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to list toolsets").Log(ctx, s.logger)
@@ -239,6 +250,10 @@ func (s *Service) ListToolsetsForOrg(ctx context.Context, payload *gen.ListTools
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeOrgRead, ResourceID: authCtx.ActiveOrganizationID}); err != nil {
+		return nil, err
+	}
+
 	toolsets, err := s.repo.ListToolsetsByOrganization(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to list toolsets for organization").Log(ctx, s.logger)
@@ -262,6 +277,10 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogToolsetSlug(string(payload.Slug)))
@@ -495,6 +514,10 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 		return oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return err
+	}
+
 	logger := s.logger
 
 	dbtx, err := s.db.Begin(ctx)
@@ -542,6 +565,10 @@ func (s *Service) GetToolset(ctx context.Context, payload *gen.GetToolsetPayload
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	return mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), &s.toolsetCache)
 }
 
@@ -549,6 +576,10 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogToolsetSlug(string(payload.Slug)))
@@ -726,6 +757,10 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	if authCtx.AccountType == "free" {
 		return nil, oops.E(oops.CodeForbidden, nil, "free accounts cannot add external OAuth servers").Log(ctx, s.logger)
 	}
@@ -816,6 +851,10 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logger := s.logger
@@ -943,6 +982,10 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	dbtx, err := s.db.Begin(ctx)

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -608,10 +608,6 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
-		return nil, err
-	}
-
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogToolsetSlug(string(payload.Slug)))
 
 	dbtx, err := s.db.Begin(ctx)
@@ -629,6 +625,14 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
+	}
+
+	if err := s.access.Require(
+		ctx,
+		access.Check{Scope: access.ScopeMCPWrite, ResourceID: authCtx.ProjectID.String()},
+		access.Check{Scope: access.ScopeMCPRead, ResourceID: originalToolset.ID.String()},
+	); err != nil {
+		return nil, err
 	}
 
 	// Generate new slug with _copy suffix

--- a/server/internal/toolsets/rbac_test.go
+++ b/server/internal/toolsets/rbac_test.go
@@ -12,21 +12,80 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-func TestToolsets_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
+func TestToolsets_RBAC_List_ReturnsEmptyWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	_ = createMinimalPrivateToolset(t, ctx, ti, "rbac-list-empty-test")
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	result, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Toolsets)
+}
+
+func TestToolsets_RBAC_List_FiltersToGrantedToolsets(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-filter-test")
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
+
+	result, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Toolsets, 1)
+	require.Equal(t, toolset.ID, result.Toolsets[0].ID)
+}
+
+func TestToolsets_RBAC_List_ReturnsEmptyWithWrongResourceGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	_ = createMinimalPrivateToolset(t, ctx, ti, "rbac-excluded-test")
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: uuid.NewString()})
+
+	result, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Toolsets)
+}
+
+func TestToolsets_RBAC_Create_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
 	ctx = withExactAccessGrants(t, ctx, ti.conn)
 
-	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
-		SessionToken:     nil,
-		ApikeyToken:      nil,
-		ProjectSlugInput: nil,
+	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		ProjectSlugInput:       nil,
+		Name:                   "rbac-test-toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           []string{},
+		DefaultEnvironmentSlug: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
-func TestToolsets_RBAC_ReadOps_AllowedWithMCPReadGrant(t *testing.T) {
+func TestToolsets_RBAC_Create_DeniedWithReadOnlyGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
@@ -37,15 +96,22 @@ func TestToolsets_RBAC_ReadOps_AllowedWithMCPReadGrant(t *testing.T) {
 
 	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: authCtx.ProjectID.String()})
 
-	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
-		SessionToken:     nil,
-		ApikeyToken:      nil,
-		ProjectSlugInput: nil,
+	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		ProjectSlugInput:       nil,
+		Name:                   "rbac-test-toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           []string{},
+		DefaultEnvironmentSlug: nil,
 	})
-	require.NoError(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
-func TestToolsets_RBAC_ReadOps_AllowedWithMCPWriteGrant(t *testing.T) {
+func TestToolsets_RBAC_Create_AllowedWithProjectWriteGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
@@ -56,91 +122,101 @@ func TestToolsets_RBAC_ReadOps_AllowedWithMCPWriteGrant(t *testing.T) {
 
 	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
 
-	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
-		SessionToken:     nil,
-		ApikeyToken:      nil,
-		ProjectSlugInput: nil,
+	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		ProjectSlugInput:       nil,
+		Name:                   "rbac-test-toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           []string{},
+		DefaultEnvironmentSlug: nil,
 	})
 	require.NoError(t, err)
-}
-
-func TestToolsets_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestToolsetsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: uuid.NewString()})
-
-	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
-		SessionToken:     nil,
-		ApikeyToken:      nil,
-		ProjectSlugInput: nil,
-	})
-	requireOopsCode(t, err, oops.CodeForbidden)
 }
 
 func TestToolsets_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-write-denied-test")
+
 	ctx = withExactAccessGrants(t, ctx, ti.conn)
 
-	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+	_, err := ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
 		SessionToken:           nil,
 		ApikeyToken:            nil,
 		ProjectSlugInput:       nil,
-		Name:                   "rbac-test-toolset",
+		Slug:                   toolset.Slug,
+		Name:                   nil,
 		Description:            nil,
-		ToolUrns:               []string{},
-		ResourceUrns:           []string{},
 		DefaultEnvironmentSlug: nil,
+		ToolUrns:               nil,
+		ResourceUrns:           nil,
+		PromptTemplateNames:    nil,
+		McpSlug:                nil,
+		McpEnabled:             nil,
+		McpIsPublic:            nil,
+		CustomDomainID:         nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestToolsets_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-write-readonly-test")
 
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: authCtx.ProjectID.String()})
-
-	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+	_, err := ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
 		SessionToken:           nil,
 		ApikeyToken:            nil,
 		ProjectSlugInput:       nil,
-		Name:                   "rbac-test-toolset",
+		Slug:                   toolset.Slug,
+		Name:                   nil,
 		Description:            nil,
-		ToolUrns:               []string{},
-		ResourceUrns:           []string{},
 		DefaultEnvironmentSlug: nil,
+		ToolUrns:               nil,
+		ResourceUrns:           nil,
+		PromptTemplateNames:    nil,
+		McpSlug:                nil,
+		McpEnabled:             nil,
+		McpIsPublic:            nil,
+		CustomDomainID:         nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
-func TestToolsets_RBAC_WriteOps_AllowedWithMCPWriteGrant(t *testing.T) {
+func TestToolsets_RBAC_WriteOps_AllowedWithToolsetWriteGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-write-allowed-test")
 
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID})
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
-
-	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+	name := "updated-name"
+	_, err := ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
 		SessionToken:           nil,
 		ApikeyToken:            nil,
 		ProjectSlugInput:       nil,
-		Name:                   "rbac-test-toolset",
+		Slug:                   toolset.Slug,
+		Name:                   &name,
 		Description:            nil,
-		ToolUrns:               []string{},
-		ResourceUrns:           []string{},
 		DefaultEnvironmentSlug: nil,
+		ToolUrns:               nil,
+		ResourceUrns:           nil,
+		PromptTemplateNames:    nil,
+		McpSlug:                nil,
+		McpEnabled:             nil,
+		McpIsPublic:            nil,
+		CustomDomainID:         nil,
 	})
 	require.NoError(t, err)
 }

--- a/server/internal/toolsets/rbac_test.go
+++ b/server/internal/toolsets/rbac_test.go
@@ -1,0 +1,146 @@
+package toolsets_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/toolsets"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestToolsets_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestToolsets_RBAC_ReadOps_AllowedWithMCPReadGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestToolsets_RBAC_ReadOps_AllowedWithMCPWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestToolsets_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: uuid.NewString()})
+
+	_, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestToolsets_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		ProjectSlugInput:       nil,
+		Name:                   "rbac-test-toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           []string{},
+		DefaultEnvironmentSlug: nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestToolsets_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		ProjectSlugInput:       nil,
+		Name:                   "rbac-test-toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           []string{},
+		DefaultEnvironmentSlug: nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestToolsets_RBAC_WriteOps_AllowedWithMCPWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		ProjectSlugInput:       nil,
+		Name:                   "rbac-test-toolset",
+		Description:            nil,
+		ToolUrns:               []string{},
+		ResourceUrns:           []string{},
+		DefaultEnvironmentSlug: nil,
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/toolsets/rbac_test.go
+++ b/server/internal/toolsets/rbac_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/toolsets"
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -219,4 +220,50 @@ func TestToolsets_RBAC_WriteOps_AllowedWithToolsetWriteGrant(t *testing.T) {
 		CustomDomainID:         nil,
 	})
 	require.NoError(t, err)
+}
+
+func TestToolsets_RBAC_UpdateOAuthProxyServer_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-update-oauth-proxy-denied-test")
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	audience := "https://api.example.com"
+	_, err := ti.service.UpdateOAuthProxyServer(ctx, &gen.UpdateOAuthProxyServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Slug:             toolset.Slug,
+		OauthProxyServer: &types.OAuthProxyServerUpdateForm{
+			Audience: &audience,
+		},
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestToolsets_RBAC_UpdateOAuthProxyServer_DeniedWithReadOnlyGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-update-oauth-proxy-readonly-test")
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
+
+	audience := "https://api.example.com"
+	_, err := ti.service.UpdateOAuthProxyServer(ctx, &gen.UpdateOAuthProxyServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Slug:             toolset.Slug,
+		OauthProxyServer: &types.OAuthProxyServerUpdateForm{
+			Audience: &audience,
+		},
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }

--- a/server/internal/toolsets/rbac_test.go
+++ b/server/internal/toolsets/rbac_test.go
@@ -136,6 +136,29 @@ func TestToolsets_RBAC_Create_AllowedWithProjectWriteGrant(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestToolsets_RBAC_CloneToolset_DeniedWithProjectWriteButNoSourceRead(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-clone-source-read-test")
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.CloneToolset(ctx, &gen.CloneToolsetPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Slug:             toolset.Slug,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
 func TestToolsets_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
@@ -262,6 +285,32 @@ func TestToolsets_RBAC_UpdateOAuthProxyServer_DeniedWithReadOnlyGrant(t *testing
 		OauthProxyServer: &types.OAuthProxyServerUpdateForm{
 			Audience: &audience,
 		},
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestToolsets_RBAC_UpdateOAuthProxyServer_EmptyForm_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	ctx = withProAccount(t, ctx)
+	toolset := createPublicToolsetWithCustomOAuthProxy(
+		t, ctx, ti,
+		"RBAC Empty Form OAuth Proxy Toolset",
+		"rbac-empty-form-env",
+		"rbac-empty-form-proxy",
+	)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.UpdateOAuthProxyServer(ctx, &gen.UpdateOAuthProxyServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Slug:             toolset.Slug,
+		OauthProxyServer: &types.OAuthProxyServerUpdateForm{},
 	})
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -400,12 +399,4 @@ func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 	require.NoError(t, err)
 
 	return access.GrantsToContext(ctx, loadedGrants)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
@@ -31,11 +33,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -370,4 +374,38 @@ func createMinimalPublicToolset(t *testing.T, ctx context.Context, ti *testInsta
 	require.True(t, *updated.McpIsPublic)
 
 	return updated
+}
+
+func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "toolsets-rbac-grants-"+uuid.NewString())
+	for _, grant := range grants {
+		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			PrincipalUrn:   principal,
+			Scope:          string(grant.Scope),
+			Resource:       grant.Resource,
+		})
+		require.NoError(t, err)
+	}
+
+	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
+	require.NoError(t, err)
+
+	return access.GrantsToContext(ctx, loadedGrants)
+}
+
+func requireOopsCode(t *testing.T, err error, code oops.Code) {
+	t.Helper()
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/toolsets/updateoauthproxyserver.go
+++ b/server/internal/toolsets/updateoauthproxyserver.go
@@ -31,6 +31,15 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 
 	form := payload.OauthProxyServer
 
+	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: toolsetDetails.ID}); err != nil {
+		return nil, err
+	}
+
 	// No-op short-circuit: if the caller sent nothing, return the current state
 	// without opening a transaction or emitting an audit event.
 	if form == nil ||
@@ -40,7 +49,7 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 			form.ScopesSupported == nil &&
 			form.TokenEndpointAuthMethodsSupported == nil &&
 			form.EnvironmentSlug == nil) {
-		return mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+		return toolsetDetails, nil
 	}
 
 	// Validate token_endpoint_auth_methods_supported values if provided.
@@ -83,13 +92,9 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
-	// Load the toolset; we need its ID and the attached OAuth proxy server reference.
-	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
+	// Load the toolset inside the transaction so the returned view reflects a consistent snapshot.
+	toolsetDetails, err = mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
 	if err != nil {
-		return nil, err
-	}
-
-	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: toolsetDetails.ID}); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/toolsets/updateoauthproxyserver.go
+++ b/server/internal/toolsets/updateoauthproxyserver.go
@@ -10,6 +10,7 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/toolsets"
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -85,6 +86,10 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	// Load the toolset; we need its ID and the attached OAuth proxy server reference.
 	toolsetDetails, err := mv.DescribeToolset(ctx, s.logger, dbtx, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(payload.Slug), new(s.toolsetCache.SkipCache()))
 	if err != nil {
+		return nil, err
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPWrite, ResourceID: toolsetDetails.ID}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Important

Please review this PR with extra care. I ran into a few nuances when defining which scopes were required for each operation, and I might've gotten it wrong.

Worth pointing out:

1. We filter on listing toolsets so we only show the ones the user has access to. If they have no grants, we don't return a forbidden, just an empty list (avoids exposing internal details).
2. We have to add additional DB fetches to get toolset IDs when only slugs were provided, as these are the ones that will be used to assign IDs to users
3. Cloning an mcp is an interesting one: but I believe the right scope here is the ability to write to projects

## Summary

Adds `access.Manager.Require` checks to the toolsets service.