### PR TITLE
fix: resolve WorkOS user ID in UpdateMemberRole

### DIFF
--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -521,20 +520,22 @@ func (s *Service) ListMembers(ctx context.Context, _ *gen.ListMembersPayload) (*
 		return nil, oops.E(oops.CodeUnexpected, err, "list org users from workos").Log(ctx, s.logger)
 	}
 
-	// Build a WorkOS-user-ID → Gram-user lookup so the member list returns
-	// Gram user IDs (the stable identity used by UpdateMemberRole and the
-	// organization_user_relationships table).
-	localUsers := make(map[string]usersrepo.User, len(users))
+	// Batch-resolve WorkOS user IDs to local Gram users so the member list
+	// returns Gram user IDs (the stable identity used by UpdateMemberRole
+	// and the organization_user_relationships table).
+	workosIDs := make([]string, 0, len(users))
 	for workosUID := range users {
-		gramID, err := usersrepo.New(s.db).GetUserIDByWorkosID(ctx, pgtype.Text{String: workosUID, Valid: true})
-		if err != nil {
-			continue // user exists in WorkOS but hasn't logged into Gram yet
+		workosIDs = append(workosIDs, workosUID)
+	}
+	localUserRows, err := usersrepo.New(s.db).GetUsersByWorkosIDs(ctx, workosIDs)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve local users by workos ids").Log(ctx, s.logger)
+	}
+	localUsers := make(map[string]usersrepo.User, len(localUserRows))
+	for _, u := range localUserRows {
+		if u.WorkosID.Valid {
+			localUsers[u.WorkosID.String] = u
 		}
-		u, err := usersrepo.New(s.db).GetUser(ctx, gramID)
-		if err != nil {
-			continue
-		}
-		localUsers[workosUID] = u
 	}
 
 	result := make([]*gen.AccessMember, 0, len(members))

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -521,6 +521,22 @@ func (s *Service) ListMembers(ctx context.Context, _ *gen.ListMembersPayload) (*
 		return nil, oops.E(oops.CodeUnexpected, err, "list org users from workos").Log(ctx, s.logger)
 	}
 
