### PR TITLE
chore: enforce RBAC for resources domain

### DIFF
--- a/server/internal/resources/impl.go
+++ b/server/internal/resources/impl.go
@@ -15,6 +15,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/resources/server"
 	gen "github.com/speakeasy-api/gram/server/gen/resources"
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -31,11 +32,12 @@ type Service struct {
 	db     *pgxpool.Pool
 	repo   *repo.Queries
 	auth   *auth.Auth
+	access *access.Manager
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, accessLoader auth.AccessLoader) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, accessManager *access.Manager) *Service {
 	logger = logger.With(attr.SlogComponent("resources"))
 
 	return &Service{
@@ -43,7 +45,8 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		logger: logger,
 		db:     db,
 		repo:   repo.New(db),
-		auth:   auth.New(logger, db, sessions, accessLoader),
+		auth:   auth.New(logger, db, sessions, accessManager),
+		access: accessManager,
 	}
 }
 
@@ -61,6 +64,10 @@ func (s *Service) ListResources(ctx context.Context, payload *gen.ListResourcesP
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	limit := conv.PtrValOrEmpty(payload.Limit, 100)

--- a/server/internal/resources/rbac_test.go
+++ b/server/internal/resources/rbac_test.go
@@ -1,0 +1,97 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/resources"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestResources_RBAC_List_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestResourcesService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Cursor:           nil,
+		Limit:            nil,
+		DeploymentID:     nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestResources_RBAC_List_DeniedWithUnrelatedGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestResourcesService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: "other-project-id"})
+
+	_, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Cursor:           nil,
+		Limit:            nil,
+		DeploymentID:     nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestResources_RBAC_List_AllowedWithBuildReadGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestResourcesService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+
+	result, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Cursor:           nil,
+		Limit:            nil,
+		DeploymentID:     nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestResources_RBAC_List_AllowedWithBuildWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestResourcesService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+
+	result, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Cursor:           nil,
+		Limit:            nil,
+		DeploymentID:     nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}

--- a/server/internal/resources/setup_test.go
+++ b/server/internal/resources/setup_test.go
@@ -1,0 +1,107 @@
+package resources_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/resources"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	infra *testenv.Environment
+)
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true})
+	if err != nil {
+		log.Fatalf("Failed to launch test infrastructure: %v", err)
+		os.Exit(1)
+	}
+
+	infra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("Failed to cleanup test infrastructure: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+type testInstance struct {
+	service        *resources.Service
+	conn           *pgxpool.Pool
+	sessionManager *sessions.Manager
+}
+
+func newTestResourcesService(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	billingClient := billing.NewStubClient(logger, tracerProvider)
+
+	sessionManager := testenv.NewTestManager(t, logger, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+
+	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
+
+	accessManager := access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{})
+	svc := resources.NewService(logger, tracerProvider, conn, sessionManager, accessManager)
+
+	return ctx, &testInstance{
+		service:        svc,
+		conn:           conn,
+		sessionManager: sessionManager,
+	}
+}
+
+func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "resources-rbac-grants-"+uuid.NewString())
+	for _, grant := range grants {
+		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			PrincipalUrn:   principal,
+			Scope:          string(grant.Scope),
+			Resource:       grant.Resource,
+		})
+		require.NoError(t, err)
+	}
+
+	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
+	require.NoError(t, err)
+
+	return access.GrantsToContext(ctx, loadedGrants)
+}


### PR DESCRIPTION
## Summary
- Add `access *access.Manager` to `resources.Service` and update `NewService` to accept a single `*access.Manager` (used for both auth and RBAC)
- Enforce `build:read` on project ID in `ListResources`
- Add `setup_test.go` and `rbac_test.go` with 4 tests covering denial and allow cases