### PR TITLE
fix: disable noisy logs from retryablehttp

### DIFF
--- a/.changeset/brown-yaks-float.md
+++ b/.changeset/brown-yaks-float.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Disabled the logger for the retryablehttp client to avoid noisy logs that can clutter the output.

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -220,6 +220,7 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 	}
 
 	retryClient := retryablehttp.NewClient()
+	retryClient.Logger = nil // avoid noisy logs from retryablehttp
 	retryClient.HTTPClient = &http.Client{
 		Transport: otelTransport,
 	}


### PR DESCRIPTION
This change disables the logger for the retryablehttp client to avoid noisy logs that can clutter the output.