### PR TITLE
chore: skip CI jobs for unrelated code changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -26,6 +26,11 @@ cli:
 tsframework:
   - "ts-framework/**"
 
+sdk:
+  - "client/sdk/**"
+  - "package.json"
+  - "pnpm-lock.yaml"
+
 elements:
   - "elements/**"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,6 +33,7 @@ jobs:
       elements: ${{ steps.gates.outputs.elements }}
       migrations: ${{ steps.gates.outputs.migrations }}
       plog: ${{ steps.gates.outputs.plog }}
+      sdk: ${{ steps.gates.outputs.sdk }}
       elements-examples: ${{ steps.list-elements-examples.outputs.examples }}
     steps:
       - name: Checkout source code
@@ -102,6 +103,13 @@ jobs:
           else
             echo "Plog jobs will be skipped."
           fi
+
+          if [[ "${{ steps.filter.outputs.sdk }}" == "true" || "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "sdk=true" >> $GITHUB_OUTPUT
+            echo "SDK jobs will run."
+          else
+            echo "SDK jobs will be skipped."
+          fi
       - id: list-elements-examples
         name: List elements examples
         run: |
@@ -111,26 +119,20 @@ jobs:
   docker-build-server:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes, server-build-lint]
+    if: needs.changes.outputs.server == 'true'
     env:
       GOMAXPROCS: 4
     steps:
-      - name: Skip if no server changes exist
-        if: ${{ needs.changes.outputs.server != 'true' }}
-        run: echo "No server changes detected — skipping server-build-lint job."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Download server build artifact
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: server-bin
           path: server/bin
 
       - id: "auth"
-        if: ${{ needs.changes.outputs.server == 'true' }}
         name: "Authenticate to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -138,7 +140,6 @@ jobs:
           workload_identity_provider: "projects/409661704476/locations/global/workloadIdentityPools/ga-pool/providers/github-oidc-provider"
           service_account: "speakeasy-registry-ga-ci@linen-analyst-344721.iam.gserviceaccount.com"
       - name: Login to GCR
-        if: ${{ needs.changes.outputs.server == 'true' }}
         env:
           GCR_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
@@ -158,7 +159,6 @@ jobs:
           exit 1
       - name: Build and Push Registry image to GCR
         id: build
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: ./.github/workflows/composite/build-push
         with:
           registry: ${{ env.REGISTRY }}
@@ -171,7 +171,6 @@ jobs:
           build-args: |
             GIT_USERNAME=speakeasybot
       - name: Pull and Run Image
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: |
           echo "Pulling image: ${{ steps.build.outputs.image-tag }}"
           docker pull ${{ steps.build.outputs.image-tag }}
@@ -235,8 +234,8 @@ jobs:
   atlas-push:
     name: Push migrations to Atlas Registry
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [changes, server-build-lint]
-    if: needs.changes.outputs.server == 'true'
+    needs: [changes]
+    if: needs.changes.outputs.migrations == 'true'
     permissions:
       contents: read
       pull-requests: write
@@ -298,6 +297,7 @@ jobs:
   server-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.server == 'true'
     env:
       GOMAXPROCS: 4
     services:
@@ -315,16 +315,10 @@ jobs:
         ports:
           - 5439:5432
     steps:
-      - name: Skip if no server changes exist
-        if: ${{ needs.changes.outputs.server != 'true' }}
-        run: echo "No server changes detected — skipping server-build-lint job."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -332,11 +326,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run github
 
       - name: Cache Go
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_GO_KEY }}
@@ -348,18 +340,15 @@ jobs:
             ${{ env.GOMODCACHE }}
 
       - name: Build
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run build:server --readonly
 
       - name: Lint with golangci-lint
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           install-mode: none
           working-directory: server
 
       - name: Upload server build
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: server-bin
@@ -367,34 +356,27 @@ jobs:
           retention-days: 2
 
       - name: Install Go tools
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: go install tool
         working-directory: server
 
         # TODO add speakeasy cli so the sdk can be generated
       - name: Run code generators
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run "gen:server"
 
       - name: Run "go mod tidy"
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run go:tidy
 
       - name: Setup Atlas
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: ariga/setup-atlas@2f3c785c89a15e1c0d07bcae3900fb5feb969eea # v0
         with:
           cloud-token: ${{ secrets.ATLAS_TOKEN }}
 
       - name: Run migrations
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run db:migrate
       - name: Diff database with schema
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run db:diff out-of-sync
 
       - name: Check for dirty files
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: |
           mise run db:migrate --dry
           mise run git:porcelain
