### PR TITLE
chore: externalize test infrastructure

### DIFF
--- a/.mise-tasks/test/server.sh
+++ b/.mise-tasks/test/server.sh
@@ -2,6 +2,20 @@
 #MISE dir="{{ config_root }}/server"
 #MISE description="Test the server with optional coverage generation. It takes the same arguments as 'go test'."
 
+declare -a EXIT_CALLBACKS=()
+
+run_exit_callbacks() {
+  for callback in "${EXIT_CALLBACKS[@]}"; do
+    eval "$callback"
+  done
+}
+
+trap run_exit_callbacks EXIT
+
+register_exit_callback() {
+  EXIT_CALLBACKS+=("$1")
+}
+
 # Check if flags are provided
 cover=false
 open_html=false
@@ -26,6 +40,84 @@ fi
 
 if [ "$cover" = true ]; then
   args=("-coverprofile=cover.out" "-covermode=atomic" "${args[@]}")
+fi
+
+
+if [ "${TEST_WITH_INFRA:-}" = "1" ]; then
+  echo "Starting test infrastructure in Docker containers..."
+
+  random_hex=$(openssl rand -hex 4)
+
+  pg_container_name="test-pgvector-${random_hex}"
+  pg_container_id=$(docker run -d -q --rm \
+    -p 5432 \
+    --tmpfs /var/lib/postgresql/data:rw \
+    --env POSTGRES_PASSWORD=gotest \
+    --env POSTGRES_USER=gotest \
+    --env POSTGRES_DB=gotestdb \
+    --env PGDATA=/var/lib/postgresql/data \
+    --volume "$(pwd)/database/schema.sql:/docker-entrypoint-initdb.d/00-init.sql:ro" \
+    --volume "$(pwd)/database/testing.sql:/docker-entrypoint-initdb.d/01-testing.sql:ro" \
+    --name "${pg_container_name}" \
+    pgvector/pgvector:pg17)
+  pg_port=$(docker port "${pg_container_name}" 5432/tcp | cut -d: -f2)
+  pg_conn_string="postgres://gotest:gotest@127.0.0.1:${pg_port}/gotestdb?sslmode=disable"
+  register_exit_callback "docker stop ${pg_container_name} > /dev/null 2>&1 || true"
+  export TESTENV_POSTGRES_URI="${pg_conn_string}"
+  echo "Started PostgreSQL container '${pg_container_name}' with connection string: ${pg_conn_string}"
+
+  ch_container_name="test-clickhouse-${random_hex}"
+  ch_container_id=$(docker run -d -q --rm \
+    -p 9000 \
+    --env CLICKHOUSE_USER=gotest \
+    --env CLICKHOUSE_PASSWORD=gotest \
+    --tmpfs /var/lib/clickhouse:rw \
+    --tmpfs /var/log/clickhouse:rw \
+    --volume "$(pwd)/clickhouse/schema.sql:/docker-entrypoint-initdb.d/00-init.sql:ro" \
+    --name "${ch_container_name}" \
+    clickhouse/clickhouse-server:25.8.3)
+  ch_port=$(docker port "${ch_container_name}" 9000/tcp | cut -d: -f2)
+  ch_conn_string="clickhouse://gotest:gotest@127.0.0.1:${ch_port}/default"
+  register_exit_callback "docker stop ${ch_container_name} > /dev/null 2>&1 || true"
+  export TESTENV_CLICKHOUSE_URI="${ch_conn_string}"
+  until docker exec "${ch_container_id}" clickhouse-client --user gotest --password gotest --query "EXISTS TABLE default.telemetry_logs" 2>/dev/null | grep -q 1; do
+    echo "Waiting for ClickHouse to be ready..."
+    sleep 1
+  done
+  echo "Started ClickHouse container '${ch_container_name}' with connection string: ${ch_conn_string}"
+
+  redis_container_name="test-redis-${random_hex}"
+  redis_container_id=$(docker run -d -q --rm \
+    -p 6379 \
+    --tmpfs /data:rw \
+    --name "${redis_container_name}" \
+    redis:6.2-alpine)
+  redis_port=$(docker port "${redis_container_name}" 6379/tcp | cut -d: -f2)
+  redis_conn_string="redis://127.0.0.1:${redis_port}"
+  register_exit_callback "docker stop ${redis_container_name} > /dev/null 2>&1 || true"
+  export TESTENV_REDIS_URI="${redis_conn_string}"
+  until docker exec "${redis_container_id}" redis-cli ping 2>/dev/null | grep -q PONG; do
+    echo "Waiting for Redis to be ready..."
+    sleep 1
+  done
+  echo "Started Redis container '${redis_container_name}' with connection string: ${redis_conn_string}"
+
+  temporal_container_name="test-temporal-${random_hex}"
+  temporal_container_id=$(docker run -d -q --rm \
+    -p 7233 \
+    --name "${temporal_container_name}" \
+    --entrypoint "temporal" \
+    temporalio/server:1.27.2 \
+    server start-dev --headless --ip 0.0.0.0 --namespace default --db-filename /home/temporal/dev.db)
+  temporal_port=$(docker port "${temporal_container_id}" 7233/tcp | cut -d: -f2)
+  temporal_conn_string="temporal://127.0.0.1:${temporal_port}/default"
+  register_exit_callback "docker stop ${temporal_container_name} > /dev/null 2>&1 || true"
+  export TESTENV_TEMPORAL_URI="${temporal_conn_string}"
+  until docker exec "${temporal_container_id}" tctl namespace list 2>/dev/null | grep -q "default"; do
+    echo "Waiting for Temporal to be ready..."
+    sleep 1
+  done
+  echo "Started Temporal container '${temporal_container_name}' with connection string: ${temporal_conn_string}"
 fi
 
 gotestsum --junitfile junit-report.xml --format-hide-empty-pkg -- "${args[@]}"

