### PR TITLE
chore: add react performance patterns to frontend skill

### DIFF
--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -49,6 +49,60 @@ Never use immediately-invoked function expressions inside JSX (`{(() => { ... })
 
 A component that has grown past ~150 lines of JSX is doing too much. Break it up. If a page has multiple tabs, each tab's content is its own component.
 
+### React Performance Patterns
+
+These patterns were established in the audit log (#2140) and deployment log (#2167) redesigns. Apply them whenever building search, filtering, or keyboard navigation.
+
+#### Hoist RegExp creation
+
+Never create `new RegExp()` inside a render callback (e.g., `highlightMatch`). Extract it to a `useMemo` keyed on the search query:
+
+```typescript
+const searchRegex = useMemo(() => {
+  if (!searchQuery) return null;
+  const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(${escaped})`, "gi");
+}, [searchQuery]);
+```
+
+Then use `searchRegex` inside `useCallback`-wrapped functions.
+
+#### Defer expensive search computations
+
+Wrap search queries with `useDeferredValue` before passing them to expensive `useMemo` computations (e.g., filtering all logs). This keeps the input responsive while React defers the downstream recomputation:
+
+```typescript
+const deferredSearchQuery = useDeferredValue(searchQuery);
+const filteredIndices = useMemo(() => { /* expensive filter */ }, [deferredSearchQuery, ...]);
+```
+
+#### Derive state during render, not via useEffect
+
+If a value can be computed from current state, derive it inline — don't sync it via `useEffect`. This prevents a flash of stale values between renders:
+
+```typescript
+// DO: derive during render
+const effectiveSearchIndex =
+  searchMatchIndices.length > 0
+    ? Math.min(currentSearchIndex, searchMatchIndices.length - 1)
+    : 0;
+
+// DON'T: clamp via useEffect (causes stale render flash)
+useEffect(() => {
+  if (currentSearchIndex >= searchMatchIndices.length) setCurrentSearchIndex(0);
+}, [searchMatchIndices.length]);
+```
+
+#### Reset navigation state on data changes
+
+When a component has keyboard navigation (j/k/g/G) with a `currentIndex` state, reset it when the underlying data changes (filters, pagination, data refresh):
+
+```typescript
+useEffect(() => {
+  setCurrentLogIndex(null);
+}, [logs]); // or parsedLogs, depending on the component
+```
+
 ### Styling and Design System
 
 - **ALWAYS use Moonshine design system utilities** from `@speakeasy-api/moonshine` instead of hardcoded Tailwind color values


### PR DESCRIPTION
## Summary

Codifies four React performance patterns discovered during the audit log (#2140) and deployment log (#2167) redesigns into the `frontend` skill so the whole team benefits.

## Patterns added

- **Hoist RegExp creation** — `useMemo` keyed on search query, not `new RegExp()` per row
- **Defer expensive search** — `useDeferredValue` before `useMemo` filters
- **Derive state during render** — inline derivation instead of `useEffect` clamp (prevents stale render flash)
- **Reset nav on data changes** — `useEffect` to null out `currentIndex` when filtered data changes

Each pattern includes a code example. The "derive state" pattern also shows the anti-pattern to avoid.

## Why a skill, not CLAUDE.md

These patterns are frontend-specific. The `frontend` skill is scoped to `client/dashboard/**` and `elements/**` via `relevant_files` metadata, so they activate only when working on React code — no noise for backend contributors.

## Test plan

- [x] Verify the skill loads when editing a file in `client/dashboard/`
- [x] Verify patterns are actionable (code examples compile conceptually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)