@@ -402,6 +384,7 @@ jobs:
   cli-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.cli == 'true'
     env:
       GOMAXPROCS: 4
     services:
@@ -419,16 +402,10 @@ jobs:
         ports:
           - 5439:5432
     steps:
-      - name: Skip if no cli changes exist
-        if: ${{ needs.changes.outputs.cli != 'true' }}
-        run: echo "No cli changes detected — skipping cli-build-lint job."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -436,11 +413,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         run: mise run github
 
       - name: Cache Go
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_GO_KEY }}
@@ -452,50 +427,39 @@ jobs:
             ${{ env.GOMODCACHE }}
 
       - name: Build
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         run: mise run build:cli --readonly
 
       - name: Lint with golangci-lint
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           install-mode: none
           working-directory: cli
 
       - name: Install Go tools
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         run: go install tool
         working-directory: cli
 
         # TODO add speakeasy cli so the sdk can be generated
       - name: Run code generators
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         run: mise run "gen:server"
 
       - name: Run "go mod tidy"
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         run: mise run go:tidy
 
       - name: Check for dirty files
-        if: ${{ needs.changes.outputs.cli == 'true' }}
         run: mise run git:porcelain
 
   plog-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.plog == 'true'
     env:
       GOMAXPROCS: 4
     steps:
-      - name: Skip if no plog changes exist
-        if: ${{ needs.changes.outputs.plog != 'true' }}
-        run: echo "No plog changes detected — skipping plog-build-lint job."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -503,11 +467,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         run: mise run github
 
       - name: Cache Go
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_GO_KEY }}
@@ -519,49 +481,38 @@ jobs:
             ${{ env.GOMODCACHE }}
 
       - name: Install Go tools
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         run: go install tool
         working-directory: plog
 
       - name: Build
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         run: mise run build:plog --readonly
 
       - name: Lint with golangci-lint
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           install-mode: none
           working-directory: plog
 
       - name: Test
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         run: mise run test:plog
 
       - name: Run "go mod tidy"
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         run: mise run go:tidy
 
       - name: Check for dirty files
-        if: ${{ needs.changes.outputs.plog == 'true' }}
         run: mise run git:porcelain
 
   server-test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.server == 'true'
     env:
       GOMAXPROCS: 4
     steps:
-      - name: Skip if no server changes exist
-        if: ${{ needs.changes.outputs.server != 'true' }}
-        run: echo "No server changes detected — skipping server-test job."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -569,11 +520,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run github
 
       - name: Cache Go
-        if: ${{ needs.changes.outputs.server == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_GO_KEY }}
@@ -585,31 +534,23 @@ jobs:
             ${{ env.GOMODCACHE }}
 
       - name: Install Go deps
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run install:go
 
       - name: Test
-        if: ${{ needs.changes.outputs.server == 'true' }}
         run: mise run test:server
 
   docker-build-client:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    # Build dashboard docker image when server OR client changes exist (needed for preview environments)
+    if: needs.changes.outputs.client == 'true' || needs.changes.outputs.server == 'true'
     env:
       GRAM_GIT_SHA: "${{ github.sha }}"
-      # Build dashboard docker image when server OR client changes exist (needed for preview environments)
-      SHOULD_BUILD_DOCKER: ${{ needs.changes.outputs.client == 'true' || needs.changes.outputs.server == 'true' }}
     steps:
-      - name: Skip if no relevant changes exist
-        if: ${{ env.SHOULD_BUILD_DOCKER != 'true' }}
-        run: echo "No server or client changes detected — skipping dashboard build job."
-
       - name: Checkout
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -617,11 +558,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -632,23 +571,19 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' }}
         env:
           NODE_ENV: production
         run: mise exec --env viteprod -- pnpm build
 
       - name: Upload source maps to DataDog
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' }}
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         run: mise run datadog:sourcemaps --git-sha "${{ github.sha }}"
 
       - id: "auth"
