### PR TITLE
fix: migrate globals.css to Tailwind CSS v4 syntax

### DIFF
--- a/.changeset/dry-plants-stand.md
+++ b/.changeset/dry-plants-stand.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+fix: migrate globals.css to Tailwind CSS v4 syntax

--- a/.changeset/purple-schools-ring.md
+++ b/.changeset/purple-schools-ring.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Move oauth config to the "authentication" tab of mcp page and provide indications for type of Oauth connection per MCP. 
+Move oauth config to the "authentication" tab of mcp page and provide indications for type of Oauth connection per MCP.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,7 +10,6 @@
     "/client/dashboard/src/App.css",
     "/client/dashboard/src/components/tools-badge.tsx",
     "/client/dashboard/src/lib/constants.ts",
-    "/client/dashboard/src/styles/globals.css",
     "/client/sdk/**",
     "/elements/docs/**",
     "/server/**/fixtures/**",

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -12,6 +12,7 @@
     "/client/dashboard/src/lib/constants.ts",
     "/client/sdk/**",
     "/elements/docs/**",
+    "/elements/examples/tanstack-start/src/routeTree.gen.ts",
     "/server/**/fixtures/**",
     "/server/gen/**"
   ],

--- a/client/dashboard/src/components/EnableLoggingOverlay.tsx
+++ b/client/dashboard/src/components/EnableLoggingOverlay.tsx
@@ -41,26 +41,26 @@ export function EnableLoggingOverlay({ onEnabled }: EnableLoggingOverlayProps) {
   };
 
   return (
-    <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/70 backdrop-blur-[2px] rounded-lg">
-      <div className="flex flex-col items-center gap-4 max-w-md text-center p-8">
-        <div className="size-14 rounded-full bg-muted flex items-center justify-center">
-          <Icon name="activity" className="size-7 text-muted-foreground" />
+    <div className="bg-background/70 absolute inset-0 z-10 flex items-center justify-center rounded-lg backdrop-blur-[2px]">
+      <div className="flex max-w-md flex-col items-center gap-4 p-8 text-center">
+        <div className="bg-muted flex size-14 items-center justify-center rounded-full">
+          <Icon name="activity" className="text-muted-foreground size-7" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold mb-1">Enable Logging</h3>
-          <p className="text-sm text-muted-foreground">
+          <h3 className="mb-1 text-lg font-semibold">Enable Logging</h3>
+          <p className="text-muted-foreground text-sm">
             Turn on logging to start collecting telemetry data for your
             organization. This will record tool call traces, agent sessions, and
             system metrics to power the observability dashboard.
           </p>
         </div>
-        <div className="rounded-lg border border-border bg-muted/30 p-4 text-left w-full">
+        <div className="border-border bg-muted/30 w-full rounded-lg border p-4 text-left">
           <div className="flex items-start gap-2">
             <Icon
               name="info"
-              className="size-4 text-muted-foreground mt-0.5 shrink-0"
+              className="text-muted-foreground mt-0.5 size-4 shrink-0"
             />
-            <p className="text-xs text-muted-foreground">
+            <p className="text-muted-foreground text-xs">
               When enabled, Gram will collect tool call payloads, response data,
               and agent session logs for analysis. This data is stored securely
               and used to generate the metrics and insights. You can disable
@@ -77,7 +77,7 @@ export function EnableLoggingOverlay({ onEnabled }: EnableLoggingOverlayProps) {
           </Button.Text>
         </Button>
         {mutationError && (
-          <span className="text-sm text-destructive">{mutationError}</span>
+          <span className="text-destructive text-sm">{mutationError}</span>
         )}
       </div>
     </div>

--- a/client/dashboard/src/components/FeatureRequestModal.tsx
+++ b/client/dashboard/src/components/FeatureRequestModal.tsx
@@ -56,8 +56,8 @@ export function FeatureRequestModal({
       <Dialog.Content className="sm:max-w-md">
         <Dialog.Header className="text-center">
           {Icon && (
-            <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-muted">
-              <Icon className="h-10 w-10 text-muted-foreground" />
+            <div className="bg-muted mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-full">
+              <Icon className="text-muted-foreground h-10 w-10" />
             </div>
           )}
           <Dialog.Title className="text-center">{title}</Dialog.Title>

--- a/client/dashboard/src/components/ObservabilitySkeleton.tsx
+++ b/client/dashboard/src/components/ObservabilitySkeleton.tsx
@@ -6,23 +6,23 @@ import { Skeleton } from "@/components/ui/skeleton";
  */
 export function ObservabilitySkeleton() {
   return (
-    <div className="flex flex-col gap-6 p-6 overflow-hidden">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 shrink-0">
+    <div className="flex flex-col gap-6 overflow-hidden p-6">
+      <div className="grid shrink-0 grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
         {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="rounded-lg border border-border bg-card p-5">
-            <Skeleton className="h-4 w-24 mb-3" />
+          <div key={i} className="border-border bg-card rounded-lg border p-5">
+            <Skeleton className="mb-3 h-4 w-24" />
             <Skeleton className="h-9 w-32" />
           </div>
         ))}
       </div>
-      <div className="rounded-lg border border-border bg-card p-6 flex-1 min-h-[120px]">
+      <div className="border-border bg-card min-h-[120px] flex-1 rounded-lg border p-6">
         <Skeleton className="h-full w-full" />
       </div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 shrink-0">
-        <div className="rounded-lg border border-border bg-card p-6">
+      <div className="grid shrink-0 grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="border-border bg-card rounded-lg border p-6">
           <Skeleton className="h-32 w-full" />
         </div>
-        <div className="rounded-lg border border-border bg-card p-6">
+        <div className="border-border bg-card rounded-lg border p-6">
           <Skeleton className="h-32 w-full" />
         </div>
       </div>

--- a/client/dashboard/src/components/OpenApiSourceInput.tsx
+++ b/client/dashboard/src/components/OpenApiSourceInput.tsx
@@ -80,16 +80,16 @@ export function OpenApiSourceInput({
         className={`grid w-full ${documentSlug ? "grid-cols-3" : "grid-cols-2"}`}
       >
         <TabsTrigger value="upload">
-          <UploadIcon className="size-4 mr-1.5" />
+          <UploadIcon className="mr-1.5 size-4" />
           Upload
         </TabsTrigger>
         <TabsTrigger value="url">
-          <LinkIcon className="size-4 mr-1.5" />
+          <LinkIcon className="mr-1.5 size-4" />
           From URL
         </TabsTrigger>
         {documentSlug && (
           <TabsTrigger value="cli">
-            <TerminalIcon className="size-4 mr-1.5" />
+            <TerminalIcon className="mr-1.5 size-4" />
             CLI
           </TabsTrigger>
         )}
@@ -108,7 +108,7 @@ export function OpenApiSourceInput({
             e.preventDefault();
             handleSubmit();
           }}
-          className="h-full flex flex-col justify-center"
+          className="flex h-full flex-col justify-center"
         >
           <Stack gap={3}>
             <input
@@ -116,7 +116,7 @@ export function OpenApiSourceInput({
               value={url}
               onChange={(e) => setUrl(e.target.value)}
               placeholder="https://example.com/openapi.yaml"
-              className="w-full px-3 py-2 border rounded-md border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
               disabled={fetchMutation.isPending}
               required
             />
@@ -125,7 +125,7 @@ export function OpenApiSourceInput({
               disabled={!url.trim() || fetchMutation.isPending}
               className="w-full"
             >
-              {fetchMutation.isPending && <Spinner className="size-4 mr-2" />}
+              {fetchMutation.isPending && <Spinner className="mr-2 size-4" />}
               {fetchMutation.isPending ? "Loading..." : "Load OpenAPI Spec"}
             </Button>
           </Stack>
@@ -134,23 +134,23 @@ export function OpenApiSourceInput({
       {documentSlug && (
         <TabsContent value="cli" className="my-3 space-y-3">
           <div>
-            <p className="text-xs text-muted-foreground mb-1.5">
+            <p className="text-muted-foreground mb-1.5 text-xs">
               Direct upload
             </p>
             <CodeBlock
               language="bash"
-              className="!border-0 !bg-muted/50 !rounded-lg"
+              className="!bg-muted/50 !rounded-lg !border-0"
             >
               {`gram upload --type openapiv3 \\\n  --slug ${documentSlug} \\\n  --name "${documentSlug}" \\\n  --location ./path/to/spec.yaml`}
             </CodeBlock>
           </div>
           <div>
-            <p className="text-xs text-muted-foreground mb-1.5">
+            <p className="text-muted-foreground mb-1.5 text-xs">
               Or stage and push (useful for CI/CD)
             </p>
             <CodeBlock
               language="bash"
-              className="!border-0 !bg-muted/50 !rounded-lg"
+              className="!bg-muted/50 !rounded-lg !border-0"
             >
               {`gram stage openapi \\\n  --slug ${documentSlug} \\\n  --location ./path/to/spec.yaml\n\ngram push`}
             </CodeBlock>

--- a/client/dashboard/src/components/add-button.tsx
+++ b/client/dashboard/src/components/add-button.tsx
@@ -9,7 +9,7 @@ export const AddButton = ({ onClick }: { onClick?: () => void }) => {
       onClick={onClick}
     >
       <Button.LeftIcon>
-        <PlusIcon className="w-4 h-4" />
+        <PlusIcon className="h-4 w-4" />
       </Button.LeftIcon>
       <Button.Text className="sr-only">Add</Button.Text>
     </Button>

--- a/client/dashboard/src/components/ai-elements/code-block.tsx
+++ b/client/dashboard/src/components/ai-elements/code-block.tsx
@@ -105,24 +105,24 @@ export const CodeBlock = ({
       <div className="group relative">
         <div
           className={cn(
-            "w-full rounded-md border bg-background text-foreground overflow-hidden",
+            "bg-background text-foreground w-full overflow-hidden rounded-md border",
             className,
           )}
           {...props}
         >
           <div
-            className="overflow-x-auto dark:hidden [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+            className="[&>pre]:bg-background! [&>pre]:text-foreground! overflow-x-auto dark:hidden [&_code]:font-mono [&_code]:text-sm [&>pre]:m-0 [&>pre]:p-4 [&>pre]:text-sm"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
             dangerouslySetInnerHTML={{ __html: html }}
           />
           <div
-            className="hidden overflow-x-auto dark:block [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+            className="[&>pre]:bg-background! [&>pre]:text-foreground! hidden overflow-x-auto dark:block [&_code]:font-mono [&_code]:text-sm [&>pre]:m-0 [&>pre]:p-4 [&>pre]:text-sm"
             // biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
             dangerouslySetInnerHTML={{ __html: darkHtml }}
           />
         </div>
         {children && (
-          <div className="absolute top-2 right-2 flex items-center gap-2 z-10">
+          <div className="absolute top-2 right-2 z-10 flex items-center gap-2">
             {children}
           </div>
         )}

--- a/client/dashboard/src/components/ai-elements/conversation.tsx
+++ b/client/dashboard/src/components/ai-elements/conversation.tsx
@@ -55,7 +55,7 @@ export const ConversationEmptyState = ({
       <>
         {icon && <div className="text-muted-foreground">{icon}</div>}
         <div className="space-y-1">
-          <h3 className="font-medium text-sm">{title}</h3>
+          <h3 className="text-sm font-medium">{title}</h3>
           {description && (
             <p className="text-muted-foreground text-sm">{description}</p>
           )}

--- a/client/dashboard/src/components/ai-elements/message.tsx
+++ b/client/dashboard/src/components/ai-elements/message.tsx
@@ -69,7 +69,7 @@ export const MessageAvatar = ({
   className,
   ...props
 }: MessageAvatarProps) => (
-  <Avatar className={cn("size-8 ring-1 ring-border", className)} {...props}>
+  <Avatar className={cn("ring-border size-8 ring-1", className)} {...props}>
     <AvatarImage alt="" className="mt-0 mb-0" src={src} />
     <AvatarFallback>{name?.slice(0, 2) || "ME"}</AvatarFallback>
   </Avatar>

--- a/client/dashboard/src/components/ai-elements/prompt-input.tsx
+++ b/client/dashboard/src/components/ai-elements/prompt-input.tsx
@@ -276,14 +276,14 @@ export function PromptInputAttachment({
       <HoverCardTrigger asChild>
         <div
           className={cn(
-            "group relative flex h-8 cursor-default select-none items-center gap-1.5 rounded-md border border-border px-1.5 font-medium text-sm transition-all hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+            "group border-border hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 relative flex h-8 cursor-default items-center gap-1.5 rounded-md border px-1.5 text-sm font-medium transition-all select-none",
             className,
           )}
           key={data.id}
           {...props}
         >
           <div className="relative size-5 shrink-0">
-            <div className="absolute inset-0 flex size-5 items-center justify-center overflow-hidden rounded bg-background transition-opacity group-hover:opacity-0">
+            <div className="bg-background absolute inset-0 flex size-5 items-center justify-center overflow-hidden rounded transition-opacity group-hover:opacity-0">
               {isImage ? (
                 <img
                   alt={filename || "attachment"}
@@ -293,7 +293,7 @@ export function PromptInputAttachment({
                   width={20}
                 />
               ) : (
-                <div className="flex size-5 items-center justify-center text-muted-foreground">
+                <div className="text-muted-foreground flex size-5 items-center justify-center">
                   <PaperclipIcon className="size-3" />
                 </div>
               )}
@@ -331,11 +331,11 @@ export function PromptInputAttachment({
           )}
           <div className="flex items-center gap-2.5">
             <div className="min-w-0 flex-1 space-y-1 px-0.5">
-              <h4 className="truncate font-semibold text-sm leading-none">
+              <h4 className="truncate text-sm leading-none font-semibold">
                 {filename || (isImage ? "Image" : "Attachment")}
               </h4>
               {data.mediaType && (
-                <p className="truncate font-mono text-muted-foreground text-xs">
+                <p className="text-muted-foreground truncate font-mono text-xs">
                   {data.mediaType}
                 </p>
               )}
@@ -1152,7 +1152,7 @@ export const PromptInputSpeechButton = ({
     <PromptInputButton
       className={cn(
         "relative transition-all duration-200",
-        isListening && "animate-pulse bg-accent text-accent-foreground",
+        isListening && "bg-accent text-accent-foreground animate-pulse",
         className,
       )}
       disabled={!recognition}
@@ -1180,7 +1180,7 @@ export const PromptInputModelSelectTrigger = ({
 }: PromptInputModelSelectTriggerProps) => (
   <SelectTrigger
     className={cn(
-      "border-none bg-transparent font-medium text-muted-foreground shadow-none transition-colors",
+      "text-muted-foreground border-none bg-transparent font-medium shadow-none transition-colors",
       'hover:bg-accent hover:text-foreground [&[aria-expanded="true"]]:bg-accent [&[aria-expanded="true"]]:text-foreground',
       className,
     )}
@@ -1270,7 +1270,7 @@ export const PromptInputTabLabel = ({
 }: PromptInputTabLabelProps) => (
   <h3
     className={cn(
-      "mb-2 px-3 font-medium text-muted-foreground text-xs",
+      "text-muted-foreground mb-2 px-3 text-xs font-medium",
       className,
     )}
     {...props}
@@ -1294,7 +1294,7 @@ export const PromptInputTabItem = ({
 }: PromptInputTabItemProps) => (
   <div
     className={cn(
-      "flex items-center gap-2 px-3 py-2 text-xs hover:bg-accent",
+      "hover:bg-accent flex items-center gap-2 px-3 py-2 text-xs",
       className,
     )}
     {...props}

--- a/client/dashboard/src/components/ai-elements/tool.tsx
+++ b/client/dashboard/src/components/ai-elements/tool.tsx
@@ -83,9 +83,9 @@ export const ToolHeader = ({
     )}
     {...props}
   >
-    <div className="flex items-center gap-2 flex-wrap">
-      <WrenchIcon className="size-4 text-muted-foreground" />
-      <span className="font-medium text-sm">
+    <div className="flex flex-wrap items-center gap-2">
+      <WrenchIcon className="text-muted-foreground size-4" />
+      <span className="text-sm font-medium">
         {title ?? type.split("-").slice(1).join("-")}
       </span>
       {getStatusBadge(state)}
@@ -95,7 +95,7 @@ export const ToolHeader = ({
         </Badge>
       )}
       {annotations?.destructiveHint && !annotations?.readOnlyHint && (
-        <Badge className="gap-1 rounded-full text-xs bg-amber-500/10 text-amber-600 border-amber-200">
+        <Badge className="gap-1 rounded-full border-amber-200 bg-amber-500/10 text-xs text-amber-600">
           Destructive
         </Badge>
       )}
@@ -105,7 +105,7 @@ export const ToolHeader = ({
         </Badge>
       )}
     </div>
-    <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+    <ChevronDownIcon className="text-muted-foreground size-4 transition-transform group-data-[state=open]:rotate-180" />
   </CollapsibleTrigger>
 );
 
@@ -114,7 +114,7 @@ export type ToolContentProps = ComponentProps<typeof CollapsibleContent>;
 export const ToolContent = ({ className, ...props }: ToolContentProps) => (
   <CollapsibleContent
     className={cn(
-      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
+      "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground data-[state=closed]:animate-out data-[state=open]:animate-in outline-none",
       className,
     )}
     {...props}
@@ -127,10 +127,10 @@ export type ToolInputProps = ComponentProps<"div"> & {
 
 export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
   <div className={cn("space-y-2 p-4", className)} {...props}>
-    <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+    <h4 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
       Parameters
     </h4>
-    <div className="rounded-md bg-muted/50 overflow-auto">
+    <div className="bg-muted/50 overflow-auto rounded-md">
       <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
     </div>
   </div>
@@ -163,7 +163,7 @@ export const ToolOutput = ({
 
   return (
     <div className={cn("space-y-2 p-4", className)} {...props}>
-      <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+      <h4 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
         {errorText ? "Error" : "Result"}
       </h4>
       <div

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -62,14 +62,14 @@ const ImpersonationBanner = () => {
   const client = useSdkClient();
 
   return (
-    <div className="flex items-center justify-center gap-3 bg-red-600 px-4 py-2 text-white text-sm">
+    <div className="flex items-center justify-center gap-3 bg-red-600 px-4 py-2 text-sm text-white">
       <ShieldAlert className="h-4 w-4 shrink-0" />
-      <span className="font-bold font-mono">
+      <span className="font-mono font-bold">
         Impersonating {organization.slug}
       </span>
       <button
         type="button"
-        className="ml-2 rounded bg-white/20 px-2 py-0.5 text-xs font-medium hover:bg-white/30 transition-colors"
+        className="ml-2 rounded bg-white/20 px-2 py-0.5 text-xs font-medium transition-colors hover:bg-white/30"
         onClick={async () => {
           document.cookie = "gram_admin_override=; path=/; max-age=0;";
           await client.auth.logout();
@@ -88,16 +88,16 @@ const AppLayoutContent = ({
   isImpersonating: boolean;
 }) => {
   return (
-    <div className="flex flex-col h-screen w-full">
+    <div className="flex h-screen w-full flex-col">
       {isImpersonating && <ImpersonationBanner />}
       <TopHeader />
-      <div className="flex flex-1 w-full overflow-hidden pt-2">
+      <div className="flex w-full flex-1 overflow-hidden pt-2">
         <AppSidebar variant="inset" />
         <SidebarInset>
           <Outlet />
           <Modal
             closable
-            className="rounded-sm min-w-auto p-0 h-full 2xl:w-2/3 w-9/12 max-w-[1100px] 2xl:max-w-[1000px] max-h-[450px] min-h-auto"
+            className="h-full max-h-[450px] min-h-auto w-9/12 max-w-[1100px] min-w-auto rounded-sm p-0 2xl:w-2/3 2xl:max-w-[1000px]"
             layout="custom"
           />
         </SidebarInset>
@@ -121,10 +121,10 @@ export const OrgLayout = () => {
       }
     >
       <ModalProvider>
-        <div className="flex flex-col h-screen w-full">
+        <div className="flex h-screen w-full flex-col">
           {isImpersonating && <ImpersonationBanner />}
           <TopHeader />
-          <div className="flex flex-1 w-full overflow-hidden pt-2">
+          <div className="flex w-full flex-1 overflow-hidden pt-2">
             <OrgSidebar variant="inset" />
             <SidebarInset>
               <Outlet />

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -59,9 +59,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <div className="mt-auto px-2 py-3">
           <Link
             to={`/${orgSlug}`}
-            className="flex items-center gap-1.5 px-2 py-1 text-sm text-muted-foreground hover:text-foreground transition-colors hover:no-underline"
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 px-2 py-1 text-sm transition-colors hover:no-underline"
           >
-            <Undo2 className="w-3.5 h-3.5" />
+            <Undo2 className="h-3.5 w-3.5" />
             <span>Back to org</span>
           </Link>
         </div>
@@ -107,7 +107,7 @@ const FreeTierExceededNotification = () => {
           <Type small>
             Free tier limits exceeded. Upgrade to continue using Gram.
           </Type>
-          <orgRoutes.billing.Link className="w-full mt-auto">
+          <orgRoutes.billing.Link className="mt-auto w-full">
             <Button size="sm" className="w-full">
               Billing →
             </Button>
@@ -145,7 +145,7 @@ const PersistentNotification = ({
       className="absolute top-0 right-0 hover:bg-transparent"
       onClick={() => setIsMinimized(true)}
     >
-      <MinusIcon className="w-4 h-4" />
+      <MinusIcon className="h-4 w-4" />
     </Button>
   );
 
@@ -167,7 +167,7 @@ const PersistentNotification = ({
         <Button
           variant="ghost"
           size="icon"
-          className="flex items-center justify-center h-full w-full"
+          className="flex h-full w-full items-center justify-center"
         >
           <Type>?</Type>
         </Button>

--- a/client/dashboard/src/components/asset-image.tsx
+++ b/client/dashboard/src/components/asset-image.tsx
@@ -11,7 +11,7 @@ export const AssetImage = ({
     <img
       src={`${getServerURL()}/rpc/assets.serveImage?id=${assetId}`}
       alt={"Uploaded image"}
-      className={cn("w-[200px] h-[200px] rounded-lg", className)}
+      className={cn("h-[200px] w-[200px] rounded-lg", className)}
     />
   );
 };

--- a/client/dashboard/src/components/auditlogs/structured-diff.tsx
+++ b/client/dashboard/src/components/auditlogs/structured-diff.tsx
@@ -30,16 +30,16 @@ function ChangedFieldRow({
   newValue: unknown;
 }) {
   return (
-    <div className="flex items-start gap-3 border-b border-border/50 px-3 py-2 last:border-b-0">
-      <span className="w-[140px] shrink-0 pt-0.5 font-mono text-xs font-medium text-muted-foreground">
+    <div className="border-border/50 flex items-start gap-3 border-b px-3 py-2 last:border-b-0">
+      <span className="text-muted-foreground w-[140px] shrink-0 pt-0.5 font-mono text-xs font-medium">
         {field}
       </span>
       <div className="flex min-w-0 flex-1 flex-wrap items-start gap-2">
-        <span className="max-w-full break-all rounded bg-red-50 px-2 py-0.5 font-mono text-xs text-red-700 line-through dark:bg-red-950 dark:text-red-400">
+        <span className="max-w-full rounded bg-red-50 px-2 py-0.5 font-mono text-xs break-all text-red-700 line-through dark:bg-red-950 dark:text-red-400">
           {formatValue(oldValue)}
         </span>
-        <span className="pt-0.5 text-xs text-muted-foreground">→</span>
-        <span className="max-w-full break-all rounded bg-emerald-50 px-2 py-0.5 font-mono text-xs text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">
+        <span className="text-muted-foreground pt-0.5 text-xs">→</span>
+        <span className="max-w-full rounded bg-emerald-50 px-2 py-0.5 font-mono text-xs break-all text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">
           {formatValue(newValue)}
         </span>
       </div>
@@ -68,7 +68,7 @@ export function StructuredDiff({ log }: { log: AuditLog }) {
         <HighlightProvider>
           <Suspense
             fallback={
-              <div className="flex items-center gap-2 text-muted-foreground">
+              <div className="text-muted-foreground flex items-center gap-2">
                 <Icon name="loader-circle" className="size-4 animate-spin" />
                 <span>Loading diff...</span>
               </div>
@@ -84,15 +84,15 @@ export function StructuredDiff({ log }: { log: AuditLog }) {
   return (
     <div className="mt-2">
       <div className="flex items-center gap-2 py-1">
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <span className="text-muted-foreground text-[11px] font-semibold tracking-wide uppercase">
           Changed fields
         </span>
-        <div className="h-px flex-1 bg-border" />
-        <span className="text-[11px] text-muted-foreground">
+        <div className="bg-border h-px flex-1" />
+        <span className="text-muted-foreground text-[11px]">
           {changes.length} field{changes.length === 1 ? "" : "s"} changed
         </span>
       </div>
-      <div className="rounded-md border bg-background">
+      <div className="bg-background rounded-md border">
         {changes.map((change) => (
           <ChangedFieldRow
             key={change.field}

--- a/client/dashboard/src/components/auto-summarize-badge.tsx
+++ b/client/dashboard/src/components/auto-summarize-badge.tsx
@@ -5,10 +5,10 @@ export const AutoSummarizeBadge = () => {
   return (
     <Badge
       size="sm"
-      className="text-sm capitalize rounded-full px-1 py-0"
+      className="rounded-full px-1 py-0 text-sm capitalize"
       tooltip="Responses from this tool are automatically summarized"
     >
-      <AArrowDown size={4} className="w-4! h-4!" />
+      <AArrowDown size={4} className="h-4! w-4!" />
     </Badge>
   );
 };

--- a/client/dashboard/src/components/block.tsx
+++ b/client/dashboard/src/components/block.tsx
@@ -18,7 +18,7 @@ export const Block = ({
 
   return (
     <Stack
-      className={cn("p-1 rounded-md w-full", className)}
+      className={cn("w-full rounded-md p-1", className)}
       align={labelRHS ? "stretch" : "start"}
     >
       <Stack
@@ -31,7 +31,7 @@ export const Block = ({
           align="center"
           justify="space-between"
           className={cn(
-            "px-2 pt-1 rounded-sm rounded-b-none",
+            "rounded-sm rounded-b-none px-2 pt-1",
             blockBackground,
             labelRHS && "w-full",
           )}
@@ -49,7 +49,7 @@ export const Block = ({
           )}
         </Stack>
         {error && !labelRHS && (
-          <Type small italic className="pt-1 text-destructive! w-full z-1">
+          <Type small italic className="text-destructive! z-1 w-full pt-1">
             {error}
           </Type>
         )}
@@ -57,7 +57,7 @@ export const Block = ({
 
       <div
         className={cn(
-          "h-full w-full p-1 rounded-md rounded-tl-none",
+          "h-full w-full rounded-md rounded-tl-none p-1",
           blockBackground,
           labelRHS && "rounded-tr-none",
         )}
@@ -78,7 +78,7 @@ export const BlockInner = ({
   return (
     <div
       className={cn(
-        "bg-card dark:bg-background rounded-sm p-2 border-1 border-stone-300 dark:border-stone-700",
+        "bg-card dark:bg-background rounded-sm border-1 border-stone-300 p-2 dark:border-stone-700",
         className,
       )}
     >

--- a/client/dashboard/src/components/chat/ChatInput.tsx
+++ b/client/dashboard/src/components/chat/ChatInput.tsx
@@ -39,7 +39,7 @@ export function ChatInput({
         onChange={(e) => setInput(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}
-        className="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        className="bg-background ring-offset-background focus-visible:ring-ring flex-1 resize-none rounded-lg border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         rows={1}
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {

--- a/client/dashboard/src/components/chat/ChatMessages.tsx
+++ b/client/dashboard/src/components/chat/ChatMessages.tsx
@@ -23,7 +23,7 @@ export function ChatMessages({
   }, [messages]);
 
   return (
-    <div className={cn("flex flex-col gap-4 p-4 overflow-y-auto", className)}>
+    <div className={cn("flex flex-col gap-4 overflow-y-auto p-4", className)}>
       {messages.map((message) => (
         <div key={message.id}>
           {renderMessage ? (
@@ -34,7 +34,7 @@ export function ChatMessages({
         </div>
       ))}
       {isLoading && (
-        <div className="flex items-center gap-2 text-muted-foreground">
+        <div className="text-muted-foreground flex items-center gap-2">
           <div className="h-2 w-2 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
           <div className="h-2 w-2 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
           <div className="h-2 w-2 animate-bounce rounded-full bg-current" />
@@ -51,8 +51,8 @@ function DefaultMessageRenderer({ message }: { message: UIMessage }) {
       className={cn(
         "flex flex-col gap-2 rounded-lg p-4",
         message.role === "user"
-          ? "ml-auto max-w-[80%] bg-primary text-primary-foreground"
-          : "mr-auto max-w-[80%] bg-muted",
+          ? "bg-primary text-primary-foreground ml-auto max-w-[80%]"
+          : "bg-muted mr-auto max-w-[80%]",
       )}
     >
       <Type variant="small" className="font-medium opacity-70">

--- a/client/dashboard/src/components/code.tsx
+++ b/client/dashboard/src/components/code.tsx
@@ -64,7 +64,7 @@ export function CodeBlock({
     "rounded-md font-mono text-sm text-wrap overflow-x-auto border break-all whitespace-pre-wrap truncate";
 
   return (
-    <div className={cn("relative group", className)}>
+    <div className={cn("group relative", className)}>
       {highlightedCode ? (
         <div
           className={cn(baseClasses, "p-4 pr-12", innerClassName)}
@@ -80,13 +80,13 @@ export function CodeBlock({
           variant="tertiary"
           size="sm"
           onClick={handleCopy}
-          className="absolute top-1/2 -translate-y-1/2 right-2 p-2"
+          className="absolute top-1/2 right-2 -translate-y-1/2 p-2"
         >
           <Button.LeftIcon>
             {copied ? (
-              <Check className="w-4 h-4" />
+              <Check className="h-4 w-4" />
             ) : (
-              <Copy className="w-4 h-4" />
+              <Copy className="h-4 w-4" />
             )}
           </Button.LeftIcon>
           <Button.Text className="sr-only">

--- a/client/dashboard/src/components/command-palette/CommandPalette.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPalette.tsx
@@ -64,7 +64,7 @@ export function CommandPalette() {
                   <span>{action.label}</span>
                 </div>
                 {action.shortcut && (
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-muted-foreground text-xs">
                     {action.shortcut}
                   </span>
                 )}

--- a/client/dashboard/src/components/content-error-boundary.tsx
+++ b/client/dashboard/src/components/content-error-boundary.tsx
@@ -15,11 +15,11 @@ function ContentErrorFallback({ error }: ContentErrorFallbackProps) {
   handleError(error, { silent: true });
 
   return (
-    <Card className="w-full max-w-lg m-8 py-8">
+    <Card className="m-8 w-full max-w-lg py-8">
       <Card.Header>
         <Card.Title>
           <Stack direction="horizontal" gap={2} align="center">
-            <Icon name="circle-alert" className="h-5 w-5 text-destructive" />
+            <Icon name="circle-alert" className="text-destructive h-5 w-5" />
             Error loading Page
           </Stack>
         </Card.Title>
@@ -28,8 +28,8 @@ function ContentErrorFallback({ error }: ContentErrorFallbackProps) {
         <Card.Description>
           We encountered an error while loading this page.
         </Card.Description>
-        <div className="bg-muted p-3 rounded-md">
-          <p className="text-sm text-muted-foreground font-mono">
+        <div className="bg-muted rounded-md p-3">
+          <p className="text-muted-foreground font-mono text-sm">
             {error.message}
           </p>
         </div>

--- a/client/dashboard/src/components/create-thing-card.tsx
+++ b/client/dashboard/src/components/create-thing-card.tsx
@@ -14,7 +14,7 @@ export function CreateThingCard({
   return (
     <Card
       className={cn(
-        "border-dashed border-2 hover:border-muted-foreground/50 bg-transparent cursor-pointer min-h-36 trans group shadow-none items-center justify-center",
+        "hover:border-muted-foreground/50 trans group min-h-36 cursor-pointer items-center justify-center border-2 border-dashed bg-transparent shadow-none",
         className,
       )}
       onClick={onClick}

--- a/client/dashboard/src/components/delete-button.tsx
+++ b/client/dashboard/src/components/delete-button.tsx
@@ -24,7 +24,7 @@ export function DeleteButton({
       tooltip={tooltip}
       onClick={onClick}
     >
-      <Trash2Icon className="w-4 h-4" />
+      <Trash2Icon className="h-4 w-4" />
     </Button>
   );
 }

--- a/client/dashboard/src/components/detail-hero.tsx
+++ b/client/dashboard/src/components/detail-hero.tsx
@@ -17,12 +17,12 @@ export function DetailHero({ children, actions, className }: DetailHeroProps) {
   return (
     <div
       className={cn(
-        "relative w-full h-48 shrink-0 overflow-hidden border-b",
+        "relative h-48 w-full shrink-0 overflow-hidden border-b",
         className,
       )}
     >
       <div
-        className="absolute inset-0 bg-muted/30 text-muted-foreground/20"
+        className="bg-muted/30 text-muted-foreground/20 absolute inset-0"
         style={{
           backgroundImage:
             "radial-gradient(circle, currentColor 1px, transparent 1px)",
@@ -30,12 +30,12 @@ export function DetailHero({ children, actions, className }: DetailHeroProps) {
         }}
       />
 
-      <div className="absolute bottom-0 left-0 right-0 px-8 py-6 max-w-[1270px] mx-auto w-full">
+      <div className="absolute right-0 bottom-0 left-0 mx-auto w-full max-w-[1270px] px-8 py-6">
         {children}
       </div>
 
       {actions && (
-        <div className="absolute top-6 left-0 right-0 px-8 max-w-[1270px] mx-auto w-full">
+        <div className="absolute top-6 right-0 left-0 mx-auto w-full max-w-[1270px] px-8">
           <div className="flex justify-end gap-2">{actions}</div>
         </div>
       )}

--- a/client/dashboard/src/components/enterprise-gate.tsx
+++ b/client/dashboard/src/components/enterprise-gate.tsx
@@ -23,14 +23,14 @@ export function EnterpriseGate({
   }
 
   return (
-    <div className="flex flex-col items-center justify-center py-24 px-8 m-8 rounded-xl border border-dashed bg-muted/20">
-      <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-4">
-        <Icon name={icon} className="w-6 h-6 text-muted-foreground" />
+    <div className="bg-muted/20 m-8 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-24">
+      <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+        <Icon name={icon} className="text-muted-foreground h-6 w-6" />
       </div>
       <Type variant="subheading" className="mb-1">
         {title}
       </Type>
-      <Type small muted className="text-center mb-4 max-w-md">
+      <Type small muted className="mb-4 max-w-md text-center">
         {description}
       </Type>
       <Button variant="brand" asChild>

--- a/client/dashboard/src/components/environments/EnvironmentEntriesFormFields.tsx
+++ b/client/dashboard/src/components/environments/EnvironmentEntriesFormFields.tsx
@@ -166,10 +166,10 @@ function EnvironmentEntryInput({
   }
 
   return (
-    <div className="grid grid-cols-2 gap-4 items-center">
+    <div className="grid grid-cols-2 items-center gap-4">
       <label
         htmlFor={`env-${entry.varName}`}
-        className="text-sm font-medium text-foreground"
+        className="text-foreground text-sm font-medium"
       >
         {entry.varName}
       </label>
@@ -199,8 +199,8 @@ export function EnvironmentEntriesFormFields({
 }: EnvironmentEntriesFormFieldsProps) {
   if (relevantEnvVars.length === 0) {
     return (
-      <div className="text-center py-8">
-        <p className="text-sm text-muted-foreground">
+      <div className="py-8 text-center">
+        <p className="text-muted-foreground text-sm">
           No authentication required for this toolset
         </p>
       </div>

--- a/client/dashboard/src/components/environments/ToolsetEnvironmentForm.tsx
+++ b/client/dashboard/src/components/environments/ToolsetEnvironmentForm.tsx
@@ -40,14 +40,14 @@ function ActionBar({
     <div className="flex items-center justify-between pt-4">
       {error && (
         <div
-          className="flex items-center gap-2 text-sm text-destructive"
+          className="text-destructive flex items-center gap-2 text-sm"
           role="alert"
         >
           <AlertCircle className="h-4 w-4" aria-hidden="true" />
           {error}
         </div>
       )}
-      <div className="flex items-center gap-3 ml-auto">
+      <div className="ml-auto flex items-center gap-3">
         <Button
           type="button"
           variant="tertiary"
@@ -118,16 +118,16 @@ export function ToolsetEnvironmentForm({
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h2 className="text-heading-xs">Environment Variables</h2>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Configure required API credentials for this toolset to use in the
             Gram dashboard
           </p>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             View the MCP page for options on how to provide relevant credentials
             to an MCP server
           </p>
         </div>
-        <div className="flex-shrink-0 flex items-center gap-2">
+        <div className="flex flex-shrink-0 items-center gap-2">
           <EnvironmentSelector
             selectedEnvironment={
               attachedEnvForm.selectedEnvironment?.slug ?? ""
@@ -143,7 +143,7 @@ export function ToolsetEnvironmentForm({
               onClick={() => attachedEnvForm.onEnvironmentSelectorChange("")}
               aria-label="Clear environment"
             >
-              <X className="h-4 w-4 mr-1" aria-hidden="true" />
+              <X className="mr-1 h-4 w-4" aria-hidden="true" />
               Clear
             </Button>
           )}
@@ -151,8 +151,8 @@ export function ToolsetEnvironmentForm({
       </div>
 
       {!attachedEnvForm.selectedEnvironment && (
-        <div className="flex flex-col items-center justify-center py-12 px-4 border border-dashed rounded-lg">
-          <p className="text-sm text-muted-foreground mb-4">
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed px-4 py-12">
+          <p className="text-muted-foreground mb-4 text-sm">
             No currently attached environment. Choose one:
           </p>
           <div className="flex items-center gap-2">
@@ -170,7 +170,7 @@ export function ToolsetEnvironmentForm({
               onClick={() => routes.environments.goTo()}
               aria-label="Add new environment"
             >
-              <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+              <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
               Add New
             </Button>
           </div>
@@ -201,9 +201,9 @@ export function ToolsetEnvironmentForm({
       <Collapsible
         open={isAdvancedOpen}
         onOpenChange={setIsAdvancedOpen}
-        className="pt-4 border-t"
+        className="border-t pt-4"
       >
-        <CollapsibleTrigger className="flex items-center gap-2 text-sm font-medium hover:text-foreground transition-colors">
+        <CollapsibleTrigger className="hover:text-foreground flex items-center gap-2 text-sm font-medium transition-colors">
           <ChevronDown
             className={`h-4 w-4 transition-transform ${isAdvancedOpen ? "" : "-rotate-90"}`}
             aria-hidden="true"
@@ -212,7 +212,7 @@ export function ToolsetEnvironmentForm({
         </CollapsibleTrigger>
 
         <CollapsibleContent>
-          <div className="mt-4 p-4 border rounded-lg space-y-4">
+          <div className="mt-4 space-y-4 rounded-lg border p-4">
             <div className="flex items-center gap-2">
               <h3 className="text-base font-medium">
                 Attach Selected Environment
@@ -224,19 +224,19 @@ export function ToolsetEnvironmentForm({
               )}
             </div>
 
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               Attaching an environment at the toolset level will automatically
               apply these environment variables to all users of tools from this
               toolset. This can be useful when the toolset requires
               configuration that should remain hidden to users.
             </p>
 
-            <div className="flex items-start gap-2 px-4 py-3 bg-warning/10 border border-warning/20 rounded-md">
+            <div className="bg-warning/10 border-warning/20 flex items-start gap-2 rounded-md border px-4 py-3">
               <TriangleAlert
-                className="h-4 w-4 text-warning flex-shrink-0 mt-0.5"
+                className="text-warning mt-0.5 h-4 w-4 flex-shrink-0"
                 aria-hidden="true"
               />
-              <p className="text-sm text-warning">
+              <p className="text-warning text-sm">
                 Environments attached here will apply to all users in both
                 public and private servers
               </p>

--- a/client/dashboard/src/components/expandable.tsx
+++ b/client/dashboard/src/components/expandable.tsx
@@ -37,7 +37,7 @@ function ExpandableTrigger({
   return (
     <AccordionTrigger
       className={cn(
-        "text-base border-1 px-4 py-2 w-full [&[data-state=open]]:rounded-b-none items-center",
+        "w-full items-center border-1 px-4 py-2 text-base [&[data-state=open]]:rounded-b-none",
         className,
       )}
     >
@@ -56,7 +56,7 @@ function ExpandableContent({
   return (
     <AccordionContent
       className={cn(
-        "p-4 bg-background h-48 overflow-y-auto border-1 border-t-0 rounded-b-md",
+        "bg-background h-48 overflow-y-auto rounded-b-md border-1 border-t-0 p-4",
         className,
       )}
     >

--- a/client/dashboard/src/components/full-page-error.tsx
+++ b/client/dashboard/src/components/full-page-error.tsx
@@ -7,23 +7,23 @@ interface FullPageErrorProps {
 
 export function FullPageError({ error }: FullPageErrorProps) {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background p-8">
+    <main className="bg-background flex min-h-screen items-center justify-center p-8">
       <Stack gap={6} align="center" className="max-w-md text-center">
         <GramLogo variant="vertical" />
 
         <Stack gap={3} align="center">
           <Stack direction="horizontal" gap={2} align="center">
-            <Icon name="circle-alert" className="h-5 w-5 text-destructive" />
+            <Icon name="circle-alert" className="text-destructive h-5 w-5" />
             <h2 className="text-lg font-medium">Something went wrong</h2>
           </Stack>
 
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             An unexpected error occurred. Try reloading the page or contact
             support if the problem persists.
           </p>
 
-          <div className="w-full rounded-md bg-muted p-3">
-            <p className="text-xs font-mono text-muted-foreground break-all">
+          <div className="bg-muted w-full rounded-md p-3">
+            <p className="text-muted-foreground font-mono text-xs break-all">
               {error.message}
             </p>
           </div>

--- a/client/dashboard/src/components/functions/GettingStartedInstructions.tsx
+++ b/client/dashboard/src/components/functions/GettingStartedInstructions.tsx
@@ -23,8 +23,8 @@ export function GettingStartedInstructions() {
       {commands.map((item, index) => (
         <Stack key={index} gap={2}>
           <Stack direction="horizontal" gap={3} align="center">
-            <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center shrink-0">
-              <Type small className="font-medium text-muted-foreground">
+            <div className="bg-muted flex h-6 w-6 shrink-0 items-center justify-center rounded-full">
+              <Type small className="text-muted-foreground font-medium">
                 {index + 1}
               </Type>
             </div>
@@ -32,7 +32,7 @@ export function GettingStartedInstructions() {
           </Stack>
           <CodeBlock
             language="bash"
-            className="!border-0 !bg-muted/50 !rounded-lg"
+            className="!bg-muted/50 !rounded-lg !border-0"
           >
             {item.command}
           </CodeBlock>

--- a/client/dashboard/src/components/gram-logo/index.tsx
+++ b/client/dashboard/src/components/gram-logo/index.tsx
@@ -16,7 +16,7 @@ export const GramLogo = ({
     icon: GramIcon,
   };
   return (
-    <div className={cn("dark:invert flex items-center", className)}>
+    <div className={cn("flex items-center dark:invert", className)}>
       {variantsMap[variant]()}
     </div>
   );

--- a/client/dashboard/src/components/http-route.tsx
+++ b/client/dashboard/src/components/http-route.tsx
@@ -11,9 +11,9 @@ export const HttpRoute = ({
   className?: string;
 }) => {
   return (
-    <div className={cn("flex gap-2 font-mono items-start", className)}>
+    <div className={cn("flex items-start gap-2 font-mono", className)}>
       <HttpMethod method={method} />
-      <Type className="text-xs text-muted-foreground wrap-anywhere">
+      <Type className="text-muted-foreground text-xs wrap-anywhere">
         {path}
       </Type>
     </div>

--- a/client/dashboard/src/components/input-dialog.tsx
+++ b/client/dashboard/src/components/input-dialog.tsx
@@ -122,7 +122,7 @@ export function InputDialog({
                 />
               )}
               {input.hint && (
-                <div className="text-sm text-muted-foreground">
+                <div className="text-muted-foreground text-sm">
                   {typeof input.hint === "function"
                     ? input.hint(input.value)
                     : input.hint}

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -119,7 +119,7 @@ When the user asks about "current period", "selected period", "this timeframe", 
       <div className="flex h-full w-full">
         {/* Main content area - shrinks when sidebar opens */}
         <div
-          className="flex-1 min-w-0 transition-all duration-300 ease-in-out overflow-hidden"
+          className="min-w-0 flex-1 overflow-hidden transition-all duration-300 ease-in-out"
           style={{
             marginRight: isExpanded ? sidebarWidth : 0,
           }}
@@ -141,8 +141,8 @@ When the user asks about "current period", "selected period", "this timeframe", 
           <button
             onClick={() => setIsExpanded(!isExpanded)}
             className={cn(
-              "fixed right-0 top-1/2 -translate-y-1/2 z-40 flex items-center gap-1.5 bg-primary text-primary-foreground px-3 py-2.5 rounded-l-lg shadow-lg hover:bg-primary/90 transition-all duration-300 group",
-              isExpanded && "opacity-0 pointer-events-none",
+              "bg-primary text-primary-foreground hover:bg-primary/90 group fixed top-1/2 right-0 z-40 flex -translate-y-1/2 items-center gap-1.5 rounded-l-lg px-3 py-2.5 shadow-lg transition-all duration-300",
+              isExpanded && "pointer-events-none opacity-0",
             )}
             aria-label="Open AI Insights"
           >
@@ -154,20 +154,20 @@ When the user asks about "current period", "selected period", "this timeframe", 
         {/* Sidebar panel - fixed position that slides in */}
         <div
           className={cn(
-            "fixed right-0 top-0 bottom-0 z-30 flex flex-col bg-background border-l border-border shadow-xl transition-transform duration-300 ease-in-out",
+            "bg-background border-border fixed top-0 right-0 bottom-0 z-30 flex flex-col border-l shadow-xl transition-transform duration-300 ease-in-out",
             isExpanded ? "translate-x-0" : "translate-x-full",
           )}
           style={{ width: sidebarWidth }}
         >
           {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/30">
+          <div className="border-border bg-muted/30 flex items-center justify-between border-b px-4 py-3">
             <div className="flex items-center gap-2">
-              <Sparkles className="size-5 text-primary" />
+              <Sparkles className="text-primary size-5" />
               <span className="font-semibold">AI Insights</span>
             </div>
             <button
               onClick={() => setIsExpanded(false)}
-              className="p-1.5 rounded hover:bg-muted transition-colors"
+              className="hover:bg-muted rounded p-1.5 transition-colors"
               aria-label="Close AI Insights"
             >
               <ChevronRight className="size-5" />
@@ -176,11 +176,11 @@ When the user asks about "current period", "selected period", "this timeframe", 
 
           {/* Dev notice when MCP is not configured */}
           {devObservabilityMcpMissing && !("mcp" in mcpConfig) && (
-            <div className="mx-4 mt-3 flex items-start gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+            <div className="border-border bg-muted/50 text-muted-foreground mx-4 mt-3 flex items-start gap-2 rounded-md border px-3 py-2 text-xs">
               <Terminal className="mt-0.5 size-3.5 shrink-0" />
               <span>
                 AI tools are unavailable. Run{" "}
-                <code className="rounded bg-muted px-1 py-0.5 font-mono text-foreground">
+                <code className="bg-muted text-foreground rounded px-1 py-0.5 font-mono">
                   mise seed
                 </code>{" "}
                 to enable the observability MCP server.

--- a/client/dashboard/src/components/mcp/BuiltInMCPCard.tsx
+++ b/client/dashboard/src/components/mcp/BuiltInMCPCard.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@speakeasy-api/moonshine";
 import { Network, ScrollText } from "lucide-react";
 
 const BUILT_IN_ICONS: Record<string, React.ReactNode> = {
-  logs: <ScrollText className="w-8 h-8 text-muted-foreground" />,
+  logs: <ScrollText className="text-muted-foreground h-8 w-8" />,
 };
 
 interface BuiltInMCPCardProps {
@@ -27,16 +27,16 @@ export function BuiltInMCPCard({
       onClick={() => routes.mcp.builtIn.goTo(slug)}
       icon={
         BUILT_IN_ICONS[slug] ?? (
-          <Network className="w-8 h-8 text-muted-foreground" />
+          <Network className="text-muted-foreground h-8 w-8" />
         )
       }
     >
       {/* Header row with name and badge */}
-      <div className="flex items-start justify-between gap-2 mb-2">
+      <div className="mb-2 flex items-start justify-between gap-2">
         <Type
           variant="subheading"
           as="div"
-          className="truncate flex-1 text-md group-hover:text-primary transition-colors"
+          className="text-md group-hover:text-primary flex-1 truncate transition-colors"
           title={name}
         >
           {name}

--- a/client/dashboard/src/components/mcp/MCPCard.tsx
+++ b/client/dashboard/src/components/mcp/MCPCard.tsx
@@ -62,14 +62,14 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
         {toolset.mcpEnabled && (
           <span
             className={cn(
-              "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
+              "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
               status.pulseColor,
             )}
           />
         )}
         <span
           className={cn(
-            "relative inline-flex rounded-full h-2.5 w-2.5",
+            "relative inline-flex h-2.5 w-2.5 rounded-full",
             status.color,
           )}
         />
@@ -89,19 +89,19 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
           <img
             src={externalMcpInfo.logoUrl}
             alt={toolset.name}
-            className="w-12 h-12 object-contain"
+            className="h-12 w-12 object-contain"
           />
         ) : (
-          <Network className="w-8 h-8 text-muted-foreground" />
+          <Network className="text-muted-foreground h-8 w-8" />
         )
       }
     >
       {/* Header row with name */}
-      <div className="flex items-start justify-between gap-2 mb-2">
+      <div className="mb-2 flex items-start justify-between gap-2">
         <Type
           variant="subheading"
           as="div"
-          className="truncate flex-1 text-md group-hover:text-primary transition-colors"
+          className="text-md group-hover:text-primary flex-1 truncate transition-colors"
           title={toolset.name}
         >
           {toolset.name}
@@ -120,11 +120,11 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
       </div>
 
       {/* Footer row with status indicator and open link */}
-      <div className="flex items-center justify-between gap-2 mt-auto pt-2">
+      <div className="mt-auto flex items-center justify-between gap-2 pt-2">
         {statusIndicator}
-        <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+        <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
           <span>Open</span>
-          <ArrowRight className="w-3.5 h-3.5" />
+          <ArrowRight className="h-3.5 w-3.5" />
         </div>
       </div>
     </DotCard>
@@ -134,16 +134,16 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
 export function MCPCardSkeleton() {
   return (
     <DotCard>
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="h-5 w-2/3 bg-muted rounded animate-pulse" />
-        <div className="h-5 w-10 bg-muted rounded-full animate-pulse" />
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <div className="bg-muted h-5 w-2/3 animate-pulse rounded" />
+        <div className="bg-muted h-5 w-10 animate-pulse rounded-full" />
       </div>
-      <div className="flex items-center justify-between gap-2 mt-auto pt-2">
+      <div className="mt-auto flex items-center justify-between gap-2 pt-2">
         <div className="flex items-center gap-2">
-          <div className="h-2.5 w-2.5 rounded-full bg-muted animate-pulse" />
-          <div className="h-3.5 w-12 bg-muted rounded animate-pulse" />
+          <div className="bg-muted h-2.5 w-2.5 animate-pulse rounded-full" />
+          <div className="bg-muted h-3.5 w-12 animate-pulse rounded" />
         </div>
-        <div className="h-3.5 w-10 bg-muted rounded animate-pulse" />
+        <div className="bg-muted h-3.5 w-10 animate-pulse rounded" />
       </div>
     </DotCard>
   );

--- a/client/dashboard/src/components/mcp/MCPTableRow.tsx
+++ b/client/dashboard/src/components/mcp/MCPTableRow.tsx
@@ -58,10 +58,10 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
           <img
             src={externalMcpInfo.logoUrl}
             alt={toolset.name}
-            className="w-6 h-6 object-contain"
+            className="h-6 w-6 object-contain"
           />
         ) : (
-          <Network className="w-5 h-5 text-muted-foreground" />
+          <Network className="text-muted-foreground h-5 w-5" />
         )
       }
     >
@@ -70,7 +70,7 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
         <Type
           variant="subheading"
           as="div"
-          className="truncate text-sm group-hover:text-primary transition-colors"
+          className="group-hover:text-primary truncate text-sm transition-colors"
           title={toolset.name}
         >
           {toolset.name}
@@ -84,14 +84,14 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
             {toolset.mcpEnabled && (
               <span
                 className={cn(
-                  "animate-ping absolute inline-flex h-full w-full rounded-full opacity-75",
+                  "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
                   status.pulseColor,
                 )}
               />
             )}
             <span
               className={cn(
-                "relative inline-flex rounded-full h-2 w-2",
+                "relative inline-flex h-2 w-2 rounded-full",
                 status.color,
               )}
             />
@@ -103,7 +103,7 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
       </td>
 
       {/* URL */}
-      <td className="px-3 py-3 max-w-xs">
+      <td className="max-w-xs px-3 py-3">
         {mcpUrl ? (
           <div className="flex items-center gap-1.5">
             <Type small muted className="truncate">
@@ -135,19 +135,19 @@ export function MCPTableRowSkeleton() {
   return (
     <DotRow>
       <td className="px-3 py-3">
-        <div className="h-4 w-2/3 bg-muted rounded animate-pulse" />
+        <div className="bg-muted h-4 w-2/3 animate-pulse rounded" />
       </td>
       <td className="px-3 py-3">
         <div className="flex items-center gap-2">
-          <div className="h-2 w-2 rounded-full bg-muted animate-pulse" />
-          <div className="h-3.5 w-12 bg-muted rounded animate-pulse" />
+          <div className="bg-muted h-2 w-2 animate-pulse rounded-full" />
+          <div className="bg-muted h-3.5 w-12 animate-pulse rounded" />
         </div>
       </td>
       <td className="px-3 py-3">
-        <div className="h-3.5 w-40 bg-muted rounded animate-pulse" />
+        <div className="bg-muted h-3.5 w-40 animate-pulse rounded" />
       </td>
       <td className="px-3 py-3">
-        <div className="h-5 w-10 bg-muted rounded-full animate-pulse" />
+        <div className="bg-muted h-5 w-10 animate-pulse rounded-full" />
       </td>
     </DotRow>
   );

--- a/client/dashboard/src/components/mcp_install_page/config_form.tsx
+++ b/client/dashboard/src/components/mcp_install_page/config_form.tsx
@@ -273,7 +273,7 @@ export function useMcpMetadataMetadataForm(
         metadataParams.logoAssetId ? (
           <AssetImage
             assetId={metadataParams.logoAssetId}
-            className="w-16 h-16"
+            className="h-16 w-16"
           />
         ) : undefined,
     },
@@ -338,7 +338,7 @@ export function InstallPageConfigForm({
   }
 
   return (
-    <div className="flex items-center gap-2 rounded-lg border bg-muted/20 p-2">
+    <div className="bg-muted/20 flex items-center gap-2 rounded-lg border p-2">
       <CodeBlock
         className="flex-grow overflow-hidden"
         innerClassName="!p-2 !pr-10 !bg-white dark:!bg-zinc-950"
@@ -380,7 +380,7 @@ export function InstallPageConfigForm({
                 allowedExtensions={["png", "jpg", "jpeg"]}
                 onUpload={form.logoUploadHandlers.onUpload}
                 renderFilePreview={form.logoUploadHandlers.renderFilePreview}
-                className="w-full max-h-[200px]"
+                className="max-h-[200px] w-full"
               />
             </div>
             <div>
@@ -398,7 +398,7 @@ export function InstallPageConfigForm({
                 {...form.urlInputHandlers}
               />
               {form.valid.message && (
-                <span className="absolute -bottom-4 left-0 text-xs text-destructive">
+                <span className="text-destructive absolute -bottom-4 left-0 text-xs">
                   {form.valid.message}
                 </span>
               )}
@@ -417,7 +417,7 @@ export function InstallPageConfigForm({
                 {...form.docsTextInputHandlers}
               />
               {form.valid.message && (
-                <span className="absolute -bottom-4 left-0 text-xs text-destructive">
+                <span className="text-destructive absolute -bottom-4 left-0 text-xs">
                   {form.valid.message}
                 </span>
               )}
@@ -437,7 +437,7 @@ export function InstallPageConfigForm({
                 {...form.installationOverrideUrlInputHandlers}
               />
               {form.valid.message && (
-                <span className="absolute -bottom-4 left-0 text-xs text-destructive">
+                <span className="text-destructive absolute -bottom-4 left-0 text-xs">
                   {form.valid.message}
                 </span>
               )}
@@ -466,7 +466,7 @@ export function InstallPageConfigForm({
       <Link external to={installPageUrl} noIcon>
         <Button variant="primary" className="px-4">
           <Button.LeftIcon>
-            <Icon name="external-link" className="w-4 h-4" />
+            <Icon name="external-link" className="h-4 w-4" />
           </Button.LeftIcon>
           <Button.Text>View</Button.Text>
         </Button>

--- a/client/dashboard/src/components/monaco-editor.tsx
+++ b/client/dashboard/src/components/monaco-editor.tsx
@@ -118,7 +118,7 @@ export function MonacoEditor({
           wordWrap,
         }}
         loading={
-          <div className="flex items-center justify-center h-full">
+          <div className="flex h-full items-center justify-center">
             <div className="text-muted-foreground">Loading editor...</div>
           </div>
         }

--- a/client/dashboard/src/components/moon/any-field.tsx
+++ b/client/dashboard/src/components/moon/any-field.tsx
@@ -30,12 +30,12 @@ export function AnyField({
   const descriptors = `${hintId} ${errorId}`;
 
   return (
-    <div className="flex flex-col gap-2 group">
+    <div className="group flex flex-col gap-2">
       <Label
         htmlFor={id}
         className={cn(
           optionality === "visible"
-            ? "after:content-(--optional-label) after:inline-block after:text-sm after:text-muted-foreground after:ms-2 group-has-[[readonly],[disabled],[required]]:after:content-['']"
+            ? "after:text-muted-foreground after:ms-2 after:inline-block after:text-sm after:content-(--optional-label) group-has-[[readonly],[disabled],[required]]:after:content-['']"
             : null,
         )}
       >
@@ -45,13 +45,13 @@ export function AnyField({
       {hint ? (
         <p
           id={hintId}
-          className={cn("text-sm text-muted-foreground", error && "sr-only")}
+          className={cn("text-muted-foreground text-sm", error && "sr-only")}
         >
           {hint}
         </p>
       ) : null}
       {error ? (
-        <p id={errorId} className="text-sm text-destructive">
+        <p id={errorId} className="text-destructive text-sm">
           {error}
         </p>
       ) : null}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -60,7 +60,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     titleNode={
                       <span className="flex items-center gap-1.5">
                         Team
-                        <ExternalLink className="w-3 h-3 text-muted-foreground" />
+                        <ExternalLink className="text-muted-foreground h-3 w-3" />
                       </span>
                     }
                     href={externalTeamUrl}

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -20,8 +20,8 @@ function PageHeaderComponent({
         className,
       )}
     >
-      <div className="flex w-full items-center px-3 gap-3">
-        <SidebarTrigger className="-ml-1 mx-0 px-0" />
+      <div className="flex w-full items-center gap-3 px-3">
+        <SidebarTrigger className="mx-0 -ml-1 px-0" />
         <Separator
           orientation="vertical"
           className="data-[orientation=vertical]:h-4"
@@ -43,7 +43,7 @@ function PageHeaderTitle({
     // 1270 carefully chosen to make the header line up with the max width of the page content
     <Heading
       variant="h4"
-      className={cn("ml-1 max-w-[1270px] w-full mx-auto", className)}
+      className={cn("mx-auto ml-1 w-full max-w-[1270px]", className)}
     >
       {children}
     </Heading>

--- a/client/dashboard/src/components/page-layout.tsx
+++ b/client/dashboard/src/components/page-layout.tsx
@@ -15,7 +15,7 @@ import { XYFade } from "./ui/xy-fade.tsx";
 function PageLayout({ children }: { children: React.ReactNode }) {
   return (
     // The height calculation accounts for the page body "visual" gutter
-    <div className="h-[calc(100vh-16px)] flex flex-col overflow-hidden">
+    <div className="flex h-[calc(100vh-16px)] flex-col overflow-hidden">
       <ContentErrorBoundary>{children}</ContentErrorBoundary>
     </div>
   );
@@ -41,17 +41,17 @@ function PageBody({
     <div
       className={cn(
         "h-full w-full",
-        overflowHidden ? "overflow-hidden flex flex-col" : "overflow-y-auto",
+        overflowHidden ? "flex flex-col overflow-hidden" : "overflow-y-auto",
       )}
     >
       <div
         className={cn(
-          "@container/main flex flex-col gap-4 w-full",
+          "@container/main flex w-full flex-col gap-4",
           noPadding ? "p-0" : "p-8",
           !noPadding && "pb-24",
-          !fullWidth && "max-w-7xl mx-auto",
+          !fullWidth && "mx-auto max-w-7xl",
           fullHeight && "h-full",
-          overflowHidden && "flex-1 min-h-0",
+          overflowHidden && "min-h-0 flex-1",
           className,
         )}
       >
@@ -97,7 +97,7 @@ function PageSectionComponent({ children }: { children: PageSectionChild[] }) {
   });
 
   return (
-    <Stack gap={2} className="mb-6 mt-3">
+    <Stack gap={2} className="mt-3 mb-6">
       {/* Render header with title, description, and CTA if they exist */}
       {(slots.title || slots.description || slots.ctas.length > 0) && (
         <Stack
@@ -195,7 +195,7 @@ export function EmptyState({
   // For empty projects, show the onboarding choice cards
   if (isEmpty && !isLoading) {
     return (
-      <Stack gap={8} className="w-full max-w-xl m-8">
+      <Stack gap={8} className="m-8 w-full max-w-xl">
         <InitialChoiceStep
           routes={routes}
           isFunctionsEnabled={isFunctionsEnabled}
@@ -222,15 +222,15 @@ export function EmptyState({
   }
 
   return (
-    <div className="w-full h-[600px] flex items-center justify-center bg-background rounded-xl border">
+    <div className="bg-background flex h-[600px] w-full items-center justify-center rounded-xl border">
       <Stack
         gap={1}
-        className="w-full max-w-sm m-8"
+        className="m-8 w-full max-w-sm"
         align="center"
         justify="center"
       >
         <XYFade
-          className={cn("w-full h-[250px]", graphicClassName)}
+          className={cn("h-[250px] w-full", graphicClassName)}
           fadeColor="var(--background)"
         >
           {graphic}

--- a/client/dashboard/src/components/product-tier-badge.tsx
+++ b/client/dashboard/src/components/product-tier-badge.tsx
@@ -20,7 +20,7 @@ export const ProductTierBadge = ({
 
   return (
     <div
-      className={`w-fit text-xs text-muted-foreground px-1 py-0.5 rounded-sm ${classes.bg} ${classes.text}`}
+      className={`text-muted-foreground w-fit rounded-sm px-1 py-0.5 text-xs ${classes.bg} ${classes.text}`}
     >
       {name}
     </div>

--- a/client/dashboard/src/components/project-menu.tsx
+++ b/client/dashboard/src/components/project-menu.tsx
@@ -96,9 +96,9 @@ export function ProjectMenu() {
     <>
       <dl>
         <dt className="text-muted-foreground">Organization ID</dt>
-        <dd className="text-xs font-mono">{organization?.id}</dd>
+        <dd className="font-mono text-xs">{organization?.id}</dd>
         <dt className="text-muted-foreground">Project ID</dt>
-        <dd className="text-xs font-mono">{project?.id}</dd>
+        <dd className="font-mono text-xs">{project?.id}</dd>
       </dl>
       <Separator className="my-2" />
     </>
@@ -111,15 +111,15 @@ export function ProjectMenu() {
           variant="ghost"
           role="combobox"
           aria-expanded={open}
-          className="w-full justify-between h-12 p-2"
+          className="h-12 w-full justify-between p-2"
         >
           <Stack direction={"horizontal"} gap={3} align="center">
             <ProjectAvatar project={project} className="h-8 w-8 rounded-md" />
             <Stack align="start">
-              <Type className="normal-case -mb-1">
+              <Type className="-mb-1 normal-case">
                 {project?.slug ?? "Select Project"}
               </Type>
-              <Type variant="small" muted className="truncate max-w-[120px]">
+              <Type variant="small" muted className="max-w-[120px] truncate">
                 {organization?.name}
               </Type>
             </Stack>
@@ -134,7 +134,7 @@ export function ProjectMenu() {
             <Type variant="small" className="px-2">
               {organization?.name}
             </Type>
-            <Type muted variant="small" className="px-2 truncate">
+            <Type muted variant="small" className="truncate px-2">
               {session.user.email}
             </Type>
           </Stack>
@@ -213,7 +213,7 @@ export function ProjectSelector() {
     value: project.slug,
     label: project.slug,
     icon: (
-      <ProjectAvatar project={project} className="h-4 w-4 min-w-4 min-h-4" />
+      <ProjectAvatar project={project} className="h-4 min-h-4 w-4 min-w-4" />
     ),
   }));
 
@@ -259,10 +259,10 @@ export function ProjectSelector() {
         onSelectionChange={(value) => changeProject(value.value)}
         items={projectWithIcons ?? []}
       >
-        <div className="flex items-center gap-2 w-full">
+        <div className="flex w-full items-center gap-2">
           <ProjectAvatar
             project={selected}
-            className="h-4 w-4 min-w-4 min-h-4"
+            className="h-4 min-h-4 w-4 min-w-4"
           />
           <Type className="truncate" variant="small">
             {selected?.label}

--- a/client/dashboard/src/components/rbac-dev-toolbar.tsx
+++ b/client/dashboard/src/components/rbac-dev-toolbar.tsx
@@ -199,41 +199,41 @@ export function RBACDevToolbar() {
   ).length;
 
   return (
-    <div className="fixed bottom-4 right-4 z-[9999] select-none">
+    <div className="fixed right-4 bottom-4 z-[9999] select-none">
       <div className={`
           rounded-xl border shadow-2xl backdrop-blur-md transition-all duration-200
           ${collapsed ? "w-auto" : "w-80"}
-          ${state.enabled ? "bg-background/98 border-foreground/15 dark:bg-gray-950/98 dark:border-foreground/15" : "bg-white/98 border-border dark:bg-gray-950/98"}
+          ${state.enabled ? "bg-background/98 border-foreground/15 dark:border-foreground/15 dark:bg-gray-950/98" : "border-border bg-white/98 dark:bg-gray-950/98"}
         `}>
         {/* Header */}
         <button
           type="button"
           onClick={() => setCollapsed((c) => !c)}
           className={`
-            flex items-center gap-2.5 w-full px-3.5 py-2.5 transition-colors
+            flex w-full items-center gap-2.5 px-3.5 py-2.5 transition-colors
             ${collapsed ? "rounded-xl" : "rounded-t-xl"}
             hover:bg-black/[0.03] dark:hover:bg-white/[0.03]
           `}
         >
           <div className={`
-              flex items-center justify-center w-6 h-6 rounded-md
+              flex h-6 w-6 items-center justify-center rounded-md
               ${state.enabled ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}
             `}>
-            <Shield className="w-3.5 h-3.5" />
+            <Shield className="h-3.5 w-3.5" />
           </div>
-          <span className="text-xs font-semibold tracking-wide text-foreground">
+          <span className="text-foreground text-xs font-semibold tracking-wide">
             RBAC Dev Tools
           </span>
           {state.enabled && (
-            <span className="text-[10px] font-mono tabular-nums text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+            <span className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums">
               {activeCount}/{SCOPE_DEFS.length}
             </span>
           )}
-          <div className="ml-auto text-muted-foreground">
+          <div className="text-muted-foreground ml-auto">
             {collapsed ? (
-              <ChevronUp className="w-3.5 h-3.5" />
+              <ChevronUp className="h-3.5 w-3.5" />
             ) : (
-              <ChevronDown className="w-3.5 h-3.5" />
+              <ChevronDown className="h-3.5 w-3.5" />
             )}
           </div>
         </button>
@@ -242,12 +242,12 @@ export function RBACDevToolbar() {
         {!collapsed && (
           <div className="border-t border-inherit">
             {/* Master toggle */}
-            <div className="flex items-center justify-between px-3.5 py-2.5 border-b border-inherit">
+            <div className="flex items-center justify-between border-b border-inherit px-3.5 py-2.5">
               <div className="flex items-center gap-2">
                 <div
-                  className={`w-1.5 h-1.5 rounded-full ${state.enabled ? "bg-emerald-500 animate-pulse" : "bg-muted-foreground/30"}`}
+                  className={`h-1.5 w-1.5 rounded-full ${state.enabled ? "animate-pulse bg-emerald-500" : "bg-muted-foreground/30"}`}
                 />
-                <span className="text-xs font-medium text-foreground">
+                <span className="text-foreground text-xs font-medium">
                   {state.enabled ? "Override active" : "Override disabled"}
                 </span>
               </div>
@@ -260,7 +260,7 @@ export function RBACDevToolbar() {
 
             {/* Scope groups */}
             <div
-              className={`px-2 py-2 space-y-1 max-h-[400px] overflow-y-auto ${!state.enabled ? "opacity-40 pointer-events-none" : ""}`}
+              className={`max-h-[400px] space-y-1 overflow-y-auto px-2 py-2 ${!state.enabled ? "pointer-events-none opacity-40" : ""}`}
             >
               {GROUP_ORDER.map((group) => {
                 const scopes = SCOPE_DEFS.filter(
@@ -269,7 +269,7 @@ export function RBACDevToolbar() {
                 return (
                   <div key={group.key}>
                     <div className="px-2 pt-1.5 pb-1">
-                      <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                      <span className="text-muted-foreground text-[10px] font-semibold tracking-widest uppercase">
                         {group.label}
                       </span>
                     </div>
@@ -294,17 +294,17 @@ export function RBACDevToolbar() {
                       return (
                         <div key={def.scope}>
                           <div className={`
-                              flex items-center gap-2 px-2 py-1.5 rounded-lg cursor-pointer transition-colors
+                              flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 transition-colors
                               ${scopeState.enabled ? "hover:bg-black/[0.04] dark:hover:bg-white/[0.04]" : ""}
                             `} onClick={() => toggleScope(def.scope)}>
                             <div className={`
-                                w-3.5 h-3.5 rounded border-[1.5px] flex items-center justify-center transition-all text-[9px]
+                                flex h-3.5 w-3.5 items-center justify-center rounded border-[1.5px] text-[9px] transition-all
                                 ${scopeState.enabled ? "bg-foreground border-foreground text-background" : "border-muted-foreground/30 bg-transparent"}
                               `}>{scopeState.enabled && "✓"}</div>
-                            <div className="flex-1 min-w-0">
+                            <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-1.5">
                                 <span
-                                  className={`text-xs font-mono font-medium ${
+                                  className={`font-mono text-xs font-medium ${
                                     scopeState.enabled
                                       ? "text-foreground"
                                       : "text-muted-foreground line-through"
@@ -313,7 +313,7 @@ export function RBACDevToolbar() {
                                   {def.label}
                                 </span>
                                 {isRestricted && scopeState.enabled && (
-                                  <span className="text-[9px] px-1 py-px rounded bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400 font-medium">
+                                  <span className="rounded bg-blue-100 px-1 py-px text-[9px] font-medium text-blue-600 dark:bg-blue-900/50 dark:text-blue-400">
                                     scoped
                                   </span>
                                 )}
@@ -323,7 +323,7 @@ export function RBACDevToolbar() {
                               def.resourceType !== "org" && (
                                 <button
                                   type="button"
-                                  className="p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 text-muted-foreground"
+                                  className="text-muted-foreground rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10"
                                   onClick={(e) => {
                                     e.stopPropagation();
                                     setExpandedScope(
@@ -332,9 +332,9 @@ export function RBACDevToolbar() {
                                   }}
                                 >
                                   {isExpanded ? (
-                                    <ChevronUp className="w-3 h-3" />
+                                    <ChevronUp className="h-3 w-3" />
                                   ) : (
-                                    <ChevronDown className="w-3 h-3" />
+                                    <ChevronDown className="h-3 w-3" />
                                   )}
                                 </button>
                               )}
@@ -360,13 +360,13 @@ export function RBACDevToolbar() {
             </div>
 
             {/* Footer */}
-            <div className="border-t border-inherit px-3.5 py-2 flex items-center justify-between">
-              <span className="text-[10px] text-muted-foreground">
+            <div className="flex items-center justify-between border-t border-inherit px-3.5 py-2">
+              <span className="text-muted-foreground text-[10px]">
                 local only
               </span>
               <button
                 type="button"
-                className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                className="text-muted-foreground hover:text-foreground text-[10px] transition-colors"
                 onClick={() => {
                   setState({
                     enabled: false,
@@ -421,9 +421,9 @@ function ResourcePicker({
   };
 
   return (
-    <div className="ml-7 mr-2 mb-1.5 rounded-lg border border-dashed border-border bg-muted/30 p-2 space-y-1.5">
+    <div className="border-border bg-muted/30 mr-2 mb-1.5 ml-7 space-y-1.5 rounded-lg border border-dashed p-2">
       <div className="flex items-center justify-between">
-        <span className="text-[10px] font-medium text-muted-foreground">
+        <span className="text-muted-foreground text-[10px] font-medium">
           Resources
         </span>
         <button
@@ -445,27 +445,27 @@ function ResourcePicker({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="filter…"
-          className="w-full text-[11px] font-mono bg-background border border-border rounded px-1.5 py-0.5 text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-foreground/30"
+          className="bg-background border-border text-foreground placeholder:text-muted-foreground/50 focus:border-foreground/30 w-full rounded border px-1.5 py-0.5 font-mono text-[11px] outline-none"
         />
       )}
 
       {/* Resource list */}
-      <div className="max-h-[140px] overflow-y-auto space-y-0.5">
+      <div className="max-h-[140px] space-y-0.5 overflow-y-auto">
         {suggestions.map((r) => {
           const isChecked = alreadySelected.has(r.id);
           return (
             <button
               key={r.id}
               type="button"
-              className={`w-full text-left px-1.5 py-0.5 rounded hover:bg-muted/50 transition-colors flex items-center gap-1.5 ${isChecked ? "bg-muted/30" : ""}`}
+              className={`hover:bg-muted/50 flex w-full items-center gap-1.5 rounded px-1.5 py-0.5 text-left transition-colors ${isChecked ? "bg-muted/30" : ""}`}
               onClick={() => toggleResource(r.id)}
             >
               <div
-                className={`w-3 h-3 shrink-0 rounded-sm border flex items-center justify-center text-[8px] transition-all ${isChecked ? "bg-foreground border-foreground text-background" : "border-muted-foreground/30"}`}
+                className={`flex h-3 w-3 shrink-0 items-center justify-center rounded-sm border text-[8px] transition-all ${isChecked ? "bg-foreground border-foreground text-background" : "border-muted-foreground/30"}`}
               >
                 {isChecked && "✓"}
               </div>
-              <span className="text-[11px] font-mono text-foreground truncate">
+              <span className="text-foreground truncate font-mono text-[11px]">
                 {r.label}
               </span>
             </button>

--- a/client/dashboard/src/components/require-scope.tsx
+++ b/client/dashboard/src/components/require-scope.tsx
@@ -52,7 +52,7 @@ export function RequireScope(props: RequireScopeProps) {
     if (level === "section") return null;
     // For component-level, show disabled state while loading
     return (
-      <div className="opacity-50 pointer-events-none select-none">
+      <div className="pointer-events-none opacity-50 select-none">
         {children}
       </div>
     );
@@ -88,7 +88,7 @@ function ScopeDisabled({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="opacity-50 pointer-events-none select-none cursor-not-allowed inline-flex">
+          <div className="pointer-events-none inline-flex cursor-not-allowed opacity-50 select-none">
             {/* Wrapper div that re-enables pointer events for the tooltip to work */}
             <div
               className="pointer-events-auto"
@@ -118,13 +118,13 @@ export function Unauthorized({
   description?: string;
 }) {
   return (
-    <div className="flex items-center justify-center h-full w-full min-h-[400px]">
-      <div className="flex flex-col items-center gap-3 max-w-sm text-center">
-        <div className="flex items-center justify-center w-12 h-12 rounded-full bg-muted">
-          <Icon name="lock" className="h-5 w-5 text-muted-foreground" />
+    <div className="flex h-full min-h-[400px] w-full items-center justify-center">
+      <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+        <div className="bg-muted flex h-12 w-12 items-center justify-center rounded-full">
+          <Icon name="lock" className="text-muted-foreground h-5 w-5" />
         </div>
         <h2 className="text-lg font-medium">{title}</h2>
-        <p className="text-sm text-muted-foreground">{description}</p>
+        <p className="text-muted-foreground text-sm">{description}</p>
       </div>
     </div>
   );

--- a/client/dashboard/src/components/server-card.tsx
+++ b/client/dashboard/src/components/server-card.tsx
@@ -135,20 +135,20 @@ export function ServerCard({
     <Badge
       variant="outline"
       size="sm"
-      className="cursor-pointer hover:bg-green-50 transition-colors flex items-center gap-1 uppercase font-mono"
+      className="flex cursor-pointer items-center gap-1 font-mono uppercase transition-colors hover:bg-green-50"
       onClick={(e) => e.stopPropagation()}
     >
-      <CheckCircleIcon className="w-3 h-3 text-green-500" />
+      <CheckCircleIcon className="h-3 w-3 text-green-500" />
       Public
     </Badge>
   ) : (
     <Badge
       variant="outline"
       size="sm"
-      className="cursor-pointer hover:bg-muted/50 transition-colors flex items-center gap-1 uppercase font-mono"
+      className="hover:bg-muted/50 flex cursor-pointer items-center gap-1 font-mono uppercase transition-colors"
       onClick={(e) => e.stopPropagation()}
     >
-      <LockIcon className="w-3 h-3 text-muted-foreground" />
+      <LockIcon className="text-muted-foreground h-3 w-3" />
       Private
     </Badge>
   );
@@ -158,10 +158,10 @@ export function ServerCard({
       <Badge
         variant="outline"
         size="sm"
-        className="cursor-pointer hover:bg-muted/50 transition-colors flex items-center gap-1 uppercase font-mono text-muted-foreground"
+        className="hover:bg-muted/50 text-muted-foreground flex cursor-pointer items-center gap-1 font-mono uppercase transition-colors"
         onClick={(e) => e.stopPropagation()}
       >
-        <XCircleIcon className="w-3 h-3 text-muted-foreground" />
+        <XCircleIcon className="text-muted-foreground h-3 w-3" />
         Disabled
       </Badge>
     );
@@ -171,12 +171,12 @@ export function ServerCard({
     (tool) => tool.type === ToolEntryType.Externalmcp,
   );
   const externalMcpBadge = isExternalMcp ? (
-    <ExternalMcpIcon className="text-neutral-600 size-5" />
+    <ExternalMcpIcon className="size-5 text-neutral-600" />
   ) : null;
 
   return (
     <Card
-      className={cn(className, "group transition-colors hover:bg-muted/50")}
+      className={cn(className, "group hover:bg-muted/50 transition-colors")}
     >
       <Card.Header
         className="cursor-pointer items-start"
@@ -184,7 +184,7 @@ export function ServerCard({
       >
         <div className="flex flex-col gap-1">
           <Card.Title className="text-base">
-            <div className="flex items-center gap-1 group">
+            <div className="group flex items-center gap-1">
               {externalMcpBadge}
               {toolset.name}
               <CopyButton
@@ -221,7 +221,7 @@ export function ServerCard({
                   <div className="flex items-center justify-between">
                     <div>
                       <h4 className="text-base font-normal">Server Enabled</h4>
-                      <p className="text-xs text-muted-foreground">
+                      <p className="text-muted-foreground text-xs">
                         {toolset.mcpEnabled
                           ? "Server is active, can receive requests"
                           : "Server is disabled, cannot receive requests"}
@@ -248,7 +248,7 @@ export function ServerCard({
                           <h4 className="text-base font-normal">
                             Server Privacy
                           </h4>
-                          <p className="text-xs text-muted-foreground">
+                          <p className="text-muted-foreground text-xs">
                             {toolset.mcpIsPublic
                               ? "Publicly accessible and installable"
                               : "Private, only accessible to you"}
@@ -269,11 +269,11 @@ export function ServerCard({
                       {/* MCP URL Section */}
                       {mcpUrl && (
                         <div className="space-y-2">
-                          <label className="text-xs text-muted-foreground">
+                          <label className="text-muted-foreground text-xs">
                             MCP URL
                           </label>
                           <div className="flex items-center gap-3">
-                            <code className="flex-1 text-xs bg-muted/50 px-2 py-1 rounded border text-muted-foreground font-mono overflow-x-auto whitespace-nowrap min-w-0">
+                            <code className="bg-muted/50 text-muted-foreground min-w-0 flex-1 overflow-x-auto rounded border px-2 py-1 font-mono text-xs whitespace-nowrap">
                               {mcpUrl}
                             </code>
                             <div className="flex-shrink-0">
@@ -285,12 +285,12 @@ export function ServerCard({
 
                       {/* Install URL Section */}
                       <div className="space-y-2">
-                        <label className="text-xs text-muted-foreground">
+                        <label className="text-muted-foreground text-xs">
                           Install Page
                         </label>
                         {installPageUrl ? (
                           <div className="flex items-center gap-3">
-                            <code className="flex-1 text-xs bg-muted/50 px-2 py-1 rounded border text-muted-foreground font-mono overflow-x-auto whitespace-nowrap min-w-0">
+                            <code className="bg-muted/50 text-muted-foreground min-w-0 flex-1 overflow-x-auto rounded border px-2 py-1 font-mono text-xs whitespace-nowrap">
                               {installPageUrl}
                             </code>
                             <div className="flex-shrink-0">
@@ -302,7 +302,7 @@ export function ServerCard({
                           </div>
                         ) : (
                           <div className="flex items-center gap-3">
-                            <code className="flex-1 text-xs bg-muted/30 px-2 py-1 rounded border border-dashed text-muted-foreground font-mono">
+                            <code className="bg-muted/30 text-muted-foreground flex-1 rounded border border-dashed px-2 py-1 font-mono text-xs">
                               No install page available
                             </code>
                           </div>
@@ -344,9 +344,9 @@ export function ServerCard({
             <Badge
               variant="outline"
               size="sm"
-              className="cursor-pointer hover:bg-muted/50 transition-colors flex items-center gap-1 uppercase font-mono"
+              className="hover:bg-muted/50 flex cursor-pointer items-center gap-1 font-mono uppercase transition-colors"
             >
-              <MessageCircleIcon className="w-3 h-3" />
+              <MessageCircleIcon className="h-3 w-3" />
               Test
             </Badge>
           </div>
@@ -367,9 +367,9 @@ export function ServerCard({
               <Badge
                 variant="outline"
                 size="sm"
-                className="cursor-pointer hover:bg-muted/50 transition-colors flex items-center gap-1 uppercase font-mono"
+                className="hover:bg-muted/50 flex cursor-pointer items-center gap-1 font-mono uppercase transition-colors"
               >
-                <ExternalLinkIcon className="w-3 h-3" />
+                <ExternalLinkIcon className="h-3 w-3" />
                 Install
               </Badge>
             </div>

--- a/client/dashboard/src/components/server-enable-dialog.tsx
+++ b/client/dashboard/src/components/server-enable-dialog.tsx
@@ -49,7 +49,7 @@ export function ServerEnableDialog({
       <Dialog.Content className="max-w-md">
         <Dialog.Header>
           <Dialog.Title className="flex items-center gap-2">
-            <Server className="w-5 h-5" />
+            <Server className="h-5 w-5" />
             {currentlyEnabled ? "Disable" : "Enable"} MCP Server
           </Dialog.Title>
         </Dialog.Header>
@@ -75,7 +75,7 @@ export function ServerEnableDialog({
           </Button>
           {!canEnable ? (
             <Button onClick={handleUpgrade} className="gap-2">
-              <CreditCard className="w-4 h-4" />
+              <CreditCard className="h-4 w-4" />
               Upgrade Plan
             </Button>
           ) : (

--- a/client/dashboard/src/components/sources/ExternalMCPServerCard.tsx
+++ b/client/dashboard/src/components/sources/ExternalMCPServerCard.tsx
@@ -13,12 +13,12 @@ export function ExternalMCPServerCard({ toolset }: ExternalMCPServerCardProps) {
   const routes = useRoutes();
 
   return (
-    <div className="rounded-lg border bg-card p-6">
-      <Type as="h2" className="text-lg font-semibold mb-4">
+    <div className="bg-card rounded-lg border p-6">
+      <Type as="h2" className="mb-4 text-lg font-semibold">
         MCP Server
       </Type>
 
-      <Type className="text-sm text-muted-foreground mb-4">
+      <Type className="text-muted-foreground mb-4 text-sm">
         This external MCP source is exposed through a single MCP server. Changes
         to the source will be reflected in this server.
       </Type>
@@ -26,24 +26,24 @@ export function ExternalMCPServerCard({ toolset }: ExternalMCPServerCardProps) {
       {/* MCP Server Card - Clickable */}
       <routes.mcp.details.Link
         params={[toolset.slug]}
-        className="block rounded-md border  hover:bg-surface-secondary transition-colors cursor-pointer hover:no-underline"
+        className="hover:bg-surface-secondary block cursor-pointer  rounded-md border transition-colors hover:no-underline"
       >
         <div className="p-4">
           {/* Header Section */}
-          <div className="flex justify-between gap-3 items-center">
+          <div className="flex items-center justify-between gap-3">
             <div className="flex-1">
-              <div className="flex items-center gap-2 mb-1">
-                <Type className="font-semibold text-base">{toolset.name}</Type>
+              <div className="mb-1 flex items-center gap-2">
+                <Type className="text-base font-semibold">{toolset.name}</Type>
                 <McpEnabledBadge enabled={!!toolset.mcpEnabled} />
                 <McpPublicBadge isPublic={!!toolset.mcpIsPublic} />
               </div>
               {toolset.description && (
-                <Type className="text-sm text-muted-foreground">
+                <Type className="text-muted-foreground text-sm">
                   {toolset.description}
                 </Type>
               )}
             </div>
-            <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
+            <ChevronRight className="text-muted-foreground h-5 w-5 shrink-0" />
           </div>
         </div>
       </routes.mcp.details.Link>
@@ -53,12 +53,12 @@ export function ExternalMCPServerCard({ toolset }: ExternalMCPServerCardProps) {
 
 export function ExternalMCPServerCardLoading() {
   return (
-    <div className="rounded-lg border bg-card p-6">
-      <Type as="h2" className="text-lg font-semibold mb-4">
+    <div className="bg-card rounded-lg border p-6">
+      <Type as="h2" className="mb-4 text-lg font-semibold">
         MCP Server
       </Type>
-      <div className="text-center py-8 text-muted-foreground">
-        <Server className="h-12 w-12 mx-auto mb-3 opacity-50 animate-pulse" />
+      <div className="text-muted-foreground py-8 text-center">
+        <Server className="mx-auto mb-3 h-12 w-12 animate-pulse opacity-50" />
         <Type>Loading MCP server information...</Type>
       </div>
     </div>

--- a/client/dashboard/src/components/sources/ImportMCPTabContent.tsx
+++ b/client/dashboard/src/components/sources/ImportMCPTabContent.tsx
@@ -34,9 +34,9 @@ function MCPServerCard({
       type="button"
       onClick={() => onImport(server)}
       disabled={isImporting}
-      className="flex items-start gap-3 rounded-lg border border-border bg-card p-4 hover:border-border-hover transition-colors cursor-pointer text-left w-full disabled:opacity-50 disabled:cursor-not-allowed"
+      className="border-border bg-card hover:border-border-hover flex w-full cursor-pointer items-start gap-3 rounded-lg border p-4 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50"
     >
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
+      <div className="bg-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-md">
         {server.iconUrl ? (
           <img
             src={server.iconUrl}
@@ -44,22 +44,22 @@ function MCPServerCard({
             className="h-6 w-6 rounded"
           />
         ) : (
-          <ServerIcon className="h-5 w-5 text-muted-foreground" />
+          <ServerIcon className="text-muted-foreground h-5 w-5" />
         )}
       </div>
-      <div className="flex-1 min-w-0">
-        <h3 className="font-medium text-foreground truncate">
+      <div className="min-w-0 flex-1">
+        <h3 className="text-foreground truncate font-medium">
           {server.title ?? server.registrySpecifier}
         </h3>
-        <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+        <p className="text-muted-foreground mt-1 line-clamp-2 text-sm">
           {server.description}
         </p>
-        <p className="text-xs text-muted-foreground/70 mt-2">
+        <p className="text-muted-foreground/70 mt-2 text-xs">
           {server.registrySpecifier} v{server.version}
         </p>
       </div>
       {isImporting && (
-        <Loader2Icon className="h-4 w-4 animate-spin text-muted-foreground" />
+        <Loader2Icon className="text-muted-foreground h-4 w-4 animate-spin" />
       )}
     </button>
   );
@@ -67,9 +67,9 @@ function MCPServerCard({
 
 function MCPServerCardSkeleton() {
   return (
-    <div className="flex items-start gap-3 rounded-lg border border-border bg-card p-4">
+    <div className="border-border bg-card flex items-start gap-3 rounded-lg border p-4">
       <Skeleton className="h-10 w-10 shrink-0 rounded-md" />
-      <div className="flex-1 min-w-0 space-y-2">
+      <div className="min-w-0 flex-1 space-y-2">
         <Skeleton className="h-4 w-[150px]" />
         <Skeleton className="h-4 w-full" />
         <Skeleton className="h-3 w-[100px]" />
@@ -146,7 +146,7 @@ export default function ImportMCPTabContent({
   return (
     <div className="flex flex-col gap-4 p-4">
       <div className="relative">
-        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-500" />
+        <SearchIcon className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-neutral-500" />
         <Input
           type="text"
           placeholder="Search MCP servers..."
@@ -165,23 +165,23 @@ export default function ImportMCPTabContent({
       )}
 
       {error && (
-        <div className="rounded-lg border border-destructive bg-destructive/10 p-4 text-destructive">
+        <div className="border-destructive bg-destructive/10 text-destructive rounded-lg border p-4">
           Failed to load MCP catalog: {error.message}
         </div>
       )}
 
       {data && data.servers.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
-          <ServerIcon className="h-12 w-12 mb-4" />
+        <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
+          <ServerIcon className="mb-4 h-12 w-12" />
           <p>No MCP servers found</p>
           {debouncedSearch && (
-            <p className="text-sm mt-1">Try a different search term</p>
+            <p className="mt-1 text-sm">Try a different search term</p>
           )}
         </div>
       )}
 
       {data && data.servers.length > 0 && (
-        <div className="grid gap-3 max-h-[400px] overflow-y-auto">
+        <div className="grid max-h-[400px] gap-3 overflow-y-auto">
           {data.servers.map((server) => {
             const serverKey = `${server.registryId}-${server.registrySpecifier}`;
             return (

--- a/client/dashboard/src/components/sources/SourceCard.tsx
+++ b/client/dashboard/src/components/sources/SourceCard.tsx
@@ -103,14 +103,14 @@ export function SourceCard({
         <img
           src={asset.iconUrl}
           alt={asset.name}
-          className="w-12 h-12 object-contain"
+          className="h-12 w-12 object-contain"
         />
       );
     }
     if (asset.type === "externalmcp") {
-      return <Network className="w-8 h-8 text-muted-foreground" />;
+      return <Network className="text-muted-foreground h-8 w-8" />;
     }
-    return <FileCode className="w-8 h-8 text-muted-foreground" />;
+    return <FileCode className="text-muted-foreground h-8 w-8" />;
   })();
 
   return (
@@ -121,16 +121,16 @@ export function SourceCard({
     >
       <DotCard icon={iconContent}>
         {/* Header row with name and actions */}
-        <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="mb-2 flex items-start justify-between gap-2">
           <Type
             variant="subheading"
             as="div"
-            className="truncate flex-1 text-md group-hover:text-primary transition-colors"
+            className="text-md group-hover:text-primary flex-1 truncate transition-colors"
             title={displayName}
           >
             {displayName}
           </Type>
-          <div className="flex items-center gap-1 shrink-0">
+          <div className="flex shrink-0 items-center gap-1">
             {causingFailure && <AssetIsCausingFailureNotice />}
             <div onClick={(e) => e.stopPropagation()}>
               <MoreActions actions={actions} />
@@ -139,11 +139,11 @@ export function SourceCard({
         </div>
 
         {/* Footer row with type badge and open link */}
-        <div className="flex items-center justify-between gap-2 mt-auto pt-2">
+        <div className="mt-auto flex items-center justify-between gap-2 pt-2">
           <Badge variant="neutral">{config.label}</Badge>
-          <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+          <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
             <span>Open</span>
-            <ArrowRight className="w-3.5 h-3.5" />
+            <ArrowRight className="h-3.5 w-3.5" />
           </div>
         </div>
       </DotCard>
@@ -153,19 +153,19 @@ export function SourceCard({
 
 export function SourceCardSkeleton() {
   return (
-    <div className="bg-card text-card-foreground flex flex-row rounded-xl border overflow-hidden">
+    <div className="bg-card text-card-foreground flex flex-row overflow-hidden rounded-xl border">
       {/* Dot pattern sidebar placeholder */}
-      <div className="w-40 shrink-0 bg-muted/50 animate-pulse border-r" />
+      <div className="bg-muted/50 w-40 shrink-0 animate-pulse border-r" />
 
       {/* Content area */}
-      <div className="p-4 flex flex-col flex-1">
+      <div className="flex flex-1 flex-col p-4">
         {/* Name placeholder */}
-        <div className="h-5 w-2/3 bg-muted rounded animate-pulse mb-2" />
+        <div className="bg-muted mb-2 h-5 w-2/3 animate-pulse rounded" />
 
         {/* Footer row */}
-        <div className="flex items-center justify-between gap-2 mt-auto pt-2">
-          <div className="h-5 w-16 bg-muted rounded-full animate-pulse" />
-          <div className="h-4 w-24 bg-muted rounded animate-pulse" />
+        <div className="mt-auto flex items-center justify-between gap-2 pt-2">
+          <div className="bg-muted h-5 w-16 animate-pulse rounded-full" />
+          <div className="bg-muted h-4 w-24 animate-pulse rounded" />
         </div>
       </div>
     </div>
@@ -182,7 +182,7 @@ const AssetIsCausingFailureNotice = () => {
         className="cursor-pointer"
         aria-label="View deployment failure details"
       >
-        <CircleAlertIcon className="size-3 text-destructive" />
+        <CircleAlertIcon className="text-destructive size-3" />
       </HoverCardTrigger>
       <HoverCardPortal>
         <HoverCardContent side="bottom" className="text-sm" asChild>
@@ -191,7 +191,7 @@ const AssetIsCausingFailureNotice = () => {
               This API source caused the latest deployment to fail. Remove or
               update it to prevent future failures.
             </div>
-            <div className="flex justify-end mt-3">
+            <div className="mt-3 flex justify-end">
               <routes.deployments.deployment.Link
                 className="text-link"
                 params={[latestDeployment.data?.deployment?.id ?? ""]}

--- a/client/dashboard/src/components/sources/SourceCardIllustrations.tsx
+++ b/client/dashboard/src/components/sources/SourceCardIllustrations.tsx
@@ -67,7 +67,7 @@ export function MCPPatternIllustration({
     <img
       src={patternImage}
       alt=""
-      className={cn("w-full h-full object-fill", className)}
+      className={cn("h-full w-full object-fill", className)}
       aria-hidden="true"
     />
   );
@@ -98,7 +98,7 @@ export function ExternalMCPIllustration({
 
   if (logoUrl) {
     return (
-      <div className={cn("w-full h-full relative", className)}>
+      <div className={cn("relative h-full w-full", className)}>
         {/* Pattern background */}
         <MCPPatternIllustration
           toolsetSlug={slug}
@@ -106,11 +106,11 @@ export function ExternalMCPIllustration({
         />
         {/* Logo overlay */}
         <div className="absolute inset-0 flex items-center justify-center">
-          <div className="bg-background/90 backdrop-blur-sm rounded-lg p-3 shadow-lg">
+          <div className="bg-background/90 rounded-lg p-3 shadow-lg backdrop-blur-sm">
             <img
               src={logoUrl}
               alt={name || "MCP Server"}
-              className="w-12 h-12 object-contain"
+              className="h-12 w-12 object-contain"
             />
           </div>
         </div>
@@ -120,7 +120,7 @@ export function ExternalMCPIllustration({
 
   // Fallback: just use the pattern illustration
   return (
-    <div className={cn("w-full h-full", className)}>
+    <div className={cn("h-full w-full", className)}>
       <MCPPatternIllustration
         toolsetSlug={slug}
         className={cn("transition-all duration-300", saturationClass)}

--- a/client/dashboard/src/components/sources/SourceTableRow.tsx
+++ b/client/dashboard/src/components/sources/SourceTableRow.tsx
@@ -84,14 +84,14 @@ export function SourceTableRow({
         <img
           src={asset.iconUrl}
           alt={asset.name}
-          className="w-6 h-6 object-contain"
+          className="h-6 w-6 object-contain"
         />
       );
     }
     if (asset.type === "externalmcp") {
-      return <Network className="w-5 h-5 text-muted-foreground" />;
+      return <Network className="text-muted-foreground h-5 w-5" />;
     }
-    return <FileCode className="w-5 h-5 text-muted-foreground" />;
+    return <FileCode className="text-muted-foreground h-5 w-5" />;
   })();
 
   return (
@@ -104,7 +104,7 @@ export function SourceTableRow({
         <Type
           variant="subheading"
           as="div"
-          className="truncate text-sm group-hover:text-primary transition-colors"
+          className="group-hover:text-primary truncate text-sm transition-colors"
           title={asset.name}
         >
           {asset.name}
@@ -140,7 +140,7 @@ export function SourceTableRow({
       {/* Health */}
       <td className="px-3 py-3">
         {causingFailure && (
-          <div className="flex items-center gap-1.5 text-destructive">
+          <div className="text-destructive flex items-center gap-1.5">
             <CircleAlertIcon className="size-3.5" />
             <Type small className="text-destructive">
               Error

--- a/client/dashboard/src/components/sources/SourceToolsetsCard.tsx
+++ b/client/dashboard/src/components/sources/SourceToolsetsCard.tsx
@@ -32,12 +32,12 @@ function ToolsetItem({
     <routes.mcp.details.Link
       key={toolset.slug}
       params={[toolset.slug]}
-      className="flex items-center justify-between p-3 rounded-md border bg-surface-secondary hover:bg-surface-tertiary transition-colors"
+      className="bg-surface-secondary hover:bg-surface-tertiary flex items-center justify-between rounded-md border p-3 transition-colors"
     >
       <div className="flex-1">
         <Type className="font-medium">{toolset.name}</Type>
         {toolset.description && (
-          <Type className="text-sm text-muted-foreground mt-1">
+          <Type className="text-muted-foreground mt-1 text-sm">
             {toolset.description}
           </Type>
         )}
@@ -54,13 +54,13 @@ export function SourceToolsetsCard({
   sourceToolUrns,
 }: SourceToolsetsCardProps) {
   return (
-    <div className="rounded-lg border bg-card p-6">
-      <Type as="h2" className="text-lg font-semibold mb-4">
+    <div className="bg-card rounded-lg border p-6">
+      <Type as="h2" className="mb-4 text-lg font-semibold">
         Used in Toolsets ({toolsetsUsingSource.length})
       </Type>
       {toolsetsUsingSource.length === 0 ? (
-        <div className="text-center py-8 text-muted-foreground">
-          <Package className="h-12 w-12 mx-auto mb-3 opacity-50" />
+        <div className="text-muted-foreground py-8 text-center">
+          <Package className="mx-auto mb-3 h-12 w-12 opacity-50" />
           <Type>This source is not currently used in any toolsets</Type>
         </div>
       ) : (

--- a/client/dashboard/src/components/sources/Sources.tsx
+++ b/client/dashboard/src/components/sources/Sources.tsx
@@ -268,25 +268,25 @@ export default function Sources() {
             <DropdownMenuTrigger asChild>
               <Button variant="secondary">
                 <Button.LeftIcon>
-                  <Plus className="w-4 h-4" />
+                  <Plus className="h-4 w-4" />
                 </Button.LeftIcon>
                 <Button.Text>Add Source</Button.Text>
                 <Button.RightIcon>
-                  <ChevronDown className="w-4 h-4" />
+                  <ChevronDown className="h-4 w-4" />
                 </Button.RightIcon>
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-[320px] p-1">
               <DropdownMenuItem
                 onSelect={() => routes.sources.addOpenAPI.goTo()}
-                className="cursor-pointer flex items-start gap-3 p-2 rounded-md"
+                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
               >
-                <div className="w-10 h-10 rounded-lg bg-blue-500/10 dark:bg-blue-500/20 flex items-center justify-center shrink-0">
-                  <FileCode className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 dark:bg-blue-500/20">
+                  <FileCode className="h-5 w-5 text-blue-600 dark:text-blue-400" />
                 </div>
                 <div className="flex flex-col gap-0.5">
                   <span className="font-medium">From your API</span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-muted-foreground text-xs">
                     Upload an OpenAPI spec to generate tools
                   </span>
                 </div>
@@ -294,14 +294,14 @@ export default function Sources() {
               {isFunctionsEnabled && (
                 <DropdownMenuItem
                   onSelect={() => routes.sources.addFunction.goTo()}
-                  className="cursor-pointer flex items-start gap-3 p-2 rounded-md"
+                  className="flex cursor-pointer items-start gap-3 rounded-md p-2"
                 >
-                  <div className="w-10 h-10 rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20 flex items-center justify-center shrink-0">
-                    <Code className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20">
+                    <Code className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                   </div>
                   <div className="flex flex-col gap-0.5">
                     <span className="font-medium">Write custom code</span>
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-muted-foreground text-xs">
                       Create tools with TypeScript functions
                     </span>
                   </div>
@@ -309,14 +309,14 @@ export default function Sources() {
               )}
               <DropdownMenuItem
                 onSelect={() => routes.sources.addFromCatalog.goTo()}
-                className="cursor-pointer flex items-start gap-3 p-2 rounded-md"
+                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
               >
-                <div className="w-10 h-10 rounded-lg bg-violet-500/10 dark:bg-violet-500/20 flex items-center justify-center shrink-0">
-                  <Server className="w-5 h-5 text-violet-600 dark:text-violet-400" />
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
+                  <Server className="h-5 w-5 text-violet-600 dark:text-violet-400" />
                 </div>
                 <div className="flex flex-col gap-0.5">
                   <span className="font-medium">Third party server</span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-muted-foreground text-xs">
                     Add pre-built servers from the catalog
                   </span>
                 </div>
@@ -326,13 +326,13 @@ export default function Sources() {
         </Page.Section.CTA>
         <Page.Section.Body>
           {isLoading ? (
-            <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
               <SourceCardSkeleton />
               <SourceCardSkeleton />
               <SourceCardSkeleton />
             </div>
           ) : viewMode === "grid" ? (
-            <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
               {allSources?.map((asset: NamedAsset) => (
                 <SourceCard
                   key={asset.id}
@@ -384,7 +384,7 @@ export default function Sources() {
             <Dialog.Content
               className={
                 dialogState.type === "view-asset"
-                  ? "min-w-[80vw] h-[90vh]"
+                  ? "h-[90vh] min-w-[80vw]"
                   : "max-w-2xl!"
               }
             >
@@ -523,7 +523,7 @@ function DeploymentsButton({ deploymentId }: { deploymentId?: string }) {
       <a href={routes.deployments.deployment.href(deploymentId)}>
         <Button variant="secondary" className="text-destructive">
           <Button.LeftIcon>
-            <CircleAlert className="w-4 h-4" />
+            <CircleAlert className="h-4 w-4" />
           </Button.LeftIcon>
           <Button.Text>Deployment Errors</Button.Text>
         </Button>

--- a/client/dashboard/src/components/sources/SourcesEmptyState.tsx
+++ b/client/dashboard/src/components/sources/SourcesEmptyState.tsx
@@ -33,14 +33,14 @@ export function SourcesEmptyState() {
           : "OpenAPI documents and third-party MCP servers providing tools for your project"}
       </Page.Section.Description>
       <Page.Section.Body>
-        <div className="flex flex-col items-center justify-center py-16 px-8 rounded-xl border border-dashed bg-muted/20">
-          <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-4">
-            <Database className="w-6 h-6 text-muted-foreground" />
+        <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+          <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+            <Database className="text-muted-foreground h-6 w-6" />
           </div>
           <Type variant="subheading" className="mb-1">
             No sources yet
           </Type>
-          <Type small muted className="text-center mb-4 max-w-md">
+          <Type small muted className="mb-4 max-w-md text-center">
             Add an OpenAPI spec, custom function, or third-party server to
             generate tools for your MCP server.
           </Type>
@@ -48,23 +48,23 @@ export function SourcesEmptyState() {
             <DropdownMenuTrigger asChild>
               <Button>
                 <Button.LeftIcon>
-                  <Plus className="w-4 h-4" />
+                  <Plus className="h-4 w-4" />
                 </Button.LeftIcon>
                 <Button.Text>Add Source</Button.Text>
-                <ChevronDown className="w-4 h-4 ml-1" />
+                <ChevronDown className="ml-1 h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="center" className="w-[320px] p-1">
               <DropdownMenuItem
                 onSelect={() => routes.sources.addOpenAPI.goTo()}
-                className="cursor-pointer flex items-start gap-3 p-2 rounded-md"
+                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
               >
-                <div className="w-10 h-10 rounded-lg bg-blue-500/10 dark:bg-blue-500/20 flex items-center justify-center shrink-0">
-                  <FileCode className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 dark:bg-blue-500/20">
+                  <FileCode className="h-5 w-5 text-blue-600 dark:text-blue-400" />
                 </div>
                 <div className="flex flex-col gap-0.5">
                   <span className="font-medium">From your API</span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-muted-foreground text-xs">
                     Upload an OpenAPI spec to generate tools
                   </span>
                 </div>
@@ -72,14 +72,14 @@ export function SourcesEmptyState() {
               {isFunctionsEnabled && (
                 <DropdownMenuItem
                   onSelect={() => routes.sources.addFunction.goTo()}
-                  className="cursor-pointer flex items-start gap-3 p-2 rounded-md"
+                  className="flex cursor-pointer items-start gap-3 rounded-md p-2"
                 >
-                  <div className="w-10 h-10 rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20 flex items-center justify-center shrink-0">
-                    <Code className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20">
+                    <Code className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                   </div>
                   <div className="flex flex-col gap-0.5">
                     <span className="font-medium">Write custom code</span>
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-muted-foreground text-xs">
                       Create tools with TypeScript functions
                     </span>
                   </div>
@@ -87,14 +87,14 @@ export function SourcesEmptyState() {
               )}
               <DropdownMenuItem
                 onSelect={() => routes.sources.addFromCatalog.goTo()}
-                className="cursor-pointer flex items-start gap-3 p-2 rounded-md"
+                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
               >
-                <div className="w-10 h-10 rounded-lg bg-violet-500/10 dark:bg-violet-500/20 flex items-center justify-center shrink-0">
-                  <Server className="w-5 h-5 text-violet-600 dark:text-violet-400" />
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
+                  <Server className="h-5 w-5 text-violet-600 dark:text-violet-400" />
                 </div>
                 <div className="flex flex-col gap-0.5">
                   <span className="font-medium">Third party server</span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-muted-foreground text-xs">
                     Add pre-built servers from the catalog
                   </span>
                 </div>

--- a/client/dashboard/src/components/sources/ViewAssetDialogContent.tsx
+++ b/client/dashboard/src/components/sources/ViewAssetDialogContent.tsx
@@ -108,7 +108,7 @@ export function ViewAssetDialogContent({ asset }: ViewAssetDialogContentProps) {
           {asset.type === "openapi" ? "OpenAPI Specification" : "Tool Manifest"}
         </Dialog.Title>
         {asset.type !== "openapi" && (
-          <Type className="text-muted-foreground text-sm mt-1">
+          <Type className="text-muted-foreground mt-1 text-sm">
             Shows the tool definitions extracted from the function bundle
           </Type>
         )}
@@ -117,7 +117,7 @@ export function ViewAssetDialogContent({ asset }: ViewAssetDialogContentProps) {
         {isLoading ? (
           <SkeletonCode lines={20} />
         ) : error ? (
-          <div className="text-center py-8">
+          <div className="py-8 text-center">
             <Type className="text-destructive">
               {error instanceof Error
                 ? error.message
@@ -139,7 +139,7 @@ export function ViewAssetDialogContent({ asset }: ViewAssetDialogContentProps) {
             height="calc(90vh - 120px)"
           />
         ) : (
-          <Type className="text-muted-foreground text-center py-8">
+          <Type className="text-muted-foreground py-8 text-center">
             No content available
           </Type>
         )}

--- a/client/dashboard/src/components/sources/ViewSourceDialogContent.tsx
+++ b/client/dashboard/src/components/sources/ViewSourceDialogContent.tsx
@@ -126,7 +126,7 @@ export function ViewSourceDialogContent({
           {isOpenAPI ? "OpenAPI Specification" : "Tool Manifest"}
         </Dialog.Title>
         {!isOpenAPI && (
-          <Type className="text-muted-foreground text-sm mt-1">
+          <Type className="text-muted-foreground mt-1 text-sm">
             Shows the tool definitions extracted from the function bundle
           </Type>
         )}
@@ -135,7 +135,7 @@ export function ViewSourceDialogContent({
         {isLoading ? (
           <SkeletonCode lines={20} />
         ) : error ? (
-          <div className="text-center py-8">
+          <div className="py-8 text-center">
             <Type className="text-destructive">
               {error instanceof Error
                 ? error.message
@@ -157,7 +157,7 @@ export function ViewSourceDialogContent({
             height="calc(90vh - 120px)"
           />
         ) : (
-          <Type className="text-muted-foreground text-center py-8">
+          <Type className="text-muted-foreground py-8 text-center">
             No content available
           </Type>
         )}

--- a/client/dashboard/src/components/stepper.tsx
+++ b/client/dashboard/src/components/stepper.tsx
@@ -29,10 +29,10 @@ function StepNumber({
   return (
     <div
       className={cn(
-        "flex items-center justify-center w-7 h-7 rounded-full bg-accent mt-1",
+        "bg-accent mt-1 flex h-7 w-7 items-center justify-center rounded-full",
         active && "bg-primary text-primary-foreground",
         completed &&
-          "dark:bg-emerald-900 dark:text-emerald-300 bg-emerald-300 text-emerald-900",
+          "bg-emerald-300 text-emerald-900 dark:bg-emerald-900 dark:text-emerald-300",
         failed && "bg-destructive text-destructive-foreground",
       )}
     >
@@ -111,8 +111,8 @@ export function Step({
       gap={4}
       direction={"horizontal"}
       className={cn(
-        "trans opacity-50 mb-4 w-full",
-        isActive && "opacity-100 mb-8",
+        "trans mb-4 w-full opacity-50",
+        isActive && "mb-8 opacity-100",
       )}
     >
       <StepNumber

--- a/client/dashboard/src/components/tool-list/AnnotationBadges.tsx
+++ b/client/dashboard/src/components/tool-list/AnnotationBadges.tsx
@@ -38,25 +38,25 @@ export function AnnotationBadges({ tool }: { tool: Tool }) {
   if (!readOnly && !destructive && !idempotent && !openWorld) return null;
 
   return (
-    <div className="flex items-center gap-1 shrink-0">
+    <div className="flex shrink-0 items-center gap-1">
       {readOnly && (
         <SimpleTooltip tooltip="Read-only">
-          <Shield className="size-3.5 text-muted-foreground/70" />
+          <Shield className="text-muted-foreground/70 size-3.5" />
         </SimpleTooltip>
       )}
       {destructive && !readOnly && (
         <SimpleTooltip tooltip="Destructive">
-          <AlertTriangle className="size-3.5 text-muted-foreground/70" />
+          <AlertTriangle className="text-muted-foreground/70 size-3.5" />
         </SimpleTooltip>
       )}
       {idempotent && !readOnly && (
         <SimpleTooltip tooltip="Idempotent">
-          <Repeat className="size-3.5 text-muted-foreground/70" />
+          <Repeat className="text-muted-foreground/70 size-3.5" />
         </SimpleTooltip>
       )}
       {openWorld && (
         <SimpleTooltip tooltip="Open-world">
-          <Globe className="size-3.5 text-muted-foreground/70" />
+          <Globe className="text-muted-foreground/70 size-3.5" />
         </SimpleTooltip>
       )}
     </div>

--- a/client/dashboard/src/components/tool-list/ToolList.tsx
+++ b/client/dashboard/src/components/tool-list/ToolList.tsx
@@ -404,13 +404,13 @@ function ToolRow({
     <>
       <div
         className={cn(
-          "group flex items-center justify-between overflow-hidden pl-4 pr-3 py-4 relative border-b border-neutral-softest last:border-b-0 transition-colors hover:bg-muted",
+          "group border-neutral-softest hover:bg-muted relative flex items-center justify-between overflow-hidden border-b py-4 pr-3 pl-4 transition-colors last:border-b-0",
           isFocused && "bg-muted",
           onToolClick && "cursor-pointer",
         )}
         onClick={() => onToolClick?.(tool)}
       >
-        <div className="flex gap-4 items-center min-w-0 flex-[0_1_60%]">
+        <div className="flex min-w-0 flex-[0_1_60%] items-center gap-4">
           <Checkbox
             checked={isSelected}
             onCheckedChange={onCheckboxChange}
@@ -420,9 +420,9 @@ function ToolRow({
               !isSelected && !isFocused && "opacity-0 group-hover:opacity-100",
             )}
           />
-          <div className="flex flex-col min-w-0 flex-1">
+          <div className="flex min-w-0 flex-1 flex-col">
             <Stack direction="horizontal" gap={2} align="center">
-              <p className="text-sm leading-6 text-foreground truncate">
+              <p className="text-foreground truncate text-sm leading-6">
                 {toolPrefix && (
                   <Type small muted className="inline">
                     {toolPrefix}
@@ -433,12 +433,12 @@ function ToolRow({
               <ToolVariationBadge tool={tool} />
               <AnnotationBadges tool={tool} />
             </Stack>
-            <p className="text-sm leading-6 text-muted-foreground truncate">
+            <p className="text-muted-foreground truncate text-sm leading-6">
               {tool.description || "No description"}
             </p>
           </div>
         </div>
-        <div className="flex gap-4 items-center shrink-0">
+        <div className="flex shrink-0 items-center gap-4">
           {tool.type === "http" && tool.httpMethod && (
             <MethodBadge method={tool.httpMethod} />
           )}
@@ -487,7 +487,7 @@ function ToolRow({
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="text-sm">Read-only</p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-muted-foreground text-xs">
                           Tool does not modify its environment
                         </p>
                       </div>
@@ -500,7 +500,7 @@ function ToolRow({
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="text-sm">Destructive</p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-muted-foreground text-xs">
                           Tool may perform destructive updates
                         </p>
                       </div>
@@ -513,7 +513,7 @@ function ToolRow({
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="text-sm">Idempotent</p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-muted-foreground text-xs">
                           Repeated calls with same arguments have no additional
                           effect
                         </p>
@@ -527,7 +527,7 @@ function ToolRow({
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="text-sm">Open-world</p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-muted-foreground text-xs">
                           Tool interacts with external entities
                         </p>
                       </div>
@@ -575,7 +575,7 @@ function ToolRow({
                 {tool.variation?.description &&
                   tool.variation?.description !==
                     tool.canonical?.description && (
-                    <Stack className="p-2 border rounded-md border-border/70">
+                    <Stack className="border-border/70 rounded-md border p-2">
                       <Type small muted className="inline font-medium">
                         <Icon
                           name="layers-2"
@@ -591,7 +591,7 @@ function ToolRow({
                   )}
               </Stack>
             )}
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && <p className="text-destructive text-sm">{error}</p>}
           </div>
           <Dialog.Footer>
             <Button variant="ghost" onClick={() => setEditDialogOpen(false)}>
@@ -625,21 +625,21 @@ function ToolGroupHeader({
   return (
     <div
       className={cn(
-        "group/header bg-surface-secondary-default flex items-center justify-between pl-4 pr-3 py-4 w-full",
-        isExpanded && "border-b border-neutral-softest",
-        !isFirstGroup && "border-t border-neutral-softest",
+        "group/header bg-surface-secondary-default flex w-full items-center justify-between py-4 pr-3 pl-4",
+        isExpanded && "border-neutral-softest border-b",
+        !isFirstGroup && "border-neutral-softest border-t",
       )}
     >
       <button
         onClick={onToggle}
         aria-expanded={isExpanded}
         aria-label={`${isExpanded ? "Collapse" : "Expand"} ${group.title} group`}
-        className="flex gap-4 items-center hover:opacity-70 transition-opacity"
+        className="flex items-center gap-4 transition-opacity hover:opacity-70"
       >
         <div className="relative size-4 shrink-0">
           <Icon
             className={cn(
-              "size-4 absolute inset-0 transition-opacity",
+              "absolute inset-0 size-4 transition-opacity",
               "group-hover/header:opacity-0",
             )}
             strokeWidth={1.5}
@@ -654,19 +654,19 @@ function ToolGroupHeader({
                 e.stopPropagation();
               }}
               className={cn(
-                "absolute inset-0 transition-opacity opacity-0",
+                "absolute inset-0 opacity-0 transition-opacity",
                 "group-hover/header:opacity-100",
               )}
             />
           </SimpleTooltip>
         </div>
-        <p className="text-sm leading-6 text-foreground">{group.title}</p>
+        <p className="text-foreground text-sm leading-6">{group.title}</p>
       </button>
       <button
         onClick={onToggle}
         aria-expanded={isExpanded}
         aria-label={`${isExpanded ? "Collapse" : "Expand"} ${group.title} group`}
-        className="hover:opacity-70 transition-opacity"
+        className="transition-opacity hover:opacity-70"
       >
         <ChevronDown
           className={cn(
@@ -983,7 +983,7 @@ export function ToolList({
     <div className="relative w-full">
       <div
         className={cn(
-          "border border-neutral-softest rounded-lg overflow-hidden w-full",
+          "border-neutral-softest w-full overflow-hidden rounded-lg border",
           className,
         )}
       >
@@ -1051,16 +1051,16 @@ export function ToolList({
       </div>
 
       {hasChanges && !selectionMode && (
-        <div className="sticky bottom-0 left-0 right-0 flex justify-center mt-4">
-          <div className="border border-neutral-softest bg-background shadow-lg rounded-lg px-4 py-3 flex items-center gap-4">
-            <p className="text-sm text-foreground">
+        <div className="sticky right-0 bottom-0 left-0 mt-4 flex justify-center">
+          <div className="border-neutral-softest bg-background flex items-center gap-4 rounded-lg border px-4 py-3 shadow-lg">
+            <p className="text-foreground text-sm">
               {selectedForRemoval.size} tool(s) selected
             </p>
             <div className="flex items-center gap-2">
-              <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border border-neutral-softest bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+              <kbd className="border-neutral-softest bg-muted text-muted-foreground pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none">
                 <span className="text-xs">⌘</span>K
               </kbd>
-              <span className="text-sm text-muted-foreground">for actions</span>
+              <span className="text-muted-foreground text-sm">for actions</span>
             </div>
             <Button variant="outline" onClick={handleCancel}>
               Cancel

--- a/client/dashboard/src/components/top-header.tsx
+++ b/client/dashboard/src/components/top-header.tsx
@@ -100,12 +100,12 @@ export function TopHeader() {
 
   return (
     <>
-      <header className="flex items-center h-14 pl-5 pr-4 border-b bg-white dark:bg-background shrink-0">
+      <header className="dark:bg-background flex h-14 shrink-0 items-center border-b bg-white pr-4 pl-5">
         <div className="flex items-center gap-3">
           {/* Logo */}
           <Link
             to={projectSlug ? routes.home.href() : `/${organization.slug}`}
-            className="hover:no-underline flex items-center"
+            className="flex items-center hover:no-underline"
           >
             <GramLogo className="w-28" />
           </Link>
@@ -118,7 +118,7 @@ export function TopHeader() {
           {/* Org link */}
           <Link
             to={`/${organization.slug}`}
-            className="text-base font-medium text-foreground/80 hover:text-foreground hover:bg-accent hover:no-underline transition-colors rounded-md px-2 py-1 whitespace-nowrap"
+            className="text-foreground/80 hover:text-foreground hover:bg-accent rounded-md px-2 py-1 text-base font-medium whitespace-nowrap transition-colors hover:no-underline"
           >
             {organization.slug}
           </Link>
@@ -133,16 +133,16 @@ export function TopHeader() {
                 <PopoverTrigger asChild>
                   <Button
                     variant="ghost"
-                    className="h-8 !px-2 gap-2 relative -left-1"
+                    className="relative -left-1 h-8 gap-2 !px-2"
                   >
                     <ProjectAvatar
                       project={project}
-                      className="h-5 w-5 rounded shrink-0"
+                      className="h-5 w-5 shrink-0 rounded"
                     />
                     <span className="text-base font-medium">
                       {project?.slug || projectSlug || "Select"}
                     </span>
-                    <ChevronsUpDown className="w-4 h-4 text-muted-foreground shrink-0" />
+                    <ChevronsUpDown className="text-muted-foreground h-4 w-4 shrink-0" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-[240px] p-0" align="start">
@@ -163,15 +163,15 @@ export function TopHeader() {
                               key={p.id}
                               value={p.slug}
                               onSelect={() => handleProjectSelect(p.slug)}
-                              className="flex items-center gap-2 cursor-pointer"
+                              className="flex cursor-pointer items-center gap-2"
                             >
                               <ProjectAvatar
                                 project={p}
-                                className="h-5 w-5 rounded shrink-0"
+                                className="h-5 w-5 shrink-0 rounded"
                               />
                               <span className="flex-1 truncate">{p.slug}</span>
                               {p.id === project.id && (
-                                <CheckIcon className="w-4 h-4 shrink-0" />
+                                <CheckIcon className="h-4 w-4 shrink-0" />
                               )}
                             </CommandItem>
                           ))}
@@ -180,9 +180,9 @@ export function TopHeader() {
                   </Command>
                   <button
                     onClick={() => handleProjectSelect("new-project")}
-                    className="flex items-center gap-2 w-full px-3 py-2 text-sm cursor-pointer hover:bg-accent border-t"
+                    className="hover:bg-accent flex w-full cursor-pointer items-center gap-2 border-t px-3 py-2 text-sm"
                   >
-                    <PlusIcon className="w-5 h-5 text-muted-foreground shrink-0" />
+                    <PlusIcon className="text-muted-foreground h-5 w-5 shrink-0" />
                     <span>Create Project</span>
                   </button>
                 </PopoverContent>
@@ -193,7 +193,7 @@ export function TopHeader() {
 
         {/* Right side - Nav links, Theme toggle & User menu */}
         <div className="ml-auto flex items-center gap-4">
-          <nav className="hidden lg:flex items-center gap-2">
+          <nav className="hidden items-center gap-2 lg:flex">
             {"Pylon" in window && (
               <Button
                 variant="default"
@@ -228,7 +228,7 @@ export function TopHeader() {
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
-                className="size-9 rounded-full p-0 border border-[#dbdbdb] dark:border-[#333]/30"
+                className="size-9 rounded-full border border-[#dbdbdb] p-0 dark:border-[#333]/30"
               >
                 <Avatar className="size-9">
                   <AvatarImage
@@ -244,10 +244,10 @@ export function TopHeader() {
             <DropdownMenuContent align="end" className="w-56">
               <DropdownMenuLabel className="font-normal">
                 <div className="flex flex-col space-y-1">
-                  <p className="text-sm font-medium leading-none">
+                  <p className="text-sm leading-none font-medium">
                     {user.displayName || "User"}
                   </p>
-                  <p className="text-xs leading-none text-muted-foreground">
+                  <p className="text-muted-foreground text-xs leading-none">
                     {user.email}
                   </p>
                 </div>

--- a/client/dashboard/src/components/ui/InputAndMultiselect.tsx
+++ b/client/dashboard/src/components/ui/InputAndMultiselect.tsx
@@ -109,12 +109,12 @@ export function InputAndMultiselect({
           onChange={(e) => onChange(e.target.value)}
           onFocus={handleFocus}
           placeholder={placeholder}
-          className="w-full h-9 px-3 pr-9 rounded-md border border-input bg-background text-sm font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          className="border-input bg-background placeholder:text-muted-foreground focus:ring-ring h-9 w-full rounded-md border px-3 pr-9 font-mono text-sm focus:ring-2 focus:outline-none"
         />
         {type === "password" && (
           <button
             onClick={() => setShowValue(!showValue)}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2 transition-colors"
             type="button"
           >
             {showValue ? (
@@ -131,7 +131,7 @@ export function InputAndMultiselect({
         createPortal(
           <div
             ref={dropdownRef}
-            className="bg-popover border border-border rounded-md shadow-md z-100 p-1 max-h-[300px] overflow-y-auto"
+            className="bg-popover border-border z-100 max-h-[300px] overflow-y-auto rounded-md border p-1 shadow-md"
             style={{
               position: "absolute",
               top: `${dropdownPosition.top}px`,
@@ -147,12 +147,12 @@ export function InputAndMultiselect({
               return (
                 <div
                   key={option.value}
-                  className="px-3 py-2 text-sm rounded-sm cursor-pointer hover:bg-accent flex items-center gap-2"
+                  className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-sm px-3 py-2 text-sm"
                   onClick={() => toggleOption(option.value)}
                 >
                   <div
                     className={cn(
-                      "w-4 h-4 rounded-sm border flex items-center justify-center",
+                      "flex h-4 w-4 items-center justify-center rounded-sm border",
                       isSelected
                         ? "bg-primary border-primary text-primary-foreground"
                         : isIndeterminate

--- a/client/dashboard/src/components/ui/alert.tsx
+++ b/client/dashboard/src/components/ui/alert.tsx
@@ -41,7 +41,7 @@ const AlertTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h5
     ref={ref}
-    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    className={cn("mb-1 leading-none font-medium tracking-tight", className)}
     {...props}
   />
 ));
@@ -82,7 +82,7 @@ const ErrorAlert = ({
         {onDismiss && (
           <button
             onClick={onDismiss}
-            className="ml-2 opacity-70 hover:opacity-100 transition-opacity"
+            className="ml-2 opacity-70 transition-opacity hover:opacity-100"
             aria-label="Dismiss"
           >
             <Icon name="x" className="h-4 w-4" />

--- a/client/dashboard/src/components/ui/big-toggle.tsx
+++ b/client/dashboard/src/components/ui/big-toggle.tsx
@@ -34,7 +34,7 @@ export const BigToggle = ({
   };
 
   const toggle = (
-    <Stack gap={1} className="border rounded-md p-1 w-fit bg-background">
+    <Stack gap={1} className="bg-background w-fit rounded-md border p-1">
       {options.map((option) => {
         const isActive = selectedValue === option.value;
         return (

--- a/client/dashboard/src/components/ui/button-rainbow.tsx
+++ b/client/dashboard/src/components/ui/button-rainbow.tsx
@@ -37,12 +37,12 @@ export const ButtonRainbow = ({
         disabled={inProgress}
         className={cn(
           "relative inline-flex items-center justify-center gap-2 px-4 py-2",
-          "font-mono text-sm uppercase text-foreground",
-          "rounded-md cursor-pointer",
+          "text-foreground font-mono text-sm uppercase",
+          "cursor-pointer rounded-md",
           "transition-all outline-none",
-          "w-full rounded-[7px] bg-background border-0",
+          "bg-background w-full rounded-[7px] border-0",
           "hover:bg-background/95",
-          "focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-neutral-500",
+          "focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2",
         )}
       >
         {children}

--- a/client/dashboard/src/components/ui/button.tsx
+++ b/client/dashboard/src/components/ui/button.tsx
@@ -79,7 +79,7 @@ export function Button({
     <Icon
       name={iconName}
       className={cn(
-        "w-4 h-4 text-muted-foreground group-hover:text-foreground",
+        "text-muted-foreground group-hover:text-foreground h-4 w-4",
         iconColors,
       )}
     />
@@ -119,8 +119,8 @@ export function Button({
       data-slot="button"
       className={cn(
         buttonVariants({ variant, size, className }),
-        "cursor-pointer group trans",
-        caps && "uppercase font-mono",
+        "group trans cursor-pointer",
+        caps && "font-mono uppercase",
       )}
       {...props}
       {...(onClick ? { onClick } : {})}

--- a/client/dashboard/src/components/ui/card-mini.tsx
+++ b/client/dashboard/src/components/ui/card-mini.tsx
@@ -36,13 +36,13 @@ const MiniCardComponent = ({
     <div
       data-slot="card"
       className={cn(
-        "bg-card max-w-sm max-h-fit text-card-foreground flex justify-between items-center rounded-md border px-3 py-4 group/card",
+        "bg-card text-card-foreground group/card flex max-h-fit max-w-sm items-center justify-between rounded-md border px-3 py-4",
         size === "sm" && "gap-4 py-4",
         className,
       )}
       {...props}
     >
-      <div data-slot="card-content" className={"flex flex-col gap-1.5 w-full"}>
+      <div data-slot="card-content" className={"flex w-full flex-col gap-1.5"}>
         {slots.title}
         {slots.description}
       </div>
@@ -59,7 +59,7 @@ function MiniCardTitle({
   return (
     <Type
       data-slot="card-title"
-      className={cn("leading-none font-normal text-foreground!", className)}
+      className={cn("text-foreground! leading-none font-normal", className)}
       {...props}
     />
   );
@@ -110,10 +110,10 @@ function MiniCardSkeleton() {
   return (
     <MiniCard>
       <MiniCard.Title>
-        <Skeleton className="w-[150px] h-4" />
+        <Skeleton className="h-4 w-[150px]" />
       </MiniCard.Title>
       <MiniCard.Description>
-        <Skeleton className="w-full h-4" />
+        <Skeleton className="h-4 w-full" />
       </MiniCard.Description>
     </MiniCard>
   );

--- a/client/dashboard/src/components/ui/card.tsx
+++ b/client/dashboard/src/components/ui/card.tsx
@@ -15,7 +15,7 @@ const CardComponent = ({
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-5 rounded-xl border p-4 group/card",
+        "bg-card text-card-foreground group/card flex flex-col gap-5 rounded-xl border p-4",
         size === "sm" && "gap-4 py-4",
         className,
       )}
@@ -49,7 +49,7 @@ function CardTitle({
       variant="h4"
       data-slot="card-title"
       className={cn(
-        "leading-none [a:has([data-slot=card]):hover_&]:underline normal-case", // Underline the title when the card is hovered, if the card is a link
+        "leading-none normal-case [a:has([data-slot=card]):hover_&]:underline", // Underline the title when the card is hovered, if the card is a link
         className,
       )}
       {...props}
@@ -77,7 +77,7 @@ function CardInfo({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-info"
       className={cn(
-        "gap-2 flex justify-start ml-auto",
+        "ml-auto flex justify-start gap-2",
         "group-hover/card:has([data-slot=card-action]):opacity-0", // Only hide info when card has an action and is hovered
         className,
       )}
@@ -101,7 +101,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "mt-auto flex items-center justify-between [.border-t]:pt-6 w-full",
+        "mt-auto flex w-full items-center justify-between [.border-t]:pt-6",
         className,
       )}
       {...props}
@@ -157,7 +157,7 @@ export function Cards({
       <Grid
         columns={1}
         className={cn(
-          "grid-cols-1 gap-x-8 gap-y-4 mb-8",
+          "mb-8 grid-cols-1 gap-x-8 gap-y-4",
           !noGrid &&
             "@lg/cards:grid-cols-2 @3xl/cards:grid-cols-4 @7xl/cards:grid-cols-6",
           className,

--- a/client/dashboard/src/components/ui/cardOld.tsx
+++ b/client/dashboard/src/components/ui/cardOld.tsx
@@ -13,7 +13,7 @@ const CardComponent = ({
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 group/card",
+        "bg-card text-card-foreground group/card flex flex-col gap-6 rounded-xl border py-6",
         size === "sm" && "gap-4 py-4",
         className,
       )}
@@ -56,7 +56,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm w-full mt-1", className)}
+      className={cn("text-muted-foreground mt-1 w-full text-sm", className)}
       {...props}
     />
   );
@@ -67,7 +67,7 @@ function CardInfo({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-info"
       className={cn(
-        "gap-2 flex justify-start",
+        "flex justify-start gap-2",
         "group-hover/card:has([data-slot=card-action]):opacity-0", // Only hide info when card has an action and is hovered
         className,
       )}
@@ -81,7 +81,7 @@ function CardActions({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-action"
       className={cn(
-        "absolute top-[-8px] right-4 bg-card opacity-0 group-hover/card:opacity-100 trans flex",
+        "bg-card trans absolute top-[-8px] right-4 flex opacity-0 group-hover/card:opacity-100",
         className,
       )}
       {...props}

--- a/client/dashboard/src/components/ui/carousel.tsx
+++ b/client/dashboard/src/components/ui/carousel.tsx
@@ -256,7 +256,7 @@ function CarouselDots({ className, ...props }: React.ComponentProps<"div">) {
       direction={"horizontal"}
       gap={2}
       className={cn(
-        "flex absolute bottom-2 left-1/2 -translate-x-1/2",
+        "absolute bottom-2 left-1/2 flex -translate-x-1/2",
         className,
       )}
       {...props}
@@ -265,7 +265,7 @@ function CarouselDots({ className, ...props }: React.ComponentProps<"div">) {
         <button
           key={index}
           className={cn(
-            "w-2 h-2 rounded-full bg-muted-foreground/30",
+            "bg-muted-foreground/30 h-2 w-2 rounded-full",
             activeIndex === index && "bg-muted-foreground",
           )}
           onClick={() => setActiveIndex(index)}

--- a/client/dashboard/src/components/ui/code-block.tsx
+++ b/client/dashboard/src/components/ui/code-block.tsx
@@ -32,7 +32,7 @@ function CopyButton({ content }: { content: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="text-slate-400 hover:text-slate-200 rounded p-1 transition-colors"
+      className="rounded p-1 text-slate-400 transition-colors hover:text-slate-200"
       aria-label="Copy to clipboard"
     >
       {copied ? (
@@ -147,9 +147,9 @@ export function CodeBlock({ content, title, className }: CodeBlockProps) {
   }, [content]);
 
   return (
-    <div className={cn("w-full rounded-lg overflow-hidden", className)}>
+    <div className={cn("w-full overflow-hidden rounded-lg", className)}>
       {title && (
-        <div className="flex items-center justify-between bg-slate-900 px-4 py-2 border-b border-slate-700">
+        <div className="flex items-center justify-between border-b border-slate-700 bg-slate-900 px-4 py-2">
           <span className="text-xs font-medium text-slate-400">{title}</span>
           <CopyButton content={formattedContent} />
         </div>
@@ -192,7 +192,7 @@ export function CollapsibleCodeSection({
   }, [content]);
 
   return (
-    <div className="border-t border-border">
+    <div className="border-border border-t">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
         className="hover:bg-muted/50 flex w-full cursor-pointer items-center justify-between px-4 py-2.5 text-left transition-colors"
@@ -209,7 +209,7 @@ export function CollapsibleCodeSection({
         </div>
       </button>
       {isExpanded && (
-        <div className="border-t border-border">
+        <div className="border-border border-t">
           <CodeBlock content={content} />
         </div>
       )}

--- a/client/dashboard/src/components/ui/combobox.tsx
+++ b/client/dashboard/src/components/ui/combobox.tsx
@@ -65,7 +65,7 @@ export function Combobox<T extends DropdownItem>({
         disabled={!!disabledMessage}
         tooltip={disabledMessage || tooltip}
       >
-        <div className="flex items-center justify-between w-full gap-2">
+        <div className="flex w-full items-center justify-between gap-2">
           <div className="truncate font-medium">{children}</div>
           <ChevronsUpDown className="opacity-50" />
         </div>
@@ -78,7 +78,7 @@ export function Combobox<T extends DropdownItem>({
       <Stack
         direction="horizontal"
         align="center"
-        className="bg-stone-200 dark:bg-stone-800 rounded-md w-fit"
+        className="w-fit rounded-md bg-stone-200 dark:bg-stone-800"
       >
         <Type variant="small" className="px-2">
           {label}

--- a/client/dashboard/src/components/ui/command.tsx
+++ b/client/dashboard/src/components/ui/command.tsx
@@ -32,7 +32,7 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <Dialog.Content className="overflow-hidden p-0 max-w-2xl">
+      <Dialog.Content className="max-w-2xl overflow-hidden p-0">
         <Dialog.Header className="sr-only">
           <Dialog.Title>{title}</Dialog.Title>
           <Dialog.Description>{description}</Dialog.Description>

--- a/client/dashboard/src/components/ui/dialog.tsx
+++ b/client/dashboard/src/components/ui/dialog.tsx
@@ -65,7 +65,7 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer">
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <XIcon />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/client/dashboard/src/components/ui/dot-card.tsx
+++ b/client/dashboard/src/components/ui/dot-card.tsx
@@ -27,15 +27,15 @@ export function DotCard({
     <div
       onClick={onClick}
       className={cn(
-        "dot-card group bg-card text-card-foreground flex flex-row rounded-xl border !border-foreground/10 overflow-hidden",
-        "hover:!border-foreground/30 hover:shadow-md transition-all h-full min-h-[156px]",
+        "dot-card group bg-card text-card-foreground !border-foreground/10 flex flex-row overflow-hidden rounded-xl border",
+        "hover:!border-foreground/30 h-full min-h-[156px] transition-all hover:shadow-md",
         className,
       )}
     >
       {/* Dot pattern sidebar */}
-      <div className="w-40 shrink-0 overflow-hidden border-r relative bg-muted/30 text-muted-foreground/20">
+      <div className="bg-muted/30 text-muted-foreground/20 relative w-40 shrink-0 overflow-hidden border-r">
         <div
-          className="absolute inset-0 scroll-dots-target"
+          className="scroll-dots-target absolute inset-0"
           style={{
             backgroundImage:
               "radial-gradient(circle, currentColor 1px, transparent 1px)",
@@ -44,7 +44,7 @@ export function DotCard({
         />
         {icon && (
           <div className="absolute inset-0 flex items-center justify-center">
-            <div className="bg-background/90 backdrop-blur-sm dark:bg-neutral-800 dark:backdrop-blur-none rounded-lg p-3 shadow-lg">
+            <div className="bg-background/90 rounded-lg p-3 shadow-lg backdrop-blur-sm dark:bg-neutral-800 dark:backdrop-blur-none">
               {icon}
             </div>
           </div>
@@ -53,7 +53,7 @@ export function DotCard({
       </div>
 
       {/* Content area */}
-      <div className="p-4 flex flex-col flex-1 min-w-0">{children}</div>
+      <div className="flex min-w-0 flex-1 flex-col p-4">{children}</div>
     </div>
   );
 }

--- a/client/dashboard/src/components/ui/dot-row.tsx
+++ b/client/dashboard/src/components/ui/dot-row.tsx
@@ -19,17 +19,17 @@ export function DotRow({ children, icon, className, onClick }: DotRowProps) {
     <tr
       onClick={onClick}
       className={cn(
-        "dot-card group border-b border-foreground/10 transition-all",
+        "dot-card group border-foreground/10 border-b transition-all",
         "hover:bg-muted/30",
         onClick && "cursor-pointer",
         className,
       )}
     >
       {/* Dot pattern cell */}
-      <td className="size-17 p-0 relative overflow-hidden">
-        <div className="absolute inset-0 bg-muted/30 text-muted-foreground/20">
+      <td className="relative size-17 overflow-hidden p-0">
+        <div className="bg-muted/30 text-muted-foreground/20 absolute inset-0">
           <div
-            className="absolute inset-0 scroll-dots-target"
+            className="scroll-dots-target absolute inset-0"
             style={{
               backgroundImage:
                 "radial-gradient(circle, currentColor 1px, transparent 1px)",
@@ -38,7 +38,7 @@ export function DotRow({ children, icon, className, onClick }: DotRowProps) {
           />
           {icon && (
             <div className="absolute inset-0 flex items-center justify-center">
-              <div className="bg-background/90 backdrop-blur-sm dark:bg-neutral-800 dark:backdrop-blur-none rounded-md p-1.5 shadow-sm">
+              <div className="bg-background/90 rounded-md p-1.5 shadow-sm backdrop-blur-sm dark:bg-neutral-800 dark:backdrop-blur-none">
                 {icon}
               </div>
             </div>

--- a/client/dashboard/src/components/ui/dot-table.tsx
+++ b/client/dashboard/src/components/ui/dot-table.tsx
@@ -16,20 +16,20 @@ export function DotTable({
   return (
     <div
       className={cn(
-        "w-full rounded-xl border !border-foreground/10 overflow-hidden",
+        "!border-foreground/10 w-full overflow-hidden rounded-xl border",
         className,
       )}
     >
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b bg-muted/30">
+          <tr className="bg-muted/30 border-b">
             {/* Empty header for the dot-pattern column */}
             <th className="w-17" />
             {headers.map((header, index) => (
               <th
                 key={header.label || `header-${index}`}
                 className={cn(
-                  "px-3 py-2.5 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider",
+                  "text-muted-foreground px-3 py-2.5 text-left text-xs font-medium tracking-wider uppercase",
                   header.className,
                 )}
               >

--- a/client/dashboard/src/components/ui/editable.tsx
+++ b/client/dashboard/src/components/ui/editable.tsx
@@ -18,7 +18,7 @@ export function Editable({
 
   return (
     <div
-      className={cn("relative group cursor-pointer", className)}
+      className={cn("group relative cursor-pointer", className)}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={() => !disabled && onClick?.()}
@@ -36,7 +36,7 @@ export function Editable({
             </Type>
           ) : (
             <>
-              <Pencil className="w-4 h-4 text-muted-foreground mr-1" />
+              <Pencil className="text-muted-foreground mr-1 h-4 w-4" />
               <Type
                 className={cn(
                   "font-medium text-inherit",

--- a/client/dashboard/src/components/ui/hover-card.tsx
+++ b/client/dashboard/src/components/ui/hover-card.tsx
@@ -16,7 +16,7 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
+      "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-md border p-4 shadow-md outline-none",
       className,
     )}
     {...props}

--- a/client/dashboard/src/components/ui/input-group.tsx
+++ b/client/dashboard/src/components/ui/input-group.tsx
@@ -14,7 +14,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="input-group"
       role="group"
       className={cn(
-        "group/input-group border-neutral-softest dark:bg-input/30 relative flex w-full items-center rounded-tl-[2px] rounded-tr-[2px] rounded-bl-lg rounded-br-lg border shadow-xs transition-[color,box-shadow] outline-none",
+        "group/input-group border-neutral-softest dark:bg-input/30 relative flex w-full items-center rounded-tl-[2px] rounded-tr-[2px] rounded-br-lg rounded-bl-lg border shadow-xs transition-[color,box-shadow] outline-none",
         "h-9 min-w-0 has-[>textarea]:h-auto",
 
         // Variants based on alignment.

--- a/client/dashboard/src/components/ui/input.tsx
+++ b/client/dashboard/src/components/ui/input.tsx
@@ -132,11 +132,11 @@ function Input({
     );
 
   return (
-    <div className="mb-[-8px] relative">
+    <div className="relative mb-[-8px]">
       {requiredPrefix && (
         <span
           ref={prefixRef}
-          className="absolute left-3 top-[8px] text-muted-foreground text-sm pointer-events-none select-none"
+          className="text-muted-foreground pointer-events-none absolute top-[8px] left-3 text-sm select-none"
           aria-hidden="true"
         >
           {requiredPrefix}

--- a/client/dashboard/src/components/ui/link.tsx
+++ b/client/dashboard/src/components/ui/link.tsx
@@ -17,7 +17,7 @@ export function Link({
     content = (
       <Stack direction="horizontal" gap={1} align="center">
         {content}
-        <ExternalLinkIcon className="w-4 h-4 text-muted-foreground group-hover:text-foreground" />
+        <ExternalLinkIcon className="text-muted-foreground group-hover:text-foreground h-4 w-4" />
       </Stack>
     );
   }

--- a/client/dashboard/src/components/ui/more-actions.tsx
+++ b/client/dashboard/src/components/ui/more-actions.tsx
@@ -41,10 +41,10 @@ export function MoreActions({
         {triggerLabel ? (
           <Button size="sm">
             {triggerLabel}
-            <Icon name="chevron-down" className="size-4 ml-1" />
+            <Icon name="chevron-down" className="ml-1 size-4" />
           </Button>
         ) : (
-          <Button variant="ghost" size="sm" className="h-8 w-8 p-0 mx-[-4px]">
+          <Button variant="ghost" size="sm" className="mx-[-4px] h-8 w-8 p-0">
             <Icon name="ellipsis-vertical" className="size-4" />
             <span className="sr-only">Open menu</span>
           </Button>
@@ -62,7 +62,7 @@ export function MoreActions({
             onClick={wrapOnClick(action.onClick)}
             disabled={action.disabled}
             className={cn(
-              "cursor-pointer justify-between flex items-center group",
+              "group flex cursor-pointer items-center justify-between",
               action.destructive &&
                 "text-destructive hover:bg-destructive! hover:text-background! trans",
             )}

--- a/client/dashboard/src/components/ui/multi-search.tsx
+++ b/client/dashboard/src/components/ui/multi-search.tsx
@@ -29,21 +29,21 @@ export function MultiSearch({
       direction="horizontal"
       gap={2}
       className={cn(
-        "min-h-[42px] border border-border rounded-md px-3 py-2",
-        disabled && "opacity-50 cursor-not-allowed",
+        "border-border min-h-[42px] rounded-md border px-3 py-2",
+        disabled && "cursor-not-allowed opacity-50",
         className,
       )}
       align="center"
     >
-      <SearchIcon className="size-4 opacity-50 shrink-0" />
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
 
       {/* Filter chips */}
       {chips.length > 0 && (
-        <div className="flex items-center gap-1.5 flex-wrap">
+        <div className="flex flex-wrap items-center gap-1.5">
           {chips.map((chip) => (
             <div
               key={chip.value}
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-primary/10 text-primary border border-primary/20 text-xs"
+              className="bg-primary/10 text-primary border-primary/20 inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs"
             >
               <span className="font-medium">{chip.display}</span>
               {onRemoveChip && !disabled && (
@@ -66,14 +66,14 @@ export function MultiSearch({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
-        className="flex-1 bg-transparent outline-none min-w-0 disabled:cursor-not-allowed"
+        className="min-w-0 flex-1 bg-transparent outline-none disabled:cursor-not-allowed"
       />
 
       {/* Clear button */}
       {value && !disabled && (
         <button
           onClick={() => onChange("")}
-          className="opacity-50 hover:opacity-100 transition-opacity shrink-0"
+          className="shrink-0 opacity-50 transition-opacity hover:opacity-100"
           aria-label="Clear search"
         >
           <X className="size-4" />

--- a/client/dashboard/src/components/ui/multi-select.tsx
+++ b/client/dashboard/src/components/ui/multi-select.tsx
@@ -187,18 +187,18 @@ export const MultiSelect = React.forwardRef<
             {...props}
             onClick={handleTogglePopover}
             className={cn(
-              "flex w-full p-1 rounded-md border min-h-10 h-auto items-center justify-between bg-inherit hover:bg-inherit [&_svg]:pointer-events-auto",
+              "flex h-auto min-h-10 w-full items-center justify-between rounded-md border bg-inherit p-1 hover:bg-inherit [&_svg]:pointer-events-auto",
               className,
             )}
           >
             {selectedValues.length > 0 ? (
-              <div className="flex justify-between items-center w-full">
+              <div className="flex w-full items-center justify-between">
                 <div className="flex flex-wrap items-center">
                   {selectedValues.slice(0, maxCount).map((value) => {
                     const option = options.find((o) => o.value === value);
                     const IconComponent = option?.icon;
                     return (
-                      <div key={value} className="flex items-center group">
+                      <div key={value} className="group flex items-center">
                         <Badge
                           className={cn(
                             multiSelectVariants({ variant }),
@@ -211,10 +211,10 @@ export const MultiSelect = React.forwardRef<
                           }}
                         >
                           {IconComponent && (
-                            <IconComponent className="h-4 w-4 mr-2" />
+                            <IconComponent className="mr-2 h-4 w-4" />
                           )}
                           {option?.label}
-                          <XIcon className="size-3 cursor-pointer text-muted-foreground/80 hover:text-destructive transition-colors" />
+                          <XIcon className="text-muted-foreground/80 hover:text-destructive size-3 cursor-pointer transition-colors" />
                         </Badge>
                       </div>
                     );
@@ -222,7 +222,7 @@ export const MultiSelect = React.forwardRef<
                   {selectedValues.length > maxCount && (
                     <Badge
                       className={cn(
-                        "bg-transparent text-foreground border-foreground/1 hover:bg-transparent",
+                        "text-foreground border-foreground/1 bg-transparent hover:bg-transparent",
                         multiSelectVariants({ variant }),
                       )}
                       style={{ animationDuration: `${animation}s` }}
@@ -241,7 +241,7 @@ export const MultiSelect = React.forwardRef<
                 <div className="flex items-center justify-between">
                   {selectedValues.length > 1 && (
                     <XIcon
-                      className="h-4 mx-2 cursor-pointer text-muted-foreground"
+                      className="text-muted-foreground mx-2 h-4 cursor-pointer"
                       onClick={(event) => {
                         event.stopPropagation();
                         handleClear();
@@ -250,17 +250,17 @@ export const MultiSelect = React.forwardRef<
                   )}
                   <Separator
                     orientation="vertical"
-                    className="flex min-h-6 h-full"
+                    className="flex h-full min-h-6"
                   />
-                  <ChevronDown className="h-4 mx-2 cursor-pointer text-muted-foreground" />
+                  <ChevronDown className="text-muted-foreground mx-2 h-4 cursor-pointer" />
                 </div>
               </div>
             ) : (
-              <div className="flex items-center justify-between w-full mx-auto">
-                <span className="text-sm text-muted-foreground mx-3">
+              <div className="mx-auto flex w-full items-center justify-between">
+                <span className="text-muted-foreground mx-3 text-sm">
                   {placeholder}
                 </span>
-                <ChevronDown className="h-4 cursor-pointer text-muted-foreground mx-2" />
+                <ChevronDown className="text-muted-foreground mx-2 h-4 cursor-pointer" />
               </div>
             )}
           </Button>
@@ -286,13 +286,13 @@ export const MultiSelect = React.forwardRef<
                   >
                     <div
                       className={cn(
-                        "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
+                        "border-primary mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
                         selectedValues.length === options.length
                           ? "bg-primary text-primary-foreground"
                           : "opacity-50 [&_svg]:invisible",
                       )}
                     >
-                      <CheckIcon className="h-4 w-4 color-current" />
+                      <CheckIcon className="color-current h-4 w-4" />
                     </div>
                     <span>(Select All)</span>
                   </CommandItem>
@@ -307,7 +307,7 @@ export const MultiSelect = React.forwardRef<
                     >
                       <div
                         className={cn(
-                          "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
+                          "border-primary mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
                           isSelected
                             ? "bg-primary text-primary-foreground"
                             : "opacity-50 [&_svg]:invisible",
@@ -316,7 +316,7 @@ export const MultiSelect = React.forwardRef<
                         <CheckIcon className="h-4 w-4 text-current" />
                       </div>
                       {option.icon && (
-                        <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+                        <option.icon className="text-muted-foreground mr-2 h-4 w-4" />
                       )}
                       <span>{option.label}</span>
                     </CommandItem>
@@ -330,19 +330,19 @@ export const MultiSelect = React.forwardRef<
                     <>
                       <CommandItem
                         onSelect={handleClear}
-                        className="flex-1 justify-center cursor-pointer"
+                        className="flex-1 cursor-pointer justify-center"
                       >
                         Clear
                       </CommandItem>
                       <Separator
                         orientation="vertical"
-                        className="flex min-h-6 h-full"
+                        className="flex h-full min-h-6"
                       />
                     </>
                   )}
                   <CommandItem
                     onSelect={() => setIsPopoverOpen(false)}
-                    className="flex-1 justify-center cursor-pointer max-w-full"
+                    className="max-w-full flex-1 cursor-pointer justify-center"
                   >
                     Close
                   </CommandItem>

--- a/client/dashboard/src/components/ui/private-input.tsx
+++ b/client/dashboard/src/components/ui/private-input.tsx
@@ -38,7 +38,7 @@ export function PrivateInput({
         type="button"
         tabIndex={-1}
         onClick={() => setIsVisible(!isVisible)}
-        className="absolute right-2 top-[6px] flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+        className="text-muted-foreground hover:text-foreground absolute top-[6px] right-2 flex items-center justify-center transition-colors"
         disabled={disabled || readOnly}
       >
         {isVisible ? (

--- a/client/dashboard/src/components/ui/progress.tsx
+++ b/client/dashboard/src/components/ui/progress.tsx
@@ -15,7 +15,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
       <div
         ref={ref}
         className={cn(
-          "relative h-2 w-full overflow-hidden rounded-full bg-muted border",
+          "bg-muted relative h-2 w-full overflow-hidden rounded-full border",
           className,
         )}
         {...props}

--- a/client/dashboard/src/components/ui/search-bar.tsx
+++ b/client/dashboard/src/components/ui/search-bar.tsx
@@ -20,8 +20,8 @@ export function SearchBar({
       direction="horizontal"
       gap={2}
       className={cn(
-        "h-[42px] border border-border rounded-md px-3",
-        disabled && "opacity-50 cursor-not-allowed",
+        "border-border h-[42px] rounded-md border px-3",
+        disabled && "cursor-not-allowed opacity-50",
         className,
       )}
       align="center"
@@ -32,12 +32,12 @@ export function SearchBar({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
-        className="flex-1 bg-transparent outline-none min-w-0 disabled:cursor-not-allowed"
+        className="min-w-0 flex-1 bg-transparent outline-none disabled:cursor-not-allowed"
       />
       {value && !disabled && (
         <button
           onClick={() => onChange("")}
-          className="opacity-50 hover:opacity-100 transition-opacity"
+          className="opacity-50 transition-opacity hover:opacity-100"
           aria-label="Clear search"
         >
           <X className="size-4" />

--- a/client/dashboard/src/components/ui/sidebar.tsx
+++ b/client/dashboard/src/components/ui/sidebar.tsx
@@ -262,7 +262,7 @@ function SidebarTrigger({
       variant="tertiary"
       size="sm"
       className={cn(
-        "size-7 cursor-pointer text-muted-foreground hover:text-foreground transition",
+        "text-muted-foreground hover:text-foreground size-7 cursor-pointer transition",
         className,
       )}
       onClick={(event) => {
@@ -309,7 +309,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-surface-primary relative flex flex-1 min-w-0 flex-col overflow-auto",
+        "bg-surface-primary relative flex min-w-0 flex-1 flex-col overflow-auto",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}
@@ -337,7 +337,7 @@ function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-header"
       data-sidebar="header"
-      className={cn("flex flex-col gap-2 p-2 mb-3", className)}
+      className={cn("mb-3 flex flex-col gap-2 p-2", className)}
       {...props}
     />
   );
@@ -405,7 +405,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-foreground ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs uppercase font-mono font-normal outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-foreground ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 font-mono text-xs font-normal uppercase outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
@@ -525,7 +525,7 @@ function SidebarMenuButton({
       className={cn(
         sidebarMenuButtonVariants({ variant, size }),
         className,
-        "cursor-pointer trans",
+        "trans cursor-pointer",
         props.href && "hover:no-underline",
       )}
       {...(props.href && { to: props.href })}

--- a/client/dashboard/src/components/ui/skeleton.tsx
+++ b/client/dashboard/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"span">) {
     <span
       data-slot="skeleton"
       className={cn(
-        "block bg-foreground/7 animate-pulse rounded-md",
+        "bg-foreground/7 block animate-pulse rounded-md",
         className,
       )}
       {...props}
@@ -60,7 +60,7 @@ export function SkeletonCode({ lines = 24 }: { lines?: number }) {
   const importLines = Math.floor(lines / 4);
   const codeLines = lines - importLines;
 
-  const LineNumber = () => <Skeleton className="h-5 w-6 mr-4 flex-shrink-0" />;
+  const LineNumber = () => <Skeleton className="mr-4 h-5 w-6 flex-shrink-0" />;
 
   const EmptyLine = () => <LineNumber />;
 
@@ -72,7 +72,7 @@ export function SkeletonCode({ lines = 24 }: { lines?: number }) {
   );
 
   return (
-    <div className="border rounded-lg p-4">
+    <div className="rounded-lg border p-4">
       <Stack gap={2}>
         {/* Import lines - typically shorter */}
         {Array.from({ length: importLines }).map((_, i) => (

--- a/client/dashboard/src/components/ui/slider.tsx
+++ b/client/dashboard/src/components/ui/slider.tsx
@@ -27,7 +27,7 @@ const Slider = forwardRef<HTMLInputElement, SliderProps>(
         max={max}
         step={step}
         className={cn(
-          "w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer",
+          "bg-muted h-2 w-full cursor-pointer appearance-none rounded-lg",
           "[&::-webkit-slider-thumb]:appearance-none",
           "[&::-webkit-slider-thumb]:w-4",
           "[&::-webkit-slider-thumb]:h-4",
@@ -44,7 +44,7 @@ const Slider = forwardRef<HTMLInputElement, SliderProps>(
           "[&::-moz-range-thumb]:cursor-pointer",
           "[&::-moz-range-thumb]:hover:bg-foreground/80",
           "[&::-moz-range-thumb]:transition-colors",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
+          "disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}

--- a/client/dashboard/src/components/ui/spinner.tsx
+++ b/client/dashboard/src/components/ui/spinner.tsx
@@ -2,5 +2,5 @@ import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
 
 export function Spinner({ className }: { className?: string }) {
-  return <Loader2 className={cn("w-4 h-4 mr-2 animate-spin", className)} />;
+  return <Loader2 className={cn("mr-2 h-4 w-4 animate-spin", className)} />;
 }

--- a/client/dashboard/src/components/ui/switch.tsx
+++ b/client/dashboard/src/components/ui/switch.tsx
@@ -28,14 +28,14 @@ export function Switch({
       role="switch"
       aria-checked={checked}
       className={cn(
-        "relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "focus-visible:ring-ring relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
         checked ? "bg-primary" : "bg-input",
         className,
       )}
     >
       <span
         className={cn(
-          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
+          "bg-background pointer-events-none block h-4 w-4 rounded-full shadow-lg ring-0 transition-transform",
           checked ? "translate-x-4" : "translate-x-0.5",
         )}
       />

--- a/client/dashboard/src/components/ui/tabs.tsx
+++ b/client/dashboard/src/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-1 bg-muted",
+        "text-muted-foreground bg-muted inline-flex h-9 w-fit items-center justify-center rounded-lg p-1",
         className,
       )}
       {...props}
@@ -70,7 +70,7 @@ function PageTabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative h-11 px-1 pb-3 pt-3 text-sm bg-transparent! rounded-none border-none shadow-none! text-muted-foreground data-[state=active]:text-foreground data-[state=active]:bg-transparent! after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary",
+        "text-muted-foreground data-[state=active]:text-foreground data-[state=active]:after:bg-primary relative h-11 rounded-none border-none bg-transparent! px-1 pt-3 pb-3 text-sm shadow-none! after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent data-[state=active]:bg-transparent!",
         className,
       )}
       {...props}

--- a/client/dashboard/src/components/ui/tooltip.tsx
+++ b/client/dashboard/src/components/ui/tooltip.tsx
@@ -45,7 +45,7 @@ function TooltipContent({
         className={cn(
           "bg-primary text-primary-foreground",
           "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin) ",
-          "z-50 rounded-md px-3 py-1.5 text-xs text-pretty w-fit max-w-sm",
+          "z-50 w-fit max-w-sm rounded-md px-3 py-1.5 text-xs text-pretty",
           inverted &&
             "bg-background [&_svg]:fill-background [&_svg]:bg-background shadow-md dark:border-1",
           className,

--- a/client/dashboard/src/components/ui/urgent-warning-icon.tsx
+++ b/client/dashboard/src/components/ui/urgent-warning-icon.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle } from "lucide-react";
 export function UrgentWarningIcon({ className }: { className?: string }) {
   return (
     <AlertTriangle
-      className={cn("w-4 h-4 text-orange-700 dark:text-orange-300", className)}
+      className={cn("h-4 w-4 text-orange-700 dark:text-orange-300", className)}
     />
   );
 }

--- a/client/dashboard/src/components/ui/xy-fade.tsx
+++ b/client/dashboard/src/components/ui/xy-fade.tsx
@@ -41,7 +41,7 @@ export function XYFade({
       {/* Top fade overlay */}
       {direction === "vertical" || direction === "both" ? (
         <div
-          className="absolute top-0 left-0 right-0 z-10 pointer-events-none"
+          className="pointer-events-none absolute top-0 right-0 left-0 z-10"
           style={fadeStyle}
         />
       ) : null}
@@ -49,7 +49,7 @@ export function XYFade({
       {/* Bottom fade overlay */}
       {direction === "vertical" || direction === "both" ? (
         <div
-          className="absolute bottom-0 left-0 right-0 z-10 pointer-events-none"
+          className="pointer-events-none absolute right-0 bottom-0 left-0 z-10"
           style={bottomFadeStyle}
         />
       ) : null}
@@ -57,7 +57,7 @@ export function XYFade({
       {/* Left fade overlay */}
       {direction === "horizontal" || direction === "both" ? (
         <div
-          className="absolute top-0 bottom-0 left-0 z-10 pointer-events-none"
+          className="pointer-events-none absolute top-0 bottom-0 left-0 z-10"
           style={horizontalFadeStyle}
         />
       ) : null}
@@ -65,13 +65,13 @@ export function XYFade({
       {/* Right fade overlay */}
       {direction === "horizontal" || direction === "both" ? (
         <div
-          className="absolute top-0 bottom-0 right-0 z-10 pointer-events-none"
+          className="pointer-events-none absolute top-0 right-0 bottom-0 z-10"
           style={horizontalBottomFadeStyle}
         />
       ) : null}
 
       {/* Content - centered */}
-      <div className="relative z-0 flex items-center justify-center min-h-full">
+      <div className="relative z-0 flex min-h-full items-center justify-center">
         {children}
       </div>
     </div>

--- a/client/dashboard/src/components/updated-at.tsx
+++ b/client/dashboard/src/components/updated-at.tsx
@@ -29,7 +29,7 @@ export function UpdatedAt({
       variant="body"
       muted
       className={cn(
-        "text-sm flex items-center gap-1",
+        "flex items-center gap-1 text-sm",
         italic && "italic",
         recentnessClassName,
         className,

--- a/client/dashboard/src/components/upload-asset/deploy-step.tsx
+++ b/client/dashboard/src/components/upload-asset/deploy-step.tsx
@@ -248,15 +248,15 @@ function DeploymentDetailsCollapsible({
 
   return (
     <Collapsible open={open} onOpenChange={onOpenChange}>
-      <CollapsibleTrigger className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors">
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors">
         <ChevronDownIcon
           className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
         />
         Deployment details
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2">
-        <div className="rounded-md border bg-muted/30 p-3 space-y-2">
-          <div className="font-mono text-xs max-h-60 overflow-y-scroll space-y-1">
+        <div className="bg-muted/30 space-y-2 rounded-md border p-3">
+          <div className="max-h-60 space-y-1 overflow-y-scroll font-mono text-xs">
             {logs.map((log) => (
               <div
                 key={log.id}
@@ -266,10 +266,10 @@ function DeploymentDetailsCollapsible({
               </div>
             ))}
           </div>
-          <div className="pt-2 border-t">
+          <div className="border-t pt-2">
             <routes.deployments.deployment.Link
               params={[deployment.id]}
-              className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
             >
               View full deployment details
               <ExternalLinkIcon className="h-3 w-3" />

--- a/client/dashboard/src/components/upload-asset/name-deployment-step.tsx
+++ b/client/dashboard/src/components/upload-asset/name-deployment-step.tsx
@@ -62,7 +62,7 @@ export default function NameDeploymentStep() {
           <Stack
             direction={"horizontal"}
             gap={2}
-            className="max-w-sm z-10 items-center"
+            className="z-10 max-w-sm items-center"
           >
             <Input
               value={value}

--- a/client/dashboard/src/components/upload-asset/step/frame.tsx
+++ b/client/dashboard/src/components/upload-asset/step/frame.tsx
@@ -25,12 +25,12 @@ export default function Frame({ children }: FrameProps) {
   return (
     <div
       className={cn(
-        "flex flex-row gap-4 p-0 flex-nowrap items-stretch justify-start trans w-full",
+        "trans flex w-full flex-row flex-nowrap items-stretch justify-start gap-4 p-0",
         step.isCurrentStep ? "opacity-100" : "opacity-50",
       )}
     >
       {indicator}
-      <div className="flex flex-col gap-4 p-0 flex-nowrap items-stretch justify-start w-full">
+      <div className="flex w-full flex-col flex-nowrap items-stretch justify-start gap-4 p-0">
         {header}
         {content}
       </div>

--- a/client/dashboard/src/components/upload-asset/step/index.tsx
+++ b/client/dashboard/src/components/upload-asset/step/index.tsx
@@ -31,10 +31,10 @@ function Indicator() {
   return (
     <div
       className={cn(
-        "flex items-center justify-center w-7 h-7 rounded-full bg-accent mt-1 [grid-area:indicator]",
+        "bg-accent mt-1 flex h-7 w-7 items-center justify-center rounded-full [grid-area:indicator]",
         step.isCurrentStep && "bg-primary text-primary-foreground",
         step.state === "completed" &&
-          "dark:bg-emerald-900 dark:text-emerald-300 bg-emerald-300 text-emerald-900",
+          "bg-emerald-300 text-emerald-900 dark:bg-emerald-900 dark:text-emerald-300",
         step.state === "failed" && "bg-destructive text-destructive-foreground",
       )}
     >
@@ -69,7 +69,7 @@ function Header({
     <div className="[grid-area=header]">
       <h2 className="text-2xl font-normal capitalize">{title}</h2>
       {description && (
-        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        <p className="text-muted-foreground mt-1 text-sm">{description}</p>
       )}
     </div>
   );

--- a/client/dashboard/src/components/upload.tsx
+++ b/client/dashboard/src/components/upload.tsx
@@ -53,15 +53,15 @@ export function ImageUpload({
   if (assetId) {
     return (
       <div
-        className="group relative cursor-pointer w-fit"
+        className="group relative w-fit cursor-pointer"
         onClick={() => {
           setAssetId(null);
           onUpload({ id: "" } as Asset);
         }}
       >
         <AssetImage assetId={assetId} className={className} />
-        <div className="absolute inset-0 bg-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-          <span className="text-white font-medium">Change</span>
+        <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+          <span className="font-medium text-white">Change</span>
         </div>
       </div>
     );
@@ -150,14 +150,14 @@ export function FullWidthUpload({
   return (
     <div
       tabIndex={0}
-      className={cn("grid gap-4 w-full max-w-2xl", className)}
+      className={cn("grid w-full max-w-2xl gap-4", className)}
       {...(isLoading ? {} : handlers)}
     >
-      <div className="flex items-center justify-center w-full">
+      <div className="flex w-full items-center justify-center">
         <label
           htmlFor="dropzone-file"
           className={cn(
-            "flex flex-col items-center justify-center w-full p-10 border-1 border-dashed rounded-lg trans",
+            "trans flex w-full flex-col items-center justify-center rounded-lg border-1 border-dashed p-10",
             isLoading
               ? "border-primary/50 bg-primary/5 cursor-default"
               : !handlers.isValidFile
@@ -167,8 +167,8 @@ export function FullWidthUpload({
         >
           {isLoading ? (
             <Stack align={"center"} justify={"center"} gap={3}>
-              <Loader2 className="w-5 h-5 animate-spin text-primary" />
-              <p className="my-2 text-sm text-card-foreground font-semibold">
+              <Loader2 className="text-primary h-5 w-5 animate-spin" />
+              <p className="text-card-foreground my-2 text-sm font-semibold">
                 Uploading and validating...
               </p>
               <Type small mono muted>
@@ -177,8 +177,8 @@ export function FullWidthUpload({
             </Stack>
           ) : (
             <Stack align={"center"} justify={"center"} gap={3}>
-              <UploadIcon className="w-4 h-4" />
-              <p className="my-2 text-sm text-card-foreground">
+              <UploadIcon className="h-4 w-4" />
+              <p className="text-card-foreground my-2 text-sm">
                 {label ?? (
                   <>
                     <span className="font-semibold">Click to upload</span> or
@@ -234,8 +234,8 @@ export function CompactUpload({
       htmlFor="dropzone-file"
       tabIndex={0}
       className={cn(
-        "inline-flex flex-col gap-2 items-center justify-center",
-        "p-6 border-1 border-dashed rounded-lg cursor-pointer",
+        "inline-flex flex-col items-center justify-center gap-2",
+        "cursor-pointer rounded-lg border-1 border-dashed p-6",
         "aspect-square",
         !isValidFile
           ? "border-destructive bg-destructive/10"
@@ -246,7 +246,7 @@ export function CompactUpload({
     >
       {(renderFilePreview && renderFilePreview()) ?? (
         <Stack align={"center"} gap={2}>
-          <UploadIcon className="w-4 h-4" />
+          <UploadIcon className="h-4 w-4" />
           <Type mono muted className="text-xs">
             {allowedExtensions?.map((ext) => `.${ext}`)?.join(", ")}
           </Type>

--- a/client/dashboard/src/components/webgl/ascii-video.tsx
+++ b/client/dashboard/src/components/webgl/ascii-video.tsx
@@ -37,7 +37,7 @@ export function AsciiVideo({
       priority={priority}
       flipX={flipX}
       flipY={flipY}
-      className={cn("w-full h-full", className)}
+      className={cn("h-full w-full", className)}
     />
   );
 }

--- a/client/dashboard/src/components/webgl/components/ascii-effect/font-texture.tsx
+++ b/client/dashboard/src/components/webgl/components/ascii-effect/font-texture.tsx
@@ -87,7 +87,7 @@ export function FontTexture() {
   return (
     <div
       ref={(n) => setContainer(n)}
-      className="fixed top-0 left-0 pointer-events-none hidden"
+      className="pointer-events-none fixed top-0 left-0 hidden"
     >
       <canvas
         className="h-full w-full"

--- a/client/dashboard/src/components/webgl/components/html-shadow-element.tsx
+++ b/client/dashboard/src/components/webgl/components/html-shadow-element.tsx
@@ -67,7 +67,7 @@ export const HtmlShadowElement = memo(
         id={`shadow-element-${id}`}
         ref={mergeRefs([registerElement, ref])}
         className={cn(
-          "relative z-10 h-full w-full pointer-events-none",
+          "pointer-events-none relative z-10 h-full w-full",
           "[&_video]:opacity-0",
           className,
         )}

--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -427,9 +427,9 @@ const AppLoadingShell = () => (
   <SidebarProvider
     style={{ "--sidebar-width": "14rem" } as React.CSSProperties}
   >
-    <div className="flex flex-col h-screen w-full">
+    <div className="flex h-screen w-full flex-col">
       {/* Header */}
-      <header className="flex items-center h-14 pl-5 pr-4 border-b bg-white dark:bg-background shrink-0">
+      <header className="dark:bg-background flex h-14 shrink-0 items-center border-b bg-white pr-4 pl-5">
         <div className="flex items-center gap-3">
           <GramLogo className="w-28" />
           <span className="text-muted-foreground/50 text-xl select-none">
@@ -446,7 +446,7 @@ const AppLoadingShell = () => (
         </div>
       </header>
       {/* Body */}
-      <div className="flex flex-1 w-full overflow-hidden pt-2">
+      <div className="flex w-full flex-1 overflow-hidden pt-2">
         <Sidebar collapsible="offcanvas" variant="inset">
           <SidebarContent className="pt-2">
             {Object.entries(LOADING_NAV).map(([group, items]) => (
@@ -476,7 +476,7 @@ const AppLoadingShell = () => (
         <SidebarInset>
           <PageHeader>
             <PageHeader.Breadcrumbs />
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
           </PageHeader>
         </SidebarInset>
       </div>

--- a/client/dashboard/src/pages/CLIs.tsx
+++ b/client/dashboard/src/pages/CLIs.tsx
@@ -9,14 +9,14 @@ export default function CLIs() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <div className="flex flex-col items-center justify-center py-24 px-8 m-8 rounded-xl border border-dashed bg-muted/20">
-          <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-4">
-            <Icon name="terminal" className="w-6 h-6 text-muted-foreground" />
+        <div className="bg-muted/20 m-8 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-24">
+          <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+            <Icon name="terminal" className="text-muted-foreground h-6 w-6" />
           </div>
           <Type variant="subheading" className="mb-1">
             Skills
           </Type>
-          <Type small muted className="text-center mb-4 max-w-md">
+          <Type small muted className="mb-4 max-w-md text-center">
             Build and distribute skills with your team. Track usage, enable
             discovery and improve performance.
           </Type>

--- a/client/dashboard/src/pages/access/Access.tsx
+++ b/client/dashboard/src/pages/access/Access.tsx
@@ -73,8 +73,8 @@ export default function Access() {
         </div>
 
         <Tabs value={currentTab} onValueChange={handleTabChange}>
-          <div className="border-b border-border -mx-8 px-8">
-            <TabsList className="bg-transparent p-0 h-auto rounded-none justify-start gap-4 text-sm">
+          <div className="border-border -mx-8 border-b px-8">
+            <TabsList className="h-auto justify-start gap-4 rounded-none bg-transparent p-0 text-sm">
               <PageTabsTrigger value="roles">
                 Roles{roleCount != null ? ` (${roleCount})` : ""}
               </PageTabsTrigger>

--- a/client/dashboard/src/pages/access/ChangeRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/ChangeRoleDialog.tsx
@@ -78,7 +78,7 @@ export function ChangeRoleDialog({
 
         {member && (
           <div className="space-y-4 py-2">
-            <div className="flex items-center gap-3 rounded-md border border-border p-3">
+            <div className="border-border flex items-center gap-3 rounded-md border p-3">
               <Avatar className="h-9 w-9">
                 {member.photoUrl && (
                   <AvatarImage src={member.photoUrl} alt={member.name} />

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -248,13 +248,13 @@ export function CreateRoleDialog({
     <Sheet open={open} onOpenChange={handleClose}>
       <SheetContent
         side="right"
-        className="sm:max-w-lg w-full flex flex-col overflow-hidden"
+        className="flex w-full flex-col overflow-hidden sm:max-w-lg"
       >
         <SheetHeader>
           <SheetTitle>{isEditing ? "Edit Role" : "Create Role"}</SheetTitle>
         </SheetHeader>
 
-        <div className="flex-1 overflow-y-auto px-4 space-y-4">
+        <div className="flex-1 space-y-4 overflow-y-auto px-4">
           <InputField
             label="Name"
             placeholder="e.g., Project Manager"
@@ -276,17 +276,17 @@ export function CreateRoleDialog({
                 placeholder="Describe what this role can do..."
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex w-full resize-none rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
               />
             )}
           />
 
           {/* Permissions / Grants */}
-          <div className="border-t border-border pt-4">
+          <div className="border-border border-t pt-4">
             <button
               type="button"
               onClick={() => setShowPermissions(!showPermissions)}
-              className="flex items-center gap-1 w-full text-left"
+              className="flex w-full items-center gap-1 text-left"
             >
               <ChevronRight
                 className={cn(
@@ -317,7 +317,7 @@ export function CreateRoleDialog({
                   return (
                     <div
                       key={group.label}
-                      className="border border-border rounded-md"
+                      className="border-border rounded-md border"
                     >
                       {/* Group header */}
                       <div className="flex items-center justify-between px-3 py-2">
@@ -342,13 +342,13 @@ export function CreateRoleDialog({
                           >
                             <ChevronRight
                               className={cn(
-                                "h-3.5 w-3.5 transition-transform text-muted-foreground",
+                                "text-muted-foreground h-3.5 w-3.5 transition-transform",
                                 isExpanded && "rotate-90",
                               )}
                             />
                             <Type
                               variant="body"
-                              className="font-medium text-sm"
+                              className="text-sm font-medium"
                             >
                               {group.label}
                             </Type>
@@ -364,7 +364,7 @@ export function CreateRoleDialog({
 
                       {/* Expanded scope rows */}
                       {isExpanded && (
-                        <div className="border-t border-border bg-muted/40">
+                        <div className="border-border bg-muted/40 border-t">
                           {group.scopes.map((scopeDef) => {
                             const grant = grants[scopeDef.slug];
                             const isChecked = !!grant;
@@ -372,21 +372,21 @@ export function CreateRoleDialog({
                             return (
                               <div
                                 key={scopeDef.slug}
-                                className="flex items-start gap-3 px-3 py-2.5 pl-10 hover:bg-muted/50"
+                                className="hover:bg-muted/50 flex items-start gap-3 px-3 py-2.5 pl-10"
                               >
-                                <label className="flex items-start gap-3 flex-1 min-w-0 cursor-pointer">
+                                <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
                                   <Checkbox
                                     disabled={isSystemRole}
                                     checked={isChecked}
                                     onCheckedChange={() =>
                                       toggleScope(scopeDef.slug)
                                     }
-                                    className="mt-0.5 bg-background"
+                                    className="bg-background mt-0.5"
                                   />
-                                  <div className="flex-1 min-w-0">
+                                  <div className="min-w-0 flex-1">
                                     <Type
                                       variant="body"
-                                      className="font-medium text-sm font-mono"
+                                      className="font-mono text-sm font-medium"
                                     >
                                       {scopeDef.slug}
                                     </Type>
@@ -399,7 +399,7 @@ export function CreateRoleDialog({
                                   </div>
                                 </label>
 
-                                <div className="w-[110px] shrink-0 flex justify-end">
+                                <div className="flex w-[110px] shrink-0 justify-end">
                                   {isChecked && !isSystemRole && (
                                     <ScopePickerPopover
                                       resourceType={scopeDef.resourceType}
@@ -426,11 +426,11 @@ export function CreateRoleDialog({
           </div>
 
           {/* Assign Members */}
-          <div className="border-t border-border pt-4 pb-4">
+          <div className="border-border border-t pt-4 pb-4">
             <button
               type="button"
               onClick={() => setShowMembers(!showMembers)}
-              className="flex items-center gap-1 w-full text-left"
+              className="flex w-full items-center gap-1 text-left"
             >
               <ChevronRight
                 className={cn(
@@ -447,7 +447,7 @@ export function CreateRoleDialog({
             </button>
 
             {showMembers && (
-              <div className="mt-3 border border-border rounded-md divide-y divide-border">
+              <div className="border-border divide-border mt-3 divide-y rounded-md border">
                 {members.map((member) => {
                   const alreadyHasRole =
                     isEditing && member.roleId === editingRole?.id;
@@ -455,8 +455,8 @@ export function CreateRoleDialog({
                     <label
                       key={member.id}
                       className={cn(
-                        "flex items-center gap-3 px-3 py-2.5 hover:bg-muted/50 cursor-pointer",
-                        alreadyHasRole && "opacity-50 cursor-default",
+                        "hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2.5",
+                        alreadyHasRole && "cursor-default opacity-50",
                       )}
                     >
                       <Checkbox
@@ -484,9 +484,9 @@ export function CreateRoleDialog({
                             .slice(0, 2)}
                         </AvatarFallback>
                       </Avatar>
-                      <div className="flex-1 min-w-0 space-y-0.5">
+                      <div className="min-w-0 flex-1 space-y-0.5">
                         <div className="flex items-center gap-2">
-                          <Type variant="body" className="font-medium text-sm">
+                          <Type variant="body" className="text-sm font-medium">
                             {member.name}
                           </Type>
                           {member.roleId && roleNameById.get(member.roleId) && (
@@ -508,11 +508,11 @@ export function CreateRoleDialog({
                                 member.roleId !== editingRole?.id &&
                                 name.trim() && (
                                   <>
-                                    <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                                    <ArrowRight className="text-muted-foreground h-3 w-3 shrink-0" />
                                     <Badge
                                       variant="outline"
                                       size="sm"
-                                      className="font-mono text-[10px] uppercase border-primary text-primary"
+                                      className="border-primary text-primary font-mono text-[10px] uppercase"
                                     >
                                       {name}
                                     </Badge>
@@ -536,7 +536,7 @@ export function CreateRoleDialog({
           </div>
         </div>
 
-        <SheetFooter className="border-t border-border flex-row justify-end">
+        <SheetFooter className="border-border flex-row justify-end border-t">
           <Button variant="secondary" onClick={handleClose}>
             Cancel
           </Button>

--- a/client/dashboard/src/pages/access/DeleteRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/DeleteRoleDialog.tsx
@@ -28,7 +28,7 @@ export const DeleteRoleDialog = ({
         </Dialog.Header>
         <div className="space-y-4 py-4">
           <Type variant="body">
-            <code className="font-mono font-bold px-1 py-0.5 bg-muted rounded">
+            <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
               {role?.name}
             </code>{" "}
             will be permanently deleted. This action cannot be undone.

--- a/client/dashboard/src/pages/access/MembersTab.tsx
+++ b/client/dashboard/src/pages/access/MembersTab.tsx
@@ -94,7 +94,7 @@ export function MembersTab() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-1">
+      <div className="mb-1 flex items-center justify-between">
         <div>
           <Heading variant="h4">Team Members</Heading>
           <Type muted small className="mt-1">
@@ -115,7 +115,7 @@ export function MembersTab() {
           className="mt-4 rounded-b-none"
         />
       )}
-      <div className="flex justify-center border border-t-0 border-border rounded-b-lg py-3">
+      <div className="border-border flex justify-center rounded-b-lg border border-t-0 py-3">
         <Button variant="tertiary" size="sm">
           <Button.Text>Manage Team</Button.Text>
           <Button.RightIcon>

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -123,7 +123,7 @@ export function RolesTab() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-1">
+      <div className="mb-1 flex items-center justify-between">
         <div>
           <Heading variant="h4">Roles</Heading>
           <Type muted small className="mt-1">
@@ -151,7 +151,7 @@ export function RolesTab() {
         />
       )}
 
-      <div className="mt-12 rounded-md border border-border/50 bg-muted/30 px-4 py-3">
+      <div className="border-border/50 bg-muted/30 mt-12 rounded-md border px-4 py-3">
         <Type variant="subheading" className="mb-4">
           About System roles
         </Type>
@@ -159,7 +159,7 @@ export function RolesTab() {
           <Badge
             variant="outline"
             size="sm"
-            className="shrink-0 mt-0.5 bg-white dark:bg-zinc-900 w-16 justify-center"
+            className="mt-0.5 w-16 shrink-0 justify-center bg-white dark:bg-zinc-900"
           >
             Member
           </Badge>
@@ -168,11 +168,11 @@ export function RolesTab() {
             organization and the ability to connect to MCP servers.
           </Type>
         </div>
-        <div className="flex items-start gap-3 text-sm mt-2">
+        <div className="mt-2 flex items-start gap-3 text-sm">
           <Badge
             variant="outline"
             size="sm"
-            className="shrink-0 mt-0.5 bg-white dark:bg-zinc-900 w-16 justify-center"
+            className="mt-0.5 w-16 shrink-0 justify-center bg-white dark:bg-zinc-900"
           >
             Admin
           </Badge>

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -58,7 +58,7 @@ export function ScopePickerPopover({
   // Org-scoped permissions have no resource picker — they're always org-wide
   if (resourceType === "org") {
     return (
-      <span className="inline-flex items-center rounded-md border border-input bg-transparent px-2 py-1 text-xs text-muted-foreground h-7">
+      <span className="border-input text-muted-foreground inline-flex h-7 items-center rounded-md border bg-transparent px-2 py-1 text-xs">
         All
       </span>
     );
@@ -83,15 +83,15 @@ export function ScopePickerPopover({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-1 rounded-md border border-input bg-transparent px-2 py-1 text-xs shadow-xs hover:bg-muted/50 transition-colors shrink-0 h-7"
+          className="border-input hover:bg-muted/50 inline-flex h-7 shrink-0 items-center gap-1 rounded-md border bg-transparent px-2 py-1 text-xs shadow-xs transition-colors"
         >
-          <span className="truncate max-w-[120px]">{label}</span>
-          <ChevronDown className="h-3 w-3 opacity-50 shrink-0" />
+          <span className="max-w-[120px] truncate">{label}</span>
+          <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
         </button>
       </PopoverTrigger>
       <PopoverContent
         align="end"
-        className="w-56 p-1 max-h-[300px] overflow-y-auto"
+        className="max-h-[300px] w-56 overflow-y-auto p-1"
       >
         {/* Scope mode options */}
         <ScopeOption
@@ -114,7 +114,7 @@ export function ScopePickerPopover({
         {/* Resource list when scoped */}
         {!isUnrestricted && (
           <>
-            <div className="my-1 h-px bg-border" />
+            <div className="bg-border my-1 h-px" />
             {resourceType === "project"
               ? projectList.map((resource) => (
                   <ResourceCheckbox
@@ -127,7 +127,7 @@ export function ScopePickerPopover({
                 ))
               : mcpServers.map((group) => (
                   <div key={group.projectId}>
-                    <div className="px-2 py-1 text-xs text-muted-foreground font-medium">
+                    <div className="text-muted-foreground px-2 py-1 text-xs font-medium">
                       {group.projectName}
                     </div>
                     {group.servers.map((server) => (
@@ -164,7 +164,7 @@ function ResourceCheckbox({
       type="button"
       onClick={() => onToggle(id)}
       className={cn(
-        "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent cursor-pointer",
+        "hover:bg-accent flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
         checked && "font-medium",
       )}
     >
@@ -192,11 +192,11 @@ function ScopeOption({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent cursor-pointer",
+        "hover:bg-accent flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
         selected && "font-medium",
       )}
     >
-      <span className="w-4 flex items-center justify-center shrink-0">
+      <span className="flex w-4 shrink-0 items-center justify-center">
         {selected && <Check className="h-3.5 w-3.5" />}
       </span>
       <span>{label}</span>

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -74,7 +74,7 @@ const UsageSection = () => {
             {label}
           </Type>
           <SimpleTooltip tooltip={tooltip}>
-            <Info className="w-4 h-4 text-muted-foreground" />
+            <Info className="text-muted-foreground h-4 w-4" />
           </SimpleTooltip>
         </Stack>
         <UsageProgress
@@ -452,13 +452,13 @@ const UsageProgress = ({
   const includedProgress = (
     <div
       className={cn(
-        "h-4 bg-muted dark:bg-neutral-800 rounded-md overflow-hidden relative",
+        "bg-muted relative h-4 overflow-hidden rounded-md dark:bg-neutral-800",
         anyOverage && "rounded-r-none",
       )}
       style={{ width: `${includedWidth}%` }}
     >
       <div
-        className="h-full bg-success-default transition-all duration-300"
+        className="bg-success-default h-full transition-all duration-300"
         style={{
           width: `${Math.min((value / included) * 100, 100)}%`,
         }}
@@ -468,11 +468,11 @@ const UsageProgress = ({
 
   const overageProgress = anyOverage ? (
     <div
-      className="h-4 bg-muted dark:bg-neutral-800 rounded-r-md overflow-hidden relative"
+      className="bg-muted relative h-4 overflow-hidden rounded-r-md dark:bg-neutral-800"
       style={{ width: `${overageWidth}%` }}
     >
       <div
-        className="h-full bg-warning-default transition-all duration-300"
+        className="bg-warning-default h-full transition-all duration-300"
         style={{
           width: `${Math.min(((value - included) / overageMax) * 100, 100)}%`,
         }}
@@ -489,7 +489,7 @@ const UsageProgress = ({
       </div>
       {/* Included label underneath, always show */}
       <div
-        className="absolute top-6 text-xs text-muted-foreground whitespace-nowrap"
+        className="text-muted-foreground absolute top-6 text-xs whitespace-nowrap"
         style={{ right: `${101 - includedWidth}%` }}
       >
         {anyOverage
@@ -503,12 +503,12 @@ const UsageProgress = ({
       {anyOverage && (
         <>
           <div
-            className="absolute top-0 w-[2px] h-8 bg-neutral-600"
+            className="absolute top-0 h-8 w-[2px] bg-neutral-600"
             style={{ left: `${includedWidth}%` }}
           />
           {/* Overage label underneath */}
           <div
-            className="absolute top-6 text-xs text-muted-foreground whitespace-nowrap"
+            className="text-muted-foreground absolute top-6 text-xs whitespace-nowrap"
             style={{ left: `${includedWidth + 1}%` }}
           >
             Extra: {(value - included).toLocaleString()}
@@ -524,7 +524,7 @@ const UsageProgress = ({
               return (
                 <div
                   key={index}
-                  className="absolute top-0 w-[2px] h-5 bg-neutral-600"
+                  className="absolute top-0 h-5 w-[2px] bg-neutral-600"
                   style={{ left: `${incrementPosition}%` }}
                 />
               );

--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -335,8 +335,8 @@ export function AddServerDialog({
             <Dialog.Title>Loading...</Dialog.Title>
             <Dialog.Description>Fetching server details...</Dialog.Description>
           </Dialog.Header>
-          <div className="py-8 flex items-center justify-center gap-2">
-            <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+          <div className="flex items-center justify-center gap-2 py-8">
+            <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
             <Type muted>Loading server configuration...</Type>
           </div>
         </Dialog.Content>
@@ -356,8 +356,8 @@ export function AddServerDialog({
             </Dialog.Description>
           </Dialog.Header>
           <div className="py-4">
-            <div className="flex items-start gap-3 p-3 rounded-lg border border-destructive/30 bg-destructive/5">
-              <AlertCircle className="w-5 h-5 text-destructive shrink-0 mt-0.5" />
+            <div className="border-destructive/30 bg-destructive/5 flex items-start gap-3 rounded-lg border p-3">
+              <AlertCircle className="text-destructive mt-0.5 h-5 w-5 shrink-0" />
               <Type small className="text-destructive/80">
                 {detailsError}
               </Type>
@@ -556,19 +556,19 @@ function SelectRemotesPhaseContent({
 
         {/* Server icon and info */}
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+          <div className="bg-primary/10 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg">
             {currentConfig.server.iconUrl ? (
               <img
                 src={currentConfig.server.iconUrl}
                 alt=""
-                className="w-6 h-6 rounded"
+                className="h-6 w-6 rounded"
               />
             ) : (
-              <ServerIcon className="w-5 h-5 text-muted-foreground" />
+              <ServerIcon className="text-muted-foreground h-5 w-5" />
             )}
           </div>
-          <div className="flex-1 min-w-0">
-            <Type className="font-medium truncate">
+          <div className="min-w-0 flex-1">
+            <Type className="truncate font-medium">
               {currentConfig.server.title ??
                 currentConfig.server.registrySpecifier}
             </Type>
@@ -594,7 +594,7 @@ function SelectRemotesPhaseContent({
         </div>
 
         {/* Remote checkboxes */}
-        <div className="flex flex-col gap-2 mt-2">
+        <div className="mt-2 flex flex-col gap-2">
           <div className="flex items-center justify-between">
             <Label>Select endpoints to include</Label>
             <button
@@ -615,7 +615,7 @@ function SelectRemotesPhaseContent({
                   });
                 }
               }}
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              className="text-muted-foreground hover:text-foreground text-sm transition-colors"
             >
               {currentConfig.selectedRemoteUrls.size ===
               currentConfig.remotes.length
@@ -623,7 +623,7 @@ function SelectRemotesPhaseContent({
                 : "Select all"}
             </button>
           </div>
-          <div className="space-y-2 max-h-64 overflow-y-auto rounded-lg border bg-muted/50 p-4">
+          <div className="bg-muted/50 max-h-64 space-y-2 overflow-y-auto rounded-lg border p-4">
             {currentConfig.remotes.map((remote) => {
               const isSelected = currentConfig.selectedRemoteUrls.has(
                 remote.url,
@@ -633,7 +633,7 @@ function SelectRemotesPhaseContent({
                 <label
                   key={remote.url}
                   className={cn(
-                    "flex items-start gap-3 p-3 rounded-md cursor-pointer transition-colors border bg-background",
+                    "bg-background flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors",
                     isSelected
                       ? "border-primary/40"
                       : "border-border hover:border-muted-foreground/30",
@@ -644,7 +644,7 @@ function SelectRemotesPhaseContent({
                     onCheckedChange={() => handleRemoteToggle(remote.url)}
                     className="mt-0.5"
                   />
-                  <div className="flex-1 min-w-0">
+                  <div className="min-w-0 flex-1">
                     <Type small className="font-medium">
                       {name}
                     </Type>
@@ -669,7 +669,7 @@ function SelectRemotesPhaseContent({
         >
           <Button.Text>{isLast ? "Continue" : "Next"}</Button.Text>
           <Button.RightIcon>
-            <ArrowRight className="w-4 h-4" />
+            <ArrowRight className="h-4 w-4" />
           </Button.RightIcon>
         </Button>
       </Dialog.Footer>
@@ -729,8 +729,8 @@ function ConfigurePhaseContent({
   // If all servers were multi-remote, show loading state while auto-deploying
   if (!hasOnlySingleRemote && !allAlreadyAdded) {
     return (
-      <div className="py-4 flex items-center justify-center gap-2">
-        <Loader2 className="w-4 h-4 animate-spin" />
+      <div className="flex items-center justify-center gap-2 py-4">
+        <Loader2 className="h-4 w-4 animate-spin" />
         <Type small muted>
           Starting deployment...
         </Type>
@@ -742,8 +742,8 @@ function ConfigurePhaseContent({
     <div onKeyDown={handleKeyDown}>
       <Stack gap={4} className="py-2">
         {allAlreadyAdded ? (
-          <div className="flex items-start gap-3 p-3 rounded-lg border bg-muted/30">
-            <AlertCircle className="size-4 text-muted-foreground shrink-0 mt-0.5" />
+          <div className="bg-muted/30 flex items-start gap-3 rounded-lg border p-3">
+            <AlertCircle className="text-muted-foreground mt-0.5 size-4 shrink-0" />
             <Type small muted>
               {releaseState.serverConfigs.length === 1
                 ? "This source is"
@@ -832,7 +832,7 @@ function BatchServerConfig({
 }) {
   const { existingSpecifiers } = releaseState;
   return (
-    <div className="space-y-3 max-h-80 overflow-y-auto">
+    <div className="max-h-80 space-y-3 overflow-y-auto">
       {singleRemoteConfigs.map((config) => {
         const isAlreadyAdded = existingSpecifiers.has(
           config.server.registrySpecifier,
@@ -845,22 +845,22 @@ function BatchServerConfig({
           <div
             key={config.server.registrySpecifier}
             className={cn(
-              "flex items-center gap-3 p-3 rounded-lg border",
+              "flex items-center gap-3 rounded-lg border p-3",
               isAlreadyAdded && "opacity-50",
             )}
           >
-            <div className="w-6 h-6 rounded bg-primary/10 flex items-center justify-center shrink-0">
+            <div className="bg-primary/10 flex h-6 w-6 shrink-0 items-center justify-center rounded">
               {config.server.iconUrl ? (
                 <img
                   src={config.server.iconUrl}
                   alt=""
-                  className="w-4 h-4 rounded"
+                  className="h-4 w-4 rounded"
                 />
               ) : (
-                <ServerIcon className="w-3 h-3 text-muted-foreground" />
+                <ServerIcon className="text-muted-foreground h-3 w-3" />
               )}
             </div>
-            <div className="flex-1 min-w-0">
+            <div className="min-w-0 flex-1">
               <Input
                 placeholder={
                   config.server.title || config.server.registrySpecifier
@@ -875,7 +875,7 @@ function BatchServerConfig({
               />
             </div>
             {isAlreadyAdded && (
-              <span className="text-xs text-muted-foreground shrink-0">
+              <span className="text-muted-foreground shrink-0 text-xs">
                 Already added
               </span>
             )}
@@ -907,15 +907,15 @@ function DeployingPhaseContent({
   })();
 
   return (
-    <div className="py-2 space-y-4">
+    <div className="space-y-4 py-2">
       <Stack direction="horizontal" gap={2} align="center">
-        <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+        <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
         <Type small muted>
           {statusText}
         </Type>
       </Stack>
       {releaseState.deploymentLogs.length > 0 && (
-        <div className="rounded-lg border bg-muted/30 p-3 max-h-48 overflow-y-auto font-mono text-xs space-y-1">
+        <div className="bg-muted/30 max-h-48 space-y-1 overflow-y-auto rounded-lg border p-3 font-mono text-xs">
           {releaseState.deploymentLogs.map((log) => (
             <div
               key={log.id}
@@ -952,12 +952,12 @@ function CompletePhaseContent({
   ).length;
 
   return (
-    <div className="pb-2 space-y-4">
+    <div className="space-y-4 pb-2">
       {/* Success header when all done */}
       {allDone && allSucceeded && (
-        <div className="flex items-center gap-3 p-3 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
-          <div className="w-8 h-8 rounded-full bg-emerald-500/20 flex items-center justify-center">
-            <Check className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
+        <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/20">
+            <Check className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
           </div>
           <div>
             <Type className="font-medium text-emerald-700 dark:text-emerald-300">
@@ -1025,15 +1025,15 @@ function ToolsetStatusRow({
   const isCompleted = status.status === "completed" && status.toolsetSlug;
 
   const content = (
-    <div className="flex items-center gap-3 p-2 rounded-lg border">
-      <div className="flex-1 min-w-0 flex items-center gap-2">
+    <div className="flex items-center gap-3 rounded-lg border p-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         <Type small className="truncate">
           {status.name}
         </Type>
       </div>
       <div className="flex items-center gap-2">
         {isCompleted && (
-          <ArrowRight className="w-3 h-3 text-muted-foreground" />
+          <ArrowRight className="text-muted-foreground h-3 w-3" />
         )}
         <ToolsetStatusIcon status={status.status} />
       </div>
@@ -1044,7 +1044,7 @@ function ToolsetStatusRow({
     return (
       <routes.mcp.details.Link
         params={[status.toolsetSlug!]}
-        className="no-underline hover:no-underline block hover:opacity-80 transition-opacity"
+        className="block no-underline transition-opacity hover:no-underline hover:opacity-80"
       >
         {content}
       </routes.mcp.details.Link>
@@ -1061,15 +1061,15 @@ function ToolsetStatusIcon({
 }) {
   switch (status) {
     case "pending":
-      return <Circle className="w-4 h-4 text-muted-foreground shrink-0" />;
+      return <Circle className="text-muted-foreground h-4 w-4 shrink-0" />;
     case "creating":
       return (
-        <Loader2 className="w-4 h-4 animate-spin text-muted-foreground shrink-0" />
+        <Loader2 className="text-muted-foreground h-4 w-4 shrink-0 animate-spin" />
       );
     case "completed":
-      return <Check className="w-4 h-4 text-emerald-500 shrink-0" />;
+      return <Check className="h-4 w-4 shrink-0 text-emerald-500" />;
     case "failed":
-      return <X className="w-4 h-4 text-destructive shrink-0" />;
+      return <X className="text-destructive h-4 w-4 shrink-0" />;
   }
 }
 
@@ -1086,35 +1086,35 @@ function SingleServerNextSteps({
 
   return (
     <div>
-      <Type className="font-medium mb-2">Next steps</Type>
+      <Type className="mb-2 font-medium">Next steps</Type>
       <div className="grid grid-cols-2 gap-2">
         <routes.sources.Link className="no-underline hover:no-underline">
-          <div className="group flex items-center gap-3 p-3 rounded-lg border hover:border-foreground/20 hover:bg-muted/30 transition-all [&_*]:no-underline h-full">
-            <div className="w-8 h-8 rounded-md bg-blue-500/10 dark:bg-blue-500/20 flex items-center justify-center shrink-0">
-              <Plus className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+          <div className="group hover:border-foreground/20 hover:bg-muted/30 flex h-full items-center gap-3 rounded-lg border p-3 transition-all [&_*]:no-underline">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-blue-500/10 dark:bg-blue-500/20">
+              <Plus className="h-4 w-4 text-blue-600 dark:text-blue-400" />
             </div>
             <div className="flex-1">
               <Type className="text-sm font-medium no-underline">
                 Add more sources
               </Type>
             </div>
-            <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+            <ArrowRight className="text-muted-foreground h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />
           </div>
         </routes.sources.Link>
         <routes.elements.Link
           className="no-underline hover:no-underline"
           queryParams={{ toolset: toolsetSlug }}
         >
-          <div className="group flex items-center gap-3 p-3 rounded-lg border hover:border-foreground/20 hover:bg-muted/30 transition-all [&_*]:no-underline h-full">
-            <div className="w-8 h-8 rounded-md bg-violet-500/10 dark:bg-violet-500/20 flex items-center justify-center shrink-0">
-              <MessageCircle className="w-4 h-4 text-violet-600 dark:text-violet-400" />
+          <div className="group hover:border-foreground/20 hover:bg-muted/30 flex h-full items-center gap-3 rounded-lg border p-3 transition-all [&_*]:no-underline">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-violet-500/10 dark:bg-violet-500/20">
+              <MessageCircle className="h-4 w-4 text-violet-600 dark:text-violet-400" />
             </div>
             <div className="flex-1">
               <Type className="text-sm font-medium no-underline">
                 Deploy as chat
               </Type>
             </div>
-            <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+            <ArrowRight className="text-muted-foreground h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />
           </div>
         </routes.elements.Link>
         <a
@@ -1123,32 +1123,32 @@ function SingleServerNextSteps({
           rel="noopener noreferrer"
           className="no-underline hover:no-underline"
         >
-          <div className="group flex items-center gap-3 p-3 rounded-lg border hover:border-foreground/20 hover:bg-muted/30 transition-all [&_*]:no-underline h-full">
-            <div className="w-8 h-8 rounded-md bg-emerald-500/10 dark:bg-emerald-500/20 flex items-center justify-center shrink-0">
-              <Plug className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
+          <div className="group hover:border-foreground/20 hover:bg-muted/30 flex h-full items-center gap-3 rounded-lg border p-3 transition-all [&_*]:no-underline">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-emerald-500/10 dark:bg-emerald-500/20">
+              <Plug className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
             </div>
             <div className="flex-1">
               <Type className="text-sm font-medium no-underline">
                 Connect via Claude, Cursor
               </Type>
             </div>
-            <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+            <ArrowRight className="text-muted-foreground h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />
           </div>
         </a>
         <routes.mcp.details.Link
           params={[toolsetSlug]}
           className="no-underline hover:no-underline"
         >
-          <div className="group flex items-center gap-3 p-3 rounded-lg border hover:border-foreground/20 hover:bg-muted/30 transition-all [&_*]:no-underline h-full">
-            <div className="w-8 h-8 rounded-md bg-orange-500/10 dark:bg-orange-500/20 flex items-center justify-center shrink-0">
-              <Settings className="w-4 h-4 text-orange-600 dark:text-orange-400" />
+          <div className="group hover:border-foreground/20 hover:bg-muted/30 flex h-full items-center gap-3 rounded-lg border p-3 transition-all [&_*]:no-underline">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-orange-500/10 dark:bg-orange-500/20">
+              <Settings className="h-4 w-4 text-orange-600 dark:text-orange-400" />
             </div>
             <div className="flex-1">
               <Type className="text-sm font-medium no-underline">
                 Configure MCP settings
               </Type>
             </div>
-            <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+            <ArrowRight className="text-muted-foreground h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />
           </div>
         </routes.mcp.details.Link>
       </div>
@@ -1168,11 +1168,11 @@ function ErrorPhaseContent({
   const routes = useTargetRoutes(releaseState);
 
   return (
-    <div className="py-2 space-y-4">
-      <div className="flex items-start gap-3 p-3 rounded-lg border border-destructive/30 bg-destructive/5">
-        <AlertCircle className="w-5 h-5 text-destructive shrink-0 mt-0.5" />
+    <div className="space-y-4 py-2">
+      <div className="border-destructive/30 bg-destructive/5 flex items-start gap-3 rounded-lg border p-3">
+        <AlertCircle className="text-destructive mt-0.5 h-5 w-5 shrink-0" />
         <div className="flex-1">
-          <Type className="font-medium text-destructive">
+          <Type className="text-destructive font-medium">
             Deployment failed
           </Type>
           <Type small className="text-destructive/80 mt-1">
@@ -1181,7 +1181,7 @@ function ErrorPhaseContent({
         </div>
       </div>
       {releaseState.deploymentLogs.length > 0 && (
-        <div className="rounded-lg border bg-muted/30 p-3 max-h-48 overflow-y-auto font-mono text-xs space-y-1">
+        <div className="bg-muted/30 max-h-48 space-y-1 overflow-y-auto rounded-lg border p-3 font-mono text-xs">
           {releaseState.deploymentLogs.map((log) => (
             <div
               key={log.id}
@@ -1199,7 +1199,7 @@ function ErrorPhaseContent({
             className="no-underline hover:no-underline"
           >
             <Button variant="secondary">
-              <ExternalLink className="w-4 h-4" />
+              <ExternalLink className="h-4 w-4" />
               <Button.Text>View Deployment</Button.Text>
             </Button>
           </routes.deployments.deployment.Link>

--- a/client/dashboard/src/pages/catalog/Catalog.tsx
+++ b/client/dashboard/src/pages/catalog/Catalog.tsx
@@ -156,20 +156,20 @@ export default function Catalog() {
               >
                 <Stack direction="horizontal" gap={3} align="center">
                   <div className="relative w-64">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                    <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
                     <Input
                       placeholder="Search MCP servers..."
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
-                      className="pl-10 pr-9 h-10"
+                      className="h-10 pr-9 pl-10"
                     />
                     {searchQuery && (
                       <button
                         onClick={() => setSearchQuery("")}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                        className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
                         aria-label="Clear search"
                       >
-                        <X className="w-4 h-4" />
+                        <X className="h-4 w-4" />
                       </button>
                     )}
                   </div>
@@ -208,7 +208,7 @@ export default function Catalog() {
 
               {/* Server grid / table */}
               {isLoading ? (
-                <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+                <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
                   {Array.from({ length: 6 }, (_, i) => `skeleton-${i}`).map(
                     (id) => (
                       <Skeleton key={id} className="h-[200px]" />
@@ -218,7 +218,7 @@ export default function Catalog() {
               ) : viewMode === "grid" ? (
                 <div
                   ref={setGridElement}
-                  className="grid grid-cols-1 xl:grid-cols-2 gap-6"
+                  className="grid grid-cols-1 gap-6 xl:grid-cols-2"
                 >
                   {filteredServers.map((server) => {
                     const serverKey = `${server.registryId}-${server.registrySpecifier}`;
@@ -273,11 +273,11 @@ export default function Catalog() {
               {!isLoading && hasNextPage && !searchQuery && (
                 <div
                   ref={loadMoreRef}
-                  className="flex justify-center items-center py-8"
+                  className="flex items-center justify-center py-8"
                 >
                   {isFetchingNextPage && (
                     <Stack direction="horizontal" gap={2} align="center">
-                      <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+                      <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
                       <Type small muted>
                         Loading more...
                       </Type>
@@ -335,15 +335,15 @@ function EmptySearchResult({
   onClear: () => void;
 }) {
   return (
-    <div className="w-full flex items-center justify-center bg-background rounded-xl border py-8">
+    <div className="bg-background flex w-full items-center justify-center rounded-xl border py-8">
       <Stack
         gap={1}
-        className="w-full max-w-sm m-8"
+        className="m-8 w-full max-w-sm"
         align="center"
         justify="center"
       >
         <div className="py-6">
-          <SearchXIcon className="size-16 text-foreground" />
+          <SearchXIcon className="text-foreground size-16" />
         </div>
         <Heading variant="h5" className="font-medium">
           No matching servers

--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -119,7 +119,7 @@ export default function CatalogDetail() {
           />
         </Page.Header>
         <Page.Body>
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
             <div className="lg:col-span-2">
               <Skeleton className="h-[400px] rounded-xl" />
             </div>
@@ -145,7 +145,7 @@ export default function CatalogDetail() {
         <Page.Body>
           <Card>
             <Card.Content className="py-12 text-center">
-              <ServerIcon className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+              <ServerIcon className="text-muted-foreground mx-auto mb-4 h-12 w-12" />
               <Type variant="subheading">Server not found</Type>
               <Type muted className="mt-2">
                 The requested MCP server could not be found in the catalog.
@@ -175,23 +175,23 @@ export default function CatalogDetail() {
         />
       </Page.Header>
       <Page.Body>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           {/* Left Column - Server Details */}
-          <div className="lg:col-span-2 space-y-6">
+          <div className="space-y-6 lg:col-span-2">
             {/* Header */}
             <div className="flex items-start gap-6">
-              <div className="w-24 h-24 rounded-xl bg-primary/5 dark:bg-neutral-800 flex items-center justify-center shrink-0">
+              <div className="bg-primary/5 flex h-24 w-24 shrink-0 items-center justify-center rounded-xl dark:bg-neutral-800">
                 {server.iconUrl ? (
                   <img
                     src={server.iconUrl}
                     alt={displayName}
-                    className="w-16 h-16 rounded-lg object-contain"
+                    className="h-16 w-16 rounded-lg object-contain"
                   />
                 ) : (
-                  <ServerIcon className="w-12 h-12 text-muted-foreground" />
+                  <ServerIcon className="text-muted-foreground h-12 w-12" />
                 )}
               </div>
-              <div className="flex-1 min-w-0">
+              <div className="min-w-0 flex-1">
                 <Stack
                   direction="horizontal"
                   gap={3}
@@ -230,19 +230,19 @@ export default function CatalogDetail() {
                     >
                       {removeServerMutation.isPending ? (
                         <>
-                          <Loader2 className="w-4 h-4 animate-spin" />
+                          <Loader2 className="h-4 w-4 animate-spin" />
                           <Button.Text>Removing...</Button.Text>
                         </>
                       ) : (
                         <>
-                          <Minus className="w-4 h-4" />
+                          <Minus className="h-4 w-4" />
                           <Button.Text>Remove</Button.Text>
                         </>
                       )}
                     </Button>
                   ) : (
                     <Button size="md" onClick={() => setShowAddDialog(true)}>
-                      <Plus className="w-4 h-4" />
+                      <Plus className="h-4 w-4" />
                       <Button.Text>Add</Button.Text>
                     </Button>
                   )}
@@ -256,7 +256,7 @@ export default function CatalogDetail() {
                 <Card.Title>About</Card.Title>
               </Card.Header>
               <Card.Content>
-                <Type className="whitespace-pre-wrap leading-relaxed">
+                <Type className="leading-relaxed whitespace-pre-wrap">
                   {server.description || "No description available."}
                 </Type>
               </Card.Content>
@@ -368,12 +368,12 @@ export default function CatalogDetail() {
                         }
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-primary hover:underline"
+                        className="text-primary flex items-center gap-1 hover:underline"
                       >
-                        <Type className="text-right truncate max-w-[150px]">
+                        <Type className="max-w-[150px] truncate text-right">
                           {versionMeta.source}
                         </Type>
-                        <ExternalLink className="w-3 h-3 shrink-0" />
+                        <ExternalLink className="h-3 w-3 shrink-0" />
                       </a>
                     </div>
                   )}
@@ -394,11 +394,11 @@ export default function CatalogDetail() {
                     </Type>
                     <Type className="text-right">{server.registryId}</Type>
                   </div>
-                  <div className="flex justify-between items-center gap-4">
+                  <div className="flex items-center justify-between gap-4">
                     <Type small muted>
                       Specifier
                     </Type>
-                    <Type className="font-mono text-xs text-right break-all">
+                    <Type className="text-right font-mono text-xs break-all">
                       {server.registrySpecifier}
                     </Type>
                   </div>
@@ -452,10 +452,10 @@ function ToolCard({ tool }: { tool: Tool }) {
     tool.description && tool.description.length > firstSentence.length;
 
   return (
-    <div className="flex flex-col gap-1 p-3 rounded-lg bg-muted/50 overflow-hidden">
+    <div className="bg-muted/50 flex flex-col gap-1 overflow-hidden rounded-lg p-3">
       <button
         onClick={() => hasMoreContent && setIsExpanded(!isExpanded)}
-        className={`flex flex-col gap-1 text-left w-full ${hasMoreContent ? "cursor-pointer" : "cursor-default"}`}
+        className={`flex w-full flex-col gap-1 text-left ${hasMoreContent ? "cursor-pointer" : "cursor-default"}`}
       >
         <Stack
           direction="horizontal"
@@ -496,7 +496,7 @@ function ToolCard({ tool }: { tool: Tool }) {
               animate={{ rotate: isExpanded ? 180 : 0 }}
               transition={{ duration: 0.2 }}
             >
-              <ChevronDown className="w-4 h-4 text-muted-foreground" />
+              <ChevronDown className="text-muted-foreground h-4 w-4" />
             </motion.div>
           )}
         </Stack>
@@ -525,10 +525,10 @@ function ToolCard({ tool }: { tool: Tool }) {
             transition={{ duration: 0.2 }}
             className="overflow-hidden"
           >
-            <div className="mt-2 pt-2 border-t">
+            <div className="mt-2 border-t pt-2">
               <Type
                 small
-                className="whitespace-pre-wrap prose prose-sm max-w-none"
+                className="prose prose-sm max-w-none whitespace-pre-wrap"
               >
                 {tool.description}
               </Type>
@@ -550,7 +550,7 @@ function ToolsSection({ tools }: { tools: Tool[] }) {
       <Card.Header>
         <Card.Title>
           <Stack direction="horizontal" gap={2} align="center">
-            <Wrench className="w-4 h-4" />
+            <Wrench className="h-4 w-4" />
             Available Tools ({tools.length})
           </Stack>
         </Card.Title>
@@ -564,16 +564,16 @@ function ToolsSection({ tools }: { tools: Tool[] }) {
         {hasMore && (
           <button
             onClick={() => setShowAll(!showAll)}
-            className="mt-4 w-full flex items-center justify-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground hover:text-foreground mt-4 flex w-full items-center justify-center gap-1 text-sm transition-colors"
           >
             {showAll ? (
               <>
-                Show less <ChevronUp className="w-4 h-4" />
+                Show less <ChevronUp className="h-4 w-4" />
               </>
             ) : (
               <>
                 Show {tools.length - INITIAL_TOOLS_SHOWN} more tools{" "}
-                <ChevronDown className="w-4 h-4" />
+                <ChevronDown className="h-4 w-4" />
               </>
             )}
           </button>

--- a/client/dashboard/src/pages/catalog/CategoryTabs.tsx
+++ b/client/dashboard/src/pages/catalog/CategoryTabs.tsx
@@ -27,7 +27,7 @@ const CATEGORIES: CategoryConfig[] = [
   {
     value: "popular",
     label: "Popular",
-    icon: <Flame className="w-3.5 h-3.5" />,
+    icon: <Flame className="h-3.5 w-3.5" />,
     description: "Most used servers",
   },
 ];
@@ -51,9 +51,9 @@ export function CategoryTabs({ value, onChange, counts }: CategoryTabsProps) {
             key={category.value}
             onClick={() => onChange(category.value)}
             className={cn(
-              "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-sm font-medium transition-all",
+              "inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-all",
               "hover:border-primary/50 hover:bg-primary/5",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "focus-visible:ring-ring focus:outline-none focus-visible:ring-2",
               isActive
                 ? "border-primary bg-primary/10 text-primary"
                 : "border-border bg-background text-muted-foreground hover:text-foreground",
@@ -65,7 +65,7 @@ export function CategoryTabs({ value, onChange, counts }: CategoryTabsProps) {
             {count !== undefined && (
               <span
                 className={cn(
-                  "ml-1 px-1.5 py-0.5 rounded text-xs",
+                  "ml-1 rounded px-1.5 py-0.5 text-xs",
                   isActive
                     ? "bg-primary text-white"
                     : "bg-muted text-muted-foreground",

--- a/client/dashboard/src/pages/catalog/CommandBar.tsx
+++ b/client/dashboard/src/pages/catalog/CommandBar.tsx
@@ -99,7 +99,7 @@ export function CommandBar({
     <AnimatePresence>
       {selectedCount > 0 && (
         <motion.div
-          className="z-50 fixed bottom-14"
+          className="fixed bottom-14 z-50"
           style={{ left: leftPosition, x: "-50%" }}
           initial={{ opacity: 0, scale: 0.8, y: 40 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -113,7 +113,7 @@ export function CommandBar({
           <div
             ref={barRef}
             data-command-bar
-            className="relative rounded-2xl overflow-hidden border border-primary/20 dark:border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.25),0_0_40px_rgba(59,130,246,0.2),0_0_80px_rgba(59,130,246,0.1)] dark:shadow-none"
+            className="border-primary/20 relative overflow-hidden rounded-2xl border shadow-[0_8px_32px_rgba(0,0,0,0.25),0_0_40px_rgba(59,130,246,0.2),0_0_80px_rgba(59,130,246,0.1)] dark:border-white/10 dark:shadow-none"
           >
             {/* Glass effect layer - blur + distortion */}
             <div
@@ -123,22 +123,22 @@ export function CommandBar({
             {/* Tint layer - opaque enough for text readability */}
             <div className="absolute inset-0 bg-white/80 dark:bg-black/70" />
             {/* Shine layer - light mode only */}
-            <div className="absolute inset-0 dark:hidden shadow-[inset_2px_2px_1px_0_rgba(255,255,255,0.5),inset_-1px_-1px_1px_1px_rgba(255,255,255,0.3)]" />
+            <div className="absolute inset-0 shadow-[inset_2px_2px_1px_0_rgba(255,255,255,0.5),inset_-1px_-1px_1px_1px_rgba(255,255,255,0.3)] dark:hidden" />
             {/* Content layer */}
-            <div className="relative z-10 px-4 py-3 flex items-center gap-4">
+            <div className="relative z-10 flex items-center gap-4 px-4 py-3">
               {/* Clear button */}
               <SimpleTooltip tooltip="Clear selection">
                 <button
                   onClick={onClear}
-                  className="p-1.5 rounded-full text-black/50 hover:text-black hover:bg-black/10 dark:text-white/50 dark:hover:text-white dark:hover:bg-white/10 transition-colors"
+                  className="rounded-full p-1.5 text-black/50 transition-colors hover:bg-black/10 hover:text-black dark:text-white/50 dark:hover:bg-white/10 dark:hover:text-white"
                   aria-label="Clear selection"
                 >
-                  <X className="w-4 h-4" />
+                  <X className="h-4 w-4" />
                 </button>
               </SimpleTooltip>
 
               {/* Divider */}
-              <div className="w-px h-5 bg-black/20 dark:bg-white/20" />
+              <div className="h-5 w-px bg-black/20 dark:bg-white/20" />
 
               {/* Count */}
               <Type small className="font-medium text-black dark:text-white">
@@ -147,14 +147,14 @@ export function CommandBar({
               </Type>
 
               {/* Divider */}
-              <div className="w-px h-5 bg-black/20 dark:bg-white/20" />
+              <div className="h-5 w-px bg-black/20 dark:bg-white/20" />
 
               {/* Add button - min-w to prevent layout shift */}
               <button
                 onClick={onAdd}
-                className="flex items-center justify-center gap-1.5 min-w-[5.5rem] px-3 py-1.5 rounded-full text-sm font-medium bg-foreground text-background hover:bg-foreground/90 transition-colors"
+                className="bg-foreground text-background hover:bg-foreground/90 flex min-w-[5.5rem] items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors"
               >
-                <Plus className="w-3.5 h-3.5" />
+                <Plus className="h-3.5 w-3.5" />
                 Add to project
               </button>
             </div>

--- a/client/dashboard/src/pages/catalog/FilterChips.tsx
+++ b/client/dashboard/src/pages/catalog/FilterChips.tsx
@@ -123,22 +123,22 @@ export function FilterChips({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="text-sm text-muted-foreground">Active:</span>
+      <span className="text-muted-foreground text-sm">Active:</span>
       {chips.map((chip) => (
         <button
           key={chip.key}
           onClick={chip.onRemove}
-          className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-secondary text-secondary-foreground text-sm hover:bg-secondary/80 transition-colors group"
+          className="bg-secondary text-secondary-foreground hover:bg-secondary/80 group inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm transition-colors"
         >
           <span>{chip.label}</span>
-          <X className="w-3 h-3 text-muted-foreground group-hover:text-foreground" />
+          <X className="text-muted-foreground group-hover:text-foreground h-3 w-3" />
         </button>
       ))}
       <Button
         variant="ghost"
         size="sm"
         onClick={onClearAll}
-        className="h-7 text-xs text-muted-foreground hover:text-foreground"
+        className="text-muted-foreground hover:text-foreground h-7 text-xs"
       >
         Clear all
       </Button>

--- a/client/dashboard/src/pages/catalog/FilterSidebar.tsx
+++ b/client/dashboard/src/pages/catalog/FilterSidebar.tsx
@@ -114,21 +114,21 @@ export function FilterSidebar({
         <Button
           variant="outline"
           className={cn(
-            "gap-2 h-10 bg-background border-input",
+            "bg-background border-input h-10 gap-2",
             activeCount > 0 && "border-primary text-primary",
           )}
         >
-          <Filter className="w-4 h-4" />
+          <Filter className="h-4 w-4" />
           <span>Filters</span>
           {activeCount > 0 && (
-            <span className="ml-1 px-1.5 py-0.5 rounded-full bg-primary text-primary-foreground text-xs">
+            <span className="bg-primary text-primary-foreground ml-1 rounded-full px-1.5 py-0.5 text-xs">
               {activeCount}
             </span>
           )}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80 p-0" align="end">
-        <div className="flex items-center justify-between p-4 border-b">
+        <div className="flex items-center justify-between border-b p-4">
           <span className="font-medium">Filters</span>
           {activeCount > 0 && (
             <Button
@@ -137,15 +137,15 @@ export function FilterSidebar({
               onClick={() => {
                 onClear();
               }}
-              className="h-auto p-1 text-muted-foreground hover:text-foreground"
+              className="text-muted-foreground hover:text-foreground h-auto p-1"
             >
-              <X className="w-4 h-4 mr-1" />
+              <X className="mr-1 h-4 w-4" />
               Clear all
             </Button>
           )}
         </div>
 
-        <div className="p-4 space-y-6 max-h-[400px] overflow-y-auto">
+        <div className="max-h-[400px] space-y-6 overflow-y-auto p-4">
           {/* Auth Type */}
           <div className="space-y-3">
             <Label className="text-sm font-medium">Auth Type</Label>
@@ -161,7 +161,7 @@ export function FilterSidebar({
                   />
                   <Label
                     htmlFor={`auth-${option.value}`}
-                    className="text-sm font-normal cursor-pointer"
+                    className="cursor-pointer text-sm font-normal"
                   >
                     {option.label}
                   </Label>
@@ -187,7 +187,7 @@ export function FilterSidebar({
                   />
                   <Label
                     htmlFor={`behavior-${option.value}`}
-                    className="text-sm font-normal cursor-pointer"
+                    className="cursor-pointer text-sm font-normal"
                   >
                     {option.label}
                   </Label>
@@ -218,7 +218,7 @@ export function FilterSidebar({
                   />
                   <Label
                     htmlFor={`popularity-${option.value}`}
-                    className="text-sm font-normal cursor-pointer"
+                    className="cursor-pointer text-sm font-normal"
                   >
                     {option.label}
                   </Label>
@@ -246,7 +246,7 @@ export function FilterSidebar({
                   />
                   <Label
                     htmlFor={`updated-${option.value}`}
-                    className="text-sm font-normal cursor-pointer"
+                    className="cursor-pointer text-sm font-normal"
                   >
                     {option.label}
                   </Label>
@@ -277,7 +277,7 @@ export function FilterSidebar({
                   />
                   <Label
                     htmlFor={`tools-${option.value}`}
-                    className="text-sm font-normal cursor-pointer"
+                    className="cursor-pointer text-sm font-normal"
                   >
                     {option.label}
                   </Label>

--- a/client/dashboard/src/pages/catalog/ServerCard.tsx
+++ b/client/dashboard/src/pages/catalog/ServerCard.tsx
@@ -71,14 +71,14 @@ export function ServerCard({
       <DotCard
         className={cn(
           "cursor-pointer",
-          isAdded && "border-success/50 ring-1 ring-success/20",
+          isAdded && "border-success/50 ring-success/20 ring-1",
         )}
         icon={
           server.iconUrl ? (
             <img
               src={server.iconUrl}
               alt={displayName}
-              className="w-12 h-12 object-contain"
+              className="h-12 w-12 object-contain"
             />
           ) : undefined
         }
@@ -96,13 +96,13 @@ export function ServerCard({
         }
       >
         {/* Header row with name and tool badge */}
-        <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="mb-2 flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <Type
                 variant="subheading"
                 as="div"
-                className="truncate text-md group-hover:text-primary transition-colors"
+                className="text-md group-hover:text-primary truncate transition-colors"
                 title={displayName}
               >
                 {displayName}
@@ -121,19 +121,19 @@ export function ServerCard({
         </div>
 
         {/* Description */}
-        <Type small muted className="line-clamp-2 mb-3">
+        <Type small muted className="mb-3 line-clamp-2">
           {server.description}
         </Type>
 
         {/* Footer row with stats and actions */}
-        <div className="flex items-center justify-between gap-2 mt-auto pt-2">
+        <div className="mt-auto flex items-center justify-between gap-2 pt-2">
           {/* Selection indicator */}
           {isSelected ? (
-            <div className="size-6 rounded-full bg-[#1DA1F2] flex items-center justify-center">
+            <div className="flex size-6 items-center justify-center rounded-full bg-[#1DA1F2]">
               <Check className="size-3.5 text-white" strokeWidth={5} />
             </div>
           ) : (
-            <div className="size-6 rounded-full border-2 border-muted-foreground/30" />
+            <div className="border-muted-foreground/30 size-6 rounded-full border-2" />
           )}
 
           {/* View Details button */}
@@ -145,7 +145,7 @@ export function ServerCard({
             <Button variant="secondary" size="sm">
               <Button.Text>View</Button.Text>
               <Button.RightIcon>
-                <ArrowRight className="w-4 h-4" />
+                <ArrowRight className="h-4 w-4" />
               </Button.RightIcon>
             </Button>
           </Link>

--- a/client/dashboard/src/pages/catalog/ServerTableRow.tsx
+++ b/client/dashboard/src/pages/catalog/ServerTableRow.tsx
@@ -48,25 +48,25 @@ export function ServerTableRow({
   return (
     <DotRow
       onClick={handleRowClick}
-      className={cn(isAdded && "border-l-2 border-l-success/50")}
+      className={cn(isAdded && "border-l-success/50 border-l-2")}
       icon={
         server.iconUrl ? (
           <img
             src={server.iconUrl}
             alt={displayName}
-            className="w-6 h-6 object-contain"
+            className="h-6 w-6 object-contain"
           />
         ) : undefined
       }
     >
       {/* Selection */}
-      <td className="px-3 py-3 w-10">
+      <td className="w-10 px-3 py-3">
         {isSelected ? (
-          <div className="size-5 rounded-full bg-[#1DA1F2] flex items-center justify-center">
+          <div className="flex size-5 items-center justify-center rounded-full bg-[#1DA1F2]">
             <Check className="size-3 text-white" strokeWidth={5} />
           </div>
         ) : (
-          <div className="size-5 rounded-full border-2 border-muted-foreground/30" />
+          <div className="border-muted-foreground/30 size-5 rounded-full border-2" />
         )}
       </td>
 
@@ -76,7 +76,7 @@ export function ServerTableRow({
           <Type
             variant="subheading"
             as="div"
-            className="truncate text-sm group-hover:text-primary transition-colors"
+            className="group-hover:text-primary truncate text-sm transition-colors"
             title={displayName}
           >
             {displayName}
@@ -105,8 +105,8 @@ export function ServerTableRow({
       </td>
 
       {/* Description */}
-      <td className="px-3 py-3 max-w-xs">
-        <Type small muted className="truncate block">
+      <td className="max-w-xs px-3 py-3">
+        <Type small muted className="block truncate">
           {server.description}
         </Type>
       </td>
@@ -122,7 +122,7 @@ export function ServerTableRow({
           <Button variant="secondary" size="sm">
             <Button.Text>View</Button.Text>
             <Button.RightIcon>
-              <ArrowRight className="w-3.5 h-3.5" />
+              <ArrowRight className="h-3.5 w-3.5" />
             </Button.RightIcon>
           </Button>
         </Link>

--- a/client/dashboard/src/pages/catalog/SortDropdown.tsx
+++ b/client/dashboard/src/pages/catalog/SortDropdown.tsx
@@ -26,7 +26,7 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 export function SortDropdown({ value, onChange }: SortDropdownProps) {
   return (
     <Select value={value} onValueChange={(v) => onChange(v as SortOption)}>
-      <SelectTrigger className="w-[164px] !h-10 bg-background">
+      <SelectTrigger className="bg-background !h-10 w-[164px]">
         <SelectValue placeholder="Sort by" />
       </SelectTrigger>
       <SelectContent>

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -91,7 +91,7 @@ function TelemetryLogsTab({
 }) {
   if (isLoading) {
     return (
-      <div className="p-6 text-center text-muted-foreground">
+      <div className="text-muted-foreground p-6 text-center">
         Loading telemetry logs...
       </div>
     );
@@ -99,7 +99,7 @@ function TelemetryLogsTab({
 
   if (error) {
     return (
-      <div className="p-6 text-center text-destructive">
+      <div className="text-destructive p-6 text-center">
         Failed to load logs: {error.message}
       </div>
     );
@@ -107,28 +107,28 @@ function TelemetryLogsTab({
 
   if (logs.length === 0) {
     return (
-      <div className="p-6 text-center text-muted-foreground">
+      <div className="text-muted-foreground p-6 text-center">
         No telemetry logs found for this agent session.
       </div>
     );
   }
 
   return (
-    <div className="divide-y divide-border">
+    <div className="divide-border divide-y">
       {logs.map((log) => (
-        <div key={log.id} className="p-4 hover:bg-muted/30 transition-colors">
+        <div key={log.id} className="hover:bg-muted/30 p-4 transition-colors">
           <div className="flex items-start gap-3">
             <Badge
               variant={getSeverityBadgeVariant(log.severityText)}
-              className="shrink-0 mt-0.5"
+              className="mt-0.5 shrink-0"
             >
               {log.severityText || "INFO"}
             </Badge>
-            <div className="flex-1 min-w-0 space-y-1">
+            <div className="min-w-0 flex-1 space-y-1">
               <div className="text-sm font-medium break-words">
                 {log.body.trim()}
               </div>
-              <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <div className="text-muted-foreground flex items-center gap-3 text-xs">
                 <span>{formatTimestamp(log.timeUnixNano)}</span>
                 {log.service?.name && (
                   <span className="flex items-center gap-1">
@@ -144,10 +144,10 @@ function TelemetryLogsTab({
               </div>
               {log.attributes && Object.keys(log.attributes).length > 0 && (
                 <details className="mt-2">
-                  <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
+                  <summary className="text-muted-foreground hover:text-foreground cursor-pointer text-xs">
                     Show attributes
                   </summary>
-                  <pre className="mt-1 p-2 bg-muted/50 rounded text-xs overflow-x-auto">
+                  <pre className="bg-muted/50 mt-1 overflow-x-auto rounded p-2 text-xs">
                     {JSON.stringify(log.attributes, null, 2)}
                   </pre>
                 </details>
@@ -186,7 +186,7 @@ function ToolCallsTab({
 }) {
   if (isLoading) {
     return (
-      <div className="p-6 text-center text-muted-foreground">
+      <div className="text-muted-foreground p-6 text-center">
         Loading tool call logs...
       </div>
     );
@@ -194,7 +194,7 @@ function ToolCallsTab({
 
   if (error) {
     return (
-      <div className="p-6 text-center text-destructive">
+      <div className="text-destructive p-6 text-center">
         Failed to load tool calls: {error.message}
       </div>
     );
@@ -202,14 +202,14 @@ function ToolCallsTab({
 
   if (toolLogs.length === 0) {
     return (
-      <div className="p-6 text-center text-muted-foreground">
+      <div className="text-muted-foreground p-6 text-center">
         No tool call logs found for this agent session.
       </div>
     );
   }
 
   return (
-    <div className="divide-y divide-border">
+    <div className="divide-border divide-y">
       {toolLogs.map((log) => {
         const attrs = log.attributes || {};
         const toolName = attrs.tool_name || attrs.function_name || "Unknown";
@@ -217,11 +217,11 @@ function ToolCallsTab({
         const status = attrs.http_status_code;
 
         return (
-          <div key={log.id} className="p-4 hover:bg-muted/30 transition-colors">
+          <div key={log.id} className="hover:bg-muted/30 p-4 transition-colors">
             <div className="flex items-start gap-3">
               <div
                 className={cn(
-                  "size-8 rounded-full flex items-center justify-center shrink-0",
+                  "flex size-8 shrink-0 items-center justify-center rounded-full",
                   status && status >= 400
                     ? "bg-destructive/10"
                     : "bg-primary/10",
@@ -237,7 +237,7 @@ function ToolCallsTab({
                   )}
                 />
               </div>
-              <div className="flex-1 min-w-0 space-y-1">
+              <div className="min-w-0 flex-1 space-y-1">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium">{toolName}</span>
                   {status && (
@@ -247,15 +247,15 @@ function ToolCallsTab({
                   )}
                 </div>
                 {gramUrn && (
-                  <div className="text-xs text-muted-foreground font-mono">
+                  <div className="text-muted-foreground font-mono text-xs">
                     {gramUrn}
                   </div>
                 )}
-                <div className="text-xs text-muted-foreground">
+                <div className="text-muted-foreground text-xs">
                   {formatTimestamp(log.timeUnixNano)}
                 </div>
                 {log.body && (
-                  <div className="text-sm text-muted-foreground mt-1">
+                  <div className="text-muted-foreground mt-1 text-sm">
                     {log.body.trim()}
                   </div>
                 )}
@@ -336,10 +336,10 @@ export function ChatDetailPanel({
   });
 
   return (
-    <div className="h-full flex flex-col bg-background">
+    <div className="bg-background flex h-full flex-col">
       {/* Header */}
-      <div className="p-6 border-b">
-        <div className="flex items-center justify-between mb-2">
+      <div className="border-b p-6">
+        <div className="mb-2 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <h2 className="text-xl font-semibold">{getTraceId(chatId)}</h2>
             {status !== "unresolved" && (
@@ -363,48 +363,48 @@ export function ChatDetailPanel({
           </div>
           <button
             onClick={onClose}
-            className="p-1 rounded-md hover:bg-muted transition-colors"
+            className="hover:bg-muted rounded-md p-1 transition-colors"
             aria-label="Close panel"
           >
             <Icon name="x" className="size-5" />
           </button>
         </div>
-        <div className="text-sm text-muted-foreground mb-3">
+        <div className="text-muted-foreground mb-3 text-sm">
           {format(new Date(chat.createdAt), "yyyy-MM-dd HH:mm:ss")}
         </div>
         <div className="text-sm">{chat.title}</div>
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue="overview" className="flex-1 flex flex-col min-h-0">
-        <TabsList className="w-full h-auto justify-start px-6 py-0 bg-transparent border-b rounded-none gap-0">
+      <Tabs defaultValue="overview" className="flex min-h-0 flex-1 flex-col">
+        <TabsList className="h-auto w-full justify-start gap-0 rounded-none border-b bg-transparent px-6 py-0">
           <TabsTrigger
             value="overview"
-            className="relative rounded-none border-0 border-b-2 border-transparent shadow-none px-4 py-3 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+            className="data-[state=active]:border-b-primary relative rounded-none border-0 border-b-2 border-transparent px-4 py-3 shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
           >
-            <Icon name="message-circle" className="size-4 mr-2" />
+            <Icon name="message-circle" className="mr-2 size-4" />
             Overview
           </TabsTrigger>
           <TabsTrigger
             value="logs"
-            className="relative rounded-none border-0 border-b-2 border-transparent shadow-none px-4 py-3 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+            className="data-[state=active]:border-b-primary relative rounded-none border-0 border-b-2 border-transparent px-4 py-3 shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
           >
-            <Icon name="list" className="size-4 mr-2" />
+            <Icon name="list" className="mr-2 size-4" />
             Telemetry Logs
             {logs.length > 0 && (
-              <span className="ml-1.5 text-xs bg-muted px-1.5 rounded-full">
+              <span className="bg-muted ml-1.5 rounded-full px-1.5 text-xs">
                 {logs.length}
               </span>
             )}
           </TabsTrigger>
           <TabsTrigger
             value="tools"
-            className="relative rounded-none border-0 border-b-2 border-transparent shadow-none px-4 py-3 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+            className="data-[state=active]:border-b-primary relative rounded-none border-0 border-b-2 border-transparent px-4 py-3 shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
           >
-            <Icon name="zap" className="size-4 mr-2" />
+            <Icon name="zap" className="mr-2 size-4" />
             Tool Calls
             {toolLogs.length > 0 && (
-              <span className="ml-1.5 text-xs bg-muted px-1.5 rounded-full">
+              <span className="bg-muted ml-1.5 rounded-full px-1.5 text-xs">
                 {toolLogs.length}
               </span>
             )}
@@ -412,9 +412,9 @@ export function ChatDetailPanel({
           {systemMessages.length > 0 && (
             <TabsTrigger
               value="system"
-              className="relative rounded-none border-0 border-b-2 border-transparent shadow-none px-4 py-3 data-[state=active]:border-b-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+              className="data-[state=active]:border-b-primary relative rounded-none border-0 border-b-2 border-transparent px-4 py-3 shadow-none data-[state=active]:bg-transparent data-[state=active]:shadow-none"
             >
-              <Icon name="settings" className="size-4 mr-2" />
+              <Icon name="settings" className="mr-2 size-4" />
               System Prompt
             </TabsTrigger>
           )}
@@ -423,13 +423,13 @@ export function ChatDetailPanel({
         {/* Overview Tab */}
         <TabsContent
           value="overview"
-          className="flex-1 overflow-y-auto m-0 data-[state=inactive]:hidden"
+          className="m-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
         >
           {/* Metadata Grid */}
-          <div className="p-6 border-b bg-muted/10">
+          <div className="bg-muted/10 border-b p-6">
             <div className="grid grid-cols-2 gap-x-8 gap-y-4">
               <div>
-                <div className="text-xs text-muted-foreground mb-1">
+                <div className="text-muted-foreground mb-1 text-xs">
                   User ID:
                 </div>
                 <div className="text-sm font-medium">
@@ -438,10 +438,10 @@ export function ChatDetailPanel({
               </div>
               {chat.source && (
                 <div>
-                  <div className="text-xs text-muted-foreground mb-1">
+                  <div className="text-muted-foreground mb-1 text-xs">
                     Source:
                   </div>
-                  <div className="text-sm font-medium flex items-center gap-2">
+                  <div className="flex items-center gap-2 text-sm font-medium">
                     {chat.source.toLowerCase().includes("claude") ||
                     chat.source.toLowerCase().includes("cursor") ? (
                       <HookSourceIcon source={chat.source} className="size-4" />
@@ -453,13 +453,13 @@ export function ChatDetailPanel({
                 </div>
               )}
               <div>
-                <div className="text-xs text-muted-foreground mb-1">
+                <div className="text-muted-foreground mb-1 text-xs">
                   Duration:
                 </div>
                 <div className="text-sm font-medium">{duration}s</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground mb-1">
+                <div className="text-muted-foreground mb-1 text-xs">
                   Messages:
                 </div>
                 <div className="text-sm font-medium">
@@ -467,7 +467,7 @@ export function ChatDetailPanel({
                 </div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground mb-1">
+                <div className="text-muted-foreground mb-1 text-xs">
                   Tool Calls:
                 </div>
                 <div className="text-sm font-medium">{toolLogs.length}</div>
@@ -475,13 +475,13 @@ export function ChatDetailPanel({
               {resolutions.length > 0 && (
                 <>
                   <div>
-                    <div className="text-xs text-muted-foreground mb-1">
+                    <div className="text-muted-foreground mb-1 text-xs">
                       Resolution Score:
                     </div>
                     <div className="text-lg font-medium">{averageScore}%</div>
                   </div>
                   <div>
-                    <div className="text-xs text-muted-foreground mb-1">
+                    <div className="text-muted-foreground mb-1 text-xs">
                       Context Quality:
                     </div>
                     <Badge variant={contextQuality.variant}>
@@ -496,7 +496,7 @@ export function ChatDetailPanel({
 
           {/* Resolutions Summary */}
           {resolutions.length > 0 && (
-            <div className="p-6 border-b">
+            <div className="border-b p-6">
               <Stack direction="vertical" gap={3}>
                 {resolutions.map((resolution) => (
                   <div key={resolution.id} className="flex items-start gap-4">
@@ -510,11 +510,11 @@ export function ChatDetailPanel({
                       }
                       size="sm"
                     />
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium mb-1">
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-1 text-sm font-medium">
                         {resolution.userGoal}
                       </div>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="text-muted-foreground text-xs">
                         {resolution.resolutionNotes}
                       </div>
                     </div>
@@ -534,7 +534,7 @@ export function ChatDetailPanel({
                   <div key={message.id}>
                     {/* Resolution breakpoint */}
                     {resolution && (
-                      <div className="mb-3 p-3 rounded-lg bg-primary/10 border-l-4 border-primary">
+                      <div className="bg-primary/10 border-primary mb-3 rounded-lg border-l-4 p-3">
                         <div className="text-xs font-semibold">
                           Resolution Point: {resolution.resolution}
                         </div>
@@ -554,23 +554,23 @@ export function ChatDetailPanel({
                                   key={tc.id || idx}
                                   className="flex items-start gap-3"
                                 >
-                                  <div className="size-8 rounded-full bg-primary flex items-center justify-center flex-shrink-0">
+                                  <div className="bg-primary flex size-8 flex-shrink-0 items-center justify-center rounded-full">
                                     <Icon
                                       name="zap"
-                                      className="size-4 text-primary-foreground"
+                                      className="text-primary-foreground size-4"
                                     />
                                   </div>
-                                  <div className="flex-1 min-w-0">
-                                    <div className="flex items-center gap-2 mb-1">
+                                  <div className="min-w-0 flex-1">
+                                    <div className="mb-1 flex items-center gap-2">
                                       <span className="text-sm font-semibold">
                                         Tool Call
                                       </span>
                                       {tc.id && (
-                                        <code className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-mono">
+                                        <code className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                                           {tc.id}
                                         </code>
                                       )}
-                                      <span className="text-xs text-muted-foreground">
+                                      <span className="text-muted-foreground text-xs">
                                         {message.createdAt &&
                                           format(
                                             new Date(message.createdAt),
@@ -578,12 +578,12 @@ export function ChatDetailPanel({
                                           )}
                                       </span>
                                     </div>
-                                    <div className="rounded-lg text-sm overflow-hidden bg-background border">
-                                      <div className="p-3 border-b bg-muted/30">
+                                    <div className="bg-background overflow-hidden rounded-lg border text-sm">
+                                      <div className="bg-muted/30 border-b p-3">
                                         <div className="flex items-center gap-2">
                                           <Icon
                                             name="zap"
-                                            className="size-4 text-primary"
+                                            className="text-primary size-4"
                                           />
                                           <span className="font-semibold">
                                             {tc.function?.name ||
@@ -619,44 +619,44 @@ export function ChatDetailPanel({
                     ) : (
                       <div className="flex items-start gap-3">
                         {message.role === "user" && (
-                          <div className="size-8 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0">
-                            <Icon name="user" className="size-4 text-primary" />
+                          <div className="bg-primary/10 flex size-8 flex-shrink-0 items-center justify-center rounded-full">
+                            <Icon name="user" className="text-primary size-4" />
                           </div>
                         )}
                         {message.role === "assistant" && (
-                          <div className="size-8 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+                          <div className="bg-muted flex size-8 flex-shrink-0 items-center justify-center rounded-full">
                             <Icon name="bot" className="size-4" />
                           </div>
                         )}
                         {message.role === "tool" && (
-                          <div className="size-8 rounded-full bg-primary flex items-center justify-center flex-shrink-0">
+                          <div className="bg-primary flex size-8 flex-shrink-0 items-center justify-center rounded-full">
                             <Icon
                               name="zap"
-                              className="size-4 text-primary-foreground"
+                              className="text-primary-foreground size-4"
                             />
                           </div>
                         )}
 
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
+                        <div className="min-w-0 flex-1">
+                          <div className="mb-1 flex items-center gap-2">
                             <span className="text-sm font-semibold capitalize">
                               {message.role === "tool"
                                 ? "Tool Result"
                                 : message.role}
                             </span>
                             {message.toolCallId && (
-                              <code className="text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-mono">
+                              <code className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                                 {message.toolCallId}
                               </code>
                             )}
-                            <span className="text-xs text-muted-foreground">
+                            <span className="text-muted-foreground text-xs">
                               {message.createdAt &&
                                 format(new Date(message.createdAt), "HH:mm:ss")}
                             </span>
                           </div>
                           <div
                             className={cn(
-                              "rounded-lg text-sm overflow-hidden",
+                              "overflow-hidden rounded-lg text-sm",
                               message.role === "user" && "bg-primary/5 p-3",
                               message.role === "assistant" && "bg-muted/50 p-3",
                               message.role === "tool" && "bg-background border",
@@ -688,7 +688,7 @@ export function ChatDetailPanel({
         {/* Telemetry Logs Tab */}
         <TabsContent
           value="logs"
-          className="flex-1 overflow-y-auto m-0 data-[state=inactive]:hidden"
+          className="m-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
         >
           <TelemetryLogsTab
             logs={logs}
@@ -700,7 +700,7 @@ export function ChatDetailPanel({
         {/* Tool Calls Tab */}
         <TabsContent
           value="tools"
-          className="flex-1 overflow-y-auto m-0 data-[state=inactive]:hidden"
+          className="m-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
         >
           <ToolCallsTab
             toolLogs={toolLogs}
@@ -713,27 +713,27 @@ export function ChatDetailPanel({
         {systemMessages.length > 0 && (
           <TabsContent
             value="system"
-            className="flex-1 overflow-y-auto m-0 data-[state=inactive]:hidden"
+            className="m-0 flex-1 overflow-y-auto data-[state=inactive]:hidden"
           >
             <div className="p-6">
               <Stack direction="vertical" gap={4}>
                 {systemMessages.map((message) => (
                   <div key={message.id}>
-                    <div className="flex items-center gap-2 mb-2">
-                      <div className="size-8 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+                    <div className="mb-2 flex items-center gap-2">
+                      <div className="bg-muted flex size-8 flex-shrink-0 items-center justify-center rounded-full">
                         <Icon name="settings" className="size-4" />
                       </div>
                       <span className="text-sm font-semibold">
                         System Prompt
                       </span>
                       {message.createdAt && (
-                        <span className="text-xs text-muted-foreground">
+                        <span className="text-muted-foreground text-xs">
                           {format(new Date(message.createdAt), "HH:mm:ss")}
                         </span>
                       )}
                     </div>
-                    <div className="p-4 rounded-lg bg-muted/30 border">
-                      <pre className="text-sm whitespace-pre-wrap font-mono">
+                    <div className="bg-muted/30 rounded-lg border p-4">
+                      <pre className="font-mono text-sm whitespace-pre-wrap">
                         {typeof message.content === "string"
                           ? message.content.trim()
                           : JSON.stringify(message.content, null, 2)}

--- a/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
@@ -72,19 +72,19 @@ function ScoreIndicator({
 // Score legend component
 function ScoreLegend() {
   return (
-    <div className="flex items-center px-5 py-3 bg-background border-b text-xs text-muted-foreground whitespace-nowrap overflow-x-auto">
+    <div className="bg-background text-muted-foreground flex items-center overflow-x-auto border-b px-5 py-3 text-xs whitespace-nowrap">
       {/* Spacer to align icon with score rings - matches the score ring column width */}
-      <div className="w-[44px] shrink-0 flex items-center justify-center">
+      <div className="flex w-[44px] shrink-0 items-center justify-center">
         <Icon name="gauge" className="size-5" />
       </div>
-      <div className="flex items-center gap-4 flex-1">
-        <div className="flex items-center gap-2 shrink-0">
+      <div className="flex flex-1 items-center gap-4">
+        <div className="flex shrink-0 items-center gap-2">
           <span className="font-medium">Resolution Score</span>
           <span className="text-muted-foreground/70">
             — How well the assistant resolved user goals
           </span>
         </div>
-        <div className="flex items-center gap-4 ml-auto shrink-0">
+        <div className="ml-auto flex shrink-0 items-center gap-4">
           <ScoreIndicator colorClass={resolutionBgColors.success}>
             80-100 Good
           </ScoreIndicator>
@@ -416,21 +416,21 @@ function ChatLogsContent({
 }) {
   if (isLogsDisabled) {
     return (
-      <div className="h-full overflow-hidden flex flex-col">
+      <div className="flex h-full flex-col overflow-hidden">
         <Page>
           <Page.Header>
             <Page.Header.Breadcrumbs fullWidth />
           </Page.Header>
           <Page.Body fullWidth className="space-y-6">
-            <div className="flex flex-col gap-1 min-w-0">
+            <div className="flex min-w-0 flex-col gap-1">
               <h1 className="text-xl font-semibold">Agent Sessions</h1>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-muted-foreground text-sm">
                 View and debug individual agent sessions
               </p>
             </div>
-            <div className="flex-1 relative">
+            <div className="relative flex-1">
               <div
-                className="pointer-events-none select-none h-full"
+                className="pointer-events-none h-full select-none"
                 aria-hidden="true"
               >
                 <ObservabilitySkeleton />
@@ -445,18 +445,18 @@ function ChatLogsContent({
 
   return (
     <>
-      <div className="h-full overflow-hidden flex flex-col">
+      <div className="flex h-full flex-col overflow-hidden">
         <Page>
           <Page.Header>
             <Page.Header.Breadcrumbs fullWidth />
           </Page.Header>
           <Page.Body fullWidth noPadding overflowHidden>
-            <div className="flex flex-col flex-1 min-h-0 w-full">
+            <div className="flex min-h-0 w-full flex-1 flex-col">
               {/* Header section */}
-              <div className="px-8 py-4 shrink-0 space-y-4">
-                <div className="flex flex-col gap-1 min-w-0">
+              <div className="shrink-0 space-y-4 px-8 py-4">
+                <div className="flex min-w-0 flex-col gap-1">
                   <h1 className="text-xl font-semibold">Agent Sessions</h1>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-muted-foreground text-sm">
                     View and debug individual agent sessions
                   </p>
                 </div>
@@ -468,18 +468,18 @@ function ChatLogsContent({
                     resolutionStatus={resolutionStatus}
                     onResolutionStatusChange={setResolutionStatus}
                   />
-                  <div className="flex items-center gap-3 ml-auto shrink-0">
+                  <div className="ml-auto flex shrink-0 items-center gap-3">
                     {/* Sort segmented control: label + dropdown + direction button */}
-                    <div className="flex items-center h-10 rounded-md border border-border">
-                      <span className="px-3 text-sm font-medium text-muted-foreground">
+                    <div className="border-border flex h-10 items-center rounded-md border">
+                      <span className="text-muted-foreground px-3 text-sm font-medium">
                         Sort
                       </span>
-                      <div className="w-px h-5 bg-border" />
+                      <div className="bg-border h-5 w-px" />
                       <Select
                         value={sortField}
                         onValueChange={(v) => setSortField(v as SortField)}
                       >
-                        <SelectTrigger className="h-full border-0 shadow-none rounded-none min-w-[100px]">
+                        <SelectTrigger className="h-full min-w-[100px] rounded-none border-0 shadow-none">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent className="w-[280px]">
@@ -503,13 +503,13 @@ function ChatLogsContent({
                           </SelectItem>
                         </SelectContent>
                       </Select>
-                      <div className="w-px h-5 bg-border" />
+                      <div className="bg-border h-5 w-px" />
                       <div className="flex items-center px-1.5">
                         <SimpleTooltip tooltip="Sort direction">
                           <button
                             type="button"
                             onClick={toggleSortOrder}
-                            className="size-7 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+                            className="text-muted-foreground hover:text-foreground hover:bg-accent flex size-7 items-center justify-center rounded transition-colors"
                           >
                             {sortOrder === "desc" ? (
                               <ArrowDownIcon className="size-4" />
@@ -532,15 +532,15 @@ function ChatLogsContent({
               </div>
 
               {/* Content section - full width */}
-              <div className="flex-1 overflow-hidden min-h-0 border-t">
-                <div className="h-full flex flex-col bg-background overflow-hidden">
+              <div className="min-h-0 flex-1 overflow-hidden border-t">
+                <div className="bg-background flex h-full flex-col overflow-hidden">
                   {/* Score legend header */}
                   <div className="shrink-0">
                     <ScoreLegend />
                   </div>
 
                   {/* Scrollable chat list */}
-                  <div className="overflow-y-auto flex-1">
+                  <div className="flex-1 overflow-y-auto">
                     <ChatLogsTable
                       chats={chats}
                       selectedChatId={selectedChat?.id}
@@ -552,14 +552,14 @@ function ChatLogsContent({
 
                   {/* Sticky pagination at bottom */}
                   {(hasMore || offset > 0) && (
-                    <div className="p-4 flex justify-center items-center gap-4 border-t bg-background shrink-0">
+                    <div className="bg-background flex shrink-0 items-center justify-center gap-4 border-t p-4">
                       <Button
                         onClick={() => setOffset(Math.max(0, offset - limit))}
                         disabled={offset === 0}
                       >
                         Previous
                       </Button>
-                      <span className="text-sm text-muted-foreground tabular-nums">
+                      <span className="text-muted-foreground text-sm tabular-nums">
                         Page {Math.floor(offset / limit) + 1}
                         {total > 0 && ` of ${Math.ceil(total / limit)}`}
                       </span>

--- a/client/dashboard/src/pages/chatLogs/ChatLogsFilters.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsFilters.tsx
@@ -76,12 +76,12 @@ export function ChatLogsFilters({
   };
 
   return (
-    <div className="flex items-center gap-3 flex-1">
+    <div className="flex flex-1 items-center gap-3">
       <SearchBar
         value={localSearch}
         onChange={setLocalSearch}
         placeholder="Search by chat ID, user ID, or title..."
-        className="flex-1 !h-10"
+        className="!h-10 flex-1"
         disabled={disabled}
       />
 
@@ -91,7 +91,7 @@ export function ChatLogsFilters({
         disabled={disabled}
       >
         <SelectTrigger
-          className="w-[150px] !h-10 border-border"
+          className="border-border !h-10 w-[150px]"
           disabled={disabled}
         >
           <SelectValue placeholder="All Statuses" />

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -85,7 +85,7 @@ function CopyButton({
     <button
       onClick={handleCopy}
       className={cn(
-        "p-0.5 rounded transition-colors",
+        "rounded p-0.5 transition-colors",
         "opacity-50 hover:opacity-100",
         "hover:bg-muted/80",
         copied && "opacity-100",
@@ -132,7 +132,7 @@ function ScoreRing({
   return (
     <div className="flex flex-col items-center gap-1">
       <div className="relative" style={{ width: size, height: size }}>
-        <svg className="transform -rotate-90" width={size} height={size}>
+        <svg className="-rotate-90 transform" width={size} height={size}>
           {/* Background circle */}
           <circle
             cx={size / 2}
@@ -161,7 +161,7 @@ function ScoreRing({
           <span className="text-xs font-semibold tabular-nums">{score}</span>
         </div>
       </div>
-      <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">
+      <span className="text-muted-foreground text-[9px] font-medium tracking-wider uppercase">
         Score
       </span>
     </div>
@@ -195,10 +195,10 @@ export function ChatLogsTable({
 }: ChatLogsTableProps) {
   if (isLoading && chats.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div className="flex h-64 items-center justify-center">
         <div className="flex flex-col items-center gap-3">
-          <div className="size-5 border-2 border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin" />
-          <span className="text-sm text-muted-foreground">
+          <div className="border-muted-foreground/30 border-t-muted-foreground size-5 animate-spin rounded-full border-2" />
+          <span className="text-muted-foreground text-sm">
             Loading traces...
           </span>
         </div>
@@ -208,16 +208,16 @@ export function ChatLogsTable({
 
   if (error) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="flex flex-col items-center gap-3 text-center px-4">
-          <div className="size-10 rounded-full bg-rose-500/10 flex items-center justify-center">
+      <div className="flex h-64 items-center justify-center">
+        <div className="flex flex-col items-center gap-3 px-4 text-center">
+          <div className="flex size-10 items-center justify-center rounded-full bg-rose-500/10">
             <Icon name="triangle-alert" className="size-5 text-rose-500" />
           </div>
           <div>
-            <p className="text-sm font-medium text-foreground">
+            <p className="text-foreground text-sm font-medium">
               Failed to load traces
             </p>
-            <p className="text-xs text-muted-foreground mt-1">
+            <p className="text-muted-foreground mt-1 text-xs">
               {error.message}
             </p>
           </div>
@@ -228,16 +228,16 @@ export function ChatLogsTable({
 
   if (chats.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="flex flex-col items-center gap-3 text-center px-4">
-          <div className="size-10 rounded-full bg-muted flex items-center justify-center">
-            <Icon name="inbox" className="size-5 text-muted-foreground" />
+      <div className="flex h-64 items-center justify-center">
+        <div className="flex flex-col items-center gap-3 px-4 text-center">
+          <div className="bg-muted flex size-10 items-center justify-center rounded-full">
+            <Icon name="inbox" className="text-muted-foreground size-5" />
           </div>
           <div>
-            <p className="text-sm font-medium text-foreground">
+            <p className="text-foreground text-sm font-medium">
               No traces found
             </p>
-            <p className="text-xs text-muted-foreground mt-1">
+            <p className="text-muted-foreground mt-1 text-xs">
               Try adjusting your filters or time range
             </p>
           </div>
@@ -247,7 +247,7 @@ export function ChatLogsTable({
   }
 
   return (
-    <div className="divide-y divide-border/50">
+    <div className="divide-border/50 divide-y">
       {chats.map((chat) => {
         const status = getOverallResolutionStatus(chat.resolutions);
         const averageScore = getAverageScore(chat.resolutions);
@@ -260,9 +260,9 @@ export function ChatLogsTable({
             key={chat.id}
             onClick={() => onSelectChat(chat)}
             className={cn(
-              "w-full text-left px-5 py-4 transition-all duration-150",
+              "w-full px-5 py-4 text-left transition-all duration-150",
               "hover:bg-muted/50",
-              "focus:outline-none focus-visible:bg-muted/50",
+              "focus-visible:bg-muted/50 focus:outline-none",
               isSelected && "bg-primary/[0.03] hover:bg-primary/[0.05]",
             )}
           >
@@ -274,12 +274,12 @@ export function ChatLogsTable({
                 ) : (
                   <SimpleTooltip tooltip="This session hasn't been analyzed yet. Scores are generated automatically after a conversation ends.">
                     <div className="flex flex-col items-center gap-1">
-                      <div className="size-[44px] rounded-full border-[3px] border-muted-foreground/30 flex items-center justify-center">
-                        <span className="text-[10px] font-semibold text-muted-foreground">
+                      <div className="border-muted-foreground/30 flex size-[44px] items-center justify-center rounded-full border-[3px]">
+                        <span className="text-muted-foreground text-[10px] font-semibold">
                           N/A
                         </span>
                       </div>
-                      <span className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium">
+                      <span className="text-muted-foreground text-[9px] font-medium tracking-wider uppercase">
                         Score
                       </span>
                     </div>
@@ -288,30 +288,30 @@ export function ChatLogsTable({
               </div>
 
               {/* Center: Main content */}
-              <div className="flex-1 min-w-0">
+              <div className="min-w-0 flex-1">
                 {/* Header row */}
-                <div className="flex items-center gap-2 mb-1.5">
+                <div className="mb-1.5 flex items-center gap-2">
                   <StatusDot status={status} />
-                  <span className="text-xs font-semibold text-muted-foreground tracking-wide uppercase">
+                  <span className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
                     {getTraceId(chat.id)}
                   </span>
                   <CopyButton value={chat.id} label="Chat ID" />
                   <span className="text-muted-foreground/40">·</span>
-                  <span className="text-sm text-muted-foreground">
+                  <span className="text-muted-foreground text-sm">
                     {format(chat.createdAt, "MMM d, HH:mm")}
                   </span>
                 </div>
 
                 {/* Title */}
-                <h3 className="text-sm font-medium text-foreground leading-snug line-clamp-2 mb-2">
+                <h3 className="text-foreground mb-2 line-clamp-2 text-sm leading-snug font-medium">
                   {chat.title}
                 </h3>
 
                 {/* Metadata row */}
-                <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                <div className="text-muted-foreground flex items-center gap-4 text-sm">
                   <span className="flex items-center gap-1.5">
                     <Icon name="user" className="size-4 opacity-60" />
-                    <span className="truncate max-w-[120px]">
+                    <span className="max-w-[120px] truncate">
                       {chat.externalUserId || "anonymous"}
                     </span>
                   </span>

--- a/client/dashboard/src/pages/chatLogs/ResolutionBadges.tsx
+++ b/client/dashboard/src/pages/chatLogs/ResolutionBadges.tsx
@@ -8,7 +8,7 @@ interface ResolutionBadgesProps {
 export function ResolutionBadges({ resolutions }: ResolutionBadgesProps) {
   if (resolutions.length === 0) {
     return (
-      <div className="text-xs text-muted-foreground italic">
+      <div className="text-muted-foreground text-xs italic">
         Chat in progress...
       </div>
     );

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -74,9 +74,9 @@ export default function CliCallback(props: CliCallbackProps) {
 
 function FailedScreen({ error }: { error: string }) {
   return (
-    <div className="flex items-center justify-center h-screen">
+    <div className="flex h-screen items-center justify-center">
       <div className="text-center">
-        <h1 className="text-2xl font-bold text-red-600 mb-2">Error</h1>
+        <h1 className="mb-2 text-2xl font-bold text-red-600">Error</h1>
         <p className="text-gray-600">{error}</p>
       </div>
     </div>
@@ -85,9 +85,9 @@ function FailedScreen({ error }: { error: string }) {
 
 function WaitScreen() {
   return (
-    <div className="flex items-center justify-center h-screen">
+    <div className="flex h-screen items-center justify-center">
       <div className="text-center">
-        <h1 className="text-2xl font-bold mb-2">Redirecting...</h1>
+        <h1 className="mb-2 text-2xl font-bold">Redirecting...</h1>
         <p className="text-gray-600">You will be redirected shortly</p>
       </div>
     </div>

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -11,12 +11,12 @@ export default function BookDemo() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
+    <div className="bg-background flex min-h-screen items-center justify-center">
       <Button
         variant="ghost"
         size="sm"
         onClick={handleLogout}
-        className="absolute right-4 top-4"
+        className="absolute top-4 right-4"
       >
         <LogOutIcon className="mr-2 h-4 w-4" />
         Log out

--- a/client/dashboard/src/pages/deployments/Deployments.tsx
+++ b/client/dashboard/src/pages/deployments/Deployments.tsx
@@ -109,7 +109,7 @@ function DeploymentActionsDropdown({
           disabled={redeployMutation.isPending}
           className="cursor-pointer"
         >
-          <Icon name="refresh-cw" className="size-4 mr-2" />
+          <Icon name="refresh-cw" className="mr-2 size-4" />
           {buttonText}
         </DropdownMenuItem>
       </DropdownMenuContent>
@@ -139,19 +139,19 @@ export function DeploymentsTable({
         switch (row.status) {
           case "completed":
             return (
-              <div className="flex items-center justify-center rounded-full bg-success p-1">
+              <div className="bg-success flex items-center justify-center rounded-full p-1">
                 <Icon name="check" className="text-success-foreground" />
               </div>
             );
           case "failed":
             return (
-              <div className="flex items-center justify-center rounded-full bg-destructive/20 p-1">
+              <div className="bg-destructive/20 flex items-center justify-center rounded-full p-1">
                 <Icon name="x" className="text-destructive-foreground" />
               </div>
             );
           default:
             return (
-              <div className="flex items-center justify-center rounded-full bg-warning p-1">
+              <div className="bg-warning flex items-center justify-center rounded-full p-1">
                 <Icon
                   name="circle-dashed"
                   className="text-warning-foreground"
@@ -173,7 +173,7 @@ export function DeploymentsTable({
             <div className="flex gap-2">
               <p className="text-muted-foreground text-sm">{createdAt}</p>
               {activeDeployment === row && (
-                <Badge variant="success" className="py-0.25 px-1.5">
+                <Badge variant="success" className="px-1.5 py-0.25">
                   Active
                 </Badge>
               )}
@@ -219,7 +219,7 @@ export function DeploymentsTable({
     <>
       {showHeader && (
         <>
-          <div className="flex items-center justify-between mb-2">
+          <div className="mb-2 flex items-center justify-between">
             <Heading variant="h2">Recent Deployments</Heading>
             {activeDeployment && (
               <routes.deployments.deployment.Link
@@ -235,12 +235,12 @@ export function DeploymentsTable({
             )}
           </div>
 
-          <div className="bg-secondary p-6 rounded-lg mb-6 space-y-2">
-            <p className="text-sm text-muted-foreground">
+          <div className="bg-secondary mb-6 space-y-2 rounded-lg p-6">
+            <p className="text-muted-foreground text-sm">
               Each time you add a new source or update an existing source a new
               deployment is created.
             </p>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               For each deployment all sources are analyzed in the project to
               generate or update the corresponding tool definitions.
             </p>

--- a/client/dashboard/src/pages/deployments/ToolsList.tsx
+++ b/client/dashboard/src/pages/deployments/ToolsList.tsx
@@ -33,8 +33,8 @@ const columns: Column<ToolWithDisplayName>[] = [
     header: "Name",
     key: "name",
     render: (row) => (
-      <Stack gap={2} className="break-all min-w-[175px] mr-[-24px]">
-        <Type className="text-wrap break-all font-medium ">
+      <Stack gap={2} className="mr-[-24px] min-w-[175px] break-all">
+        <Type className="font-medium text-wrap break-all ">
           {row.displayName || row.name}
         </Type>
         {row.type === "http" && (
@@ -48,7 +48,7 @@ const columns: Column<ToolWithDisplayName>[] = [
     header: "Description",
     key: "description",
     render: (row) => (
-      <Type muted className="line-clamp-2 overflow-auto self-start">
+      <Type muted className="line-clamp-2 self-start overflow-auto">
         {row.description}
         {!row.description && (
           <span className="text-muted-foreground italic">No description.</span>
@@ -146,7 +146,7 @@ export function ToolsList(props: { deploymentId?: string }) {
               hideHeader
               renderExpandedContent={(group) => (
                 // This div is necessary to apply the bottom border to the table
-                <div className="bg-stone-50 border-b-1 dark:bg-card max-h-[500px] overflow-y-auto">
+                <div className="dark:bg-card max-h-[500px] overflow-y-auto border-b-1 bg-stone-50">
                   <Table
                     columns={columns}
                     data={group.tools}

--- a/client/dashboard/src/pages/deployments/deployment/AssetsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/AssetsTabContent.tsx
@@ -75,7 +75,7 @@ export const AssetsTabContent = () => {
             </Type>
           </Stack>
 
-          <ul className="flex flex-col gap-4 flex-wrap">
+          <ul className="flex flex-col flex-wrap gap-4">
             {errAll.map((asset) => {
               return (
                 <li key={asset.id}>
@@ -93,7 +93,7 @@ export const AssetsTabContent = () => {
             Functions
           </Heading>
 
-          <ul className="flex flex-col gap-4 flex-wrap">
+          <ul className="flex flex-col flex-wrap gap-4">
             {okFunctions.map((asset) => {
               return (
                 <li key={asset.id}>
@@ -110,7 +110,7 @@ export const AssetsTabContent = () => {
           <Heading variant="h2" className="mb-6">
             OpenAPI
           </Heading>
-          <ul className="flex flex-col gap-4 flex-wrap">
+          <ul className="flex flex-col flex-wrap gap-4">
             {okOpenAPI.map((asset) => {
               return (
                 <li key={asset.id}>
@@ -136,25 +136,25 @@ const AssetItem = ({ asset }: AssetItemProps) => {
     icon = <SquareFunctionIcon strokeWidth={1} className="size-12 min-w-12" />;
   }
   let type = (
-    <span className="text-xs text-muted leading-5">OpenAPI Document</span>
+    <span className="text-muted text-xs leading-5">OpenAPI Document</span>
   );
   if (asset.type === "function") {
     type = (
-      <span className="text-xs text-muted leading-5 font-mono">
+      <span className="text-muted font-mono text-xs leading-5">
         {asset.runtime}
       </span>
     );
   }
 
   return (
-    <MiniCard className="w-full max-w-full bg-surface-secondary-default border-neutral-softest p-6">
+    <MiniCard className="bg-surface-secondary-default border-neutral-softest w-full max-w-full p-6">
       <MiniCard.Title>
-        <div className="flex gap-4 w-full items-center">
+        <div className="flex w-full items-center gap-4">
           {icon}
           <div className="flex flex-col">
             <span className="text-base leading-7">{asset.name}</span>
             <div className="flex items-center gap-2">
-              <span className="text-xs text-muted leading-5">{type}</span>
+              <span className="text-muted text-xs leading-5">{type}</span>
               {asset.report.toolCount === 0 && <AssetErrorBadge />}
             </div>
           </div>
@@ -179,7 +179,7 @@ const AssetErrorBadge = () => {
       <TooltipTrigger>
         <Badge
           variant="destructive"
-          className="px-0.5 py-1 leading-2 items-center flex text-xs"
+          className="flex items-center px-0.5 py-1 text-xs leading-2"
         >
           Error
         </Badge>

--- a/client/dashboard/src/pages/deployments/deployment/Deployment.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/Deployment.tsx
@@ -65,8 +65,8 @@ function DeploymentLogs(props: { deploymentId: string }) {
   };
 
   return (
-    <div className="grid gap-16 w-full overflow-x-hidden">
-      <section className="space-y-6 min-w-0">
+    <div className="grid w-full gap-16 overflow-x-hidden">
+      <section className="min-w-0 space-y-6">
         <HeadingSection />
 
         <Suspense
@@ -95,7 +95,7 @@ function DeploymentLogs(props: { deploymentId: string }) {
       <Tabs
         value={searchParams.tab}
         onValueChange={handleUpdateTab}
-        className="gap-16 min-w-0"
+        className="min-w-0 gap-16"
       >
         <TabsList>
           <TabsTrigger value="logs">Logs</TabsTrigger>
@@ -215,7 +215,7 @@ const StatsSection = ({
   assetCount += deployment.externalMcps?.length ?? 0;
 
   return (
-    <div className="text-sm flex items-center gap-3 h-4">
+    <div className="flex h-4 items-center gap-3 text-sm">
       <span>{deployment.id}</span>
       <Separator orientation="vertical" />
       <div className="flex items-center gap-0.5">
@@ -260,7 +260,7 @@ const HumanizedDeploymentStatus = memo((props: { status: string }) => {
   if (props.status === "completed") {
     return (
       <div className="flex items-center">
-        <CheckIcon className="size-4 text-default-success" />
+        <CheckIcon className="text-default-success size-4" />
         <span className="ml-2">Succeeded</span>
       </div>
     );
@@ -269,7 +269,7 @@ const HumanizedDeploymentStatus = memo((props: { status: string }) => {
   if (props.status === "failed") {
     return (
       <div className="flex items-center">
-        <XIcon className="size-4 text-destructive" />
+        <XIcon className="text-destructive size-4" />
         <span className="ml-2">Failed</span>
       </div>
     );

--- a/client/dashboard/src/pages/deployments/deployment/FailedSourcesSection.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/FailedSourcesSection.tsx
@@ -165,9 +165,9 @@ export function FailedSourcesSection({
 
   return (
     <>
-      <section className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 space-y-3">
+      <section className="border-destructive/40 bg-destructive/5 space-y-3 rounded-lg border p-4">
         <div className="flex items-center gap-2">
-          <CircleAlert className="size-5 text-destructive shrink-0" />
+          <CircleAlert className="text-destructive size-5 shrink-0" />
           <h3 className="text-sm font-semibold">
             {failedSources.length > 0
               ? `${failedSources.length} source${failedSources.length !== 1 ? "s" : ""} failed`
@@ -176,12 +176,12 @@ export function FailedSourcesSection({
         </div>
 
         {failedSources.length > 0 && (
-          <p className="text-sm text-muted-foreground">
+          <p className="text-muted-foreground text-sm">
             Select the sources to remove and redeploy without them.
           </p>
         )}
 
-        <div className="max-h-80 overflow-y-auto space-y-2">
+        <div className="max-h-80 space-y-2 overflow-y-auto">
           {failedSources.map((source) => {
             const IconComponent = SOURCE_ICONS[source.type];
             const isSelected = selected.has(source.id);
@@ -203,14 +203,14 @@ export function FailedSourcesSection({
                     onCheckedChange={() => toggleSelected(source.id)}
                     disabled={pending}
                   />
-                  <div className="w-8 h-8 rounded-md bg-destructive/10 flex items-center justify-center shrink-0">
-                    <IconComponent className="w-4 h-4 text-destructive" />
+                  <div className="bg-destructive/10 flex h-8 w-8 shrink-0 items-center justify-center rounded-md">
+                    <IconComponent className="text-destructive h-4 w-4" />
                   </div>
-                  <div className="flex-1 min-w-0">
-                    <span className="text-sm font-medium truncate block">
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">
                       {source.name}
                     </span>
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-muted-foreground text-xs">
                       {source.type === "openapi"
                         ? "API Source"
                         : source.type === "function"
@@ -223,7 +223,7 @@ export function FailedSourcesSection({
                   {source.toolCount > 0 && (
                     <Badge
                       variant="neutral"
-                      className="shrink-0 flex items-center gap-1"
+                      className="flex shrink-0 items-center gap-1"
                     >
                       <Wrench className="size-3" />
                       {`${source.toolCount} ${source.toolCount === 1 ? "tool" : "tools"}`}
@@ -233,7 +233,7 @@ export function FailedSourcesSection({
                     <button
                       type="button"
                       onClick={() => toggleExpanded(source.id)}
-                      className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground"
+                      className="hover:bg-muted text-muted-foreground rounded p-1 transition-colors"
                     >
                       {isExpanded ? (
                         <ChevronDown className="size-4" />
@@ -248,7 +248,7 @@ export function FailedSourcesSection({
                     {source.errors.map((err) => (
                       <div
                         key={err.id}
-                        className="text-xs text-destructive bg-destructive/5 rounded px-2 py-1.5 font-mono break-all"
+                        className="text-destructive bg-destructive/5 rounded px-2 py-1.5 font-mono text-xs break-all"
                       >
                         {err.message}
                       </div>
@@ -260,13 +260,13 @@ export function FailedSourcesSection({
           })}
 
           {generalErrors.length > 0 && (
-            <div className="rounded-lg border border-border bg-card p-3">
+            <div className="border-border bg-card rounded-lg border p-3">
               <span className="text-sm font-medium">General errors</span>
               <div className="mt-2 space-y-1">
                 {generalErrors.map((err) => (
                   <div
                     key={err.id}
-                    className="text-xs text-destructive bg-destructive/5 rounded px-2 py-1.5 font-mono break-all"
+                    className="text-destructive bg-destructive/5 rounded px-2 py-1.5 font-mono text-xs break-all"
                   >
                     {err.message}
                   </div>
@@ -312,10 +312,10 @@ export function FailedSourcesSection({
             Removing these sources will break toolsets that depend on their
             tools. You may need to update affected toolsets afterward.
           </Alert>
-          <ul className="text-sm space-y-1">
+          <ul className="space-y-1 text-sm">
             {selectedWithTools.map((s) => (
               <li key={s.id} className="flex items-center gap-2">
-                <Wrench className="size-3 text-muted-foreground shrink-0" />
+                <Wrench className="text-muted-foreground size-3 shrink-0" />
                 <span className="font-medium">{s.name}</span>
                 <span className="text-muted-foreground">
                   {`${s.toolCount} ${s.toolCount === 1 ? "tool" : "tools"}`}

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -557,7 +557,7 @@ export const LogsTabContent = ({
             part.toLowerCase() === searchQuery.toLowerCase() ? (
               <mark
                 key={i}
-                className="bg-yellow-200 dark:bg-yellow-800 text-inherit"
+                className="bg-yellow-200 text-inherit dark:bg-yellow-800"
               >
                 {part}
               </mark>
@@ -585,7 +585,7 @@ export const LogsTabContent = ({
               Source
             </Type>
             <Select value={selectedSource} onValueChange={setSelectedSource}>
-              <SelectTrigger size="sm" className="min-w-[180px] bg-background">
+              <SelectTrigger size="sm" className="bg-background min-w-[180px]">
                 <SelectValue placeholder="All sources" />
               </SelectTrigger>
               <SelectContent>
@@ -606,28 +606,28 @@ export const LogsTabContent = ({
       )}
 
       {/* Logs container */}
-      <div className="relative bg-surface rounded-lg border border-border overflow-hidden">
+      <div className="bg-surface border-border relative overflow-hidden rounded-lg border">
         <div
           className={cn(
-            "flex items-center gap-2 p-2 bg-surface/50 transition-all",
-            isScrolled && "border-b border-border",
+            "bg-surface/50 flex items-center gap-2 p-2 transition-all",
+            isScrolled && "border-border border-b",
           )}
         >
-          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+          <div className="text-muted-foreground flex items-center gap-3 text-[11px]">
             {searchQuery ? (
               <>
                 <span className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                  <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     N
                   </kbd>
                   <span>/</span>
-                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                  <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     ⇧N
                   </kbd>
                   <span className="ml-0.5">results</span>
                 </span>
                 <span className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                  <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     ESC
                   </kbd>
                   <span>clear</span>
@@ -636,23 +636,23 @@ export const LogsTabContent = ({
             ) : (
               <>
                 <span className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                  <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     J
                   </kbd>
                   <span>/</span>
-                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                  <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     K
                   </kbd>
                   <span className="ml-0.5">navigate</span>
                 </span>
                 <span className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                  <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     G
                   </kbd>
                   <span>first</span>
                 </span>
                 <span className="flex items-center gap-1">
-                  <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                  <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     ⇧G
                   </kbd>
                   <span>last</span>
@@ -664,7 +664,7 @@ export const LogsTabContent = ({
             <div className="relative">
               <Icon
                 name="search"
-                className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3 -translate-y-1/2"
               />
               <Input
                 data-search-input
@@ -674,28 +674,28 @@ export const LogsTabContent = ({
                 onChange={(e) => handleSearchChange(e.target.value)}
                 onFocus={() => setSearchInputFocused(true)}
                 onBlur={() => setSearchInputFocused(false)}
-                className="pl-7 pr-16 w-48 text-xs py-1 rounded-sm"
+                className="w-48 rounded-sm py-1 pr-16 pl-7 text-xs"
               />
               {searchQuery || searchInputFocused ? (
                 filteredIndices.length > 0 ? (
-                  <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                    <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                  <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5">
+                    <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
                       ESC
                     </span>
-                    <span className="text-[10px] text-muted-foreground mx-0.5">
+                    <span className="text-muted-foreground mx-0.5 text-[10px]">
                       {effectiveSearchIndex + 1}/{filteredIndices.length}
                     </span>
                     <div className="flex items-center">
                       <button
                         onClick={() => navigateToResult("prev")}
-                        className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                        className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
                         title="Previous (Shift+N)"
                       >
                         <Icon name="chevron-up" className="size-2.5" />
                       </button>
                       <button
                         onClick={() => navigateToResult("next")}
-                        className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                        className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
                         title="Next (N)"
                       >
                         <Icon name="chevron-down" className="size-2.5" />
@@ -703,18 +703,18 @@ export const LogsTabContent = ({
                     </div>
                   </div>
                 ) : (
-                  <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                    <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                  <div className="absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center gap-0.5">
+                    <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
                       ESC
                     </span>
-                    <span className="text-[10px] text-muted-foreground ml-0.5">
+                    <span className="text-muted-foreground ml-0.5 text-[10px]">
                       0/0
                     </span>
                   </div>
                 )
               ) : (
-                <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
-                  <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm font-mono">
+                <div className="absolute top-1/2 right-2 flex -translate-y-1/2 items-center">
+                  <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                     /
                   </span>
                 </div>
@@ -726,21 +726,21 @@ export const LogsTabContent = ({
         <div
           ref={logsContainerRef}
           tabIndex={0}
-          className="font-mono text-xs max-h-[500px] overflow-y-auto pb-2 focus:outline-none"
+          className="max-h-[500px] overflow-y-auto pb-2 font-mono text-xs focus:outline-none"
         >
           {parsedLogs.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
-              <Icon name="file-text" className="size-8 mb-3 opacity-30" />
-              <p className="text-sm font-sans">No logs to display</p>
+            <div className="text-muted-foreground flex flex-col items-center justify-center py-12">
+              <Icon name="file-text" className="mb-3 size-8 opacity-30" />
+              <p className="font-sans text-sm">No logs to display</p>
             </div>
           ) : groupBySource && groupedLogs ? (
             // Grouped view
             groupedLogs.map(([source, group]) => (
               <details key={source} className="group" open>
-                <summary className="px-3 py-3 cursor-pointer hover:bg-muted/30 flex items-center gap-2 border-b border-border">
+                <summary className="hover:bg-muted/30 border-border flex cursor-pointer items-center gap-2 border-b px-3 py-3">
                   <Icon
                     name="chevron-right"
-                    className="size-3 group-open:rotate-90 transition-transform"
+                    className="size-3 transition-transform group-open:rotate-90"
                   />
                   <span className="font-sans font-medium">{source}</span>
                   <span className="text-muted-foreground font-sans text-xs">
@@ -767,16 +767,16 @@ export const LogsTabContent = ({
                           `fallback-${globalIndex}`
                         }
                         className={cn(
-                          "px-3 py-1.5 transition-colors relative",
+                          "relative px-3 py-1.5 transition-colors",
                           "hover:bg-muted/20",
                           isError && "bg-destructive/10 text-destructive",
                           isWarn && "bg-warning/10 text-warning",
                           isSkipped && "bg-muted/50 text-muted-foreground",
                           isHighlighted &&
-                            "border-l-4 border-l-foreground pl-2",
+                            "border-l-foreground border-l-4 pl-2",
                         )}
                       >
-                        <div className="flex items-center gap-2.5 min-w-0">
+                        <div className="flex min-w-0 items-center gap-2.5">
                           <span
                             className={cn(
                               "size-1.5 shrink-0 rounded-full",
@@ -785,7 +785,7 @@ export const LogsTabContent = ({
                           />
                           <span
                             className={cn(
-                              "text-[11px] tabular-nums shrink-0",
+                              "shrink-0 text-[11px] tabular-nums",
                               isError
                                 ? "text-destructive"
                                 : isWarn
@@ -831,15 +831,15 @@ export const LogsTabContent = ({
                   }}
                   key={visibleEvents[index]?.id || `fallback-${index}`}
                   className={cn(
-                    "px-3 py-1.5 transition-colors relative",
+                    "relative px-3 py-1.5 transition-colors",
                     "hover:bg-muted/20",
                     isError && "bg-destructive/10 text-destructive",
                     isWarn && "bg-warning/10 text-warning",
                     isSkipped && "bg-muted/50 text-muted-foreground",
-                    isHighlighted && "border-l-4 border-l-foreground pl-2",
+                    isHighlighted && "border-l-foreground border-l-4 pl-2",
                   )}
                 >
-                  <div className="flex items-center gap-2.5 min-w-0">
+                  <div className="flex min-w-0 items-center gap-2.5">
                     <span
                       className={cn(
                         "size-1.5 shrink-0 rounded-full",
@@ -848,7 +848,7 @@ export const LogsTabContent = ({
                     />
                     <span
                       className={cn(
-                        "text-[11px] tabular-nums shrink-0",
+                        "shrink-0 text-[11px] tabular-nums",
                         isError
                           ? "text-destructive"
                           : isWarn
@@ -878,7 +878,7 @@ export const LogsTabContent = ({
         </div>
 
         {showBottomFade && (
-          <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-background to-transparent pointer-events-none rounded-b-lg" />
+          <div className="from-background pointer-events-none absolute right-0 bottom-0 left-0 h-12 rounded-b-lg bg-gradient-to-t to-transparent" />
         )}
       </div>
     </>

--- a/client/dashboard/src/pages/elements/Elements.tsx
+++ b/client/dashboard/src/pages/elements/Elements.tsx
@@ -109,16 +109,16 @@ function ConfigSection({
     <div>
       <button
         onClick={onToggle}
-        className="flex items-center justify-between w-full group"
+        className="group flex w-full items-center justify-between"
       >
-        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+        <h3 className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
           {title}
         </h3>
         <motion.div
           animate={{ rotate: isOpen ? 0 : -90 }}
           transition={{ duration: 0.2, ease: "easeInOut" }}
         >
-          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          <ChevronDown className="text-muted-foreground h-4 w-4" />
         </motion.div>
       </button>
       <AnimatePresence initial={false}>
@@ -130,7 +130,7 @@ function ConfigSection({
             transition={{ duration: 0.2, ease: "easeInOut" }}
             className="overflow-hidden"
           >
-            <div className="pt-3 space-y-4">{children}</div>
+            <div className="space-y-4 pt-3">{children}</div>
           </motion.div>
         )}
       </AnimatePresence>
@@ -151,7 +151,7 @@ function ConfigField({
     <div className="space-y-1.5">
       <Label className="text-sm font-medium">{label}</Label>
       {description && (
-        <p className="text-xs text-muted-foreground">{description}</p>
+        <p className="text-muted-foreground text-xs">{description}</p>
       )}
       {children}
     </div>
@@ -174,7 +174,7 @@ function SwitchField({
       <div className="space-y-0.5">
         <Label className="text-sm font-medium">{label}</Label>
         {description && (
-          <p className="text-xs text-muted-foreground">{description}</p>
+          <p className="text-muted-foreground text-xs">{description}</p>
         )}
       </div>
       <Switch checked={checked} onCheckedChange={onCheckedChange} />
@@ -349,7 +349,7 @@ export default function ChatElements() {
           </Page.Section.Description>
           <Page.Section.Body>
             {/* Top-level tabs: Manual vs Hosted */}
-            <div className="mt-3 border border-border rounded-lg p-0 overflow-hidden">
+            <div className="border-border mt-3 overflow-hidden rounded-lg border p-0">
               <Tabs
                 value={installMethod}
                 onValueChange={(v) =>
@@ -357,8 +357,8 @@ export default function ChatElements() {
                 }
                 className="gap-0"
               >
-                <div className="w-full bg-stone-200 dark:bg-stone-800 rounded-t-lg py-2 px-4">
-                  <TabsList className="rounded-b-none bg-transparent p-0 h-auto">
+                <div className="w-full rounded-t-lg bg-stone-200 px-4 py-2 dark:bg-stone-800">
+                  <TabsList className="h-auto rounded-b-none bg-transparent p-0">
                     <TabsTrigger value="manual">
                       Manual installation
                     </TabsTrigger>
@@ -370,10 +370,10 @@ export default function ChatElements() {
                 <div
                   className={installMethod === "manual" ? "block" : "hidden"}
                 >
-                  <div className="flex gap-12 min-h-fit p-6">
+                  <div className="flex min-h-fit gap-12 p-6">
                     {/* Config Panel */}
 
-                    <div className="w-1/3 h-full overflow-y-auto pr-4 space-y-6 flex flex-col">
+                    <div className="flex h-full w-1/3 flex-col space-y-6 overflow-y-auto pr-4">
                       {/* Connection */}
                       <ConfigSection
                         title="MCP"
@@ -390,11 +390,11 @@ export default function ChatElements() {
                         >
                           <div className="space-y-3">
                             {toolsetsLoading ? (
-                              <div className="text-sm text-muted-foreground">
+                              <div className="text-muted-foreground text-sm">
                                 Loading MCP servers...
                               </div>
                             ) : toolsets.length === 0 ? (
-                              <div className="text-sm text-muted-foreground">
+                              <div className="text-muted-foreground text-sm">
                                 No MCP servers available. Add a source to create
                                 one.
                               </div>
@@ -416,10 +416,10 @@ export default function ChatElements() {
                                         disabled={!toolset.mcpEnabled}
                                       >
                                         <div className="flex items-center gap-2">
-                                          <Server className="h-4 w-4 text-muted-foreground" />
+                                          <Server className="text-muted-foreground h-4 w-4" />
                                           <span>{toolset.name}</span>
                                           {!toolset.mcpEnabled && (
-                                            <span className="text-xs text-muted-foreground">
+                                            <span className="text-muted-foreground text-xs">
                                               (disabled)
                                             </span>
                                           )}
@@ -436,7 +436,7 @@ export default function ChatElements() {
                               className="w-full"
                               onClick={() => routes.mcp.goTo()}
                             >
-                              <Plus className="h-4 w-4 mr-2" />
+                              <Plus className="mr-2 h-4 w-4" />
                               Add New MCP Server
                             </Button>
                           </div>
@@ -727,24 +727,24 @@ export default function ChatElements() {
                         className="w-full"
                         onClick={() => setShowInstallGuide(true)}
                       >
-                        <ArrowRight className="h-4 w-4 mr-2" />
+                        <ArrowRight className="mr-2 h-4 w-4" />
                         Setup
                       </Button>
                     </div>
 
                     {/* Preview Panel */}
-                    <div className="w-2/3 flex flex-col h-[700px]">
-                      <div className="relative flex-1 rounded-lg border overflow-hidden bg-muted/30">
+                    <div className="flex h-[700px] w-2/3 flex-col">
+                      <div className="bg-muted/30 relative flex-1 overflow-hidden rounded-lg border">
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={refreshPreview}
                           className={cn(
-                            "absolute top-6 right-6 z-10 h-8 px-2 bg-foreground/[0.7] text-background backdrop-blur-sm hover:bg-foreground/80 hover:text-background",
-                            config.variant === "sidecar" && "left-6 right-auto",
+                            "bg-foreground/[0.7] text-background hover:bg-foreground/80 hover:text-background absolute top-6 right-6 z-10 h-8 px-2 backdrop-blur-sm",
+                            config.variant === "sidecar" && "right-auto left-6",
                           )}
                         >
-                          <RefreshCw className="h-4 w-4 mr-1" />
+                          <RefreshCw className="mr-1 h-4 w-4" />
                           Reset Preview
                         </Button>
                         <ElementsPreview
@@ -764,11 +764,11 @@ export default function ChatElements() {
                     installMethod === "hosted" ? "block px-4 py-4" : "hidden"
                   }
                 >
-                  <div className="flex flex-col items-center justify-center h-[700px] text-center">
-                    <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
-                      <Server className="w-8 h-8 text-muted-foreground" />
+                  <div className="flex h-[700px] flex-col items-center justify-center text-center">
+                    <div className="bg-muted mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                      <Server className="text-muted-foreground h-8 w-8" />
                     </div>
-                    <h3 className="text-lg font-semibold mb-2">Coming Soon</h3>
+                    <h3 className="mb-2 text-lg font-semibold">Coming Soon</h3>
                     <p className="text-muted-foreground max-w-md">
                       Hosted Elements will allow you to deploy chat experiences
                       without any code changes. Stay tuned!
@@ -783,7 +783,7 @@ export default function ChatElements() {
 
       {/* Installation Guide Dialog */}
       <Dialog open={showInstallGuide} onOpenChange={setShowInstallGuide}>
-        <Dialog.Content className="max-w-6xl sm:max-w-6xl max-h-[90vh] overflow-y-auto">
+        <Dialog.Content className="max-h-[90vh] max-w-6xl overflow-y-auto sm:max-w-6xl">
           <Dialog.Header>
             <Dialog.Title>Setup Guide</Dialog.Title>
           </Dialog.Header>
@@ -1219,7 +1219,7 @@ export default function GramChat() {
   return (
     <div className="relative pl-10">
       {/* Vertical line */}
-      <div className="absolute left-[11px] top-6 bottom-0 w-px bg-border" />
+      <div className="bg-border absolute top-6 bottom-0 left-[11px] w-px" />
 
       {/* Step 1: What are you building? */}
       <WizardStep
@@ -1235,15 +1235,15 @@ export default function GramChat() {
         }
         onEdit={() => setCurrentStep(1)}
       >
-        <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
+        <div className="mt-6 grid grid-cols-2 gap-4 lg:grid-cols-3">
           {products.map((product) => (
             <button
               key={product.id}
               onClick={() => handleProductSelect(product.id)}
               disabled={!product.available}
-              className={`group relative flex flex-col rounded-lg border text-left transition-all overflow-hidden bg-background ${
+              className={`group bg-background relative flex flex-col overflow-hidden rounded-lg border text-left transition-all ${
                 selectedProduct === product.id && product.available
-                  ? "border-primary ring-2 ring-primary"
+                  ? "border-primary ring-primary ring-2"
                   : product.available
                     ? "border-border hover:border-muted-foreground/50 hover:shadow-sm"
                     : "border-border/50 cursor-not-allowed"
@@ -1251,7 +1251,7 @@ export default function GramChat() {
             >
               {/* Preview area */}
               <div
-                className={`h-36 w-full p-3 overflow-hidden transition-all duration-200 ${
+                className={`h-36 w-full overflow-hidden p-3 transition-all duration-200 ${
                   selectedProduct === product.id
                     ? ""
                     : "grayscale group-hover:grayscale-0"
@@ -1268,24 +1268,24 @@ export default function GramChat() {
                 <product.preview />
               </div>
               {/* Content */}
-              <div className="p-4 pt-3 border-t">
+              <div className="border-t p-4 pt-3">
                 <div className="flex items-start justify-between">
                   <div>
-                    <span className="font-medium text-sm block">
+                    <span className="block text-sm font-medium">
                       {product.name}
                     </span>
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-muted-foreground text-xs">
                       {product.description}
                     </span>
                   </div>
                   {selectedProduct === product.id && product.available && (
-                    <Check className="h-5 w-5 text-primary shrink-0" />
+                    <Check className="text-primary h-5 w-5 shrink-0" />
                   )}
                 </div>
               </div>
               {!product.available && (
-                <div className="absolute inset-0 flex items-center justify-center bg-background/70 backdrop-blur-[1px]">
-                  <span className="text-[10px] font-semibold text-muted-foreground bg-muted px-2.5 py-1 rounded-full uppercase tracking-wide">
+                <div className="bg-background/70 absolute inset-0 flex items-center justify-center backdrop-blur-[1px]">
+                  <span className="text-muted-foreground bg-muted rounded-full px-2.5 py-1 text-[10px] font-semibold tracking-wide uppercase">
                     Coming Soon
                   </span>
                 </div>
@@ -1310,23 +1310,23 @@ export default function GramChat() {
         onEdit={() => setCurrentStep(2)}
       >
         {currentStep >= 2 && (
-          <div className="flex gap-4 mt-6">
+          <div className="mt-6 flex gap-4">
             {frameworks.map((fw) => (
               <button
                 key={fw.id}
                 onClick={() => handleFrameworkSelect(fw.id)}
-                className={`relative flex flex-col items-start p-4 rounded-lg border text-left transition-all min-w-[140px] ${
+                className={`relative flex min-w-[140px] flex-col items-start rounded-lg border p-4 text-left transition-all ${
                   selectedFramework === fw.id
-                    ? "border-primary ring-2 ring-primary bg-primary/5"
+                    ? "border-primary ring-primary bg-primary/5 ring-2"
                     : "border-border hover:border-muted-foreground/50"
                 }`}
               >
-                <fw.icon className="h-6 w-6 mb-3" />
-                <span className="font-medium text-sm flex items-center gap-1.5">
+                <fw.icon className="mb-3 h-6 w-6" />
+                <span className="flex items-center gap-1.5 text-sm font-medium">
                   {fw.name}
-                  <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+                  <ArrowRight className="text-muted-foreground h-3.5 w-3.5" />
                 </span>
-                <span className="text-[10px] font-semibold tracking-wide text-amber-700 dark:text-amber-400 uppercase mt-2">
+                <span className="mt-2 text-[10px] font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-400">
                   AI Chat
                 </span>
               </button>
@@ -1367,7 +1367,7 @@ export default function GramChat() {
               description={
                 <>
                   Add to{" "}
-                  <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">
+                  <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                     .env.local
                   </code>
                 </>
@@ -1390,14 +1390,14 @@ export default function GramChat() {
                 selectedFramework === "nextjs" ? (
                   <>
                     Create{" "}
-                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">
+                    <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                       pages/api/session.ts
                     </code>
                   </>
                 ) : (
                   <>
                     Create{" "}
-                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">
+                    <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                       server.ts
                     </code>
                   </>
@@ -1425,14 +1425,14 @@ export default function GramChat() {
                 selectedFramework === "nextjs" ? (
                   <>
                     Update{" "}
-                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">
+                    <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                       app/page.tsx
                     </code>
                   </>
                 ) : (
                   <>
                     Update{" "}
-                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">
+                    <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                       src/App.tsx
                     </code>
                   </>
@@ -1471,26 +1471,26 @@ export default function GramChat() {
                 href="https://github.com/speakeasy-api/gram/blob/main/elements/docs/_media/ElementsConfig.md"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-3 p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors group"
+                className="bg-card hover:bg-muted/50 group flex items-center gap-3 rounded-lg border p-4 transition-colors"
               >
-                <div className="w-10 h-10 rounded-lg bg-[#24292f] dark:bg-[#f0f6fc] flex items-center justify-center shrink-0">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[#24292f] dark:bg-[#f0f6fc]">
                   <svg
-                    className="w-6 h-6 text-white dark:text-[#24292f]"
+                    className="h-6 w-6 text-white dark:text-[#24292f]"
                     viewBox="0 0 24 24"
                     fill="currentColor"
                   >
                     <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                   </svg>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium group-hover:text-primary transition-colors">
+                <div className="min-w-0 flex-1">
+                  <p className="group-hover:text-primary text-sm font-medium transition-colors">
                     ElementsConfig.md
                   </p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-muted-foreground text-xs">
                     speakeasy-api/gram
                   </p>
                 </div>
-                <ArrowRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
+                <ArrowRight className="text-muted-foreground group-hover:text-primary h-4 w-4 transition-colors" />
               </a>
             </NextStep>
 
@@ -1503,20 +1503,20 @@ export default function GramChat() {
                 href="https://calendly.com/d/ctgg-5dv-3kw/intro-to-gram-call"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-4 p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors group"
+                className="bg-card hover:bg-muted/50 group flex items-center gap-4 rounded-lg border p-4 transition-colors"
               >
-                <div className="w-12 h-12 rounded-full bg-linear-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-blue-500 to-blue-600">
                   <span className="text-lg font-semibold text-white">S</span>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium group-hover:text-primary transition-colors">
+                <div className="min-w-0 flex-1">
+                  <p className="group-hover:text-primary text-sm font-medium transition-colors">
                     Book a call with us
                   </p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-muted-foreground text-xs">
                     Schedule time to get help setting up
                   </p>
                 </div>
-                <ArrowRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
+                <ArrowRight className="text-muted-foreground group-hover:text-primary h-4 w-4 transition-colors" />
               </a>
             </NextStep>
           </div>
@@ -1539,15 +1539,15 @@ function SetupStep({
 }) {
   return (
     <div className="flex gap-4">
-      <div className="shrink-0 w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-        <span className="text-xs font-semibold text-muted-foreground">
+      <div className="bg-muted flex h-7 w-7 shrink-0 items-center justify-center rounded-full">
+        <span className="text-muted-foreground text-xs font-semibold">
           {number}
         </span>
       </div>
-      <div className="flex-1 min-w-0 space-y-3">
+      <div className="min-w-0 flex-1 space-y-3">
         <div>
           <h4 className="text-sm font-semibold">{title}</h4>
-          <p className="text-sm text-muted-foreground">{description}</p>
+          <p className="text-muted-foreground text-sm">{description}</p>
         </div>
         <div>{children}</div>
       </div>
@@ -1568,15 +1568,15 @@ function NextStep({
 }) {
   return (
     <div className="flex gap-4">
-      <div className="shrink-0 w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-        <span className="text-xs font-semibold text-muted-foreground">
+      <div className="bg-muted flex h-7 w-7 shrink-0 items-center justify-center rounded-full">
+        <span className="text-muted-foreground text-xs font-semibold">
           {letter}
         </span>
       </div>
-      <div className="flex-1 min-w-0 space-y-3">
+      <div className="min-w-0 flex-1 space-y-3">
         <div>
           <h4 className="text-sm font-semibold">{title}</h4>
-          <p className="text-sm text-muted-foreground">{description}</p>
+          <p className="text-muted-foreground text-sm">{description}</p>
         </div>
         <div>{children}</div>
       </div>
@@ -1607,11 +1607,11 @@ function WizardStep({
 }) {
   return (
     <div
-      className={`relative pb-10 ${isLast ? "pb-0" : ""} ${!isActive ? "opacity-40 pointer-events-none" : ""}`}
+      className={`relative pb-10 ${isLast ? "pb-0" : ""} ${!isActive ? "pointer-events-none opacity-40" : ""}`}
     >
       {/* Step indicator - positioned to the left of the content */}
       <div
-        className={`absolute -left-10 top-0 w-6 h-6 rounded-full flex items-center justify-center bg-background border ${
+        className={`bg-background absolute top-0 -left-10 flex h-6 w-6 items-center justify-center rounded-full border ${
           isCompleted
             ? "border-primary bg-primary text-primary-foreground"
             : isActive
@@ -1634,16 +1634,16 @@ function WizardStep({
         {isCompleted && completedSummary ? (
           // Collapsed completed state
           <div className="flex items-center gap-2">
-            <span className="font-semibold text-[15px] text-muted-foreground">
+            <span className="text-muted-foreground text-[15px] font-semibold">
               {title}
             </span>
-            <span className="text-[15px] text-foreground">
+            <span className="text-foreground text-[15px]">
               {completedSummary}
             </span>
             {onEdit && (
               <button
                 onClick={onEdit}
-                className="ml-1 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                className="hover:bg-muted text-muted-foreground hover:text-foreground ml-1 rounded p-1 transition-colors"
                 title="Change selection"
               >
                 <Pencil className="h-3.5 w-3.5" />
@@ -1653,9 +1653,9 @@ function WizardStep({
         ) : (
           // Active/pending state
           <>
-            <h3 className="font-semibold text-[15px] leading-6">{title}</h3>
+            <h3 className="text-[15px] leading-6 font-semibold">{title}</h3>
             {description && !isCompleted && (
-              <p className="text-sm text-muted-foreground mt-1">
+              <p className="text-muted-foreground mt-1 text-sm">
                 {description}
               </p>
             )}
@@ -1670,39 +1670,39 @@ function WizardStep({
 // Product Preview Components
 function ChatPreview() {
   return (
-    <div className="w-full h-full bg-white rounded-md border shadow-sm flex flex-col text-[10px]">
+    <div className="flex h-full w-full flex-col rounded-md border bg-white text-[10px] shadow-sm">
       {/* Header */}
-      <div className="px-2 py-1.5 border-b flex items-center gap-1.5">
-        <div className="w-2 h-2 rounded-full bg-blue-500" />
-        <span className="font-medium text-[9px] text-slate-600">
+      <div className="flex items-center gap-1.5 border-b px-2 py-1.5">
+        <div className="h-2 w-2 rounded-full bg-blue-500" />
+        <span className="text-[9px] font-medium text-slate-600">
           AI Assistant
         </span>
       </div>
       {/* Messages */}
-      <div className="flex-1 p-2 space-y-1.5 overflow-hidden">
+      <div className="flex-1 space-y-1.5 overflow-hidden p-2">
         <div className="flex gap-1.5">
-          <div className="w-4 h-4 rounded-full bg-linear-to-br from-blue-400 to-purple-500 shrink-0" />
-          <div className="bg-slate-100 rounded px-1.5 py-1 max-w-[80%]">
-            <div className="w-16 h-1.5 bg-slate-300 rounded" />
+          <div className="h-4 w-4 shrink-0 rounded-full bg-linear-to-br from-blue-400 to-purple-500" />
+          <div className="max-w-[80%] rounded bg-slate-100 px-1.5 py-1">
+            <div className="h-1.5 w-16 rounded bg-slate-300" />
           </div>
         </div>
-        <div className="flex gap-1.5 justify-end">
-          <div className="bg-blue-500 rounded px-1.5 py-1 max-w-[80%]">
-            <div className="w-12 h-1.5 bg-blue-300 rounded" />
+        <div className="flex justify-end gap-1.5">
+          <div className="max-w-[80%] rounded bg-blue-500 px-1.5 py-1">
+            <div className="h-1.5 w-12 rounded bg-blue-300" />
           </div>
         </div>
         <div className="flex gap-1.5">
-          <div className="w-4 h-4 rounded-full bg-linear-to-br from-blue-400 to-purple-500 shrink-0" />
-          <div className="bg-slate-100 rounded px-1.5 py-1 max-w-[80%]">
-            <div className="w-20 h-1.5 bg-slate-300 rounded mb-1" />
-            <div className="w-14 h-1.5 bg-slate-300 rounded" />
+          <div className="h-4 w-4 shrink-0 rounded-full bg-linear-to-br from-blue-400 to-purple-500" />
+          <div className="max-w-[80%] rounded bg-slate-100 px-1.5 py-1">
+            <div className="mb-1 h-1.5 w-20 rounded bg-slate-300" />
+            <div className="h-1.5 w-14 rounded bg-slate-300" />
           </div>
         </div>
       </div>
       {/* Input */}
-      <div className="px-2 py-1.5 border-t">
-        <div className="bg-slate-100 rounded-full px-2 py-1 flex items-center">
-          <div className="w-10 h-1.5 bg-slate-300 rounded" />
+      <div className="border-t px-2 py-1.5">
+        <div className="flex items-center rounded-full bg-slate-100 px-2 py-1">
+          <div className="h-1.5 w-10 rounded bg-slate-300" />
         </div>
       </div>
     </div>
@@ -1711,25 +1711,25 @@ function ChatPreview() {
 
 function SearchPreview() {
   return (
-    <div className="w-full h-full bg-white rounded-md border shadow-sm flex flex-col text-[10px] p-2">
+    <div className="flex h-full w-full flex-col rounded-md border bg-white p-2 text-[10px] shadow-sm">
       {/* Search bar */}
-      <div className="bg-slate-100 rounded-md px-2 py-1.5 flex items-center gap-1.5 mb-2">
-        <Search className="w-3 h-3 text-violet-500" />
-        <div className="w-16 h-1.5 bg-slate-300 rounded" />
+      <div className="mb-2 flex items-center gap-1.5 rounded-md bg-slate-100 px-2 py-1.5">
+        <Search className="h-3 w-3 text-violet-500" />
+        <div className="h-1.5 w-16 rounded bg-slate-300" />
       </div>
       {/* Results */}
-      <div className="space-y-1.5 flex-1">
-        <div className="bg-violet-50 rounded p-1.5 border-l-2 border-violet-400">
-          <div className="w-full h-1.5 bg-slate-400 rounded mb-1" />
-          <div className="w-3/4 h-1.5 bg-slate-300 rounded" />
+      <div className="flex-1 space-y-1.5">
+        <div className="rounded border-l-2 border-violet-400 bg-violet-50 p-1.5">
+          <div className="mb-1 h-1.5 w-full rounded bg-slate-400" />
+          <div className="h-1.5 w-3/4 rounded bg-slate-300" />
         </div>
-        <div className="bg-slate-50 rounded p-1.5">
-          <div className="w-full h-1.5 bg-slate-300 rounded mb-1" />
-          <div className="w-2/3 h-1.5 bg-slate-200 rounded" />
+        <div className="rounded bg-slate-50 p-1.5">
+          <div className="mb-1 h-1.5 w-full rounded bg-slate-300" />
+          <div className="h-1.5 w-2/3 rounded bg-slate-200" />
         </div>
-        <div className="bg-slate-50 rounded p-1.5">
-          <div className="w-3/4 h-1.5 bg-slate-300 rounded mb-1" />
-          <div className="w-1/2 h-1.5 bg-slate-200 rounded" />
+        <div className="rounded bg-slate-50 p-1.5">
+          <div className="mb-1 h-1.5 w-3/4 rounded bg-slate-300" />
+          <div className="h-1.5 w-1/2 rounded bg-slate-200" />
         </div>
       </div>
     </div>
@@ -1738,36 +1738,36 @@ function SearchPreview() {
 
 function NotificationsPreview() {
   return (
-    <div className="w-full h-full bg-white rounded-md border shadow-sm flex flex-col text-[10px]">
+    <div className="flex h-full w-full flex-col rounded-md border bg-white text-[10px] shadow-sm">
       {/* Header */}
-      <div className="px-2 py-1.5 border-b flex items-center justify-between">
-        <span className="font-medium text-[9px] text-slate-600">
+      <div className="flex items-center justify-between border-b px-2 py-1.5">
+        <span className="text-[9px] font-medium text-slate-600">
           Notifications
         </span>
         <div className="text-[8px] text-blue-500">Mark all as read</div>
       </div>
       {/* Notifications */}
-      <div className="flex-1 p-1.5 space-y-1">
-        <div className="flex gap-1.5 p-1 rounded bg-blue-50">
-          <div className="w-4 h-4 rounded-full bg-linear-to-br from-green-400 to-emerald-500 shrink-0" />
+      <div className="flex-1 space-y-1 p-1.5">
+        <div className="flex gap-1.5 rounded bg-blue-50 p-1">
+          <div className="h-4 w-4 shrink-0 rounded-full bg-linear-to-br from-green-400 to-emerald-500" />
           <div className="flex-1">
-            <div className="w-full h-1.5 bg-slate-400 rounded mb-1" />
-            <div className="w-2/3 h-1.5 bg-slate-300 rounded" />
+            <div className="mb-1 h-1.5 w-full rounded bg-slate-400" />
+            <div className="h-1.5 w-2/3 rounded bg-slate-300" />
           </div>
-          <div className="w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
+          <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500" />
         </div>
-        <div className="flex gap-1.5 p-1 rounded">
-          <div className="w-4 h-4 rounded-full bg-linear-to-br from-orange-400 to-red-500 shrink-0" />
+        <div className="flex gap-1.5 rounded p-1">
+          <div className="h-4 w-4 shrink-0 rounded-full bg-linear-to-br from-orange-400 to-red-500" />
           <div className="flex-1">
-            <div className="w-3/4 h-1.5 bg-slate-300 rounded mb-1" />
-            <div className="w-1/2 h-1.5 bg-slate-200 rounded" />
+            <div className="mb-1 h-1.5 w-3/4 rounded bg-slate-300" />
+            <div className="h-1.5 w-1/2 rounded bg-slate-200" />
           </div>
         </div>
-        <div className="flex gap-1.5 p-1 rounded">
-          <div className="w-4 h-4 rounded-full bg-linear-to-br from-purple-400 to-pink-500 shrink-0" />
+        <div className="flex gap-1.5 rounded p-1">
+          <div className="h-4 w-4 shrink-0 rounded-full bg-linear-to-br from-purple-400 to-pink-500" />
           <div className="flex-1">
-            <div className="w-full h-1.5 bg-slate-300 rounded mb-1" />
-            <div className="w-3/4 h-1.5 bg-slate-200 rounded" />
+            <div className="mb-1 h-1.5 w-full rounded bg-slate-300" />
+            <div className="h-1.5 w-3/4 rounded bg-slate-200" />
           </div>
         </div>
       </div>
@@ -1777,26 +1777,26 @@ function NotificationsPreview() {
 
 function DocsPreview() {
   return (
-    <div className="w-full h-full bg-white rounded-md border shadow-sm flex text-[10px]">
+    <div className="flex h-full w-full rounded-md border bg-white text-[10px] shadow-sm">
       {/* Sidebar */}
-      <div className="w-1/3 border-r p-1.5 space-y-1 bg-slate-50">
-        <div className="w-full h-1.5 bg-blue-500 rounded" />
-        <div className="w-3/4 h-1.5 bg-blue-300 rounded ml-1.5" />
-        <div className="w-2/3 h-1.5 bg-slate-300 rounded ml-1.5" />
-        <div className="w-full h-1.5 bg-slate-400 rounded mt-2" />
-        <div className="w-3/4 h-1.5 bg-slate-300 rounded ml-1.5" />
+      <div className="w-1/3 space-y-1 border-r bg-slate-50 p-1.5">
+        <div className="h-1.5 w-full rounded bg-blue-500" />
+        <div className="ml-1.5 h-1.5 w-3/4 rounded bg-blue-300" />
+        <div className="ml-1.5 h-1.5 w-2/3 rounded bg-slate-300" />
+        <div className="mt-2 h-1.5 w-full rounded bg-slate-400" />
+        <div className="ml-1.5 h-1.5 w-3/4 rounded bg-slate-300" />
       </div>
       {/* Content */}
-      <div className="flex-1 p-2 space-y-2">
-        <div className="w-1/2 h-2 bg-slate-700 rounded" />
+      <div className="flex-1 space-y-2 p-2">
+        <div className="h-2 w-1/2 rounded bg-slate-700" />
         <div className="space-y-1">
-          <div className="w-full h-1.5 bg-slate-300 rounded" />
-          <div className="w-full h-1.5 bg-slate-300 rounded" />
-          <div className="w-3/4 h-1.5 bg-slate-300 rounded" />
+          <div className="h-1.5 w-full rounded bg-slate-300" />
+          <div className="h-1.5 w-full rounded bg-slate-300" />
+          <div className="h-1.5 w-3/4 rounded bg-slate-300" />
         </div>
-        <div className="bg-slate-800 rounded p-1.5 mt-2">
-          <div className="w-full h-1.5 bg-emerald-400 rounded" />
-          <div className="w-2/3 h-1.5 bg-slate-500 rounded mt-1" />
+        <div className="mt-2 rounded bg-slate-800 p-1.5">
+          <div className="h-1.5 w-full rounded bg-emerald-400" />
+          <div className="mt-1 h-1.5 w-2/3 rounded bg-slate-500" />
         </div>
       </div>
     </div>

--- a/client/dashboard/src/pages/environments/Environment.tsx
+++ b/client/dashboard/src/pages/environments/Environment.tsx
@@ -33,17 +33,17 @@ function SaveActionBar({
   onCancel,
 }: SaveActionBarProps) {
   return (
-    <div className="flex items-center justify-between pt-4 border-t">
+    <div className="flex items-center justify-between border-t pt-4">
       {saveError && (
         <div
-          className="flex items-center gap-2 text-sm text-destructive"
+          className="text-destructive flex items-center gap-2 text-sm"
           role="alert"
         >
           <AlertCircle className="h-4 w-4" aria-hidden="true" />
           {saveError}
         </div>
       )}
-      <div className="flex items-center gap-3 ml-auto">
+      <div className="ml-auto flex items-center gap-3">
         <Button
           type="button"
           variant="tertiary"
@@ -134,7 +134,7 @@ function ToolsetDialog({ open, onOpenChange, onSubmit }: ToolsetDialogProps) {
             <select
               value={selectedToolset}
               onChange={(e) => setSelectedToolset(e.target.value)}
-              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+              className="border-input placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             >
               <option value="">Select a toolset</option>
               {options.map((option) => (
@@ -526,17 +526,17 @@ export default function EnvironmentPage() {
                   return (
                     <div
                       key={entry.name}
-                      className="grid grid-cols-2 gap-4 items-center mb-2"
+                      className="mb-2 grid grid-cols-2 items-center gap-4"
                     >
-                      <label className="text-sm font-medium text-foreground">
+                      <label className="text-foreground text-sm font-medium">
                         {entry.name}
                         {isNew && (
-                          <span className="ml-2 text-xs text-blue-600 font-normal">
+                          <span className="ml-2 text-xs font-normal text-blue-600">
                             (new)
                           </span>
                         )}
                       </label>
-                      <div className="flex items-center gap-2 w-full">
+                      <div className="flex w-full items-center gap-2">
                         <div className="flex-1">
                           <Input
                             value={displayValue}
@@ -555,14 +555,14 @@ export default function EnvironmentPage() {
                                 ? "text"
                                 : "password"
                             }
-                            className={`font-mono text-sm w-full ${isEdited ? "ring-1 ring-blue-500" : ""}`}
+                            className={`w-full font-mono text-sm ${isEdited ? "ring-1 ring-blue-500" : ""}`}
                             disabled={isSaving}
                           />
                         </div>
                         <Button
                           variant="tertiary"
                           size="sm"
-                          className="h-8 w-8 flex-shrink-0 self-start mt-[1px]"
+                          className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
                           onClick={() => handleToggleVisibility(entry.name)}
                           disabled={isSaving}
                           aria-label={
@@ -582,7 +582,7 @@ export default function EnvironmentPage() {
                         <Button
                           variant="tertiary"
                           size="sm"
-                          className="h-8 w-8 flex-shrink-0 self-start mt-[1px]"
+                          className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
                           onClick={() => handleRemoveVariable(entry.name)}
                           disabled={isSaving}
                           aria-label={`Remove ${entry.name}`}
@@ -598,7 +598,7 @@ export default function EnvironmentPage() {
 
                 {isAddingNew && (
                   <div className="space-y-2">
-                    <div className="grid grid-cols-2 gap-4 items-center mb-2">
+                    <div className="mb-2 grid grid-cols-2 items-center gap-4">
                       <Input
                         value={newEntryName}
                         onChange={(value) =>
@@ -610,25 +610,25 @@ export default function EnvironmentPage() {
                           }
                         }}
                         placeholder="NAME"
-                        className="font-mono text-sm w-full"
+                        className="w-full font-mono text-sm"
                         disabled={isSaving}
                         autoFocus
                       />
-                      <div className="flex items-center gap-2 w-full">
+                      <div className="flex w-full items-center gap-2">
                         <div className="flex-1">
                           <Input
                             value={newEntryValue}
                             onChange={setNewEntryValue}
                             placeholder="Value"
                             type={newEntryVisible ? "text" : "password"}
-                            className="font-mono text-sm w-full"
+                            className="w-full font-mono text-sm"
                             disabled={isSaving}
                           />
                         </div>
                         <Button
                           variant="tertiary"
                           size="sm"
-                          className="h-8 w-8 flex-shrink-0 self-start mt-[1px]"
+                          className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
                           onClick={() => setNewEntryVisible(!newEntryVisible)}
                           disabled={isSaving}
                           aria-label={
@@ -646,7 +646,7 @@ export default function EnvironmentPage() {
                         <Button
                           variant="tertiary"
                           size="sm"
-                          className="h-8 w-8 flex-shrink-0 self-start mt-[1px]"
+                          className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
                           onClick={handleCancelNewEntry}
                           disabled={isSaving}
                           aria-label="Cancel new entry"
@@ -659,7 +659,7 @@ export default function EnvironmentPage() {
                     </div>
                     {!validateEntryName(newEntryName) &&
                       newEntryName.length > 0 && (
-                        <p className="text-xs text-destructive">
+                        <p className="text-destructive text-xs">
                           Variable name must start with a letter, underscore,
                           dash, or period and contain only alphanumeric
                           characters, underscores, dashes, or periods
@@ -679,13 +679,13 @@ export default function EnvironmentPage() {
               )}
 
               {allEntries.length === 0 && !isAddingNew && (
-                <div className="text-center py-8">
-                  <p className="text-sm text-muted-foreground">
+                <div className="py-8 text-center">
+                  <p className="text-muted-foreground text-sm">
                     No environment variables defined
                   </p>
-                  <div className="mt-4 flex flex-col gap-2 items-center">
+                  <div className="mt-4 flex flex-col items-center gap-2">
                     <Button onClick={handleAddNewEntry}>
-                      <Plus className="h-4 w-4 mr-2" />
+                      <Plus className="mr-2 h-4 w-4" />
                       ADD YOUR FIRST VARIABLE
                     </Button>
                     <Button

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -85,7 +85,7 @@ export default function Environments() {
           <Page.Section.CTA>
             <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
               <Button.LeftIcon>
-                <Plus className="w-4 h-4" />
+                <Plus className="h-4 w-4" />
               </Button.LeftIcon>
               <Button.Text>New Environment</Button.Text>
             </Button>

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -95,12 +95,12 @@ export default function Home() {
             >
               <h2 className="text-lg font-semibold">MCP Servers</h2>
               <routes.mcp.Link>
-                <span className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1">
-                  View all <ArrowRight className="w-4 h-4" />
+                <span className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm">
+                  View all <ArrowRight className="h-4 w-4" />
                 </span>
               </routes.mcp.Link>
             </Stack>
-            <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
               {isToolsetsLoading &&
                 [...Array(4)].map((_, i) => (
                   <Skeleton key={i} className="h-[120px] rounded-xl" />
@@ -113,18 +113,18 @@ export default function Home() {
           </div>
         )}
 
-        <h2 className="text-lg font-semibold mb-4">Quick actions</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="relative flex flex-col gap-3 rounded-lg border bg-background p-4 pb-5 overflow-hidden">
-            <div className="absolute bottom-0 inset-x-0 h-[3px] bg-gradient-primary" />
+        <h2 className="mb-4 text-lg font-semibold">Quick actions</h2>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="bg-background relative flex flex-col gap-3 overflow-hidden rounded-lg border p-4 pb-5">
+            <div className="bg-gradient-primary absolute inset-x-0 bottom-0 h-[3px]" />
             <div className="flex flex-row items-start gap-2">
               <MessageCircleIcon
-                className="h-[18px] w-[18px] mt-0.5 shrink-0"
+                className="mt-0.5 h-[18px] w-[18px] shrink-0"
                 strokeWidth={1.5}
               />
               <div className="flex flex-col gap-1">
                 <h3 className="font-medium">Deploy chat</h3>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   Embed an AI chat interface on your website with tool access
                 </p>
               </div>
@@ -144,16 +144,16 @@ export default function Home() {
               </routes.elements.Link>
             </div>
           </div>
-          <div className="relative flex flex-col gap-3 rounded-lg border bg-background p-4 pb-5 overflow-hidden">
-            <div className="absolute bottom-0 inset-x-0 h-[3px] bg-gradient-primary" />
+          <div className="bg-background relative flex flex-col gap-3 overflow-hidden rounded-lg border p-4 pb-5">
+            <div className="bg-gradient-primary absolute inset-x-0 bottom-0 h-[3px]" />
             <div className="flex flex-row items-start gap-2">
               <BlocksIcon
-                className="h-[18px] w-[18px] mt-0.5 shrink-0"
+                className="mt-0.5 h-[18px] w-[18px] shrink-0"
                 strokeWidth={1.5}
               />
               <div className="flex flex-col gap-1">
                 <h3 className="font-medium">Connect to popular tools</h3>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   Browse and connect pre-built integrations from our catalog
                 </p>
               </div>
@@ -166,16 +166,16 @@ export default function Home() {
               </routes.catalog.Link>
             </div>
           </div>
-          <div className="relative flex flex-col gap-3 rounded-lg border bg-background p-4 pb-5 overflow-hidden">
-            <div className="absolute bottom-0 inset-x-0 h-[3px] bg-gradient-primary" />
+          <div className="bg-background relative flex flex-col gap-3 overflow-hidden rounded-lg border p-4 pb-5">
+            <div className="bg-gradient-primary absolute inset-x-0 bottom-0 h-[3px]" />
             <div className="flex flex-row items-start gap-2">
               <ServerIcon
-                className="h-[18px] w-[18px] mt-0.5 shrink-0"
+                className="mt-0.5 h-[18px] w-[18px] shrink-0"
                 strokeWidth={1.5}
               />
               <div className="flex flex-col gap-1">
                 <h3 className="font-medium">Connect to existing APIs</h3>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   Create and deploy custom MCP servers from your APIs
                 </p>
               </div>
@@ -189,16 +189,16 @@ export default function Home() {
             </div>
           </div>
           {isFunctionsEnabled && (
-            <div className="relative flex flex-col gap-3 rounded-lg border bg-background p-4 pb-5 overflow-hidden">
-              <div className="absolute bottom-0 inset-x-0 h-[3px] bg-gradient-primary" />
+            <div className="bg-background relative flex flex-col gap-3 overflow-hidden rounded-lg border p-4 pb-5">
+              <div className="bg-gradient-primary absolute inset-x-0 bottom-0 h-[3px]" />
               <div className="flex flex-row items-start gap-2">
                 <Code
-                  className="h-[18px] w-[18px] mt-0.5 shrink-0"
+                  className="mt-0.5 h-[18px] w-[18px] shrink-0"
                   strokeWidth={1.5}
                 />
                 <div className="flex flex-col gap-1">
                   <h3 className="font-medium">Build and host custom tools</h3>
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-muted-foreground text-sm">
                     Write and deploy custom functions as MCP servers
                   </p>
                 </div>
@@ -227,12 +227,12 @@ export default function Home() {
                 Featured Third-Party Servers
               </h2>
               <routes.catalog.Link>
-                <span className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1">
-                  Browse all <ArrowRight className="w-4 h-4" />
+                <span className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm">
+                  Browse all <ArrowRight className="h-4 w-4" />
                 </span>
               </routes.catalog.Link>
             </Stack>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
               {isLoading &&
                 [...Array(6)].map((_, i) => (
                   <Skeleton key={i} className="h-[140px] rounded-xl" />
@@ -276,17 +276,17 @@ function FeaturedServerCard({
 
   return (
     <Link to={detailHref}>
-      <div className="group flex flex-col gap-4 rounded-xl border bg-card p-5 hover:border-primary/50 hover:shadow-md transition-all h-full">
+      <div className="group bg-card hover:border-primary/50 flex h-full flex-col gap-4 rounded-xl border p-5 transition-all hover:shadow-md">
         <Stack direction="horizontal" gap={3}>
-          <div className="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 group-hover:bg-primary/15 transition-colors">
+          <div className="bg-primary/10 group-hover:bg-primary/15 flex h-12 w-12 shrink-0 items-center justify-center rounded-lg transition-colors">
             {server.iconUrl ? (
               <img
                 src={server.iconUrl}
                 alt={displayName}
-                className="w-8 h-8 rounded"
+                className="h-8 w-8 rounded"
               />
             ) : (
-              <ServerIcon className="w-6 h-6 text-muted-foreground" />
+              <ServerIcon className="text-muted-foreground h-6 w-6" />
             )}
           </div>
           <Stack gap={1} className="min-w-0">
@@ -319,7 +319,7 @@ function FeaturedServerCard({
             {isAdded ? (
               <Button variant="secondary" size="sm">
                 <Button.LeftIcon>
-                  <CheckCircle className="w-3.5 h-3.5" />
+                  <CheckCircle className="h-3.5 w-3.5" />
                 </Button.LeftIcon>
                 <Button.Text>Added</Button.Text>
               </Button>

--- a/client/dashboard/src/pages/hooks/EditServerNameDialog.tsx
+++ b/client/dashboard/src/pages/hooks/EditServerNameDialog.tsx
@@ -182,7 +182,7 @@ export function EditServerNameDialog({
               {allServers.map((server) => (
                 <div key={server.rawServerName} className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <Label className="flex-1 font-mono text-xs text-muted-foreground">
+                    <Label className="text-muted-foreground flex-1 font-mono text-xs">
                       {server.rawServerName}
                     </Label>
                     {server.id && (
@@ -191,7 +191,7 @@ export function EditServerNameDialog({
                         size="sm"
                         onClick={() => handleDelete(server.id)}
                         disabled={deletingIds.has(server.id) || isProcessing}
-                        className="h-7 px-2 shrink-0"
+                        className="h-7 shrink-0 px-2"
                       >
                         {deletingIds.has(server.id) ? (
                           <Icon
@@ -223,7 +223,7 @@ export function EditServerNameDialog({
                   />
                 </div>
               ))}
-              <p className="text-xs text-muted-foreground">
+              <p className="text-muted-foreground text-xs">
                 Change a server's display name to move it to a different group,
                 or restore its original name to ungroup it. Click the trash icon
                 to remove the override entirely.
@@ -243,7 +243,7 @@ export function EditServerNameDialog({
                     id="raw-name"
                     value={groupedOverrides[0].rawServerName}
                     readOnly
-                    className="font-mono text-sm bg-muted"
+                    className="bg-muted font-mono text-sm"
                   />
                 </div>
               )}
@@ -266,7 +266,7 @@ export function EditServerNameDialog({
                     }
                   }}
                 />
-                <p className="text-xs text-muted-foreground mt-3">
+                <p className="text-muted-foreground mt-3 text-xs">
                   This name will be shown in the UI instead of the raw server
                   name
                 </p>
@@ -293,7 +293,7 @@ export function EditServerNameDialog({
                 <>
                   <Icon
                     name="loader-circle"
-                    className="size-4 animate-spin mr-2"
+                    className="mr-2 size-4 animate-spin"
                   />
                   Removing...
                 </>
@@ -317,7 +317,7 @@ export function EditServerNameDialog({
               <>
                 <Icon
                   name="loader-circle"
-                  className="size-4 animate-spin mr-2"
+                  className="mr-2 size-4 animate-spin"
                 />
                 Saving...
               </>

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -513,22 +513,22 @@ function HooksContent() {
       subtitle="Ask me about your hooks! Powered by Elements + Gram MCP"
       hideTrigger={isLogsDisabled}
     >
-      <div className="h-full overflow-hidden flex flex-col">
+      <div className="flex h-full flex-col overflow-hidden">
         <Page>
           <Page.Header>
             <Page.Header.Breadcrumbs fullWidth />
           </Page.Header>
           {isLogsDisabled ? (
             <Page.Body fullWidth className="space-y-6">
-              <div className="flex flex-col gap-1 min-w-0">
+              <div className="flex min-w-0 flex-col gap-1">
                 <h1 className="text-xl font-semibold">Hooks</h1>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   Monitor hook events and tool executions across all servers
                 </p>
               </div>
-              <div className="flex-1 relative">
+              <div className="relative flex-1">
                 <div
-                  className="pointer-events-none select-none h-full"
+                  className="pointer-events-none h-full select-none"
                   aria-hidden="true"
                 >
                   <ObservabilitySkeleton />
@@ -663,13 +663,13 @@ function HooksInnerContent({
 
   return (
     <>
-      <div className="flex flex-col flex-1 min-h-0 w-full">
+      <div className="flex min-h-0 w-full flex-1 flex-col">
         {/* Header section */}
-        <div className="px-8 pt-8 pb-4 shrink-0">
-          <div className="flex items-start justify-between gap-4 mb-4">
-            <div className="flex flex-col gap-1 min-w-0">
+        <div className="shrink-0 px-8 pt-8 pb-4">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="flex min-w-0 flex-col gap-1">
               <h1 className="text-xl font-semibold">Hooks</h1>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-muted-foreground text-sm">
                 Monitor hook events and tool executions across all servers
               </p>
             </div>
@@ -689,7 +689,7 @@ function HooksInnerContent({
             (summaryData.servers.length > 0 ||
               (summaryData.users && summaryData.users.length > 0) ||
               (summaryData.skills && summaryData.skills.length > 0)) && (
-              <div className="mb-4 border rounded-lg overflow-hidden">
+              <div className="mb-4 overflow-hidden rounded-lg border">
                 {summaryData.servers.length > 0 && (
                   <div className={summaryView !== "servers" ? "hidden" : ""}>
                     <HooksServerTable
@@ -724,12 +724,12 @@ function HooksInnerContent({
             )}
 
           {/* Filter and Search Row */}
-          <div className="flex items-center gap-2 flex-wrap mt-4">
+          <div className="mt-4 flex flex-wrap items-center gap-2">
             <MultiSearch
               value={serverInput}
               onChange={setServerInput}
               placeholder="Filter by server name"
-              className="flex-1 min-w-[200px]"
+              className="min-w-[200px] flex-1"
               chips={activeFilters
                 .filter((f) => f.path === "gram.tool_call.source")
                 .map((f) => ({ display: f.display, value: f.display }))}
@@ -741,7 +741,7 @@ function HooksInnerContent({
               value={userEmailInput}
               onChange={setUserEmailInput}
               placeholder="Filter by user email"
-              className="flex-1 min-w-[200px]"
+              className="min-w-[200px] flex-1"
               chips={activeFilters
                 .filter((f) => f.path === "user.email")
                 .map((f) => ({ display: f.display, value: f.display }))}
@@ -766,28 +766,28 @@ function HooksInnerContent({
         </div>
 
         {/* Content section */}
-        <div className="flex-1 overflow-hidden min-h-0 border-t">
-          <div className="h-full flex flex-col bg-background">
+        <div className="min-h-0 flex-1 overflow-hidden border-t">
+          <div className="bg-background flex h-full flex-col">
             {isFetching && groupedTraces.length > 0 && (
-              <div className="absolute top-0 left-0 right-0 h-1 bg-primary/20 z-20">
-                <div className="h-full bg-primary animate-pulse" />
+              <div className="bg-primary/20 absolute top-0 right-0 left-0 z-20 h-1">
+                <div className="bg-primary h-full animate-pulse" />
               </div>
             )}
 
             {/* Header */}
-            <div className="flex items-center gap-3 px-5 py-2.5 bg-muted/30 border-b text-xs font-medium text-muted-foreground uppercase tracking-wide shrink-0">
-              <div className="shrink-0 w-[150px]">Timestamp</div>
-              <div className="shrink-0 w-5" />
-              <div className="flex-1 min-w-0">Server / Tool</div>
-              <div className="shrink-0 w-[260px]">User</div>
-              <div className="shrink-0 w-[120px]">Source</div>
-              <div className="shrink-0 w-20 text-right">Status</div>
+            <div className="bg-muted/30 text-muted-foreground flex shrink-0 items-center gap-3 border-b px-5 py-2.5 text-xs font-medium tracking-wide uppercase">
+              <div className="w-[150px] shrink-0">Timestamp</div>
+              <div className="w-5 shrink-0" />
+              <div className="min-w-0 flex-1">Server / Tool</div>
+              <div className="w-[260px] shrink-0">User</div>
+              <div className="w-[120px] shrink-0">Source</div>
+              <div className="w-20 shrink-0 text-right">Status</div>
             </div>
 
             {/* Scrollable trace list */}
             <div
               ref={containerRef}
-              className="overflow-y-auto flex-1"
+              className="flex-1 overflow-y-auto"
               onScroll={handleScroll}
             >
               <HooksTraceContent
@@ -805,7 +805,7 @@ function HooksInnerContent({
 
             {/* Footer */}
             {groupedTraces.length > 0 && (
-              <div className="flex items-center gap-4 px-5 py-3 bg-muted/30 border-t text-sm text-muted-foreground shrink-0">
+              <div className="bg-muted/30 text-muted-foreground flex shrink-0 items-center gap-4 border-t px-5 py-3 text-sm">
                 <span>
                   {groupedTraces.length}{" "}
                   {groupedTraces.length === 1 ? "trace" : "traces"}
@@ -864,10 +864,10 @@ function HookTypeFilter({
         <Button
           variant="outline"
           size="sm"
-          className="shrink-0 w-[200px] h-[42px] justify-between"
+          className="h-[42px] w-[200px] shrink-0 justify-between"
         >
           <span className="text-sm">{getButtonText()}</span>
-          <Icon name="chevron-down" className="size-4 ml-2" />
+          <Icon name="chevron-down" className="ml-2 size-4" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-3" align="start">
@@ -889,7 +889,7 @@ function HookTypeFilter({
               />
               <label
                 htmlFor={`hook-type-${option.value}`}
-                className="text-sm font-medium leading-none cursor-pointer"
+                className="cursor-pointer text-sm leading-none font-medium"
               >
                 {option.label}
               </label>
@@ -942,9 +942,9 @@ function SummaryTable({
   return (
     <div className="bg-background relative">
       {/* Header */}
-      <div className="flex items-center gap-3 px-5 py-1 bg-muted/30 border-b text-xs font-medium text-muted-foreground uppercase tracking-wide">
+      <div className="bg-muted/30 text-muted-foreground flex items-center gap-3 border-b px-5 py-1 text-xs font-medium tracking-wide uppercase">
         {/* First column - tabs or header */}
-        <div className="flex-1 min-w-0">
+        <div className="min-w-0 flex-1">
           {tabs && tabValue && onTabChange ? (
             <Tabs value={tabValue} onValueChange={onTabChange}>
               <TabsList className="h-7 p-0.5">
@@ -952,7 +952,7 @@ function SummaryTable({
                   <TabsTrigger
                     key={tab.value}
                     value={tab.value}
-                    className="text-xs px-2.5 h-6"
+                    className="h-6 px-2.5 text-xs"
                   >
                     {tab.label}
                   </TabsTrigger>
@@ -963,9 +963,9 @@ function SummaryTable({
             "Name"
           )}
         </div>
-        <div className="shrink-0 w-[100px] text-right">{uniqueToolsLabel}</div>
-        <div className="shrink-0 w-[100px] text-right">{toolCallsLabel}</div>
-        <div className="shrink-0 w-[100px] text-right">Success Rate</div>
+        <div className="w-[100px] shrink-0 text-right">{uniqueToolsLabel}</div>
+        <div className="w-[100px] shrink-0 text-right">{toolCallsLabel}</div>
+        <div className="w-[100px] shrink-0 text-right">Success Rate</div>
       </div>
 
       {/* Rows */}
@@ -978,34 +978,34 @@ function SummaryTable({
         {sortedItems.map((item) => (
           <div
             key={item.name}
-            className="group w-full flex items-center gap-3 px-5 py-3 border-b last:border-b-0"
+            className="group flex w-full items-center gap-3 border-b px-5 py-3 last:border-b-0"
           >
             {/* Name + Actions */}
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              <span className="text-sm font-medium truncate">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <span className="truncate text-sm font-medium">
                 {item.displayName || item.name}
               </span>
 
               {/* Actions - shown on hover */}
-              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+              <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 {!hideFilterAction && (
                   <button
                     onClick={() => onItemSelect(item.name)}
-                    className="p-1.5 rounded hover:bg-primary/10"
+                    className="hover:bg-primary/10 rounded p-1.5"
                     title={`Filter by ${item.displayName || item.name}`}
                   >
-                    <Filter className="size-4 text-muted-foreground hover:text-primary" />
+                    <Filter className="text-muted-foreground hover:text-primary size-4" />
                   </button>
                 )}
                 {onItemEdit && (
                   <button
                     onClick={() => onItemEdit(item.name)}
-                    className="p-1.5 rounded hover:bg-primary/10"
+                    className="hover:bg-primary/10 rounded p-1.5"
                     title={`Edit display name for ${item.displayName || item.name}`}
                   >
                     <Icon
                       name="pencil"
-                      className="size-4 text-muted-foreground hover:text-primary"
+                      className="text-muted-foreground hover:text-primary size-4"
                     />
                   </button>
                 )}
@@ -1013,17 +1013,17 @@ function SummaryTable({
             </div>
 
             {/* Unique Tools */}
-            <div className="shrink-0 w-[100px] text-right text-sm text-muted-foreground">
+            <div className="text-muted-foreground w-[100px] shrink-0 text-right text-sm">
               {item.uniqueTools}
             </div>
 
             {/* Tool Calls (successCount + failureCount (eventCount is something else)) */}
-            <div className="shrink-0 w-[100px] text-right text-sm">
+            <div className="w-[100px] shrink-0 text-right text-sm">
               {item.toolCallCount}
             </div>
 
             {/* Success Rate */}
-            <div className="shrink-0 w-[100px] flex justify-end items-center gap-1.5">
+            <div className="flex w-[100px] shrink-0 items-center justify-end gap-1.5">
               <span className="text-sm font-medium tabular-nums">
                 {Math.round((1 - item.failureRate) * 100)}%
               </span>
@@ -1042,13 +1042,13 @@ function SummaryTable({
           variant="ghost"
           size="sm"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="absolute bottom-2 left-1/2 -translate-x-1/2 h-7 px-2 bg-background/95 backdrop-blur-sm shadow-sm border border-border/50 hover:bg-muted"
+          className="bg-background/95 border-border/50 hover:bg-muted absolute bottom-2 left-1/2 h-7 -translate-x-1/2 border px-2 shadow-sm backdrop-blur-sm"
         >
           <Icon
             name={isExpanded ? "chevrons-up" : "chevrons-down"}
             className="size-3.5"
           />
-          <span className="text-xs ml-1">
+          <span className="ml-1 text-xs">
             {isExpanded ? "Collapse" : "Expand"}
           </span>
         </Button>
@@ -1382,13 +1382,13 @@ function HooksTraceContent({
   if (error) {
     return (
       <div className="flex flex-col items-center gap-3 py-12">
-        <div className="size-12 rounded-full bg-destructive/10 flex items-center justify-center">
-          <Icon name="x" className="size-6 text-destructive" />
+        <div className="bg-destructive/10 flex size-12 items-center justify-center rounded-full">
+          <Icon name="x" className="text-destructive size-6" />
         </div>
-        <span className="font-medium text-foreground">
+        <span className="text-foreground font-medium">
           Error loading hook events
         </span>
-        <span className="text-sm text-muted-foreground max-w-sm text-center">
+        <span className="text-muted-foreground max-w-sm text-center text-sm">
           {error.message}
         </span>
       </div>
@@ -1397,7 +1397,7 @@ function HooksTraceContent({
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+      <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
         <Icon name="loader-circle" className="size-5 animate-spin" />
         <span>Loading hook events...</span>
       </div>
@@ -1416,13 +1416,13 @@ function HooksTraceContent({
     return (
       <div className="py-12 text-center">
         <div className="flex flex-col items-center gap-3">
-          <div className="size-12 rounded-full bg-muted flex items-center justify-center">
-            <Icon name="inbox" className="size-6 text-muted-foreground" />
+          <div className="bg-muted flex size-12 items-center justify-center rounded-full">
+            <Icon name="inbox" className="text-muted-foreground size-6" />
           </div>
-          <span className="font-medium text-foreground">
+          <span className="text-foreground font-medium">
             No matching hook events
           </span>
-          <span className="text-sm text-muted-foreground max-w-sm">
+          <span className="text-muted-foreground max-w-sm text-sm">
             Try adjusting your search query or time range
           </span>
         </div>
@@ -1444,7 +1444,7 @@ function HooksTraceContent({
       ))}
 
       {isFetchingNextPage && (
-        <div className="flex items-center justify-center gap-2 py-4 text-muted-foreground border-t">
+        <div className="text-muted-foreground flex items-center justify-center gap-2 border-t py-4">
           <Icon name="loader-circle" className="size-4 animate-spin" />
           <span className="text-sm">Loading more events...</span>
         </div>
@@ -1499,7 +1499,7 @@ function HookTraceRow({
     // For skills, show [Skill] badge
     if (toolName === "Skill" && skillName) {
       return (
-        <span className="text-xs font-mono truncate px-2 py-1 rounded-md shrink-0 bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20 font-medium">
+        <span className="shrink-0 truncate rounded-md border border-purple-500/20 bg-purple-500/10 px-2 py-1 font-mono text-xs font-medium text-purple-600 dark:text-purple-400">
           Skill
         </span>
       );
@@ -1509,10 +1509,10 @@ function HookTraceRow({
     return (
       <span
         className={cn(
-          "text-xs font-mono truncate px-2 py-1 rounded-md shrink-0",
+          "shrink-0 truncate rounded-md px-2 py-1 font-mono text-xs",
           isLocal
             ? "bg-muted/50 text-muted-foreground"
-            : "bg-primary/10 text-primary border border-primary/20 font-medium",
+            : "bg-primary/10 text-primary border-primary/20 border font-medium",
         )}
       >
         {displayServerName || "local"}
@@ -1542,29 +1542,29 @@ function HookTraceRow({
   }, [trace.hookStatus]);
 
   return (
-    <div className="border-b border-border/50 last:border-b-0">
+    <div className="border-border/50 border-b last:border-b-0">
       {/* Parent trace row */}
       <button
         onClick={onToggle}
-        className="w-full flex items-center gap-3 px-5 py-2.5 hover:bg-muted/50 transition-colors text-left"
+        className="hover:bg-muted/50 flex w-full items-center gap-3 px-5 py-2.5 text-left transition-colors"
       >
         {/* Timestamp */}
-        <div className="shrink-0 w-[150px] text-sm text-muted-foreground font-mono">
+        <div className="text-muted-foreground w-[150px] shrink-0 font-mono text-sm">
           {timeAgo}
         </div>
 
         {/* Expand/collapse indicator */}
-        <div className="shrink-0 w-5 flex items-center justify-center">
+        <div className="flex w-5 shrink-0 items-center justify-center">
           <Icon
             name={isExpanded ? "chevron-down" : "chevron-right"}
-            className="size-4 text-muted-foreground"
+            className="text-muted-foreground size-4"
           />
         </div>
 
         {/* Server badge + Tool name */}
-        <div className="flex items-center gap-2 flex-1 min-w-0">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           {serverNameBadge}
-          <span className="text-sm font-mono truncate">
+          <span className="truncate font-mono text-sm">
             {toolName === "Skill" && skillName
               ? skillName
               : toolName || "unknown"}
@@ -1572,25 +1572,25 @@ function HookTraceRow({
         </div>
 
         {/* User email */}
-        <div className="shrink-0 w-[260px] text-sm text-muted-foreground truncate">
+        <div className="text-muted-foreground w-[260px] shrink-0 truncate text-sm">
           {userEmail || "—"}
         </div>
 
         {/* Hook source */}
-        <div className="shrink-0 w-[120px] flex items-center gap-2">
+        <div className="flex w-[120px] shrink-0 items-center gap-2">
           <HookSourceIcon source={hookSource} className="size-4 shrink-0" />
           {hookSource && (
-            <span className="text-xs text-foreground font-medium truncate">
+            <span className="text-foreground truncate text-xs font-medium">
               {hookSource}
             </span>
           )}
         </div>
 
         {/* Status badge */}
-        <div className="shrink-0 w-20 flex justify-end">
+        <div className="flex w-20 shrink-0 justify-end">
           <div
             className={cn(
-              "inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium",
+              "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium",
               statusConfig.bgColor,
               statusConfig.color,
             )}

--- a/client/dashboard/src/pages/hooks/HooksEmptyState.tsx
+++ b/client/dashboard/src/pages/hooks/HooksEmptyState.tsx
@@ -33,17 +33,17 @@ function ProviderCard({
     <button
       onClick={onInstall}
       className={cn(
-        "relative flex flex-col items-center p-6 rounded-lg border transition-all min-w-[160px]",
+        "relative flex min-w-[160px] flex-col items-center rounded-lg border p-6 transition-all",
         status === "available"
           ? "border-border hover:border-primary hover:bg-muted/50 cursor-pointer"
           : "border-border/50 hover:border-primary/50 hover:bg-muted/30 cursor-pointer opacity-60",
       )}
     >
-      <IconComponent className="size-12 mb-3" />
-      <span className="font-medium text-sm">{name}</span>
+      <IconComponent className="mb-3 size-12" />
+      <span className="text-sm font-medium">{name}</span>
       {isComingSoon && (
         <div className="absolute top-3 right-3">
-          <span className="text-[10px] font-semibold text-muted-foreground bg-muted px-2 py-0.5 rounded-full uppercase tracking-wide">
+          <span className="text-muted-foreground bg-muted rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
             Coming Soon
           </span>
         </div>
@@ -73,16 +73,16 @@ export function HooksEmptyState() {
 
   return (
     <>
-      <div className="flex flex-col items-center justify-center py-16 px-4">
-        <div className="max-w-2xl w-full text-center space-y-8">
+      <div className="flex flex-col items-center justify-center px-4 py-16">
+        <div className="w-full max-w-2xl space-y-8 text-center">
           {/* Icon and Title */}
           <div className="flex flex-col items-center gap-4">
-            <div className="size-16 rounded-full bg-muted flex items-center justify-center">
-              <Icon name="workflow" className="size-8 text-muted-foreground" />
+            <div className="bg-muted flex size-16 items-center justify-center rounded-full">
+              <Icon name="workflow" className="text-muted-foreground size-8" />
             </div>
             <div>
-              <h2 className="text-xl font-semibold mb-2">No Hook Logs Yet</h2>
-              <p className="text-sm text-muted-foreground max-w-md mx-auto">
+              <h2 className="mb-2 text-xl font-semibold">No Hook Logs Yet</h2>
+              <p className="text-muted-foreground mx-auto max-w-md text-sm">
                 Install Gram Hooks in your AI coding assistant to start
                 capturing tool execution logs
               </p>
@@ -91,10 +91,10 @@ export function HooksEmptyState() {
 
           {/* Installation Options */}
           <div>
-            <h3 className="text-sm font-medium mb-4">
+            <h3 className="mb-4 text-sm font-medium">
               Choose Your AI Coding Assistant
             </h3>
-            <div className="flex items-center justify-center gap-4 flex-wrap">
+            <div className="flex flex-wrap items-center justify-center gap-4">
               <ProviderCard
                 name="Claude Code"
                 icon={ClaudeCodeIcon}

--- a/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
+++ b/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
@@ -15,11 +15,11 @@ function ClaudeInstallContent() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-sm font-semibold mb-2">Test Yourself</h3>
-        <p className="text-sm text-muted-foreground mb-4">
+        <h3 className="mb-2 text-sm font-semibold">Test Yourself</h3>
+        <p className="text-muted-foreground mb-4 text-sm">
           Try Gram Hooks in your Claude Code instance:
         </p>
-        <div className="bg-muted/50 rounded-lg p-4 font-mono text-sm space-y-2">
+        <div className="bg-muted/50 space-y-2 rounded-lg p-4 font-mono text-sm">
           <div className="flex items-center justify-between">
             <code>claude plugin marketplace add speakeasy-api/gram</code>
           </div>
@@ -30,15 +30,15 @@ function ClaudeInstallContent() {
       </div>
 
       <div>
-        <h3 className="text-sm font-semibold mb-2">Distribute to Your Team</h3>
-        <p className="text-sm text-muted-foreground mb-4">
+        <h3 className="mb-2 text-sm font-semibold">Distribute to Your Team</h3>
+        <p className="text-muted-foreground mb-4 text-sm">
           Require your team to use Gram Hooks by configuring their Claude Code
           settings:
         </p>
 
         <div className="space-y-4">
           <div>
-            <h4 className="text-xs font-medium text-muted-foreground mb-2">
+            <h4 className="text-muted-foreground mb-2 text-xs font-medium">
               1. Require the marketplace
             </h4>
             <div className="bg-muted/50 rounded-lg p-4 font-mono text-sm">
@@ -53,7 +53,7 @@ function ClaudeInstallContent() {
           </div>
 
           <div>
-            <h4 className="text-xs font-medium text-muted-foreground mb-2">
+            <h4 className="text-muted-foreground mb-2 text-xs font-medium">
               2. Require the plugin
             </h4>
             <div className="bg-muted/50 rounded-lg p-4 font-mono text-sm">
@@ -88,8 +88,8 @@ function CursorInstallContent() {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-sm font-semibold mb-2">1. Publish the Plugin</h3>
-        <p className="text-sm text-muted-foreground mb-4">
+        <h3 className="mb-2 text-sm font-semibold">1. Publish the Plugin</h3>
+        <p className="text-muted-foreground mb-4 text-sm">
           Add the Gram hooks plugin to your Cursor team marketplace and mark it
           as required so it auto-installs for all team members:
         </p>
@@ -98,7 +98,7 @@ function CursorInstallContent() {
             href="https://cursor.com/dashboard/team-content"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
+            className="text-primary hover:text-primary/80 underline underline-offset-4"
           >
             cursor.com/dashboard/team-content
           </a>
@@ -106,42 +106,42 @@ function CursorInstallContent() {
       </div>
 
       <div>
-        <h3 className="text-sm font-semibold mb-2">2. Configure Credentials</h3>
-        <p className="text-sm text-muted-foreground mb-4">
+        <h3 className="mb-2 text-sm font-semibold">2. Configure Credentials</h3>
+        <p className="text-muted-foreground mb-4 text-sm">
           In the Cursor team dashboard, add a{" "}
-          <code className="text-xs bg-muted px-1 py-0.5 rounded">
+          <code className="bg-muted rounded px-1 py-0.5 text-xs">
             Session Start
           </code>{" "}
           hook that injects your Gram credentials. These are automatically
           passed to all subsequent hooks in the session.
         </p>
-        <p className="text-sm text-muted-foreground mb-4">
+        <p className="text-muted-foreground mb-4 text-sm">
           Go to{" "}
           <a
             href="https://cursor.com/dashboard/team-content?section=hooks"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary underline underline-offset-4 hover:text-primary/80"
+            className="text-primary hover:text-primary/80 underline underline-offset-4"
           >
             cursor.com/dashboard/team-content
           </a>{" "}
           and create a new hook with:
         </p>
-        <div className="bg-muted/50 rounded-lg p-4 text-sm space-y-3">
+        <div className="bg-muted/50 space-y-3 rounded-lg p-4 text-sm">
           <div className="flex items-baseline gap-2">
-            <span className="text-muted-foreground font-medium shrink-0">
+            <span className="text-muted-foreground shrink-0 font-medium">
               Hook Name:
             </span>
             <code>Gram Hooks</code>
           </div>
           <div className="flex items-baseline gap-2">
-            <span className="text-muted-foreground font-medium shrink-0">
+            <span className="text-muted-foreground shrink-0 font-medium">
               Hook Type:
             </span>
             <code>Command</code>
           </div>
           <div className="flex items-baseline gap-2">
-            <span className="text-muted-foreground font-medium shrink-0">
+            <span className="text-muted-foreground shrink-0 font-medium">
               Hook Step:
             </span>
             <code>Session Start</code>
@@ -150,7 +150,7 @@ function CursorInstallContent() {
             <span className="text-muted-foreground font-medium">
               Script Content:
             </span>
-            <div className="bg-background/50 rounded mt-1 p-3 font-mono text-xs whitespace-pre-wrap break-all overflow-x-auto">
+            <div className="bg-background/50 mt-1 overflow-x-auto rounded p-3 font-mono text-xs break-all whitespace-pre-wrap">
               {`#!/bin/bash\necho '{"env":{"GRAM_API_KEY":"`}
               <span className="text-primary font-semibold">{`<YOUR_API_KEY>`}</span>
               {`","GRAM_PROJECT_SLUG":"`}
@@ -159,16 +159,16 @@ function CursorInstallContent() {
             </div>
           </div>
           <div className="flex items-baseline gap-2">
-            <span className="text-muted-foreground font-medium shrink-0">
+            <span className="text-muted-foreground shrink-0 font-medium">
               Platforms:
             </span>
             <code>Mac, Linux</code>
           </div>
         </div>
-        <p className="text-xs text-muted-foreground mt-2">
+        <p className="text-muted-foreground mt-2 text-xs">
           Replace{" "}
-          <code className="text-xs text-primary">{`<YOUR_API_KEY>`}</code> and{" "}
-          <code className="text-xs text-primary">{`<YOUR_PROJECT_SLUG>`}</code>{" "}
+          <code className="text-primary text-xs">{`<YOUR_API_KEY>`}</code> and{" "}
+          <code className="text-primary text-xs">{`<YOUR_PROJECT_SLUG>`}</code>{" "}
           with your Gram credentials. Find your API key in your project's API
           Keys settings. This config syncs to all team members automatically.
         </p>
@@ -263,7 +263,7 @@ export function HooksSetupDialog({
           <Dialog.Title>Setup Hooks</Dialog.Title>
         </Dialog.Header>
 
-        <div className="flex gap-3 mb-6 flex-wrap">
+        <div className="mb-6 flex flex-wrap gap-3">
           <TooltipProvider>
             {providers.map((p) => {
               const button = (
@@ -272,18 +272,18 @@ export function HooksSetupDialog({
                   onClick={() => p.available && setSelected(p.id)}
                   disabled={!p.available}
                   className={cn(
-                    "flex items-center gap-2 px-3 py-2 rounded-md border text-sm font-medium transition-colors relative",
+                    "relative flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors",
                     selected === p.id
                       ? "border-primary bg-primary/5"
                       : "border-border hover:border-primary/50 hover:bg-muted/50",
                     !p.available &&
-                      "opacity-50 cursor-not-allowed hover:border-border hover:bg-transparent",
+                      "hover:border-border cursor-not-allowed opacity-50 hover:bg-transparent",
                   )}
                 >
                   <HookSourceIcon source={p.source} className="size-5" />
                   {p.label}
                   {!p.available && (
-                    <span className="ml-1 text-[10px] text-muted-foreground uppercase tracking-wide">
+                    <span className="text-muted-foreground ml-1 text-[10px] tracking-wide uppercase">
                       Soon
                     </span>
                   )}

--- a/client/dashboard/src/pages/integrations/Integrations.tsx
+++ b/client/dashboard/src/pages/integrations/Integrations.tsx
@@ -47,7 +47,7 @@ export default function Integrations() {
       </Page.Header>
       <Page.Body>
         {isAdmin && (
-          <div className="flex justify-end mb-4">
+          <div className="mb-4 flex justify-end">
             <AddButton onClick={() => setCreateIntegrationDialogOpen(true)} />
           </div>
         )}
@@ -279,12 +279,12 @@ export function IntegrationCard({
             {integration.packageImageAssetId && (
               <AssetImage
                 assetId={integration.packageImageAssetId}
-                className="w-8 h-8 rounded-md"
+                className="h-8 w-8 rounded-md"
               />
             )}
             <span>
               {integration.packageTitle}
-              <span className="text-muted-foreground text-sm ml-2">
+              <span className="text-muted-foreground ml-2 text-sm">
                 v{integration.version}
               </span>
             </span>
@@ -301,7 +301,7 @@ export function IntegrationCard({
           <Button variant="secondary" onClick={toggleEnabled}>
             {isEnabled ? (
               <>
-                <CheckIcon className="w-4 h-4" />
+                <CheckIcon className="h-4 w-4" />
                 Enabled
               </>
             ) : (
@@ -353,7 +353,7 @@ function RequestIntegrationDialog({
           Not seeing the integration you need? Request it here.
         </Dialog.Description>
         <Stack gap={2}>
-          <Heading variant="h5" className="normal-case font-medium">
+          <Heading variant="h5" className="font-medium normal-case">
             What integration are you looking for?
           </Heading>
           <Input

--- a/client/dashboard/src/pages/invite/AcceptInvite.tsx
+++ b/client/dashboard/src/pages/invite/AcceptInvite.tsx
@@ -26,7 +26,7 @@ export default function AcceptInvite() {
   if (error === "already_member") {
     return (
       <InvitePage>
-        <p className="text-sm text-muted-foreground text-center">
+        <p className="text-muted-foreground text-center text-sm">
           You&apos;re already a member of another organization. Please leave
           your current organization before accepting this invite.
         </p>
@@ -43,7 +43,7 @@ export default function AcceptInvite() {
   if (!token) {
     return (
       <InvitePage>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           Invalid invite link. No token provided.
         </p>
       </InvitePage>
@@ -64,7 +64,7 @@ function InviteDetails({ token }: { token: string }) {
   if (infoLoading) {
     return (
       <InvitePage>
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
       </InvitePage>
     );
   }
@@ -72,7 +72,7 @@ function InviteDetails({ token }: { token: string }) {
   if (infoError || !inviteInfo) {
     return (
       <InvitePage>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           This invite link is invalid or has already been used.
         </p>
         <Button
@@ -94,7 +94,7 @@ function InviteDetails({ token }: { token: string }) {
           : "This invite has been revoked.";
     return (
       <InvitePage>
-        <p className="text-sm text-muted-foreground">{message}</p>
+        <p className="text-muted-foreground text-sm">{message}</p>
         <Button
           variant="secondary"
           onClick={() => navigate("/", { replace: true })}
@@ -112,7 +112,7 @@ function InviteDetails({ token }: { token: string }) {
 
   return (
     <InvitePage>
-      <p className="text-body-lg text-center text-foreground">
+      <p className="text-body-lg text-foreground text-center">
         You&apos;ve been invited to join{" "}
         {inviteInfo.organizationName ? (
           <span className="font-semibold">{inviteInfo.organizationName}</span>
@@ -131,12 +131,12 @@ function InviteDetails({ token }: { token: string }) {
 
 function InvitePage({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-col justify-center items-center w-full min-h-screen p-8 bg-background relative">
-      <div className="w-full flex flex-col items-center gap-8 max-w-xs">
-        <GramLogo className="w-25 mb-2" variant="vertical" />
+    <div className="bg-background relative flex min-h-screen w-full flex-col items-center justify-center p-8">
+      <div className="flex w-full max-w-xs flex-col items-center gap-8">
+        <GramLogo className="mb-2 w-25" variant="vertical" />
         {children}
       </div>
-      <div className="bottom-16 left-0 right-0 absolute flex justify-center items-center text-foreground">
+      <div className="text-foreground absolute right-0 bottom-16 left-0 flex items-center justify-center">
         <SpeakeasyLogo />
       </div>
     </div>

--- a/client/dashboard/src/pages/login/components/button.tsx
+++ b/client/dashboard/src/pages/login/components/button.tsx
@@ -12,7 +12,7 @@ type ButtonSize = "lg";
 
 const shareFocusAndHoverClasses = cn(
   // Focus
-  "focus-visible:ring-1 focus-visible:ring-offset-3 focus-visible:ring-[#979797] dark:focus-visible:ring-[#DCDCDC] focus-visible:ring-offset-background",
+  "focus-visible:ring-offset-background focus-visible:ring-1 focus-visible:ring-[#979797] focus-visible:ring-offset-3 dark:focus-visible:ring-[#DCDCDC]",
   // Disabled
   "disabled:opacity-50",
 );

--- a/client/dashboard/src/pages/login/components/journey-demo.tsx
+++ b/client/dashboard/src/pages/login/components/journey-demo.tsx
@@ -14,7 +14,7 @@ function MovingDotBackground() {
         }
       `}</style>
       <div
-        className="login-dots absolute inset-0 pointer-events-none text-muted-foreground/20"
+        className="login-dots text-muted-foreground/20 pointer-events-none absolute inset-0"
         style={{
           backgroundImage:
             "radial-gradient(circle, currentColor 1px, transparent 1px)",
@@ -27,31 +27,31 @@ function MovingDotBackground() {
 
 export function JourneyDemo() {
   return (
-    <div className="login-pane hidden md:flex flex-col justify-center items-center w-full md:w-1/2 min-h-screen relative bg-slate-50 overflow-y-auto">
+    <div className="login-pane relative hidden min-h-screen w-full flex-col items-center justify-center overflow-y-auto bg-slate-50 md:flex md:w-1/2">
       {/* Moving dot background — same pattern as MCP cards */}
       <MovingDotBackground />
 
       {/* Soft gradient overlays for depth */}
-      <div className="absolute inset-0 bg-gradient-to-br from-blue-50/50 via-transparent to-emerald-50/30 pointer-events-none" />
-      <div className="absolute inset-0 bg-gradient-to-t from-white/60 via-transparent to-white/40 pointer-events-none" />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-50/50 via-transparent to-emerald-50/30" />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-white/60 via-transparent to-white/40" />
 
       {/* Main platform diagram */}
       <PlatformDiagram className="relative z-10 w-full px-8 py-12" />
 
       {/* Top/Bottom gradient fades */}
-      <div className="absolute top-0 left-0 right-0 h-16 bg-gradient-to-b from-slate-50 to-transparent pointer-events-none z-20" />
-      <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-slate-50 to-transparent pointer-events-none z-20" />
+      <div className="pointer-events-none absolute top-0 right-0 left-0 z-20 h-16 bg-gradient-to-b from-slate-50 to-transparent" />
+      <div className="pointer-events-none absolute right-0 bottom-0 left-0 z-20 h-16 bg-gradient-to-t from-slate-50 to-transparent" />
 
       {/* Fixed bottom social links */}
-      <div className="absolute bottom-6 left-0 right-0 flex items-center justify-center gap-4 z-30">
+      <div className="absolute right-0 bottom-6 left-0 z-30 flex items-center justify-center gap-4">
         <a
           href="https://x.com/speakeasydev"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-slate-400 hover:text-slate-600 transition-colors"
+          className="text-slate-400 transition-colors hover:text-slate-600"
           aria-label="Follow us on X"
         >
-          <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
           </svg>
         </a>
@@ -59,10 +59,10 @@ export function JourneyDemo() {
           href="https://github.com/speakeasy-api/gram"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-slate-400 hover:text-slate-600 transition-colors"
+          className="text-slate-400 transition-colors hover:text-slate-600"
           aria-label="View on GitHub"
         >
-          <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
           </svg>
         </a>
@@ -70,11 +70,11 @@ export function JourneyDemo() {
           href="https://www.speakeasy.com/docs/mcp"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-slate-400 hover:text-slate-600 transition-colors"
+          className="text-slate-400 transition-colors hover:text-slate-600"
           aria-label="Documentation"
         >
           <svg
-            className="w-5 h-5"
+            className="h-5 w-5"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/client/dashboard/src/pages/login/components/login-section.tsx
+++ b/client/dashboard/src/pages/login/components/login-section.tsx
@@ -36,7 +36,7 @@ function FeatureBadges({ labels = FEATURE_BADGES }: { labels?: string[] }) {
       {labels.map((label) => (
         <span
           key={label}
-          className="rounded-full border border-[#D3D3D3] px-3 py-1 font-mono text-xs uppercase tracking-[0.01em] text-[#8B8684]"
+          className="rounded-full border border-[#D3D3D3] px-3 py-1 font-mono text-xs tracking-[0.01em] text-[#8B8684] uppercase"
         >
           {label}
         </span>
@@ -49,7 +49,7 @@ function FeatureBadges({ labels = FEATURE_BADGES }: { labels?: string[] }) {
 function BrandGradientBar() {
   return (
     <div
-      className="absolute bottom-0 left-0 right-0 h-[6px]"
+      className="absolute right-0 bottom-0 left-0 h-[6px]"
       style={{
         background:
           "linear-gradient(90deg, #320F1E 0%, #C83228 12.5%, #FB873F 25%, #D2DC91 37.5%, #5A8250 50%, #002314 62%, #00143C 74%, #2873D7 86%, #9BC3FF 100%)",
@@ -72,7 +72,7 @@ function DotBackground() {
         }
       `}</style>
       <div
-        className="login-right-dots absolute inset-0 pointer-events-none text-muted-foreground/10"
+        className="login-right-dots text-muted-foreground/10 pointer-events-none absolute inset-0"
         style={{
           backgroundImage:
             "radial-gradient(circle, currentColor 1px, transparent 1px)",
@@ -85,11 +85,11 @@ function DotBackground() {
 
 function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="login-right-pane flex flex-col justify-center items-center w-full md:w-1/2 min-h-screen p-8 md:p-16 bg-[#FAFAFA] relative overflow-hidden">
+    <div className="login-right-pane relative flex min-h-screen w-full flex-col items-center justify-center overflow-hidden bg-[#FAFAFA] p-8 md:w-1/2 md:p-16">
       {/* Moving dot background — scrolls on hover */}
       <DotBackground />
 
-      <div className="relative z-10 w-full flex flex-col items-center gap-8 max-w-sm">
+      <div className="relative z-10 flex w-full max-w-sm flex-col items-center gap-8">
         <div className="flex flex-col items-center gap-4">
           <a
             href="https://www.speakeasy.com/product/mcp-platform"
@@ -97,11 +97,11 @@ function AuthLayout({ children }: { children: React.ReactNode }) {
             rel="noopener noreferrer"
           >
             <GramLogo
-              className="w-[200px] mb-2 dark:!invert-0"
+              className="mb-2 w-[200px] dark:!invert-0"
               variant="vertical"
             />
           </a>
-          <div className="flex flex-col gap-2 text-sm text-center dark:text-black">
+          <div className="flex flex-col gap-2 text-center text-sm dark:text-black">
             <p>Securely scale AI usage across your organization.</p>
             <p className="text-[#8B8684]">
               Control plane for distribution of MCP, Skills, Assistants and
@@ -114,7 +114,7 @@ function AuthLayout({ children }: { children: React.ReactNode }) {
         {children}
       </div>
 
-      <p className="absolute bottom-10 z-10 text-[11px] text-[#8B8684] text-center px-8">
+      <p className="absolute bottom-10 z-10 px-8 text-center text-[11px] text-[#8B8684]">
         By continuing, you agree to Speakeasy&apos;s{" "}
         <a
           href="https://www.speakeasy.com/terms-of-service"
@@ -161,7 +161,7 @@ export function LoginSection(props: LoginSectionProps) {
   return (
     <AuthLayout>
       {signinError && (
-        <p className="text-red-600 text-center mb-4">
+        <p className="mb-4 text-center text-red-600">
           login error: {getAuthErrorMessage(signinError)}
         </p>
       )}
@@ -255,12 +255,12 @@ export function RegisterSection() {
   return (
     <AuthLayout>
       {signinError && (
-        <p className="text-red-600 text-center mb-4">
+        <p className="mb-4 text-center text-red-600">
           login error: {getAuthErrorMessage(signinError)}
         </p>
       )}
 
-      <form onSubmit={handleSubmit} className="w-full flex flex-col gap-4">
+      <form onSubmit={handleSubmit} className="flex w-full flex-col gap-4">
         <div className="flex flex-col gap-2">
           <label
             htmlFor="companyName"
@@ -274,13 +274,13 @@ export function RegisterSection() {
             value={companyName}
             onChange={handleCompanyNameChange}
             placeholder="company name"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-500 text-gray-900"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-gray-900 placeholder-gray-500 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
             disabled={registerMutation.isPending}
           />
         </div>
 
         {(validationError || registerMutation.error) && (
-          <p className="text-red-600 text-sm text-center">
+          <p className="text-center text-sm text-red-600">
             {validationError || registerMutation.error?.message}
           </p>
         )}

--- a/client/dashboard/src/pages/login/components/platform-diagram.tsx
+++ b/client/dashboard/src/pages/login/components/platform-diagram.tsx
@@ -11,13 +11,13 @@ const BRAND_COLORS = {
 
 // Service logo components (simplified SVG icons)
 const GitHubLogo = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5" fill="currentColor">
+  <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor">
     <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
   </svg>
 );
 
 const FigmaLogo = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5">
+  <svg viewBox="0 0 24 24" className="h-5 w-5">
     <path
       d="M8 24c2.2 0 4-1.8 4-4v-4H8c-2.2 0-4 1.8-4 4s1.8 4 4 4z"
       fill="#0ACF83"
@@ -33,7 +33,7 @@ const FigmaLogo = () => (
 );
 
 const SlackLogo = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5">
+  <svg viewBox="0 0 24 24" className="h-5 w-5">
     <path
       d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"
       fill="#E01E5A"
@@ -42,13 +42,13 @@ const SlackLogo = () => (
 );
 
 const NotionLogo = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5" fill="currentColor">
+  <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor">
     <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.98-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.886l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.139c-.093-.514.28-.886.747-.933zM2.081 1.333C3.153.4 4.459.026 6.09.166L18.38.926c1.495.14 1.869.42 2.802 1.12l3.921 2.799c.653.466.839.7.839 1.213v14.089c0 1.12-.373 1.773-1.588 1.866l-15.085.933c-.934.047-1.401-.14-1.915-.746L2.221 18.2c-.653-.793-.935-1.4-.935-2.146V2.5c0-.933.373-1.026.795-1.167z" />
   </svg>
 );
 
 const LinearLogo = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5">
+  <svg viewBox="0 0 24 24" className="h-5 w-5">
     <path
       d="M3.152 14.192c-.166-.164-.166-.428 0-.592l7.048-6.956c.166-.164.434-.164.6 0l6.952 6.956c.166.164.166.428 0 .592l-7.048 6.956c-.166.164-.434.164-.6 0z"
       fill="#5E6AD2"
@@ -57,7 +57,7 @@ const LinearLogo = () => (
 );
 
 const JiraLogo = () => (
-  <svg viewBox="0 0 24 24" className="w-5 h-5">
+  <svg viewBox="0 0 24 24" className="h-5 w-5">
     <path
       d="M12.005 0C8.41 0 5.705 3.105 5.705 6.523c0 .105 0 .21.007.315h-.007v10.639l6.3 6.523 6.295-6.523V6.838h-.007c.007-.105.007-.21.007-.315C18.3 3.105 15.596 0 12.005 0zm0 2.526c2.108 0 3.818 1.79 3.818 4 0 2.206-1.71 4-3.818 4s-3.818-1.794-3.818-4c0-2.21 1.71-4 3.818-4z"
       fill="#2684FF"
@@ -155,7 +155,7 @@ function ClientCluster({
       {Array.from({ length: count - 1 }).map((_, i) => (
         <div
           key={i}
-          className="absolute bg-white border border-slate-200 rounded-lg shadow-sm"
+          className="absolute rounded-lg border border-slate-200 bg-white shadow-sm"
           style={{
             top: i * 5,
             left: i * 5,
@@ -165,8 +165,8 @@ function ClientCluster({
         />
       ))}
       {/* Front card */}
-      <div className="relative flex items-center gap-2 px-3 py-2.5 bg-white border border-slate-200 rounded-lg shadow-sm">
-        <Icon className="w-5 h-5" />
+      <div className="relative flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2.5 shadow-sm">
+        <Icon className="h-5 w-5" />
         <span className="text-xs font-medium text-slate-600">{name}</span>
       </div>
     </motion.div>
@@ -180,27 +180,27 @@ function MiniChatApp({ label, delay }: { label: string; delay: number }) {
       initial={{ opacity: 0, scale: 0.9 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.25, delay }}
-      className="bg-white border border-slate-200 rounded shadow-sm overflow-hidden"
+      className="overflow-hidden rounded border border-slate-200 bg-white shadow-sm"
     >
-      <div className="flex items-center gap-1 px-2 py-1 bg-slate-100 border-b border-slate-200">
+      <div className="flex items-center gap-1 border-b border-slate-200 bg-slate-100 px-2 py-1">
         <div className="flex gap-0.5">
-          <div className="w-1.5 h-1.5 rounded-full bg-red-400" />
-          <div className="w-1.5 h-1.5 rounded-full bg-yellow-400" />
-          <div className="w-1.5 h-1.5 rounded-full bg-green-400" />
+          <div className="h-1.5 w-1.5 rounded-full bg-red-400" />
+          <div className="h-1.5 w-1.5 rounded-full bg-yellow-400" />
+          <div className="h-1.5 w-1.5 rounded-full bg-green-400" />
         </div>
-        <span className="text-[7px] text-slate-400 font-mono ml-1">
+        <span className="ml-1 font-mono text-[7px] text-slate-400">
           {label}
         </span>
       </div>
-      <div className="p-1.5 flex gap-1">
-        <div className="flex-1 flex flex-col gap-0.5">
-          <div className="h-1 w-full bg-slate-100 rounded" />
-          <div className="h-1 w-3/4 bg-slate-100 rounded" />
-          <div className="h-1 w-1/2 bg-slate-100 rounded" />
+      <div className="flex gap-1 p-1.5">
+        <div className="flex flex-1 flex-col gap-0.5">
+          <div className="h-1 w-full rounded bg-slate-100" />
+          <div className="h-1 w-3/4 rounded bg-slate-100" />
+          <div className="h-1 w-1/2 rounded bg-slate-100" />
         </div>
-        <div className="w-8 bg-slate-50 rounded border border-slate-100 flex items-center justify-center">
+        <div className="flex w-8 items-center justify-center rounded border border-slate-100 bg-slate-50">
           <svg
-            className="w-2.5 h-2.5 text-slate-300"
+            className="h-2.5 w-2.5 text-slate-300"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -225,7 +225,7 @@ function DistributedClients({ delay }: { delay: number }) {
     >
       {/* Left: AI Client clusters */}
       <div className="flex-1">
-        <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wider mb-3">
+        <div className="mb-3 text-[10px] font-medium tracking-wider text-slate-400 uppercase">
           AI Agents
         </div>
         <div className="flex flex-wrap gap-4">
@@ -258,7 +258,7 @@ function DistributedClients({ delay }: { delay: number }) {
 
       {/* Right: Chat apps */}
       <div className="flex-1">
-        <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wider mb-3">
+        <div className="mb-3 text-[10px] font-medium tracking-wider text-slate-400 uppercase">
           Product Agents
         </div>
         <div className="flex flex-col gap-1.5">
@@ -286,7 +286,7 @@ function FeatureBar({
       initial={{ opacity: 0, x: -10 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.4, delay }}
-      className="flex items-center gap-2 px-3 py-2 bg-slate-50 border border-slate-200 rounded text-xs text-slate-600"
+      className="flex items-center gap-2 rounded border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600"
     >
       <span className="text-slate-400">{icon}</span>
       <span className="font-medium">{label}</span>
@@ -340,11 +340,11 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
   return (
     <div
       className={cn(
-        "relative w-full h-full flex flex-col justify-center",
+        "relative flex h-full w-full flex-col justify-center",
         className,
       )}
     >
-      <div className="flex flex-col items-center gap-4 max-w-md mx-auto py-6">
+      <div className="mx-auto flex max-w-md flex-col items-center gap-4 py-6">
         {/* Top - Distributed AI clients and chat apps across the org */}
         <DistributedClients delay={0.1} />
 
@@ -356,11 +356,11 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4, delay: 0.6 }}
-          className="w-full bg-white border border-slate-200 rounded-lg p-3"
+          className="w-full rounded-lg border border-slate-200 bg-white p-3"
         >
-          <div className="flex items-center mb-3">
+          <div className="mb-3 flex items-center">
             <GramLogo variant="horizontal" className="w-20" />
-            <span className="text-[10px] font-medium text-slate-400 uppercase tracking-wider ml-1">
+            <span className="ml-1 text-[10px] font-medium tracking-wider text-slate-400 uppercase">
               Control Plane
             </span>
           </div>
@@ -369,7 +369,7 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
               delay={0.7}
               icon={
                 <svg
-                  className="w-3.5 h-3.5"
+                  className="h-3.5 w-3.5"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -384,7 +384,7 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
               delay={0.75}
               icon={
                 <svg
-                  className="w-3.5 h-3.5"
+                  className="h-3.5 w-3.5"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -400,7 +400,7 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
               delay={0.8}
               icon={
                 <svg
-                  className="w-3.5 h-3.5"
+                  className="h-3.5 w-3.5"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -440,10 +440,10 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
                 : { duration: 3, repeat: Infinity, ease: "easeInOut" }
             }
           />
-          <div className="relative bg-white rounded-lg p-3">
-            <div className="flex items-center mb-3">
+          <div className="relative rounded-lg bg-white p-3">
+            <div className="mb-3 flex items-center">
               <GramLogo variant="horizontal" className="w-20" />
-              <span className="text-[10px] font-medium text-slate-400 uppercase tracking-wider ml-1">
+              <span className="ml-1 text-[10px] font-medium tracking-wider text-slate-400 uppercase">
                 Tools Platform
               </span>
             </div>
@@ -452,7 +452,7 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
                 delay={1.0}
                 icon={
                   <svg
-                    className="w-3.5 h-3.5"
+                    className="h-3.5 w-3.5"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -467,7 +467,7 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
                 delay={1.05}
                 icon={
                   <svg
-                    className="w-3.5 h-3.5"
+                    className="h-3.5 w-3.5"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -483,7 +483,7 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
                 delay={1.1}
                 icon={
                   <svg
-                    className="w-3.5 h-3.5"
+                    className="h-3.5 w-3.5"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -503,21 +503,21 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
         <PulseConnector delay={0.8} disabled={prefersReducedMotion ?? false} />
 
         {/* Bottom - Data Sources */}
-        <div className="grid grid-cols-2 gap-3 w-full">
+        <div className="grid w-full grid-cols-2 gap-3">
           {/* Your Data */}
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, delay: 1.2 }}
-            className="bg-white border border-slate-200 rounded-lg p-3"
+            className="rounded-lg border border-slate-200 bg-white p-3"
           >
-            <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wider mb-2">
+            <div className="mb-2 text-[10px] font-medium tracking-wider text-slate-400 uppercase">
               Your Data
             </div>
             <div className="flex flex-col gap-1">
-              <span className="text-xs text-slate-600 flex items-center gap-1.5">
+              <span className="flex items-center gap-1.5 text-xs text-slate-600">
                 <svg
-                  className="w-3 h-3 text-slate-400"
+                  className="h-3 w-3 text-slate-400"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -527,9 +527,9 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
                 </svg>
                 APIs
               </span>
-              <span className="text-xs text-slate-600 flex items-center gap-1.5">
+              <span className="flex items-center gap-1.5 text-xs text-slate-600">
                 <svg
-                  className="w-3 h-3 text-slate-400"
+                  className="h-3 w-3 text-slate-400"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -548,28 +548,28 @@ export function PlatformDiagram({ className }: PlatformDiagramProps) {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, delay: 1.3 }}
-            className="bg-white border border-slate-200 rounded-lg p-3"
+            className="rounded-lg border border-slate-200 bg-white p-3"
           >
-            <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wider mb-2">
+            <div className="mb-2 text-[10px] font-medium tracking-wider text-slate-400 uppercase">
               Your SaaS
             </div>
             <div className="grid grid-cols-3 gap-1.5">
-              <div className="flex items-center justify-center p-1 bg-slate-50 rounded">
+              <div className="flex items-center justify-center rounded bg-slate-50 p-1">
                 <GitHubLogo />
               </div>
-              <div className="flex items-center justify-center p-1 bg-slate-50 rounded">
+              <div className="flex items-center justify-center rounded bg-slate-50 p-1">
                 <FigmaLogo />
               </div>
-              <div className="flex items-center justify-center p-1 bg-slate-50 rounded">
+              <div className="flex items-center justify-center rounded bg-slate-50 p-1">
                 <SlackLogo />
               </div>
-              <div className="flex items-center justify-center p-1 bg-slate-50 rounded">
+              <div className="flex items-center justify-center rounded bg-slate-50 p-1">
                 <NotionLogo />
               </div>
-              <div className="flex items-center justify-center p-1 bg-slate-50 rounded">
+              <div className="flex items-center justify-center rounded bg-slate-50 p-1">
                 <LinearLogo />
               </div>
-              <div className="flex items-center justify-center p-1 bg-slate-50 rounded">
+              <div className="flex items-center justify-center rounded bg-slate-50 p-1">
                 <JiraLogo />
               </div>
             </div>

--- a/client/dashboard/src/pages/login/components/prompt-section.tsx
+++ b/client/dashboard/src/pages/login/components/prompt-section.tsx
@@ -194,7 +194,7 @@ export function PromptsSection() {
   return (
     <div
       ref={sectionRef}
-      className="relative w-full md:w-1/2 min-h-screen bg-[#F9F9F9] overflow-hidden"
+      className="relative min-h-screen w-full overflow-hidden bg-[#F9F9F9] md:w-1/2"
     >
       {/* Add CSS for animations directly in the component */}
       <style>{`
@@ -220,7 +220,7 @@ export function PromptsSection() {
       {/* Angled grid container */}
       <div
         ref={containerRef}
-        className="absolute inset-0 z-10 flex flex-col justify-center transform rotate-12 scale-[1.35]"
+        className="absolute inset-0 z-10 flex scale-[1.35] rotate-12 transform flex-col justify-center"
       >
         {ALL_ROWS.map((row, rowIndex) => {
           // Get color for this row (cycle through the colors)
@@ -230,7 +230,7 @@ export function PromptsSection() {
           return (
             <div
               key={rowIndex}
-              className={`prompt-row flex whitespace-nowrap py-2 hover-row`}
+              className={`prompt-row hover-row flex py-2 whitespace-nowrap`}
               style={{
                 willChange: "transform", // Optimize for animation performance
               }}
@@ -240,7 +240,7 @@ export function PromptsSection() {
                   key={`${rowIndex}-${promptIndex}`}
                   service={prompt.service}
                   prompt={prompt.prompt}
-                  className="mx-3 flex-shrink-0 prompt-card"
+                  className="prompt-card mx-3 flex-shrink-0"
                   borderColor={borderColor}
                 />
               ))}
@@ -250,7 +250,7 @@ export function PromptsSection() {
                   key={`${rowIndex}-${promptIndex}-dup`}
                   service={prompt.service}
                   prompt={prompt.prompt}
-                  className="mx-3 flex-shrink-0 prompt-card"
+                  className="prompt-card mx-3 flex-shrink-0"
                   borderColor={borderColor}
                 />
               ))}

--- a/client/dashboard/src/pages/login/components/prompt.card.tsx
+++ b/client/dashboard/src/pages/login/components/prompt.card.tsx
@@ -19,7 +19,7 @@ export function PromptCard({
   return (
     <div
       className={cn(
-        "relative rounded-full px-6 py-2 shadow-sm bg-white w-64 flex-shrink-0 border border-[#D1D1D1]",
+        "relative w-64 flex-shrink-0 rounded-full border border-[#D1D1D1] bg-white px-6 py-2 shadow-sm",
         "transition-all duration-300 ease-in-out",
         className,
       )}
@@ -27,9 +27,9 @@ export function PromptCard({
       {...props}
     >
       {/* Content */}
-      <div className="relative z-10 flex items-center gap-2 text-sm md:text-base truncate">
+      <div className="relative z-10 flex items-center gap-2 truncate text-sm md:text-base">
         <span className="font-semibold whitespace-nowrap">@{service}</span>
-        <span className="text-gray-700 truncate">{prompt}</span>
+        <span className="truncate text-gray-700">{prompt}</span>
       </div>
     </div>
   );

--- a/client/dashboard/src/pages/logs/LogDetailSheet.tsx
+++ b/client/dashboard/src/pages/logs/LogDetailSheet.tsx
@@ -104,12 +104,12 @@ function LogDetailContent({ log }: { log: TelemetryLogRecord }) {
   }
 
   return (
-    <div className="flex flex-col gap-6 pt-6 px-5 pb-6">
+    <div className="flex flex-col gap-6 px-5 pt-6 pb-6">
       {/* Header with span info */}
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-3">
           <div
-            className={`text-xs font-semibold uppercase px-2 py-1 rounded ${severityClass} bg-muted`}
+            className={`rounded px-2 py-1 text-xs font-semibold uppercase ${severityClass} bg-muted`}
           >
             {log.severityText || "INFO"}
           </div>
@@ -166,14 +166,14 @@ function LogDetailContent({ log }: { log: TelemetryLogRecord }) {
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="details" className="flex flex-col gap-5 mt-5">
+        <TabsContent value="details" className="mt-5 flex flex-col gap-5">
           {/* Message */}
           <div className="flex flex-col gap-2">
-            <div className="text-xs font-medium uppercase text-muted-foreground tracking-wide">
+            <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
               Message
             </div>
-            <div className="bg-muted border border-border rounded-lg p-4">
-              <pre className="font-mono text-sm whitespace-pre-wrap break-words">
+            <div className="bg-muted border-border rounded-lg border p-4">
+              <pre className="font-mono text-sm break-words whitespace-pre-wrap">
                 {log.body || "(no message)"}
               </pre>
             </div>
@@ -204,13 +204,13 @@ function LogDetailContent({ log }: { log: TelemetryLogRecord }) {
             )}
         </TabsContent>
 
-        <TabsContent value="raw" className="flex flex-col gap-3 mt-5">
+        <TabsContent value="raw" className="mt-5 flex flex-col gap-3">
           <div className="flex items-center justify-between">
-            <div className="text-xs font-medium uppercase text-muted-foreground tracking-wide">
+            <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
               Full Log Record
             </div>
             <button
-              className="p-1.5 rounded hover:bg-muted"
+              className="hover:bg-muted rounded p-1.5"
               onClick={() => {
                 void navigator.clipboard.writeText(
                   JSON.stringify(log, null, 2),
@@ -220,8 +220,8 @@ function LogDetailContent({ log }: { log: TelemetryLogRecord }) {
               <Copy className="size-4" />
             </button>
           </div>
-          <div className="bg-muted border border-border rounded-lg p-4 overflow-y-auto flex-1">
-            <pre className="font-mono text-sm whitespace-pre-wrap break-all">
+          <div className="bg-muted border-border flex-1 overflow-y-auto rounded-lg border p-4">
+            <pre className="font-mono text-sm break-all whitespace-pre-wrap">
               {JSON.stringify(log, null, 2)}
             </pre>
           </div>
@@ -253,14 +253,14 @@ function CollapsibleBodySection({
     <div className="flex flex-col gap-2">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between group"
+        className="group flex items-center justify-between"
       >
-        <div className="text-xs font-medium uppercase text-muted-foreground tracking-wide">
+        <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
           {title}
         </div>
         <div className="flex items-center gap-1">
           <button
-            className="p-1.5 rounded hover:bg-muted"
+            className="hover:bg-muted rounded p-1.5"
             onClick={(e) => {
               e.stopPropagation();
               void navigator.clipboard.writeText(content);
@@ -270,15 +270,15 @@ function CollapsibleBodySection({
           </button>
           <ChevronDown
             className={cn(
-              "size-4 text-muted-foreground transition-transform",
+              "text-muted-foreground size-4 transition-transform",
               !isOpen && "-rotate-90",
             )}
           />
         </div>
       </button>
       {isOpen && (
-        <div className="bg-muted border border-border rounded-lg p-4 max-h-96 overflow-y-auto">
-          <pre className="font-mono text-sm whitespace-pre-wrap break-words">
+        <div className="bg-muted border-border max-h-96 overflow-y-auto rounded-lg border p-4">
+          <pre className="font-mono text-sm break-words whitespace-pre-wrap">
             {displayContent}
           </pre>
         </div>
@@ -300,7 +300,7 @@ function MetadataBadge({
 }) {
   return (
     <button
-      className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-muted/50 hover:bg-muted transition-colors text-sm"
+      className="bg-muted/50 hover:bg-muted flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm transition-colors"
       onClick={() => {
         if (copyValue) {
           void navigator.clipboard.writeText(copyValue);
@@ -328,11 +328,11 @@ function AttributesSection({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <div className="text-xs font-medium uppercase text-muted-foreground tracking-wide">
+        <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
           {title}
         </div>
         <button
-          className="p-1.5 rounded hover:bg-muted"
+          className="hover:bg-muted rounded p-1.5"
           onClick={() => {
             void navigator.clipboard.writeText(JSON.stringify(data, null, 2));
           }}
@@ -340,14 +340,14 @@ function AttributesSection({
           <Copy className="size-4" />
         </button>
       </div>
-      <div className="bg-muted border border-border rounded-lg divide-y divide-border">
+      <div className="bg-muted border-border divide-border divide-y rounded-lg border">
         {flatEntries.map(([key, value]) => (
           <div
             key={key}
-            className="flex flex-col gap-1 px-4 py-2.5 hover:bg-muted/50 transition-colors"
+            className="hover:bg-muted/50 flex flex-col gap-1 px-4 py-2.5 transition-colors"
           >
-            <span className="text-xs text-muted-foreground">{key}</span>
-            <span className="text-sm font-mono break-all">{value}</span>
+            <span className="text-muted-foreground text-xs">{key}</span>
+            <span className="font-mono text-sm break-all">{value}</span>
           </div>
         ))}
       </div>

--- a/client/dashboard/src/pages/logs/LogFilterBar.tsx
+++ b/client/dashboard/src/pages/logs/LogFilterBar.tsx
@@ -259,31 +259,31 @@ export function LogFilterBar({
         <PopoverAnchor asChild>
           <div
             className={cn(
-              "flex flex-wrap items-center gap-1.5 min-h-[42px] border border-border rounded-md px-3 py-1.5 transition-[border-color,box-shadow]",
-              inputFocused && "border-ring ring-[3px] ring-ring/50",
+              "border-border flex min-h-[42px] flex-wrap items-center gap-1.5 rounded-md border px-3 py-1.5 transition-[border-color,box-shadow]",
+              inputFocused && "border-ring ring-ring/50 ring-[3px]",
             )}
           >
-            <Search className="size-4 text-muted-foreground shrink-0" />
+            <Search className="text-muted-foreground size-4 shrink-0" />
             {filters.map((filter) => (
               <button
                 key={filter.id}
                 onClick={() => removeFilter(filter.id)}
-                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-border bg-accent text-accent-foreground text-xs font-mono hover:bg-accent/80 transition-colors group shrink-0"
+                className="border-border bg-accent text-accent-foreground hover:bg-accent/80 group inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors"
               >
                 <span>
                   {filter.path} {OP_LABELS[filter.op]}
                   {filter.value !== undefined ? ` ${filter.value}` : ""}
                 </span>
-                <X className="size-3 text-muted-foreground group-hover:text-foreground" />
+                <X className="text-muted-foreground group-hover:text-foreground size-3" />
               </button>
             ))}
             {step === "operator" && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-ring bg-accent text-accent-foreground text-xs font-mono shrink-0">
+              <span className="border-ring bg-accent text-accent-foreground inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs">
                 {selectedKey}
               </span>
             )}
             {step === "value" ? (
-              <span className="inline-flex items-center px-2 py-0.5 rounded-md border border-ring bg-accent text-accent-foreground text-xs font-mono shrink-0">
+              <span className="border-ring bg-accent text-accent-foreground inline-flex shrink-0 items-center rounded-md border px-2 py-0.5 font-mono text-xs">
                 <span>
                   {selectedKey} {selectedOp && OP_LABELS[selectedOp]}
                   {"\u00A0"}
@@ -309,7 +309,7 @@ export function LogFilterBar({
                     }
                   }}
                   placeholder={valuePlaceholder}
-                  className="bg-transparent outline-none text-xs font-mono w-[80px]"
+                  className="w-[80px] bg-transparent font-mono text-xs outline-none"
                   style={{
                     width: `${Math.max(filterValue.length, valuePlaceholder.length)}ch`,
                   }}
@@ -337,7 +337,7 @@ export function LogFilterBar({
                       ? "Add filter..."
                       : "Search by URN or filter (e.g. http.response.status_code != 200)"
                 }
-                className="flex-1 min-w-[120px] bg-transparent outline-none min-h-[24px] text-sm"
+                className="min-h-[24px] min-w-[120px] flex-1 bg-transparent text-sm outline-none"
               />
             )}
             {searchInput && (
@@ -347,7 +347,7 @@ export function LogFilterBar({
                   resetFlow();
                   onSearchSubmit("");
                 }}
-                className="text-muted-foreground hover:text-foreground transition-opacity shrink-0"
+                className="text-muted-foreground hover:text-foreground shrink-0 transition-opacity"
                 aria-label="Clear search"
               >
                 <X className="size-4" />
@@ -356,7 +356,7 @@ export function LogFilterBar({
             {filters.length > 0 && !searchInput && (
               <button
                 onClick={clearAll}
-                className="text-muted-foreground hover:text-foreground transition-opacity shrink-0"
+                className="text-muted-foreground hover:text-foreground shrink-0 transition-opacity"
                 aria-label="Clear all filters"
               >
                 <X className="size-4" />
@@ -411,11 +411,11 @@ export function LogFilterBar({
                     onSelect={() => handleOpSelect(op.value)}
                     className="cursor-pointer"
                   >
-                    <div className="flex items-center justify-between w-full">
+                    <div className="flex w-full items-center justify-between">
                       <span className="font-mono text-xs">
                         {OP_LABELS[op.value]}
                       </span>
-                      <span className="text-xs text-muted-foreground">
+                      <span className="text-muted-foreground text-xs">
                         {op.description}
                       </span>
                     </div>

--- a/client/dashboard/src/pages/logs/Logs.tsx
+++ b/client/dashboard/src/pages/logs/Logs.tsx
@@ -118,28 +118,28 @@ function MCPServerFilter({
 
   return (
     <div
-      className={`flex items-center gap-2 ${disabled ? "opacity-50 pointer-events-none" : ""}`}
+      className={`flex items-center gap-2 ${disabled ? "pointer-events-none opacity-50" : ""}`}
     >
-      <div className="flex items-center h-[42px] rounded-md p-1 border border-border">
-        <div className="flex items-center gap-1.5 h-8 px-3">
-          <McpIcon className="size-3.5 text-muted-foreground" />
-          <span className="text-sm font-medium text-foreground">Server</span>
+      <div className="border-border flex h-[42px] items-center rounded-md border p-1">
+        <div className="flex h-8 items-center gap-1.5 px-3">
+          <McpIcon className="text-muted-foreground size-3.5" />
+          <span className="text-foreground text-sm font-medium">Server</span>
         </div>
-        <div className="w-px h-6 bg-border/50 mx-1" />
+        <div className="bg-border/50 mx-1 h-6 w-px" />
         <Popover open={!disabled && open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <button
               disabled={disabled || isLoading}
-              className={`h-8 min-w-[140px] flex items-center justify-between gap-2 text-sm px-2 rounded transition-colors ${
+              className={`flex h-8 min-w-[140px] items-center justify-between gap-2 rounded px-2 text-sm transition-colors ${
                 disabled || isLoading
-                  ? "opacity-40 cursor-not-allowed"
+                  ? "cursor-not-allowed opacity-40"
                   : "hover:bg-muted/50"
               }`}
             >
-              <span className="truncate max-w-[120px]">
+              <span className="max-w-[120px] truncate">
                 {isLoading ? "Loading..." : displayLabel}
               </span>
-              <ChevronDown className="size-3.5 text-muted-foreground shrink-0" />
+              <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
             </button>
           </PopoverTrigger>
           <PopoverContent className="w-[220px] p-0" align="end">
@@ -656,9 +656,9 @@ function LogsInnerContent({
   const orgRoutes = useOrgRoutes();
 
   const pageTitle = (
-    <div className="flex flex-col gap-1 min-w-0">
+    <div className="flex min-w-0 flex-col gap-1">
       <h1 className="text-xl font-semibold">Logs</h1>
-      <p className="text-sm text-muted-foreground">
+      <p className="text-muted-foreground text-sm">
         Browse raw tool call traces and telemetry data
       </p>
     </div>
@@ -666,7 +666,7 @@ function LogsInnerContent({
 
   return (
     <>
-      <div className="h-full overflow-hidden flex flex-col">
+      <div className="flex h-full flex-col overflow-hidden">
         <Page>
           <Page.Header>
             <Page.Header.Breadcrumbs fullWidth />
@@ -674,9 +674,9 @@ function LogsInnerContent({
           {isLogsDisabled ? (
             <Page.Body fullWidth className="space-y-6">
               {pageTitle}
-              <div className="flex-1 relative">
+              <div className="relative flex-1">
                 <div
-                  className="pointer-events-none select-none h-full"
+                  className="pointer-events-none h-full select-none"
                   aria-hidden="true"
                 >
                   <ObservabilitySkeleton />
@@ -686,10 +686,10 @@ function LogsInnerContent({
             </Page.Body>
           ) : (
             <Page.Body fullWidth noPadding overflowHidden>
-              <div className="flex flex-col flex-1 min-h-0 w-full">
+              <div className="flex min-h-0 w-full flex-1 flex-col">
                 {/* Header section */}
-                <div className="px-8 py-4 shrink-0">
-                  <div className="flex items-start justify-between gap-4 mb-4">
+                <div className="shrink-0 px-8 py-4">
+                  <div className="mb-4 flex items-start justify-between gap-4">
                     {pageTitle}
                     <Button variant="outline" size="sm" asChild>
                       <Link to={orgRoutes.logs.href()}>
@@ -699,7 +699,7 @@ function LogsInnerContent({
                     </Button>
                   </div>
                   {/* Filter and Search Row */}
-                  <div className="flex items-center gap-4 flex-wrap">
+                  <div className="flex flex-wrap items-center gap-4">
                     <MCPServerFilter
                       selectedServer={selectedServer}
                       onServerChange={onServerChange}
@@ -732,27 +732,27 @@ function LogsInnerContent({
                 </div>
 
                 {/* Content section - full width */}
-                <div className="flex-1 overflow-hidden min-h-0 border-t">
-                  <div className="h-full flex flex-col bg-background">
+                <div className="min-h-0 flex-1 overflow-hidden border-t">
+                  <div className="bg-background flex h-full flex-col">
                     {/* Loading indicator */}
                     {isFetching && allTraces.length > 0 && (
-                      <div className="absolute top-0 left-0 right-0 h-1 bg-primary/20 z-20">
-                        <div className="h-full bg-primary animate-pulse" />
+                      <div className="bg-primary/20 absolute top-0 right-0 left-0 z-20 h-1">
+                        <div className="bg-primary h-full animate-pulse" />
                       </div>
                     )}
 
                     {/* Header */}
-                    <div className="flex items-center gap-3 px-8 py-2.5 bg-muted/30 border-b text-xs font-medium text-muted-foreground uppercase tracking-wide shrink-0">
-                      <div className="shrink-0 w-[150px]">Timestamp</div>
-                      <div className="shrink-0 w-5" />
+                    <div className="bg-muted/30 text-muted-foreground flex shrink-0 items-center gap-3 border-b px-8 py-2.5 text-xs font-medium tracking-wide uppercase">
+                      <div className="w-[150px] shrink-0">Timestamp</div>
+                      <div className="w-5 shrink-0" />
                       <div className="flex-1">Source / Tool</div>
-                      <div className="shrink-0 w-16 text-right">Status</div>
+                      <div className="w-16 shrink-0 text-right">Status</div>
                     </div>
 
                     {/* Scrollable trace list */}
                     <div
                       ref={containerRef}
-                      className="overflow-y-auto flex-1"
+                      className="flex-1 overflow-y-auto"
                       onScroll={handleScroll}
                     >
                       <TraceListContent
@@ -769,7 +769,7 @@ function LogsInnerContent({
 
                     {/* Footer */}
                     {allTraces.length > 0 && (
-                      <div className="flex items-center gap-4 px-8 py-3 bg-muted/30 border-t text-sm text-muted-foreground shrink-0">
+                      <div className="bg-muted/30 text-muted-foreground flex shrink-0 items-center gap-4 border-t px-8 py-3 text-sm">
                         <span>
                           {allTraces.length}{" "}
                           {allTraces.length === 1 ? "trace" : "traces"}
@@ -846,7 +846,7 @@ function TraceListContent({
       ))}
 
       {isFetchingNextPage && (
-        <div className="flex items-center justify-center gap-2 py-4 text-muted-foreground border-t">
+        <div className="text-muted-foreground flex items-center justify-center gap-2 border-t py-4">
           <Icon name="loader-circle" className="size-4 animate-spin" />
           <span className="text-sm">Loading more traces...</span>
         </div>
@@ -858,11 +858,11 @@ function TraceListContent({
 function LogsError({ error }: { error: Error }) {
   return (
     <div className="flex flex-col items-center gap-3 py-12">
-      <div className="size-12 rounded-full bg-destructive/10 flex items-center justify-center">
-        <XIcon className="size-6 text-destructive" />
+      <div className="bg-destructive/10 flex size-12 items-center justify-center rounded-full">
+        <XIcon className="text-destructive size-6" />
       </div>
-      <span className="font-medium text-foreground">Error loading traces</span>
-      <span className="text-sm text-muted-foreground max-w-sm text-center">
+      <span className="text-foreground font-medium">Error loading traces</span>
+      <span className="text-muted-foreground max-w-sm text-center text-sm">
         {error.message}
       </span>
     </div>
@@ -871,7 +871,7 @@ function LogsError({ error }: { error: Error }) {
 
 function LogsLoading() {
   return (
-    <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+    <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
       <Icon name="loader-circle" className="size-5 animate-spin" />
       <span>Loading traces...</span>
     </div>
@@ -882,13 +882,13 @@ function LogsEmptyState({ hasActiveFilters }: { hasActiveFilters: boolean }) {
   return (
     <div className="py-12 text-center">
       <div className="flex flex-col items-center gap-3">
-        <div className="size-12 rounded-full bg-muted flex items-center justify-center">
-          <Icon name="inbox" className="size-6 text-muted-foreground" />
+        <div className="bg-muted flex size-12 items-center justify-center rounded-full">
+          <Icon name="inbox" className="text-muted-foreground size-6" />
         </div>
-        <span className="font-medium text-foreground">
+        <span className="text-foreground font-medium">
           {hasActiveFilters ? "No matching traces" : "No traces found"}
         </span>
-        <span className="text-sm text-muted-foreground max-w-sm">
+        <span className="text-muted-foreground max-w-sm text-sm">
           {hasActiveFilters
             ? "Try adjusting your search or filters"
             : "Traces will appear here when tool calls are made"}

--- a/client/dashboard/src/pages/logs/StatusBadge.tsx
+++ b/client/dashboard/src/pages/logs/StatusBadge.tsx
@@ -23,20 +23,20 @@ export function StatusBadge({
 
     if (is5xx) {
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-destructive-softest text-destructive-default">
+        <span className="bg-destructive-softest text-destructive-default rounded px-1.5 py-0.5 text-[10px] font-medium">
           {httpStatusCode}
         </span>
       );
     }
     if (is4xx) {
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-warning-softest text-warning-default">
+        <span className="bg-warning-softest text-warning-default rounded px-1.5 py-0.5 text-[10px] font-medium">
           {httpStatusCode}
         </span>
       );
     }
     return (
-      <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-success-softest text-success-default">
+      <span className="bg-success-softest text-success-default rounded px-1.5 py-0.5 text-[10px] font-medium">
         {httpStatusCode}
       </span>
     );
@@ -45,14 +45,14 @@ export function StatusBadge({
   // Default OK/ERROR badge
   if (isSuccess) {
     return (
-      <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-success-softest text-success-default">
+      <span className="bg-success-softest text-success-default rounded px-1.5 py-0.5 text-[10px] font-medium">
         OK
       </span>
     );
   }
 
   return (
-    <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-destructive-softest text-destructive-default">
+    <span className="bg-destructive-softest text-destructive-default rounded px-1.5 py-0.5 text-[10px] font-medium">
       ERROR
     </span>
   );
@@ -65,27 +65,27 @@ function SeverityBadge({ severity }: { severity: string }) {
     case "ERROR":
     case "FATAL":
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-destructive-softest text-destructive-default">
+        <span className="bg-destructive-softest text-destructive-default rounded px-1.5 py-0.5 text-[10px] font-medium">
           {upper}
         </span>
       );
     case "WARN":
     case "WARNING":
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-warning-softest text-warning-default">
+        <span className="bg-warning-softest text-warning-default rounded px-1.5 py-0.5 text-[10px] font-medium">
           WARN
         </span>
       );
     case "DEBUG":
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-surface-secondary-default text-muted-foreground">
+        <span className="bg-surface-secondary-default text-muted-foreground rounded px-1.5 py-0.5 text-[10px] font-medium">
           DEBUG
         </span>
       );
     case "INFO":
     default:
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-primary-softest text-primary-default">
+        <span className="bg-primary-softest text-primary-default rounded px-1.5 py-0.5 text-[10px] font-medium">
           INFO
         </span>
       );
@@ -102,25 +102,25 @@ export function SpanTypeBadge({ urn }: SpanTypeBadgeProps) {
   switch (kind) {
     case "http":
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-cyan-500/20 text-cyan-400 uppercase">
+        <span className="rounded bg-cyan-500/20 px-1.5 py-0.5 text-[10px] font-medium text-cyan-400 uppercase">
           HTTP
         </span>
       );
     case "function":
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-500/20 text-purple-400 uppercase">
+        <span className="rounded bg-purple-500/20 px-1.5 py-0.5 text-[10px] font-medium text-purple-400 uppercase">
           FN
         </span>
       );
     case "prompt":
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-500/20 text-amber-400 uppercase">
+        <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-medium text-amber-400 uppercase">
           PROMPT
         </span>
       );
     default:
       return (
-        <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-surface-secondary-default text-muted-foreground uppercase">
+        <span className="bg-surface-secondary-default text-muted-foreground rounded px-1.5 py-0.5 text-[10px] font-medium uppercase">
           {kind || "SPAN"}
         </span>
       );

--- a/client/dashboard/src/pages/logs/TraceLogsList.tsx
+++ b/client/dashboard/src/pages/logs/TraceLogsList.tsx
@@ -46,9 +46,9 @@ export function TraceLogsList({
 
   if (isPending) {
     return (
-      <div className="flex items-center gap-3 px-5 py-2 text-muted-foreground bg-muted/30">
-        <div className="shrink-0 w-[150px]" />
-        <div className="shrink-0 w-5 flex justify-center">
+      <div className="text-muted-foreground bg-muted/30 flex items-center gap-3 px-5 py-2">
+        <div className="w-[150px] shrink-0" />
+        <div className="flex w-5 shrink-0 justify-center">
           <Icon name="loader-circle" className="size-4 animate-spin" />
         </div>
         <span className="text-sm">Loading spans...</span>
@@ -58,10 +58,10 @@ export function TraceLogsList({
 
   if (error) {
     return (
-      <div className="flex items-center gap-3 px-5 py-2 bg-muted/30">
-        <div className="shrink-0 w-[150px]" />
-        <div className="shrink-0 w-5" />
-        <span className="text-sm text-destructive">
+      <div className="bg-muted/30 flex items-center gap-3 px-5 py-2">
+        <div className="w-[150px] shrink-0" />
+        <div className="w-5 shrink-0" />
+        <span className="text-destructive text-sm">
           Failed to load spans: {error.message}
         </span>
       </div>
@@ -72,9 +72,9 @@ export function TraceLogsList({
 
   if (logs.length === 0) {
     return (
-      <div className="flex items-center gap-3 px-5 py-2 text-muted-foreground bg-muted/30">
-        <div className="shrink-0 w-[150px]" />
-        <div className="shrink-0 w-5" />
+      <div className="text-muted-foreground bg-muted/30 flex items-center gap-3 px-5 py-2">
+        <div className="w-[150px] shrink-0" />
+        <div className="w-5 shrink-0" />
         <span className="text-sm">No spans found for this trace</span>
       </div>
     );
@@ -114,35 +114,35 @@ function ChildLogRow({
 
   return (
     <div
-      className="flex items-center gap-3 px-5 py-2 cursor-pointer hover:bg-background transition-colors group"
+      className="hover:bg-background group flex cursor-pointer items-center gap-3 px-5 py-2 transition-colors"
       onClick={onClick}
     >
       {/* Timestamp - same width as parent for alignment, hidden if same as parent */}
-      <div className="shrink-0 w-[150px] text-sm text-muted-foreground font-mono whitespace-nowrap">
+      <div className="text-muted-foreground w-[150px] shrink-0 font-mono text-sm whitespace-nowrap">
         {showTimestamp ? formattedTimestamp : null}
       </div>
 
       {/* Tree line area - aligns with parent's chevron */}
-      <div className="shrink-0 w-5 flex justify-center relative h-6">
+      <div className="relative flex h-6 w-5 shrink-0 justify-center">
         {/* Vertical line */}
         <div
-          className={`absolute left-1/2 -translate-x-1/2 w-px bg-border ${
+          className={`bg-border absolute left-1/2 w-px -translate-x-1/2 ${
             isLast ? "-top-2 h-5" : "-top-2 -bottom-2"
           }`}
         />
         {/* Horizontal connector */}
-        <div className="absolute top-1/2 left-1/2 w-3 h-px bg-border" />
+        <div className="bg-border absolute top-1/2 left-1/2 h-px w-3" />
       </div>
 
       {/* Severity badge inline */}
       <span
-        className={`shrink-0 px-1.5 py-0.5 text-xs font-medium rounded ${getSeverityBadgeClass(log.severityText)}`}
+        className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${getSeverityBadgeClass(log.severityText)}`}
       >
         {log.severityText?.toLowerCase() || "info"}
       </span>
 
       {/* Message - takes remaining space */}
-      <span className="flex-1 min-w-0 text-sm text-muted-foreground truncate">
+      <span className="text-muted-foreground min-w-0 flex-1 truncate text-sm">
         {formatLogBody(log)}
       </span>
     </div>

--- a/client/dashboard/src/pages/logs/TraceRow.tsx
+++ b/client/dashboard/src/pages/logs/TraceRow.tsx
@@ -32,39 +32,39 @@ export function TraceRow({
   const ToolIcon = getToolIcon(trace);
 
   return (
-    <div className="border-b border-border/50 last:border-b-0">
+    <div className="border-border/50 border-b last:border-b-0">
       {/* Parent trace row */}
       <div
-        className="flex items-center gap-3 px-8 py-2.5 cursor-pointer hover:bg-muted/50 transition-colors"
+        className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-8 py-2.5 transition-colors"
         onClick={onToggle}
       >
         {/* Timestamp */}
-        <div className="shrink-0 w-[150px] text-sm text-muted-foreground font-mono whitespace-nowrap">
+        <div className="text-muted-foreground w-[150px] shrink-0 font-mono text-sm whitespace-nowrap">
           {formatNanoTimestamp(trace.startTimeUnixNano)}
         </div>
 
         {/* Expand/collapse indicator */}
-        <div className="shrink-0 w-5 flex items-center justify-center">
+        <div className="flex w-5 shrink-0 items-center justify-center">
           {isExpanded ? (
-            <ChevronDownIcon className="size-4 text-muted-foreground" />
+            <ChevronDownIcon className="text-muted-foreground size-4" />
           ) : (
-            <ChevronRightIcon className="size-4 text-muted-foreground" />
+            <ChevronRightIcon className="text-muted-foreground size-4" />
           )}
         </div>
 
         {/* Icon + Source badge + Tool name */}
-        <div className="flex items-center gap-2 flex-1 min-w-0">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
           <ToolIcon className="size-4 shrink-0" strokeWidth={1.5} />
           {sourceName && (
-            <span className="shrink-0 px-1.5 py-0.5 text-xs font-medium rounded bg-muted text-muted-foreground">
+            <span className="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-xs font-medium">
               {sourceName}
             </span>
           )}
-          <span className="text-sm font-mono truncate">{toolName}</span>
+          <span className="truncate font-mono text-sm">{toolName}</span>
         </div>
 
         {/* Log count */}
-        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+        <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
           {trace.logCount} {trace.logCount === 1 ? "log" : "logs"}
         </span>
 

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
@@ -99,7 +99,7 @@ export function AddVariableSheet({
     >
       <SheetContent
         side="right"
-        className="w-[500px] sm:max-w-[500px] flex flex-col"
+        className="flex w-[500px] flex-col sm:max-w-[500px]"
       >
         <SheetHeader className="px-6 pt-6 pb-0">
           <SheetTitle className="text-lg font-semibold">
@@ -107,30 +107,30 @@ export function AddVariableSheet({
           </SheetTitle>
         </SheetHeader>
 
-        <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6">
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-6">
           {/* Load from environment section */}
           {attachedEnvironment && availableEnvVarsFromAttached.length > 0 ? (
-            <div className="pb-4 border-b">
-              <Label className="text-xs text-muted-foreground mb-2 block">
+            <div className="border-b pb-4">
+              <Label className="text-muted-foreground mb-2 block text-xs">
                 Load from {attachedEnvironment.name}
               </Label>
               <Popover>
                 <PopoverTrigger asChild>
-                  <button className="w-full h-10 px-3 rounded-md border border-input bg-background text-sm flex items-center justify-between hover:bg-accent transition-colors">
+                  <button className="border-input bg-background hover:bg-accent flex h-10 w-full items-center justify-between rounded-md border px-3 text-sm transition-colors">
                     <span className="text-muted-foreground">
                       Select a variable to add...
                     </span>
-                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    <ChevronDown className="text-muted-foreground h-4 w-4" />
                   </button>
                 </PopoverTrigger>
                 <PopoverContent
                   align="start"
-                  className="w-[450px] p-1 max-h-[300px] overflow-y-auto"
+                  className="max-h-[300px] w-[450px] overflow-y-auto p-1"
                 >
                   {availableEnvVarsFromAttached.map((varName) => (
                     <div
                       key={varName}
-                      className="px-3 py-2 text-sm rounded-sm cursor-pointer hover:bg-accent flex items-center gap-2"
+                      className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-sm px-3 py-2 text-sm"
                       onClick={() => onLoadFromEnvironment(varName)}
                     >
                       <div className="font-mono">{varName}</div>
@@ -138,15 +138,15 @@ export function AddVariableSheet({
                   ))}
                 </PopoverContent>
               </Popover>
-              <p className="text-xs text-muted-foreground mt-2">
+              <p className="text-muted-foreground mt-2 text-xs">
                 Variables from the attached environment that aren't already
                 added
               </p>
             </div>
           ) : attachedEnvironment &&
             availableEnvVarsFromAttached.length === 0 ? (
-            <div className="pb-4 border-b">
-              <p className="text-xs text-muted-foreground">
+            <div className="border-b pb-4">
+              <p className="text-muted-foreground text-xs">
                 All variables from {attachedEnvironment.name} are already added
               </p>
             </div>
@@ -154,7 +154,7 @@ export function AddVariableSheet({
 
           {/* Manual entry section */}
           <div>
-            <Label className="text-xs text-muted-foreground mb-2 block">
+            <Label className="text-muted-foreground mb-2 block text-xs">
               {attachedEnvironment && availableEnvVarsFromAttached.length > 0
                 ? "Or create a new variable"
                 : "Create a new variable"}
@@ -162,10 +162,10 @@ export function AddVariableSheet({
           </div>
 
           {entries.map((entry, index) => (
-            <div key={index} className="flex gap-4 items-end">
+            <div key={index} className="flex items-end gap-4">
               <div className="flex-1">
                 {index === 0 && (
-                  <Label className="text-xs text-muted-foreground mb-1.5 block">
+                  <Label className="text-muted-foreground mb-1.5 block text-xs">
                     Key
                   </Label>
                 )}
@@ -174,12 +174,12 @@ export function AddVariableSheet({
                   value={entry.key}
                   onChange={(e) => updateEntry(index, "key", e.target.value)}
                   placeholder="CLIENT_KEY..."
-                  className="w-full h-10 px-3 rounded-md border border-input bg-background text-sm font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="border-input bg-background placeholder:text-muted-foreground focus:ring-ring h-10 w-full rounded-md border px-3 font-mono text-sm focus:ring-2 focus:outline-none"
                 />
               </div>
               <div className="flex-1">
                 {index === 0 && (
-                  <Label className="text-xs text-muted-foreground mb-1.5 block">
+                  <Label className="text-muted-foreground mb-1.5 block text-xs">
                     Value
                   </Label>
                 )}
@@ -188,14 +188,14 @@ export function AddVariableSheet({
                   value={entry.value}
                   onChange={(e) => updateEntry(index, "value", e.target.value)}
                   placeholder=""
-                  className="w-full h-10 px-3 rounded-md border border-input bg-background text-sm font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  className="border-input bg-background placeholder:text-muted-foreground focus:ring-ring h-10 w-full rounded-md border px-3 font-mono text-sm focus:ring-2 focus:outline-none"
                 />
               </div>
               {entries.length > 1 && (
                 <button
                   type="button"
                   onClick={() => removeEntry(index)}
-                  className="h-10 px-1 text-muted-foreground hover:text-foreground transition-colors"
+                  className="text-muted-foreground hover:text-foreground h-10 px-1 transition-colors"
                 >
                   <X className="h-4 w-4" />
                 </button>
@@ -207,15 +207,15 @@ export function AddVariableSheet({
           <button
             type="button"
             onClick={addEntry}
-            className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground hover:text-foreground flex items-center gap-2 text-sm transition-colors"
           >
             <Plus className="h-4 w-4" />
             Add Another
           </button>
         </div>
 
-        <SheetFooter className="px-6 py-4 border-t flex-row justify-between items-center">
-          <button className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors">
+        <SheetFooter className="flex-row items-center justify-between border-t px-6 py-4">
+          <button className="text-muted-foreground hover:text-foreground flex items-center gap-2 text-sm transition-colors">
             <svg
               className="h-4 w-4"
               fill="none"
@@ -227,7 +227,7 @@ export function AddVariableSheet({
             </svg>
             Import .env
           </button>
-          <span className="text-xs text-muted-foreground">
+          <span className="text-muted-foreground text-xs">
             or paste .env contents in Key input
           </span>
           <Button onClick={handleSave} disabled={!hasValidEntry}>

--- a/client/dashboard/src/pages/mcp/BuiltInMCPDetailPage.tsx
+++ b/client/dashboard/src/pages/mcp/BuiltInMCPDetailPage.tsx
@@ -61,9 +61,9 @@ const BUILT_IN_TOOLS = [
 ];
 
 const TAB_TRIGGER_CLASS = cn(
-  "relative h-11 px-1 pb-3 pt-3 bg-transparent! rounded-none border-none shadow-none!",
+  "relative h-11 rounded-none border-none bg-transparent! px-1 pt-3 pb-3 shadow-none!",
   "text-muted-foreground data-[state=active]:text-foreground data-[state=active]:bg-transparent!",
-  "after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary",
+  "data-[state=active]:after:bg-primary after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent",
 );
 
 export function BuiltInMCPDetailPage() {
@@ -85,14 +85,14 @@ export function BuiltInMCPDetailPage() {
         <DetailHero>
           <div className="flex items-end justify-between">
             <Stack gap={2}>
-              <div className="flex items-center gap-3 ml-1">
+              <div className="ml-1 flex items-center gap-3">
                 <Heading variant="h1">MCP Logs</Heading>
                 <Badge variant="information">
                   <Badge.Text>Built-in</Badge.Text>
                 </Badge>
               </div>
-              <div className="flex items-center gap-2 ml-1">
-                <Type className="max-w-2xl truncate text-muted-foreground">
+              <div className="ml-1 flex items-center gap-2">
+                <Type className="text-muted-foreground max-w-2xl truncate">
                   {mcpUrl}
                 </Type>
                 <Button
@@ -102,7 +102,7 @@ export function BuiltInMCPDetailPage() {
                     navigator.clipboard.writeText(mcpUrl);
                     toast.success("URL copied to clipboard");
                   }}
-                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                  className="text-muted-foreground hover:text-foreground shrink-0"
                 >
                   <Button.LeftIcon>
                     <svg
@@ -130,11 +130,11 @@ export function BuiltInMCPDetailPage() {
         <Tabs
           value={activeTab}
           onValueChange={setActiveTab}
-          className="w-full flex-1 flex flex-col"
+          className="flex w-full flex-1 flex-col"
         >
           <div className="border-b">
-            <div className="max-w-[1270px] mx-auto px-8">
-              <TabsList className="h-auto bg-transparent p-0 gap-6 rounded-none">
+            <div className="mx-auto max-w-[1270px] px-8">
+              <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
                 <TabsTrigger value="overview" className={TAB_TRIGGER_CLASS}>
                   Overview
                 </TabsTrigger>
@@ -145,7 +145,7 @@ export function BuiltInMCPDetailPage() {
             </div>
           </div>
 
-          <div className="max-w-[1270px] mx-auto px-8 py-8 w-full">
+          <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
             <TabsContent value="overview" className="mt-0 w-full">
               <BuiltInOverviewTab mcpUrl={mcpUrl} />
             </TabsContent>
@@ -174,7 +174,7 @@ function BuiltInOverviewTab({ mcpUrl }: { mcpUrl: string }) {
         heading="Install Page"
         description="Share this page to give simple instructions for getting started with this MCP server in Cursor or Claude Desktop."
       >
-        <div className="flex items-center gap-2 rounded-lg border bg-muted/20 p-2">
+        <div className="bg-muted/20 flex items-center gap-2 rounded-lg border p-2">
           <CodeBlock
             className="flex-grow overflow-hidden"
             innerClassName="!p-2 !pr-10 !bg-white dark:!bg-zinc-950"
@@ -186,7 +186,7 @@ function BuiltInOverviewTab({ mcpUrl }: { mcpUrl: string }) {
           <Link external to={`${mcpUrl}/install`} noIcon>
             <Button variant="primary" className="px-4">
               <Button.LeftIcon>
-                <Icon name="external-link" className="w-4 h-4" />
+                <Icon name="external-link" className="h-4 w-4" />
               </Button.LeftIcon>
               <Button.Text>View</Button.Text>
             </Button>
@@ -209,19 +209,19 @@ function BuiltInToolsTab() {
         <Heading variant="h3">Tools</Heading>
       </Stack>
 
-      <div className="border border-neutral-softest rounded-lg overflow-hidden w-full">
-        <div className="bg-surface-secondary-default flex items-center pl-4 pr-3 py-4 border-b border-neutral-softest">
-          <p className="text-sm leading-6 text-foreground">MCP Logs</p>
+      <div className="border-neutral-softest w-full overflow-hidden rounded-lg border">
+        <div className="bg-surface-secondary-default border-neutral-softest flex items-center border-b py-4 pr-3 pl-4">
+          <p className="text-foreground text-sm leading-6">MCP Logs</p>
         </div>
 
         {BUILT_IN_TOOLS.map((tool) => (
           <div
             key={tool.name}
-            className="flex items-center pl-4 pr-3 py-4 border-b border-neutral-softest last:border-b-0"
+            className="border-neutral-softest flex items-center border-b py-4 pr-3 pl-4 last:border-b-0"
           >
-            <div className="flex flex-col min-w-0 flex-1">
-              <p className="text-sm leading-6 text-foreground">{tool.name}</p>
-              <p className="text-sm leading-6 text-muted-foreground truncate">
+            <div className="flex min-w-0 flex-1 flex-col">
+              <p className="text-foreground text-sm leading-6">{tool.name}</p>
+              <p className="text-muted-foreground truncate text-sm leading-6">
                 {tool.description}
               </p>
             </div>

--- a/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentSwitcher.tsx
@@ -91,7 +91,7 @@ export function EnvironmentSwitcher({
             key={env.slug}
             onClick={() => onEnvironmentSelect(env.slug)}
             className={cn(
-              "flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors relative",
+              "relative flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors",
               isSelected
                 ? "text-foreground"
                 : "text-muted-foreground hover:text-foreground",
@@ -100,14 +100,14 @@ export function EnvironmentSwitcher({
             {isAttachedEnv && (
               <div
                 className={cn(
-                  "w-2 h-2 rounded-full",
+                  "h-2 w-2 rounded-full",
                   envHasAllRequired ? "bg-green-500" : "bg-yellow-500",
                 )}
               />
             )}
             {getEnvironmentDisplayName(env)}
             {isSelected && (
-              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+              <div className="bg-primary absolute right-0 bottom-0 left-0 h-0.5" />
             )}
           </button>
         );
@@ -119,8 +119,8 @@ export function EnvironmentSwitcher({
         {hasAnyUserEdits ? (
           <>
             {/* Unsaved changes indicator */}
-            <span className="text-xs text-amber-600 font-medium flex items-center gap-1.5">
-              <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
+            <span className="flex items-center gap-1.5 text-xs font-medium text-amber-600">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
               Unsaved changes
             </span>
 
@@ -143,7 +143,7 @@ export function EnvironmentSwitcher({
             {/* When no edits - show contextual actions */}
             {!hasExistingConfigs && !hasAllRequired ? (
               // Initial setup: prompt to fill required fields
-              <span className="text-xs text-muted-foreground">
+              <span className="text-muted-foreground text-xs">
                 Fill in required values to save
               </span>
             ) : isViewingNonAttached ? (
@@ -167,7 +167,7 @@ export function EnvironmentSwitcher({
                     size="xs"
                   >
                     <Button.LeftIcon>
-                      <Plus className="w-3.5 h-3.5" />
+                      <Plus className="h-3.5 w-3.5" />
                     </Button.LeftIcon>
                     <Button.Text>New Environment</Button.Text>
                   </Button>
@@ -179,7 +179,7 @@ export function EnvironmentSwitcher({
                     size="xs"
                   >
                     <Button.LeftIcon>
-                      <Unlink className="w-3.5 h-3.5" />
+                      <Unlink className="h-3.5 w-3.5" />
                     </Button.LeftIcon>
                     <Button.Text>Detach</Button.Text>
                   </Button>

--- a/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
@@ -110,31 +110,31 @@ export function EnvironmentVariableRow({
   return (
     <div
       className={cn(
-        "group grid grid-cols-[auto_1fr_auto] gap-4 items-center px-4 py-4 transition-colors relative",
+        "group relative grid grid-cols-[auto_1fr_auto] items-center gap-4 px-4 py-4 transition-colors",
         index !== totalCount - 1 && "border-b",
         hasUnsavedChanges && "bg-amber-50/50 dark:bg-amber-950/20",
       )}
     >
       {/* Unsaved changes indicator */}
       {hasUnsavedChanges && (
-        <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-amber-500" />
+        <div className="absolute top-0 bottom-0 left-0 w-0.5 bg-amber-500" />
       )}
       {/* Status indicator / Delete button */}
       <div className="relative flex items-center">
         {/* Status indicator - visible by default, hidden on hover for non-required */}
         <div
           className={cn(
-            !envVar.isRequired && "group-hover:opacity-0 transition-opacity",
+            !envVar.isRequired && "transition-opacity group-hover:opacity-0",
           )}
         >
           {envVar.state === "omitted" ? (
-            <div className="w-2 h-2 rounded-full bg-muted-foreground/30" />
+            <div className="bg-muted-foreground/30 h-2 w-2 rounded-full" />
           ) : hasValue ? (
-            <div className="w-2 h-2 rounded-full bg-green-500" />
+            <div className="h-2 w-2 rounded-full bg-green-500" />
           ) : envVar.isRequired ? (
-            <div className="w-2 h-2 rounded-full bg-yellow-500" />
+            <div className="h-2 w-2 rounded-full bg-yellow-500" />
           ) : (
-            <div className="w-2 h-2 rounded-full bg-muted-foreground/30" />
+            <div className="bg-muted-foreground/30 h-2 w-2 rounded-full" />
           )}
         </div>
       </div>
@@ -156,13 +156,13 @@ export function EnvironmentVariableRow({
             }}
             placeholder={`Display name for ${envVar.key}`}
             autoFocus
-            className="w-full h-5 px-1.5 py-0 rounded border border-input bg-background text-sm font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            className="border-input bg-background placeholder:text-muted-foreground focus:ring-ring h-5 w-full rounded border px-1.5 py-0 font-mono text-sm focus:ring-2 focus:outline-none"
           />
         ) : (
-          <div className="w-full h-6 flex items-center gap-2 group/header-edit">
+          <div className="group/header-edit flex h-6 w-full items-center gap-2">
             <div
               className={cn(
-                "font-medium text-sm truncate",
+                "truncate text-sm font-medium",
                 !showHeaderName && "font-mono",
                 envVar.state === "omitted" && "text-muted-foreground/50",
               )}
@@ -174,7 +174,7 @@ export function EnvironmentVariableRow({
                 <button
                   tabIndex={-1}
                   onClick={() => onEditHeaderName(envVar.id)}
-                  className="flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+                  className="text-muted-foreground hover:text-foreground flex items-center justify-center transition-colors"
                 >
                   <Pencil className="h-3.5 w-3.5" />
                 </button>
@@ -183,7 +183,7 @@ export function EnvironmentVariableRow({
               <button
                 tabIndex={-1}
                 onClick={() => onEditHeaderName(envVar.id)}
-                className="flex items-center justify-center text-muted-foreground hover:text-foreground opacity-0 pointer-events-none group-hover/header-edit:opacity-100 group-hover/header-edit:pointer-events-auto transition-opacity"
+                className="text-muted-foreground hover:text-foreground pointer-events-none flex items-center justify-center opacity-0 transition-opacity group-hover/header-edit:pointer-events-auto group-hover/header-edit:opacity-100"
               >
                 <Pencil className="h-3.5 w-3.5" />
               </button>
@@ -193,7 +193,7 @@ export function EnvironmentVariableRow({
         {envVar.description && (
           <div
             className={cn(
-              "text-xs text-muted-foreground mt-0.5 truncate",
+              "text-muted-foreground mt-0.5 truncate text-xs",
               envVar.state === "omitted" && "opacity-50",
             )}
           >
@@ -206,8 +206,8 @@ export function EnvironmentVariableRow({
       <div className="flex items-center">
         <div
           className={cn(
-            "flex items-center h-9 rounded-md border border-input bg-background overflow-hidden",
-            "focus-within:ring-2 focus-within:ring-ring",
+            "border-input bg-background flex h-9 items-center overflow-hidden rounded-md border",
+            "focus-within:ring-ring focus-within:ring-2",
           )}
         >
           {/* Mode Dropdown */}
@@ -220,7 +220,7 @@ export function EnvironmentVariableRow({
           >
             <SelectTrigger
               tabIndex={-1}
-              className="h-full border-0 border-r rounded-none bg-muted/50 focus:ring-0 focus-visible:ring-0 shadow-none w-[90px] text-xs uppercase font-mono gap-0.5"
+              className="bg-muted/50 h-full w-[90px] gap-0.5 rounded-none border-0 border-r font-mono text-xs uppercase shadow-none focus:ring-0 focus-visible:ring-0"
             >
               <span>
                 {MODE_OPTIONS.find((o) => o.value === envVar.state)?.label}
@@ -244,7 +244,7 @@ export function EnvironmentVariableRow({
                   >
                     <div className="flex flex-col gap-0.5 py-1">
                       <span className="font-medium">{option.label}</span>
-                      <span className="text-xs text-muted-foreground">
+                      <span className="text-muted-foreground text-xs">
                         {description}
                       </span>
                     </div>
@@ -255,13 +255,13 @@ export function EnvironmentVariableRow({
           </Select>
 
           {/* Value Input or Status Text */}
-          <div className="w-48 h-full flex items-center">
+          <div className="flex h-full w-48 items-center">
             {envVar.state === "user-provided" ? (
-              <div className="h-full flex items-center px-3 text-xs text-muted-foreground font-mono">
+              <div className="text-muted-foreground flex h-full items-center px-3 font-mono text-xs">
                 Set at runtime
               </div>
             ) : envVar.state === "omitted" ? (
-              <div className="h-full flex items-center px-3 text-xs text-muted-foreground font-mono">
+              <div className="text-muted-foreground flex h-full items-center px-3 font-mono text-xs">
                 Not included
               </div>
             ) : (
@@ -269,7 +269,7 @@ export function EnvironmentVariableRow({
                 value={editingValue}
                 onChange={(value) => onValueChange(envVar.id, value)}
                 placeholder="Enter value..."
-                className="w-full h-full px-3 pr-9 bg-transparent text-sm font-mono placeholder:text-muted-foreground focus:outline-none border-0 shadow-none focus-visible:ring-0"
+                className="placeholder:text-muted-foreground h-full w-full border-0 bg-transparent px-3 pr-9 font-mono text-sm shadow-none focus:outline-none focus-visible:ring-0"
               />
             )}
           </div>

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -97,7 +97,7 @@ export function MCPOverview() {
         onSubmit: handleCreateMcpServerSubmit,
         validate: (value) => value.length > 0 && value.length <= 40,
         hint: (value) => (
-          <div className="flex justify-between w-full">
+          <div className="flex w-full justify-between">
             <p className="text-destructive">
               {value.length > 40 && "Must be 40 characters or less"}
             </p>
@@ -116,7 +116,7 @@ export function MCPOverview() {
         from Claude Desktop, Cursor, or any MCP client.
       </Page.Section.Description>
       <Page.Section.Body>
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
           {BUILT_IN_SERVERS.map((server) => (
             <BuiltInMCPCard key={server.slug} {...server} />
           ))}
@@ -157,7 +157,7 @@ export function MCPOverview() {
         </Page.Section.Description>
         <Page.Section.Body>
           {viewMode === "grid" ? (
-            <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
               {isLoading ? (
                 <>
                   <MCPCardSkeleton />

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -103,39 +103,39 @@ function MCPLoading() {
       </Page.Header>
       <Page.Body fullWidth noPadding>
         {/* Hero skeleton */}
-        <div className="relative w-full h-64 bg-muted/30 animate-pulse">
-          <div className="absolute bottom-0 left-0 right-0 px-8 py-8 max-w-[1270px] mx-auto w-full">
+        <div className="bg-muted/30 relative h-64 w-full animate-pulse">
+          <div className="absolute right-0 bottom-0 left-0 mx-auto w-full max-w-[1270px] px-8 py-8">
             <Stack gap={2}>
-              <div className="h-8 w-64 bg-muted rounded" />
-              <div className="h-4 w-96 bg-muted rounded" />
+              <div className="bg-muted h-8 w-64 rounded" />
+              <div className="bg-muted h-4 w-96 rounded" />
             </Stack>
           </div>
         </div>
 
         {/* Tabs skeleton */}
         <div className="border-b">
-          <div className="max-w-[1270px] mx-auto px-8">
-            <div className="flex gap-6 h-11">
-              <div className="h-4 w-20 bg-muted rounded animate-pulse" />
-              <div className="h-4 w-16 bg-muted rounded animate-pulse" />
-              <div className="h-4 w-20 bg-muted rounded animate-pulse" />
-              <div className="h-4 w-28 bg-muted rounded animate-pulse" />
+          <div className="mx-auto max-w-[1270px] px-8">
+            <div className="flex h-11 gap-6">
+              <div className="bg-muted h-4 w-20 animate-pulse rounded" />
+              <div className="bg-muted h-4 w-16 animate-pulse rounded" />
+              <div className="bg-muted h-4 w-20 animate-pulse rounded" />
+              <div className="bg-muted h-4 w-28 animate-pulse rounded" />
             </div>
           </div>
         </div>
 
         {/* Content skeleton */}
-        <div className="max-w-[1270px] mx-auto px-8 py-8 w-full">
+        <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
           <Stack gap={6}>
             <div className="space-y-4">
-              <div className="h-6 w-48 bg-muted rounded animate-pulse" />
-              <div className="h-4 w-full max-w-2xl bg-muted rounded animate-pulse" />
-              <div className="h-32 w-full bg-muted rounded animate-pulse" />
+              <div className="bg-muted h-6 w-48 animate-pulse rounded" />
+              <div className="bg-muted h-4 w-full max-w-2xl animate-pulse rounded" />
+              <div className="bg-muted h-32 w-full animate-pulse rounded" />
             </div>
             <div className="space-y-4">
-              <div className="h-6 w-40 bg-muted rounded animate-pulse" />
-              <div className="h-4 w-full max-w-2xl bg-muted rounded animate-pulse" />
-              <div className="h-24 w-full bg-muted rounded animate-pulse" />
+              <div className="bg-muted h-6 w-40 animate-pulse rounded" />
+              <div className="bg-muted h-4 w-full max-w-2xl animate-pulse rounded" />
+              <div className="bg-muted h-24 w-full animate-pulse rounded" />
             </div>
           </Stack>
         </div>
@@ -207,7 +207,7 @@ export function MCPDetailPage() {
     statusBadge = (
       <Badge variant="neutral">
         <Badge.LeftIcon>
-          <XCircleIcon className="w-3 h-3" />
+          <XCircleIcon className="h-3 w-3" />
         </Badge.LeftIcon>
         <Badge.Text>Disabled</Badge.Text>
       </Badge>
@@ -216,7 +216,7 @@ export function MCPDetailPage() {
     statusBadge = (
       <Badge variant="neutral">
         <Badge.LeftIcon>
-          <CheckCircleIcon className="w-3 h-3 text-green-600" />
+          <CheckCircleIcon className="h-3 w-3 text-green-600" />
         </Badge.LeftIcon>
         <Badge.Text>Public</Badge.Text>
       </Badge>
@@ -225,7 +225,7 @@ export function MCPDetailPage() {
     statusBadge = (
       <Badge variant="neutral">
         <Badge.LeftIcon>
-          <LockIcon className="w-3 h-3" />
+          <LockIcon className="h-3 w-3" />
         </Badge.LeftIcon>
         <Badge.Text>Private</Badge.Text>
       </Badge>
@@ -248,7 +248,7 @@ export function MCPDetailPage() {
                   className="bg-background hover:bg-accent border-border"
                 >
                   <Button.LeftIcon>
-                    <Play className="w-4 h-4" />
+                    <Play className="h-4 w-4" />
                   </Button.LeftIcon>
                   <Button.Text>Playground</Button.Text>
                 </Button>
@@ -259,12 +259,12 @@ export function MCPDetailPage() {
         >
           <div className="flex items-end justify-between">
             <Stack gap={2}>
-              <div className="flex items-center gap-3 ml-1">
+              <div className="ml-1 flex items-center gap-3">
                 <Heading variant="h1">{toolset.name}</Heading>
                 {statusBadge}
               </div>
-              <div className="flex items-center gap-2 ml-1">
-                <Type className="max-w-2xl truncate text-muted-foreground">
+              <div className="ml-1 flex items-center gap-2">
+                <Type className="text-muted-foreground max-w-2xl truncate">
                   {mcpUrl}
                 </Type>
                 <Button
@@ -276,7 +276,7 @@ export function MCPDetailPage() {
                       toast.success("URL copied to clipboard");
                     }
                   }}
-                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                  className="text-muted-foreground hover:text-foreground shrink-0"
                 >
                   <Button.LeftIcon>
                     <svg
@@ -305,11 +305,11 @@ export function MCPDetailPage() {
         <Tabs
           value={activeTab}
           onValueChange={handleTabChange}
-          className="w-full flex-1 flex flex-col"
+          className="flex w-full flex-1 flex-col"
         >
           <div className="border-b">
-            <div className="max-w-[1270px] mx-auto px-8">
-              <TabsList className="h-auto bg-transparent p-0 gap-6 rounded-none">
+            <div className="mx-auto max-w-[1270px] px-8">
+              <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
                 <PageTabsTrigger value="overview">Overview</PageTabsTrigger>
                 <PageTabsTrigger value="tools">Tools</PageTabsTrigger>
                 <PageTabsTrigger value="resources">Resources</PageTabsTrigger>
@@ -318,7 +318,7 @@ export function MCPDetailPage() {
                   <span className="flex items-center gap-1.5">
                     Authentication
                     {missingRequiredEnvVars > 0 && (
-                      <AlertTriangle className="h-3.5 w-3.5 text-warning" />
+                      <AlertTriangle className="text-warning h-3.5 w-3.5" />
                     )}
                   </span>
                 </PageTabsTrigger>
@@ -331,7 +331,7 @@ export function MCPDetailPage() {
           </div>
 
           {/* Tab Content */}
-          <div className="max-w-[1270px] mx-auto px-8 py-8 w-full">
+          <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
             <TabsContent value="overview" className="mt-0 w-full">
               <MCPOverviewTab toolset={toolset} onTabChange={handleTabChange} />
             </TabsContent>
@@ -459,7 +459,7 @@ function MCPOverviewTab({
             Your server is private. To share with external users, you must make
             it public in the{" "}
             <button
-              className="underline appearance-none"
+              className="appearance-none underline"
               onClick={() => onTabChange("settings")}
             >
               server settings
@@ -512,14 +512,14 @@ function ServerInstructionsSection({
       <div className="relative">
         <Textarea
           placeholder={`Describe how your tools work together, required workflows,\nand any constraints (rate limits, auth requirements, etc.).\n\nKeep it concise — don't repeat individual tool descriptions.`}
-          className="w-full min-h-[150px]"
+          className="min-h-[150px] w-full"
           value={form.instructionsHandlers.value ?? ""}
           onChange={form.instructionsHandlers.onChange}
         />
         {charCount > 0 && (
           <span
             className={cn(
-              "absolute bottom-2 right-3 text-xs",
+              "absolute right-3 bottom-2 text-xs",
               overLimit ? "text-destructive" : "text-muted-foreground",
             )}
           >
@@ -607,7 +607,7 @@ Respond with ONLY the server instructions as plain text. Do not wrap in JSON or 
       disabled={generating || tools.length === 0}
     >
       <Button.LeftIcon>
-        <Icon name="wand-sparkles" className="w-4 h-4" />
+        <Icon name="wand-sparkles" className="h-4 w-4" />
       </Button.LeftIcon>
       <Button.Text>
         {generating ? "Generating..." : "Generate with AI"}
@@ -797,15 +797,15 @@ function MCPToolsTab({ toolset }: { toolset: Toolset }) {
           selectedValues={selectedGroups}
           setSelectedValues={setSelectedGroups}
           placeholder="Filter tools"
-          className="w-fit mb-4 capitalize"
+          className="mb-4 w-fit capitalize"
         />
       )}
 
       {/* Tools list or empty state */}
       {hasOrphanedTools ? (
         <Stack gap={4} align="center" className="py-12">
-          <div className="text-center max-w-md">
-            <AlertTriangle className="w-12 h-12 mx-auto mb-4 text-warning" />
+          <div className="max-w-md text-center">
+            <AlertTriangle className="text-warning mx-auto mb-4 h-12 w-12" />
             <Heading variant="h3" className="mb-2">
               Tool Source Deleted
             </Heading>
@@ -1213,7 +1213,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
               </Type>
               {!toolset.customDomainId ? (
                 <Input
-                  className="border rounded px-2 py-1 w-full"
+                  className="w-full rounded border px-2 py-1"
                   placeholder="Enter MCP Slug"
                   value={mcpSlug}
                   onChange={handleMcpSlugChange}
@@ -1222,7 +1222,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
                 />
               ) : (
                 <Input
-                  className="border rounded px-2 py-1 w-full"
+                  className="w-full rounded border px-2 py-1"
                   placeholder="Enter MCP Slug"
                   value={mcpSlug}
                   onChange={handleMcpSlugChange}
@@ -1281,7 +1281,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
                 disabled={!toolset?.mcpEnabled || !toolset?.mcpSlug}
               >
                 <Button.LeftIcon>
-                  <Download className="w-4 h-4" />
+                  <Download className="h-4 w-4" />
                 </Button.LeftIcon>
                 <Button.Text>Export JSON</Button.Text>
               </Button>
@@ -1296,7 +1296,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
       </PageSection>
 
       {/* Danger Zone */}
-      <div className="border border-destructive/30 rounded-lg p-6 mt-8">
+      <div className="border-destructive/30 mt-8 rounded-lg border p-6">
         <Type variant="subheading" className="text-destructive mb-1">
           Danger Zone
         </Type>
@@ -1328,7 +1328,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
           </Dialog.Header>
           <div className="space-y-4 py-4">
             <Type variant="body">
-              <code className="font-mono font-bold px-1 py-0.5 bg-muted rounded">
+              <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
                 {toolset.name}
               </code>{" "}
               and all its configuration will be permanently deleted. Connected
@@ -1453,13 +1453,13 @@ export function MCPJson({
     >
       <Grid.Item>
         <Type className="font-medium">Pass-through Authentication</Type>
-        <Type muted small className="max-w-3xl mb-2!">
+        <Type muted small className="mb-2! max-w-3xl">
           Pass API credentials directly to the MCP server.
           <br />
           <span
             className={
               !toolset.mcpIsPublic
-                ? "font-medium text-warning-foreground"
+                ? "text-warning-foreground font-medium"
                 : "italic"
             }
           >
@@ -1470,7 +1470,7 @@ export function MCPJson({
       </Grid.Item>
       <Grid.Item>
         <Type className="font-medium">Managed Authentication</Type>
-        <Type muted small className="max-w-3xl mb-2!">
+        <Type muted small className="mb-2! max-w-3xl">
           Manage API authentication with Gram environments.
           <br />
           Users need a single Gram API Key rather than bringing their own keys.
@@ -1648,7 +1648,7 @@ export function OAuthDetailsModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <Dialog.Content className="max-w-2xl max-h-[80vh] flex flex-col">
+      <Dialog.Content className="flex max-h-[80vh] max-w-2xl flex-col">
         <Dialog.Header className="shrink-0">
           <Dialog.Title>
             {toolset.externalOauthServer
@@ -1673,7 +1673,7 @@ export function OAuthDetailsModal({
                   {toolset.oauthProxyServer.oauthProxyProviders?.[0]
                     ?.environmentSlug && (
                     <div>
-                      <Type small className="font-medium text-muted-foreground">
+                      <Type small className="text-muted-foreground font-medium">
                         Environment:
                       </Type>
                       <CodeBlock className="mt-1">
@@ -1700,27 +1700,27 @@ export function OAuthDetailsModal({
                         onEditRequest();
                       }}
                     >
-                      <Pencil className="w-4 h-4 mr-2" />
+                      <Pencil className="mr-2 h-4 w-4" />
                       Edit
                     </Button>
                     <Button
                       variant="tertiary"
                       size="sm"
-                      className="hover:bg-destructive hover:text-white border-none"
+                      className="hover:bg-destructive border-none hover:text-white"
                       onClick={() =>
                         removeOAuthMutation.mutate({
                           request: { slug: toolset.slug },
                         })
                       }
                     >
-                      <Trash2 className="w-4 h-4 mr-2" />
+                      <Trash2 className="mr-2 h-4 w-4" />
                       Unlink
                     </Button>
                   </div>
                 </div>
                 <Stack gap={2} className="pl-4">
                   <div>
-                    <Type small className="font-medium text-muted-foreground">
+                    <Type small className="text-muted-foreground font-medium">
                       Server Slug:
                     </Type>
                     <CodeBlock className="mt-1">
@@ -1729,7 +1729,7 @@ export function OAuthDetailsModal({
                   </div>
                   {toolset.oauthProxyServer.audience && (
                     <div>
-                      <Type small className="font-medium text-muted-foreground">
+                      <Type small className="text-muted-foreground font-medium">
                         Audience:
                       </Type>
                       <CodeBlock className="mt-1">
@@ -1748,7 +1748,7 @@ export function OAuthDetailsModal({
                       <div>
                         <Type
                           small
-                          className="font-medium text-muted-foreground"
+                          className="text-muted-foreground font-medium"
                         >
                           Authorization Endpoint:
                         </Type>
@@ -1759,7 +1759,7 @@ export function OAuthDetailsModal({
                       <div>
                         <Type
                           small
-                          className="font-medium text-muted-foreground"
+                          className="text-muted-foreground font-medium"
                         >
                           Token Endpoint:
                         </Type>
@@ -1773,7 +1773,7 @@ export function OAuthDetailsModal({
                           <div>
                             <Type
                               small
-                              className="font-medium text-muted-foreground"
+                              className="text-muted-foreground font-medium"
                             >
                               Token Auth Method:
                             </Type>
@@ -1789,7 +1789,7 @@ export function OAuthDetailsModal({
                           <div>
                             <Type
                               small
-                              className="font-medium text-muted-foreground"
+                              className="text-muted-foreground font-medium"
                             >
                               Supported Scopes:
                             </Type>
@@ -1802,7 +1802,7 @@ export function OAuthDetailsModal({
                         <div>
                           <Type
                             small
-                            className="font-medium text-muted-foreground"
+                            className="text-muted-foreground font-medium"
                           >
                             Environment:
                           </Type>
@@ -1830,14 +1830,14 @@ export function OAuthDetailsModal({
                     }
                   >
                     <Button.LeftIcon>
-                      <Trash2 className="w-4 h-4" />
+                      <Trash2 className="h-4 w-4" />
                     </Button.LeftIcon>
                     <Button.Text className="sr-only">Remove OAuth</Button.Text>
                   </Button>
                 </div>
                 <Stack gap={2} className="pl-4">
                   <div>
-                    <Type small className="font-medium text-muted-foreground">
+                    <Type small className="text-muted-foreground font-medium">
                       External OAuth Server Slug:
                     </Type>
                     <CodeBlock className="mt-1">
@@ -1845,7 +1845,7 @@ export function OAuthDetailsModal({
                     </CodeBlock>
                   </div>
                   <div>
-                    <Type small className="font-medium text-muted-foreground">
+                    <Type small className="text-muted-foreground font-medium">
                       OAuth Authorization Server Discovery URL:
                     </Type>
                     <CodeBlock className="mt-1">
@@ -1857,7 +1857,7 @@ export function OAuthDetailsModal({
                     </CodeBlock>
                   </div>
                   <div>
-                    <Type small className="font-medium text-muted-foreground">
+                    <Type small className="text-muted-foreground font-medium">
                       OAuth Authorization Server Metadata:
                     </Type>
                     <CodeBlock className="mt-1">
@@ -1886,7 +1886,7 @@ export function OAuthDetailsModal({
                 })
               }
             >
-              <Trash2 className="w-4 h-4 mr-2" />
+              <Trash2 className="mr-2 h-4 w-4" />
               Unlink
             </Button>
           </Dialog.Footer>
@@ -1944,14 +1944,14 @@ export function GramOAuthProxyModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <Dialog.Content className="max-w-2xl max-h-[90vh] overflow-hidden">
+      <Dialog.Content className="max-h-[90vh] max-w-2xl overflow-hidden">
         <Dialog.Header>
           <Dialog.Title>Gram OAuth</Dialog.Title>
         </Dialog.Header>
 
-        <div className="space-y-4 overflow-auto max-h-[60vh]">
+        <div className="max-h-[60vh] space-y-4 overflow-auto">
           <div>
-            <Type className="font-medium mb-2">Gram OAuth Configuration</Type>
+            <Type className="mb-2 font-medium">Gram OAuth Configuration</Type>
             <Type small className="mb-4">
               Configure Gram OAuth to let users with access to your organization
               use this MCP server. Users will authenticate using their Gram
@@ -2349,7 +2349,7 @@ function OAuthTabModal({
   return (
     <>
       <Dialog open={isOpen} onOpenChange={onClose}>
-        <Dialog.Content className="max-w-6xl max-h-[90vh] overflow-hidden">
+        <Dialog.Content className="max-h-[90vh] max-w-6xl overflow-hidden">
           <Dialog.Header>
             <Dialog.Title>
               {editMode ? "Edit OAuth Proxy" : "Connect OAuth"}
@@ -2368,11 +2368,11 @@ function OAuthTabModal({
 
             <TabsContent
               value="external"
-              className="space-y-4 overflow-auto max-h-[60vh]"
+              className="max-h-[60vh] space-y-4 overflow-auto"
             >
               {hasMultipleOAuth2AuthCode && (
-                <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-4">
-                  <Type small className="text-red-600 mt-1">
+                <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-4">
+                  <Type small className="mt-1 text-red-600">
                     Not Supported: This MCP server has{" "}
                     {toolset.oauthEnablementMetadata?.oauth2SecurityCount}{" "}
                     OAuth2 security schemes detected.
@@ -2380,7 +2380,7 @@ function OAuthTabModal({
                 </div>
               )}
               {discoveredOAuth && !prefilled.external && (
-                <div className="border border-border bg-muted/50 rounded-md p-4 mb-4 flex items-start justify-between gap-4">
+                <div className="border-border bg-muted/50 mb-4 flex items-start justify-between gap-4 rounded-md border p-4">
                   <div>
                     <Type small className="font-medium">
                       OAuth detected from {discoveredOAuth.name}
@@ -2401,7 +2401,7 @@ function OAuthTabModal({
                 </div>
               )}
               <div>
-                <Type className="font-medium mb-2">
+                <Type className="mb-2 font-medium">
                   External OAuth Server Configuration
                 </Type>
                 <Type muted small className="mb-4">
@@ -2418,7 +2418,7 @@ function OAuthTabModal({
 
                 <Stack gap={4}>
                   <div>
-                    <Type className="font-medium mb-2">OAuth Server Slug</Type>
+                    <Type className="mb-2 font-medium">OAuth Server Slug</Type>
                     <Input
                       placeholder="my-oauth-server"
                       value={externalSlug}
@@ -2428,11 +2428,11 @@ function OAuthTabModal({
                   </div>
 
                   <div>
-                    <Type className="font-medium mb-2">
+                    <Type className="mb-2 font-medium">
                       OAuth Authorization Server Metadata
                     </Type>
                     {jsonError && (
-                      <Type className="text-red-500! text-sm mt-1">
+                      <Type className="mt-1 text-sm text-red-500!">
                         {jsonError}
                       </Type>
                     )}
@@ -2468,10 +2468,10 @@ function OAuthTabModal({
 
             <TabsContent
               value="proxy"
-              className="space-y-4 overflow-auto max-h-[60vh]"
+              className="max-h-[60vh] space-y-4 overflow-auto"
             >
               <div>
-                <Type className="font-medium mb-2">
+                <Type className="mb-2 font-medium">
                   OAuth Proxy Server Configuration
                 </Type>
                 <Type muted small className="mb-4">
@@ -2488,7 +2488,7 @@ function OAuthTabModal({
                 </Type>
 
                 {discoveredOAuth && !prefilled.proxy && (
-                  <div className="border border-border bg-muted/50 rounded-md p-4 mb-4 flex items-start justify-between gap-4">
+                  <div className="border-border bg-muted/50 mb-4 flex items-start justify-between gap-4 rounded-md border p-4">
                     <div>
                       <Type small className="font-medium">
                         OAuth detected from {discoveredOAuth.name}
@@ -2510,14 +2510,14 @@ function OAuthTabModal({
                 )}
 
                 {proxyError && (
-                  <Type className="text-red-500! text-sm mb-4">
+                  <Type className="mb-4 text-sm text-red-500!">
                     {proxyError}
                   </Type>
                 )}
 
                 <Stack gap={4}>
                   <div>
-                    <Type className="font-medium mb-2">
+                    <Type className="mb-2 font-medium">
                       OAuth Proxy Server Slug
                     </Type>
                     <Input
@@ -2530,7 +2530,7 @@ function OAuthTabModal({
                   </div>
 
                   <div>
-                    <Type className="font-medium mb-2">
+                    <Type className="mb-2 font-medium">
                       Authorization Endpoint
                     </Type>
                     <Input
@@ -2541,7 +2541,7 @@ function OAuthTabModal({
                   </div>
 
                   <div>
-                    <Type className="font-medium mb-2">Token Endpoint</Type>
+                    <Type className="mb-2 font-medium">Token Endpoint</Type>
                     <Input
                       placeholder="https://provider.com/oauth/token"
                       value={proxyTokenEndpoint}
@@ -2550,7 +2550,7 @@ function OAuthTabModal({
                   </div>
 
                   <div>
-                    <Type className="font-medium mb-2">
+                    <Type className="mb-2 font-medium">
                       Scopes (comma-separated)
                     </Type>
                     <Input
@@ -2561,7 +2561,7 @@ function OAuthTabModal({
                   </div>
 
                   <div>
-                    <Type className="font-medium mb-2">
+                    <Type className="mb-2 font-medium">
                       Audience (optional)
                     </Type>
                     <Input
@@ -2577,11 +2577,11 @@ function OAuthTabModal({
                   </div>
 
                   <div>
-                    <Type className="font-medium mb-2">
+                    <Type className="mb-2 font-medium">
                       Token Endpoint Auth Method
                     </Type>
                     <select
-                      className="w-full border rounded px-3 py-2 bg-background"
+                      className="bg-background w-full rounded border px-3 py-2"
                       value={proxyTokenAuthMethod}
                       onChange={(e) => setProxyTokenAuthMethod(e.target.value)}
                     >
@@ -2596,7 +2596,7 @@ function OAuthTabModal({
                   </div>
 
                   <div>
-                    <Type className="font-medium mb-2">Environment</Type>
+                    <Type className="mb-2 font-medium">Environment</Type>
                     <EnvironmentDropdown
                       selectedEnvironment={proxyEnvironmentSlug}
                       setSelectedEnvironment={setProxyEnvironmentSlug}

--- a/client/dashboard/src/pages/mcp/MCPEmptyState.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEmptyState.tsx
@@ -26,7 +26,7 @@ export default function MCPEmptyGraphic() {
         viewBox="0 0 200 180"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
-        className="w-full h-auto"
+        className="h-auto w-full"
         aria-hidden="true"
       >
         {/* Robot thinking pose */}

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -739,7 +739,7 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
 
         <div className="space-y-4">
           {envVars.length > 0 ? (
-            <div className="border rounded-lg overflow-hidden">
+            <div className="overflow-hidden rounded-lg border">
               <EnvironmentSwitcher
                 environments={environments}
                 selectedEnvironmentView={selectedEnvironmentView}
@@ -778,11 +778,11 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
               ))}
             </div>
           ) : (
-            <div className="border rounded-lg border-dashed p-8 text-center">
+            <div className="rounded-lg border border-dashed p-8 text-center">
               <p className="text-muted-foreground mb-2">
                 No environment variables configured yet.
               </p>
-              <p className="text-sm text-muted-foreground mb-4">
+              <p className="text-muted-foreground mb-4 text-sm">
                 Add key-value pairs to pass API keys, configuration, or any
                 custom data to your backend. Environments can be shared across
                 multiple MCP servers.
@@ -797,7 +797,7 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
           )}
 
           <div className="flex justify-end">
-            <routes.environments.Link className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+            <routes.environments.Link className="text-muted-foreground hover:text-foreground text-sm transition-colors">
               Manage environments →
             </routes.environments.Link>
           </div>
@@ -825,7 +825,7 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
           </Dialog.Header>
           <div className="space-y-4 py-4">
             <div>
-              <Label className="text-sm font-medium mb-2 block">
+              <Label className="mb-2 block text-sm font-medium">
                 Environment Name
               </Label>
               <Input
@@ -935,9 +935,9 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
       }
     >
       {isOAuthConnected ? (
-        <div className="border rounded-lg border-dashed p-8 text-center border-success-softest bg-success-softest">
+        <div className="border-success-softest bg-success-softest rounded-lg border border-dashed p-8 text-center">
           <p className="text-success-foreground mb-1">
-            <CheckCircle className="h-5 w-5 mx-auto mb-1 text-success-foreground" />
+            <CheckCircle className="text-success-foreground mx-auto mb-1 h-5 w-5" />
             {oauthParadigm === "external"
               ? "External OAuth"
               : oauthParadigm === "gram"
@@ -945,7 +945,7 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
                 : "OAuth Proxy"}{" "}
             is configured
           </p>
-          <p className="text-sm text-success-foreground">
+          <p className="text-success-foreground text-sm">
             {oauthParadigm === "external"
               ? "Users will authenticate with your external OAuth server before accessing this MCP server."
               : oauthParadigm === "gram"
@@ -954,12 +954,12 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
           </p>
         </div>
       ) : isOAuthEligible ? (
-        <div className="border rounded-lg border-dashed p-4 text-center">
+        <div className="rounded-lg border border-dashed p-4 text-center">
           <p className="text-muted-foreground mb-1">
-            <Shield className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+            <Shield className="text-muted-foreground mx-auto mb-1 h-5 w-5" />
             OAuth is available but not configured
           </p>
-          <p className="text-sm text-muted-foreground mb-3">
+          <p className="text-muted-foreground mb-3 text-sm">
             Enable OAuth to require users to authenticate before accessing this
             MCP server.
           </p>
@@ -975,22 +975,22 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
           </Button>
         </div>
       ) : (
-        <div className="border rounded-lg border-dashed p-4 text-center">
+        <div className="rounded-lg border border-dashed p-4 text-center">
           <p className="text-muted-foreground mb-1">
-            <Shield className="h-5 w-5 mx-auto mb-1 text-muted-foreground" />
+            <Shield className="text-muted-foreground mx-auto mb-1 h-5 w-5" />
             OAuth is not applicable
           </p>
           {!toolset.mcpEnabled ? (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               Enable the MCP server to configure OAuth.
             </p>
           ) : (
             <>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-muted-foreground text-sm">
                 OAuth cannot be configured because there are no tools in this
                 server that require OAuth authentication.
               </p>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-muted-foreground text-sm">
                 OAuth is available for public MCP servers that have at least one
                 tool requiring OAuth authentication, or private servers (using
                 Speakeasy as an auth provider).

--- a/client/dashboard/src/pages/mcp/MCPHostedPage.tsx
+++ b/client/dashboard/src/pages/mcp/MCPHostedPage.tsx
@@ -15,14 +15,14 @@ export function MCPHostedPage() {
   });
 
   return (
-    <Stack className="w-full h-full">
+    <Stack className="h-full w-full">
       <Heading variant="h2" className="mb-8">
         Hosted Page Preview
       </Heading>
       <MCPPagePreview
         toolset={toolset}
         height={600}
-        className="border-2 rounded-xl mb-12 max-w-[1200px]"
+        className="mb-12 max-w-[1200px] rounded-xl border-2"
       />
     </Stack>
   );

--- a/client/dashboard/src/pages/mcp/MCPHostedPage.tsx
+++ b/client/dashboard/src/pages/mcp/MCPHostedPage.tsx
@@ -144,7 +144,7 @@ export function MCPPagePreview({
   return (
     <div
       className={cn(
-        `w-full max-h-[${height}px] border-1 rounded-lg overflow-hidden pointer-events-none`,
+        `pointer-events-none w-full overflow-hidden rounded-lg border`,
         className,
       )}
     >

--- a/client/dashboard/src/pages/mcp/MCPPerformanceTab.tsx
+++ b/client/dashboard/src/pages/mcp/MCPPerformanceTab.tsx
@@ -36,9 +36,9 @@ function ModeCard({
       type="button"
       onClick={onSelect}
       className={cn(
-        "flex flex-col gap-4 rounded-lg border p-5 text-left transition-colors cursor-pointer",
+        "flex cursor-pointer flex-col gap-4 rounded-lg border p-5 text-left transition-colors",
         selected
-          ? "border-primary bg-card ring-1 ring-primary"
+          ? "border-primary bg-card ring-primary ring-1"
           : "border-border hover:border-muted-foreground/40 hover:bg-card/50",
       )}
     >
@@ -64,7 +64,7 @@ function ModeCard({
         <Type className="text-sm font-medium">Best for</Type>
         <ul className="flex flex-col gap-1 pl-4">
           {bestFor.map((item) => (
-            <li key={item} className="list-disc text-sm text-muted-foreground">
+            <li key={item} className="text-muted-foreground list-disc text-sm">
               {item}
             </li>
           ))}
@@ -121,7 +121,7 @@ export function MCPPerformanceTab({ toolset }: { toolset: Toolset }) {
         </Type>
       </Stack>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <ModeCard
           selected={toolSelectionMode === "static"}
           onSelect={() => onSelectMode("static")}
@@ -152,7 +152,7 @@ export function MCPPerformanceTab({ toolset }: { toolset: Toolset }) {
         href="https://www.speakeasy.com/docs/mcp/build/toolsets/dynamic-toolsets"
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm transition-colors"
       >
         Learn more about tool selection modes
         <ExternalLink className="h-3.5 w-3.5" />

--- a/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
+++ b/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
@@ -124,12 +124,12 @@ function hasTimeSeriesChatData(
  */
 function NoDataOverlay() {
   return (
-    <div className="absolute inset-0 bg-background/80 backdrop-blur-[1px] flex flex-col items-center justify-center rounded">
+    <div className="bg-background/80 absolute inset-0 flex flex-col items-center justify-center rounded backdrop-blur-[1px]">
       <Icon
         name="chart-line"
-        className="size-8 text-muted-foreground/50 mb-2"
+        className="text-muted-foreground/50 mb-2 size-8"
       />
-      <p className="text-sm text-muted-foreground">
+      <p className="text-muted-foreground text-sm">
         No data for selected time range
       </p>
     </div>
@@ -155,10 +155,10 @@ function SetupRequiredModal({
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <Dialog.Content className="sm:max-w-md">
         <Dialog.Header className="text-center">
-          <div className="mx-auto size-14 rounded-full bg-muted flex items-center justify-center mb-2">
+          <div className="bg-muted mx-auto mb-2 flex size-14 items-center justify-center rounded-full">
             <Icon
               name="message-circle"
-              className="size-7 text-muted-foreground"
+              className="text-muted-foreground size-7"
             />
           </div>
           <Dialog.Title className="text-center">
@@ -170,9 +170,9 @@ function SetupRequiredModal({
           </Dialog.Description>
         </Dialog.Header>
         <div className="space-y-4 pt-2">
-          <div className="rounded-lg border border-border bg-muted/30 p-4">
-            <h4 className="text-sm font-medium mb-2">What you'll get:</h4>
-            <ul className="text-sm text-muted-foreground space-y-1.5">
+          <div className="border-border bg-muted/30 rounded-lg border p-4">
+            <h4 className="mb-2 text-sm font-medium">What you'll get:</h4>
+            <ul className="text-muted-foreground space-y-1.5 text-sm">
               <li className="flex items-center gap-2">
                 <Icon name="check" className="size-4 text-emerald-500" />
                 Chat resolution tracking and analytics
@@ -209,7 +209,7 @@ function ViewChatsLink({ from, to }: { from: Date; to: Date }) {
   return (
     <routes.chatSessions.Link
       queryParams={{ from: from.toISOString(), to: to.toISOString() }}
-      className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline hover:no-underline"
+      className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm no-underline transition-colors hover:no-underline"
     >
       View chats
       <ChevronRight className="size-4" />
@@ -225,7 +225,7 @@ function ViewLogsLink({ from, to }: { from: Date; to: Date }) {
         from: toLocalISOString(from),
         to: toLocalISOString(to),
       }}
-      className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors no-underline hover:no-underline"
+      className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm no-underline transition-colors hover:no-underline"
     >
       View logs
       <ChevronRight className="size-4" />
@@ -271,13 +271,13 @@ function FilterBar({
 
   return (
     <div
-      className={`flex items-center gap-2 ${disabled ? "opacity-50 pointer-events-none" : ""}`}
+      className={`flex items-center gap-2 ${disabled ? "pointer-events-none opacity-50" : ""}`}
     >
-      <span className="text-sm text-muted-foreground font-medium hidden 2xl:inline">
+      <span className="text-muted-foreground hidden text-sm font-medium 2xl:inline">
         Filter by
       </span>
       {/* Integrated segmented control with dropdown */}
-      <div className="flex items-center h-[42px] rounded-md p-1 border border-border">
+      <div className="border-border flex h-[42px] items-center rounded-md border p-1">
         {(["all", "api_key", "user"] as const).map((value) => {
           const isSelected = dimension === value;
           const label =
@@ -288,10 +288,10 @@ function FilterBar({
               onClick={() => onDimensionChange(value)}
               disabled={disabled}
               className={`
-                h-8 px-3 text-sm font-medium transition-all duration-150 rounded
+                h-8 rounded px-3 text-sm font-medium transition-all duration-150
                 ${
                   isSelected
-                    ? "bg-white dark:bg-gray-900 text-foreground shadow-sm"
+                    ? "text-foreground bg-white shadow-sm dark:bg-gray-900"
                     : "text-muted-foreground hover:text-foreground"
                 }
                 disabled:cursor-not-allowed
@@ -303,7 +303,7 @@ function FilterBar({
         })}
 
         {/* Integrated searchable dropdown - always visible */}
-        <div className="w-px h-6 bg-border/50 mx-1" />
+        <div className="bg-border/50 mx-1 h-6 w-px" />
         <Popover
           open={dimension !== "all" && !disabled && open}
           onOpenChange={setOpen}
@@ -311,14 +311,14 @@ function FilterBar({
           <PopoverTrigger asChild>
             <button
               disabled={dimension === "all" || disabled}
-              className={`h-8 min-w-[140px] flex items-center justify-between gap-2 text-sm px-2 rounded transition-colors ${
+              className={`flex h-8 min-w-[140px] items-center justify-between gap-2 rounded px-2 text-sm transition-colors ${
                 dimension === "all" || disabled
-                  ? "opacity-40 cursor-not-allowed"
+                  ? "cursor-not-allowed opacity-40"
                   : "hover:bg-muted/50"
               }`}
             >
-              <span className="truncate max-w-[120px]">{displayLabel}</span>
-              <ChevronDown className="size-3.5 text-muted-foreground shrink-0" />
+              <span className="max-w-[120px] truncate">{displayLabel}</span>
+              <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
             </button>
           </PopoverTrigger>
           <PopoverContent className="w-[220px] p-0" align="end">
@@ -358,11 +358,11 @@ function FilterBar({
                       <Check
                         className={`mr-2 size-4 ${selectedValue === option.id ? "opacity-100" : "opacity-0"}`}
                       />
-                      <div className="flex items-center justify-between w-full gap-2">
+                      <div className="flex w-full items-center justify-between gap-2">
                         <span className="truncate">
                           {option.label || option.id}
                         </span>
-                        <span className="text-muted-foreground text-xs tabular-nums shrink-0">
+                        <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
                           {option.count.toLocaleString()}
                         </span>
                       </div>
@@ -401,31 +401,31 @@ function MCPServerFilter({
 
   return (
     <div
-      className={`flex items-center gap-2 ${disabled ? "opacity-50 pointer-events-none" : ""}`}
+      className={`flex items-center gap-2 ${disabled ? "pointer-events-none opacity-50" : ""}`}
     >
-      <span className="text-sm text-muted-foreground font-medium hidden 2xl:inline">
+      <span className="text-muted-foreground hidden text-sm font-medium 2xl:inline">
         Filter by
       </span>
-      <div className="flex items-center h-[42px] rounded-md p-1 border border-border">
-        <div className="flex items-center gap-1.5 h-8 px-3">
-          <McpIcon className="size-3.5 text-muted-foreground" />
-          <span className="text-sm font-medium text-foreground">Server</span>
+      <div className="border-border flex h-[42px] items-center rounded-md border p-1">
+        <div className="flex h-8 items-center gap-1.5 px-3">
+          <McpIcon className="text-muted-foreground size-3.5" />
+          <span className="text-foreground text-sm font-medium">Server</span>
         </div>
-        <div className="w-px h-6 bg-border/50 mx-1" />
+        <div className="bg-border/50 mx-1 h-6 w-px" />
         <Popover open={!disabled && open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <button
               disabled={disabled || isLoading}
-              className={`h-8 min-w-[140px] flex items-center justify-between gap-2 text-sm px-2 rounded transition-colors ${
+              className={`flex h-8 min-w-[140px] items-center justify-between gap-2 rounded px-2 text-sm transition-colors ${
                 disabled || isLoading
-                  ? "opacity-40 cursor-not-allowed"
+                  ? "cursor-not-allowed opacity-40"
                   : "hover:bg-muted/50"
               }`}
             >
-              <span className="truncate max-w-[120px]">
+              <span className="max-w-[120px] truncate">
                 {isLoading ? "Loading..." : displayLabel}
               </span>
-              <ChevronDown className="size-3.5 text-muted-foreground shrink-0" />
+              <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
             </button>
           </PopoverTrigger>
           <PopoverContent className="w-[220px] p-0" align="end">
@@ -955,9 +955,9 @@ function InsightsPageHeader({
           : "flex-row items-center justify-between",
       )}
     >
-      <div className="flex flex-col gap-1 min-w-0">
+      <div className="flex min-w-0 flex-col gap-1">
         <h1 className="text-xl font-semibold">Insights</h1>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-muted-foreground text-sm">
           Monitor agent sessions, tool performance, and system health
         </p>
       </div>
@@ -1204,16 +1204,16 @@ function ObservabilityContent({
         value={activeTab}
         onValueChange={(v) => onTabChange(v as InsightsTab)}
       >
-        <TabsList className="h-auto bg-transparent p-0 gap-8 rounded-none border-b border-border w-full justify-start">
+        <TabsList className="border-border h-auto w-full justify-start gap-8 rounded-none border-b bg-transparent p-0">
           <TabsTrigger
             value="tools"
-            className="relative h-auto pl-0 pr-8 pb-3 pt-2 flex-none bg-transparent! rounded-none border-none shadow-none! text-muted-foreground data-[state=active]:text-foreground data-[state=active]:bg-transparent! after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary"
+            className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:after:bg-primary relative h-auto flex-none rounded-none border-none bg-transparent! pt-2 pr-8 pb-3 pl-0 shadow-none! after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent data-[state=active]:bg-transparent!"
           >
             <div className="flex items-center gap-3">
               <McpIcon className="size-5" />
               <div className="flex flex-col items-start text-left">
                 <span className="font-medium">MCP</span>
-                <span className="text-xs text-muted-foreground font-normal">
+                <span className="text-muted-foreground text-xs font-normal">
                   Claude Code, Desktop, etc.
                 </span>
               </div>
@@ -1221,13 +1221,13 @@ function ObservabilityContent({
           </TabsTrigger>
           <TabsTrigger
             value="chats"
-            className="relative h-auto pl-0 pr-8 pb-3 pt-2 flex-none bg-transparent! rounded-none border-none shadow-none! text-muted-foreground data-[state=active]:text-foreground data-[state=active]:bg-transparent! after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary"
+            className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:after:bg-primary relative h-auto flex-none rounded-none border-none bg-transparent! pt-2 pr-8 pb-3 pl-0 shadow-none! after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent data-[state=active]:bg-transparent!"
           >
             <div className="flex items-center gap-3">
               <MessageCircle className="size-5" />
               <div className="flex flex-col items-start text-left">
                 <span className="font-medium">Chats</span>
-                <span className="text-xs text-muted-foreground font-normal">
+                <span className="text-muted-foreground text-xs font-normal">
                   Gram Elements SDK
                 </span>
               </div>
@@ -1236,10 +1236,10 @@ function ObservabilityContent({
         </TabsList>
 
         {/* ===== TOOLS TAB ===== */}
-        <TabsContent value="tools" className="space-y-8 mt-6">
+        <TabsContent value="tools" className="mt-6 space-y-8">
           {/* Tool Metrics Section */}
           <section>
-            <h2 className="text-lg font-semibold mb-4">Tool Metrics</h2>
+            <h2 className="mb-4 text-lg font-semibold">Tool Metrics</h2>
             <div className="space-y-4">
               <ToolCallsChart
                 data={timeSeries ?? []}
@@ -1257,8 +1257,8 @@ function ObservabilityContent({
                   isInsightsOpen ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2",
                 )}
               >
-                <div className="rounded-lg border border-border bg-card p-6">
-                  <h3 className="text-sm font-semibold mb-4">
+                <div className="border-border bg-card rounded-lg border p-6">
+                  <h3 className="mb-4 text-sm font-semibold">
                     Top Tools by Usage
                   </h3>
                   <ToolBarList
@@ -1268,8 +1268,8 @@ function ObservabilityContent({
                     onToolClick={(toolUrn) => navigateToLogs(toolUrn)}
                   />
                 </div>
-                <div className="rounded-lg border border-border bg-card p-6">
-                  <h3 className="text-sm font-semibold mb-4">
+                <div className="border-border bg-card rounded-lg border p-6">
+                  <h3 className="mb-4 text-sm font-semibold">
                     Failure Distribution by Tool
                   </h3>
                   <ToolBarList
@@ -1287,7 +1287,7 @@ function ObservabilityContent({
 
           {/* System Metrics Section */}
           <section>
-            <h2 className="text-lg font-semibold mb-4">System Metrics</h2>
+            <h2 className="mb-4 text-lg font-semibold">System Metrics</h2>
             <div
               className={cn(
                 "grid gap-4",
@@ -1329,9 +1329,9 @@ function ObservabilityContent({
         </TabsContent>
 
         {/* ===== CHATS TAB ===== */}
-        <TabsContent value="chats" className="space-y-8 mt-6">
+        <TabsContent value="chats" className="mt-6 space-y-8">
           <section>
-            <h2 className="text-lg font-semibold mb-4">Chat Resolution</h2>
+            <h2 className="mb-4 text-lg font-semibold">Chat Resolution</h2>
             <div className="space-y-4">
               <div
                 className={cn(
@@ -1520,11 +1520,11 @@ function MetricCard({
   const valueColor = getValueColor(value, thresholds);
 
   return (
-    <div className="rounded-lg border border-border bg-card p-5">
-      <div className="flex items-center justify-between mb-3">
+    <div className="border-border bg-card rounded-lg border p-5">
+      <div className="mb-3 flex items-center justify-between">
         <span className="text-sm font-semibold">{title}</span>
-        <div className="p-2 rounded-lg bg-muted/50">
-          <Icon name={icon} className="size-4 text-muted-foreground" />
+        <div className="bg-muted/50 rounded-lg p-2">
+          <Icon name={icon} className="text-muted-foreground size-4" />
         </div>
       </div>
       <div className="flex items-end justify-between">
@@ -1545,7 +1545,7 @@ function MetricCard({
               <span>{delta.toFixed(1)}%</span>
             </div>
             {comparisonLabel && (
-              <span className="text-[10px] text-muted-foreground">
+              <span className="text-muted-foreground text-[10px]">
                 {comparisonLabel}
               </span>
             )}
@@ -1762,7 +1762,7 @@ function ChartWithSelection({
       {childrenWithRef}
       {selection && selectionWidth > 5 && (
         <div
-          className="absolute top-0 bottom-0 bg-blue-500/20 border-l border-r border-blue-500/50 pointer-events-none"
+          className="pointer-events-none absolute top-0 bottom-0 border-r border-l border-blue-500/50 bg-blue-500/20"
           style={{
             left: selectionLeft,
             width: selectionWidth,
@@ -1770,7 +1770,7 @@ function ChartWithSelection({
         >
           {/* Range label */}
           {selectedRange && selectionWidth > 40 && (
-            <div className="absolute top-2 left-1/2 -translate-x-1/2 bg-background/95 border border-border rounded px-2 py-1 text-xs whitespace-nowrap shadow-sm">
+            <div className="bg-background/95 border-border absolute top-2 left-1/2 -translate-x-1/2 rounded border px-2 py-1 text-xs whitespace-nowrap shadow-sm">
               <span className="text-muted-foreground">
                 {formatRangeDate(selectedRange.from)}
               </span>
@@ -1916,15 +1916,15 @@ function ToolCallsChart({
   };
 
   return (
-    <div className="rounded-lg border border-border bg-card p-6">
-      <div className="flex items-center justify-between mb-4">
+    <div className="border-border bg-card rounded-lg border p-6">
+      <div className="mb-4 flex items-center justify-between">
         <h3 className="text-sm font-semibold">{title}</h3>
         <ViewLogsLink from={from} to={to} />
       </div>
       <div className="relative">
         {isLoading && (
-          <div className="absolute inset-0 bg-background/60 flex items-center justify-center rounded">
-            <div className="size-5 border-2 border-muted-foreground/50 border-t-transparent rounded-full animate-spin" />
+          <div className="bg-background/60 absolute inset-0 flex items-center justify-center rounded">
+            <div className="border-muted-foreground/50 size-5 animate-spin rounded-full border-2 border-t-transparent" />
           </div>
         )}
         {showNoData && <NoDataOverlay />}
@@ -2048,15 +2048,15 @@ function ResolvedChatsChart({
   };
 
   return (
-    <div className="rounded-lg border border-border bg-card p-6">
-      <div className="flex items-center justify-between mb-4">
+    <div className="border-border bg-card rounded-lg border p-6">
+      <div className="mb-4 flex items-center justify-between">
         <h3 className="text-sm font-semibold">{title}</h3>
         <ViewChatsLink from={from} to={to} />
       </div>
       <div className="relative">
         {isLoading && (
-          <div className="absolute inset-0 bg-background/60 flex items-center justify-center rounded">
-            <div className="size-5 border-2 border-muted-foreground/50 border-t-transparent rounded-full animate-spin" />
+          <div className="bg-background/60 absolute inset-0 flex items-center justify-center rounded">
+            <div className="border-muted-foreground/50 size-5 animate-spin rounded-full border-2 border-t-transparent" />
           </div>
         )}
         {showNoData && <NoDataOverlay />}
@@ -2064,7 +2064,7 @@ function ResolvedChatsChart({
           <Line data={chartData} options={options} />
         </ChartWithSelection>
       </div>
-      <p className="text-xs text-muted-foreground mt-3">
+      <p className="text-muted-foreground mt-3 text-xs">
         Percentage of chats successfully resolved per interval
       </p>
     </div>
@@ -2281,15 +2281,15 @@ function ResolutionStatusChart({
   };
 
   return (
-    <div className="rounded-lg border border-border bg-card p-6">
-      <div className="flex items-center justify-between mb-4">
+    <div className="border-border bg-card rounded-lg border p-6">
+      <div className="mb-4 flex items-center justify-between">
         <h3 className="text-sm font-semibold">{title}</h3>
         <ViewChatsLink from={from} to={to} />
       </div>
       <div className="relative">
         {isLoading && (
-          <div className="absolute inset-0 bg-background/60 flex items-center justify-center rounded">
-            <div className="size-5 border-2 border-muted-foreground/50 border-t-transparent rounded-full animate-spin" />
+          <div className="bg-background/60 absolute inset-0 flex items-center justify-center rounded">
+            <div className="border-muted-foreground/50 size-5 animate-spin rounded-full border-2 border-t-transparent" />
           </div>
         )}
         {showNoData && <NoDataOverlay />}
@@ -2297,7 +2297,7 @@ function ResolutionStatusChart({
           <Line data={chartData} options={options} />
         </ChartWithSelection>
       </div>
-      <p className="text-xs text-muted-foreground mt-3">
+      <p className="text-muted-foreground mt-3 text-xs">
         Chat counts by resolution status over time
       </p>
     </div>
@@ -2418,15 +2418,15 @@ function SessionDurationChart({
   };
 
   return (
-    <div className="rounded-lg border border-border bg-card p-6">
-      <div className="flex items-center justify-between mb-4">
+    <div className="border-border bg-card rounded-lg border p-6">
+      <div className="mb-4 flex items-center justify-between">
         <h3 className="text-sm font-semibold">{title}</h3>
         <ViewChatsLink from={from} to={to} />
       </div>
       <div className="relative">
         {isLoading && (
-          <div className="absolute inset-0 bg-background/60 flex items-center justify-center rounded">
-            <div className="size-5 border-2 border-muted-foreground/50 border-t-transparent rounded-full animate-spin" />
+          <div className="bg-background/60 absolute inset-0 flex items-center justify-center rounded">
+            <div className="border-muted-foreground/50 size-5 animate-spin rounded-full border-2 border-t-transparent" />
           </div>
         )}
         {showNoData && <NoDataOverlay />}
@@ -2434,7 +2434,7 @@ function SessionDurationChart({
           <Line data={chartData} options={options} />
         </ChartWithSelection>
       </div>
-      <p className="text-xs text-muted-foreground mt-3">
+      <p className="text-muted-foreground mt-3 text-xs">
         Values are rolled up and averaged across the time window interval
       </p>
     </div>
@@ -2513,7 +2513,7 @@ function ToolBarList({
 
   if (barListData.length === 0) {
     return (
-      <div className="text-center text-muted-foreground py-8">
+      <div className="text-muted-foreground py-8 text-center">
         No tool data available
       </div>
     );
@@ -2540,17 +2540,17 @@ function ToolBarList({
             <div
               key={item.name}
               className={cn(
-                "flex items-center gap-2 group",
+                "group flex items-center gap-2",
                 onToolClick && "cursor-pointer",
               )}
               onClick={() => onToolClick?.(item.gramUrn)}
             >
-              <span className="text-sm font-medium text-right shrink-0 min-w-[3rem]">
+              <span className="min-w-[3rem] shrink-0 text-right text-sm font-medium">
                 {displayValue}
               </span>
-              <div className="flex-1 relative h-7">
+              <div className="relative h-7 flex-1">
                 {/* Background text (for overflow outside bar) */}
-                <span className="absolute inset-y-0 left-2 flex items-center text-sm font-medium text-foreground truncate pr-8 z-0">
+                <span className="text-foreground absolute inset-y-0 left-2 z-0 flex items-center truncate pr-8 text-sm font-medium">
                   {item.name}
                 </span>
                 {/* Colored bar */}
@@ -2560,17 +2560,17 @@ function ToolBarList({
                 />
                 {/* White text clipped to bar */}
                 <div
-                  className="absolute inset-y-0 left-0 overflow-hidden z-10"
+                  className="absolute inset-y-0 left-0 z-10 overflow-hidden"
                   style={{ width: `${Math.max(widthPercent, 5)}%` }}
                 >
-                  <span className="absolute inset-y-0 left-2 flex items-center text-sm font-medium text-white truncate pr-8 whitespace-nowrap">
+                  <span className="absolute inset-y-0 left-2 flex items-center truncate pr-8 text-sm font-medium whitespace-nowrap text-white">
                     {item.name}
                   </span>
                 </div>
                 {/* Hover arrow */}
                 {onToolClick && (
-                  <div className="absolute inset-y-0 right-2 flex items-center opacity-0 group-hover:opacity-100 transition-opacity">
-                    <ChevronRight className="size-4 text-foreground" />
+                  <div className="absolute inset-y-0 right-2 flex items-center opacity-0 transition-opacity group-hover:opacity-100">
+                    <ChevronRight className="text-foreground size-4" />
                   </div>
                 )}
               </div>
@@ -2583,7 +2583,7 @@ function ToolBarList({
       {hasMore && (
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors"
         >
           {isExpanded ? (
             <>
@@ -2601,7 +2601,7 @@ function ToolBarList({
 
       {/* Legend for failure rate */}
       {showLegend && (
-        <p className="text-xs text-muted-foreground mt-2">
+        <p className="text-muted-foreground mt-2 text-xs">
           Percentage shows each tool's share of total failures (
           {totalFailures.toLocaleString()} total)
         </p>
@@ -2613,9 +2613,9 @@ function ToolBarList({
 function ErrorState({ error }: { error: Error }) {
   return (
     <div className="flex flex-col items-center justify-center py-16">
-      <Icon name="triangle-alert" className="size-12 text-destructive mb-4" />
-      <h3 className="text-lg font-medium mb-2">Error Loading Data</h3>
-      <p className="text-muted-foreground text-center max-w-md">
+      <Icon name="triangle-alert" className="text-destructive mb-4 size-12" />
+      <h3 className="mb-2 text-lg font-medium">Error Loading Data</h3>
+      <p className="text-muted-foreground max-w-md text-center">
         {error.message}
       </p>
     </div>

--- a/client/dashboard/src/pages/onboarding/FunctionsOnboarding.tsx
+++ b/client/dashboard/src/pages/onboarding/FunctionsOnboarding.tsx
@@ -16,8 +16,8 @@ export default function FunctionsOnboarding() {
           {/* Header */}
           <Stack gap={3} className="mb-8">
             <Stack direction="horizontal" gap={3} align="center">
-              <div className="w-10 h-10 rounded-lg bg-emerald-500/10 flex items-center justify-center shrink-0">
-                <CodeIcon className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
+                <CodeIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
               </div>
               <Heading variant="h3">Add Custom Functions</Heading>
             </Stack>

--- a/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
+++ b/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
@@ -58,8 +58,8 @@ export default function UploadOpenAPI() {
           {/* Header */}
           <Stack gap={3} className="mb-8">
             <Stack direction="horizontal" gap={3} align="center">
-              <div className="w-10 h-10 rounded-lg bg-blue-500/10 flex items-center justify-center shrink-0">
-                <FileTextIcon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+                <FileTextIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               <Heading variant="h3">Import OpenAPI Specification</Heading>
             </Stack>
@@ -490,7 +490,7 @@ export function UploadOpenAPIContent({
           <Stack
             direction={"horizontal"}
             gap={2}
-            className="max-w-sm relative z-10"
+            className="relative z-10 max-w-sm"
           >
             <Input value={apiName} onChange={setApiName} placeholder="My API" />
             <Button
@@ -608,7 +608,7 @@ export function DeploymentLogs(props: {
         key={e.id}
         className={cn(
           e.event.includes("error") && "text-destructive",
-          "py-1 px-4 dark:hover:bg-white/15 rounded hover:bg-gray-100",
+          "rounded px-4 py-1 hover:bg-gray-100 dark:hover:bg-white/15",
         )}
       >
         {e.message}
@@ -617,7 +617,7 @@ export function DeploymentLogs(props: {
   });
 
   return (
-    <div className="font-mono text-sm max-h-[250px] overflow-y-auto">
+    <div className="max-h-[250px] overflow-y-auto font-mono text-sm">
       {lines.length > 0 ? lines : "OpenAPI document processed without issue"}
     </div>
   );

--- a/client/dashboard/src/pages/onboarding/Wizard.tsx
+++ b/client/dashboard/src/pages/onboarding/Wizard.tsx
@@ -103,7 +103,7 @@ export function OnboardingWizard() {
 
   return (
     <Stack direction={"horizontal"} className="h-[100vh] w-full">
-      <div className="w-1/2 h-full border-r-1 ">
+      <div className="h-full w-1/2 border-r-1 ">
         <LHS
           currentStep={currentStep}
           setCurrentStep={setCurrentStep}
@@ -117,7 +117,7 @@ export function OnboardingWizard() {
           routes={routes}
         />
       </div>
-      <div className="w-1/2 h-full bg-background overflow-hidden">
+      <div className="bg-background h-full w-1/2 overflow-hidden">
         <AnimatedRightSide
           currentStep={currentStep}
           toolsetName={toolsetName}
@@ -143,13 +143,13 @@ const Step = ({
     <Stack direction={"horizontal"} gap={2} align={"center"}>
       <span
         className={cn(
-          "rounded-lg bg-muted h-8 w-8 flex items-center justify-center border border-border",
+          "bg-muted border-border flex h-8 w-8 items-center justify-center rounded-lg border",
           completed &&
             "bg-success text-success-foreground border-success-softest",
           !active && !completed && "border-neutral-softest",
         )}
       >
-        {completed ? <Check className="w-4 h-4" /> : icon}
+        {completed ? <Check className="h-4 w-4" /> : icon}
       </span>
       <span className={cn(!active && "text-muted-foreground", "text-body-sm")}>
         {text}
@@ -172,9 +172,9 @@ export const ChoiceCard = ({
   return (
     <button
       onClick={onClick}
-      className="p-5 bg-secondary rounded-lg hover:bg-accent transition-colors text-left group flex flex-col items-start relative shadow-[inset_0px_1px_1px_0px_rgba(255,255,255,0.24),inset_0px_-1px_1px_0px_rgba(0,0,0,0.08)]"
+      className="bg-secondary hover:bg-accent group relative flex flex-col items-start rounded-lg p-5 text-left shadow-[inset_0px_1px_1px_0px_rgba(255,255,255,0.24),inset_0px_-1px_1px_0px_rgba(0,0,0,0.08)] transition-colors"
     >
-      <Icon className="w-6 h-6 text-primary mb-2 shrink-0" strokeWidth={1.5} />
+      <Icon className="text-primary mb-2 h-6 w-6 shrink-0" strokeWidth={1.5} />
       <div className="flex flex-col gap-1">
         <Type className="text-heading-sm">{title}</Type>
         <Type small className="text-muted">
@@ -250,16 +250,16 @@ const LHS = ({
     );
 
   return (
-    <div className="h-full flex flex-col relative bg-card">
+    <div className="bg-card relative flex h-full flex-col">
       {/* Fixed Header */}
       <Stack align={"center"}>
         <Stack
           direction={"horizontal"}
           align={"center"}
           justify={"space-between"}
-          className="w-full border-b h-16 px-6 mb-8"
+          className="mb-8 h-16 w-full border-b px-6"
         >
-          <Link className="hover:bg-accent p-2 rounded-md" to="/">
+          <Link className="hover:bg-accent rounded-md p-2" to="/">
             <GramLogo className="w-25" />
           </Link>
           <a href="https://docs.getgram.ai/" target="_blank">
@@ -272,21 +272,21 @@ const LHS = ({
           <Stack direction={"horizontal"} gap={6} align={"center"}>
             <Step
               text={selectedPath === "cli" ? "Setup CLI" : "Upload OpenAPI"}
-              icon={<Upload className="w-4 h-4" />}
+              icon={<Upload className="h-4 w-4" />}
               active={currentStep === "upload" || currentStep === "cli-setup"}
               completed={currentStep === "toolset" || currentStep === "mcp"}
             />
-            <ChevronRight className="w-4 h-4 text-muted-foreground" />
+            <ChevronRight className="text-muted-foreground h-4 w-4" />
             <Step
               text="Create Toolset"
-              icon={<Wrench className="w-4 h-4" />}
+              icon={<Wrench className="h-4 w-4" />}
               active={currentStep === "toolset"}
               completed={currentStep === "mcp"}
             />
-            <ChevronRight className="w-4 h-4 text-muted-foreground" />
+            <ChevronRight className="text-muted-foreground h-4 w-4" />
             <Step
               text="Configure MCP"
-              icon={<ServerCog className="w-4 h-4" />}
+              icon={<ServerCog className="h-4 w-4" />}
               active={currentStep === "mcp"}
             />
           </Stack>
@@ -295,23 +295,23 @@ const LHS = ({
 
       {/* Content - absolutely positioned within left container */}
       <div
-        className="absolute inset-x-0 bottom-16 pointer-events-none"
+        className="pointer-events-none absolute inset-x-0 bottom-16"
         style={{
           top: isNotChoiceStep ? "160px" : "64px",
         }}
       >
         {/* Blur gradient at top (when scrolled) */}
         {showTopBlur && (
-          <div className="absolute inset-x-0 top-0 h-16 bg-linear-to-b from-card to-transparent pointer-events-none z-20" />
+          <div className="from-card pointer-events-none absolute inset-x-0 top-0 z-20 h-16 bg-linear-to-b to-transparent" />
         )}
 
         {/* Scrollable content */}
         <div
           ref={contentScrollRef}
           onScroll={handleScroll}
-          className="h-full overflow-y-auto px-16 flex items-center justify-center"
+          className="flex h-full items-center justify-center overflow-y-auto px-16"
         >
-          <Stack className="w-full max-w-3xl gap-8 pointer-events-auto z-10 my-auto">
+          <Stack className="pointer-events-auto z-10 my-auto w-full max-w-3xl gap-8">
             {currentStep === "initial-choice" && (
               <InitialChoiceStep
                 setCurrentStep={setCurrentStep}
@@ -356,7 +356,7 @@ const LHS = ({
 
         {/* Blur gradient at bottom (when not at bottom) */}
         {showBottomBlur && (
-          <div className="absolute inset-x-0 bottom-0 h-16 bg-linear-to-t from-card to-transparent pointer-events-none z-20" />
+          <div className="from-card pointer-events-none absolute inset-x-0 bottom-0 z-20 h-16 bg-linear-to-t to-transparent" />
         )}
       </div>
 
@@ -365,11 +365,11 @@ const LHS = ({
         direction={"horizontal"}
         justify={"space-between"}
         align={"center"}
-        className="px-6 h-16 mt-auto"
+        className="mt-auto h-16 px-6"
       >
         {lowerLeft}
         <a href="https://x.com/speakeasydev" target="_blank">
-          <TwitterIcon className="w-4 h-4 fill-muted-foreground" />
+          <TwitterIcon className="fill-muted-foreground h-4 w-4" />
         </a>
       </Stack>
     </div>
@@ -488,7 +488,7 @@ const ChoiceStep = ({
           Choose how you want to create your tools
         </span>
       </Stack>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         <ChoiceCard
           onClick={() => handleChoice("openapi")}
           icon={FileCode}
@@ -566,7 +566,7 @@ const CliSetupStep = ({
           <a
             href="https://www.speakeasy.com/docs/gram/getting-started/typescript"
             target="_blank"
-            className="text-primary underline cursor-pointer"
+            className="text-primary cursor-pointer underline"
           >
             docs
           </a>{" "}
@@ -644,7 +644,7 @@ const CliSetupStep = ({
         doesn't, click{" "}
         <span
           onClick={handleContinue}
-          className="text-primary underline cursor-pointer"
+          className="text-primary cursor-pointer underline"
         >
           here
         </span>{" "}
@@ -681,7 +681,7 @@ export const UploadedDocument = ({
     <Expandable defaultExpanded={defaultExpanded}>
       <Expandable.Trigger>
         <Stack direction={"horizontal"} gap={2} align={"center"}>
-          <FileJson2 className="w-4 h-4 text-muted-foreground/70" />
+          <FileJson2 className="text-muted-foreground/70 h-4 w-4" />
           <Type small mono>
             {file.name}
           </Type>
@@ -691,7 +691,7 @@ export const UploadedDocument = ({
             className="size-6 opacity-50 hover:opacity-100"
           >
             <Button.LeftIcon>
-              <X className="w-4 h-4" />
+              <X className="h-4 w-4" />
             </Button.LeftIcon>
             <Button.Text className="sr-only">Remove file</Button.Text>
           </Button>
@@ -699,7 +699,7 @@ export const UploadedDocument = ({
       </Expandable.Trigger>
       <Expandable.Content className="text-xs">
         {fileText?.length ? (
-          <pre className="whitespace-pre-wrap break-all">{fileText}</pre>
+          <pre className="break-all whitespace-pre-wrap">{fileText}</pre>
         ) : (
           <SkeletonParagraph lines={12} />
         )}
@@ -738,7 +738,7 @@ const UploadStep = ({
     <Stack gap={4}>
       <Stack gap={1}>
         <Stack direction={"horizontal"} gap={1} align={"center"}>
-          <CircleCheckIcon className="w-4 h-4 text-success-foreground" />
+          <CircleCheckIcon className="text-success-foreground h-4 w-4" />
           <Type small className="font-normal">
             OpenAPI Document
           </Type>
@@ -1077,25 +1077,25 @@ const AnimatedRightSide = ({
   }, [setCanvasZIndex, setShowAsciiStars]);
 
   return (
-    <div className="w-full h-full bg-background flex items-center justify-center relative overflow-hidden">
+    <div className="bg-background relative flex h-full w-full items-center justify-center overflow-hidden">
       {/* ASCII shader decorations in corners */}
       {/* Top right corner */}
-      <div className="absolute top-0 right-0 w-[300px] h-[300px] opacity-30 pointer-events-none -z-10">
-        <AsciiVideo videoSrc="/webgl/stars.mp4" className="w-full h-full" />
+      <div className="pointer-events-none absolute top-0 right-0 -z-10 h-[300px] w-[300px] opacity-30">
+        <AsciiVideo videoSrc="/webgl/stars.mp4" className="h-full w-full" />
       </div>
 
       {/* Bottom left corner - flipped both ways */}
-      <div className="absolute bottom-0 left-0 w-[300px] h-[300px] opacity-30 pointer-events-none -z-10">
+      <div className="pointer-events-none absolute bottom-0 left-0 -z-10 h-[300px] w-[300px] opacity-30">
         <AsciiVideo
           videoSrc="/webgl/stars.mp4"
           flipX={true}
           flipY={true}
-          className="w-full h-full"
+          className="h-full w-full"
         />
       </div>
 
       {/* Content layer */}
-      <div className="relative z-10 w-full h-full flex items-center justify-center">
+      <div className="relative z-10 flex h-full w-full items-center justify-center">
         <AnimatePresence mode="wait">
           {currentStep === "cli-setup" ? (
             <TerminalAnimationWithLogs key="terminal" />
@@ -1114,13 +1114,13 @@ const AnimatedRightSide = ({
 
 const DefaultLogo = () => (
   <motion.div
-    className="w-32 h-32 bg-card rounded-lg border flex items-center justify-center"
+    className="bg-card flex h-32 w-32 items-center justify-center rounded-lg border"
     exit={{
       y: [0, -20, -8],
       transition: { duration: 0.5, times: [0, 0.4, 1], ease: "easeInOut" },
     }}
   >
-    <motion.span className="font-thin text-foreground text-6xl select-none">
+    <motion.span className="text-foreground text-6xl font-thin select-none">
       <GramLogo className="w-18" variant="icon" />
     </motion.span>
   </motion.div>
@@ -1405,7 +1405,7 @@ export default gram;`;
   }
 
   return (
-    <div className="relative w-full h-full flex items-center justify-center scale-[0.65] lg:scale-75 xl:scale-90">
+    <div className="relative flex h-full w-full scale-[0.65] items-center justify-center lg:scale-75 xl:scale-90">
       {/* Terminal Window - positioned bottom-left */}
       <motion.div
         drag
@@ -1423,18 +1423,18 @@ export default gram;`;
         }}
         onDragEnd={() => setIsDraggingWindow(false)}
         className={cn(
-          "absolute w-[550px] bg-card border rounded-lg overflow-hidden cursor-pointer",
+          "bg-card absolute w-[550px] cursor-pointer overflow-hidden rounded-lg border",
           focusedWindow === "terminal" ? "z-20 shadow-xl" : "z-10 shadow-sm",
         )}
         style={{ x: terminalX, y: terminalY }}
         onClick={() => handleWindowClick("terminal")}
       >
         {/* Terminal header */}
-        <div className="bg-muted border-b px-4 py-2 flex items-center justify-between cursor-grab active:cursor-grabbing">
+        <div className="bg-muted flex cursor-grab items-center justify-between border-b px-4 py-2 active:cursor-grabbing">
           <div className="flex gap-1.5">
             <div
               className={cn(
-                "w-3 h-3 rounded-full",
+                "h-3 w-3 rounded-full",
                 focusedWindow === "terminal"
                   ? "bg-red-500/80"
                   : "bg-muted-foreground/30",
@@ -1442,7 +1442,7 @@ export default gram;`;
             />
             <div
               className={cn(
-                "w-3 h-3 rounded-full",
+                "h-3 w-3 rounded-full",
                 focusedWindow === "terminal"
                   ? "bg-yellow-500/80"
                   : "bg-muted-foreground/30",
@@ -1450,7 +1450,7 @@ export default gram;`;
             />
             <div
               className={cn(
-                "w-3 h-3 rounded-full",
+                "h-3 w-3 rounded-full",
                 focusedWindow === "terminal"
                   ? "bg-green-500/80"
                   : "bg-muted-foreground/30",
@@ -1469,7 +1469,7 @@ export default gram;`;
         {/* Terminal content */}
         <div
           ref={terminalContentRef}
-          className="p-4 font-mono text-sm space-y-1 h-[350px] overflow-y-auto"
+          className="h-[350px] space-y-1 overflow-y-auto p-4 font-mono text-sm"
         >
           {logs.map((log) => {
             const shouldShowLoading = log.loading;
@@ -1513,17 +1513,17 @@ export default gram;`;
         onDragEnd={() => setIsDraggingWindow(false)}
         style={{ x: editorX, y: editorY }}
         className={cn(
-          "absolute w-[550px] bg-card border rounded-lg overflow-hidden cursor-pointer",
+          "bg-card absolute w-[550px] cursor-pointer overflow-hidden rounded-lg border",
           focusedWindow === "editor" ? "z-30 shadow-xl" : "z-10 shadow-sm",
         )}
         onClick={() => handleWindowClick("editor")}
       >
         {/* Editor header */}
-        <div className="bg-muted border-b px-4 py-2 flex items-center justify-between cursor-grab active:cursor-grabbing">
+        <div className="bg-muted flex cursor-grab items-center justify-between border-b px-4 py-2 active:cursor-grabbing">
           <div className="flex gap-1.5">
             <div
               className={cn(
-                "w-3 h-3 rounded-full",
+                "h-3 w-3 rounded-full",
                 focusedWindow === "editor"
                   ? "bg-red-500/80"
                   : "bg-muted-foreground/30",
@@ -1531,7 +1531,7 @@ export default gram;`;
             />
             <div
               className={cn(
-                "w-3 h-3 rounded-full",
+                "h-3 w-3 rounded-full",
                 focusedWindow === "editor"
                   ? "bg-yellow-500/80"
                   : "bg-muted-foreground/30",
@@ -1539,7 +1539,7 @@ export default gram;`;
             />
             <div
               className={cn(
-                "w-3 h-3 rounded-full",
+                "h-3 w-3 rounded-full",
                 focusedWindow === "editor"
                   ? "bg-green-500/80"
                   : "bg-muted-foreground/30",
@@ -1559,7 +1559,7 @@ export default gram;`;
         <CodeBlock
           language="typescript"
           copyable={false}
-          className="!p-0 !rounded-none !border-none"
+          className="!rounded-none !border-none !p-0"
           preClassName="!bg-transparent h-[350px] overflow-y-auto p-4 whitespace-pre-wrap"
         >
           {editorCode}
@@ -1574,7 +1574,7 @@ export default gram;`;
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 10 }}
             transition={{ duration: 0.2 }}
-            className="absolute bottom-8 right-8 z-50"
+            className="absolute right-8 bottom-8 z-50"
           >
             <Button
               variant="secondary"
@@ -1582,7 +1582,7 @@ export default gram;`;
               onClick={handleReset}
               className="gap-2"
             >
-              <RefreshCcw className="w-4 h-4" />
+              <RefreshCcw className="h-4 w-4" />
               Reset
             </Button>
           </motion.div>
@@ -1611,7 +1611,7 @@ const ToolsetAnimation = ({
         }}
         className="w-70 pl-1"
       >
-        <h3 className="text-lg font-medium text-foreground mb-1">
+        <h3 className="text-foreground mb-1 text-lg font-medium">
           {toolsetName || "my-toolset"}
         </h3>
       </motion.div>
@@ -1619,12 +1619,12 @@ const ToolsetAnimation = ({
       {/* Main logo that morphs from the default logo */}
       <motion.div
         layoutId="main-container"
-        className="w-70 h-12 bg-card rounded-lg border  flex items-center px-4"
+        className="bg-card flex h-12 w-70 items-center  rounded-lg border px-4"
         transition={{ type: "spring", duration: 0.6, bounce: 0.1 }}
       >
         <motion.div
           layoutId="main-icon"
-          className="w-6 h-6 bg-background rounded flex items-center justify-center flex-shrink-0"
+          className="bg-background flex h-6 w-6 flex-shrink-0 items-center justify-center rounded"
           transition={{ type: "spring", duration: 0.6, bounce: 0.1 }}
         >
           <motion.div
@@ -1637,7 +1637,7 @@ const ToolsetAnimation = ({
               bounce: 0.3,
             }}
           >
-            <Wrench className="w-3 h-3 text-muted-foreground" />
+            <Wrench className="text-muted-foreground h-3 w-3" />
           </motion.div>
         </motion.div>
         <motion.div
@@ -1651,7 +1651,7 @@ const ToolsetAnimation = ({
           }}
           className="ml-3 flex-1"
         >
-          <div className="h-3 bg-muted rounded w-full" />
+          <div className="bg-muted h-3 w-full rounded" />
         </motion.div>
       </motion.div>
 
@@ -1666,12 +1666,12 @@ const ToolsetAnimation = ({
             duration: 0.5,
             bounce: 0.2,
           }}
-          className="w-70 h-12 bg-card rounded-lg border flex items-center px-4"
+          className="bg-card flex h-12 w-70 items-center rounded-lg border px-4"
         >
-          <div className="w-6 h-6 bg-background rounded flex items-center justify-center">
-            <Wrench className="w-3 h-3 text-muted-foreground" />
+          <div className="bg-background flex h-6 w-6 items-center justify-center rounded">
+            <Wrench className="text-muted-foreground h-3 w-3" />
           </div>
-          <div className="ml-3 h-3 bg-muted rounded w-full" />
+          <div className="bg-muted ml-3 h-3 w-full rounded" />
         </motion.div>
 
         <motion.div
@@ -1683,12 +1683,12 @@ const ToolsetAnimation = ({
             duration: 0.5,
             bounce: 0.2,
           }}
-          className="w-70 h-12 bg-card rounded-lg border  flex items-center px-4"
+          className="bg-card flex h-12 w-70 items-center  rounded-lg border px-4"
         >
-          <div className="w-6 h-6 bg-background rounded flex items-center justify-center">
-            <Wrench className="w-3 h-3 text-muted-foreground" />
+          <div className="bg-background flex h-6 w-6 items-center justify-center rounded">
+            <Wrench className="text-muted-foreground h-3 w-3" />
           </div>
-          <div className="ml-3 h-3 bg-muted rounded w-full" />
+          <div className="bg-muted ml-3 h-3 w-full rounded" />
         </motion.div>
       </AnimatePresence>
     </div>
@@ -1707,12 +1707,12 @@ const McpAnimation = ({ mcpSlug }: { mcpSlug: string | undefined }) => {
         {/* First tool transforms into server rack unit */}
         <motion.div
           layoutId="main-container"
-          className="w-48 h-10 bg-card rounded-lg border  flex items-center px-4"
+          className="bg-card flex h-10 w-48 items-center  rounded-lg border px-4"
           transition={{ type: "spring", duration: 0.6, bounce: 0.1 }}
         >
           <motion.div
             layoutId="main-icon"
-            className="flex items-center justify-center flex-shrink-0"
+            className="flex flex-shrink-0 items-center justify-center"
             transition={{ type: "spring", duration: 0.6, bounce: 0.1 }}
           >
             <motion.div
@@ -1724,7 +1724,7 @@ const McpAnimation = ({ mcpSlug }: { mcpSlug: string | undefined }) => {
                 duration: 0.4,
                 bounce: 0.3,
               }}
-              className="w-3 h-3 bg-muted-foreground rounded-full"
+              className="bg-muted-foreground h-3 w-3 rounded-full"
             />
           </motion.div>
         </motion.div>
@@ -1739,9 +1739,9 @@ const McpAnimation = ({ mcpSlug }: { mcpSlug: string | undefined }) => {
             duration: 0.5,
             bounce: 0.2,
           }}
-          className="w-48 h-10 bg-card rounded-lg border  flex items-center px-4"
+          className="bg-card flex h-10 w-48 items-center  rounded-lg border px-4"
         >
-          <div className="w-3 h-3 bg-muted-foreground rounded-full" />
+          <div className="bg-muted-foreground h-3 w-3 rounded-full" />
         </motion.div>
       </div>
 
@@ -1757,8 +1757,8 @@ const McpAnimation = ({ mcpSlug }: { mcpSlug: string | undefined }) => {
         }}
         className="text-center"
       >
-        <div className="bg-background border rounded-md px-3 py-2">
-          <p className="text-sm font-mono text-muted-foreground">{slug}</p>
+        <div className="bg-background rounded-md border px-3 py-2">
+          <p className="text-muted-foreground font-mono text-sm">{slug}</p>
         </div>
       </motion.div>
     </div>

--- a/client/dashboard/src/pages/org/OrgAdminSettings.tsx
+++ b/client/dashboard/src/pages/org/OrgAdminSettings.tsx
@@ -37,9 +37,9 @@ export default function OrgAdminSettings() {
         <Type muted small className="mb-4">
           Details about the current organization.
         </Type>
-        <div className="rounded-lg border border-border bg-card p-4 mb-8">
+        <div className="border-border bg-card mb-8 rounded-lg border p-4">
           <Stack direction="horizontal" align="center" gap={2} className="mb-3">
-            <Building2 className="h-4 w-4 text-muted-foreground" />
+            <Building2 className="text-muted-foreground h-4 w-4" />
             <Type variant="body" className="font-medium">
               Organization
             </Type>
@@ -71,9 +71,9 @@ export default function OrgAdminSettings() {
           Impersonate a different organization by switching to its slug. This
           will log you out and redirect you to the target organization.
         </Type>
-        <div className="rounded-lg border border-border bg-card p-4">
+        <div className="border-border bg-card rounded-lg border p-4">
           <Stack direction="horizontal" align="center" gap={2} className="mb-4">
-            <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
+            <ArrowRightLeft className="text-muted-foreground h-4 w-4" />
             <Type variant="body" className="font-medium">
               Switch Organization
             </Type>
@@ -91,7 +91,7 @@ export default function OrgAdminSettings() {
               await client.auth.logout();
               window.location.href = "/login";
             }}
-            className="ml-6 flex gap-2 max-w-md"
+            className="ml-6 flex max-w-md gap-2"
           >
             <Input
               placeholder="organization-slug"

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -204,7 +204,7 @@ export default function OrgApiKeys() {
           noResultsMessage={
             <Stack
               gap={2}
-              className="h-full p-4 bg-background"
+              className="bg-background h-full p-4"
               align="center"
               justify="center"
             >
@@ -239,11 +239,11 @@ export default function OrgApiKeys() {
             </Dialog.Header>
             {newlyCreatedKey ? (
               <div className="space-y-4 py-4">
-                <div className="rounded-lg border border-yellow-500/50 bg-yellow-600/50 text-foreground p-4 text-sm">
+                <div className="text-foreground rounded-lg border border-yellow-500/50 bg-yellow-600/50 p-4 text-sm">
                   You will not be able to see this token value again once you
                   close this dialog. Copy it now and store it securely.
                 </div>
-                <div className="flex items-center space-x-2 bg-muted p-3 rounded-md">
+                <div className="bg-muted flex items-center space-x-2 rounded-md p-3">
                   <code className="flex-1 break-all">
                     {newlyCreatedKey.key}
                   </code>
@@ -342,7 +342,7 @@ export default function OrgApiKeys() {
             <div className="space-y-4 py-4">
               <Type variant="body">
                 Are you sure you want to revoke the API key{" "}
-                <span className="italic font-bold">{keyToRevoke?.name}</span>?
+                <span className="font-bold italic">{keyToRevoke?.name}</span>?
                 This action cannot be undone.
               </Type>
               <div className="flex justify-end space-x-2">

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -71,7 +71,7 @@ function getDateKey(date: Date, mode: "utc" | "local") {
 }
 
 function StrongName({ children }: { children: ReactNode }) {
-  return <strong className="font-semibold text-foreground">{children}</strong>;
+  return <strong className="text-foreground font-semibold">{children}</strong>;
 }
 
 function getActorLabel(log: AuditLog) {
@@ -352,7 +352,7 @@ function AuditLogRow({
           <StrongName>
             {highlightMatch ? highlightMatch(actorLabel) : actorLabel}
           </StrongName>
-          <span className="mx-1.5 text-muted-foreground">
+          <span className="text-muted-foreground mx-1.5">
             {highlightMatch ? highlightMatch(verbText) : verbText}
           </span>
           {renderSubject(log, orgSlug)}
@@ -367,7 +367,7 @@ function AuditLogRow({
           </button>
         )}
       </div>
-      <span className="shrink-0 font-mono text-xs text-muted-foreground">
+      <span className="text-muted-foreground shrink-0 font-mono text-xs">
         {formatTimeOnly(log.createdAt, timestampMode)}
       </span>
     </div>
@@ -377,7 +377,7 @@ function AuditLogRow({
     return (
       <div
         ref={rowRef}
-        className={cn(isHighlighted && "border-l-4 border-l-foreground")}
+        className={cn(isHighlighted && "border-l-foreground border-l-4")}
       >
         <div
           className={cn(
@@ -387,7 +387,7 @@ function AuditLogRow({
         >
           {rowContent}
         </div>
-        <div className="rounded-b-lg border border-t-0 bg-background px-4 pb-3 pt-2">
+        <div className="bg-background rounded-b-lg border border-t-0 px-4 pt-2 pb-3">
           <StructuredDiff log={log} />
         </div>
       </div>
@@ -400,7 +400,7 @@ function AuditLogRow({
       className={cn(
         "rounded-none transition-colors",
         isOdd ? "bg-muted/30" : "bg-background",
-        isHighlighted && "border-l-4 border-l-foreground",
+        isHighlighted && "border-l-foreground border-l-4",
       )}
     >
       {rowContent}
@@ -417,10 +417,10 @@ function DateGroupHeader({
 }) {
   return (
     <div className="flex items-center gap-3 px-4 py-2">
-      <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+      <span className="text-muted-foreground shrink-0 text-[11px] font-semibold tracking-wide uppercase">
         {formatDateHeader(date, mode)}
       </span>
-      <div className="h-px flex-1 bg-border" />
+      <div className="bg-border h-px flex-1" />
     </div>
   );
 }
@@ -474,7 +474,7 @@ function FacetSelect({
         {label}
       </Type>
       <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger size="sm" className="min-w-[220px] bg-background">
+        <SelectTrigger size="sm" className="bg-background min-w-[220px]">
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>
@@ -691,7 +691,7 @@ export default function OrgAuditLogs() {
             part.toLowerCase() === searchQuery.toLowerCase() ? (
               <mark
                 key={i}
-                className="bg-yellow-200 dark:bg-yellow-800 text-inherit"
+                className="bg-yellow-200 text-inherit dark:bg-yellow-800"
               >
                 {part}
               </mark>
@@ -874,7 +874,7 @@ export default function OrgAuditLogs() {
               <Type small muted>
                 Timestamp
               </Type>
-              <div className="flex h-8 items-center gap-2 rounded-md border bg-background px-3">
+              <div className="bg-background flex h-8 items-center gap-2 rounded-md border px-3">
                 <Type
                   small
                   className={
@@ -906,25 +906,25 @@ export default function OrgAuditLogs() {
             </div>
           </div>
 
-          <div className="overflow-hidden rounded-lg border bg-background">
+          <div className="bg-background overflow-hidden rounded-lg border">
             {/* Search toolbar */}
             {!isLoading && !error && logs.length > 0 && (
-              <div className="flex items-center gap-2 border-b bg-surface/50 p-2">
-                <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+              <div className="bg-surface/50 flex items-center gap-2 border-b p-2">
+                <div className="text-muted-foreground flex items-center gap-3 text-[11px]">
                   {searchQuery ? (
                     <>
                       <span className="flex items-center gap-1">
-                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                           N
                         </kbd>
                         <span>/</span>
-                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                           ⇧N
                         </kbd>
                         <span className="ml-0.5">results</span>
                       </span>
                       <span className="flex items-center gap-1">
-                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                           ESC
                         </kbd>
                         <span>clear</span>
@@ -933,23 +933,23 @@ export default function OrgAuditLogs() {
                   ) : (
                     <>
                       <span className="flex items-center gap-1">
-                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                           J
                         </kbd>
                         <span>/</span>
-                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                           K
                         </kbd>
                         <span className="ml-0.5">navigate</span>
                       </span>
                       <span className="flex items-center gap-1">
-                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                           G
                         </kbd>
                         <span>first</span>
                       </span>
                       <span className="flex items-center gap-1">
-                        <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                           ⇧G
                         </kbd>
                         <span>last</span>
@@ -957,10 +957,10 @@ export default function OrgAuditLogs() {
                     </>
                   )}
                 </div>
-                <div className="ml-auto relative">
+                <div className="relative ml-auto">
                   <Icon
                     name="search"
-                    className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                    className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3 -translate-y-1/2"
                   />
                   <Input
                     data-audit-search-input
@@ -970,28 +970,28 @@ export default function OrgAuditLogs() {
                     onChange={(e) => handleSearchChange(e.target.value)}
                     onFocus={() => setSearchInputFocused(true)}
                     onBlur={() => setSearchInputFocused(false)}
-                    className="pl-7 pr-16 w-56 text-xs py-1 rounded-sm"
+                    className="w-56 rounded-sm py-1 pr-16 pl-7 text-xs"
                   />
                   {searchQuery || searchInputFocused ? (
                     searchMatchIndices.length > 0 ? (
-                      <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                        <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                      <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5">
+                        <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
                           ESC
                         </span>
-                        <span className="text-[10px] text-muted-foreground mx-0.5">
+                        <span className="text-muted-foreground mx-0.5 text-[10px]">
                           {effectiveSearchIndex + 1}/{searchMatchIndices.length}
                         </span>
                         <div className="flex items-center">
                           <button
                             onClick={() => navigateToResult("prev")}
-                            className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                            className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
                             title="Previous (Shift+N)"
                           >
                             <Icon name="chevron-up" className="size-2.5" />
                           </button>
                           <button
                             onClick={() => navigateToResult("next")}
-                            className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                            className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
                             title="Next (N)"
                           >
                             <Icon name="chevron-down" className="size-2.5" />
@@ -999,18 +999,18 @@ export default function OrgAuditLogs() {
                         </div>
                       </div>
                     ) : (
-                      <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                        <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                      <div className="absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center gap-0.5">
+                        <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
                           ESC
                         </span>
-                        <span className="text-[10px] text-muted-foreground ml-0.5">
+                        <span className="text-muted-foreground ml-0.5 text-[10px]">
                           0/0
                         </span>
                       </div>
                     )
                   ) : (
-                    <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
-                      <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm font-mono">
+                    <div className="absolute top-1/2 right-2 flex -translate-y-1/2 items-center">
+                      <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
                         /
                       </span>
                     </div>
@@ -1025,7 +1025,7 @@ export default function OrgAuditLogs() {
               className="focus:outline-none"
             >
               {isLoading ? (
-                <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+                <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
                   <Icon name="loader-circle" className="size-4 animate-spin" />
                   <span>Loading audit logs...</span>
                 </div>
@@ -1079,7 +1079,7 @@ export default function OrgAuditLogs() {
             </div>
 
             {(logs.length > 0 || isFetchingNextPage) && (
-              <div className="flex items-center justify-between border-t bg-muted/20 px-4 py-3">
+              <div className="bg-muted/20 flex items-center justify-between border-t px-4 py-3">
                 <Type muted small>
                   {logs.length.toLocaleString()} audit log
                   {logs.length === 1 ? "" : "s"}

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -148,31 +148,31 @@ export default function OrgDomains() {
           branded URL instead of the default Gram domain.
         </Type>
         {domain?.domain ? (
-          <div className="rounded-lg border border-border bg-card p-4">
+          <div className="border-border bg-card rounded-lg border p-4">
             <Stack direction="horizontal" justify="space-between" align="start">
               <Stack gap={1}>
                 <Stack direction="horizontal" align="center" gap={2}>
-                  <Globe className="h-4 w-4 text-muted-foreground" />
+                  <Globe className="text-muted-foreground h-4 w-4" />
                   <Type variant="body" className="font-mono font-medium">
                     {domain.domain}
                   </Type>
                   {domain.isUpdating ? (
                     <SimpleTooltip tooltip="Your domain is being verified. This may take a few minutes.">
-                      <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
+                      <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
                     </SimpleTooltip>
                   ) : domain.verified ? (
                     <SimpleTooltip tooltip="Domain verified and active">
-                      <Check className="w-4 h-4 stroke-3 text-green-500" />
+                      <Check className="h-4 w-4 stroke-3 text-green-500" />
                     </SimpleTooltip>
                   ) : (
                     <SimpleTooltip tooltip="Domain verification failed. Ensure your DNS records are set up correctly.">
-                      <X className="w-4 h-4 stroke-3 text-red-500" />
+                      <X className="h-4 w-4 stroke-3 text-red-500" />
                     </SimpleTooltip>
                   )}
                 </Stack>
                 <Type
                   variant="body"
-                  className="text-muted-foreground text-sm ml-6"
+                  className="text-muted-foreground ml-6 text-sm"
                 >
                   Linked <HumanizeDateTime date={domain.createdAt} />
                 </Type>
@@ -202,7 +202,7 @@ export default function OrgDomains() {
           </div>
         ) : (
           !domainIsLoading && (
-            <div className="rounded-lg border border-dashed border-border p-6">
+            <div className="border-border rounded-lg border border-dashed p-6">
               <Stack gap={2} align="center" justify="center">
                 <Type variant="body" className="text-muted-foreground">
                   No custom domain configured
@@ -244,7 +244,7 @@ export default function OrgDomains() {
             <div className="space-y-4 py-4">
               <Type variant="body">
                 Are you sure you want to remove{" "}
-                <span className="italic font-bold">{domain?.domain}</span>? This
+                <span className="font-bold italic">{domain?.domain}</span>? This
                 will delete the associated ingress and TLS certificate.
               </Type>
               <div className="flex justify-end space-x-2">
@@ -278,11 +278,11 @@ export default function OrgDomains() {
             <Dialog.Header>
               <Dialog.Title>Connect a Custom Domain</Dialog.Title>
             </Dialog.Header>
-            <div className="space-y-6 py-4 min-h-[420px]">
+            <div className="min-h-[420px] space-y-6 py-4">
               <div>
                 <Type
                   variant="body"
-                  className="font-extrabold text-lg mb-2 block"
+                  className="mb-2 block text-lg font-extrabold"
                 >
                   Step 1
                 </Type>
@@ -302,7 +302,7 @@ export default function OrgDomains() {
                     readOnly={!!domain?.domain}
                   />
                   {domainError && (
-                    <Type variant="body" className="text-red-500 text-sm">
+                    <Type variant="body" className="text-sm text-red-500">
                       {domainError}
                     </Type>
                   )}
@@ -311,7 +311,7 @@ export default function OrgDomains() {
               <div>
                 <Type
                   variant="body"
-                  className="font-extrabold text-lg mb-2 block"
+                  className="mb-2 block text-lg font-extrabold"
                 >
                   Step 2
                 </Type>
@@ -320,7 +320,7 @@ export default function OrgDomains() {
                   <span className="font-mono break-all">{subdomain}</span>{" "}
                   pointing to the following:
                 </Type>
-                <div className="flex items-center space-x-2 bg-muted p-3 rounded-md mt-2">
+                <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
                   <code className="flex-1 break-all">{CNAME_VALUE}</code>
                   <Button
                     variant="tertiary"
@@ -339,7 +339,7 @@ export default function OrgDomains() {
               <div>
                 <Type
                   variant="body"
-                  className="font-extrabold text-lg mb-2 block"
+                  className="mb-2 block text-lg font-extrabold"
                 >
                   Step 3
                 </Type>
@@ -348,7 +348,7 @@ export default function OrgDomains() {
                   <span className="font-mono break-all">{txtName}</span> with
                   the following value:
                 </Type>
-                <div className="flex items-center space-x-2 bg-muted p-3 rounded-md mt-2">
+                <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
                   <code className="flex-1 break-all">{txtValue}</code>
                   <Button
                     variant="tertiary"
@@ -364,7 +364,7 @@ export default function OrgDomains() {
                   </Button>
                 </div>
               </div>
-              <div className="flex justify-end mt-4">
+              <div className="mt-4 flex justify-end">
                 <Button
                   onClick={handleRegisterDomain}
                   disabled={

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -63,13 +63,13 @@ export default function OrgHome() {
                   setNewProjectName(search);
                   setCreateDialogOpen(true);
                 }}
-                className="text-left hover:no-underline w-full max-w-md"
+                className="w-full max-w-md text-left hover:no-underline"
               >
                 <DotCard
                   icon={
-                    <Plus className="h-10 w-10 text-muted-foreground group-hover:text-primary transition-colors" />
+                    <Plus className="text-muted-foreground group-hover:text-primary h-10 w-10 transition-colors" />
                   }
-                  className="border-dashed !border-foreground/10 hover:!border-foreground/20"
+                  className="!border-foreground/10 hover:!border-foreground/20 border-dashed"
                 >
                   <Type
                     variant="subheading"
@@ -82,10 +82,10 @@ export default function OrgHome() {
                     Create a new project with this name
                   </Type>
 
-                  <div className="flex items-center justify-end mt-auto pt-2">
-                    <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+                  <div className="mt-auto flex items-center justify-end pt-2">
+                    <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
                       <span>Create</span>
-                      <Plus className="w-3.5 h-3.5" />
+                      <Plus className="h-3.5 w-3.5" />
                     </div>
                   </div>
                 </DotCard>
@@ -93,7 +93,7 @@ export default function OrgHome() {
             </div>
           </div>
         ) : (
-          <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
             {projects.map((project) => (
               <Link
                 key={project.id}
@@ -111,18 +111,18 @@ export default function OrgHome() {
                   <Type
                     variant="subheading"
                     as="div"
-                    className="truncate text-md group-hover:text-primary transition-colors"
+                    className="text-md group-hover:text-primary truncate transition-colors"
                   >
                     {project.name}
                   </Type>
-                  <Type small muted className="truncate mb-3">
+                  <Type small muted className="mb-3 truncate">
                     {project.slug}
                   </Type>
 
-                  <div className="flex items-center justify-end mt-auto pt-2">
-                    <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+                  <div className="mt-auto flex items-center justify-end pt-2">
+                    <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
                       <span>Open</span>
-                      <ArrowRight className="w-3.5 h-3.5" />
+                      <ArrowRight className="h-3.5 w-3.5" />
                     </div>
                   </div>
                 </DotCard>
@@ -135,9 +135,9 @@ export default function OrgHome() {
             >
               <DotCard
                 icon={
-                  <Plus className="h-10 w-10 text-muted-foreground group-hover:text-primary transition-colors" />
+                  <Plus className="text-muted-foreground group-hover:text-primary h-10 w-10 transition-colors" />
                 }
-                className="border-dashed !border-foreground/10 hover:!border-foreground/20"
+                className="!border-foreground/10 hover:!border-foreground/20 border-dashed"
               >
                 <Type
                   variant="subheading"
@@ -150,10 +150,10 @@ export default function OrgHome() {
                   Create a new project for your organization
                 </Type>
 
-                <div className="flex items-center justify-end mt-auto pt-2">
-                  <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+                <div className="mt-auto flex items-center justify-end pt-2">
+                  <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
                     <span>Create</span>
-                    <Plus className="w-3.5 h-3.5" />
+                    <Plus className="h-3.5 w-3.5" />
                   </div>
                 </div>
               </DotCard>

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -101,7 +101,7 @@ export default function OrgLogs() {
           enabled, tool calls and traces are recorded for debugging and
           analytics.
         </Type>
-        <div className="rounded-lg border border-border bg-card p-4">
+        <div className="border-border bg-card rounded-lg border p-4">
           <Stack gap={4}>
             <Stack
               direction="horizontal"
@@ -110,14 +110,14 @@ export default function OrgLogs() {
             >
               <Stack gap={1}>
                 <Stack direction="horizontal" align="center" gap={2}>
-                  <FileText className="h-4 w-4 text-muted-foreground" />
+                  <FileText className="text-muted-foreground h-4 w-4" />
                   <Type variant="body" className="font-medium">
                     Enable Logs
                   </Type>
                 </Stack>
                 <Type
                   variant="body"
-                  className="text-muted-foreground text-sm ml-6"
+                  className="text-muted-foreground ml-6 text-sm"
                 >
                   Record tool call traces and telemetry data
                 </Type>
@@ -132,7 +132,7 @@ export default function OrgLogs() {
               )}
             </Stack>
 
-            <div className="border-t border-border" />
+            <div className="border-border border-t" />
 
             <Stack
               direction="horizontal"
@@ -141,14 +141,14 @@ export default function OrgLogs() {
             >
               <Stack gap={1}>
                 <Stack direction="horizontal" align="center" gap={2}>
-                  <Eye className="h-4 w-4 text-muted-foreground" />
+                  <Eye className="text-muted-foreground h-4 w-4" />
                   <Type variant="body" className="font-medium">
                     Record Tool I/O
                   </Type>
                 </Stack>
                 <Type
                   variant="body"
-                  className="text-muted-foreground text-sm ml-6"
+                  className="text-muted-foreground ml-6 text-sm"
                 >
                   Store tool inputs and outputs. May expose sensitive data in
                   logs.
@@ -164,7 +164,7 @@ export default function OrgLogs() {
               )}
             </Stack>
 
-            <div className="border-t border-border" />
+            <div className="border-border border-t" />
 
             <Stack
               direction="horizontal"
@@ -173,14 +173,14 @@ export default function OrgLogs() {
             >
               <Stack gap={1}>
                 <Stack direction="horizontal" align="center" gap={2}>
-                  <Monitor className="h-4 w-4 text-muted-foreground" />
+                  <Monitor className="text-muted-foreground h-4 w-4" />
                   <Type variant="body" className="font-medium">
                     Claude Code Session Capture
                   </Type>
                 </Stack>
                 <Type
                   variant="body"
-                  className="text-muted-foreground text-sm ml-6"
+                  className="text-muted-foreground ml-6 text-sm"
                 >
                   Capture user prompts and assistant responses from Claude Code
                   sessions. Sessions appear in the Agent Sessions tab.

--- a/client/dashboard/src/pages/org/OrgProjects.tsx
+++ b/client/dashboard/src/pages/org/OrgProjects.tsx
@@ -51,22 +51,22 @@ export default function OrgProjects() {
             No projects yet.
           </Type>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {projects.map((project) => (
               <Link
                 key={project.id}
                 to={`/${orgSlug}/projects/${project.slug}`}
-                className="group rounded-lg border border-border bg-card p-4 hover:border-foreground/20 hover:bg-accent/50 transition-colors hover:no-underline"
+                className="group border-border bg-card hover:border-foreground/20 hover:bg-accent/50 rounded-lg border p-4 transition-colors hover:no-underline"
               >
                 <div className="flex items-center gap-3">
                   <ProjectAvatar
                     project={project}
-                    className="h-8 w-8 rounded-md shrink-0"
+                    className="h-8 w-8 shrink-0 rounded-md"
                   />
                   <div className="min-w-0">
                     <Type
                       variant="body"
-                      className="font-medium truncate block text-foreground"
+                      className="text-foreground block truncate font-medium"
                     >
                       {project.name}
                     </Type>

--- a/client/dashboard/src/pages/playground/Agentify.tsx
+++ b/client/dashboard/src/pages/playground/Agentify.tsx
@@ -292,13 +292,13 @@ export const AgentifyButton = ({
           </Dialog.Header>
           <Stack gap={4}>
             <Stack gap={1}>
-              <Heading variant="h5" className="normal-case font-medium">
+              <Heading variant="h5" className="font-medium normal-case">
                 What language should the agent be written in?
               </Heading>
               <SdkLanguageDropdown lang={lang} setLang={setLang} />
             </Stack>
             <Stack gap={1}>
-              <Heading variant="h5" className="normal-case font-medium">
+              <Heading variant="h5" className="font-medium normal-case">
                 {prompt
                   ? "What should the agent do?"
                   : "Distilling chat history..."}

--- a/client/dashboard/src/pages/playground/ChatWindow.tsx
+++ b/client/dashboard/src/pages/playground/ChatWindow.tsx
@@ -551,7 +551,7 @@ function ChatInner({
     useMessageHistoryNavigation(chatMessages);
 
   const chatContent = (
-    <div className="relative h-full flex flex-col">
+    <div className="relative flex h-full flex-col">
       <Conversation className="flex-1">
         <ConversationContent>
           {messagesToDisplay.map((message) => (
@@ -576,7 +576,7 @@ function ChatInner({
           <PromptInputBody>
             <PromptInputTextarea placeholder="Send a message..." />
           </PromptInputBody>
-          <PromptInputFooter className="bg-secondary border-t border-neutral-softest rounded-bl-lg rounded-br-lg">
+          <PromptInputFooter className="bg-secondary border-neutral-softest rounded-br-lg rounded-bl-lg border-t">
             <PromptInputTools>{additionalActions}</PromptInputTools>
             <PromptInputSubmit
               disabled={status === "streaming"}

--- a/client/dashboard/src/pages/playground/EditToolDialog.tsx
+++ b/client/dashboard/src/pages/playground/EditToolDialog.tsx
@@ -182,10 +182,10 @@ export function EditToolDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content className="min-w-2xl max-w-3xl">
+      <Dialog.Content className="max-w-3xl min-w-2xl">
         <Dialog.Header>
           <Dialog.Title className="flex items-center gap-2">
-            <ToolIcon className="size-4 text-muted-foreground" />
+            <ToolIcon className="text-muted-foreground size-4" />
             <span>{source}</span>
             <Badge variant="secondary" className="text-xs">
               {typeLabel}
@@ -194,7 +194,7 @@ export function EditToolDialog({
         </Dialog.Header>
 
         {/* Editable fields */}
-        <div className="py-4 space-y-4">
+        <div className="space-y-4 py-4">
           <div className="space-y-2">
             <Label htmlFor="tool-name" className="text-sm font-medium">
               Name
@@ -239,14 +239,14 @@ export function EditToolDialog({
           {hasAnnotations && (
             <div className="space-y-3">
               <Label className="text-sm font-medium">Behavior Hints</Label>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-muted-foreground text-xs">
                 Override how this tool is presented to AI models.
               </p>
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="text-sm">Read-only</p>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       Tool does not modify its environment
                     </p>
                   </div>
@@ -259,7 +259,7 @@ export function EditToolDialog({
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="text-sm">Destructive</p>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       Tool may perform destructive updates
                     </p>
                   </div>
@@ -272,7 +272,7 @@ export function EditToolDialog({
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="text-sm">Idempotent</p>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       Repeated calls with same arguments have no additional
                       effect
                     </p>
@@ -286,7 +286,7 @@ export function EditToolDialog({
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="text-sm">Open-world</p>
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-muted-foreground text-xs">
                       Tool interacts with external entities
                     </p>
                   </div>
@@ -302,7 +302,7 @@ export function EditToolDialog({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-between pt-4 border-t">
+        <div className="flex items-center justify-between border-t pt-4">
           <Button variant="destructive-secondary" onClick={handleRemove}>
             Remove
           </Button>

--- a/client/dashboard/src/pages/playground/ManageToolsDialog.tsx
+++ b/client/dashboard/src/pages/playground/ManageToolsDialog.tsx
@@ -151,7 +151,7 @@ export function ManageToolsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content className="min-w-3xl max-h-[80vh] flex flex-col">
+      <Dialog.Content className="flex max-h-[80vh] min-w-3xl flex-col">
         <Dialog.Header>
           <Dialog.Title>
             {mode === "add" ? "Add tools" : "Manage tools"}
@@ -164,7 +164,7 @@ export function ManageToolsDialog({
           </Dialog.Description>
         </Dialog.Header>
 
-        <div className="flex flex-col gap-4 flex-1 min-h-0">
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
           {/* Mode toggle + Filters */}
           <div className="flex gap-2">
             <Select
@@ -205,11 +205,11 @@ export function ManageToolsDialog({
           {/* Tool list with selection mode */}
           <div className="flex-1 overflow-auto">
             {isLoading ? (
-              <div className="text-center py-8 text-neutral-500">
+              <div className="py-8 text-center text-neutral-500">
                 Loading tools...
               </div>
             ) : filteredTools.length === 0 ? (
-              <div className="text-center py-8 text-neutral-500">
+              <div className="py-8 text-center text-neutral-500">
                 {noResultsMessage}
               </div>
             ) : (

--- a/client/dashboard/src/pages/playground/MessageHistoryIndicator.tsx
+++ b/client/dashboard/src/pages/playground/MessageHistoryIndicator.tsx
@@ -17,7 +17,7 @@ export function MessageHistoryIndicator({
   }
 
   return (
-    <div className="absolute bottom-2 right-2 bg-background/80 backdrop-blur-sm border rounded-md px-2 py-1 z-10">
+    <div className="bg-background/80 absolute right-2 bottom-2 z-10 rounded-md border px-2 py-1 backdrop-blur-sm">
       <Stack direction="horizontal" gap={1} align="center">
         <Type variant="small" muted className="text-xs">
           History: {historyIndex + 1}/{totalMessages}

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -100,7 +100,7 @@ function PlaygroundInner() {
           <Page.Header.Breadcrumbs fullWidth />
         </Page.Header>
         <Page.Body>
-          <div className="h-full flex m-8">
+          <div className="m-8 flex h-full">
             <ToolsetsEmptyState onCreateToolset={() => routes.mcp.goTo()} />
           </div>
         </Page.Body>
@@ -110,7 +110,7 @@ function PlaygroundInner() {
 
   const logsButton = (
     <Button size="sm" variant="ghost" onClick={() => setShowLogs(!showLogs)}>
-      <ScrollTextIcon className="size-4 mr-2" />
+      <ScrollTextIcon className="mr-2 size-4" />
       {showLogs ? "Hide" : "Show"} Logs
     </Button>
   );
@@ -123,7 +123,7 @@ function PlaygroundInner() {
       <Page.Body fullWidth fullHeight className="p-0">
         <ResizablePanel
           direction="horizontal"
-          className="h-full [&>[role='separator']]:w-px [&>[role='separator']]:bg-neutral-softest [&>[role='separator']]:border-0 [&>[role='separator']]:hover:bg-primary [&>[role='separator']]:relative [&>[role='separator']]:before:absolute [&>[role='separator']]:before:inset-y-0 [&>[role='separator']]:before:-left-1 [&>[role='separator']]:before:-right-1 [&>[role='separator']]:before:cursor-col-resize"
+          className="[&>[role='separator']]:bg-neutral-softest [&>[role='separator']]:hover:bg-primary h-full [&>[role='separator']]:relative [&>[role='separator']]:w-px [&>[role='separator']]:border-0 [&>[role='separator']]:before:absolute [&>[role='separator']]:before:inset-y-0 [&>[role='separator']]:before:-right-1 [&>[role='separator']]:before:-left-1 [&>[role='separator']]:before:cursor-col-resize"
         >
           <ResizablePanel.Pane minSize={20} defaultSize={25}>
             <ToolsetPanel
@@ -140,14 +140,14 @@ function PlaygroundInner() {
             />
           </ResizablePanel.Pane>
           <ResizablePanel.Pane minSize={35} order={0}>
-            <div className="h-full flex flex-col">
+            <div className="flex h-full flex-col">
               <PlaygroundElements
                 toolsetSlug={selectedToolset}
                 environmentSlug={selectedEnvironment}
                 model={model}
                 playgroundEnvironmentSlug={playgroundEnvironmentSlug}
                 additionalActions={
-                  <div className="flex items-center justify-end w-full px-4">
+                  <div className="flex w-full items-center justify-end px-4">
                     <ShareChatButton />
                     {logsButton}
                   </div>
@@ -370,7 +370,7 @@ export function ToolsetPanel({
   // If listToolsets has completed and there's nothing there, show the onboarding panel
   if (toolsets !== undefined && !configRef.current.toolsetSlug) {
     return (
-      <div className="h-full flex items-center justify-center p-8">
+      <div className="flex h-full items-center justify-center p-8">
         <ToolsetsEmptyState onCreateToolset={() => routes.mcp.goTo()} />
       </div>
     );

--- a/client/dashboard/src/pages/playground/PlaygroundAuth.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundAuth.tsx
@@ -279,7 +279,7 @@ function ExternalMcpOAuthConnection({
     oauthMode === "custom-proxy" ? "MCP OAuth 2.1" : "OAuth";
 
   return (
-    <div className="border rounded-md p-3 bg-muted/30">
+    <div className="bg-muted/30 rounded-md border p-3">
       <Stack gap={2}>
         <Stack
           direction="horizontal"
@@ -290,10 +290,10 @@ function ExternalMcpOAuthConnection({
             {oauthVersionLabel}
           </Type>
           {statusLoading ? (
-            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            <Loader2 className="text-muted-foreground size-4 animate-spin" />
           ) : isConnected ? (
             <Badge variant="success">
-              <CheckCircle className="size-3 mr-1" />
+              <CheckCircle className="mr-1 size-3" />
               Connected
             </Badge>
           ) : (
@@ -313,7 +313,7 @@ function ExternalMcpOAuthConnection({
             onClick={() => disconnectMutation.mutate()}
             disabled={disconnectMutation.isPending}
           >
-            <LogOut className="size-3 mr-2" />
+            <LogOut className="mr-2 size-3" />
             Disconnect
           </Button>
         ) : (
@@ -323,7 +323,7 @@ function ExternalMcpOAuthConnection({
             className="w-full"
             onClick={handleConnect}
           >
-            <ExternalLink className="size-3 mr-2" />
+            <ExternalLink className="mr-2 size-3" />
             Connect
           </Button>
         )}
@@ -437,7 +437,7 @@ export function PlaygroundAuth({
   // Show "no auth required" only if there are no env vars AND no OAuth
   if (envVars.length === 0 && !hasOAuth) {
     return (
-      <div className="text-center py-4">
+      <div className="py-4 text-center">
         <Type variant="small" className="text-muted-foreground">
           No authentication required
         </Type>
@@ -536,7 +536,7 @@ export function PlaygroundAuth({
                 }));
               }}
               placeholder={placeholder}
-              className="font-mono text-xs h-7"
+              className="h-7 font-mono text-xs"
               readOnly={!isEditable}
               disabled={!isEditable}
             />
@@ -552,7 +552,7 @@ export function PlaygroundAuth({
           disabled={editedKeys.size === 0 || playgroundEnv.isSaving}
         >
           {playgroundEnv.isSaving ? (
-            <Loader2 className="size-3 mr-2 animate-spin" />
+            <Loader2 className="mr-2 size-3 animate-spin" />
           ) : null}
           Save
         </Button>
@@ -567,7 +567,7 @@ export function PlaygroundAuth({
         <routes.mcp.details.Link
           params={[toolset.slug]}
           hash="authentication"
-          className="underline hover:text-foreground"
+          className="hover:text-foreground underline"
         >
           Configure auth
         </routes.mcp.details.Link>

--- a/client/dashboard/src/pages/playground/PlaygroundConfigPanel.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundConfigPanel.tsx
@@ -295,10 +295,10 @@ export function PlaygroundConfigPanel({
   };
 
   return (
-    <div className="h-full flex flex-col border-r overflow-y-auto">
+    <div className="flex h-full flex-col overflow-y-auto border-r">
       {/* Toolset Selector - Always at top */}
-      <div className="px-4 py-3 border-b">
-        <Label className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-1.5 block">
+      <div className="border-b px-4 py-3">
+        <Label className="text-muted-foreground mb-1.5 block text-[11px] font-medium tracking-wider uppercase">
           MCP Server
         </Label>
         {toolsetSelector}
@@ -308,19 +308,19 @@ export function PlaygroundConfigPanel({
       {authSettings && (
         <div className="border-b">
           <Collapsible open={authOpen} onOpenChange={setAuthOpen}>
-            <CollapsibleTrigger className="flex w-full items-center px-4 py-2.5 hover:bg-muted/30 transition-colors group">
+            <CollapsibleTrigger className="hover:bg-muted/30 group flex w-full items-center px-4 py-2.5 transition-colors">
               <div className="flex items-center gap-1.5">
-                <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <span className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
                   Authentication
                 </span>
                 {authOpen ? (
-                  <ChevronDownIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                  <ChevronDownIcon className="text-muted-foreground h-3.5 w-3.5" />
                 ) : (
-                  <ChevronRightIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                  <ChevronRightIcon className="text-muted-foreground h-3.5 w-3.5" />
                 )}
               </div>
             </CollapsibleTrigger>
-            <CollapsibleContent className="px-4 pb-3 pt-2">
+            <CollapsibleContent className="px-4 pt-2 pb-3">
               {authSettings}
             </CollapsibleContent>
           </Collapsible>
@@ -330,15 +330,15 @@ export function PlaygroundConfigPanel({
       {/* Tools Section */}
       <div className="border-b">
         <Collapsible open={toolsOpen} onOpenChange={setToolsOpen}>
-          <CollapsibleTrigger className="flex w-full items-center justify-between px-4 py-2.5 hover:bg-muted/30 transition-colors group">
+          <CollapsibleTrigger className="hover:bg-muted/30 group flex w-full items-center justify-between px-4 py-2.5 transition-colors">
             <div className="flex items-center gap-1.5">
-              <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <span className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
                 Tools
               </span>
               {toolsOpen ? (
-                <ChevronDownIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                <ChevronDownIcon className="text-muted-foreground h-3.5 w-3.5" />
               ) : (
-                <ChevronRightIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                <ChevronRightIcon className="text-muted-foreground h-3.5 w-3.5" />
               )}
             </div>
 
@@ -364,19 +364,19 @@ export function PlaygroundConfigPanel({
                       {/* Group Header */}
                       <button
                         onClick={() => toggleGroup(group.title)}
-                        className="w-full px-3 py-2 flex items-center gap-2 bg-surface-secondary-default hover:bg-active transition-colors text-left group/item"
+                        className="bg-surface-secondary-default hover:bg-active group/item flex w-full items-center gap-2 px-3 py-2 text-left transition-colors"
                       >
-                        <group.icon className="size-3.5 shrink-0 text-muted-foreground" />
+                        <group.icon className="text-muted-foreground size-3.5 shrink-0" />
                         <div className="min-w-0 truncate text-xs">
                           {group.title}
                         </div>
                         {isExpanded ? (
-                          <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                          <ChevronDownIcon className="text-muted-foreground size-3.5 shrink-0" />
                         ) : (
-                          <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                          <ChevronRightIcon className="text-muted-foreground size-3.5 shrink-0" />
                         )}
                         <div className="flex-1" />
-                        <div className="text-[11px] text-muted-foreground tabular-nums">
+                        <div className="text-muted-foreground text-[11px] tabular-nums">
                           {group.tools.length}
                         </div>
                       </button>
@@ -388,26 +388,26 @@ export function PlaygroundConfigPanel({
                             return (
                               <div
                                 key={tool.toolUrn}
-                                className="group w-full px-3 py-2 flex items-center gap-2 hover:bg-muted/30 transition-colors"
+                                className="group hover:bg-muted/30 flex w-full items-center gap-2 px-3 py-2 transition-colors"
                               >
                                 <button
                                   onClick={() => tool && onToolClick?.(tool)}
-                                  className="flex-1 flex items-center justify-between text-left min-w-0"
+                                  className="flex min-w-0 flex-1 items-center justify-between text-left"
                                 >
-                                  <p className="text-xs leading-5 text-foreground truncate">
+                                  <p className="text-foreground truncate text-xs leading-5">
                                     {tool.name}
                                   </p>
-                                  <div className="flex items-center gap-2 shrink-0 ml-2">
+                                  <div className="ml-2 flex shrink-0 items-center gap-2">
                                     <AnnotationBadges tool={tool} />
                                     {tool.type === "http" &&
                                       tool.httpMethod && (
                                         <MethodBadge method={tool.httpMethod} />
                                       )}
                                     {tool.type === "function" && (
-                                      <SquareFunction className="size-3.5 text-muted-foreground" />
+                                      <SquareFunction className="text-muted-foreground size-3.5" />
                                     )}
                                     {tool.type === "prompt" && (
-                                      <PencilRuler className="size-3.5 text-muted-foreground" />
+                                      <PencilRuler className="text-muted-foreground size-3.5" />
                                     )}
                                   </div>
                                 </button>
@@ -434,19 +434,19 @@ export function PlaygroundConfigPanel({
       {/* Configuration Section */}
       <div className="border-b">
         <Collapsible open={configOpen} onOpenChange={setConfigOpen}>
-          <CollapsibleTrigger className="flex w-full items-center px-4 py-2.5 hover:bg-muted/30 transition-colors group">
+          <CollapsibleTrigger className="hover:bg-muted/30 group flex w-full items-center px-4 py-2.5 transition-colors">
             <div className="flex items-center gap-1.5">
-              <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <span className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
                 Model Settings
               </span>
               {configOpen ? (
-                <ChevronDownIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                <ChevronDownIcon className="text-muted-foreground h-3.5 w-3.5" />
               ) : (
-                <ChevronRightIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                <ChevronRightIcon className="text-muted-foreground h-3.5 w-3.5" />
               )}
             </div>
           </CollapsibleTrigger>
-          <CollapsibleContent className="px-4 pb-3 pt-2 space-y-4">
+          <CollapsibleContent className="space-y-4 px-4 pt-2 pb-3">
             {/* Model */}
             {model !== undefined && onModelChange && (
               <div className="space-y-2">
@@ -538,7 +538,7 @@ export function PlaygroundConfigPanel({
                     Temperature
                   </Label>
                   <SimpleTooltip tooltip="Controls randomness in responses. Lower values (0.0-0.3) make outputs more focused and deterministic. Higher values (0.7-1.0) increase creativity and variety.">
-                    <span className="text-xs text-muted-foreground cursor-help font-mono">
+                    <span className="text-muted-foreground cursor-help font-mono text-xs">
                       {temperature.toFixed(1)}
                     </span>
                   </SimpleTooltip>
@@ -563,7 +563,7 @@ export function PlaygroundConfigPanel({
                     Max Tokens
                   </Label>
                   <SimpleTooltip tooltip="Maximum number of tokens in the response. Higher values allow longer responses but may increase cost.">
-                    <span className="text-xs text-muted-foreground cursor-help font-mono">
+                    <span className="text-muted-foreground cursor-help font-mono text-xs">
                       {maxTokens}
                     </span>
                   </SimpleTooltip>

--- a/client/dashboard/src/pages/playground/PlaygroundElements.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElements.tsx
@@ -177,7 +177,7 @@ export function PlaygroundElements({
   // Don't render until we have a valid MCP URL
   if (!mcpUrl || !toolsetSlug) {
     return (
-      <div className="h-full flex items-center justify-center">
+      <div className="flex h-full items-center justify-center">
         <Type muted>Select a toolset to start chatting</Type>
       </div>
     );
@@ -254,20 +254,20 @@ export function PlaygroundElements({
         theme={resolvedTheme === "dark" ? "dark" : "light"}
         toolset={toolset}
       >
-        <div className="h-full flex flex-col min-h-0">
-          <div className="flex items-center justify-between gap-2 py-3 shrink-0 border-b-border border-b px-4">
+        <div className="flex h-full min-h-0 flex-col">
+          <div className="border-b-border flex shrink-0 items-center justify-between gap-2 border-b px-4 py-3">
             <Popover open={historyOpen} onOpenChange={setHistoryOpen}>
               <PopoverTrigger asChild>
                 <Button size="sm" variant="ghost">
-                  <HistoryIcon className="size-4 mr-2" />
+                  <HistoryIcon className="mr-2 size-4" />
                   Chat History
                 </Button>
               </PopoverTrigger>
               <PopoverContent
                 align="start"
-                className="w-72 p-0 min-h-fit max-h-96 overflow-y-scroll"
+                className="max-h-96 min-h-fit w-72 overflow-y-scroll p-0"
               >
-                <ChatHistory className="h-full min-h-fit max-h-96 overflow-y-auto" />
+                <ChatHistory className="h-full max-h-96 min-h-fit overflow-y-auto" />
               </PopoverContent>
             </Popover>
             <div className="flex items-center gap-2">{additionalActions}</div>
@@ -297,7 +297,7 @@ function AuthWarningBanner({
   const routes = useRoutes();
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2.5 bg-warning/15 border-b border-warning/30 text-sm font-medium text-warning-foreground">
+    <div className="bg-warning/15 border-warning/30 text-warning-foreground flex items-center gap-2 border-b px-4 py-2.5 text-sm font-medium">
       <AlertCircle className="size-4 shrink-0" />
       <span>
         {missingCount} authentication{" "}
@@ -305,7 +305,7 @@ function AuthWarningBanner({
         <routes.mcp.details.Link
           params={[toolsetSlug]}
           hash="authentication"
-          className="underline hover:text-foreground font-medium"
+          className="hover:text-foreground font-medium underline"
         >
           Configure now
         </routes.mcp.details.Link>
@@ -316,16 +316,16 @@ function AuthWarningBanner({
 
 function OAuthRequiredNotice({ providerName }: { providerName: string }) {
   return (
-    <div className="h-full flex items-center justify-center">
-      <div className="flex flex-col items-center gap-3 text-center max-w-md px-4">
-        <div className="rounded-full bg-warning/15 p-3">
-          <ShieldAlert className="size-6 text-warning" />
+    <div className="flex h-full items-center justify-center">
+      <div className="flex max-w-md flex-col items-center gap-3 px-4 text-center">
+        <div className="bg-warning/15 rounded-full p-3">
+          <ShieldAlert className="text-warning size-6" />
         </div>
         <Type className="font-medium">OAuth Connection Required</Type>
         <Type muted className="text-sm">
           This MCP server requires authentication with{" "}
-          <span className="font-medium text-foreground">{providerName}</span>.
-          Use the <span className="font-medium text-foreground">Connect</span>{" "}
+          <span className="text-foreground font-medium">{providerName}</span>.
+          Use the <span className="text-foreground font-medium">Connect</span>{" "}
           button in the Authentication section of the sidebar to authorize
           access.
         </Type>

--- a/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.tsx
@@ -22,7 +22,7 @@ export const GramThreadWelcome: FC = () => {
         </Type>
       </div>
       {suggestions && suggestions.length > 0 && (
-        <div className="flex flex-wrap justify-center gap-2 mt-4">
+        <div className="mt-4 flex flex-wrap justify-center gap-2">
           {suggestions.map((suggestion, index) => (
             <ThreadPrimitive.Suggestion
               key={index}
@@ -32,7 +32,7 @@ export const GramThreadWelcome: FC = () => {
             >
               <button
                 type="button"
-                className="inline-flex items-center rounded-full border border-input bg-background px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer"
+                className="border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex cursor-pointer items-center rounded-full border px-3 py-1.5 text-sm transition-colors"
               >
                 {suggestion.title}
               </button>

--- a/client/dashboard/src/pages/playground/PlaygroundLogsPanel.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundLogsPanel.tsx
@@ -19,14 +19,14 @@ import { useMemo, useState } from "react";
 function StatusIcon({ isSuccess }: { isSuccess: boolean }) {
   if (isSuccess) {
     return (
-      <div className="rounded-full bg-success-default/10 p-0.5 shrink-0">
-        <CheckIcon className="size-3 stroke-success-default stroke-2" />
+      <div className="bg-success-default/10 shrink-0 rounded-full p-0.5">
+        <CheckIcon className="stroke-success-default size-3 stroke-2" />
       </div>
     );
   }
   return (
-    <div className="rounded-full bg-destructive-default/10 p-0.5 shrink-0">
-      <XIcon className="size-3 stroke-destructive-default stroke-2" />
+    <div className="bg-destructive-default/10 shrink-0 rounded-full p-0.5">
+      <XIcon className="stroke-destructive-default size-3 stroke-2" />
     </div>
   );
 }
@@ -128,10 +128,10 @@ export function PlaygroundLogsPanel({
     error instanceof ServiceError && error.statusCode === 404;
 
   return (
-    <div className="h-full flex flex-col border-l">
+    <div className="flex h-full flex-col border-l">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <span className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
           Logs ({logs.length})
         </span>
         <div className="flex items-center gap-1">
@@ -180,41 +180,41 @@ export function PlaygroundLogsPanel({
                 <button
                   key={log.id}
                   onClick={() => setSelectedLog(log)}
-                  className="w-full text-left px-4 py-2.5 hover:bg-muted/30 transition-colors flex items-start gap-2.5 border-b border-border/40"
+                  className="hover:bg-muted/30 border-border/40 flex w-full items-start gap-2.5 border-b px-4 py-2.5 text-left transition-colors"
                 >
                   <StatusIcon isSuccess={isSuccess} />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-1.5 mb-0.5">
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-0.5 flex items-center gap-1.5">
                       {toolName && (
-                        <span className="font-medium text-xs truncate">
+                        <span className="truncate text-xs font-medium">
                           {toolName}
                         </span>
                       )}
                       {log.severityText && (
                         <Badge
                           variant={getSeverityVariant(log.severityText)}
-                          className="text-[10px] px-1 py-0 h-4 font-semibold"
+                          className="h-4 px-1 py-0 text-[10px] font-semibold"
                         >
                           {log.severityText}
                         </Badge>
                       )}
                     </div>
-                    <div className="font-mono text-[10px] text-muted-foreground truncate mb-0.5">
+                    <div className="text-muted-foreground mb-0.5 truncate font-mono text-[10px]">
                       {log.body}
                     </div>
-                    <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                    <div className="text-muted-foreground flex items-center gap-1.5 text-[10px]">
                       <span className="font-mono">{timestamp}</span>
                       {log.traceId && (
                         <>
                           <span>•</span>
-                          <span className="font-mono truncate max-w-[100px]">
+                          <span className="max-w-[100px] truncate font-mono">
                             {log.traceId.slice(0, 8)}...
                           </span>
                         </>
                       )}
                     </div>
                   </div>
-                  <ChevronRightIcon className="size-3.5 text-muted-foreground shrink-0 mt-0.5" />
+                  <ChevronRightIcon className="text-muted-foreground mt-0.5 size-3.5 shrink-0" />
                 </button>
               );
             })}
@@ -224,8 +224,8 @@ export function PlaygroundLogsPanel({
 
       {/* Detail View */}
       {selectedLog && (
-        <div className="border-t bg-muted/20">
-          <div className="px-3 py-2.5 border-b flex items-center justify-between bg-inherit">
+        <div className="bg-muted/20 border-t">
+          <div className="flex items-center justify-between border-b bg-inherit px-3 py-2.5">
             <span className="text-xs font-semibold">
               {getToolName(selectedLog) || "Log Details"}
             </span>
@@ -238,25 +238,25 @@ export function PlaygroundLogsPanel({
               <XCircleIcon className="size-3.5" />
             </Button>
           </div>
-          <div className="h-[280px] p-3 overflow-y-auto">
+          <div className="h-[280px] overflow-y-auto p-3">
             <div className="space-y-3">
               {/* Log Details */}
               <div className="space-y-1.5">
-                <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1.5">
+                <div className="text-muted-foreground mb-1.5 text-[11px] font-semibold tracking-wider uppercase">
                   Details
                 </div>
-                <div className="bg-background/60 rounded border border-border/40 divide-y divide-border/40">
-                  <div className="px-2.5 py-1.5 flex justify-between text-[11px]">
+                <div className="bg-background/60 border-border/40 divide-border/40 divide-y rounded border">
+                  <div className="flex justify-between px-2.5 py-1.5 text-[11px]">
                     <span className="text-muted-foreground font-medium">
                       Service
                     </span>
-                    <span className="font-mono text-right">
+                    <span className="text-right font-mono">
                       {selectedLog.service?.name}
                       {selectedLog.service?.version &&
                         ` (${selectedLog.service.version})`}
                     </span>
                   </div>
-                  <div className="px-2.5 py-1.5 flex justify-between text-[11px]">
+                  <div className="flex justify-between px-2.5 py-1.5 text-[11px]">
                     <span className="text-muted-foreground font-medium">
                       Severity
                     </span>
@@ -264,32 +264,32 @@ export function PlaygroundLogsPanel({
                       {selectedLog.severityText || "N/A"}
                     </span>
                   </div>
-                  <div className="px-2.5 py-1.5 flex justify-between text-[11px]">
+                  <div className="flex justify-between px-2.5 py-1.5 text-[11px]">
                     <span className="text-muted-foreground font-medium">
                       Timestamp
                     </span>
-                    <span className="font-mono text-right">
+                    <span className="text-right font-mono">
                       {new Date(
                         Number(BigInt(selectedLog.timeUnixNano) / 1_000_000n),
                       ).toISOString()}
                     </span>
                   </div>
                   {selectedLog.traceId && (
-                    <div className="px-2.5 py-1.5 flex justify-between text-[11px]">
+                    <div className="flex justify-between px-2.5 py-1.5 text-[11px]">
                       <span className="text-muted-foreground font-medium">
                         Trace ID
                       </span>
-                      <span className="font-mono text-right truncate max-w-[200px]">
+                      <span className="max-w-[200px] truncate text-right font-mono">
                         {selectedLog.traceId}
                       </span>
                     </div>
                   )}
                   {selectedLog.spanId && (
-                    <div className="px-2.5 py-1.5 flex justify-between text-[11px]">
+                    <div className="flex justify-between px-2.5 py-1.5 text-[11px]">
                       <span className="text-muted-foreground font-medium">
                         Span ID
                       </span>
-                      <span className="font-mono text-right">
+                      <span className="text-right font-mono">
                         {selectedLog.spanId}
                       </span>
                     </div>
@@ -300,10 +300,10 @@ export function PlaygroundLogsPanel({
               {/* Body */}
               {selectedLog.body && (
                 <div className="space-y-1.5">
-                  <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  <div className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
                     Message
                   </div>
-                  <pre className="bg-background/60 border border-border/40 p-2 rounded text-[10px] overflow-x-auto font-mono leading-relaxed whitespace-pre-wrap">
+                  <pre className="bg-background/60 border-border/40 overflow-x-auto rounded border p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap">
                     {selectedLog.body}
                   </pre>
                 </div>
@@ -314,10 +314,10 @@ export function PlaygroundLogsPanel({
                 typeof selectedLog.attributes === "object" &&
                 Object.keys(selectedLog.attributes).length > 0 && (
                   <div className="space-y-1.5">
-                    <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    <div className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
                       Attributes
                     </div>
-                    <pre className="bg-background/60 border border-border/40 p-2 rounded text-[10px] overflow-x-auto font-mono leading-relaxed">
+                    <pre className="bg-background/60 border-border/40 overflow-x-auto rounded border p-2 font-mono text-[10px] leading-relaxed">
                       {JSON.stringify(selectedLog.attributes, null, 2)}
                     </pre>
                   </div>
@@ -328,10 +328,10 @@ export function PlaygroundLogsPanel({
                 typeof selectedLog.resourceAttributes === "object" &&
                 Object.keys(selectedLog.resourceAttributes).length > 0 && (
                   <div className="space-y-1.5">
-                    <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    <div className="text-muted-foreground text-[11px] font-semibold tracking-wider uppercase">
                       Resource Attributes
                     </div>
-                    <pre className="bg-background/60 border border-border/40 p-2 rounded text-[10px] overflow-x-auto font-mono leading-relaxed">
+                    <pre className="bg-background/60 border-border/40 overflow-x-auto rounded border p-2 font-mono text-[10px] leading-relaxed">
                       {JSON.stringify(selectedLog.resourceAttributes, null, 2)}
                     </pre>
                   </div>

--- a/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
@@ -163,7 +163,7 @@ export const PlaygroundMcpToolFallback: ToolCallMessagePartComponent = ({
         : "Running";
 
   return (
-    <div className="flex w-full flex-col border-b border-border last:border-b-0">
+    <div className="border-border flex w-full flex-col border-b last:border-b-0">
       <div className="px-4 py-4">
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-1">
@@ -174,16 +174,16 @@ export const PlaygroundMcpToolFallback: ToolCallMessagePartComponent = ({
               {binding?.description ?? "Tool execution"}
             </Type>
           </div>
-          <span className="rounded-full border border-border bg-background px-2 py-1 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+          <span className="border-border bg-background text-muted-foreground rounded-full border px-2 py-1 text-[11px] font-medium tracking-[0.08em] uppercase">
             {statusLabel}
           </span>
         </div>
 
-        <details className="mt-3 overflow-auto rounded-xl border border-border bg-background">
-          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted-foreground">
+        <details className="border-border bg-background mt-3 overflow-auto rounded-xl border">
+          <summary className="text-muted-foreground cursor-pointer px-3 py-2 text-xs font-medium">
             Request / Result
           </summary>
-          <div className="grid gap-3 border-t border-border px-3 py-3">
+          <div className="border-border grid gap-3 border-t px-3 py-3">
             <JsonPanel label="Request" value={args} />
             <JsonPanel label="Result" value={result} />
           </div>
@@ -264,7 +264,7 @@ function PlaygroundMcpAppRenderer({
 
   if (resourceQuery.isLoading) {
     return (
-      <div className="flex items-center gap-2 border-t border-border px-4 py-4 text-sm text-muted-foreground">
+      <div className="border-border text-muted-foreground flex items-center gap-2 border-t px-4 py-4 text-sm">
         <LoaderCircle className="size-4 animate-spin" />
         Loading MCP app resource…
       </div>
@@ -273,7 +273,7 @@ function PlaygroundMcpAppRenderer({
 
   if (resourceQuery.isError) {
     return (
-      <div className="border-t border-border px-4 py-4">
+      <div className="border-border border-t px-4 py-4">
         <Type variant="small" className="font-medium">
           MCP app failed to load
         </Type>
@@ -292,7 +292,7 @@ function PlaygroundMcpAppRenderer({
   const mimeType = resource?.mimeType ?? listing?.mimeType;
   if (!resource || mimeType !== MCP_APP_MIME_TYPE) {
     return (
-      <div className="border-t border-border px-4 py-4">
+      <div className="border-border border-t px-4 py-4">
         <Type variant="small" className="font-medium">
           Unsupported MCP app resource
         </Type>
@@ -441,8 +441,8 @@ function McpAppFrame({
   }, [isInitialized, theme]);
 
   return (
-    <div className="border-t border-border px-4 pb-4">
-      <div className="overflow-hidden rounded-2xl border border-border bg-background shadow-sm">
+    <div className="border-border border-t px-4 pb-4">
+      <div className="border-border bg-background overflow-hidden rounded-2xl border shadow-sm">
         <iframe
           ref={iframeRef}
           allow={buildAllowAttribute(uiMeta)}
@@ -766,11 +766,11 @@ function JsonPanel({ label, value }: { label: string; value: unknown }) {
     <div className="space-y-1">
       <Type
         muted
-        className="text-[11px] font-medium uppercase tracking-[0.08em]"
+        className="text-[11px] font-medium tracking-[0.08em] uppercase"
       >
         {label}
       </Type>
-      <pre className="overflow-x-auto rounded-lg border border-border bg-muted/40 p-3 font-mono text-xs leading-5 text-foreground">
+      <pre className="border-border bg-muted/40 text-foreground overflow-x-auto rounded-lg border p-3 font-mono text-xs leading-5">
         {formatJson(value)}
       </pre>
     </div>

--- a/client/dashboard/src/pages/playground/ToolMentions.tsx
+++ b/client/dashboard/src/pages/playground/ToolMentions.tsx
@@ -190,7 +190,7 @@ export function ToolMentionAutocomplete({
     <div
       ref={suggestionsRef}
       className={cn(
-        "absolute z-[100] min-w-[200px] max-w-[400px] rounded-md border bg-popover shadow-md",
+        "bg-popover absolute z-[100] max-w-[400px] min-w-[200px] rounded-md border shadow-md",
         "max-h-[200px] overflow-auto",
       )}
       style={{
@@ -220,7 +220,7 @@ export function ToolMentionAutocomplete({
               name={tool.type === "http" ? "globe" : "message-square"}
               className="mt-0.5 h-3 w-3 flex-shrink-0 opacity-50"
             />
-            <div className="flex-1 min-w-0">
+            <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1">
                 <Type variant="small" className="font-medium">
                   {tool.name}
@@ -262,7 +262,7 @@ export function MentionedToolsBadges({
   if (mentionedTools.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-1 p-2 border-t bg-background">
+    <div className="bg-background flex flex-wrap gap-1 border-t p-2">
       <Type variant="small" className="text-muted-foreground mr-1">
         Selected tools:
       </Type>

--- a/client/dashboard/src/pages/prompts/PromptEditor.tsx
+++ b/client/dashboard/src/pages/prompts/PromptEditor.tsx
@@ -81,7 +81,7 @@ export function PromptEditor({
   return (
     <div className="flex gap-8">
       <form
-        className="flex-1 min-w-0 space-y-8"
+        className="min-w-0 flex-1 space-y-8"
         onSubmit={(e) => {
           e.preventDefault();
           const fd = new FormData(e.currentTarget);
@@ -151,7 +151,7 @@ export function PromptEditor({
           <div>
             <dialog
               open
-              className="bg-background text-inherit w-dvw h-dvh fixed inset-0 z-50"
+              className="bg-background fixed inset-0 z-50 h-dvh w-dvw text-inherit"
               style={{ all: fullScreenEditor ? void 0 : "unset" }}
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
@@ -163,7 +163,7 @@ export function PromptEditor({
                 className={cn(
                   "relative",
                   fullScreenEditor
-                    ? "px-8 pb-8 pt-12 h-full w-full flex flex-col"
+                    ? "flex h-full w-full flex-col px-8 pt-12 pb-8"
                     : false,
                 )}
               >
@@ -187,12 +187,12 @@ export function PromptEditor({
                     onClick={() => setFullScreenEditor(false)}
                   >
                     <span className="sr-only">Exit full screen</span>
-                    <X className="w-4 h-4" />
+                    <X className="h-4 w-4" />
                   </Button>
                 ) : null}
                 {!fullScreenEditor ? (
                   <Button
-                    className="absolute bottom-4 right-4"
+                    className="absolute right-4 bottom-4"
                     type="button"
                     variant="tertiary"
                     onClick={() => {
@@ -201,7 +201,7 @@ export function PromptEditor({
                     }}
                   >
                     <span className="sr-only">Enter full screen</span>
-                    <Fullscreen className="w-4 h-4" />
+                    <Fullscreen className="h-4 w-4" />
                   </Button>
                 ) : null}
               </div>
@@ -209,10 +209,10 @@ export function PromptEditor({
           </div>
           <div className="pt-4">
             <fieldset className="space-y-4">
-              <legend className="text-base font-medium leading-none mb-3">
+              <legend className="mb-3 text-base leading-none font-medium">
                 Arguments
               </legend>
-              <p className="text-muted-foreground text-sm mb-4">
+              <p className="text-muted-foreground mb-4 text-sm">
                 Add useful descriptions for your prompt template arguments
                 (optional)
               </p>
@@ -229,10 +229,10 @@ export function PromptEditor({
                   })}
                 </ul>
               ) : (
-                <p className="text-sm text-muted-foreground border border-dashed border-muted-foreground/20 rounded-md p-4">
+                <p className="text-muted-foreground border-muted-foreground/20 rounded-md border border-dashed p-4 text-sm">
                   No arguments found in prompt template. You can add these using
                   the syntax{" "}
-                  <code className="text-red-600 bg-red-50 px-1 py-0.5 rounded text-xs">
+                  <code className="rounded bg-red-50 px-1 py-0.5 text-xs text-red-600">
                     {"{{argument_name}}"}
                   </code>
                   .
@@ -243,46 +243,46 @@ export function PromptEditor({
         </div>
         <div className="pt-6">
           {error ? (
-            <div className="bg-red-50 border border-red-200 rounded-md p-3 mb-4">
-              <p className="text-red-700 text-sm">{error.message}</p>
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3">
+              <p className="text-sm text-red-700">{error.message}</p>
             </div>
           ) : null}
           <Button type="submit" disabled={isPending} size="md">
             {isPending ? (
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : null}
             {isPending ? "Saving..." : "Save Prompt"}
           </Button>
         </div>
       </form>
-      <aside className="w-80 flex-shrink-0 space-y-6 sticky top-8 bg-secondary p-6 rounded-lg">
+      <aside className="bg-secondary sticky top-8 w-80 flex-shrink-0 space-y-6 rounded-lg p-6">
         <div>
-          <h3 className="text-sm font-medium mb-2">Prompt Templates</h3>
-          <p className="text-sm text-muted-foreground">
+          <h3 className="mb-2 text-sm font-medium">Prompt Templates</h3>
+          <p className="text-muted-foreground text-sm">
             Create reusable prompts with dynamic variables using the Mustache
             syntax.
           </p>
         </div>
         <div>
-          <h3 className="text-sm font-medium mb-2">Using Variables</h3>
-          <p className="text-sm text-muted-foreground mb-2">
+          <h3 className="mb-2 text-sm font-medium">Using Variables</h3>
+          <p className="text-muted-foreground mb-2 text-sm">
             Add variables to your prompt using double curly braces:
           </p>
-          <code className="text-xs bg-muted px-2 py-1 rounded block">
+          <code className="bg-muted block rounded px-2 py-1 text-xs">
             {"{{variable_name}}"}
           </code>
         </div>
         <div>
-          <h3 className="text-sm font-medium mb-2">Arguments</h3>
-          <p className="text-sm text-muted-foreground">
+          <h3 className="mb-2 text-sm font-medium">Arguments</h3>
+          <p className="text-muted-foreground text-sm">
             Variables detected in your prompt will automatically appear in the
             Arguments section. Add descriptions to help users understand what
             each variable is for.
           </p>
         </div>
         <div>
-          <h3 className="text-sm font-medium mb-2">Tips</h3>
-          <ul className="text-sm text-muted-foreground space-y-1">
+          <h3 className="mb-2 text-sm font-medium">Tips</h3>
+          <ul className="text-muted-foreground space-y-1 text-sm">
             <li>• Use descriptive variable names</li>
             <li>• Keep prompts clear and concise</li>
             <li>• Test with different inputs</li>

--- a/client/dashboard/src/pages/prompts/PromptSelectPopover.tsx
+++ b/client/dashboard/src/pages/prompts/PromptSelectPopover.tsx
@@ -42,7 +42,7 @@ export function PromptSelectPopover({
                 <CommandItem
                   key={prompt.name}
                   value={prompt.name}
-                  className="cursor-pointer min-w-fit"
+                  className="min-w-fit cursor-pointer"
                   onSelect={() => {
                     onSelect(prompt);
                     setOpen(false);

--- a/client/dashboard/src/pages/prompts/Prompts.tsx
+++ b/client/dashboard/src/pages/prompts/Prompts.tsx
@@ -41,7 +41,7 @@ export default function Prompts() {
       <Page.Section.CTA>
         <Button onClick={() => routes.prompts.newPrompt.goTo()}>
           <Button.LeftIcon>
-            <Plus className="w-4 h-4" />
+            <Plus className="h-4 w-4" />
           </Button.LeftIcon>
           <Button.Text>New Prompt</Button.Text>
         </Button>

--- a/client/dashboard/src/pages/sdk/SDK.tsx
+++ b/client/dashboard/src/pages/sdk/SDK.tsx
@@ -100,7 +100,7 @@ export const SdkContent = ({
   );
 
   let heading = (
-    <div className="flex justify-between items-end gap-4">
+    <div className="flex items-end justify-between gap-4">
       <Type variant="subheading">
         Use Gram toolsets to build agentic workflows in many popular frameworks
       </Type>
@@ -113,7 +113,7 @@ export const SdkContent = ({
       <Stack gap={1}>
         <Type variant="subheading">
           What should the agent do?{" "}
-          <span className="text-muted-foreground italic text-sm">
+          <span className="text-muted-foreground text-sm italic">
             Chat history will also be included in the prompt.
           </span>
         </Type>

--- a/client/dashboard/src/pages/settings/RegistryCacheSection.tsx
+++ b/client/dashboard/src/pages/settings/RegistryCacheSection.tsx
@@ -35,7 +35,7 @@ export function RegistryCacheSection() {
       </Type>
 
       {isLoading && (
-        <div className="flex items-center gap-2 text-muted-foreground">
+        <div className="text-muted-foreground flex items-center gap-2">
           <Loader2 className="h-4 w-4 animate-spin" />
           <Type muted small>
             Loading registries…

--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -27,19 +27,19 @@ export default function Settings() {
         <SettingsDangerZone />
 
         {isAdmin && (
-          <div className="mt-8 p-4 rounded-lg bg-red-500/5 border border-red-500/20">
+          <div className="mt-8 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
             <Stack
               direction="horizontal"
               align="center"
               gap={2}
               className="mb-3"
             >
-              <ShieldAlert className="w-5 h-5 text-red-500" />
+              <ShieldAlert className="h-5 w-5 text-red-500" />
               <Heading variant="h4" className="text-red-600 dark:text-red-400">
                 Admin Only
               </Heading>
             </Stack>
-            <dl className="grid grid-cols-[max-content_auto] gap-x-6 gap-y-2 mb-4">
+            <dl className="mb-4 grid grid-cols-[max-content_auto] gap-x-6 gap-y-2">
               <dt className="text-end">Organization ID</dt>
               <dd className="font-mono text-sm">{organization.id}</dd>
               <dt className="text-end">Project ID</dt>

--- a/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
+++ b/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
@@ -49,7 +49,7 @@ export function SettingsDangerZone() {
 
   return (
     <>
-      <div className="border border-destructive/30 rounded-lg p-6">
+      <div className="border-destructive/30 rounded-lg border p-6">
         <Type variant="subheading" className="text-destructive mb-1">
           Danger Zone
         </Type>
@@ -88,7 +88,7 @@ export function SettingsDangerZone() {
           <div className="space-y-4 py-4">
             <Type variant="body">
               Are you sure you want to delete the project{" "}
-              <code className="font-mono font-bold px-1 py-0.5 bg-muted rounded">
+              <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
                 {project.name}
               </code>
               ? This action cannot be undone.

--- a/client/dashboard/src/pages/slackapp/SlackApp.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackApp.tsx
@@ -48,20 +48,20 @@ export function SlackAppsRoot() {
 
 function SlackAppsEmptyState({ onCreate }: { onCreate: () => void }) {
   return (
-    <div className="flex flex-col items-center justify-center py-16 px-8 rounded-xl border border-dashed bg-muted/20">
-      <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-4">
-        <Icon name="bot" className="w-6 h-6 text-muted-foreground" />
+    <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+      <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+        <Icon name="bot" className="text-muted-foreground h-6 w-6" />
       </div>
       <Type variant="subheading" className="mb-1">
         No assistants yet
       </Type>
-      <Type small muted className="text-center mb-4 max-w-md">
+      <Type small muted className="mb-4 max-w-md text-center">
         Create an assistant to let your team interact with Gram toolsets
         directly.
       </Type>
       <Button onClick={onCreate}>
         <Button.LeftIcon>
-          <Icon name="plus" className="w-4 h-4" />
+          <Icon name="plus" className="h-4 w-4" />
         </Button.LeftIcon>
         <Button.Text>Create new Assistant</Button.Text>
       </Button>
@@ -76,9 +76,9 @@ function SlackAppCard({ app }: { app: SlackAppResult }) {
       params={[app.id]}
       className="no-underline hover:no-underline"
     >
-      <div className="rounded-lg border bg-card p-4 transition-colors hover:bg-muted/50">
-        <div className="flex items-start justify-between mb-2">
-          <Type className="font-semibold truncate">{app.name}</Type>
+      <div className="bg-card hover:bg-muted/50 rounded-lg border p-4 transition-colors">
+        <div className="mb-2 flex items-start justify-between">
+          <Type className="truncate font-semibold">{app.name}</Type>
           <StatusBadge
             status={app.status}
             installCount={app.slackTeamId ? 1 : 0}
@@ -192,12 +192,12 @@ function CreateSlackAppDialog({
             </Type>
             <CompactUpload
               onUpload={handleIconUpload}
-              className="w-24 h-24"
+              className="h-24 w-24"
               renderFilePreview={() =>
                 iconAssetId ? (
                   <AssetImage
                     assetId={iconAssetId}
-                    className="w-16 h-16 rounded-lg"
+                    className="h-16 w-16 rounded-lg"
                   />
                 ) : undefined
               }
@@ -213,7 +213,7 @@ function CreateSlackAppDialog({
                 No toolsets available. Create a toolset first.
               </Type>
             ) : (
-              <div className="grid grid-cols-2 gap-2 max-h-60 overflow-y-auto">
+              <div className="grid max-h-60 grid-cols-2 gap-2 overflow-y-auto">
                 {toolsets.map((ts) => {
                   const selected = selectedToolsetIds.has(ts.id);
                   return (
@@ -239,10 +239,10 @@ function CreateSlackAppDialog({
                         {selected && <Icon name="check" className="h-3 w-3" />}
                       </div>
                       <div className="min-w-0">
-                        <Type className="font-medium truncate block">
+                        <Type className="block truncate font-medium">
                           {ts.name || ts.slug}
                         </Type>
-                        <Type muted small className="truncate block">
+                        <Type muted small className="block truncate">
                           {ts.slug}
                           {ts.tools
                             ? ` \u00B7 ${ts.tools.length} tool${ts.tools.length !== 1 ? "s" : ""}`
@@ -302,7 +302,7 @@ export default function SlackAppsIndex() {
               {apps.length > 0 && (
                 <Button onClick={() => setDialogOpen(true)}>
                   <Button.LeftIcon>
-                    <Icon name="plus" className="w-4 h-4" />
+                    <Icon name="plus" className="h-4 w-4" />
                   </Button.LeftIcon>
                   <Button.Text>Create new Assistant</Button.Text>
                 </Button>
@@ -313,13 +313,13 @@ export default function SlackAppsIndex() {
                 <Stack align="center" justify="center" className="py-16">
                   <Icon
                     name="loader-circle"
-                    className="w-6 h-6 animate-spin text-muted-foreground"
+                    className="text-muted-foreground h-6 w-6 animate-spin"
                   />
                 </Stack>
               ) : apps.length === 0 ? (
                 <SlackAppsEmptyState onCreate={() => setDialogOpen(true)} />
               ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
                   {apps.map((app) => (
                     <SlackAppCard key={app.id} app={app} />
                   ))}

--- a/client/dashboard/src/pages/slackapp/SlackAppDetail.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackAppDetail.tsx
@@ -50,7 +50,7 @@ export default function SlackAppDetailPage() {
           <Stack align="center" justify="center" className="py-16">
             <Icon
               name="loader-circle"
-              className="w-6 h-6 animate-spin text-muted-foreground"
+              className="text-muted-foreground h-6 w-6 animate-spin"
             />
           </Stack>
         </Page.Body>
@@ -70,7 +70,7 @@ export default function SlackAppDetailPage() {
               {app.iconAssetId && (
                 <AssetImage
                   assetId={app.iconAssetId}
-                  className="w-8 h-8 rounded-lg"
+                  className="h-8 w-8 rounded-lg"
                 />
               )}
               {app.name}
@@ -94,7 +94,7 @@ export default function SlackAppDetailPage() {
             {app.status === "unconfigured" ? (
               <DraftState app={app} />
             ) : (
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+              <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
                 <LeftPanel app={app} />
                 <RightPanel />
               </div>
@@ -177,7 +177,7 @@ function DraftState({ app }: { app: SlackAppResult }) {
           onClick={() => window.open(deepLinkUrl, "_blank")}
         >
           <Button.LeftIcon>
-            <Icon name="external-link" className="w-4 h-4" />
+            <Icon name="external-link" className="h-4 w-4" />
           </Button.LeftIcon>
           <Button.Text>Open in Slack</Button.Text>
         </Button>
@@ -193,7 +193,7 @@ function DraftState({ app }: { app: SlackAppResult }) {
         </Type>
         <Stack gap={3}>
           <div>
-            <Type variant="body" className="mb-1 font-medium text-sm">
+            <Type variant="body" className="mb-1 text-sm font-medium">
               Client ID
             </Type>
             <Input
@@ -203,7 +203,7 @@ function DraftState({ app }: { app: SlackAppResult }) {
             />
           </div>
           <div>
-            <Type variant="body" className="mb-1 font-medium text-sm">
+            <Type variant="body" className="mb-1 text-sm font-medium">
               Client Secret
             </Type>
             <Input
@@ -214,7 +214,7 @@ function DraftState({ app }: { app: SlackAppResult }) {
             />
           </div>
           <div>
-            <Type variant="body" className="mb-1 font-medium text-sm">
+            <Type variant="body" className="mb-1 text-sm font-medium">
               Signing Secret
             </Type>
             <Input
@@ -310,13 +310,13 @@ function LeftPanel({ app }: { app: SlackAppResult }) {
           onClick={() => window.open("https://api.slack.com/apps", "_blank")}
         >
           <Button.LeftIcon>
-            <Icon name="external-link" className="w-3.5 h-3.5" />
+            <Icon name="external-link" className="h-3.5 w-3.5" />
           </Button.LeftIcon>
           <Button.Text>Manage on Slack</Button.Text>
         </Button>
         <Button variant="secondary" size="sm" onClick={handleCopyInviteLink}>
           <Button.LeftIcon>
-            <Icon name={copied ? "check" : "copy"} className="w-3.5 h-3.5" />
+            <Icon name={copied ? "check" : "copy"} className="h-3.5 w-3.5" />
           </Button.LeftIcon>
           <Button.Text>{copied ? "Copied!" : "Copy Invite Link"}</Button.Text>
         </Button>
@@ -336,13 +336,13 @@ function LeftPanel({ app }: { app: SlackAppResult }) {
             {appToolsets.map((ts) => (
               <div
                 key={ts.id}
-                className="flex items-center justify-between rounded-lg border bg-card p-3"
+                className="bg-card flex items-center justify-between rounded-lg border p-3"
               >
                 <div className="min-w-0">
-                  <Type className="font-medium truncate block">
+                  <Type className="block truncate font-medium">
                     {ts.name || ts.slug}
                   </Type>
-                  <Type muted small className="truncate block">
+                  <Type muted small className="block truncate">
                     {ts.slug}
                     {ts.tools
                       ? ` \u00B7 ${ts.tools.length} tool${ts.tools.length !== 1 ? "s" : ""}`
@@ -355,7 +355,7 @@ function LeftPanel({ app }: { app: SlackAppResult }) {
                 >
                   <Button variant="tertiary" size="sm">
                     <Button.LeftIcon>
-                      <Icon name="external-link" className="w-3.5 h-3.5" />
+                      <Icon name="external-link" className="h-3.5 w-3.5" />
                     </Button.LeftIcon>
                     <Button.Text>View</Button.Text>
                   </Button>
@@ -372,26 +372,26 @@ function LeftPanel({ app }: { app: SlackAppResult }) {
           Installations
         </Type>
         {app.slackTeamId ? (
-          <div className="flex items-center justify-between rounded-lg border bg-card p-3">
+          <div className="bg-card flex items-center justify-between rounded-lg border p-3">
             <div className="min-w-0">
-              <Type className="font-medium truncate block">
+              <Type className="block truncate font-medium">
                 {app.slackTeamName || app.slackTeamId}
               </Type>
-              <Type muted small className="truncate block">
+              <Type muted small className="block truncate">
                 {app.slackTeamId}
               </Type>
             </div>
             <Button variant="tertiary" size="sm" onClick={() => {}}>
               <Button.LeftIcon>
-                <Icon name="scroll-text" className="w-3.5 h-3.5" />
+                <Icon name="scroll-text" className="h-3.5 w-3.5" />
               </Button.LeftIcon>
               <Button.Text>Logs</Button.Text>
             </Button>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-10 px-6">
-            <Icon name="slack" className="w-6 h-6 text-muted-foreground mb-3" />
-            <Type muted small className="text-center mb-3">
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed px-6 py-10">
+            <Icon name="slack" className="text-muted-foreground mb-3 h-6 w-6" />
+            <Type muted small className="mb-3 text-center">
               No installs yet. Share the invite link to get your first workspace
               connected.
             </Type>
@@ -403,7 +403,7 @@ function LeftPanel({ app }: { app: SlackAppResult }) {
               <Button.LeftIcon>
                 <Icon
                   name={copied ? "check" : "copy"}
-                  className="w-3.5 h-3.5"
+                  className="h-3.5 w-3.5"
                 />
               </Button.LeftIcon>
               <Button.Text>
@@ -427,7 +427,7 @@ function LeftPanel({ app }: { app: SlackAppResult }) {
           onChange={(e) => handlePromptChange(e.target.value)}
           placeholder="You are a helpful assistant..."
           rows={6}
-          className="w-full rounded-lg border bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+          className="placeholder:text-muted-foreground focus-visible:ring-ring w-full resize-y rounded-lg border bg-transparent px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
         />
       </Stack>
     </Stack>
@@ -440,8 +440,8 @@ function RightPanel() {
       <Type variant="body" className="font-medium">
         Chat Logs
       </Type>
-      <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-warning/40 bg-warning/5 py-16 px-6">
-        <Icon name="triangle-alert" className="w-6 h-6 text-warning mb-3" />
+      <div className="border-warning/40 bg-warning/5 flex flex-col items-center justify-center rounded-lg border border-dashed px-6 py-16">
+        <Icon name="triangle-alert" className="text-warning mb-3 h-6 w-6" />
         <Type small className="text-warning text-center">
           I need to be wired up before we remove the feature flag
         </Type>

--- a/client/dashboard/src/pages/slackapp/SlackRegister.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackRegister.tsx
@@ -72,18 +72,18 @@ export default function SlackRegister() {
   }, [token]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <div className="w-full max-w-md rounded-xl border bg-card p-8 shadow-sm">
+    <div className="bg-background flex min-h-screen items-center justify-center p-4">
+      <div className="bg-card w-full max-w-md rounded-xl border p-8 shadow-sm">
         <Stack gap={6} align="center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/50">
-            <Icon name="slack" className="h-6 w-6 text-muted-foreground" />
+          <div className="bg-muted/50 flex h-12 w-12 items-center justify-center rounded-full">
+            <Icon name="slack" className="text-muted-foreground h-6 w-6" />
           </div>
 
           {state === "loading" && (
             <Stack gap={2} align="center">
               <Icon
                 name="loader-circle"
-                className="h-6 w-6 animate-spin text-muted-foreground"
+                className="text-muted-foreground h-6 w-6 animate-spin"
               />
               <Type muted small>
                 Loading...
@@ -95,7 +95,7 @@ export default function SlackRegister() {
             <Stack gap={2} align="center">
               <Icon
                 name="loader-circle"
-                className="h-6 w-6 animate-spin text-muted-foreground"
+                className="text-muted-foreground h-6 w-6 animate-spin"
               />
               <Type muted small>
                 Linking your account...
@@ -114,7 +114,7 @@ export default function SlackRegister() {
               </Stack>
 
               {appInfo.toolsets.length > 0 && (
-                <div className="w-full rounded-lg border bg-muted/20 p-3">
+                <div className="bg-muted/20 w-full rounded-lg border p-3">
                   <Type muted small className="mb-2 block font-medium">
                     MCP Servers
                   </Type>
@@ -126,7 +126,7 @@ export default function SlackRegister() {
                       >
                         <Icon
                           name="network"
-                          className="h-3.5 w-3.5 text-muted-foreground"
+                          className="text-muted-foreground h-3.5 w-3.5"
                         />
                         <Type small>{ts.name}</Type>
                       </div>
@@ -143,8 +143,8 @@ export default function SlackRegister() {
 
           {state === "complete" && (
             <Stack gap={3} align="center">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-                <Icon name="check" className="h-5 w-5 text-primary" />
+              <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-full">
+                <Icon name="check" className="text-primary h-5 w-5" />
               </div>
               <Stack gap={1} align="center">
                 <Type variant="subheading">You're connected!</Type>
@@ -157,8 +157,8 @@ export default function SlackRegister() {
 
           {state === "error" && (
             <Stack gap={3} align="center">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
-                <Icon name="circle-x" className="h-5 w-5 text-destructive" />
+              <div className="bg-destructive/10 flex h-10 w-10 items-center justify-center rounded-full">
+                <Icon name="circle-x" className="text-destructive h-5 w-5" />
               </div>
               <Stack gap={1} align="center">
                 <Type variant="subheading">Link expired</Type>

--- a/client/dashboard/src/pages/sources/SourceDeploymentsPanel.tsx
+++ b/client/dashboard/src/pages/sources/SourceDeploymentsPanel.tsx
@@ -19,7 +19,7 @@ function StatusDot({ status }: { status: string }) {
   return (
     <span
       className={cn(
-        "size-2 rounded-full shrink-0",
+        "size-2 shrink-0 rounded-full",
         status === "completed" && "bg-success",
         status === "failed" && "bg-destructive",
         status !== "completed" && status !== "failed" && "bg-warning",
@@ -49,7 +49,7 @@ function DeploymentSidebarItem({
     <button
       onClick={onClick}
       className={cn(
-        "w-full text-left px-3 py-3 border-b border-border transition-colors",
+        "border-border w-full border-b px-3 py-3 text-left transition-colors",
         "hover:bg-muted/50",
         isSelected && "bg-muted",
       )}
@@ -59,19 +59,19 @@ function DeploymentSidebarItem({
         <span className="text-sm capitalize">{deployment.status}</span>
         <span className="ml-auto">
           {isActive ? (
-            <Badge variant="success" className="py-0 px-1.5">
+            <Badge variant="success" className="px-1.5 py-0">
               <Badge.Text className="text-[10px]">Active</Badge.Text>
             </Badge>
           ) : deployment.status === "completed" ? (
-            <Badge variant="neutral" className="py-0 px-1.5">
+            <Badge variant="neutral" className="px-1.5 py-0">
               <Badge.Text className="text-[10px]">Completed</Badge.Text>
             </Badge>
           ) : deployment.status === "failed" ? (
-            <Badge variant="destructive" className="py-0 px-1.5">
+            <Badge variant="destructive" className="px-1.5 py-0">
               <Badge.Text className="text-[10px]">Failed</Badge.Text>
             </Badge>
           ) : (
-            <Badge variant="warning" className="py-0 px-1.5">
+            <Badge variant="warning" className="px-1.5 py-0">
               <Badge.Text className="text-[10px]">
                 {deployment.status === "pending"
                   ? "Pending"
@@ -83,12 +83,12 @@ function DeploymentSidebarItem({
           )}
         </span>
       </div>
-      <div className="flex items-center gap-2 mt-1 pl-4">
-        <span className="text-xs font-mono text-muted-foreground">
+      <div className="mt-1 flex items-center gap-2 pl-4">
+        <span className="text-muted-foreground font-mono text-xs">
           {deployment.id.slice(0, 8)}
         </span>
-        <span className="text-xs text-muted-foreground">&middot;</span>
-        <span className="text-xs text-muted-foreground">{timeLabel}</span>
+        <span className="text-muted-foreground text-xs">&middot;</span>
+        <span className="text-muted-foreground text-xs">{timeLabel}</span>
       </div>
     </button>
   );
@@ -126,12 +126,12 @@ function DeploymentDetailPanel({
       : "Assets";
 
   return (
-    <div className="flex-1 overflow-y-auto p-6 space-y-6">
+    <div className="flex-1 space-y-6 overflow-y-auto p-6">
       {/* Info section */}
-      <div className="rounded-lg border border-border p-4">
+      <div className="border-border rounded-lg border p-4">
         <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
           <div>
-            <dt className="text-muted-foreground text-xs mb-0.5">
+            <dt className="text-muted-foreground mb-0.5 text-xs">
               Deployment ID
             </dt>
             <dd className="flex items-center gap-1">
@@ -141,12 +141,12 @@ function DeploymentDetailPanel({
           </div>
 
           <div>
-            <dt className="text-muted-foreground text-xs mb-0.5">Status</dt>
+            <dt className="text-muted-foreground mb-0.5 text-xs">Status</dt>
             <dd className="flex items-center gap-2">
               <StatusDot status={deployment.status} />
               <span className="capitalize">{deployment.status}</span>
               {isActive && (
-                <Badge variant="success" className="py-0 px-1.5">
+                <Badge variant="success" className="px-1.5 py-0">
                   <Badge.Text className="text-[10px]">Active</Badge.Text>
                 </Badge>
               )}
@@ -154,19 +154,19 @@ function DeploymentDetailPanel({
           </div>
 
           <div>
-            <dt className="text-muted-foreground text-xs mb-0.5">Created</dt>
+            <dt className="text-muted-foreground mb-0.5 text-xs">Created</dt>
             <dd>{dateTimeFormatters.humanize(deployment.createdAt)}</dd>
           </div>
 
           <div className="flex gap-6">
             <div>
-              <dt className="text-muted-foreground text-xs mb-0.5">
+              <dt className="text-muted-foreground mb-0.5 text-xs">
                 {assetLabel}
               </dt>
               <dd>{assetCount}</dd>
             </div>
             <div>
-              <dt className="text-muted-foreground text-xs mb-0.5">Tools</dt>
+              <dt className="text-muted-foreground mb-0.5 text-xs">Tools</dt>
               <dd>{toolCount}</dd>
             </div>
           </div>
@@ -176,7 +176,7 @@ function DeploymentDetailPanel({
       {/* Logs section */}
       <Suspense
         fallback={
-          <div className="text-sm text-muted-foreground">Loading logs...</div>
+          <div className="text-muted-foreground text-sm">Loading logs...</div>
         }
       >
         <LogsTabContent
@@ -215,8 +215,8 @@ export function SourceDeploymentsPanel({
     deployments.find((d) => d.id === selectedId) ?? deployments[0]!;
 
   return (
-    <div className="max-w-[1270px] mx-auto px-8 py-8 w-full h-full min-h-0 flex flex-col">
-      <div className="flex items-center justify-between mb-4 shrink-0">
+    <div className="mx-auto flex h-full min-h-0 w-full max-w-[1270px] flex-col px-8 py-8">
+      <div className="mb-4 flex shrink-0 items-center justify-between">
         <div>
           <Heading variant="h4">Deployments</Heading>
           <Type muted small>
@@ -233,9 +233,9 @@ export function SourceDeploymentsPanel({
         </routes.deployments.Link>
       </div>
 
-      <div className="grid grid-cols-[280px_1fr] flex-1 min-h-0 rounded-lg border border-border overflow-hidden">
+      <div className="border-border grid min-h-0 flex-1 grid-cols-[280px_1fr] overflow-hidden rounded-lg border">
         {/* ── Left sidebar ── */}
-        <div className="border-r border-border overflow-y-auto bg-muted/30">
+        <div className="border-border bg-muted/30 overflow-y-auto border-r">
           {deployments.map((d) => (
             <DeploymentSidebarItem
               key={d.id}

--- a/client/dashboard/src/pages/sources/SourceDetails.tsx
+++ b/client/dashboard/src/pages/sources/SourceDetails.tsx
@@ -240,14 +240,14 @@ export default function SourceDetails() {
       >
         <DetailHero>
           <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-3 ml-1">
+            <div className="ml-1 flex items-center gap-3">
               <Heading variant="h1">{source?.name || sourceSlug}</Heading>
               <Badge variant="neutral">
                 <Badge.Text>{sourceType}</Badge.Text>
               </Badge>
             </div>
-            <div className="flex items-center gap-2 ml-1">
-              <Type className="max-w-2xl truncate text-muted-foreground">
+            <div className="ml-1 flex items-center gap-2">
+              <Type className="text-muted-foreground max-w-2xl truncate">
                 {source?.slug}
               </Type>
             </div>
@@ -258,11 +258,11 @@ export default function SourceDetails() {
         <Tabs
           value={activeTab}
           onValueChange={handleTabChange}
-          className="w-full flex-1 flex flex-col min-h-0"
+          className="flex min-h-0 w-full flex-1 flex-col"
         >
-          <div className="border-b shrink-0">
-            <div className="max-w-[1270px] mx-auto px-8">
-              <TabsList className="h-auto bg-transparent p-0 gap-6 rounded-none">
+          <div className="shrink-0 border-b">
+            <div className="mx-auto max-w-[1270px] px-8">
+              <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
                 <PageTabsTrigger value="overview">Overview</PageTabsTrigger>
                 <PageTabsTrigger value="tools">
                   Tools {relatedTools.length > 0 && `(${relatedTools.length})`}
@@ -299,7 +299,7 @@ export default function SourceDetails() {
 
           <TabsContent
             value="tools"
-            className="mt-0 flex-1 flex flex-col min-h-0"
+            className="mt-0 flex min-h-0 flex-1 flex-col"
           >
             <SourceToolsTab
               relatedTools={relatedTools}
@@ -319,7 +319,7 @@ export default function SourceDetails() {
                   <SkeletonCode lines={20} />
                 </div>
               ) : specError ? (
-                <div className="text-center py-8">
+                <div className="py-8 text-center">
                   <Type className="text-destructive">
                     {specError instanceof Error
                       ? specError.message
@@ -342,14 +342,14 @@ export default function SourceDetails() {
                   wordWrap="on"
                 />
               ) : (
-                <Type className="text-muted-foreground text-center py-8">
+                <Type className="text-muted-foreground py-8 text-center">
                   No spec content available
                 </Type>
               )}
             </TabsContent>
           )}
 
-          <TabsContent value="deployments" className="mt-0 flex-1 min-h-0">
+          <TabsContent value="deployments" className="mt-0 min-h-0 flex-1">
             <Suspense
               fallback={<div className="p-8">Loading deployments...</div>}
             >

--- a/client/dashboard/src/pages/sources/SourceMCPServersTab.tsx
+++ b/client/dashboard/src/pages/sources/SourceMCPServersTab.tsx
@@ -13,12 +13,12 @@ function MCPServerPortalCard({ toolset }: { toolset: ToolsetEntry }) {
       params={[toolset.slug]}
       className="hover:no-underline"
     >
-      <DotCard icon={<Network className="w-10 h-10 text-muted-foreground" />}>
-        <div className="flex items-start justify-between gap-2 mb-1">
+      <DotCard icon={<Network className="text-muted-foreground h-10 w-10" />}>
+        <div className="mb-1 flex items-start justify-between gap-2">
           <Type
             variant="subheading"
             as="div"
-            className="truncate text-md group-hover:text-primary transition-colors"
+            className="text-md group-hover:text-primary truncate transition-colors"
           >
             {toolset.name}
           </Type>
@@ -30,18 +30,18 @@ function MCPServerPortalCard({ toolset }: { toolset: ToolsetEntry }) {
           {toolset.slug}
         </Type>
         {toolset.description && (
-          <Type small muted className="line-clamp-2 mt-2">
+          <Type small muted className="mt-2 line-clamp-2">
             {toolset.description}
           </Type>
         )}
-        <div className="flex items-center justify-between gap-2 mt-auto pt-2">
+        <div className="mt-auto flex items-center justify-between gap-2 pt-2">
           <div className="flex items-center gap-2">
             <div className="relative flex h-2.5 w-2.5">
               {toolset.mcpEnabled && (
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-green-400" />
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
               )}
               <span
-                className={`relative inline-flex rounded-full h-2.5 w-2.5 ${toolset.mcpEnabled ? "bg-green-500" : "bg-red-500"}`}
+                className={`relative inline-flex h-2.5 w-2.5 rounded-full ${toolset.mcpEnabled ? "bg-green-500" : "bg-red-500"}`}
               />
             </div>
             <Type variant="small" muted>
@@ -52,9 +52,9 @@ function MCPServerPortalCard({ toolset }: { toolset: ToolsetEntry }) {
                 : "Disabled"}
             </Type>
           </div>
-          <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+          <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
             <span>Open</span>
-            <ArrowRight className="w-3.5 h-3.5" />
+            <ArrowRight className="h-3.5 w-3.5" />
           </div>
         </div>
       </DotCard>
@@ -70,18 +70,18 @@ export function SourceMCPServersTab({
   const routes = useRoutes();
 
   return (
-    <div className="max-w-[1270px] mx-auto px-8 py-8 w-full">
+    <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
       {associatedToolsets.length > 0 ? (
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
           {associatedToolsets.map((toolset) => (
             <MCPServerPortalCard key={toolset.slug} toolset={toolset} />
           ))}
         </div>
       ) : (
-        <div className="border rounded-lg p-12 text-center">
-          <Server className="h-10 w-10 text-muted-foreground mx-auto mb-3 opacity-40" />
-          <Type className="block mb-1 font-medium">No MCP servers yet</Type>
-          <Type muted small className="block max-w-sm mx-auto mb-4">
+        <div className="rounded-lg border p-12 text-center">
+          <Server className="text-muted-foreground mx-auto mb-3 h-10 w-10 opacity-40" />
+          <Type className="mb-1 block font-medium">No MCP servers yet</Type>
+          <Type muted small className="mx-auto mb-4 block max-w-sm">
             Create an MCP server that includes tools from this source to expose
             them to AI agents and clients.
           </Type>

--- a/client/dashboard/src/pages/sources/SourceOverviewTab.tsx
+++ b/client/dashboard/src/pages/sources/SourceOverviewTab.tsx
@@ -70,14 +70,14 @@ export function SourceOverviewTab({
     : "Unknown";
 
   return (
-    <div className="max-w-[1270px] mx-auto px-8 py-8 w-full">
-      <div className="grid grid-cols-[280px_1fr] gap-8 items-start">
+    <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
+      <div className="grid grid-cols-[280px_1fr] items-start gap-8">
         {/* Source Information */}
         <div className="flex flex-col">
           <Heading variant="h4" className="mb-3">
             Source Information
           </Heading>
-          <div className="border rounded-lg divide-y">
+          <div className="divide-y rounded-lg border">
             <OverviewRow label={isOpenAPI ? "API name" : "Function name"}>
               <Type className="font-medium">{source?.name || "—"}</Type>
             </OverviewRow>
@@ -131,12 +131,12 @@ export function SourceOverviewTab({
                   params={[activeDeploymentItem.id]}
                   className="flex items-center gap-1 hover:no-underline"
                 >
-                  <Type className="font-mono text-sm text-primary">
+                  <Type className="text-primary font-mono text-sm">
                     {activeDeploymentItem.id.slice(0, 8)}
                   </Type>
                 </routes.deployments.deployment.Link>
               ) : (
-                <Type className="text-sm text-muted-foreground">—</Type>
+                <Type className="text-muted-foreground text-sm">—</Type>
               )}
             </OverviewRow>
           </div>
@@ -144,7 +144,7 @@ export function SourceOverviewTab({
 
         {/* Source Activity */}
         <div className="flex flex-col">
-          <div className="flex items-center justify-between mb-3">
+          <div className="mb-3 flex items-center justify-between">
             <Heading variant="h4">Source Activity</Heading>
             <Type muted small>
               Last 7 days
@@ -152,13 +152,13 @@ export function SourceOverviewTab({
           </div>
 
           {isLoadingTelemetry ? (
-            <div className="rounded-lg border p-6 animate-pulse bg-muted/20 h-48" />
+            <div className="bg-muted/20 h-48 animate-pulse rounded-lg border p-6" />
           ) : sourceToolMetrics.length > 0 ? (
             <div className="space-y-4">
               {sourceTelemetrySummary && (
                 <TelemetrySummaryRow summary={sourceTelemetrySummary} />
               )}
-              <div className="border rounded-lg p-4">
+              <div className="rounded-lg border p-4">
                 <Type muted small className="mb-3 block">
                   Tool usage
                 </Type>
@@ -166,8 +166,8 @@ export function SourceOverviewTab({
               </div>
             </div>
           ) : (
-            <div className="border rounded-lg p-12 text-center flex flex-col items-center justify-center">
-              <Type muted className="block mb-1">
+            <div className="flex flex-col items-center justify-center rounded-lg border p-12 text-center">
+              <Type muted className="mb-1 block">
                 No invocation data yet
               </Type>
               <Type muted small>
@@ -234,7 +234,7 @@ function ToolBarList({ tools }: { tools: ToolMetric[] }) {
 
   if (barListData.length === 0) {
     return (
-      <div className="text-center text-muted-foreground py-8">
+      <div className="text-muted-foreground py-8 text-center">
         No tool data available
       </div>
     );
@@ -249,11 +249,11 @@ function ToolBarList({ tools }: { tools: ToolMetric[] }) {
 
         return (
           <div key={item.name} className="flex items-center gap-2">
-            <span className="text-sm font-medium text-right shrink-0 min-w-[3rem]">
+            <span className="min-w-[3rem] shrink-0 text-right text-sm font-medium">
               {item.value.toLocaleString()}
             </span>
-            <div className="flex-1 relative h-7">
-              <span className="absolute inset-y-0 left-2 flex items-center text-sm font-medium text-foreground truncate pr-2 z-0">
+            <div className="relative h-7 flex-1">
+              <span className="text-foreground absolute inset-y-0 left-2 z-0 flex items-center truncate pr-2 text-sm font-medium">
                 {item.name}
               </span>
               <div
@@ -261,10 +261,10 @@ function ToolBarList({ tools }: { tools: ToolMetric[] }) {
                 style={{ width: `${Math.max(widthPercent, 5)}%` }}
               />
               <div
-                className="absolute inset-y-0 left-0 overflow-hidden z-10"
+                className="absolute inset-y-0 left-0 z-10 overflow-hidden"
                 style={{ width: `${Math.max(widthPercent, 5)}%` }}
               >
-                <span className="absolute inset-y-0 left-2 flex items-center text-sm font-medium text-white truncate pr-2 whitespace-nowrap">
+                <span className="absolute inset-y-0 left-2 flex items-center truncate pr-2 text-sm font-medium whitespace-nowrap text-white">
                   {item.name}
                 </span>
               </div>

--- a/client/dashboard/src/pages/sources/SourceSettingsTab.tsx
+++ b/client/dashboard/src/pages/sources/SourceSettingsTab.tsx
@@ -96,7 +96,7 @@ export function SourceSettingsTab({
 
   return (
     <>
-      <div className="max-w-[1270px] mx-auto px-8 py-8 w-full space-y-8">
+      <div className="mx-auto w-full max-w-[1270px] space-y-8 px-8 py-8">
         <div>
           <Type variant="subheading" className="mb-4">
             Source Actions
@@ -123,7 +123,7 @@ export function SourceSettingsTab({
           </Stack>
         </div>
 
-        <div className="border border-destructive/30 rounded-lg p-6">
+        <div className="border-destructive/30 rounded-lg border p-6">
           <Type variant="subheading" className="text-destructive mb-1">
             Danger Zone
           </Type>
@@ -146,7 +146,7 @@ export function SourceSettingsTab({
 
       {!isOpenAPI && (
         <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-          <Dialog.Content className="min-w-[80vw] h-[90vh]">
+          <Dialog.Content className="h-[90vh] min-w-[80vw]">
             <ViewSourceDialogContent
               source={source || null}
               isOpenAPI={isOpenAPI}

--- a/client/dashboard/src/pages/sources/SourceToolsTab.tsx
+++ b/client/dashboard/src/pages/sources/SourceToolsTab.tsx
@@ -60,30 +60,30 @@ function FilterPill({
 
 function HttpToolRow({ tool }: { tool: HttpTool }) {
   return (
-    <div className="grid grid-cols-[80px_40%_1fr] items-center px-4 py-3 border-b last:border-b-0 hover:bg-muted/30 transition-colors">
+    <div className="hover:bg-muted/30 grid grid-cols-[80px_40%_1fr] items-center border-b px-4 py-3 transition-colors last:border-b-0">
       <div>
         <Badge variant={HTTP_METHOD_VARIANT[tool.httpMethod] ?? "neutral"}>
           <Badge.Text>{tool.httpMethod}</Badge.Text>
         </Badge>
       </div>
-      <div className="font-mono text-sm text-muted-foreground truncate pr-3">
+      <div className="text-muted-foreground truncate pr-3 font-mono text-sm">
         {tool.path}
       </div>
-      <div className="text-sm truncate">{tool.name}</div>
+      <div className="truncate text-sm">{tool.name}</div>
     </div>
   );
 }
 
 function FunctionToolRow({ tool }: { tool: FunctionTool }) {
   return (
-    <div className="grid grid-cols-[120px_1fr_1.5fr] gap-4 items-center px-4 py-3 border-b last:border-b-0 hover:bg-muted/30 transition-colors">
+    <div className="hover:bg-muted/30 grid grid-cols-[120px_1fr_1.5fr] items-center gap-4 border-b px-4 py-3 transition-colors last:border-b-0">
       <div>
         <Badge variant={runtimeBadgeVariant(tool.runtime)}>
           <Badge.Text>{tool.runtime}</Badge.Text>
         </Badge>
       </div>
-      <div className="font-mono text-sm truncate">{tool.name}</div>
-      <div className="text-sm text-muted-foreground truncate">
+      <div className="truncate font-mono text-sm">{tool.name}</div>
+      <div className="text-muted-foreground truncate text-sm">
         {tool.description}
       </div>
     </div>
@@ -102,7 +102,7 @@ function ToolsTableHeader({
   const columnClass =
     "text-xs font-medium text-muted-foreground uppercase tracking-wider";
   return (
-    <div className="border-b bg-muted/50 shrink-0">
+    <div className="bg-muted/50 shrink-0 border-b">
       {isOpenAPI ? (
         <div className="grid grid-cols-[80px_40%_1fr] items-center px-4 py-1">
           <div className={columnClass}>Method</div>
@@ -118,7 +118,7 @@ function ToolsTableHeader({
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-[120px_1fr_1.5fr] gap-4 items-center px-4 py-1">
+        <div className="grid grid-cols-[120px_1fr_1.5fr] items-center gap-4 px-4 py-1">
           <div className={columnClass}>Runtime</div>
           <div className={columnClass}>Function Name</div>
           <div className={`${columnClass} flex items-center justify-between`}>
@@ -176,7 +176,7 @@ function FilteredToolsList({
 
   if (filtered.length === 0) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex h-full items-center justify-center">
         <Type muted>No matching tools found</Type>
       </div>
     );
@@ -210,8 +210,8 @@ export function SourceToolsTab({
 
   if (relatedTools.length === 0) {
     return (
-      <div className="max-w-[1270px] mx-auto px-8 py-6 w-full">
-        <div className="text-center py-12">
+      <div className="mx-auto w-full max-w-[1270px] px-8 py-6">
+        <div className="py-12 text-center">
           <Type muted>No tools derived from this source yet.</Type>
         </div>
       </div>
@@ -219,11 +219,11 @@ export function SourceToolsTab({
   }
 
   return (
-    <div className="max-w-[1270px] mx-auto px-8 py-6 w-full flex-1 flex flex-col min-h-0">
-      <div className="flex flex-col gap-4 flex-1 min-h-0">
+    <div className="mx-auto flex min-h-0 w-full max-w-[1270px] flex-1 flex-col px-8 py-6">
+      <div className="flex min-h-0 flex-1 flex-col gap-4">
         {/* HTTP method filter pills */}
         {isOpenAPI && (
-          <div className="flex gap-2 flex-wrap shrink-0">
+          <div className="flex shrink-0 flex-wrap gap-2">
             <button onClick={() => setMethodFilter(null)}>
               <Badge
                 variant={methodFilter === null ? "information" : "neutral"}
@@ -257,7 +257,7 @@ export function SourceToolsTab({
 
         {/* Runtime filter pills (only when multiple runtimes) */}
         {!isOpenAPI && uniqueRuntimes.length > 1 && (
-          <div className="flex gap-2 flex-wrap shrink-0">
+          <div className="flex shrink-0 flex-wrap gap-2">
             <button onClick={() => setRuntimeFilter(null)}>
               <Badge
                 variant={runtimeFilter === null ? "information" : "neutral"}
@@ -290,7 +290,7 @@ export function SourceToolsTab({
         )}
 
         {/* Tools table */}
-        <div className="border rounded-lg flex flex-col overflow-hidden flex-1 min-h-0 mb-4">
+        <div className="mb-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border">
           <ToolsTableHeader
             isOpenAPI={isOpenAPI}
             searchQuery={searchQuery}

--- a/client/dashboard/src/pages/sources/external-mcp/ExternalMCPDetails.tsx
+++ b/client/dashboard/src/pages/sources/external-mcp/ExternalMCPDetails.tsx
@@ -120,7 +120,7 @@ export default function ExternalMCPDetails() {
 
       <Page.Body fullWidth noPadding fullHeight overflowHidden>
         {/* Hero Header with Illustration - full width */}
-        <div className="relative w-full h-64 shrink-0 overflow-hidden">
+        <div className="relative h-64 w-full shrink-0 overflow-hidden">
           <ExternalMCPIllustration
             logoUrl={catalogIconMap.get(source?.registryServerSpecifier || "")}
             name={source?.name}
@@ -129,10 +129,10 @@ export default function ExternalMCPDetails() {
           />
 
           {/* Overlay for text readability */}
-          <div className="absolute inset-0 bg-linear-to-t from-foreground/50 via-foreground/20 to-transparent" />
-          <div className="absolute bottom-0 left-0 right-0 px-8 py-8 max-w-[1270px] mx-auto w-full">
+          <div className="from-foreground/50 via-foreground/20 absolute inset-0 bg-linear-to-t to-transparent" />
+          <div className="absolute right-0 bottom-0 left-0 mx-auto w-full max-w-[1270px] px-8 py-8">
             <Stack gap={2}>
-              <div className="flex items-center gap-3 ml-1">
+              <div className="ml-1 flex items-center gap-3">
                 <Heading variant="h1" className="text-background">
                   {source?.name || sourceSlug}
                 </Heading>
@@ -140,8 +140,8 @@ export default function ExternalMCPDetails() {
                   <Badge.Text>External MCP</Badge.Text>
                 </Badge>
               </div>
-              <div className="flex items-center gap-2 ml-1">
-                <Type className="max-w-2xl truncate text-background/70!">
+              <div className="ml-1 flex items-center gap-2">
+                <Type className="text-background/70! max-w-2xl truncate">
                   {source?.slug}
                 </Type>
               </div>
@@ -153,20 +153,20 @@ export default function ExternalMCPDetails() {
         <Tabs
           value={activeTab}
           onValueChange={handleTabChange}
-          className="w-full flex-1 flex flex-col min-h-0"
+          className="flex min-h-0 w-full flex-1 flex-col"
         >
-          <div className="border-b shrink-0">
-            <div className="max-w-[1270px] mx-auto px-8">
-              <TabsList className="h-auto bg-transparent p-0 gap-6 rounded-none">
+          <div className="shrink-0 border-b">
+            <div className="mx-auto max-w-[1270px] px-8">
+              <TabsList className="h-auto gap-6 rounded-none bg-transparent p-0">
                 <TabsTrigger
                   value="overview"
-                  className="relative h-11 px-1 pb-3 pt-3 bg-transparent! rounded-none border-none shadow-none! text-muted-foreground data-[state=active]:text-foreground data-[state=active]:bg-transparent! after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary"
+                  className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:after:bg-primary relative h-11 rounded-none border-none bg-transparent! px-1 pt-3 pb-3 shadow-none! after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent data-[state=active]:bg-transparent!"
                 >
                   Overview
                 </TabsTrigger>
                 <TabsTrigger
                   value="mcp-servers"
-                  className="relative h-11 px-1 pb-3 pt-3 bg-transparent! rounded-none border-none shadow-none! text-muted-foreground data-[state=active]:text-foreground data-[state=active]:bg-transparent! after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary"
+                  className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:after:bg-primary relative h-11 rounded-none border-none bg-transparent! px-1 pt-3 pb-3 shadow-none! after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent data-[state=active]:bg-transparent!"
                 >
                   MCP Servers{" "}
                   {associatedToolsets.length > 0 &&
@@ -174,7 +174,7 @@ export default function ExternalMCPDetails() {
                 </TabsTrigger>
                 <TabsTrigger
                   value="settings"
-                  className="relative h-11 px-1 pb-3 pt-3 bg-transparent! rounded-none border-none shadow-none! text-muted-foreground data-[state=active]:text-foreground data-[state=active]:bg-transparent! after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary"
+                  className="text-muted-foreground data-[state=active]:text-foreground data-[state=active]:after:bg-primary relative h-11 rounded-none border-none bg-transparent! px-1 pt-3 pb-3 shadow-none! after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent data-[state=active]:bg-transparent!"
                 >
                   Settings
                 </TabsTrigger>
@@ -184,7 +184,7 @@ export default function ExternalMCPDetails() {
 
           {/* Overview Tab */}
           <TabsContent value="overview" className="mt-0 flex-1">
-            <div className="max-w-[1270px] mx-auto px-8 py-8 w-full space-y-6">
+            <div className="mx-auto w-full max-w-[1270px] space-y-6 px-8 py-8">
               {/* Row 1: Name, Registry ID */}
               <div className="flex gap-16">
                 <div>
@@ -221,7 +221,7 @@ export default function ExternalMCPDetails() {
                 {deployment?.deployment?.id ? (
                   <routes.deployments.deployment.Link
                     params={[deployment.deployment.id]}
-                    className="hover:underline text-primary font-mono"
+                    className="text-primary font-mono hover:underline"
                   >
                     {deployment.deployment.id.slice(0, 8)}
                   </routes.deployments.deployment.Link>
@@ -234,19 +234,19 @@ export default function ExternalMCPDetails() {
 
           {/* MCP Servers Tab */}
           <TabsContent value="mcp-servers" className="mt-0 flex-1">
-            <div className="max-w-[1270px] mx-auto px-8 py-8 w-full">
+            <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
               {isLoadingToolsets ? (
                 <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                   {[1, 2, 3].map((i) => (
                     <div
                       key={i}
-                      className="rounded-xl border bg-card p-6 animate-pulse"
+                      className="bg-card animate-pulse rounded-xl border p-6"
                     >
-                      <div className="flex items-center gap-3 mb-4">
-                        <div className="w-10 h-10 rounded-lg bg-muted" />
+                      <div className="mb-4 flex items-center gap-3">
+                        <div className="bg-muted h-10 w-10 rounded-lg" />
                         <div className="flex-1">
-                          <div className="h-4 w-24 bg-muted rounded mb-2" />
-                          <div className="h-3 w-32 bg-muted rounded" />
+                          <div className="bg-muted mb-2 h-4 w-24 rounded" />
+                          <div className="bg-muted h-3 w-32 rounded" />
                         </div>
                       </div>
                     </div>
@@ -259,8 +259,8 @@ export default function ExternalMCPDetails() {
                   ))}
                 </div>
               ) : (
-                <div className="text-center py-12">
-                  <Server className="h-12 w-12 mx-auto mb-3 text-muted-foreground/50" />
+                <div className="py-12 text-center">
+                  <Server className="text-muted-foreground/50 mx-auto mb-3 h-12 w-12" />
                   <Type muted>No MCP servers are using this source yet.</Type>
                 </div>
               )}
@@ -269,9 +269,9 @@ export default function ExternalMCPDetails() {
 
           {/* Settings Tab */}
           <TabsContent value="settings" className="mt-0 flex-1">
-            <div className="max-w-[1270px] mx-auto px-8 py-8 w-full space-y-8">
+            <div className="mx-auto w-full max-w-[1270px] space-y-8 px-8 py-8">
               {/* Danger Zone */}
-              <div className="border border-destructive/30 rounded-lg p-6">
+              <div className="border-destructive/30 rounded-lg border p-6">
                 <Type variant="subheading" className="text-destructive mb-1">
                   Danger Zone
                 </Type>
@@ -318,38 +318,38 @@ function MCPServerPortalCard({ toolset }: { toolset: ToolsetEntry }) {
   return (
     <routes.mcp.details.Link
       params={[toolset.slug]}
-      className="group block rounded-xl border bg-card hover:bg-surface-secondary hover:border-primary/30 transition-all duration-200 cursor-pointer hover:no-underline hover:shadow-lg"
+      className="group bg-card hover:bg-surface-secondary hover:border-primary/30 block cursor-pointer rounded-xl border transition-all duration-200 hover:no-underline hover:shadow-lg"
     >
       <div className="p-5">
         {/* Header with icon */}
-        <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="mb-3 flex items-start justify-between gap-3">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
-              <Server className="h-5 w-5 text-primary" />
+            <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
+              <Server className="text-primary h-5 w-5" />
             </div>
             <div>
-              <Type className="font-semibold text-base group-hover:text-primary transition-colors">
+              <Type className="group-hover:text-primary text-base font-semibold transition-colors">
                 {toolset.name}
               </Type>
-              <div className="flex items-center gap-2 mt-1">
+              <div className="mt-1 flex items-center gap-2">
                 <McpEnabledBadge enabled={!!toolset.mcpEnabled} />
                 <McpPublicBadge isPublic={!!toolset.mcpIsPublic} />
               </div>
             </div>
           </div>
-          <ChevronRight className="h-5 w-5 text-muted-foreground group-hover:text-primary group-hover:translate-x-0.5 transition-all shrink-0 mt-2" />
+          <ChevronRight className="text-muted-foreground group-hover:text-primary mt-2 h-5 w-5 shrink-0 transition-all group-hover:translate-x-0.5" />
         </div>
 
         {/* Description */}
         {toolset.description && (
-          <Type className="text-sm text-muted-foreground line-clamp-2">
+          <Type className="text-muted-foreground line-clamp-2 text-sm">
             {toolset.description}
           </Type>
         )}
 
         {/* Footer with tool count */}
-        <div className="mt-4 pt-3 border-t">
-          <Type className="text-xs text-muted-foreground">
+        <div className="mt-4 border-t pt-3">
+          <Type className="text-muted-foreground text-xs">
             {toolset.toolUrns?.length || 0} tool
             {(toolset.toolUrns?.length || 0) !== 1 ? "s" : ""} available
           </Type>

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -163,11 +163,11 @@ export default function Team() {
             <img
               src={member.photoUrl}
               alt={member.name}
-              className="w-8 h-8 rounded-full"
+              className="h-8 w-8 rounded-full"
             />
           ) : (
             <div
-              className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white"
+              className="flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium text-white"
               style={{
                 backgroundImage: `linear-gradient(${getMemberColors(member.id).angle}deg, ${getMemberColors(member.id).from}, ${getMemberColors(member.id).to})`,
               }}
@@ -244,7 +244,7 @@ export default function Team() {
             className={isExpired ? "opacity-50" : ""}
           >
             <div
-              className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white shrink-0"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
               style={{
                 backgroundImage: `linear-gradient(${getMemberColors(invite.email).angle}deg, ${getMemberColors(invite.email).from}, ${getMemberColors(invite.email).to})`,
               }}
@@ -352,11 +352,11 @@ export default function Team() {
               noResultsMessage={
                 <Stack
                   gap={2}
-                  className="h-full p-8 bg-background"
+                  className="bg-background h-full p-8"
                   align="center"
                   justify="center"
                 >
-                  <Users className="h-12 w-12 text-muted-foreground" />
+                  <Users className="text-muted-foreground h-12 w-12" />
                   <Type variant="body" className="text-muted-foreground">
                     No team members yet
                   </Type>
@@ -394,7 +394,7 @@ export default function Team() {
             <form className="space-y-4 py-4" onSubmit={handleInvite}>
               <Type variant="body" className="text-muted-foreground">
                 Enter the email address of the person you'd like to invite to{" "}
-                <span className="font-medium text-foreground">
+                <span className="text-foreground font-medium">
                   {organization.name}
                 </span>
                 .

--- a/client/dashboard/src/pages/toolBuilder/CustomTools.tsx
+++ b/client/dashboard/src/pages/toolBuilder/CustomTools.tsx
@@ -57,7 +57,7 @@ export default function CustomTools() {
       <Page.Section.CTA>
         <Button onClick={onNewCustomTool}>
           <Button.LeftIcon>
-            <Plus className="w-4 h-4" />
+            <Plus className="h-4 w-4" />
           </Button.LeftIcon>
           <Button.Text>New Custom Tool</Button.Text>
         </Button>

--- a/client/dashboard/src/pages/toolBuilder/ToolBuilder.tsx
+++ b/client/dashboard/src/pages/toolBuilder/ToolBuilder.tsx
@@ -327,7 +327,7 @@ function ToolBuilder({ initial }: { initial: ToolBuilderState }) {
           variant="secondary"
           size="sm"
           className={
-            "bg-card dark:bg-background border-stone-300 dark:border-stone-700 border-1"
+            "bg-card dark:bg-background border-1 border-stone-300 dark:border-stone-700"
           }
           disabled={steps.length >= 10}
         >
@@ -491,7 +491,7 @@ function ToolBuilder({ initial }: { initial: ToolBuilderState }) {
   return (
     <ResizablePanel
       direction="horizontal"
-      className="h-full [&>[role='separator']]:border-border [&>[role='separator']]:mx-8 [&>[role='separator']]:border-1"
+      className="[&>[role='separator']]:border-border h-full [&>[role='separator']]:mx-8 [&>[role='separator']]:border-1"
     >
       <ResizablePanel.Pane minSize={35}>
         <Stack gap={1} className="h-full overflow-y-scroll">
@@ -737,13 +737,13 @@ const StepCard = ({
   }
 
   return (
-    <BlockInner className="p-0 rounded-md overflow-clip">
+    <BlockInner className="overflow-clip rounded-md p-0">
       <Stack>
         <Stack
           direction="horizontal"
           align="center"
           justify="space-between"
-          className="px-4 py-3 border-b border-stone-300 dark:border-stone-700 group/heading"
+          className="group/heading border-b border-stone-300 px-4 py-3 dark:border-stone-700"
         >
           {step.canonicalTool ? (
             <Type variant="subheading">Use the {toolBadge} tool to...</Type>
@@ -752,7 +752,7 @@ const StepCard = ({
           )}
           <Stack
             direction="horizontal"
-            className="mr-[-8px] mt-[-8px] group-hover/heading:opacity-100 opacity-0 trans"
+            className="trans mt-[-8px] mr-[-8px] opacity-0 group-hover/heading:opacity-100"
           >
             {moveUp && (
               <Button
@@ -797,7 +797,7 @@ const StepCard = ({
               small
               className={cn(
                 step.instructions === instructionsPlaceholder &&
-                  "italic text-muted-foreground!",
+                  "text-muted-foreground! italic",
               )}
             >
               <MustacheHighlight>{step.instructions}</MustacheHighlight>
@@ -840,7 +840,7 @@ const ToolSelectPopover = ({
               <SimpleTooltip tooltip="Create a step that doesn't use any tools">
                 <CommandItem
                   value={"none"}
-                  className="cursor-pointer min-w-fit text-sm"
+                  className="min-w-fit cursor-pointer text-sm"
                   onSelect={() => onSelect("none")}
                 >
                   <Icon name="file-text" size="small" />
@@ -858,7 +858,7 @@ const ToolSelectPopover = ({
                   <CommandItem
                     key={tool.name}
                     value={tool.name}
-                    className="cursor-pointer min-w-fit"
+                    className="min-w-fit cursor-pointer"
                     onSelect={() => onSelect(tool)}
                   >
                     {tool.displayName}

--- a/client/dashboard/src/pages/toolBuilder/Toolify.tsx
+++ b/client/dashboard/src/pages/toolBuilder/Toolify.tsx
@@ -175,7 +175,7 @@ export const ToolifyDialog = ({
         </Dialog.Header>
         <Stack gap={4}>
           <Stack gap={1}>
-            <Heading variant="h5" className="normal-case font-medium">
+            <Heading variant="h5" className="font-medium normal-case">
               What tools does this higher-order tool need access to?
             </Heading>
             <Stack direction="horizontal" gap={2} align="center">
@@ -190,7 +190,7 @@ export const ToolifyDialog = ({
             </Stack>
           </Stack>
           <Stack gap={1}>
-            <Heading variant="h5" className="normal-case font-medium">
+            <Heading variant="h5" className="font-medium normal-case">
               What should this tool do?
             </Heading>
             <TextArea

--- a/client/dashboard/src/pages/toolsets/AddToolsDialog.tsx
+++ b/client/dashboard/src/pages/toolsets/AddToolsDialog.tsx
@@ -159,7 +159,7 @@ export function AddToolsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content className="min-w-3xl max-h-[80vh] flex flex-col">
+      <Dialog.Content className="flex max-h-[80vh] min-w-3xl flex-col">
         <Dialog.Header>
           <Dialog.Title>
             Add tools to <span className="font-bold">{toolset.name}</span>
@@ -169,7 +169,7 @@ export function AddToolsDialog({
           </Dialog.Description>
         </Dialog.Header>
 
-        <div className="flex flex-col gap-4 flex-1 min-h-0">
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
           {/* Filters */}
           <div className="flex gap-2">
             <Input
@@ -197,11 +197,11 @@ export function AddToolsDialog({
           {/* Tool list with selection mode */}
           <div className="flex-1 overflow-auto">
             {isLoading ? (
-              <div className="text-center py-8 text-neutral-500">
+              <div className="py-8 text-center text-neutral-500">
                 Loading tools...
               </div>
             ) : filteredTools.length === 0 ? (
-              <div className="text-center py-8 text-neutral-500">
+              <div className="py-8 text-center text-neutral-500">
                 {noResultsMessage}
               </div>
             ) : (

--- a/client/dashboard/src/pages/toolsets/ServerTab.tsx
+++ b/client/dashboard/src/pages/toolsets/ServerTab.tsx
@@ -32,8 +32,8 @@ export function ServerTabContent({ toolset }: ServerTabContentProps) {
       <Card>
         <Card.Title>
           <Stack direction="horizontal" gap={3} align="center">
-            <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
-              <Server className="w-5 h-5 text-primary" />
+            <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
+              <Server className="text-primary h-5 w-5" />
             </div>
             <Stack gap={1}>
               <Type variant="subheading">External MCP Server</Type>
@@ -46,14 +46,14 @@ export function ServerTabContent({ toolset }: ServerTabContentProps) {
         <Card.Description>
           <Stack direction="vertical" gap={4} className="mt-4">
             <div>
-              <Type small muted className="block mb-1">
+              <Type small muted className="mb-1 block">
                 Remote URL
               </Type>
               <Type className="font-mono text-sm">{tool.remoteUrl}</Type>
             </div>
             {tool.requiresOauth && (
               <div>
-                <Type small muted className="block mb-1">
+                <Type small muted className="mb-1 block">
                   Authentication
                 </Type>
                 <Type>OAuth required</Type>

--- a/client/dashboard/src/pages/toolsets/ToolCard.tsx
+++ b/client/dashboard/src/pages/toolsets/ToolCard.tsx
@@ -88,7 +88,7 @@ export function ToolCard({
       >
         <Stack direction="horizontal" align="center">
           {prefixTrimmed && (
-            <Heading variant="h4" className="normal-case text-foreground/50">
+            <Heading variant="h4" className="text-foreground/50 normal-case">
               {sourceName}_
             </Heading>
           )}
@@ -174,7 +174,7 @@ export function ToolCard({
         </Card.Description>
       </Card.Header>
       <Card.Content className="h-full">
-        <div className="border-l-2 pl-4 h-full">
+        <div className="h-full border-l-2 pl-4">
           <EditableText
             value={tool.description}
             onSubmit={(newValue) => updateVariation({ description: newValue })}
@@ -184,7 +184,7 @@ export function ToolCard({
           >
             <Type
               className={cn(
-                "line-clamp-3 text-muted-foreground wrap-anywhere!",
+                "text-muted-foreground line-clamp-3 wrap-anywhere!",
                 !tool.description && "italic",
               )}
             >

--- a/client/dashboard/src/pages/toolsets/Toolset.tsx
+++ b/client/dashboard/src/pages/toolsets/Toolset.tsx
@@ -169,7 +169,7 @@ function AddToToolsetDialog({
           <div className="flex flex-col gap-2">
             <label className="text-sm font-medium">Select Toolset</label>
             <select
-              className="w-full px-3 py-2 border border-neutral-200 rounded-md"
+              className="w-full rounded-md border border-neutral-200 px-3 py-2"
               value={selectedToolsetSlug}
               onChange={(e) => setSelectedToolsetSlug(e.target.value)}
             >
@@ -588,7 +588,7 @@ export function ToolsetView({
       selectedValues={selectedGroups}
       setSelectedValues={setSelectedGroups}
       placeholder="Filter tools"
-      className="w-fit mb-4 capitalize"
+      className="mb-4 w-fit capitalize"
     />
   );
 
@@ -622,7 +622,7 @@ export function ToolsetView({
       <Tabs
         value={activeTab}
         onValueChange={(value) => handleTabChange(value as ToolsetTabs)}
-        className="h-full relative"
+        className="relative h-full"
       >
         <TabsList className="mb-4">
           {isExternalMcpProxy ? (
@@ -732,7 +732,7 @@ export function ToolsetView({
           onSubmit: handleCreateToolsetSubmit,
           validate: (value) => value.length > 0 && value.length <= 40,
           hint: (value) => (
-            <div className="flex justify-between w-full">
+            <div className="flex w-full justify-between">
               <p className="text-destructive">
                 {value.length > 40 && "Must be 40 characters or less"}
               </p>

--- a/client/dashboard/src/pages/toolsets/ToolsetEnvironmentBadge.tsx
+++ b/client/dashboard/src/pages/toolsets/ToolsetEnvironmentBadge.tsx
@@ -162,7 +162,7 @@ export const ToolsetEnvironmentBadge = ({
       <routes.environments.environment.Link params={[envSlug]}>
         <SimpleTooltip tooltip="The environment for this toolset is fully configured.">
           <Badge size={size} variant={variant}>
-            <Check className={cn("w-4 h-4 stroke-3", colors.success)} />
+            <Check className={cn("h-4 w-4 stroke-3", colors.success)} />
             Environment
           </Badge>
         </SimpleTooltip>

--- a/client/dashboard/src/pages/toolsets/ToolsetsEmptyState.tsx
+++ b/client/dashboard/src/pages/toolsets/ToolsetsEmptyState.tsx
@@ -78,7 +78,7 @@ export function ToolsetsGraphic({ className }: { className?: string }) {
         {toolsets.map((toolset, index) => (
           <motion.div
             key={toolset.id}
-            className="bg-white rounded-xl p-4 border border-neutral-200"
+            className="rounded-xl border border-neutral-200 bg-white p-4"
             initial={{ opacity: 1, y: 0 }}
             animate={{
               opacity: 1,
@@ -95,9 +95,9 @@ export function ToolsetsGraphic({ className }: { className?: string }) {
               boxShadow: "0px 8px 16px rgba(0,0,0,0.08)",
             }}
           >
-            <div className="flex items-center gap-3 mb-3">
+            <div className="mb-3 flex items-center gap-3">
               <motion.div
-                className="w-8 h-8 rounded-lg bg-neutral-100 flex items-center justify-center"
+                className="flex h-8 w-8 items-center justify-center rounded-lg bg-neutral-100"
                 animate={{
                   backgroundColor: isHovered ? "#f3f4f6" : "#f5f5f5",
                 }}
@@ -124,9 +124,9 @@ export function ToolsetsGraphic({ className }: { className?: string }) {
               {toolset.tools.map((tool, toolIndex) => (
                 <motion.div
                   key={tool.name}
-                  className={`px-2.5 py-1 rounded-md text-xs font-medium ${
+                  className={`rounded-md px-2.5 py-1 text-xs font-medium ${
                     tool.type === "internal"
-                      ? "bg-neutral-100 text-neutral-900 ring-1 ring-inset ring-neutral-900/10"
+                      ? "bg-neutral-100 text-neutral-900 ring-1 ring-neutral-900/10 ring-inset"
                       : "bg-neutral-50 text-neutral-600"
                   }`}
                   initial={{ opacity: 1, scale: 1 }}

--- a/client/dashboard/src/pages/toolsets/resources/ResourcesTab.tsx
+++ b/client/dashboard/src/pages/toolsets/resources/ResourcesTab.tsx
@@ -146,16 +146,16 @@ function ResourceCard({
     <Card>
       <Card.Header>
         <Stack direction="horizontal" gap={2} align="center">
-          <div className="p-2 rounded-md bg-muted shrink-0">
+          <div className="bg-muted shrink-0 rounded-md p-2">
             <Newspaper
-              className="size-5 text-muted-foreground"
+              className="text-muted-foreground size-5"
               strokeWidth={1.5}
             />
           </div>
           <Card.Title className="normal-case">
             {resource.name}
             {functionName && (
-              <span className="text-xs text-muted-foreground font-normal ml-1">
+              <span className="text-muted-foreground ml-1 text-xs font-normal">
                 ({functionName})
               </span>
             )}
@@ -196,12 +196,12 @@ function ResourceSelectPopover({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <div>
-          <Card className="cursor-pointer hover:bg-muted/50 transition-colors">
+          <Card className="hover:bg-muted/50 cursor-pointer transition-colors">
             <Card.Header>
               <Stack direction="horizontal" gap={2} align="center">
-                <div className="p-2 rounded-md bg-muted shrink-0">
+                <div className="bg-muted shrink-0 rounded-md p-2">
                   <Newspaper
-                    className="size-5 text-muted-foreground"
+                    className="text-muted-foreground size-5"
                     strokeWidth={1.5}
                   />
                 </div>
@@ -239,12 +239,12 @@ function ResourceSelectPopover({
                       setOpen(false);
                     }}
                   >
-                    <div className="flex items-start gap-3 w-full">
+                    <div className="flex w-full items-start gap-3">
                       <Newspaper
-                        className="size-4 text-muted-foreground shrink-0 mt-0.5"
+                        className="text-muted-foreground mt-0.5 size-4 shrink-0"
                         strokeWidth={1.5}
                       />
-                      <Stack gap={0.5} className="flex-1 min-w-0">
+                      <Stack gap={0.5} className="min-w-0 flex-1">
                         <Type small className="font-medium">
                           {resource.name}
                         </Type>
@@ -254,7 +254,7 @@ function ResourceSelectPopover({
                         <Type
                           small
                           muted
-                          className="font-mono truncate text-xs"
+                          className="truncate font-mono text-xs"
                         >
                           {resource.uri}
                         </Type>

--- a/client/dashboard/src/styles/globals.css
+++ b/client/dashboard/src/styles/globals.css
@@ -1,10 +1,12 @@
-/* Import Tailwind CSS v4 */
-@import "tailwindcss";
-
-/* Import Google Fonts */
+/* Google Fonts must be imported before Tailwind — @import "tailwindcss" expands inline to full
+   CSS rules, and the CSS spec requires all @import statements to precede any other rules.
+   Imports after that expansion are invalid and silently ignored by browsers. */
 @import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Cormorant:wght@300;400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400&display=swap");
+
+/* Import Tailwind CSS v4 */
+@import "tailwindcss";
 
 /* Define CSS variables for font families using system fonts and fallbacks */
 :root {

--- a/client/dashboard/src/styles/globals.css
+++ b/client/dashboard/src/styles/globals.css
@@ -1,3 +1,11 @@
+/* Import Tailwind CSS v4 */
+@import "tailwindcss";
+
+/* Import Google Fonts */
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Cormorant:wght@300;400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400&display=swap");
+
 /* Define CSS variables for font families using system fonts and fallbacks */
 :root {
   /* DM Sans fallback - use system UI fonts that are similar */
@@ -13,15 +21,6 @@
     SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
 }
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-/* Import Google Fonts */
-@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Cormorant:wght@300;400;500;600;700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400&display=swap");
 
 @layer base {
   :root {
@@ -89,10 +88,11 @@
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
   body {
-    @apply bg-background text-foreground;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace `@tailwind base/components/utilities` with `@import "tailwindcss"` (Tailwind v4)
- Move Google Fonts `@import` statements to top of file (CSS spec requires `@import` before other rules)
- Replace `@apply border-border`, `@apply bg-background text-foreground` with direct `hsl(var(...))` CSS — Tailwind v4 doesn't generate utilities from CSS variable-based
theme values, so `@apply` on custom color classes fails at build time
- Ran `pnpm oxfmt` which detected the v4 setup and applied v4's canonical class order, which differs slightly from v3's

## Test plan
- [ ] `pnpm oxfmt` passes without errors
- [ ] Dashboard renders correctly in `pnpm dev` — spot-check borders, background, and text colors in light and dark mode

## Notes
The class sorting changed because `oxfmt` uses Prettier with the `prettier-plugin-tailwindcss` plugin, which sorts classes according to Tailwind's recommended order. That order is derived from the Tailwind config — specifically the theme and plugin definitions.

When you switched from Tailwind v3 (@tailwind directives) to v4 (`@import "tailwindcss"`). The Tailwind Prettier plugin detected the v4 setup and applied v4's canonical class order, which differs slightly from v3's. The plugin re-sorted all 225 files to match the new order in one pass.

It's a one-time churn — now that the codebase is on v4's order, future runs of `oxfmt` won't re-sort anything unless new classes are added.

You can verify this with a script

```
# Save the full diff to a temp file
git diff HEAD~1 -- '*.tsx' '*.ts' '*.jsx' > /tmp/oxfmt.diff

# Extract class tokens from removed lines, sort them
grep '^-[^-]' /tmp/oxfmt.diff | grep -oE 'className="[^"]*"' | sed 's/className="//;s/"//' | tr ' ' '\n' | sort > /tmp/removed_tokens.txt

# Extract class tokens from added lines, sort them
grep '^+[^+]' /tmp/oxfmt.diff | grep -oE 'className="[^"]*"' | sed 's/className="//;s/"//' | tr ' ' '\n' | sort > /tmp/added_tokens.txt

# Compare — no output means only order changed, nothing added or removed
diff /tmp/removed_tokens.txt /tmp/added_tokens.txt
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change, but it can cause visual regressions (border/background/text colors) if the new CSS variable HSL mappings or Tailwind v4 import behavior differ from prior builds.
> 
> **Overview**
> Migrates the dashboard `globals.css` to Tailwind CSS v4 by switching from `@tailwind base/components/utilities` to `@import "tailwindcss"` and reordering `@import` statements.
> 
> Replaces a few `@apply` usages for theme-driven colors with explicit `hsl(var(--...))` CSS to avoid Tailwind v4 build-time failures, and updates `.oxfmtrc.json` to stop ignoring `globals.css` so it can be formatted/sorted. Adds a patch changeset for the dashboard package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee3d69dbfc4143e74597c6d523a6be26b68c33d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->