### PR TITLE
fix: gate Atlas push on migrations filter, not server

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -236,7 +236,7 @@ jobs:
     name: Push migrations to Atlas Registry
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes, server-build-lint]
-    if: needs.changes.outputs.server == 'true'
+    if: needs.changes.outputs.migrations == 'true'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

- **"Push migrations to Atlas Registry"** was gated on `server` changes, causing it to run on every server PR even when no migrations were touched
- Now uses the existing `migrations` filter which only matches `server/migrations/**` and `server/clickhouse/migrations/**`

## Test plan

- [ ] PR with only server code changes (no migrations) → Atlas push should be skipped
- [ ] PR with migration changes → Atlas push should run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)