-        if: env.SHOULD_BUILD_DOCKER == 'true'
         name: "Authenticate to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -656,7 +591,6 @@ jobs:
           workload_identity_provider: "projects/409661704476/locations/global/workloadIdentityPools/ga-pool/providers/github-oidc-provider"
           service_account: "speakeasy-registry-ga-ci@linen-analyst-344721.iam.gserviceaccount.com"
       - name: Login to GCR
-        if: env.SHOULD_BUILD_DOCKER == 'true'
         env:
           GCR_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
@@ -676,7 +610,6 @@ jobs:
           exit 1
       - name: Build and Push Registry image to GCR
         id: build
-        if: env.SHOULD_BUILD_DOCKER == 'true'
         uses: ./.github/workflows/composite/build-push
         with:
           registry: ${{ env.REGISTRY }}
@@ -688,23 +621,18 @@ jobs:
           git-auth-token: ${{ secrets.BOT_REPO_TOKEN }}
 
       - name: Prune PNPM store
-        if: ${{ env.SHOULD_BUILD_DOCKER == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   client-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.client == 'true'
     steps:
-      - name: Skip if no client changes exist
-        if: ${{ needs.changes.outputs.client != 'true' }}
-        run: echo "No client changes detected — skipping client-lint-test job."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.client == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.client == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -712,11 +640,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.client == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -727,26 +653,22 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: ${{ needs.changes.outputs.client == 'true' }}
         env:
           NODE_ENV: production
         run: mise exec --env viteprod -- pnpm build
 
       - name: Lint
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: pnpm lint
         working-directory: client/dashboard
 
       - name: Check for dirty files
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: mise run git:porcelain
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.client == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   ts-sdk-build-lint:
@@ -755,17 +677,12 @@ jobs:
         target: ["client/sdk"]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.sdk == 'true'
     steps:
-      - name: Skip if no client changes exist
-        if: ${{ needs.changes.outputs.client != 'true' }}
-        run: echo "No client changes detected — skipping ts-sdk-build-lint."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.client == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.client == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -773,11 +690,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.client == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -788,41 +703,32 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: pnpm build
         working-directory: ${{ matrix.target }}
 
       - name: Lint
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: pnpm lint
         working-directory: ${{ matrix.target }}
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.client == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
       - name: Check for dirty files
-        if: ${{ needs.changes.outputs.client == 'true' }}
         run: mise run git:porcelain
 
   functions-build-host:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.functions == 'true'
     steps:
-      - name: Skip if no functions changes exist
-        if: ${{ needs.changes.outputs.functions != 'true' }}
-        run: echo "No functions changes detected — skipping functions-build-bin."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -830,11 +736,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: mise run github
 
       - name: Cache Go
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_GO_KEY }}
@@ -846,7 +750,6 @@ jobs:
             ${{ env.GOMODCACHE }}
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -857,41 +760,33 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install Go tools
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: go install tool
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Test functions runner
         working-directory: functions
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: mise run test:functions
 
       - name: Test functions entrypoint
         working-directory: functions
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: pnpm test
 
       - name: Type check functions entrypoint
         working-directory: functions
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: pnpm type-check
 
       - name: Lint Go server
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           install-mode: none
           working-directory: functions
 
       - name: Test Go server
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: mise run test:functions
 
       - name: Build Gram Functions host
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         env:
           MELANGE_PRIVATE_KEY: ${{ secrets.MELANGE_PRIVATE_KEY }}
         run: |
@@ -902,7 +797,6 @@ jobs:
           rm -rf "$KEY_DIR"
 
       - name: Upload melange packages artifact
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: functions-packages
@@ -910,20 +804,19 @@ jobs:
           retention-days: 2
 
       - name: Run "go mod tidy"
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: mise run go:tidy
 
       - name: Check for dirty files
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: mise run git:porcelain
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.functions == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   functions-image:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes, functions-build-host]
+    if: needs.changes.outputs.functions == 'true'
     strategy:
       matrix:
         include:
@@ -932,16 +825,10 @@ jobs:
           - runtime: nodejs24
             apko-config: ./images/nodejs24-alpine3.23.yaml
     steps:
-      - name: Skip if no functions changes exist
-        if: ${{ needs.changes.outputs.functions != 'true' }}
-        run: echo "No functions changes detected — skipping functions-image (${{ matrix.runtime }})."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -949,11 +836,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -964,11 +849,9 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Download melange packages artifact
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: functions-packages
@@ -976,7 +859,6 @@ jobs:
 
       - name: Build apko image (${{ matrix.runtime }})
         id: apko
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         env:
           MELANGE_PUBLIC_KEY: ${{ vars.MELANGE_PUBLIC_KEY }}
         run: |