+	// Build a WorkOS-user-ID → Gram-user lookup so the member list returns
+	// Gram user IDs (the stable identity used by UpdateMemberRole and the
+	// organization_user_relationships table).
+	localUsers := make(map[string]usersrepo.User, len(users))
+	for workosUID := range users {
+		gramID, err := usersrepo.New(s.db).GetUserIDByWorkosID(ctx, pgtype.Text{String: workosUID, Valid: true})
+		if err != nil {
+			continue // user exists in WorkOS but hasn't logged into Gram yet
+		}
+		u, err := usersrepo.New(s.db).GetUser(ctx, gramID)
+		if err != nil {
+			continue
+		}
+		localUsers[workosUID] = u
+	}
+
 	result := make([]*gen.AccessMember, 0, len(members))
 	for _, member := range members {
 		user, ok := users[member.UserID]
@@ -528,11 +544,16 @@ func (s *Service) ListMembers(ctx context.Context, _ *gen.ListMembersPayload) (*
 			continue
 		}
 
+		local, ok := localUsers[member.UserID]
+		if !ok {
+			continue // user exists in WorkOS but hasn't logged into Gram yet
+		}
+
 		result = append(result, &gen.AccessMember{
-			ID:       user.ID,
+			ID:       local.ID,
 			Name:     formatUserName(user),
 			Email:    user.Email,
-			PhotoURL: nil,
+			PhotoURL: conv.FromPGText[string](local.PhotoUrl),
 			RoleID:   roleIDBySlug[member.RoleSlug],
 			JoinedAt: conv.Default(member.CreatedAt, time.Time{}.UTC().Format(time.RFC3339)),
 		})
@@ -639,16 +660,7 @@ func (s *Service) UpdateMemberRole(ctx context.Context, payload *gen.UpdateMembe
 		attr.AccessRoleSlug(roleSlug),
 	)
 
-	// The frontend sends the member ID returned by ListMembers, which is the
-	// WorkOS user ID. Try resolving it to a local Gram user ID first; if that
-	// fails, fall back to treating it as a Gram user ID directly (backwards
-	// compatibility).
-	userID := payload.UserID
-	if gramID, err := usersrepo.New(s.db).GetUserIDByWorkosID(ctx, pgtype.Text{String: userID, Valid: true}); err == nil {
-		userID = gramID
-	}
-
-	connectedUser, err := connectedUser(ctx, s.db, ac.ActiveOrganizationID, userID)
+	connectedUser, err := connectedUser(ctx, s.db, ac.ActiveOrganizationID, payload.UserID)
 	switch {
 	case errors.Is(err, errConnectedUserNotFound):
 		return nil, oops.E(oops.CodeNotFound, nil, "member has not joined this organization").Log(ctx, logger)

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -638,7 +639,16 @@ func (s *Service) UpdateMemberRole(ctx context.Context, payload *gen.UpdateMembe
 		attr.AccessRoleSlug(roleSlug),
 	)
 
-	connectedUser, err := connectedUser(ctx, s.db, ac.ActiveOrganizationID, payload.UserID)
+	// The frontend sends the member ID returned by ListMembers, which is the
+	// WorkOS user ID. Try resolving it to a local Gram user ID first; if that
+	// fails, fall back to treating it as a Gram user ID directly (backwards
+	// compatibility).
+	userID := payload.UserID
+	if gramID, err := usersrepo.New(s.db).GetUserIDByWorkosID(ctx, pgtype.Text{String: userID, Valid: true}); err == nil {
+		userID = gramID
+	}
+
+	connectedUser, err := connectedUser(ctx, s.db, ac.ActiveOrganizationID, userID)
 	switch {
 	case errors.Is(err, errConnectedUserNotFound):
 		return nil, oops.E(oops.CodeNotFound, nil, "member is not connected locally").Log(ctx, logger)

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -568,7 +568,7 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 	connectedUser, err := connectedUser(ctx, s.db, ac.ActiveOrganizationID, ac.UserID)
 	switch {
 	case errors.Is(err, errConnectedUserNotFound):
-		return nil, oops.E(oops.CodeNotFound, nil, "current user is not connected locally").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "current user has not joined this organization").Log(ctx, logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "load connected user").Log(ctx, logger)
 	}
@@ -651,7 +651,7 @@ func (s *Service) UpdateMemberRole(ctx context.Context, payload *gen.UpdateMembe
 	connectedUser, err := connectedUser(ctx, s.db, ac.ActiveOrganizationID, userID)
 	switch {
 	case errors.Is(err, errConnectedUserNotFound):
-		return nil, oops.E(oops.CodeNotFound, nil, "member is not connected locally").Log(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, nil, "member has not joined this organization").Log(ctx, logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "load connected user").Log(ctx, logger)
 	}

--- a/server/internal/access/listmembers_test.go
+++ b/server/internal/access/listmembers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
@@ -15,6 +16,11 @@ func TestService_ListMembers(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAccessService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+
+	// Seed local users so that the WorkOS-to-Gram ID resolution succeeds.
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "ada@example.com", "Ada Lovelace", "user_1", "membership_1")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", "grace@example.com", "Grace", "user_2", "membership_2")
 
 	ti.roles.On("ListRoles", mock.Anything, "org_workos_test").Return([]thirdpartyworkos.Role{
 		mockSystemRole("role_admin", "Admin", "admin"),
@@ -38,14 +44,14 @@ func TestService_ListMembers(t *testing.T) {
 		byID[member.ID] = member
 	}
 
-	require.Equal(t, "Ada Lovelace", byID["user_1"].Name)
-	require.Equal(t, "ada@example.com", byID["user_1"].Email)
-	require.Equal(t, "role_admin", byID["user_1"].RoleID)
-	require.Nil(t, byID["user_1"].PhotoURL)
-	require.Equal(t, "2024-11-15T15:04:05Z", byID["user_1"].JoinedAt)
+	// IDs should be Gram user IDs, not WorkOS user IDs.
+	require.Equal(t, "Ada Lovelace", byID["local_user_1"].Name)
+	require.Equal(t, "ada@example.com", byID["local_user_1"].Email)
+	require.Equal(t, "role_admin", byID["local_user_1"].RoleID)
+	require.Equal(t, "2024-11-15T15:04:05Z", byID["local_user_1"].JoinedAt)
 
-	require.Equal(t, "Grace", byID["user_2"].Name)
-	require.Equal(t, "role_builder", byID["user_2"].RoleID)
+	require.Equal(t, "Grace", byID["local_user_2"].Name)
+	require.Equal(t, "role_builder", byID["local_user_2"].RoleID)
 }
 
 func TestService_ListMembers_WorkOSUsersFailure(t *testing.T) {

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -71,7 +71,7 @@ func TestService_ListGrants_NotConnected(t *testing.T) {
 
 	_, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "current user is not connected locally")
+	require.Contains(t, err.Error(), "current user has not joined this organization")
 }
 
 func TestService_ListGrants_WorkOSMembersFailure(t *testing.T) {

--- a/server/internal/access/rbac_test.go
+++ b/server/internal/access/rbac_test.go
@@ -107,7 +107,10 @@ func TestService_ListMembers_AllowsOrgReadGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAccessService(t)
-	ctx = withRBACGrants(t, ctx, Grant{Scope: ScopeOrgRead, Resource: testAccessAuthContext(t, ctx).ActiveOrganizationID})
+	authCtx := testAccessAuthContext(t, ctx)
+	ctx = withRBACGrants(t, ctx, Grant{Scope: ScopeOrgRead, Resource: authCtx.ActiveOrganizationID})
+
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "ada@example.com", "Ada Lovelace", "user_1", "membership_1")
 
 	ti.roles.On("ListRoles", mock.Anything, "org_workos_test").Return([]thirdpartyworkos.Role{
 		mockSystemRole("role_admin", "Admin", "admin"),

--- a/server/internal/access/updatememberrole_test.go
+++ b/server/internal/access/updatememberrole_test.go
@@ -76,7 +76,7 @@ func TestService_UpdateMemberRole_MemberNotFound(t *testing.T) {
 
 	_, err := ti.service.UpdateMemberRole(ctx, &gen.UpdateMemberRolePayload{UserID: "user_missing", RoleID: "role_builder"})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "member is not connected locally")
+	require.Contains(t, err.Error(), "member has not joined this organization")
 }
 
 func TestService_UpdateMemberRole_WorkOSMembershipNotFound(t *testing.T) {

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -23,6 +23,10 @@ SELECT id FROM users
 WHERE workos_id = $1
 LIMIT 1;
 
+-- name: GetUsersByWorkosIDs :many
+SELECT * FROM users
+WHERE workos_id = ANY(@workos_ids::text[]);
+
 -- name: SetUserWorkosID :exec
 UPDATE users 
 SET workos_id = @workos_id, 

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -68,6 +68,41 @@ func (q *Queries) GetUserIDByWorkosID(ctx context.Context, workosID pgtype.Text)
 	return id, err
 }
 
+const getUsersByWorkosIDs = `-- name: GetUsersByWorkosIDs :many
+SELECT id, email, display_name, photo_url, admin, last_login, workos_id, created_at, updated_at FROM users
+WHERE workos_id = ANY($1::text[])
+`
+
+func (q *Queries) GetUsersByWorkosIDs(ctx context.Context, workosIds []string) ([]User, error) {
+	rows, err := q.db.Query(ctx, getUsersByWorkosIDs, workosIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []User
+	for rows.Next() {
+		var i User
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.DisplayName,
+			&i.PhotoUrl,
+			&i.Admin,
+			&i.LastLogin,
+			&i.WorkosID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const setUserWorkosID = `-- name: SetUserWorkosID :exec
 UPDATE users 
 SET workos_id = $1, 


### PR DESCRIPTION
## Summary

- Fixes "member is not connected locally" error when assigning/changing a member's role in the Members tab
- **Root cause**: `ListMembers` returned WorkOS user IDs, but `UpdateMemberRole` looked up users in `organization_user_relationships` which is keyed by Gram/IDP user ID
- `ListMembers` now resolves WorkOS user IDs to Gram user IDs via a single batch query (`GetUsersByWorkosIDs`), and only includes members who have logged into Gram
- Also populates `PhotoURL` from local user data and improves error messages

Closes AGE-1770

## Test plan

- [x] All `TestService_UpdateMemberRole` tests pass (all variants)
- [x] All `TestService_ListMembers` tests pass (updated to verify Gram IDs returned)
- [ ] Manual: assign a member a different role in local dev — should succeed instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)