### PR TITLE
fix: make local dev toolbar draggable, tabbed, and always interactable

### DIFF
--- a/client/dashboard/src/components/rbac-dev-toolbar.tsx
+++ b/client/dashboard/src/components/rbac-dev-toolbar.tsx
@@ -1,8 +1,15 @@
 import { useOrganization } from "@/contexts/Auth";
 import { Switch } from "./ui/switch";
 import { useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronUp, Shield } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import {
+  ChevronDown,
+  ChevronUp,
+  GripVertical,
+  Shield,
+  Wrench,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 const STORAGE_KEY = "gram-rbac-dev-override";
 
@@ -106,6 +113,18 @@ function saveState(state: OverrideState) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
+const POSITION_KEY = "gram-rbac-dev-toolbar-pos";
+
+function loadPosition(): { x: number; y: number } | null {
+  try {
+    const raw = localStorage.getItem(POSITION_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
 /**
  * Returns the X-Gram-Scope-Override header value if the dev override is active,
  * or null if disabled. Called by the SDK fetcher on every request.
@@ -145,14 +164,75 @@ const GROUP_ORDER: { key: ResourceType; label: string }[] = [
 export function RBACDevToolbar() {
   const [state, setState] = useState<OverrideState>(loadState);
   const [collapsed, setCollapsed] = useState(true);
+  const [activeTab, setActiveTab] = useState("rbac");
   const [expandedScope, setExpandedScope] = useState<string | null>(null);
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(loadPosition);
   const queryClient = useQueryClient();
   const organization = useOrganization();
   const projects = organization?.projects ?? [];
+  const rootRef = useRef<HTMLDivElement>(null);
+  const dragOffset = useRef<{
+    ox: number;
+    oy: number;
+    startX: number;
+    startY: number;
+  } | null>(null);
+  const hasDragged = useRef(false);
 
   useEffect(() => {
     saveState(state);
   }, [state]);
+
+  useEffect(() => {
+    if (pos) localStorage.setItem(POSITION_KEY, JSON.stringify(pos));
+  }, [pos]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (e.button !== 0) return;
+      const el = rootRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      dragOffset.current = {
+        ox: e.clientX - rect.left,
+        oy: e.clientY - rect.top,
+        startX: e.clientX,
+        startY: e.clientY,
+      };
+      hasDragged.current = false;
+    },
+    [],
+  );
+
+  // Window-level listeners so drag works even when cursor moves fast off the button
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      if (!dragOffset.current) return;
+      const { ox, oy, startX, startY } = dragOffset.current;
+      if (!hasDragged.current) {
+        if (Math.hypot(e.clientX - startX, e.clientY - startY) < 4) return;
+        hasDragged.current = true;
+      }
+      const el = rootRef.current;
+      const w = el ? el.offsetWidth : 320;
+      const h = el ? el.offsetHeight : 50;
+      const newX = Math.max(0, Math.min(window.innerWidth - w, e.clientX - ox));
+      const newY = Math.max(
+        0,
+        Math.min(window.innerHeight - h, e.clientY - oy),
+      );
+      setPos({ x: newX, y: newY });
+    };
+    const onUp = () => {
+      dragOffset.current = null;
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+  }, []);
 
   const invalidate = useCallback(() => {
     setTimeout(() => queryClient.invalidateQueries(), 0);
@@ -198,37 +278,41 @@ export function RBACDevToolbar() {
     (s) => s.enabled,
   ).length;
 
-  return (
-    <div className="fixed right-4 bottom-4 z-[9999] select-none">
+  return createPortal(
+    <div
+      ref={rootRef}
+      className="pointer-events-auto fixed z-[99999] select-none"
+      style={pos ? { left: pos.x, top: pos.y } : { left: 16, bottom: 16 }}
+    >
       <div className={`
-          rounded-xl border shadow-2xl backdrop-blur-md transition-all duration-200
-          ${collapsed ? "w-auto" : "w-80"}
+          ${collapsed ? "w-fit" : "w-80"} rounded-xl border shadow-2xl backdrop-blur-md transition-all
+          duration-200
           ${state.enabled ? "bg-background/98 border-foreground/15 dark:border-foreground/15 dark:bg-gray-950/98" : "border-border bg-white/98 dark:bg-gray-950/98"}
         `}>
-        {/* Header */}
+        {/* Header – drag handle */}
         <button
           type="button"
-          onClick={() => setCollapsed((c) => !c)}
+          onPointerDown={onPointerDown}
+          onClick={() => {
+            if (hasDragged.current) {
+              hasDragged.current = false;
+              return;
+            }
+            setCollapsed((c) => !c);
+          }}
           className={`
-            flex w-full items-center gap-2.5 px-3.5 py-2.5 transition-colors
+            flex w-full cursor-grab items-center gap-2.5 px-3.5 py-2.5 transition-colors active:cursor-grabbing
             ${collapsed ? "rounded-xl" : "rounded-t-xl"}
             hover:bg-black/[0.03] dark:hover:bg-white/[0.03]
           `}
         >
-          <div className={`
-              flex h-6 w-6 items-center justify-center rounded-md
-              ${state.enabled ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}
-            `}>
-            <Shield className="h-3.5 w-3.5" />
+          <GripVertical className="text-muted-foreground/40 h-3.5 w-3.5 shrink-0" />
+          <div className="bg-muted text-muted-foreground flex h-6 w-6 items-center justify-center rounded-md">
+            <Wrench className="h-3.5 w-3.5" />
           </div>
           <span className="text-foreground text-xs font-semibold tracking-wide">
-            RBAC Dev Tools
+            Local Dev Tools
           </span>
-          {state.enabled && (
-            <span className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-[10px] tabular-nums">
-              {activeCount}/{SCOPE_DEFS.length}
-            </span>
-          )}
           <div className="text-muted-foreground ml-auto">
             {collapsed ? (
               <ChevronUp className="h-3.5 w-3.5" />
@@ -241,147 +325,174 @@ export function RBACDevToolbar() {
         {/* Panel */}
         {!collapsed && (
           <div className="border-t border-inherit">
-            {/* Master toggle */}
-            <div className="flex items-center justify-between border-b border-inherit px-3.5 py-2.5">
-              <div className="flex items-center gap-2">
-                <div
-                  className={`h-1.5 w-1.5 rounded-full ${state.enabled ? "animate-pulse bg-emerald-500" : "bg-muted-foreground/30"}`}
-                />
-                <span className="text-foreground text-xs font-medium">
-                  {state.enabled ? "Override active" : "Override disabled"}
-                </span>
-              </div>
-              <Switch
-                checked={state.enabled}
-                onCheckedChange={toggleEnabled}
-                aria-label="Toggle RBAC override"
-              />
+            {/* Tab bar */}
+            <div className="flex border-b border-inherit px-2">
+              <button
+                type="button"
+                onClick={() => setActiveTab("rbac")}
+                className={`-mb-px flex items-center gap-1.5 border-b-2 px-2 py-2 text-[11px] font-medium transition-colors ${
+                  activeTab === "rbac"
+                    ? "border-foreground text-foreground"
+                    : "text-muted-foreground hover:text-foreground border-transparent"
+                }`}
+              >
+                <Shield className="h-3 w-3" />
+                RBAC
+                {state.enabled && (
+                  <span className="bg-muted text-muted-foreground rounded px-1 py-px font-mono text-[9px] tabular-nums">
+                    {activeCount}/{SCOPE_DEFS.length}
+                  </span>
+                )}
+              </button>
             </div>
 
-            {/* Scope groups */}
-            <div
-              className={`max-h-[400px] space-y-1 overflow-y-auto px-2 py-2 ${!state.enabled ? "pointer-events-none opacity-40" : ""}`}
-            >
-              {GROUP_ORDER.map((group) => {
-                const scopes = SCOPE_DEFS.filter(
-                  (s) => s.resourceType === group.key,
-                );
-                return (
-                  <div key={group.key}>
-                    <div className="px-2 pt-1.5 pb-1">
-                      <span className="text-muted-foreground text-[10px] font-semibold tracking-widest uppercase">
-                        {group.label}
-                      </span>
-                    </div>
-                    {scopes.map((def) => {
-                      const scopeState = state.scopes[def.scope] ?? {
-                        enabled: true,
-                        resources: null,
-                      };
-                      const isExpanded = expandedScope === def.scope;
-                      const isRestricted =
-                        scopeState.resources !== null &&
-                        scopeState.resources.length > 0;
-                      const knownResources =
-                        def.resourceType === "project" ||
-                        def.resourceType === "mcp"
-                          ? projects.map((p) => ({
-                              id: p.id,
-                              label: p.slug,
-                            }))
-                          : [];
+            {/* RBAC tab */}
+            {activeTab === "rbac" && (
+              <>
+                {/* Master toggle */}
+                <div className="flex items-center justify-between border-b border-inherit px-3.5 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className={`h-1.5 w-1.5 rounded-full ${state.enabled ? "animate-pulse bg-emerald-500" : "bg-muted-foreground/30"}`}
+                    />
+                    <span className="text-foreground text-xs font-medium">
+                      {state.enabled ? "Override active" : "Override disabled"}
+                    </span>
+                  </div>
+                  <Switch
+                    checked={state.enabled}
+                    onCheckedChange={toggleEnabled}
+                    aria-label="Toggle RBAC override"
+                  />
+                </div>
 
-                      return (
-                        <div key={def.scope}>
-                          <div className={`
+                {/* Scope groups */}
+                <div
+                  className={`max-h-[400px] space-y-1 overflow-y-auto px-2 py-2 ${!state.enabled ? "pointer-events-none opacity-40" : ""}`}
+                >
+                  {GROUP_ORDER.map((group) => {
+                    const scopes = SCOPE_DEFS.filter(
+                      (s) => s.resourceType === group.key,
+                    );
+                    return (
+                      <div key={group.key}>
+                        <div className="px-2 pt-1.5 pb-1">
+                          <span className="text-muted-foreground text-[10px] font-semibold tracking-widest uppercase">
+                            {group.label}
+                          </span>
+                        </div>
+                        {scopes.map((def) => {
+                          const scopeState = state.scopes[def.scope] ?? {
+                            enabled: true,
+                            resources: null,
+                          };
+                          const isExpanded = expandedScope === def.scope;
+                          const isRestricted =
+                            scopeState.resources !== null &&
+                            scopeState.resources.length > 0;
+                          const knownResources =
+                            def.resourceType === "project" ||
+                            def.resourceType === "mcp"
+                              ? projects.map((p) => ({
+                                  id: p.id,
+                                  label: p.slug,
+                                }))
+                              : [];
+
+                          return (
+                            <div key={def.scope}>
+                              <div className={`
                               flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 transition-colors
                               ${scopeState.enabled ? "hover:bg-black/[0.04] dark:hover:bg-white/[0.04]" : ""}
                             `} onClick={() => toggleScope(def.scope)}>
-                            <div className={`
+                                <div className={`
                                 flex h-3.5 w-3.5 items-center justify-center rounded border-[1.5px] text-[9px] transition-all
                                 ${scopeState.enabled ? "bg-foreground border-foreground text-background" : "border-muted-foreground/30 bg-transparent"}
                               `}>{scopeState.enabled && "✓"}</div>
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-1.5">
-                                <span
-                                  className={`font-mono text-xs font-medium ${
-                                    scopeState.enabled
-                                      ? "text-foreground"
-                                      : "text-muted-foreground line-through"
-                                  }`}
-                                >
-                                  {def.label}
-                                </span>
-                                {isRestricted && scopeState.enabled && (
-                                  <span className="rounded bg-blue-100 px-1 py-px text-[9px] font-medium text-blue-600 dark:bg-blue-900/50 dark:text-blue-400">
-                                    scoped
-                                  </span>
-                                )}
-                              </div>
-                            </div>
-                            {scopeState.enabled &&
-                              def.resourceType !== "org" && (
-                                <button
-                                  type="button"
-                                  className="text-muted-foreground rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    setExpandedScope(
-                                      isExpanded ? null : def.scope,
-                                    );
-                                  }}
-                                >
-                                  {isExpanded ? (
-                                    <ChevronUp className="h-3 w-3" />
-                                  ) : (
-                                    <ChevronDown className="h-3 w-3" />
+                                <div className="min-w-0 flex-1">
+                                  <div className="flex items-center gap-1.5">
+                                    <span
+                                      className={`font-mono text-xs font-medium ${
+                                        scopeState.enabled
+                                          ? "text-foreground"
+                                          : "text-muted-foreground line-through"
+                                      }`}
+                                    >
+                                      {def.label}
+                                    </span>
+                                    {isRestricted && scopeState.enabled && (
+                                      <span className="rounded bg-blue-100 px-1 py-px text-[9px] font-medium text-blue-600 dark:bg-blue-900/50 dark:text-blue-400">
+                                        scoped
+                                      </span>
+                                    )}
+                                  </div>
+                                </div>
+                                {scopeState.enabled &&
+                                  def.resourceType !== "org" && (
+                                    <button
+                                      type="button"
+                                      className="text-muted-foreground rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setExpandedScope(
+                                          isExpanded ? null : def.scope,
+                                        );
+                                      }}
+                                    >
+                                      {isExpanded ? (
+                                        <ChevronUp className="h-3 w-3" />
+                                      ) : (
+                                        <ChevronDown className="h-3 w-3" />
+                                      )}
+                                    </button>
                                   )}
-                                </button>
+                              </div>
+
+                              {/* Resource picker */}
+                              {/* TODO: verify resource-scoped overrides are enforced end-to-end (header → backend → UI) */}
+                              {isExpanded && scopeState.enabled && (
+                                <ResourcePicker
+                                  knownResources={knownResources}
+                                  selected={scopeState.resources}
+                                  onChange={(resources) =>
+                                    setScopeResources(def.scope, resources)
+                                  }
+                                />
                               )}
-                          </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    );
+                  })}
+                </div>
 
-                          {/* Resource picker */}
-                          {/* TODO: verify resource-scoped overrides are enforced end-to-end (header → backend → UI) */}
-                          {isExpanded && scopeState.enabled && (
-                            <ResourcePicker
-                              knownResources={knownResources}
-                              selected={scopeState.resources}
-                              onChange={(resources) =>
-                                setScopeResources(def.scope, resources)
-                              }
-                            />
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                );
-              })}
-            </div>
-
-            {/* Footer */}
-            <div className="flex items-center justify-between border-t border-inherit px-3.5 py-2">
-              <span className="text-muted-foreground text-[10px]">
-                local only
-              </span>
-              <button
-                type="button"
-                className="text-muted-foreground hover:text-foreground text-[10px] transition-colors"
-                onClick={() => {
-                  setState({
-                    enabled: false,
-                    scopes: defaultScopeState(),
-                  });
-                  invalidate();
-                }}
-              >
-                Reset
-              </button>
-            </div>
+                {/* Footer */}
+                <div className="flex items-center justify-between border-t border-inherit px-3.5 py-2">
+                  <span className="text-muted-foreground text-[10px]">
+                    local only
+                  </span>
+                  <button
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground text-[10px] transition-colors"
+                    onClick={() => {
+                      setState({
+                        enabled: false,
+                        scopes: defaultScopeState(),
+                      });
+                      invalidate();
+                    }}
+                  >
+                    Reset
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/client/dashboard/src/components/rbac-dev-toolbar.tsx
+++ b/client/dashboard/src/components/rbac-dev-toolbar.tsx
@@ -310,8 +310,8 @@ export function RBACDevToolbar() {
           <span className="rounded bg-amber-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold tracking-widest text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
             DEV
           </span>
-          <span className="text-foreground text-xs font-semibold">
-            GRAM DEVELOPER TOOLKIT
+          <span className="text-muted-foreground text-xs font-semibold">
+            Developer Toolkit
           </span>
           <div className="text-muted-foreground ml-auto">
             {collapsed ? (

--- a/client/dashboard/src/components/rbac-dev-toolbar.tsx
+++ b/client/dashboard/src/components/rbac-dev-toolbar.tsx
@@ -112,7 +112,13 @@ const POSITION_KEY = "gram-rbac-dev-toolbar-pos";
 function loadPosition(): { x: number; y: number } | null {
   try {
     const raw = localStorage.getItem(POSITION_KEY);
-    if (raw) return JSON.parse(raw);
+    if (raw) {
+      const pos = JSON.parse(raw);
+      return {
+        x: Math.max(0, Math.min(pos.x, window.innerWidth - 320)),
+        y: Math.max(0, Math.min(pos.y, window.innerHeight - 44)),
+      };
+    }
   } catch {
     // ignore
   }

--- a/client/dashboard/src/components/rbac-dev-toolbar.tsx
+++ b/client/dashboard/src/components/rbac-dev-toolbar.tsx
@@ -1,13 +1,7 @@
 import { useOrganization } from "@/contexts/Auth";
 import { Switch } from "./ui/switch";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  ChevronDown,
-  ChevronUp,
-  GripVertical,
-  Shield,
-  Wrench,
-} from "lucide-react";
+import { ChevronDown, ChevronUp, GripVertical, Shield } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -285,7 +279,7 @@ export function RBACDevToolbar() {
       style={pos ? { left: pos.x, top: pos.y } : { left: 16, bottom: 16 }}
     >
       <div className={`
-          ${collapsed ? "w-fit" : "w-80"} rounded-xl border shadow-2xl backdrop-blur-md transition-all
+          w-80 rounded-xl border shadow-2xl backdrop-blur-md transition-all
           duration-200
           ${state.enabled ? "bg-background/98 border-foreground/15 dark:border-foreground/15 dark:bg-gray-950/98" : "border-border bg-white/98 dark:bg-gray-950/98"}
         `}>
@@ -307,11 +301,11 @@ export function RBACDevToolbar() {
           `}
         >
           <GripVertical className="text-muted-foreground/40 h-3.5 w-3.5 shrink-0" />
-          <div className="bg-muted text-muted-foreground flex h-6 w-6 items-center justify-center rounded-md">
-            <Wrench className="h-3.5 w-3.5" />
-          </div>
-          <span className="text-foreground text-xs font-semibold tracking-wide">
-            Local Dev Tools
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold tracking-widest text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+            DEV
+          </span>
+          <span className="text-foreground text-xs font-semibold">
+            GRAM DEVELOPER TOOLKIT
           </span>
           <div className="text-muted-foreground ml-auto">
             {collapsed ? (


### PR DESCRIPTION
## Summary

- Renames toolbar from "RBAC Dev Tools" → **"Local Dev Tools"** with a generic `Wrench` icon, ready to host multiple dev tools
- Adds a **tab structure** (starting with an RBAC tab) so future tools can be added without redesign
- Makes the toolbar **draggable** — pointer-based drag with 4px threshold to distinguish click from drag; position persists to `localStorage`
- Default position: **bottom-left corner** (away from modal action buttons)
- Wraps the portal in `createPortal(…, document.body)` to **escape React app stacking contexts** and ensure `z-[99999]` beats sheet/dialog overlays
- Adds `pointer-events-auto` so the toolbar stays **interactable when a modal/drawer is open** (overrides any inherited `pointer-events: none` from `react-remove-scroll`)
- Uses **window-level `pointermove`/`pointerup` listeners** instead of `setPointerCapture` so the collapse-on-click still works correctly

## Test plan

- [ ] Toolbar appears at bottom-left by default
- [ ] Toolbar can be dragged and position is remembered after page reload
- [ ] Clicking the header collapses/expands correctly (no accidental collapse when dragging)
- [ ] RBAC tab content works as before (toggle override, scope checkboxes, reset)
- [ ] Toolbar is fully interactable when a drawer/dialog is open (no pointer-event blocking)
- [ ] Toolbar renders above dialogs and sheets visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)