@@ -992,7 +874,6 @@ jobs:
             --out oci/${{ matrix.runtime }}
 
       - name: Run safety checks
-        if: ${{ needs.changes.outputs.functions == 'true' }}
         run: |
           mise run test:apko-functions \
             --image ${{ steps.apko.outputs.image }} \
@@ -1000,7 +881,7 @@ jobs:
 
       - name: "[DEV] Create fly app"
         id: flyCreateDev
-        if: ${{ needs.changes.outputs.functions == 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
@@ -1013,7 +894,7 @@ jobs:
 
       - name: "[PROD] Create fly app"
         id: flyCreateProd
-        if: ${{ needs.changes.outputs.functions == 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: bash
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
@@ -1025,11 +906,11 @@ jobs:
             --force
 
       - name: Set up Docker Buildx
-        if: ${{ needs.changes.outputs.functions == 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Extract Docker metadata
-        if: ${{ needs.changes.outputs.functions == 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
@@ -1044,7 +925,7 @@ jobs:
             type=sha,format=long,prefix=,suffix=-${{ matrix.runtime }}
 
       - name: Tag images
-        if: ${{ needs.changes.outputs.functions == 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         working-directory: functions
         run: |
           set -x
@@ -1058,7 +939,7 @@ jobs:
           done
 
       - name: "[DEV] Push images"
-        if: ${{ needs.changes.outputs.functions == 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
         run: |
@@ -1067,7 +948,7 @@ jobs:
           docker push --all-tags "${{ steps.flyCreateDev.outputs.flyAppRegistry }}"
 
       - name: "[PROD] Push images"
-        if: ${{ needs.changes.outputs.functions == 'true' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
         run: |
@@ -1076,23 +957,18 @@ jobs:
           docker push --all-tags "${{ steps.flyCreateProd.outputs.flyAppRegistry }}"
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.functions == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   ts-framework-test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes]
+    if: needs.changes.outputs.tsframework == 'true'
     steps:
-      - name: Skip if no ts framework changes exist
-        if: ${{ needs.changes.outputs.tsframework != 'true' }}
-        run: echo "No TypeScript framework changes detected — skipping ts-framework-test."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.tsframework == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.tsframework == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -1100,11 +976,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.tsframework == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.tsframework == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -1115,37 +989,29 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.tsframework == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Test TypeScript framework
-        if: ${{ needs.changes.outputs.tsframework == 'true' }}
         run: pnpm --filter "./ts-framework/**" test
 
       - name: Build TypeScript framework
-        if: ${{ needs.changes.outputs.tsframework == 'true' }}
         run: pnpm --filter "./ts-framework/**" build
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.tsframework == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   elements-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.elements == 'true'
     env:
       GRAM_GIT_SHA: "${{ github.sha }}"
     steps:
-      - name: Skip if no elements changes exist
-        if: ${{ needs.changes.outputs.elements != 'true' }}
-        run: echo "No elements changes detected — skipping elements-build-lint."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -1153,11 +1019,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -1168,42 +1032,33 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm build
         working-directory: elements
 
       - name: Lint
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm lint
         working-directory: elements
 
       - name: Type check
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm type-check
         working-directory: elements
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.elements == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   elements-test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.elements == 'true'
     steps:
-      - name: Skip if no elements changes exist
-        if: ${{ needs.changes.outputs.elements != 'true' }}
-        run: echo "No elements changes detected — skipping elements-test."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -1211,11 +1066,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -1226,36 +1079,29 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Test
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm test
         working-directory: elements
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.elements == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   elements-examples:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    if: needs.changes.outputs.elements == 'true'
     strategy:
       fail-fast: false
       matrix:
         example: ${{ fromJSON(needs.changes.outputs.elements-examples) }}
     steps:
-      - name: Skip if no elements changes exist
-        if: ${{ needs.changes.outputs.elements != 'true' }}
-        run: echo "No elements changes detected — skipping elements-examples (${{ matrix.example }})."
-
       - name: Checkout
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       - name: Setup Mise
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -1263,11 +1109,9 @@ jobs:
           env: false
 
       - name: Prepare GitHub Actions environment
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: mise run github
 
       - name: Cache PNPM
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: ${{ env.GH_CACHE_PNPM_KEY }}
@@ -1278,28 +1122,24 @@ jobs:
             ${{ env.PNPM_STORE_PATH }}
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build elements library
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm build
         working-directory: elements
 
       - name: Type check
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm run check
         working-directory: elements/examples/${{ matrix.example }}
 
       - name: Build example
-        if: ${{ needs.changes.outputs.elements == 'true' }}
         run: pnpm run build:example
         working-directory: elements/examples/${{ matrix.example }}
         env:
           NEXT_TELEMETRY_DISABLED: 1
 
       - name: Prune PNPM store
-        if: ${{ needs.changes.outputs.elements == 'true' && success() }}
+        if: success()
         run: pnpm store prune
 
   dispatch-release:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -234,8 +234,8 @@ jobs:
   atlas-push:
     name: Push migrations to Atlas Registry
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [changes]
-    if: needs.changes.outputs.migrations == 'true'
+    needs: [changes, server-build-lint]
+    if: needs.changes.outputs.server == 'true'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1142,6 +1142,43 @@ jobs:
         if: success()
         run: pnpm store prune
 
+  # Gate job: aggregates all check results into a single required status check.
+  # This allows domain-specific jobs to skip (via job-level `if`) without blocking
+  # merge, since skipped jobs don't report a status to rulesets.
+  ci-gate:
+    name: CI Gate
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: always()
+    needs:
+      - changes
+      - server-build-lint
+      - server-test
+      - docker-build-server
+      - docker-build-client
+      - client-build-lint
+      - ts-sdk-build-lint
+      - cli-build-lint
+      - plog-build-lint
+      - functions-build-host
+      - functions-image
+      - ts-framework-test
+      - elements-build-lint
+      - elements-test
+      - elements-examples
+      - atlas-lint
+      - atlas-push
+    steps:
+      - name: Check results
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          for result in $results; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "CI failed: found job with result '$result'"
+              exit 1
+            fi
+          done
+          echo "All CI checks passed or were skipped."
+
   dispatch-release:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [docker-build-server]


### PR DESCRIPTION
## Summary

- **Add CI Gate job**: A single `ci-gate` job aggregates all CI results, compatible with GitHub Rulesets (which treat skipped jobs as non-passing). This replaces needing 18 individual required status checks.
- **Job-level `if` conditions**: All PR jobs now use job-level `if` instead of step-level soft-skips. This prevents runner allocation entirely (instead of spinning up a 4-vCPU runner just to echo a skip message).
- **Separate SDK filter**: `ts-sdk-build-lint` now has its own `sdk` filter (`client/sdk/**`) instead of triggering on any `client/**` change.

### Impact

For a PR like #2155 (single dashboard file), this reduces from **24 jobs running** (most doing nothing) to **~4 jobs running** (only the relevant ones). The rest show as "skipped" with no runner allocated.

### Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Dashboard-only PR | 24 jobs run (most echo "skipping") | ~4 jobs run |
| Server-only PR | 24 jobs run | ~6 jobs run |
| SDK-only PR | Triggered by any client change | Only triggers on `client/sdk/**` changes |

### How it works

Jobs that previously used this pattern:
```yaml
steps:
  - name: Skip if no changes
    if: ${{ needs.changes.outputs.X != 'true' }}
    run: echo "Skipping..."  # still allocates a runner!
```

Now use:
```yaml
job-name:
  if: needs.changes.outputs.X == 'true'  # no runner allocated when false
```

The new `ci-gate` job uses `if: always()` and checks all upstream job results — it passes when everything either succeeds or is skipped, failing only on actual failures or cancellations.

On push to main, all gates force `true`, so every job still runs — no change to main branch behavior.

### Required Ruleset change

After merging, update the "Merge to main" ruleset to require only:
- `CI Gate`
- `Lint PR Title and Changesets`
- `Tag branch changes`

...instead of the current 18 individual job names.

## Test plan

- [ ] Verify this PR itself shows most jobs as "skipped" (only relevant client jobs should run)
- [ ] Verify `CI Gate` job passes (aggregates skipped + success results)
- [ ] After merge, verify push-to-main still runs all jobs
- [ ] After merge, update ruleset required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)