### PR TITLE
chore: add Zed editor settings for oxfmt formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ junit-report.xml
 .assets
 .vscode/*
 .zed/*
+!.zed/settings.json
 !.vscode/extensions.json
 *.code-workspace
 .idea

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,95 @@
+{
+  "languages": {
+    "JavaScript": {
+      "formatter": {
+        "external": {
+          "command": "./node_modules/.bin/oxfmt",
+          "arguments": [
+            "-c",
+            ".oxfmtrc.json",
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    },
+    "TypeScript": {
+      "formatter": {
+        "external": {
+          "command": "./node_modules/.bin/oxfmt",
+          "arguments": [
+            "-c",
+            ".oxfmtrc.json",
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    },
+    "JSX": {
+      "formatter": {
+        "external": {
+          "command": "./node_modules/.bin/oxfmt",
+          "arguments": [
+            "-c",
+            ".oxfmtrc.json",
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    },
+    "TSX": {
+      "formatter": {
+        "external": {
+          "command": "./node_modules/.bin/oxfmt",
+          "arguments": [
+            "-c",
+            ".oxfmtrc.json",
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    },
+    "JSON": {
+      "formatter": {
+        "external": {
+          "command": "./node_modules/.bin/oxfmt",
+          "arguments": [
+            "-c",
+            ".oxfmtrc.json",
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    },
+    "CSS": {
+      "formatter": {
+        "external": {
+          "command": "./node_modules/.bin/oxfmt",
+          "arguments": [
+            "-c",
+            ".oxfmtrc.json",
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    },
+    "Markdown": {
+      "formatter": {
+        "external": {
+          "command": "./node_modules/.bin/oxfmt",
+          "arguments": [
+            "-c",
+            ".oxfmtrc.json",
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.zed/settings.json` to configure Zed's formatter to use the project's `oxfmt` binary and `.oxfmtrc.json` config for JS, TS, JSX, TSX, JSON, CSS, and Markdown
- Updates `.gitignore` to unignore just `.zed/settings.json` so the config is shared with the team

## Why

Without this, Zed's OXC extension uses its own default settings rather than the project's `.oxfmtrc.json`, causing inconsistent formatting on save.

## Test plan

- [ ] Open a TS/TSX file in Zed and save — formatting should match `pnpm lint` output
