### PR TITLE
chore: enforce RBAC for variations and templates domains

### DIFF
--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -51,6 +51,7 @@ type Service struct {
 	repo       *repo.Queries
 	variations *variations.Service
 	toolsets   ToolsetsService
+	access     *access.Manager
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -67,6 +68,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		repo:       repo.New(db),
 		variations: variations.NewService(logger, tracerProvider, db, sessions, accessManager),
 		toolsets:   toolsets,
+		access:     accessManager,
 	}
 }
 
@@ -91,6 +93,10 @@ func (s *Service) CreateTemplate(ctx context.Context, payload *gen.CreateTemplat
 	}
 
 	projectID := *authCtx.ProjectID
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildWrite, ResourceID: projectID.String()}); err != nil {
+		return nil, err
+	}
 
 	logger := s.logger.With(attr.SlogProjectID(projectID.String()))
 
@@ -177,6 +183,11 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 	}
 
 	projectID := *authCtx.ProjectID
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildWrite, ResourceID: projectID.String()}); err != nil {
+		return nil, err
+	}
+
 	logger := s.logger.With(attr.SlogProjectID(projectID.String()))
 
 	dbtx, err := s.db.Begin(ctx)
@@ -319,8 +330,13 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 		return oops.C(oops.CodeUnauthorized)
 	}
 
-	logger := s.logger
 	projectID := *authCtx.ProjectID
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildWrite, ResourceID: projectID.String()}); err != nil {
+		return err
+	}
+
+	logger := s.logger
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -423,6 +439,11 @@ func (s *Service) GetTemplate(ctx context.Context, payload *gen.GetTemplatePaylo
 	}
 
 	projectID := *authCtx.ProjectID
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: projectID.String()}); err != nil {
+		return nil, err
+	}
+
 	var id uuid.NullUUID
 	if payload.ID != nil && *payload.ID != "" {
 		parsed, err := uuid.Parse(*payload.ID)
@@ -454,6 +475,10 @@ func (s *Service) ListTemplates(ctx context.Context, payload *gen.ListTemplatesP
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	pt, err := mv.DescribePromptTemplates(ctx, s.logger, s.db, mv.ProjectID(*authCtx.ProjectID))
 	if err != nil {
 		return nil, err
@@ -469,6 +494,11 @@ func (s *Service) RenderTemplateByID(ctx context.Context, payload *gen.RenderTem
 	}
 
 	projectID := *authCtx.ProjectID
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: projectID.String()}); err != nil {
+		return nil, err
+	}
+
 	logger := s.logger.With(attr.SlogProjectID(projectID.String()))
 
 	id, err := uuid.Parse(payload.ID)
@@ -502,6 +532,11 @@ func (s *Service) RenderTemplate(ctx context.Context, payload *gen.RenderTemplat
 	}
 
 	projectID := *authCtx.ProjectID
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: projectID.String()}); err != nil {
+		return nil, err
+	}
+
 	logger := s.logger.With(attr.SlogProjectID(projectID.String()))
 
 	data, err := RenderTemplate(ctx, logger, payload.Prompt, payload.Kind, payload.Engine, payload.Arguments)

--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -22,6 +22,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/templates/server"
 	gen "github.com/speakeasy-api/gram/server/gen/templates"
 	variationsTypes "github.com/speakeasy-api/gram/server/gen/variations"
+	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
@@ -55,16 +56,16 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, toolsets ToolsetsService, accessLoader auth.AccessLoader) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, toolsets ToolsetsService, accessManager *access.Manager) *Service {
 	logger = logger.With(attr.SlogComponent("templates"))
 
 	return &Service{
 		tracer:     tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/templates"),
 		logger:     logger,
 		db:         db,
-		auth:       auth.New(logger, db, sessions, accessLoader),
+		auth:       auth.New(logger, db, sessions, accessManager),
 		repo:       repo.New(db),
-		variations: variations.NewService(logger, tracerProvider, db, sessions, accessLoader),
+		variations: variations.NewService(logger, tracerProvider, db, sessions, accessManager),
 		toolsets:   toolsets,
 	}
 }

--- a/server/internal/templates/rbac_test.go
+++ b/server/internal/templates/rbac_test.go
@@ -146,18 +146,13 @@ func TestTemplates_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
 
 	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
