### PR TITLE
chore: improve typeface readability across dashboard

### DIFF
--- a/client/dashboard/src/components/server-card.tsx
+++ b/client/dashboard/src/components/server-card.tsx
@@ -220,7 +220,7 @@ export function ServerCard({
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <div>
-                      <h4 className="text-base font-light">Server Enabled</h4>
+                      <h4 className="text-base font-normal">Server Enabled</h4>
                       <p className="text-xs text-muted-foreground">
                         {toolset.mcpEnabled
                           ? "Server is active, can receive requests"
@@ -245,7 +245,7 @@ export function ServerCard({
                     <div className="space-y-3">
                       <div className="flex items-center justify-between">
                         <div>
-                          <h4 className="text-base font-light">
+                          <h4 className="text-base font-normal">
                             Server Privacy
                           </h4>
                           <p className="text-xs text-muted-foreground">

--- a/client/dashboard/src/components/ui/breadcrumb.tsx
+++ b/client/dashboard/src/components/ui/breadcrumb.tsx
@@ -13,7 +13,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
+        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm font-medium break-words sm:gap-2.5",
         className,
       )}
       {...props}

--- a/client/dashboard/src/components/ui/heading.tsx
+++ b/client/dashboard/src/components/ui/heading.tsx
@@ -28,7 +28,7 @@ export function Heading({
 
   let base = null;
 
-  const baseClasses = cn("font-light capitalize", className);
+  const baseClasses = cn("font-normal capitalize", className);
 
   switch (variant) {
     case "h1":

--- a/client/dashboard/src/components/ui/sidebar.tsx
+++ b/client/dashboard/src/components/ui/sidebar.tsx
@@ -405,7 +405,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-foreground ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs uppercase font-mono font-light outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-foreground ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs uppercase font-mono font-normal outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
@@ -474,7 +474,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-light data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/client/dashboard/src/components/ui/type.tsx
+++ b/client/dashboard/src/components/ui/type.tsx
@@ -68,7 +68,7 @@ export function Type({
     return <Skeleton className={cn(variantWidth, variantHeight)} />;
   }
 
-  let baseClass = "font-light";
+  let baseClass = "font-normal";
 
   if (mono) {
     baseClass += " font-mono";

--- a/client/dashboard/src/components/upload-asset/step/index.tsx
+++ b/client/dashboard/src/components/upload-asset/step/index.tsx
@@ -67,7 +67,7 @@ function Header({
 }) {
   return (
     <div className="[grid-area=header]">
-      <h2 className="text-2xl font-light capitalize">{title}</h2>
+      <h2 className="text-2xl font-normal capitalize">{title}</h2>
       {description && (
         <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       )}


### PR DESCRIPTION
## Summary
- Bump font weights on navigational and heading elements to improve scannability
- Headings (h1–h6), Type component base: `font-light` (300) → `font-normal` (400)
- Breadcrumb list: added `font-medium` (500) for wayfinding clarity
- Sidebar group labels: `font-light` → `font-normal`; active menu button: `font-light` → `font-medium`

## Test plan
- [x] Visual check: sidebar group labels ("PROJECT", "CONNECT", "BUILD", etc.) are more readable
- [x] Visual check: active nav item has clear "you are here" weight distinction
- [x] Visual check: breadcrumbs feel present without competing with page content
- [x] Visual check: page headings and card descriptions scan well at new weight
- [x] No regressions on other pages that use Heading/Type/Breadcrumb components

🤖 Generated with [Claude Code](https://claude.com/claude-code)