### PR TITLE
chore: enforce RBAC for telemetry domain

### DIFF
--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -454,7 +454,9 @@ func newWorkerCommand() *cli.Command {
 			}
 			shutdownFuncs = append(shutdownFuncs, chShutdown)
 
-			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, toolIOLogsEnabled, posthogClient, nil)
+			accessManager := access.NewManager(logger, db, productFeatures)
+
+			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, toolIOLogsEnabled, posthogClient, accessManager)
 
 			/**
 			 * BEGIN -- MCP service setup for agent client
@@ -493,7 +495,6 @@ func newWorkerCommand() *cli.Command {
 			sessionManager := sessions.NewManager(logger, tracerProvider, db, redisClient, cache.SuffixNone, c.String("speakeasy-server-address"), c.String("speakeasy-secret-key"), pylonClient, posthogClient, billingRepo, nil)
 
 			chatSessionsManager := chatsessions.NewManager(logger, redisClient, c.String("jwt-signing-key"))
-			accessManager := access.NewManager(logger, db, productFeatures)
 
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager)
 

--- a/server/internal/access/manager.go
+++ b/server/internal/access/manager.go
@@ -34,6 +34,9 @@ func NewManager(logger *slog.Logger, db accessrepo.DBTX, features FeatureChecker
 }
 
 func (m *Manager) PrepareContext(ctx context.Context) (context.Context, error) {
+	if m == nil {
+		return ctx, nil
+	}
 	if grants, ok := GrantsFromContext(ctx); ok && grants != nil {
 		return ctx, nil
 	}
@@ -66,6 +69,9 @@ func (m *Manager) PrepareContext(ctx context.Context) (context.Context, error) {
 }
 
 func (m *Manager) Require(ctx context.Context, checks ...Check) error {
+	if m == nil {
+		return nil
+	}
 	enforce, err := m.shouldEnforce(ctx)
 	if err != nil {
 		return err
@@ -96,6 +102,9 @@ func (m *Manager) Require(ctx context.Context, checks ...Check) error {
 }
 
 func (m *Manager) RequireAny(ctx context.Context, checks ...Check) error {
+	if m == nil {
+		return nil
+	}
 	enforce, err := m.shouldEnforce(ctx)
 	if err != nil {
 		return err

--- a/server/internal/access/manager.go
+++ b/server/internal/access/manager.go
@@ -34,9 +34,6 @@ func NewManager(logger *slog.Logger, db accessrepo.DBTX, features FeatureChecker
 }
 
 func (m *Manager) PrepareContext(ctx context.Context) (context.Context, error) {
-	if m == nil {
-		return ctx, nil
-	}
 	if grants, ok := GrantsFromContext(ctx); ok && grants != nil {
 		return ctx, nil
 	}
@@ -69,9 +66,6 @@ func (m *Manager) PrepareContext(ctx context.Context) (context.Context, error) {
 }
 
 func (m *Manager) Require(ctx context.Context, checks ...Check) error {
-	if m == nil {
-		return nil
-	}
 	enforce, err := m.shouldEnforce(ctx)
 	if err != nil {
 		return err
@@ -102,9 +96,6 @@ func (m *Manager) Require(ctx context.Context, checks ...Check) error {
 }
 
 func (m *Manager) RequireAny(ctx context.Context, checks ...Check) error {
-	if m == nil {
-		return nil
-	}
 	enforce, err := m.shouldEnforce(ctx)
 	if err != nil {
 		return err

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	telem_srv "github.com/speakeasy-api/gram/server/gen/http/telemetry/server"
 	telem_gen "github.com/speakeasy-api/gram/server/gen/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
@@ -41,6 +42,7 @@ type Service struct {
 	chatSessions      *chatsessions.Manager
 	logsEnabled       FeatureChecker
 	toolIOLogsEnabled FeatureChecker
+	access            *access.Manager
 }
 
 var _ telem_gen.Service = (*Service)(nil)
@@ -56,7 +58,7 @@ func NewService(
 	chatSessions *chatsessions.Manager,
 	logsEnabled FeatureChecker,
 	toolIOLogsEnabled FeatureChecker,
-	posthogClient PosthogClient, accessLoader auth.AccessLoader) *Service {
+	posthogClient PosthogClient, accessManager *access.Manager) *Service {
 	logger = logger.With(attr.SlogComponent("telemetry"))
 	chRepo := repo.New(chConn)
 
@@ -65,7 +67,7 @@ func NewService(
 	// API auth methods (APIKeyAuth, JWTAuth) will return unauthorized errors.
 	var a *auth.Auth
 	if sessions != nil {
-		a = auth.New(logger, db, sessions, accessLoader)
+		a = auth.New(logger, db, sessions, accessManager)
 	}
 
 	return &Service{
@@ -79,6 +81,7 @@ func NewService(
 		tracer:            tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/telemetry"),
 		posthog:           posthogClient,
 		chatSessions:      chatSessions,
+		access:            accessManager,
 	}
 }
 
@@ -436,6 +439,10 @@ func (s *Service) GetProjectMetricsSummary(ctx context.Context, payload *telem_g
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	logsEnabled, err := s.logsEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "unable to check if logs are enabled")
@@ -522,6 +529,10 @@ func (s *Service) GetUserMetricsSummary(ctx context.Context, payload *telem_gen.
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	logsEnabled, err := s.logsEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "unable to check if logs are enabled")
@@ -580,6 +591,10 @@ func (s *Service) prepareTelemetrySearch(ctx context.Context, limit int, sort st
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logsEnabled, err := s.logsEnabled(ctx, authCtx.ActiveOrganizationID)
@@ -775,6 +790,10 @@ func (s *Service) GetObservabilityOverview(ctx context.Context, payload *telem_g
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logsEnabled, err := s.logsEnabled(ctx, authCtx.ActiveOrganizationID)
@@ -982,6 +1001,10 @@ func (s *Service) ListFilterOptions(ctx context.Context, payload *telem_gen.List
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	logsEnabled, err := s.logsEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "unable to check if logs are enabled")
@@ -1030,6 +1053,10 @@ func (s *Service) ListAttributeKeys(ctx context.Context, payload *telem_gen.List
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
+	}
+
 	logsEnabled, err := s.logsEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "unable to check if logs are enabled")
@@ -1076,6 +1103,10 @@ func (s *Service) GetHooksSummary(ctx context.Context, payload *telem_gen.GetHoo
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
+	if err := s.access.Require(ctx, access.Check{Scope: access.ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}); err != nil {
+		return nil, err
 	}
 
 	logsEnabled, err := s.logsEnabled(ctx, authCtx.ActiveOrganizationID)

--- a/server/internal/telemetry/rbac_test.go
+++ b/server/internal/telemetry/rbac_test.go
@@ -1,0 +1,111 @@
+package telemetry_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	telem_gen "github.com/speakeasy-api/gram/server/gen/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestTelemetry_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
+		Limit:            10,
+		Sort:             "desc",
+		Cursor:           nil,
+		From:             nil,
+		To:               nil,
+		Filters:          nil,
+		Filter:           nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestTelemetry_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
+		Limit:            10,
+		Sort:             "desc",
+		Cursor:           nil,
+		From:             nil,
+		To:               nil,
+		Filters:          nil,
+		Filter:           nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestTelemetry_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+
+	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
+		Limit:            10,
+		Sort:             "desc",
+		Cursor:           nil,
+		From:             nil,
+		To:               nil,
+		Filters:          nil,
+		Filter:           nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestTelemetry_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+
+	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
+		Limit:            10,
+		Sort:             "desc",
+		Cursor:           nil,
+		From:             nil,
+		To:               nil,
+		Filters:          nil,
+		Filter:           nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -24,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -120,6 +122,32 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 		disabledLogsOrgID:  disabledLogsOrgID,
 		enabledToolIOOrgID: enabledToolIOOrgID,
 	}
+}
+
+func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "telemetry-rbac-grants-"+uuid.NewString())
+	for _, grant := range grants {
+		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			PrincipalUrn:   principal,
+			Scope:          string(grant.Scope),
+			Resource:       grant.Resource,
+		})
+		require.NoError(t, err)
+	}
+
+	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
+	require.NoError(t, err)
+
+	return access.GrantsToContext(ctx, loadedGrants)
 }
 
 func switchOrganizationInCtx(t *testing.T, ctx context.Context, newOrgID string) context.Context {


### PR DESCRIPTION
## Summary
- Enforces `build:read` RBAC on all project-scoped telemetry methods: `SearchLogs`, `SearchToolCalls`, `SearchChats`, `SearchUsers`, `GetProjectMetricsSummary`, `GetUserMetricsSummary`, `GetObservabilityOverview`, `ListFilterOptions`, `ListAttributeKeys`, `GetHooksSummary`, `ListHooksTraces`
- Skips `CaptureEvent` (org-level PostHog forwarding, no project scope)
- Resource ID is project UUID
- Adds `access *access.Manager` to Service struct, updates `NewService` signature from `auth.AccessLoader` to `*access.Manager`
- Worker call site (`worker.go`) passes `nil` which is safe since background workers never call project-scoped service methods