### PR TITLE
fix: attempt to find servers without a custom domain

### DIFF
--- a/.changeset/swift-feet-leave.md
+++ b/.changeset/swift-feet-leave.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Allow resolving a server without a custom domain attached when the user is authenticated and a custom domain is available.

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1066,13 +1066,21 @@ func (s *Service) resolveDomainIDFromContext(ctx context.Context) *uuid.UUID {
 func (s *Service) loadToolsetFromContextAndSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, error) {
 	var toolset toolsets_repo.Toolset
 	var toolsetErr error
+	isCustomDomainRequest := customdomains.FromContext(ctx) != nil
 	domainID := s.resolveDomainIDFromContext(ctx)
 	if domainID != nil {
 		toolset, toolsetErr = s.toolsetRepo.GetToolsetByMcpSlugAndCustomDomain(ctx, toolsets_repo.GetToolsetByMcpSlugAndCustomDomainParams{
 			McpSlug:        conv.ToPGText(mcpSlug),
 			CustomDomainID: uuid.NullUUID{UUID: *domainID, Valid: true},
 		})
-	} else {
+	}
+
+	// Fall back to slug-only lookup when the request did not arrive through a
+	// custom domain. This keeps platform-domain install pages working when the
+	// logged-in user's org happens to have a custom domain configured, while
+	// still preventing cross-domain toolset leakage for actual custom-domain
+	// requests.
+	if domainID == nil || (!isCustomDomainRequest && toolsetErr != nil) {
 		toolset, toolsetErr = s.toolsetRepo.GetToolsetByMcpSlug(ctx, conv.ToPGText(mcpSlug))
 	}
 

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -822,3 +822,74 @@ func TestServeInstallPage_CustomDomain_DeletedToolsetReturnsNotFound(t *testing.
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Server Not Found")
 }
+
+// TestServeInstallPage_NoDomain_AuthedUserWithOrgDomain verifies that a toolset
+// WITHOUT a custom domain can still be loaded via the platform domain when the
+// logged-in user's organization happens to have a custom domain configured. This
+// guards against a regression where resolveDomainIDFromContext returning the
+// org's domain from auth context would prevent the slug-only fallback.
+func TestServeInstallPage_NoDomain_AuthedUserWithOrgDomain(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotNil(t, authCtx.SessionID)
+
+	domainsRepo := customdomains_repo.New(testInstance.conn)
+
+	// Create and activate a custom domain for this organization so that
+	// resolveDomainIDFromContext returns non-nil via the auth context path.
+	domain, err := domainsRepo.CreateCustomDomain(ctx, customdomains_repo.CreateCustomDomainParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         "org-has-domain.example.com",
+		IngressName:    pgtype.Text{String: "", Valid: false},
+		CertSecretName: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	_, err = domainsRepo.UpdateCustomDomain(ctx, customdomains_repo.UpdateCustomDomainParams{
+		ID:             domain.ID,
+		Verified:       true,
+		Activated:      true,
+		IngressName:    pgtype.Text{String: "", Valid: false},
+		CertSecretName: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	// Create a toolset WITHOUT linking it to any custom domain.
+	mcpSlug := "no-domain-" + uuid.New().String()[:8]
+	_, err = testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "No Domain Toolset",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("toolset with no custom domain"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	// Make the toolset public.
+	_, err = testInstance.conn.Exec(ctx,
+		"UPDATE toolsets SET mcp_is_public = true WHERE mcp_slug = $1", mcpSlug)
+	require.NoError(t, err)
+
+	// Build a request through the platform domain (no custom domain context)
+	// but with a valid session token so that auth context is populated.
+	reqCtx := contextvalues.SetSessionTokenInContext(context.Background(), *authCtx.SessionID)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(reqCtx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = testInstance.service.ServeInstallPage(rr, req)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "text/html", rr.Header().Get("Content-Type"))
+}


### PR DESCRIPTION
This fixes a bug wherein we fail to load servers without custom domains attached.

Note this only impacts authenticated users whose org has a custom domain attached BUT the associated server is served on a non-custom domain (that is to say a very rare circumstance)