### PR TITLE
fix: shorten playground environment slug to fit 40-char limit

### DIFF
--- a/.changeset/fix-playground-slug.md
+++ b/.changeset/fix-playground-slug.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix playground credential saving failing with "length of slug must be lesser or equal than 40" error. The environment slug format was shortened to stay within the server's 40-character limit.

--- a/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
+++ b/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
@@ -59,10 +59,9 @@ export function usePlaygroundEnvironment(
   // server (server/design/shared/datatypes.go). We take the suffix
   // because IDs are lexicographically sortable (timestamp-prefixed),
   // so the trailing random component provides better uniqueness.
-  const slug = toServerSlug(`pg-${user.id.slice(-8)}-${toolset.slug}`).slice(
-    0,
-    40,
-  );
+  const slug = toServerSlug(`pg-${user.id.slice(-8)}-${toolset.slug}`)
+    .slice(0, 40)
+    .replace(/-+$/, "");
 
   const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];

--- a/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
+++ b/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
@@ -54,10 +54,12 @@ export function usePlaygroundEnvironment(
   // We normalize on the client to match the server's transformation
   // (server/internal/conv/from.go:163), otherwise IDs containing
   // characters like underscores would diverge between client and server.
-  // Use a short prefix ("pg-") and only the first 8 hex chars of the
-  // user ID to stay within the 40-character slug limit enforced by the
-  // server (server/design/shared/datatypes.go).
-  const slug = toServerSlug(`pg-${user.id.slice(0, 8)}-${toolset.slug}`).slice(
+  // Use a short prefix ("pg-") and only the last 8 chars of the user
+  // ID to stay within the 40-character slug limit enforced by the
+  // server (server/design/shared/datatypes.go). We take the suffix
+  // because IDs are lexicographically sortable (timestamp-prefixed),
+  // so the trailing random component provides better uniqueness.
+  const slug = toServerSlug(`pg-${user.id.slice(-8)}-${toolset.slug}`).slice(
     0,
     40,
   );

--- a/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
+++ b/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
@@ -54,7 +54,13 @@ export function usePlaygroundEnvironment(
   // We normalize on the client to match the server's transformation
   // (server/internal/conv/from.go:163), otherwise IDs containing
   // characters like underscores would diverge between client and server.
-  const slug = toServerSlug(`playground-${user.id}-${toolset.slug}`);
+  // Use a short prefix ("pg-") and only the first 8 hex chars of the
+  // user ID to stay within the 40-character slug limit enforced by the
+  // server (server/design/shared/datatypes.go).
+  const slug = toServerSlug(`pg-${user.id.slice(0, 8)}-${toolset.slug}`).slice(
+    0,
+    40,
+  );
 
   const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];


### PR DESCRIPTION
## Summary

- Playground environment slugs used the format `playground-{full-uuid}-{toolset}`, producing 57+ character slugs that exceeded the server's 40-character `Slug` type limit (`server/design/shared/datatypes.go`)
- Shortened to `pg-{last-8-of-user-id}-{toolset}` with a `.slice(0, 40)` safety net
- Uses the ID suffix (random component) rather than the prefix (timestamp) for better uniqueness across users
- Example: `playground-038491fd-9397-476a-be37-6d900854b128-speakeasy` (57 chars) → `pg-54b128-speakeasy` (~19 chars)

## Root Cause

The Goa API type `Slug` enforces `MaxLength(40)`. The original slug template embedded the full 36-character UUID, making it impossible to stay under the limit regardless of toolset name length.

## Datadog RUM

11 errors observed in a single session over ~10 minutes (2026-04-10, 20:30–20:40 UTC), all identical:
```
ServiceError: length of slug must be lesser or equal than 40 but got value
"playground-038491fd-9397-476a-be37-6d900854b128-speakeasy" (len=57)
```

## Test plan

- [ ] Save credentials in playground for a toolset — verify environment is created
- [ ] Re-open playground for same toolset — verify saved credentials are loaded
- [ ] Verify with a long toolset slug (30+ chars) that truncation doesn't break lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)