### PR TITLE
chore: replace bash 4+ mapfile/readarray in mise tasks for macOS compat

### DIFF
--- a/.agents/skills/mise-tasks/SKILL.md
+++ b/.agents/skills/mise-tasks/SKILL.md
@@ -23,6 +23,7 @@ description: Rules and best practices for writing and editing mise tasks.
 - Tasks options MUST come right after the initial shebang line
 - Each task option must be listed one a separate line and MUST follow the form `#MISE <option>=<value>`.
 - All shell scripts MUST start with `#!/usr/bin/env bash` followed by a blank line without exception.
+- Tasks MUST be compatible with bash 3.2+ since that is the default version on macOS.
 - `gum` is a really good tool for building interactive scripts if these are needed.
 
 <detail open><summary>Example</summary>

--- a/.mise-tasks/gen/sdk.sh
+++ b/.mise-tasks/gen/sdk.sh
@@ -15,7 +15,10 @@ check_inputs() {
   source_key=".sources.Gram-Internal"
   schema=$(yq "${source_key}.inputs[0].location" "$workflow")
   output=$(yq "${source_key}.output" "$workflow")
-  readarray -t overlays < <(yq -r "${source_key}.overlays[].location" "$workflow")
+  overlays=()
+  while IFS= read -r line; do
+    overlays+=("$line")
+  done < <(yq -r "${source_key}.overlays[].location" "$workflow")
 
   args=(--schema "$schema")
   for overlay in "${overlays[@]}"; do

--- a/.mise-tasks/lint/migrations.sh
+++ b/.mise-tasks/lint/migrations.sh
@@ -18,7 +18,9 @@ files=()
 if [ -n "$usage_file" ]; then
   files=("${usage_file[@]}")
 else
-  mapfile -t files < <(git diff --relative --diff-filter=d --name-only "$base_ref" -- 'server/migrations/*.sql')
+  while IFS= read -r line; do
+    files+=("$line")
+  done < <(git diff --relative --diff-filter=d --name-only "$base_ref" -- 'server/migrations/*.sql')
 fi
 
 if [ ${#files[@]} -eq 0 ]; then


### PR DESCRIPTION
macOS ships `/bin/bash` 3.2.57 which lacks `mapfile` and `readarray` (both added in bash 4). `mise run lint:migrations` was failing locally with `mapfile: command not found`. Replace with portable `while IFS= read` loops in `.mise-tasks/lint/migrations.sh` and `.mise-tasks/gen/sdk.sh`, and note the bash 3.2+ requirement in the `mise-tasks` skill.