--- a/server/database/testing.sql
+++ b/server/database/testing.sql
@@ -1,0 +1,1 @@
+ALTER DATABASE gotestdb WITH is_template = true;

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -84,7 +84,7 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 
 	f := &feature.InMemory{}
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
+	temporalEnv := infra.NewTemporalEnv(t)
 	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()

--- a/server/internal/functions/setup_test.go
+++ b/server/internal/functions/setup_test.go
@@ -88,7 +88,7 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 	tigrisStore := assets.NewTigrisStore(assetStorage)
 	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
+	temporalEnv := infra.NewTemporalEnv(t)
 	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -133,7 +133,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 		access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}),
 	)
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
+	temporalEnv := infra.NewTemporalEnv(t)
 
 	redisClient, err2 := infra.NewRedisClient(t, 0)
 	require.NoError(t, err2)

--- a/server/internal/testenv/clickhouse.go
+++ b/server/internal/testenv/clickhouse.go
@@ -3,6 +3,8 @@ package testenv
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -12,13 +14,14 @@ import (
 
 type ClickhouseClientFunc func(t *testing.T) (clickhouse.Conn, error)
 
-// NewTestClickhouse creates a new ClickHouse container with the schema initialized
+// NewClickhouseContainer creates a new ClickHouse container with the schema initialized
 // from migration files. Returns a container reference and a function to create
 // test connections. The container is automatically cleaned up when the test ends.
-func NewTestClickhouse(ctx context.Context) (*clickhousecontainer.ClickHouseContainer, ClickhouseClientFunc, error) {
+func NewClickhouseContainer(ctx context.Context) (*clickhousecontainer.ClickHouseContainer, ClickhouseClientFunc, error) {
 	container, err := clickhousecontainer.Run(ctx, "clickhouse/clickhouse-server:25.8.3",
-		clickhousecontainer.WithUsername("gram"),
-		clickhousecontainer.WithPassword("gram"),
+		clickhousecontainer.WithUsername("gotest"),
+		clickhousecontainer.WithPassword("gotest"),
+		clickhousecontainer.WithDatabase("gotestdb"),
 		clickhousecontainer.WithInitScripts(rootPath("clickhouse", "schema.sql")),
 		testcontainers.WithLogger(NewTestcontainersLogger()),
 	)
@@ -26,30 +29,51 @@ func NewTestClickhouse(ctx context.Context) (*clickhousecontainer.ClickHouseCont
 		return nil, nil, fmt.Errorf("failed to start clickhouse container: %w", err)
 	}
 
-	return container, newClickhouseClientFunc(container), nil
+	host, err := container.Host(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get clickhouse host: %w", err)
+	}
+
+	port, err := container.MappedPort(ctx, "9000/tcp")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get clickhouse port: %w", err)
+	}
+
+	uri := url.URL{
+		Scheme: "clickhouse",
+		User:   url.UserPassword("gotest", "gotest"),
+		Host:   fmt.Sprintf("%s:%s", host, port.Port()),
+		Path:   "gotestdb",
+	}
+
+	return container, newClickhouseClientFunc(uri.String()), nil
 }
 
-func newClickhouseClientFunc(container *clickhousecontainer.ClickHouseContainer) ClickhouseClientFunc {
+func newClickhouseClientFunc(uri string) ClickhouseClientFunc {
 	return func(t *testing.T) (clickhouse.Conn, error) {
 		t.Helper()
 
 		ctx := t.Context()
-		host, err := container.Host(ctx)
+
+		parsed, err := url.Parse(uri)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get clickhouse host: %w", err)
+			return nil, fmt.Errorf("failed to parse clickhouse URI: %w", err)
 		}
 
-		port, err := container.MappedPort(ctx, "9000/tcp")
-		if err != nil {
-			return nil, fmt.Errorf("failed to get clickhouse port: %w", err)
+		host, port, _ := net.SplitHostPort(parsed.Host)
+		if host == "localhost" {
+			host = "127.0.0.1"
 		}
 
 		conn, err := clickhouse.Open(&clickhouse.Options{
-			Addr: []string{fmt.Sprintf("%s:%s", host, port.Port())},
+			Addr: []string{net.JoinHostPort(host, port)},
 			Auth: clickhouse.Auth{
-				Database: "default",
-				Username: "gram",
-				Password: "gram",
+				Database: parsed.Path[1:],
+				Username: parsed.User.Username(),
+				Password: func() string {
+					password, _ := parsed.User.Password()
+					return password
+				}(),
 			},
 			Settings: clickhouse.Settings{
 				"async_insert":          0, // Forces inserts to be synchronous

--- a/server/internal/testenv/launch.go
+++ b/server/internal/testenv/launch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -32,7 +33,7 @@ type Environment struct {
 	CloneTestDatabase   PostgresDBCloneFunc
 	NewRedisClient      RedisClientFunc
 	NewClickhouseClient ClickhouseClientFunc
-	NewTemporalEnv      func(t *testing.T) (env *temporal.Environment, server *testsuite.DevServer)
+	NewTemporalEnv      func(t *testing.T) (env *temporal.Environment)
 }
 
 func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error, error) {
@@ -55,45 +56,72 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 	}
 
 	if opts.Postgres {
-		container, cloner, err := NewTestPostgres(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start postgres container: %w", err)
+		existing := os.Getenv("TESTENV_POSTGRES_URI")
+		if existing == "" {
+			container, cloner, err := NewPostgresContainer(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("start postgres container: %w", err)
+			}
+			pgcontainer = container
+			res.CloneTestDatabase = cloner
+		} else {
+			res.CloneTestDatabase = newPostgresCloneFunc(existing)
 		}
-		pgcontainer = container
-		res.CloneTestDatabase = cloner
 	}
 
 	if opts.Redis {
-		container, rcFactory, err := NewTestRedis(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start redis container: %w", err)
+		existing := os.Getenv("TESTENV_REDIS_URI")
+		if existing == "" {
+			container, rcFactory, err := NewRedisContainer(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("start redis container: %w", err)
+			}
+			rediscontainer = container
+			res.NewRedisClient = rcFactory
+		} else {
+			res.NewRedisClient = newRedisClientFunc(existing)
 		}
-		rediscontainer = container
-		res.NewRedisClient = rcFactory
 	}
 
 	if opts.ClickHouse {
-		container, chFactory, err := NewTestClickhouse(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start clickhouse container: %w", err)
+		existing := os.Getenv("TESTENV_CLICKHOUSE_URI")
+		if existing == "" {
+			container, chFactory, err := NewClickhouseContainer(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("start clickhouse container: %w", err)
+			}
+			clickhousecontainer = container
+			res.NewClickhouseClient = chFactory
+		} else {
+			res.NewClickhouseClient = newClickhouseClientFunc(existing)
 		}
-		clickhousecontainer = container
-		res.NewClickhouseClient = chFactory
 	}
 
 	if opts.Temporal {
-		res.NewTemporalEnv = func(t *testing.T) (*temporal.Environment, *testsuite.DevServer) {
-			t.Helper()
+		existing := os.Getenv("TESTENV_TEMPORAL_URI")
+		if existing == "" {
+			res.NewTemporalEnv = func(t *testing.T) *temporal.Environment {
+				t.Helper()
 
-			temporalserverOnce.Do(func() {
-				temporalserver, temporalserverErr = NewTemporalDevServer(ctx)
-			})
-			require.NoError(t, temporalserverErr, "start temporal dev server")
+				var uri string
 
-			env, err := NewTemporalEnvironment(t, temporalserver)
-			require.NoError(t, err, "create temporal environment")
+				temporalserverOnce.Do(func() {
+					temporalserver, uri, temporalserverErr = NewTemporalDevServer(ctx)
+				})
+				require.NoError(t, temporalserverErr, "start temporal dev server")
 
-			return env, temporalserver
+				env, err := NewTemporalEnvironment(t, uri)
+				require.NoError(t, err, "create temporal environment")
+
+				return env
+			}
+		} else {
+			res.NewTemporalEnv = func(t *testing.T) *temporal.Environment {
+				env, err := NewTemporalEnvironment(t, existing)
+				require.NoError(t, err, "create temporal environment")
+
+				return env
+			}
 		}
 	}
 
@@ -165,10 +193,10 @@ func unsupportedClickhouseClientFunc() ClickhouseClientFunc {
 	}
 }
 
-func unsupportedTemporalEnvFunc() func(t *testing.T) (env *temporal.Environment, server *testsuite.DevServer) {
-	return func(t *testing.T) (*temporal.Environment, *testsuite.DevServer) {
+func unsupportedTemporalEnvFunc() func(t *testing.T) (env *temporal.Environment) {
+	return func(t *testing.T) *temporal.Environment {
 		t.Helper()
 		require.FailNow(t, fmt.Errorf("new temporal environment: %w", errCapabilityNotEnabled).Error())
-		return nil, nil
+		return nil
 	}
 }

--- a/server/internal/testenv/postgresql.go
+++ b/server/internal/testenv/postgresql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -16,7 +15,9 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
-var pgCloneMutex sync.Mutex
+// Advisory lock ID used to serialize CREATE DATABASE ... WITH TEMPLATE across
+// concurrent test processes sharing the same PostgreSQL instance.
+const pgCloneAdvisoryLockID int64 = 716713
 
 func nextRandom() string {
 	return fmt.Sprintf("%d", uuid.New().ID())
@@ -24,11 +25,11 @@ func nextRandom() string {
 
 type PostgresDBCloneFunc func(t *testing.T, name string) (*pgxpool.Pool, error)
 
-// NewTestPostgres creates a new Postgres container with a template database built
+// NewPostgresContainer creates a new Postgres container with a template database built
 // from a SQL init script. A reference to the container is returned as well as
 // a function to create test databases from the template. All "clone" databases
 // are automatically dropped when the test ends using t.Cleanup() hooks.
-func NewTestPostgres(ctx context.Context) (*postgres.PostgresContainer, PostgresDBCloneFunc, error) {
+func NewPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, PostgresDBCloneFunc, error) {
 	container, err := postgres.Run(
 		ctx,
 		"pgvector/pgvector:pg17",
@@ -64,28 +65,31 @@ func NewTestPostgres(ctx context.Context) (*postgres.PostgresContainer, Postgres
 		return nil, nil, fmt.Errorf("mark template database: %w", err)
 	}
 
-	return container, newPostgresCloneFunc(container), nil
+	return container, newPostgresCloneFunc(uri), nil
 }
 
-func newPostgresCloneFunc(container *postgres.PostgresContainer) PostgresDBCloneFunc {
+func newPostgresCloneFunc(uri string) PostgresDBCloneFunc {
+	// Connect to the 'postgres' database for admin operations so we don't hold
+	// sessions on the template database, which would block CREATE DATABASE.
+	adminURI := strings.Replace(uri, "/gotestdb", "/postgres", 1)
+
 	return func(t *testing.T, name string) (*pgxpool.Pool, error) {
 		t.Helper()
 		ctx := t.Context()
-		uri, err := container.ConnectionString(ctx, "sslmode=disable")
-		if err != nil {
-			return nil, fmt.Errorf("read connection string: %w", err)
-		}
 
-		pgCloneMutex.Lock()
-		defer pgCloneMutex.Unlock()
-
-		conn, err := pgx.Connect(ctx, uri)
+		conn, err := pgx.Connect(ctx, adminURI)
 		if err != nil {
-			return nil, fmt.Errorf("connect to template database: %w", err)
+			return nil, fmt.Errorf("connect for database cloning: %w", err)
 		}
 		defer o11y.NoLogDefer(func() error {
 			return conn.Close(ctx)
 		})
+
+		// Acquire an advisory lock to serialize CREATE DATABASE across processes.
+		// Released automatically when the connection is closed.
+		if _, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", pgCloneAdvisoryLockID); err != nil {
+			return nil, fmt.Errorf("acquire advisory lock: %w", err)
+		}
 
 		clonename := fmt.Sprintf("%s_%s", name, nextRandom())
 		_, err = conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s WITH TEMPLATE gotestdb;", clonename))
@@ -93,7 +97,7 @@ func newPostgresCloneFunc(container *postgres.PostgresContainer) PostgresDBClone
 			return nil, fmt.Errorf("create test database: %w", err)
 		}
 
-		cloneuri := strings.Replace(uri, "gotestdb", clonename, 1)
+		cloneuri := strings.Replace(uri, "/gotestdb", "/"+clonename, 1)
 		pool, err := pgxpool.New(ctx, cloneuri)
 		if err != nil {
 			return nil, fmt.Errorf("create pgx pool: %w", err)
@@ -105,7 +109,7 @@ func newPostgresCloneFunc(container *postgres.PostgresContainer) PostgresDBClone
 
 			pool.Close()
 
-			conn, err := pgx.Connect(timeoutCtx, uri)
+			conn, err := pgx.Connect(timeoutCtx, adminURI)
 			if err != nil {
 				panic(fmt.Errorf("drop test database: connect: %w", err))
 			}

--- a/server/internal/testenv/redis.go
+++ b/server/internal/testenv/redis.go
@@ -16,7 +16,7 @@ import (
 
 type RedisClientFunc func(t *testing.T, db int) (*redis.Client, error)
 
-func NewTestRedis(ctx context.Context) (*tcr.RedisContainer, RedisClientFunc, error) {
+func NewRedisContainer(ctx context.Context) (*tcr.RedisContainer, RedisClientFunc, error) {
 	container, err := tcr.Run(
 		ctx, "redis:6.2-alpine",
 		testcontainers.WithLogger(NewTestcontainersLogger()),
@@ -29,24 +29,24 @@ func NewTestRedis(ctx context.Context) (*tcr.RedisContainer, RedisClientFunc, er
 		return nil, nil, fmt.Errorf("failed to start redis container: %w", err)
 	}
 
-	return container, newRedisClientFunc(container), nil
+	uri, err := container.ConnectionString(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get redis connection string: %w", err)
+	}
+
+	return container, newRedisClientFunc(uri), nil
 }
 
-func newRedisClientFunc(container *tcr.RedisContainer) RedisClientFunc {
+func newRedisClientFunc(uri string) RedisClientFunc {
 	return func(t *testing.T, db int) (*redis.Client, error) {
 		t.Helper()
 
-		cstr, err := container.ConnectionString(t.Context())
-		if err != nil {
-			return nil, fmt.Errorf("failed to get redis connection string: %w", err)
-		}
-
-		uri, err := url.Parse(cstr)
+		parsed, err := url.Parse(uri)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse redis connection string: %w", err)
 		}
 
-		host, port, err := net.SplitHostPort(uri.Host)
+		host, port, err := net.SplitHostPort(parsed.Host)
 		if err != nil {
 			return nil, fmt.Errorf("split redis host/port: %w", err)
 		}

--- a/server/internal/testenv/temporal.go
+++ b/server/internal/testenv/temporal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"testing"
 	"time"
 
@@ -12,10 +13,11 @@ import (
 	"go.temporal.io/sdk/testsuite"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	servertemporal "github.com/speakeasy-api/gram/server/internal/temporal"
 )
 
-func NewTemporalDevServer(ctx context.Context) (*testsuite.DevServer, error) {
+func NewTemporalDevServer(ctx context.Context) (*testsuite.DevServer, string, error) {
 	var stdout io.Writer
 	var stderr io.Writer
 	if !isTestingVerbose() {
@@ -44,33 +46,58 @@ func NewTemporalDevServer(ctx context.Context) (*testsuite.DevServer, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("start temporal dev server: %w", err)
+		return nil, "", fmt.Errorf("start temporal dev server: %w", err)
 	}
 
-	return devserver, nil
+	uri := url.URL{
+		Scheme: "temporal",
+		Host:   devserver.FrontendHostPort(),
+		Path:   "default",
+	}
+
+	return devserver, uri.String(), nil
 }
 
-func NewTemporalEnvironment(t *testing.T, devserver *testsuite.DevServer) (*servertemporal.Environment, error) {
+func NewTemporalEnvironment(t *testing.T, uri string) (*servertemporal.Environment, error) {
 	t.Helper()
 
 	namespace := fmt.Sprintf("test_%s", nextRandom())
 	queue := fmt.Sprintf("main_%s", nextRandom())
 
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("parse temporal URI: %w", err)
+	}
+
+	logger := NewLogger(t)
+
 	request := new(workflowservice.RegisterNamespaceRequest)
 	request.Namespace = namespace
 	request.WorkflowExecutionRetentionPeriod = durationpb.New(24 * time.Hour)
 
-	_, err := devserver.Client().WorkflowService().RegisterNamespace(t.Context(), request)
+	defaultNSOptions := client.Options{
+		HostPort:  parsed.Host,
+		Namespace: conv.Default(parsed.Path, "/default")[1:], // skip leading slash
+		Logger:    logger,
+	}
+	temporalClient, err := client.DialContext(t.Context(), defaultNSOptions)
+	if err != nil {
+		return nil, fmt.Errorf("dial temporal client to default namespace: %w", err)
+	}
+
+	_, err = temporalClient.WorkflowService().RegisterNamespace(t.Context(), request)
 	if err != nil {
 		return nil, fmt.Errorf("register temporal namespace: %w", err)
 	}
 
-	clientOptions := client.Options{}
-	clientOptions.HostPort = devserver.FrontendHostPort()
-	clientOptions.Namespace = namespace
-	clientOptions.Logger = NewLogger(t)
+	temporalClient.Close()
 
-	temporalClient, err := client.DialContext(t.Context(), clientOptions)
+	clientOptions := client.Options{}
+	clientOptions.HostPort = parsed.Host
+	clientOptions.Namespace = namespace
+	clientOptions.Logger = logger
+
+	temporalClient, err = client.DialContext(t.Context(), clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("dial temporal client: %w", err)
 	}

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -105,7 +105,7 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 
 	f := &feature.InMemory{}
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
+	temporalEnv := infra.NewTemporalEnv(t)
 	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -97,7 +97,7 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 
 	f := &feature.InMemory{}
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
+	temporalEnv := infra.NewTemporalEnv(t)
 	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
 	t.Cleanup(func() {
 		worker.Stop()


### PR DESCRIPTION
This change updates the test:server mise task to start postgres, clickhouse, redis, and temporal in separate containers instead of starting them in-process. The `server/internal/testenv` package detects the presence of these containers and avoids using testcontainers.

To run, use:

```
TEST_WITH_INFRA=1 mise test:server
```