### PR TITLE
fix: log telemetry events even after context cancellation

### DIFF
--- a/.changeset/gentle-goats-show.md
+++ b/.changeset/gentle-goats-show.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+---
+
+Ensure telemetry logs continue to be inserted into ClickHouse even if the
+request context has been canceled.

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -75,15 +75,17 @@ func (l *Logger) checkToolIOLogsEnabled(ctx context.Context, organizationID stri
 }
 
 func (l *Logger) Log(ctx context.Context, params LogParams) {
+	shutdownCtx := l.shutdownCtx()
+
 	chRepo := repo.New(l.chConn)
 
-	enabled, err := l.logsEnabled(ctx, params.ToolInfo.OrganizationID)
+	enabled, err := l.logsEnabled(shutdownCtx, params.ToolInfo.OrganizationID)
 	if err != nil || !enabled {
 		return
 	}
 
 	// Scrub tool IO content if the feature is disabled for this organization.
-	if !l.checkToolIOLogsEnabled(ctx, params.ToolInfo.OrganizationID) {
+	if !l.checkToolIOLogsEnabled(shutdownCtx, params.ToolInfo.OrganizationID) {
 		delete(params.Attributes, attr.GenAIToolCallArgumentsKey)
 		delete(params.Attributes, attr.GenAIToolCallResultKey)
 	}
@@ -94,7 +96,7 @@ func (l *Logger) Log(ctx context.Context, params LogParams) {
 		return
 	}
 
-	if err := chRepo.InsertTelemetryLog(l.shutdownCtx(), *logParams); err != nil {
+	if err := chRepo.InsertTelemetryLog(shutdownCtx, *logParams); err != nil {
 		l.logger.ErrorContext(ctx, "failed to insert telemetry log", attr.SlogError(err))
 	}
 }


### PR DESCRIPTION
The Log method used the request context for `logsEnabled`, `checkToolIOLogsEnabled` checks but only used the shutdown context for the final ClickHouse insert. If the request context was cancelled (e.g. client disconnect), these checks would fail early and the telemetry log would be silently dropped.

Use `l.shutdownCtx()` consistently for all operations in Log so that telemetry events are recorded even when the originating request context has been cancelled.