-	_, err := ti.service.CreateTemplate(ctx, &gen.CreateTemplatePayload{
+	name := "nonexistent-template"
+	err := ti.service.DeleteTemplate(ctx, &gen.DeleteTemplatePayload{
+		ID:               nil,
+		Name:             &name,
 		SessionToken:     nil,
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,
-		Name:             "test-template",
-		Prompt:           "hello",
-		Description:      nil,
-		Arguments:        nil,
-		Engine:           "",
-		Kind:             "",
-		ToolsHint:        nil,
-		ToolUrnsHint:     nil,
 	})
 	require.NoError(t, err)
 }

--- a/server/internal/templates/rbac_test.go
+++ b/server/internal/templates/rbac_test.go
@@ -1,0 +1,163 @@
+package templates_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/templates"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestTemplates_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestTemplateService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestTemplates_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestTemplateService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestTemplates_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestTemplateService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestTemplates_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestTemplateService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+
+	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestTemplates_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestTemplateService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.CreateTemplate(ctx, &gen.CreateTemplatePayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Name:             "test-template",
+		Prompt:           "hello",
+		Description:      nil,
+		Arguments:        nil,
+		Engine:           "",
+		Kind:             "",
+		ToolsHint:        nil,
+		ToolUrnsHint:     nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestTemplates_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestTemplateService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.CreateTemplate(ctx, &gen.CreateTemplatePayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Name:             "test-template",
+		Prompt:           "hello",
+		Description:      nil,
+		Arguments:        nil,
+		Engine:           "",
+		Kind:             "",
+		ToolsHint:        nil,
+		ToolUrnsHint:     nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestTemplates_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestTemplateService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.CreateTemplate(ctx, &gen.CreateTemplatePayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Name:             "test-template",
+		Prompt:           "hello",
+		Description:      nil,
+		Arguments:        nil,
+		Engine:           "",
+		Kind:             "",
+		ToolsHint:        nil,
+		ToolUrnsHint:     nil,
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/templates/setup_test.go
+++ b/server/internal/templates/setup_test.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/templates"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -92,4 +94,30 @@ type toolsetsServiceStub struct {
 
 func (s *toolsetsServiceStub) InvalidateCacheByTool(ctx context.Context, toolURN urn.Tool, projectID uuid.UUID) error {
 	return s.InvalidateCacheByToolFunc(ctx, toolURN, projectID)
+}
+
+func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "templates-rbac-grants-"+uuid.NewString())
+	for _, grant := range grants {
+		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			PrincipalUrn:   principal,
+			Scope:          string(grant.Scope),
+			Resource:       grant.Resource,
+		})
+		require.NoError(t, err)
+	}
+
+	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
+	require.NoError(t, err)
+
+	return access.GrantsToContext(ctx, loadedGrants)
 }

--- a/server/internal/variations/impl.go
+++ b/server/internal/variations/impl.go
@@ -16,6 +16,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/variations/server"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	gen "github.com/speakeasy-api/gram/server/gen/variations"
+	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
@@ -35,11 +36,12 @@ type Service struct {
 	db     *pgxpool.Pool
 	repo   *repo.Queries
 	auth   *auth.Auth
+	access *access.Manager
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, accessLoader auth.AccessLoader) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, accessManager *access.Manager) *Service {
 	logger = logger.With(attr.SlogComponent("variations"))
 
 	return &Service{
@@ -47,7 +49,8 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		logger: logger,
 		db:     db,
 		repo:   repo.New(db),
-		auth:   auth.New(logger, db, sessions, accessLoader),
+		auth:   auth.New(logger, db, sessions, accessManager),
+		access: accessManager,
 	}
 }
 
@@ -69,6 +72,10 @@ func (s *Service) ListGlobal(ctx context.Context, payload *gen.ListGlobalPayload
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	rows, err := s.repo.ListGlobalToolVariations(ctx, *authCtx.ProjectID)
@@ -107,6 +114,10 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logger := s.logger
@@ -217,6 +228,10 @@ func (s *Service) DeleteGlobal(ctx context.Context, payload *gen.DeleteGlobalPay
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildWrite, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	variationID, err := uuid.Parse(payload.VariationID)

--- a/server/internal/variations/rbac_test.go
+++ b/server/internal/variations/rbac_test.go
@@ -1,0 +1,145 @@
+package variations_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/variations"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestVariations_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestVariations_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestVariations_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestVariations_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+
+	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestVariations_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.UpsertGlobal(ctx, &gen.UpsertGlobalPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		SrcToolUrn:       "tools:http:my-source:my-tool",
+		SrcToolName:      "my-tool",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestVariations_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.UpsertGlobal(ctx, &gen.UpsertGlobalPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		SrcToolUrn:       "tools:http:my-source:my-tool",
+		SrcToolName:      "my-tool",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestVariations_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestVariationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.UpsertGlobal(ctx, &gen.UpsertGlobalPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		SrcToolUrn:       "tools:http:my-source:my-tool",
+		SrcToolName:      "my-tool",
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/variations/setup_test.go
+++ b/server/internal/variations/setup_test.go
@@ -6,13 +6,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/variations"
 	"github.com/stretchr/testify/require"
 )
@@ -73,4 +77,30 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
+}
+
+func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "variations-rbac-grants-"+uuid.NewString())
+	for _, grant := range grants {
+		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			PrincipalUrn:   principal,
+			Scope:          string(grant.Scope),
+			Resource:       grant.Resource,
+		})
+		require.NoError(t, err)
+	}
+
+	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
+	require.NoError(t, err)
+
+	return access.GrantsToContext(ctx, loadedGrants)
 }


### PR DESCRIPTION
## Summary
- Enforces RBAC for the `variations` domain: `build:read` on `ListGlobal`, `build:write` on `UpsertGlobal` / `DeleteGlobal`
- Enforces RBAC for the `templates` domain: `build:read` on `GetTemplate` / `ListTemplates` / `RenderTemplate` / `RenderTemplateByID`, `build:write` on `CreateTemplate` / `UpdateTemplate` / `DeleteTemplate`
- Resource ID is project UUID for both domains
- Uses `build:*` scopes since both are project-level build config