### PR TITLE
chore: enforce RBAC for MCP domain

### DIFF
--- a/server/internal/access/expand_test.go
+++ b/server/internal/access/expand_test.go
@@ -27,11 +27,10 @@ func TestCheckExpand_mcpConnect(t *testing.T) {
 	require.Contains(t, checks, Check{Scope: ScopeRoot, ResourceID: WildcardResource})
 	require.Contains(t, checks, Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"})
 	require.Contains(t, checks, Check{Scope: ScopeMCPConnect, ResourceID: WildcardResource})
-	// mcp:connect is not implied by mcp:write — it is a distinct capability
-	for _, c := range checks {
-		require.NotEqual(t, ScopeMCPWrite, c.Scope)
-		require.NotEqual(t, ScopeMCPRead, c.Scope)
-	}
+	require.Contains(t, checks, Check{Scope: ScopeMCPRead, ResourceID: "tool_a"})
+	require.Contains(t, checks, Check{Scope: ScopeMCPRead, ResourceID: WildcardResource})
+	require.Contains(t, checks, Check{Scope: ScopeMCPWrite, ResourceID: "tool_a"})
+	require.Contains(t, checks, Check{Scope: ScopeMCPWrite, ResourceID: WildcardResource})
 }
 
 func TestGrantsHasAccess_orgAdminSatisfiesOrgRead(t *testing.T) {
@@ -74,6 +73,20 @@ func TestGrantsHasAccess_mcpConnectDoesNotSatisfyMCPRead(t *testing.T) {
 
 	g := &Grants{rows: []Grant{{Scope: ScopeMCPConnect, Resource: "tool_a"}}}
 	require.False(t, g.satisfies(Check{Scope: ScopeMCPRead, ResourceID: "tool_a"}.expand()))
+}
+
+func TestGrantsHasAccess_mcpReadSatisfiesMCPConnect(t *testing.T) {
+	t.Parallel()
+
+	g := &Grants{rows: []Grant{{Scope: ScopeMCPRead, Resource: "tool_a"}}}
+	require.True(t, g.satisfies(Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
+}
+
+func TestGrantsHasAccess_mcpWriteSatisfiesMCPConnect(t *testing.T) {
+	t.Parallel()
+
+	g := &Grants{rows: []Grant{{Scope: ScopeMCPWrite, Resource: "tool_a"}}}
+	require.True(t, g.satisfies(Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
 }
 
 func TestGrantsHasAccess_mcpWriteSatisfiesMCPRead(t *testing.T) {

--- a/server/internal/access/scopes.go
+++ b/server/internal/access/scopes.go
@@ -15,8 +15,7 @@ const (
 )
 
 // scopeExpansions maps a required scope to the higher-privilege scopes that also satisfy it.
-// Scopes with no higher-privilege implication (admin tiers and mcp:connect) map to nil.
-// mcp:connect is a distinct capability — it is not implied by mcp:write.
+// Scopes with no higher-privilege implication (admin tiers) map to nil.
 var scopeExpansions = map[Scope][]Scope{
 	ScopeRoot:       nil,
 	ScopeOrgRead:    {ScopeOrgAdmin},
@@ -25,5 +24,5 @@ var scopeExpansions = map[Scope][]Scope{
 	ScopeBuildWrite: nil,
 	ScopeMCPRead:    {ScopeMCPWrite},
 	ScopeMCPWrite:   nil,
-	ScopeMCPConnect: nil,
+	ScopeMCPConnect: {ScopeMCPRead, ScopeMCPWrite},
 }

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -30,6 +30,7 @@ import (
 	"goa.design/goa/v3/security"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
@@ -92,6 +93,7 @@ type Service struct {
 	externalmcpRepo     *externalmcp_repo.Queries
 	deploymentsRepo     *deployments_repo.Queries
 	enc                 *encryption.Client
+	access              *access.Manager
 }
 
 type oauthTokenInputs struct {
@@ -135,7 +137,7 @@ func NewService(
 	features *productfeatures.Client,
 	vectorToolStore *rag.ToolsetVectorStore,
 	temporal *temporal.Environment,
-	accessLoader auth.AccessLoader,
+	accessManager *access.Manager,
 ) *Service {
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcp")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcp")
@@ -154,7 +156,7 @@ func NewService(
 		orgsRepo:        organizations_repo.New(db),
 		deploymentsRepo: deployments_repo.New(db),
 		externalmcpRepo: externalmcp_repo.New(db),
-		auth:            auth.New(logger, db, sessions, accessLoader),
+		auth:            auth.New(logger, db, sessions, accessManager),
 		env:             env,
 		serverURL:       serverURL,
 		posthog:         posthog,
@@ -181,6 +183,7 @@ func NewService(
 		sessions:            sessions,
 		chatSessionsManager: chatSessionsManager,
 		enc:                 enc,
+		access:              accessManager,
 	}
 }
 
@@ -551,8 +554,23 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 		return oops.C(oops.CodeNotFound)
 	}
 
-	// IMPORTANT: We should not use gram environments if we are not in an authenticated context
 	if authenticated {
+		// Private MCPs require mcp:connect on the specific toolset.
+		// Public MCPs are open to everyone — no RBAC enforcement.
+		if !toolset.McpIsPublic {
+			// Ensure grants are loaded — not all auth strategies in authenticateToken
+			// go through auth.Authorize (which calls PrepareContext). This is a no-op
+			// if grants are already in context.
+			ctx, err = s.access.PrepareContext(ctx)
+			if err != nil {
+				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").Log(ctx, s.logger)
+			}
+			if err := s.access.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()}); err != nil {
+				return err
+			}
+		}
+
+		// IMPORTANT: We should not use gram environments if we are not in an authenticated context
 		selectedEnvironment = conv.PtrValOr(conv.FromPGText[string](toolset.DefaultEnvironmentSlug), "")
 		if passedEnv := r.Header.Get("Gram-Environment"); passedEnv != "" {
 			selectedEnvironment = conv.ToSlug(passedEnv)

--- a/server/internal/mcp/rbac_test.go
+++ b/server/internal/mcp/rbac_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -21,56 +23,56 @@ func TestServePublic_RBAC_PrivateMCP_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-denied-"+uuid.NewString()[:8])
 
+	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{})
 	ctx = withExactAccessGrants(t, ctx, ti)
 
-	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "forbidden")
+	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestServePublic_RBAC_PrivateMCP_DeniedWithUnrelatedGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-unrelated-"+uuid.NewString()[:8])
 
+	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{})
 	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: uuid.NewString()})
 
-	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "forbidden")
+	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestServePublic_RBAC_PrivateMCP_AllowedWithWriteGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-write-implies-connect-"+uuid.NewString()[:8])
 
+	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{})
 	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID.String()})
 
