### PR TITLE
feat: visual redesign with color-coded badges and react fixes for deployment logs

### DIFF
--- a/.changeset/deployment-logs-redesign.md
+++ b/.changeset/deployment-logs-redesign.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Redesign deployment logs with color-coded level badges, dot indicators, inline keyboard hints, and React performance fixes

--- a/client/dashboard/src/pages/deployments/Deployments.tsx
+++ b/client/dashboard/src/pages/deployments/Deployments.tsx
@@ -120,6 +120,7 @@ function DeploymentActionsDropdown({
 export function DeploymentsTable({
   showHeader = true,
 }: { showHeader?: boolean } = {}) {
+  const routes = useRoutes();
   const { data: res } = useListDeploymentsSuspense();
   const deployments = res.items ?? [];
 
@@ -218,16 +219,29 @@ export function DeploymentsTable({
     <>
       {showHeader && (
         <>
-          <Heading variant="h2">Recent Deployments</Heading>
+          <div className="flex items-center justify-between mb-2">
+            <Heading variant="h2">Recent Deployments</Heading>
+            {activeDeployment && (
+              <routes.deployments.deployment.Link
+                params={[activeDeployment.id]}
+              >
+                <Button variant="secondary" size="sm">
+                  <Button.LeftIcon>
+                    <Icon name="radio" className="size-4" />
+                  </Button.LeftIcon>
+                  <Button.Text>View Active Deployment</Button.Text>
+                </Button>
+              </routes.deployments.deployment.Link>
+            )}
+          </div>
 
           <div className="bg-secondary p-6 rounded-lg mb-6 space-y-2">
             <p className="text-sm text-muted-foreground">
               Each time you add a new source or update an existing source a new
-              deployment is created in Gram. These are collectively called
-              assets.
+              deployment is created.
             </p>
             <p className="text-sm text-muted-foreground">
-              For each deployment, Gram analyzes all sources in the project to
+              For each deployment all sources are analyzed in the project to
               generate or update the corresponding tool definitions.
             </p>
           </div>

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -16,13 +16,31 @@ import { useDeploymentSearchParams } from "./use-deployment-search-params";
 
 type LogLevel = "WARN" | "INFO" | "DEBUG" | "ERROR" | "OK" | "SKIP";
 
+// Uses design system tokens where available (destructive, warning, success, muted).
+// INFO/DEBUG have no semantic tokens — hardcoded Tailwind is intentional.
 const levelColors = {
   INFO: { dot: "bg-blue-500", text: "text-blue-700", bg: "bg-blue-50" },
-  WARN: { dot: "bg-yellow-500", text: "text-yellow-700", bg: "bg-yellow-50" },
-  ERROR: { dot: "bg-red-500", text: "text-red-700", bg: "bg-red-50" },
-  SKIP: { dot: "bg-slate-400", text: "text-slate-600", bg: "bg-slate-100" },
-  OK: { dot: "bg-emerald-500", text: "text-emerald-700", bg: "bg-emerald-50" },
-  DEBUG: { dot: "bg-gray-400", text: "text-gray-600", bg: "bg-gray-100" },
+  WARN: { dot: "bg-warning", text: "text-warning", bg: "bg-warning/10" },
+  ERROR: {
+    dot: "bg-destructive",
+    text: "text-destructive",
+    bg: "bg-destructive/10",
+  },
+  SKIP: {
+    dot: "bg-muted-foreground",
+    text: "text-muted-foreground",
+    bg: "bg-muted",
+  },
+  OK: {
+    dot: "bg-success",
+    text: "text-success-foreground",
+    bg: "bg-success/10",
+  },
+  DEBUG: {
+    dot: "bg-muted-foreground",
+    text: "text-muted-foreground",
+    bg: "bg-muted",
+  },
 } as const;
 
 function getLevelColors(level: LogLevel) {
@@ -791,9 +809,9 @@ export const LogsTabContent = ({
                             className={cn(
                               "text-[11px] tabular-nums shrink-0",
                               isError
-                                ? "text-red-700"
+                                ? "text-destructive"
                                 : isWarn
-                                  ? "text-yellow-700"
+                                  ? "text-warning"
                                   : "text-muted-foreground/60",
                             )}
                           >
@@ -854,9 +872,9 @@ export const LogsTabContent = ({
                       className={cn(
                         "text-[11px] tabular-nums shrink-0",
                         isError
-                          ? "text-red-700"
+                          ? "text-destructive"
                           : isWarn
-                            ? "text-yellow-700"
+                            ? "text-warning"
                             : "text-muted-foreground/60",
                       )}
                     >

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -58,19 +58,6 @@ function getLevelColors(level: LogLevel) {
   return levelColors[level] ?? levelColors.INFO;
 }
 
-function formatSourceLabel(attachmentType: string): string {
-  switch (attachmentType) {
-    case "openapi":
-      return "OpenAPI";
-    case "functions":
-      return "Functions";
-    case "external_mcp":
-      return "External MCP";
-    default:
-      return attachmentType.replace(/_/g, " ");
-  }
-}
-
 type LogFocus = "all" | "warns" | "errors" | "skipped";
 
 interface ParsedLogEntry {
@@ -288,16 +275,6 @@ export const LogsTabContent = ({
 
   useEffect(() => {
     setCurrentLogIndex(null);
-  }, [parsedLogs]);
-
-  const logStats = useMemo(() => {
-    const stats = { warns: 0, errors: 0, skipped: 0 };
-    parsedLogs.forEach((log) => {
-      if (log.level === "WARN") stats.warns++;
-      if (log.level === "ERROR") stats.errors++;
-      if (log.level === "SKIP") stats.skipped++;
-    });
-    return stats;
   }, [parsedLogs]);
 
   const groupedLogs = useMemo(() => {

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -15,6 +15,20 @@ import { useParams } from "react-router";
 import { useDeploymentSearchParams } from "./use-deployment-search-params";
 
 type LogLevel = "WARN" | "INFO" | "DEBUG" | "ERROR" | "OK" | "SKIP";
+
+const levelColors = {
+  INFO: { dot: "bg-blue-500", text: "text-blue-700", bg: "bg-blue-50" },
+  WARN: { dot: "bg-yellow-500", text: "text-yellow-700", bg: "bg-yellow-50" },
+  ERROR: { dot: "bg-red-500", text: "text-red-700", bg: "bg-red-50" },
+  SKIP: { dot: "bg-slate-400", text: "text-slate-600", bg: "bg-slate-100" },
+  OK: { dot: "bg-emerald-500", text: "text-emerald-700", bg: "bg-emerald-50" },
+  DEBUG: { dot: "bg-gray-400", text: "text-gray-600", bg: "bg-gray-100" },
+} as const;
+
+function getLevelColors(level: LogLevel) {
+  return levelColors[level] ?? levelColors.INFO;
+}
+
 type LogFocus = "all" | "warns" | "errors" | "skipped";
 
 interface ParsedLogEntry {
@@ -709,7 +723,7 @@ export const LogsTabContent = ({
                           `fallback-${globalIndex}`
                         }
                         className={cn(
-                          "px-3 py-2 transition-colors relative",
+                          "px-3 py-1.5 transition-colors relative",
                           "hover:bg-muted/20",
                           isError && "bg-destructive/10 text-destructive",
                           isWarn && "bg-warning/10 text-warning",
@@ -718,11 +732,21 @@ export const LogsTabContent = ({
                             "border-l-4 border-l-foreground pl-2",
                         )}
                       >
-                        <div className="flex items-start gap-4">
+                        <div className="flex items-center gap-2.5 min-w-0">
                           <span
                             className={cn(
-                              "text-muted-foreground tabular-nums",
-                              (isError || isWarn) && "text-inherit",
+                              "size-1.5 shrink-0 rounded-full",
+                              getLevelColors(log.level).dot,
+                            )}
+                          />
+                          <span
+                            className={cn(
+                              "text-[11px] tabular-nums shrink-0",
+                              isError
+                                ? "text-red-700"
+                                : isWarn
+                                  ? "text-yellow-700"
+                                  : "text-muted-foreground/60",
                             )}
                           >
                             {formatLogTimestamp(
@@ -731,19 +755,14 @@ export const LogsTabContent = ({
                           </span>
                           <span
                             className={cn(
-                              "font-medium uppercase",
-                              isError && "text-destructive",
-                              isWarn && "text-warning",
-                              isSkipped && "text-muted-foreground",
-                              !isError &&
-                                !isWarn &&
-                                !isSkipped &&
-                                "text-muted-foreground",
+                              "shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium uppercase",
+                              getLevelColors(log.level).bg,
+                              getLevelColors(log.level).text,
                             )}
                           >
-                            [{log.level}]
+                            {log.level}
                           </span>
-                          <span className="flex-1">
+                          <span className="min-w-0 flex-1">
                             {highlightMatch(log.message)}
                           </span>
                         </div>
@@ -768,7 +787,7 @@ export const LogsTabContent = ({
                   }}
                   key={visibleEvents[index]?.id || `fallback-${index}`}
                   className={cn(
-                    "px-3 py-2 transition-colors relative",
+                    "px-3 py-1.5 transition-colors relative",
                     "hover:bg-muted/20",
                     isError && "bg-destructive/10 text-destructive",
                     isWarn && "bg-warning/10 text-warning",
@@ -776,30 +795,35 @@ export const LogsTabContent = ({
                     isHighlighted && "border-l-4 border-l-foreground pl-2",
                   )}
                 >
-                  <div className="flex items-start gap-4">
+                  <div className="flex items-center gap-2.5 min-w-0">
                     <span
                       className={cn(
-                        "text-muted-foreground tabular-nums",
-                        (isError || isWarn) && "text-inherit",
+                        "size-1.5 shrink-0 rounded-full",
+                        getLevelColors(log.level).dot,
+                      )}
+                    />
+                    <span
+                      className={cn(
+                        "text-[11px] tabular-nums shrink-0",
+                        isError
+                          ? "text-red-700"
+                          : isWarn
+                            ? "text-yellow-700"
+                            : "text-muted-foreground/60",
                       )}
                     >
                       {formatLogTimestamp(visibleEvents[index]!.createdAt)}
                     </span>
                     <span
                       className={cn(
-                        "font-medium uppercase",
-                        isError && "text-destructive",
-                        isWarn && "text-warning",
-                        isSkipped && "text-muted-foreground",
-                        !isError &&
-                          !isWarn &&
-                          !isSkipped &&
-                          "text-muted-foreground",
+                        "shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium uppercase",
+                        getLevelColors(log.level).bg,
+                        getLevelColors(log.level).text,
                       )}
                     >
-                      [{log.level}]
+                      {log.level}
                     </span>
-                    <span className="flex-1">
+                    <span className="min-w-0 flex-1">
                       {highlightMatch(log.message)}
                     </span>
                   </div>

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -600,6 +600,54 @@ export const LogsTabContent = ({
           )}
 
           <div className="ml-auto flex items-center gap-2">
+            <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+              {searchQuery ? (
+                <>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                      N
+                    </kbd>
+                    <span>/</span>
+                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                      ⇧N
+                    </kbd>
+                    <span className="ml-0.5">results</span>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                      ESC
+                    </kbd>
+                    <span>clear</span>
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                      J
+                    </kbd>
+                    <span>/</span>
+                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                      K
+                    </kbd>
+                    <span className="ml-0.5">navigate</span>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                      G
+                    </kbd>
+                    <span>first</span>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                      ⇧G
+                    </kbd>
+                    <span>last</span>
+                  </span>
+                </>
+              )}
+            </div>
+
             <button
               onClick={() => setGroupBySource(!groupBySource)}
               className={cn(
@@ -670,8 +718,8 @@ export const LogsTabContent = ({
                 )
               ) : (
                 <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
-                  <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
-                    ⌘F
+                  <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm font-mono">
+                    /
                   </span>
                 </div>
               )}
@@ -836,46 +884,6 @@ export const LogsTabContent = ({
         {showBottomFade && (
           <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-background to-transparent pointer-events-none rounded-b-lg" />
         )}
-      </div>
-
-      <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
-        <div className="flex items-center gap-4">
-          {searchQuery ? (
-            <>
-              <div className="flex items-center gap-1">
-                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">N</kbd>
-                <span>/</span>
-                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">⇧N</kbd>
-                <span className="ml-1">navigate results</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">ESC</kbd>
-                <span>clear search</span>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="flex items-center gap-1">
-                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">⌘F</kbd>
-                <span>or</span>
-                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">/</kbd>
-                <span>to search</span>
-              </div>
-              {!groupBySource && (
-                <div className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">^G</kbd>
-                  <span>group by source</span>
-                </div>
-              )}
-              <div className="flex items-center gap-1">
-                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">J</kbd>
-                <span>/</span>
-                <kbd className="bg-muted px-1.5 py-0.5 rounded-sm">K</kbd>
-                <span className="ml-1">navigate logs</span>
-              </div>
-            </>
-          )}
-        </div>
       </div>
     </>
   );

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -5,6 +5,7 @@ import { useDeploymentLogsSuspense } from "@gram/client/react-query";
 import { Icon, Input } from "@speakeasy-api/moonshine";
 import React, {
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -174,6 +175,10 @@ export const LogsTabContent = ({
     [visibleEvents],
   );
 
+  useEffect(() => {
+    setCurrentLogIndex(null);
+  }, [parsedLogs]);
+
   const logStats = useMemo(() => {
     const stats = { warns: 0, errors: 0, skipped: 0 };
     parsedLogs.forEach((log) => {
@@ -206,8 +211,10 @@ export const LogsTabContent = ({
     );
   }, [parsedLogs, groupBySource]);
 
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+
   const filteredIndices = useMemo(() => {
-    if (focus === "all" && !searchQuery) return [];
+    if (focus === "all" && !deferredSearchQuery) return [];
 
     const indices: number[] = [];
     parsedLogs.forEach((log, index) => {
@@ -218,8 +225,8 @@ export const LogsTabContent = ({
         (focus === "skipped" && log.level === "SKIP");
 
       const matchesSearch =
-        !searchQuery ||
-        log.message.toLowerCase().includes(searchQuery.toLowerCase());
+        !deferredSearchQuery ||
+        log.message.toLowerCase().includes(deferredSearchQuery.toLowerCase());
 
       if (matchesFocus && matchesSearch) {
         indices.push(index);
@@ -227,7 +234,12 @@ export const LogsTabContent = ({
     });
 
     return indices;
-  }, [focus, searchQuery, parsedLogs]);
+  }, [focus, deferredSearchQuery, parsedLogs]);
+
+  const effectiveSearchIndex =
+    filteredIndices.length > 0
+      ? Math.min(currentSearchIndex, filteredIndices.length - 1)
+      : 0;
 
   const scrollToLog = useCallback((index: number) => {
     const element = logRefs.current.get(index);
@@ -243,12 +255,12 @@ export const LogsTabContent = ({
 
       let newIndex: number;
       if (direction === "next") {
-        newIndex = (currentSearchIndex + 1) % filteredIndices.length;
+        newIndex = (effectiveSearchIndex + 1) % filteredIndices.length;
       } else {
         newIndex =
-          currentSearchIndex === 0
+          effectiveSearchIndex === 0
             ? filteredIndices.length - 1
-            : currentSearchIndex - 1;
+            : effectiveSearchIndex - 1;
       }
 
       setCurrentSearchIndex(newIndex);
@@ -257,7 +269,7 @@ export const LogsTabContent = ({
         scrollToLog(targetIndex);
       }
     },
-    [currentSearchIndex, filteredIndices, scrollToLog],
+    [effectiveSearchIndex, filteredIndices, scrollToLog],
   );
 
   const handleFocusChange = (newFocus: LogFocus) => {
@@ -441,27 +453,35 @@ export const LogsTabContent = ({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [currentLogIndex, parsedLogs.length, navigateToResult, groupBySource]);
 
-  const highlightMatch = (text: string) => {
-    if (!searchQuery) return text;
+  const searchRegex = useMemo(() => {
+    if (!searchQuery) return null;
+    const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(${escaped})`, "gi");
+  }, [searchQuery]);
 
-    const parts = text.split(new RegExp(`(${searchQuery})`, "gi"));
-    return (
-      <>
-        {parts.map((part, i) =>
-          part.toLowerCase() === searchQuery.toLowerCase() ? (
-            <mark
-              key={i}
-              className="bg-yellow-200 dark:bg-yellow-800 text-inherit"
-            >
-              {part}
-            </mark>
-          ) : (
-            part
-          ),
-        )}
-      </>
-    );
-  };
+  const highlightMatch = useCallback(
+    (text: string) => {
+      if (!searchRegex) return text;
+      const parts = text.split(searchRegex);
+      return (
+        <>
+          {parts.map((part, i) =>
+            part.toLowerCase() === searchQuery.toLowerCase() ? (
+              <mark
+                key={i}
+                className="bg-yellow-200 dark:bg-yellow-800 text-inherit"
+              >
+                {part}
+              </mark>
+            ) : (
+              part
+            ),
+          )}
+        </>
+      );
+    },
+    [searchQuery, searchRegex],
+  );
 
   return (
     <>
@@ -605,7 +625,7 @@ export const LogsTabContent = ({
                       ESC
                     </span>
                     <span className="text-[10px] text-muted-foreground mx-0.5">
-                      {currentSearchIndex + 1}/{filteredIndices.length}
+                      {effectiveSearchIndex + 1}/{filteredIndices.length}
                     </span>
                     <div className="flex items-center">
                       <button

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -1,7 +1,18 @@
 import { Heading } from "@/components/ui/heading";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Type } from "@/components/ui/type";
 import { dateTimeFormatters } from "@/lib/dates";
 import { cn } from "@/lib/utils";
-import { useDeploymentLogsSuspense } from "@gram/client/react-query";
+import {
+  useDeploymentLogsSuspense,
+  useDeploymentSuspense,
+} from "@gram/client/react-query";
 import { Icon, Input } from "@speakeasy-api/moonshine";
 import React, {
   useCallback,
@@ -45,6 +56,19 @@ const levelColors = {
 
 function getLevelColors(level: LogLevel) {
   return levelColors[level] ?? levelColors.INFO;
+}
+
+function formatSourceLabel(attachmentType: string): string {
+  switch (attachmentType) {
+    case "openapi":
+      return "OpenAPI";
+    case "functions":
+      return "Functions";
+    case "external_mcp":
+      return "External MCP";
+    default:
+      return attachmentType.replace(/_/g, " ");
+  }
 }
 
 type LogFocus = "all" | "warns" | "errors" | "skipped";
@@ -161,7 +185,18 @@ export const LogsTabContent = ({
     },
   );
 
+  const { data: deployment } = useDeploymentSuspense(
+    { id: deploymentId },
+    undefined,
+    {
+      staleTime: Infinity,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  );
+
   const [focus, setFocus] = useState<LogFocus>("all");
+  const [selectedSource, setSelectedSource] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [currentLogIndex, setCurrentLogIndex] = useState<number | null>(null);
   const [currentSearchIndex, setCurrentSearchIndex] = useState(0);
@@ -193,13 +228,57 @@ export const LogsTabContent = ({
   const logsContainerRef = useRef<HTMLDivElement>(null);
   const logRefs = useRef<Map<number, HTMLDivElement>>(new Map());
 
+  // Build a map of attachmentId → asset name from the deployment data.
+  // Log events store the deployment asset ID (not the uploaded assetId).
+  const assetNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const asset of deployment.openapiv3Assets ?? []) {
+      map.set(asset.id, asset.name);
+    }
+    for (const asset of deployment.functionsAssets ?? []) {
+      map.set(asset.id, asset.name);
+    }
+    for (const mcp of deployment.externalMcps ?? []) {
+      if ("id" in mcp && "name" in mcp) {
+        map.set(String(mcp.id), String(mcp.name));
+      }
+    }
+    return map;
+  }, [deployment]);
+
+  // Build source filter options from individual assets in the log events
+  const sourceOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const event of deploymentLogs.events) {
+      if (event.attachmentId) {
+        counts.set(
+          event.attachmentId,
+          (counts.get(event.attachmentId) ?? 0) + 1,
+        );
+      }
+    }
+    return Array.from(counts.entries())
+      .sort((a, b) => {
+        const nameA = assetNameMap.get(a[0]) ?? a[0];
+        const nameB = assetNameMap.get(b[0]) ?? b[0];
+        return nameA.localeCompare(nameB);
+      })
+      .map(([id, count]) => ({
+        value: id,
+        label: assetNameMap.get(id) ?? id.slice(0, 8),
+        count,
+      }));
+  }, [deploymentLogs.events, assetNameMap]);
+
+  const activeSourceFilter =
+    attachmentType ?? (selectedSource !== "all" ? selectedSource : undefined);
+
   const visibleEvents = useMemo(() => {
-    if (!attachmentType) return deploymentLogs.events;
+    if (!activeSourceFilter) return deploymentLogs.events;
     return deploymentLogs.events.filter(
-      (event) =>
-        !event.attachmentType || event.attachmentType === attachmentType,
+      (event) => event.attachmentId === activeSourceFilter,
     );
-  }, [deploymentLogs.events, attachmentType]);
+  }, [deploymentLogs.events, activeSourceFilter]);
 
   const parsedLogs = useMemo(
     () =>
@@ -517,9 +596,37 @@ export const LogsTabContent = ({
 
   return (
     <>
-      <Heading variant="h2" className="mb-6">
+      <Heading variant="h2" className="mb-4">
         Logs
       </Heading>
+
+      {/* Filters row */}
+      {!embeddedMode && sourceOptions.length > 0 && (
+        <div className="mb-4 flex flex-wrap items-end gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Type small muted>
+              Source
+            </Type>
+            <Select value={selectedSource} onValueChange={setSelectedSource}>
+              <SelectTrigger size="sm" className="min-w-[180px] bg-background">
+                <SelectValue placeholder="All sources" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All sources</SelectItem>
+                {sourceOptions.map((opt) => (
+                  <SelectItem
+                    key={opt.value}
+                    value={opt.value}
+                    description={`${opt.count} log${opt.count === 1 ? "" : "s"}`}
+                  >
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      )}
 
       {/* Logs container */}
       <div className="relative bg-surface rounded-lg border border-border overflow-hidden">
@@ -529,160 +636,54 @@ export const LogsTabContent = ({
             isScrolled && "border-b border-border",
           )}
         >
-          <button
-            onClick={() => handleFocusChange("all")}
-            className={cn(
-              "flex items-center gap-2 p-1 text-xs font-mono uppercase rounded-sm border border-border transition-colors",
-              focus === "all" ? "bg-btn-secondary" : "hover:bg-muted/50",
+          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+            {searchQuery ? (
+              <>
+                <span className="flex items-center gap-1">
+                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                    N
+                  </kbd>
+                  <span>/</span>
+                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                    ⇧N
+                  </kbd>
+                  <span className="ml-0.5">results</span>
+                </span>
+                <span className="flex items-center gap-1">
+                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                    ESC
+                  </kbd>
+                  <span>clear</span>
+                </span>
+              </>
+            ) : (
+              <>
+                <span className="flex items-center gap-1">
+                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                    J
+                  </kbd>
+                  <span>/</span>
+                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                    K
+                  </kbd>
+                  <span className="ml-0.5">navigate</span>
+                </span>
+                <span className="flex items-center gap-1">
+                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                    G
+                  </kbd>
+                  <span>first</span>
+                </span>
+                <span className="flex items-center gap-1">
+                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                    ⇧G
+                  </kbd>
+                  <span>last</span>
+                </span>
+              </>
             )}
-          >
-            <Icon
-              name="list"
-              className={cn(
-                "size-3",
-                focus === "all" ? "" : "text-muted-foreground",
-              )}
-            />
-            <span>All logs</span>
-            <span className="text-muted-foreground opacity-60">
-              {parsedLogs.length}
-            </span>
-          </button>
-
-          {logStats.warns > 0 && (
-            <button
-              onClick={() => handleFocusChange("warns")}
-              className={cn(
-                "flex items-center gap-2 p-1 text-xs font-mono uppercase rounded-sm border border-border transition-colors",
-                focus === "warns" ? "bg-btn-secondary" : "hover:bg-muted/50",
-              )}
-            >
-              <Icon
-                name="triangle-alert"
-                className={cn(
-                  "size-3",
-                  focus === "warns" ? "text-warning" : "text-muted-foreground",
-                )}
-              />
-              <span>Warns</span>
-              <span className="text-muted-foreground opacity-60">
-                {logStats.warns}
-              </span>
-            </button>
-          )}
-
-          {logStats.errors > 0 && (
-            <button
-              onClick={() => handleFocusChange("errors")}
-              className={cn(
-                "flex items-center gap-2 p-1 text-xs font-mono uppercase rounded-sm border border-border transition-colors",
-                focus === "errors" ? "bg-btn-secondary" : "hover:bg-muted/50",
-              )}
-            >
-              <Icon
-                name="circle-x"
-                className={cn(
-                  "size-3",
-                  focus === "errors"
-                    ? "text-destructive"
-                    : "text-muted-foreground",
-                )}
-              />
-              <span>Errors</span>
-              <span className="text-muted-foreground opacity-60">
-                {logStats.errors}
-              </span>
-            </button>
-          )}
-
-          {logStats.skipped > 0 && (
-            <button
-              onClick={() => handleFocusChange("skipped")}
-              className={cn(
-                "flex items-center gap-2 p-1 text-xs font-mono uppercase rounded-sm border border-border transition-colors",
-                focus === "skipped" ? "bg-btn-secondary" : "hover:bg-muted/50",
-              )}
-            >
-              <Icon
-                name="skip-forward"
-                className={cn(
-                  "size-3",
-                  focus === "skipped" ? "" : "text-muted-foreground",
-                )}
-              />
-              <span>Skipped</span>
-              <span className="text-muted-foreground opacity-60">
-                {logStats.skipped}
-              </span>
-            </button>
-          )}
-
-          <div className="ml-auto flex items-center gap-2">
-            <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
-              {searchQuery ? (
-                <>
-                  <span className="flex items-center gap-1">
-                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                      N
-                    </kbd>
-                    <span>/</span>
-                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                      ⇧N
-                    </kbd>
-                    <span className="ml-0.5">results</span>
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                      ESC
-                    </kbd>
-                    <span>clear</span>
-                  </span>
-                </>
-              ) : (
-                <>
-                  <span className="flex items-center gap-1">
-                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                      J
-                    </kbd>
-                    <span>/</span>
-                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                      K
-                    </kbd>
-                    <span className="ml-0.5">navigate</span>
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                      G
-                    </kbd>
-                    <span>first</span>
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                      ⇧G
-                    </kbd>
-                    <span>last</span>
-                  </span>
-                </>
-              )}
-            </div>
-
-            <button
-              onClick={() => setGroupBySource(!groupBySource)}
-              className={cn(
-                "flex items-center gap-2 p-1 text-xs font-mono uppercase rounded-sm border border-border transition-colors",
-                groupBySource ? "bg-btn-secondary" : "hover:bg-muted/50",
-              )}
-            >
-              <Icon
-                name="layers"
-                className={cn(
-                  "size-3",
-                  groupBySource ? "" : "text-muted-foreground",
-                )}
-              />
-              <span>{groupBySource ? "Grouped" : "Group"}</span>
-            </button>
-
+          </div>
+          <div className="ml-auto">
             <div className="relative">
               <Icon
                 name="search"


### PR DESCRIPTION
## Summary

Redesigns the deployment logs and deployments page with visual improvements, React performance fixes, and new filtering capabilities.

<img width="2650" height="926" alt="CleanShot 2026-04-12 at 17 27 07@2x" src="https://github.com/user-attachments/assets/89e70e0d-6f84-499d-b72e-48522eb0d302" />

## Changes

**Deployment logs — visual upgrades**
- Color-coded level badges (INFO/blue, WARN/yellow, ERROR/red, SKIP/slate, OK/emerald) using design system tokens
- Dot indicators on the left edge for rapid scanning
- Dimmed timestamps at 11px — secondary info
- Tighter row padding for better density

**Deployment logs — source filter**
- Dropdown filter above logs to filter by individual deployed source (e.g., "petstore.yaml", "my-functions")
- Maps log event `attachmentId` to deployment asset names via `useDeploymentSuspense`
- System logs hidden when filtering by a specific source

**Deployment logs — toolbar cleanup**
- Moved level filter buttons (All/Warns/Errors/Skipped) and Group button out of the log table toolbar
- Toolbar now only shows keyboard hints + search, matching the audit logs page pattern
- Context-sensitive hints: J/K/G/⇧G when idle, N/⇧N/ESC when searching

**Deployment logs — React fixes**
- Hoist search regex into `useMemo` — was recreated per row in `highlightMatch`
- Add `useDeferredValue` for search filtering — keeps input responsive on large logs
- Derive `effectiveSearchIndex` during render — prevents flash of stale counter values
- Reset `currentLogIndex` when `parsedLogs` changes — fixes stale j/k navigation after filter changes

**Deployments list page**
- Add "View Active Deployment" convenience button in the header
- Simplify deployment description copy (remove "in Gram" and "assets" reference)

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] Navigate to a deployment's Logs tab
- [x] Verify color-coded badges for INFO/WARN/ERROR/SKIP/OK levels
- [x] Verify dot indicators on left edge
- [x] Select a source from the Source dropdown → verify only that source's logs show
- [x] Verify keyboard hints in toolbar (J/K/G/⇧G when idle, N/⇧N/ESC when searching)
- [x] Press `/` → search input focuses, type a query → verify highlighting
- [x] j/k/g/G navigation still works
- [x] Toggle "Group by source" via Ctrl+G keyboard shortcut still works
- [x] Navigate to Deployments list → verify "View Active Deployment" button
- [x] Click the button → navigates to the active deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)