-	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
+	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestServePublic_RBAC_PrivateMCP_AllowedWithConnectGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-allowed-"+uuid.NewString()[:8])
 
+	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{})
 	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: toolset.ID.String()})
 
-	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
+	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestServePublic_RBAC_PublicMCP_AllowedWithoutGrants(t *testing.T) {

--- a/server/internal/mcp/rbac_test.go
+++ b/server/internal/mcp/rbac_test.go
@@ -1,0 +1,137 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/access"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestServePublic_RBAC_PrivateMCP_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-denied-"+uuid.NewString()[:8])
+
+	ctx = withExactAccessGrants(t, ctx, ti)
+
+	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "forbidden")
+}
+
+func TestServePublic_RBAC_PrivateMCP_DeniedWithUnrelatedGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-unrelated-"+uuid.NewString()[:8])
+
+	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: uuid.NewString()})
+
+	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "forbidden")
+}
+
+func TestServePublic_RBAC_PrivateMCP_AllowedWithWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-write-implies-connect-"+uuid.NewString()[:8])
+
+	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID.String()})
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestServePublic_RBAC_PrivateMCP_AllowedWithConnectGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-allowed-"+uuid.NewString()[:8])
+
+	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: toolset.ID.String()})
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestServePublic_RBAC_PublicMCP_AllowedWithoutGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "rbac-public-"+uuid.NewString()[:8])
+
+	ctx = withExactAccessGrants(t, ctx, ti)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func withExactAccessGrants(t *testing.T, ctx context.Context, ti *testInstance, grants ...access.Grant) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "mcp-rbac-grants-"+uuid.NewString())
+	for _, grant := range grants {
+		_, err := accessrepo.New(ti.conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			PrincipalUrn:   principal,
+			Scope:          string(grant.Scope),
+			Resource:       grant.Resource,
+		})
+		require.NoError(t, err)
+	}
+
+	loadedGrants, err := access.LoadGrants(ctx, ti.conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
+	require.NoError(t, err)
+
+	return access.GrantsToContext(ctx, loadedGrants)
+}
+
+func createPrivateMCPToolset(t *testing.T, ctx context.Context, ti *testInstance, slug string) toolsets_repo.Toolset {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Test Private MCP " + slug,
+		Slug:                   slug,
+		Description:            conv.ToPGText("A test private MCP for RBAC testing"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText(slug),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	return toolset
+}

--- a/server/internal/mcp/rbac_test.go
+++ b/server/internal/mcp/rbac_test.go
@@ -21,11 +21,12 @@ func TestServePublic_RBAC_PrivateMCP_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
+	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-denied-"+uuid.NewString()[:8])
 
 	ctx = withExactAccessGrants(t, ctx, ti)
 
-	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "forbidden")
 }
@@ -34,11 +35,12 @@ func TestServePublic_RBAC_PrivateMCP_DeniedWithUnrelatedGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
+	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-unrelated-"+uuid.NewString()[:8])
 
 	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: uuid.NewString()})
 
-	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "forbidden")
 }
@@ -47,11 +49,12 @@ func TestServePublic_RBAC_PrivateMCP_AllowedWithWriteGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
+	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-write-implies-connect-"+uuid.NewString()[:8])
 
 	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID.String()})
 
-	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -60,11 +63,12 @@ func TestServePublic_RBAC_PrivateMCP_AllowedWithConnectGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
+	apiKey := ti.createTestAPIKey(ctx, t)
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-allowed-"+uuid.NewString()[:8])
 
 	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: toolset.ID.String()})
 
-	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), apiKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 }


### PR DESCRIPTION
## Summary
- Enforce `mcp:connect` on toolset UUID in `ServePublic` for private MCPs only — public MCPs require no permissions
- Explicitly call `PrepareContext` before RBAC check since not all auth strategies in `authenticateToken` go through `auth.Authorize`
- Update scope hierarchy: `mcp:connect` is now implied by both `mcp:read` and `mcp:write` (previously standalone)
- Add 5 RBAC tests covering private denied/allowed and public MCP bypass
- Add scope expansion tests for `mcp:read` → `mcp:connect` and `mcp:write` → `mcp:connect`