### PR TITLE
feat: lockdown dashboard with RBAC enforcement - org level routes

### DIFF
--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -27,7 +27,7 @@ import {
 } from "./contexts/CommandPalette";
 import { SdkProvider, useSlugs } from "./contexts/Sdk.tsx";
 import { TelemetryProvider } from "./contexts/Telemetry.tsx";
-import { RBACDevToolbar } from "./components/rbac-dev-toolbar";
+import { RBACDevToolbar } from "./components/dev-toolbar";
 import { usePageTitle } from "./hooks/use-page-title";
 import CliCallback from "./pages/cli/CliCallback";
 import SlackRegister from "./pages/slackapp/SlackRegister";

--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -235,7 +235,10 @@ export function RBACDevToolbar() {
   }, []);
 
   const invalidate = useCallback(() => {
-    setTimeout(() => queryClient.invalidateQueries(), 0);
+    setTimeout(() => {
+      queryClient.invalidateQueries();
+      window.dispatchEvent(new Event("rbac-override-change"));
+    }, 0);
   }, [queryClient]);
 
   const toggleEnabled = useCallback(() => {

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -1,18 +1,42 @@
-import { NavButton, NavMenu } from "@/components/nav-menu";
+import { NavButton } from "@/components/nav-menu";
+import { RequireScope } from "@/components/require-scope";
 import {
   Sidebar,
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
+  SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { useIsAdmin, useOrganization } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
-import { useOrgRoutes } from "@/routes";
+import { Scope } from "@/hooks/useRBAC";
+import { AppRoute, useOrgRoutes } from "@/routes";
 import { Icon } from "@speakeasy-api/moonshine";
 import { ExternalLink } from "lucide-react";
 import * as React from "react";
+
+function ScopeGatedNavItem({
+  item,
+  scope,
+}: {
+  item: AppRoute;
+  scope: Scope | Scope[];
+}) {
+  return (
+    <SidebarMenuItem>
+      <RequireScope scope={scope} level="component">
+        <NavButton
+          title={item.title}
+          href={item.href()}
+          active={item.active}
+          Icon={item.Icon}
+        />
+      </RequireScope>
+    </SidebarMenuItem>
+  );
+}
 
 export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const orgRoutes = useOrgRoutes();
@@ -35,41 +59,54 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupLabel>projects</SidebarGroupLabel>
           <SidebarGroupContent>
-            <NavMenu items={[orgRoutes.home]} />
+            <SidebarMenu>
+              <ScopeGatedNavItem item={orgRoutes.home} scope="build:read" />
+            </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup>
           <SidebarGroupLabel>settings</SidebarGroupLabel>
           <SidebarGroupContent>
-            <NavMenu
-              items={[
-                orgRoutes.billing,
-                ...(isTeamPageEnabled ? [orgRoutes.team] : []),
-                orgRoutes.apiKeys,
-                orgRoutes.domains,
-                orgRoutes.logs,
-                orgRoutes.auditLogs,
-                ...(isRbacEnabled ? [orgRoutes.access] : []),
-                ...(isAdmin ? [orgRoutes.adminSettings] : []),
-              ]}
-            >
-              {!isTeamPageEnabled && (
+            <SidebarMenu>
+              <ScopeGatedNavItem item={orgRoutes.billing} scope="org:read" />
+              {isTeamPageEnabled ? (
+                <ScopeGatedNavItem item={orgRoutes.team} scope="org:read" />
+              ) : (
+                <SidebarMenuItem>
+                  <RequireScope scope="org:read" level="component">
+                    <NavButton
+                      title="Team"
+                      titleNode={
+                        <span className="flex items-center gap-1.5">
+                          Team
+                          <ExternalLink className="w-3 h-3 text-muted-foreground" />
+                        </span>
+                      }
+                      href={externalTeamUrl}
+                      target="_blank"
+                      Icon={(props) => <Icon name="users-round" {...props} />}
+                    />
+                  </RequireScope>
+                </SidebarMenuItem>
+              )}
+              <ScopeGatedNavItem item={orgRoutes.apiKeys} scope="org:admin" />
+              <ScopeGatedNavItem item={orgRoutes.domains} scope="org:read" />
+              <ScopeGatedNavItem item={orgRoutes.logs} scope="org:read" />
+              <ScopeGatedNavItem item={orgRoutes.auditLogs} scope="org:read" />
+              {isRbacEnabled && (
+                <ScopeGatedNavItem item={orgRoutes.access} scope="org:read" />
+              )}
+              {isAdmin && (
                 <SidebarMenuItem>
                   <NavButton
-                    title="Team"
-                    titleNode={
-                      <span className="flex items-center gap-1.5">
-                        Team
-                        <ExternalLink className="text-muted-foreground h-3 w-3" />
-                      </span>
-                    }
-                    href={externalTeamUrl}
-                    target="_blank"
-                    Icon={(props) => <Icon name="users-round" {...props} />}
+                    title={orgRoutes.adminSettings.title}
+                    href={orgRoutes.adminSettings.href()}
+                    active={orgRoutes.adminSettings.active}
+                    Icon={orgRoutes.adminSettings.Icon}
                   />
                 </SidebarMenuItem>
               )}
-            </NavMenu>
+            </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -96,7 +96,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       titleNode={
                         <span className="flex items-center gap-1.5">
                           Team
-                          <ExternalLink className="w-3 h-3 text-muted-foreground" />
+                          <ExternalLink className="text-muted-foreground h-3 w-3" />
                         </span>
                       }
                       href={externalTeamUrl}
@@ -106,10 +106,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   </RequireScope>
                 </SidebarMenuItem>
               )}
-              <ScopeGatedNavItem
-                item={orgRoutes.apiKeys}
-                scope={["org:read", "org:admin"]}
-              />
+              <ScopeGatedNavItem item={orgRoutes.apiKeys} scope="org:admin" />
               <ScopeGatedNavItem
                 item={orgRoutes.domains}
                 scope={["org:read", "org:admin"]}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -17,6 +17,11 @@ import { Icon } from "@speakeasy-api/moonshine";
 import { ExternalLink } from "lucide-react";
 import * as React from "react";
 
+/**
+ * Nav items use hasAnyScope — the link is enabled if the user holds ANY of the
+ * provided scopes (view OR mutate). Fine-grained enforcement happens inside
+ * each page via page-level and component-level RequireScope guards.
+ */
 function ScopeGatedNavItem({
   item,
   scope,
@@ -60,7 +65,10 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <SidebarGroupLabel>projects</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <ScopeGatedNavItem item={orgRoutes.home} scope="build:read" />
+              <ScopeGatedNavItem
+                item={orgRoutes.home}
+                scope={["build:read", "org:admin"]}
+              />
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -68,12 +76,21 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <SidebarGroupLabel>settings</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <ScopeGatedNavItem item={orgRoutes.billing} scope="org:read" />
+              <ScopeGatedNavItem
+                item={orgRoutes.billing}
+                scope={["org:read", "org:admin"]}
+              />
               {isTeamPageEnabled ? (
-                <ScopeGatedNavItem item={orgRoutes.team} scope="org:read" />
+                <ScopeGatedNavItem
+                  item={orgRoutes.team}
+                  scope={["org:read", "org:admin"]}
+                />
               ) : (
                 <SidebarMenuItem>
-                  <RequireScope scope="org:read" level="component">
+                  <RequireScope
+                    scope={["org:read", "org:admin"]}
+                    level="component"
+                  >
                     <NavButton
                       title="Team"
                       titleNode={
@@ -89,12 +106,27 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   </RequireScope>
                 </SidebarMenuItem>
               )}
-              <ScopeGatedNavItem item={orgRoutes.apiKeys} scope="org:admin" />
-              <ScopeGatedNavItem item={orgRoutes.domains} scope="org:read" />
-              <ScopeGatedNavItem item={orgRoutes.logs} scope="org:read" />
-              <ScopeGatedNavItem item={orgRoutes.auditLogs} scope="org:read" />
+              <ScopeGatedNavItem
+                item={orgRoutes.apiKeys}
+                scope={["org:read", "org:admin"]}
+              />
+              <ScopeGatedNavItem
+                item={orgRoutes.domains}
+                scope={["org:read", "org:admin"]}
+              />
+              <ScopeGatedNavItem
+                item={orgRoutes.logs}
+                scope={["org:read", "org:admin"]}
+              />
+              <ScopeGatedNavItem
+                item={orgRoutes.auditLogs}
+                scope={["org:read", "org:admin"]}
+              />
               {isRbacEnabled && (
-                <ScopeGatedNavItem item={orgRoutes.access} scope="org:read" />
+                <ScopeGatedNavItem
+                  item={orgRoutes.access}
+                  scope={["org:read", "org:admin"]}
+                />
               )}
               {isAdmin && (
                 <SidebarMenuItem>

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -31,7 +31,7 @@ function ScopeGatedNavItem({
 }) {
   return (
     <SidebarMenuItem>
-      <RequireScope scope={scope} level="component">
+      <RequireScope scope={scope} level="component" className="w-full">
         <NavButton
           title={item.title}
           href={item.href()}
@@ -90,6 +90,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   <RequireScope
                     scope={["org:read", "org:admin"]}
                     level="component"
+                    className="w-full"
                   >
                     <NavButton
                       title="Team"

--- a/client/dashboard/src/components/require-scope.tsx
+++ b/client/dashboard/src/components/require-scope.tsx
@@ -1,5 +1,6 @@
 import { Scope } from "@/hooks/useRBAC";
 import { useRBAC } from "@/hooks/useRBAC";
+import { cn } from "@/lib/utils";
 import { Icon } from "@speakeasy-api/moonshine";
 import React from "react";
 import {
@@ -34,6 +35,8 @@ type RequireScopeProps = {
       level: "component";
       /** Tooltip text shown on hover when disabled. */
       reason?: string;
+      /** Extra classes applied to the disabled wrapper div (e.g. "w-full" for block-level children). */
+      className?: string;
     }
 );
 
@@ -70,7 +73,11 @@ export function RequireScope(props: RequireScopeProps) {
       return <>{props.fallback ?? null}</>;
 
     case "component":
-      return <ScopeDisabled reason={props.reason}>{children}</ScopeDisabled>;
+      return (
+        <ScopeDisabled reason={props.reason} className={props.className}>
+          {children}
+        </ScopeDisabled>
+      );
   }
 }
 
@@ -79,19 +86,26 @@ export function RequireScope(props: RequireScopeProps) {
  */
 function ScopeDisabled({
   reason = "You don't have permission to perform this action.",
+  className,
   children,
 }: {
   reason?: string;
+  className?: string;
   children: React.ReactNode;
 }) {
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="pointer-events-none inline-flex cursor-not-allowed opacity-50 select-none">
+          <div
+            className={cn(
+              "pointer-events-none inline-flex cursor-not-allowed opacity-50 select-none",
+              className,
+            )}
+          >
             {/* Wrapper div that re-enables pointer events for the tooltip to work */}
             <div
-              className="pointer-events-auto"
+              className="pointer-events-auto w-full"
               onClickCapture={(e) => {
                 e.preventDefault();
                 e.stopPropagation();

--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -1,4 +1,4 @@
-import { getRBACScopeOverrideHeader } from "@/components/rbac-dev-toolbar";
+import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar";
 import { handleError } from "@/lib/errors";
 import { getServerURL } from "@/lib/utils";
 import { datadogRum } from "@datadog/browser-rum";

--- a/client/dashboard/src/hooks/useRBAC.ts
+++ b/client/dashboard/src/hooks/useRBAC.ts
@@ -2,7 +2,7 @@ import { getRBACScopeOverrideHeader } from "@/components/rbac-dev-toolbar";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { useGrants } from "@gram/client/react-query/grants.js";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 export type { Scope };
 
@@ -20,12 +20,36 @@ export function useRBAC() {
     import.meta.env.DEV && getRBACScopeOverrideHeader() !== null;
   const isRbacEnabled = featureFlagEnabled || devOverrideActive;
 
+  // Re-render when the dev toolbar changes scopes in localStorage.
+  const [overrideVersion, setOverrideVersion] = useState(0);
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const handler = () => setOverrideVersion((v) => v + 1);
+    window.addEventListener("rbac-override-change", handler);
+    return () => window.removeEventListener("rbac-override-change", handler);
+  }, []);
+
+  // Only fetch from server when RBAC is feature-flagged on (not dev override).
+  // The dev toolbar synthesises grants client-side so it works without server support.
   const { data, isLoading } = useGrants(undefined, undefined, {
-    enabled: isRbacEnabled,
+    enabled: isRbacEnabled && !devOverrideActive,
     staleTime: 30_000,
   });
 
-  const grants = data?.grants;
+  const grants = useMemo(() => {
+    if (devOverrideActive) {
+      const header = getRBACScopeOverrideHeader();
+      if (!header) return [];
+      return header.split(",").map((part) => {
+        const [scope, resourcesStr] = part.split("=");
+        return {
+          scope: scope as Scope,
+          resources: resourcesStr ? resourcesStr.split("|") : undefined,
+        };
+      });
+    }
+    return data?.grants;
+  }, [devOverrideActive, data?.grants, overrideVersion]);
 
   /**
    * Check if the user has a given scope, optionally scoped to a resource ID.

--- a/client/dashboard/src/hooks/useRBAC.ts
+++ b/client/dashboard/src/hooks/useRBAC.ts
@@ -1,4 +1,4 @@
-import { getRBACScopeOverrideHeader } from "@/components/rbac-dev-toolbar";
+import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { useGrants } from "@gram/client/react-query/grants.js";
@@ -29,27 +29,18 @@ export function useRBAC() {
     return () => window.removeEventListener("rbac-override-change", handler);
   }, []);
 
-  // Only fetch from server when RBAC is feature-flagged on (not dev override).
-  // The dev toolbar synthesises grants client-side so it works without server support.
+  // Fetch grants from the server. When dev override is active the SDK fetcher
+  // attaches X-Gram-Scope-Override so the server returns the filtered grant set.
   const { data, isLoading } = useGrants(undefined, undefined, {
-    enabled: isRbacEnabled && !devOverrideActive,
+    enabled: isRbacEnabled,
     staleTime: 30_000,
   });
 
+  // overrideVersion triggers a re-render (and therefore a re-read of devOverrideActive)
+  // when the dev toolbar changes; the query invalidation handles the actual refetch.
   const grants = useMemo(() => {
-    if (devOverrideActive) {
-      const header = getRBACScopeOverrideHeader();
-      if (!header) return [];
-      return header.split(",").map((part) => {
-        const [scope, resourcesStr] = part.split("=");
-        return {
-          scope: scope as Scope,
-          resources: resourcesStr ? resourcesStr.split("|") : undefined,
-        };
-      });
-    }
     return data?.grants;
-  }, [devOverrideActive, data?.grants, overrideVersion]);
+  }, [data?.grants, overrideVersion]);
 
   /**
    * Check if the user has a given scope, optionally scoped to a resource ID.
@@ -65,7 +56,9 @@ export function useRBAC() {
       if (!grants) return false;
 
       return grants.some((grant) => {
-        if (grant.scope !== scope) return false;
+        // evaluate if the grant's scope or any of its sub scopes matches the required scope
+        if (grant.scope !== scope && !grant.subScopes?.includes(scope))
+          return false;
         // Unrestricted grant — no resource allowlist
         if (!grant.resources) return true;
         // Resource-scoped grant — check if the resource is in the allowlist

--- a/client/dashboard/src/pages/access/Access.tsx
+++ b/client/dashboard/src/pages/access/Access.tsx
@@ -61,7 +61,7 @@ export default function Access() {
   }
 
   return (
-    <RequireScope scope="org:read" level="page">
+    <RequireScope scope={["org:read", "org:admin"]} level="page">
       <Page>
         <Page.Header>
           <Page.Header.Breadcrumbs substitutions={tabDisplayNames} />

--- a/client/dashboard/src/pages/access/Access.tsx
+++ b/client/dashboard/src/pages/access/Access.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import {
   PageTabsTrigger,
   Tabs,
@@ -60,39 +61,41 @@ export default function Access() {
   }
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs substitutions={tabDisplayNames} />
-      </Page.Header>
-      <Page.Body>
-        <div className="-mt-4">
-          <Type variant="body" className="text-muted-foreground mb-2">
-            Manage access control for your team by defining roles and assigning
-            permissions.
-          </Type>
-        </div>
-
-        <Tabs value={currentTab} onValueChange={handleTabChange}>
-          <div className="border-border -mx-8 border-b px-8">
-            <TabsList className="h-auto justify-start gap-4 rounded-none bg-transparent p-0 text-sm">
-              <PageTabsTrigger value="roles">
-                Roles{roleCount != null ? ` (${roleCount})` : ""}
-              </PageTabsTrigger>
-              <PageTabsTrigger value="members">
-                Members{memberCount != null ? ` (${memberCount})` : ""}
-              </PageTabsTrigger>
-            </TabsList>
+    <RequireScope scope="org:read" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs substitutions={tabDisplayNames} />
+        </Page.Header>
+        <Page.Body>
+          <div className="-mt-4">
+            <Type variant="body" className="text-muted-foreground mb-2">
+              Manage access control for your team by defining roles and
+              assigning permissions.
+            </Type>
           </div>
 
-          <TabsContent value="roles" className="mt-6">
-            <RolesTab />
-          </TabsContent>
+          <Tabs value={currentTab} onValueChange={handleTabChange}>
+            <div className="border-b border-border -mx-8 px-8">
+              <TabsList className="bg-transparent p-0 h-auto rounded-none justify-start gap-4 text-sm">
+                <PageTabsTrigger value="roles">
+                  Roles{roleCount != null ? ` (${roleCount})` : ""}
+                </PageTabsTrigger>
+                <PageTabsTrigger value="members">
+                  Members{memberCount != null ? ` (${memberCount})` : ""}
+                </PageTabsTrigger>
+              </TabsList>
+            </div>
 
-          <TabsContent value="members" className="mt-6">
-            <MembersTab />
-          </TabsContent>
-        </Tabs>
-      </Page.Body>
-    </Page>
+            <TabsContent value="roles" className="mt-6">
+              <RolesTab />
+            </TabsContent>
+
+            <TabsContent value="members" className="mt-6">
+              <MembersTab />
+            </TabsContent>
+          </Tabs>
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/access/Access.tsx
+++ b/client/dashboard/src/pages/access/Access.tsx
@@ -26,27 +26,46 @@ const tabDisplayNames: Record<string, string> = {
 
 export default function Access() {
   const location = useLocation();
-  const navigate = useNavigate();
   const telemetry = useTelemetry();
   const isRbacEnabled = telemetry.isFeatureEnabled("gram-rbac") ?? false;
 
   const pathSegments = location.pathname.split("/");
   const lastSegment = pathSegments[pathSegments.length - 1];
-  const currentTab = tabFromPath[lastSegment] || "roles";
   const shouldRedirect = lastSegment === "access";
-
-  const { data: rolesData } = useRoles(undefined, undefined, {
-    enabled: isRbacEnabled,
-  });
-  const { data: membersData } = useMembers(undefined, undefined, {
-    enabled: isRbacEnabled,
-  });
-  const roleCount = rolesData?.roles?.length;
-  const memberCount = membersData?.members?.length;
 
   if (!isRbacEnabled) {
     return <Navigate to=".." replace />;
   }
+
+  if (shouldRedirect) {
+    return <Navigate to="roles" replace />;
+  }
+
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs substitutions={tabDisplayNames} />
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["org:read", "org:admin"]} level="page">
+          <AccessInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function AccessInner() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { data: rolesData } = useRoles();
+  const { data: membersData } = useMembers();
+  const roleCount = rolesData?.roles?.length;
+  const memberCount = membersData?.members?.length;
+
+  const pathSegments = location.pathname.split("/");
+  const lastSegment = pathSegments[pathSegments.length - 1];
+  const currentTab = tabFromPath[lastSegment] || "roles";
 
   const basePath = pathSegments
     .slice(0, lastSegment === "access" ? pathSegments.length : -1)
@@ -56,46 +75,35 @@ export default function Access() {
     navigate(`${basePath}/${value}`);
   };
 
-  if (shouldRedirect) {
-    return <Navigate to="roles" replace />;
-  }
-
   return (
-    <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs substitutions={tabDisplayNames} />
-        </Page.Header>
-        <Page.Body>
-          <div className="-mt-4">
-            <Type variant="body" className="text-muted-foreground mb-2">
-              Manage access control for your team by defining roles and
-              assigning permissions.
-            </Type>
-          </div>
+    <>
+      <div className="-mt-4">
+        <Type variant="body" className="text-muted-foreground mb-2">
+          Manage access control for your team by defining roles and assigning
+          permissions.
+        </Type>
+      </div>
 
-          <Tabs value={currentTab} onValueChange={handleTabChange}>
-            <div className="border-b border-border -mx-8 px-8">
-              <TabsList className="bg-transparent p-0 h-auto rounded-none justify-start gap-4 text-sm">
-                <PageTabsTrigger value="roles">
-                  Roles{roleCount != null ? ` (${roleCount})` : ""}
-                </PageTabsTrigger>
-                <PageTabsTrigger value="members">
-                  Members{memberCount != null ? ` (${memberCount})` : ""}
-                </PageTabsTrigger>
-              </TabsList>
-            </div>
+      <Tabs value={currentTab} onValueChange={handleTabChange}>
+        <div className="border-border -mx-8 border-b px-8">
+          <TabsList className="h-auto justify-start gap-4 rounded-none bg-transparent p-0 text-sm">
+            <PageTabsTrigger value="roles">
+              Roles{roleCount != null ? ` (${roleCount})` : ""}
+            </PageTabsTrigger>
+            <PageTabsTrigger value="members">
+              Members{memberCount != null ? ` (${memberCount})` : ""}
+            </PageTabsTrigger>
+          </TabsList>
+        </div>
 
-            <TabsContent value="roles" className="mt-6">
-              <RolesTab />
-            </TabsContent>
+        <TabsContent value="roles" className="mt-6">
+          <RolesTab />
+        </TabsContent>
 
-            <TabsContent value="members" className="mt-6">
-              <MembersTab />
-            </TabsContent>
-          </Tabs>
-        </Page.Body>
-      </Page>
-    </RequireScope>
+        <TabsContent value="members" className="mt-6">
+          <MembersTab />
+        </TabsContent>
+      </Tabs>
+    </>
   );
 }

--- a/client/dashboard/src/pages/access/MembersTab.tsx
+++ b/client/dashboard/src/pages/access/MembersTab.tsx
@@ -97,7 +97,7 @@ export function MembersTab() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-1">
+      <div className="mb-1 flex items-center justify-between">
         <div>
           <Heading variant="h4">Team Members</Heading>
           <Type muted small className="mt-1">
@@ -118,7 +118,7 @@ export function MembersTab() {
           className="mt-4 rounded-b-none"
         />
       )}
-      <div className="flex justify-center border border-t-0 border-border rounded-b-lg py-3">
+      <div className="border-border flex justify-center rounded-b-lg border border-t-0 py-3">
         <RequireScope scope="org:admin" level="component">
           <Button variant="tertiary" size="sm">
             <Button.Text>Manage Team</Button.Text>

--- a/client/dashboard/src/pages/access/MembersTab.tsx
+++ b/client/dashboard/src/pages/access/MembersTab.tsx
@@ -9,6 +9,7 @@ import { SkeletonTable } from "@/components/ui/skeleton";
 import { Button, Column, Icon, Table } from "@speakeasy-api/moonshine";
 import { useState } from "react";
 import { ChangeRoleDialog } from "./ChangeRoleDialog";
+import { RequireScope } from "@/components/require-scope";
 
 function getInitials(name: string) {
   return name
@@ -81,20 +82,22 @@ export function MembersTab() {
       header: "",
       width: "100px",
       render: (member) => (
-        <Button
-          variant="tertiary"
-          size="sm"
-          onClick={() => setChangingMember(member)}
-        >
-          <Button.Text className="text-primary">Change</Button.Text>
-        </Button>
+        <RequireScope scope="org:admin" level="component">
+          <Button
+            variant="tertiary"
+            size="sm"
+            onClick={() => setChangingMember(member)}
+          >
+            <Button.Text className="text-primary">Change</Button.Text>
+          </Button>
+        </RequireScope>
       ),
     },
   ];
 
   return (
     <div>
-      <div className="mb-1 flex items-center justify-between">
+      <div className="flex items-center justify-between mb-1">
         <div>
           <Heading variant="h4">Team Members</Heading>
           <Type muted small className="mt-1">
@@ -115,13 +118,15 @@ export function MembersTab() {
           className="mt-4 rounded-b-none"
         />
       )}
-      <div className="border-border flex justify-center rounded-b-lg border border-t-0 py-3">
-        <Button variant="tertiary" size="sm">
-          <Button.Text>Manage Team</Button.Text>
-          <Button.RightIcon>
-            <Icon name="arrow-right" className="h-4 w-4" />
-          </Button.RightIcon>
-        </Button>
+      <div className="flex justify-center border border-t-0 border-border rounded-b-lg py-3">
+        <RequireScope scope="org:admin" level="component">
+          <Button variant="tertiary" size="sm">
+            <Button.Text>Manage Team</Button.Text>
+            <Button.RightIcon>
+              <Icon name="arrow-right" className="h-4 w-4" />
+            </Button.RightIcon>
+          </Button>
+        </RequireScope>
       </div>
 
       <ChangeRoleDialog

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -24,6 +24,7 @@ import { useState } from "react";
 import { CreateRoleDialog } from "./CreateRoleDialog";
 import { DeleteRoleDialog } from "./DeleteRoleDialog";
 import { Ellipsis } from "lucide-react";
+import { RequireScope } from "@/components/require-scope";
 
 export function RolesTab() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -101,19 +102,23 @@ export function RolesTab() {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onSelect={() => setTimeout(() => setEditingRole(role), 0)}
-            >
-              Edit
-            </DropdownMenuItem>
-            {!role.isSystem && (
+            <RequireScope scope="org:admin" level="component">
               <DropdownMenuItem
-                className="text-destructive focus:text-destructive cursor-pointer"
-                onSelect={() => setTimeout(() => setDeletingRole(role), 0)}
+                className="cursor-pointer"
+                onSelect={() => setTimeout(() => setEditingRole(role), 0)}
               >
-                Delete
+                Edit
               </DropdownMenuItem>
+            </RequireScope>
+            {!role.isSystem && (
+              <RequireScope scope="org:admin" level="component">
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive cursor-pointer"
+                  onSelect={() => setTimeout(() => setDeletingRole(role), 0)}
+                >
+                  Delete
+                </DropdownMenuItem>
+              </RequireScope>
             )}
           </DropdownMenuContent>
         </DropdownMenu>
@@ -130,12 +135,14 @@ export function RolesTab() {
             Define roles and their associated permissions.
           </Type>
         </div>
-        <Button onClick={() => setIsCreateOpen(true)}>
-          <Button.LeftIcon>
-            <Icon name="plus" className="h-4 w-4" />
-          </Button.LeftIcon>
-          <Button.Text>Add Role</Button.Text>
-        </Button>
+        <RequireScope scope="org:admin" level="component">
+          <Button onClick={() => setIsCreateOpen(true)}>
+            <Button.LeftIcon>
+              <Icon name="plus" className="h-4 w-4" />
+            </Button.LeftIcon>
+            <Button.Text>Add Role</Button.Text>
+          </Button>
+        </RequireScope>
       </div>
 
       {isLoading ? (

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -26,22 +26,31 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { RequireScope } from "@/components/require-scope";
 
 export default function Billing() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Billing</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope="org:admin" level="page">
+          <BillingInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function BillingInner() {
   const productTier = useProductTier();
 
   return (
-    <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <UsageSection />
-          {/* The product tiers / self serve billing section is DEPRECATED, and thus only shown to users already on a paid, non-enterprise tier */}
-          {(productTier === "base_PAID" ||
-            productTier === "__deprecated__pro") && <UsageTiers />}
-        </Page.Body>
-      </Page>
-    </RequireScope>
+    <>
+      <UsageSection />
+      {/* The product tiers / self serve billing section is DEPRECATED, and thus only shown to users already on a paid, non-enterprise tier */}
+      {(productTier === "base_PAID" || productTier === "__deprecated__pro") && (
+        <UsageTiers />
+      )}
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -29,7 +29,7 @@ export default function Billing() {
   const productTier = useProductTier();
 
   return (
-    <RequireScope scope="org:read" level="page">
+    <RequireScope scope={["org:read", "org:admin"]} level="page">
       <Page>
         <Page.Header>
           <Page.Header.Breadcrumbs />

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -32,7 +32,7 @@ export default function Billing() {
         <Page.Header.Title>Billing</Page.Header.Title>
       </Page.Header>
       <Page.Body>
-        <RequireScope scope="org:admin" level="page">
+        <RequireScope scope={["org:read", "org:admin"]} level="page">
           <BillingInner />
         </RequireScope>
       </Page.Body>

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -23,22 +23,25 @@ import { PolarEmbedCheckout } from "@polar-sh/checkout/embed";
 import { Button, cn, Stack } from "@speakeasy-api/moonshine";
 import { Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { RequireScope } from "@/components/require-scope";
 
 export default function Billing() {
   const productTier = useProductTier();
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>
-        <UsageSection />
-        {/* The product tiers / self serve billing section is DEPRECATED, and thus only shown to users already on a paid, non-enterprise tier */}
-        {(productTier === "base_PAID" ||
-          productTier === "__deprecated__pro") && <UsageTiers />}
-      </Page.Body>
-    </Page>
+    <RequireScope scope="org:read" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs />
+        </Page.Header>
+        <Page.Body>
+          <UsageSection />
+          {/* The product tiers / self serve billing section is DEPRECATED, and thus only shown to users already on a paid, non-enterprise tier */}
+          {(productTier === "base_PAID" ||
+            productTier === "__deprecated__pro") && <UsageTiers />}
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }
 
@@ -383,7 +386,9 @@ const UsageTiers = () => {
       <Page.Section.Description>
         A breakdown of our pricing tiers.
       </Page.Section.Description>
-      {productTier === "base" ? UpgradeCTA : polarPortalCTA}
+      <RequireScope scope="org:admin" level="section">
+        {productTier === "base" ? UpgradeCTA : polarPortalCTA}
+      </RequireScope>
       <Page.Section.Body>
         <Stack direction={"horizontal"} gap={4}>
           {isLoading ? (

--- a/client/dashboard/src/pages/org/OrgAdminSettings.tsx
+++ b/client/dashboard/src/pages/org/OrgAdminSettings.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
 import { Input } from "@/components/ui/input";
 import { Type } from "@/components/ui/type";
@@ -26,94 +27,106 @@ export default function OrgAdminSettings() {
   }
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Title>Super Admin</Page.Header.Title>
-      </Page.Header>
-      <Page.Body>
-        <Heading variant="h4" className="mb-2">
-          Organization Info
-        </Heading>
-        <Type muted small className="mb-4">
-          Details about the current organization.
-        </Type>
-        <div className="border-border bg-card mb-8 rounded-lg border p-4">
-          <Stack direction="horizontal" align="center" gap={2} className="mb-3">
-            <Building2 className="text-muted-foreground h-4 w-4" />
-            <Type variant="body" className="font-medium">
-              Organization
-            </Type>
-          </Stack>
-          <div className="ml-6 space-y-1">
-            <div className="flex gap-3">
-              <Type variant="body" className="text-muted-foreground text-sm">
-                Slug
+    <RequireScope scope="org:admin" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Title>Super Admin</Page.Header.Title>
+        </Page.Header>
+        <Page.Body>
+          <Heading variant="h4" className="mb-2">
+            Organization Info
+          </Heading>
+          <Type muted small className="mb-4">
+            Details about the current organization.
+          </Type>
+          <div className="rounded-lg border border-border bg-card p-4 mb-8">
+            <Stack
+              direction="horizontal"
+              align="center"
+              gap={2}
+              className="mb-3"
+            >
+              <Building2 className="h-4 w-4 text-muted-foreground" />
+              <Type variant="body" className="font-medium">
+                Organization
               </Type>
-              <Type variant="body" className="font-mono text-sm">
-                {organization.slug}
-              </Type>
-            </div>
-            <div className="flex gap-3">
-              <Type variant="body" className="text-muted-foreground text-sm">
-                ID
-              </Type>
-              <Type variant="body" className="font-mono text-sm">
-                {organization.id}
-              </Type>
+            </Stack>
+            <div className="ml-6 space-y-1">
+              <div className="flex gap-3">
+                <Type variant="body" className="text-muted-foreground text-sm">
+                  Slug
+                </Type>
+                <Type variant="body" className="font-mono text-sm">
+                  {organization.slug}
+                </Type>
+              </div>
+              <div className="flex gap-3">
+                <Type variant="body" className="text-muted-foreground text-sm">
+                  ID
+                </Type>
+                <Type variant="body" className="font-mono text-sm">
+                  {organization.id}
+                </Type>
+              </div>
             </div>
           </div>
-        </div>
 
-        <Heading variant="h4" className="mb-2">
-          Organization Override
-        </Heading>
-        <Type muted small className="mb-4">
-          Impersonate a different organization by switching to its slug. This
-          will log you out and redirect you to the target organization.
-        </Type>
-        <div className="border-border bg-card rounded-lg border p-4">
-          <Stack direction="horizontal" align="center" gap={2} className="mb-4">
-            <ArrowRightLeft className="text-muted-foreground h-4 w-4" />
-            <Type variant="body" className="font-medium">
-              Switch Organization
-            </Type>
-          </Stack>
-          <form
-            onSubmit={async (e) => {
-              e.preventDefault();
-              const formData = new FormData(e.currentTarget);
-              const val = formData.get("gram_admin_override");
-              if (typeof val !== "string" || !val.trim()) {
-                return;
-              }
+          <Heading variant="h4" className="mb-2">
+            Organization Override
+          </Heading>
+          <Type muted small className="mb-4">
+            Impersonate a different organization by switching to its slug. This
+            will log you out and redirect you to the target organization.
+          </Type>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <Stack
+              direction="horizontal"
+              align="center"
+              gap={2}
+              className="mb-4"
+            >
+              <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
+              <Type variant="body" className="font-medium">
+                Switch Organization
+              </Type>
+            </Stack>
+            <form
+              onSubmit={async (e) => {
+                e.preventDefault();
+                const formData = new FormData(e.currentTarget);
+                const val = formData.get("gram_admin_override");
+                if (typeof val !== "string" || !val.trim()) {
+                  return;
+                }
 
-              document.cookie = `gram_admin_override=${val.trim()}; path=/; max-age=31536000;`;
-              await client.auth.logout();
-              window.location.href = "/login";
-            }}
-            className="ml-6 flex max-w-md gap-2"
-          >
-            <Input
-              placeholder="organization-slug"
-              name="gram_admin_override"
-              className="flex-1"
-              required
-            />
-            <Button type="submit">Go to Org</Button>
-            <Button
-              variant="secondary"
-              type="button"
-              onClick={async () => {
-                document.cookie = `gram_admin_override=; path=/; max-age=0;`;
+                document.cookie = `gram_admin_override=${val.trim()}; path=/; max-age=31536000;`;
                 await client.auth.logout();
                 window.location.href = "/login";
               }}
+              className="ml-6 flex gap-2 max-w-md"
             >
-              Clear override
-            </Button>
-          </form>
-        </div>
-      </Page.Body>
-    </Page>
+              <Input
+                placeholder="organization-slug"
+                name="gram_admin_override"
+                className="flex-1"
+                required
+              />
+              <Button type="submit">Go to Org</Button>
+              <Button
+                variant="secondary"
+                type="button"
+                onClick={async () => {
+                  document.cookie = `gram_admin_override=; path=/; max-age=0;`;
+                  await client.auth.logout();
+                  window.location.href = "/login";
+                }}
+              >
+                Clear override
+              </Button>
+            </form>
+          </div>
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/org/OrgAdminSettings.tsx
+++ b/client/dashboard/src/pages/org/OrgAdminSettings.tsx
@@ -9,9 +9,7 @@ import { Building2, ArrowRightLeft } from "lucide-react";
 import { Button, Stack } from "@speakeasy-api/moonshine";
 
 export default function OrgAdminSettings() {
-  const organization = useOrganization();
   const isAdmin = useIsAdmin();
-  const client = useSdkClient();
 
   if (!isAdmin) {
     return (
@@ -27,106 +25,107 @@ export default function OrgAdminSettings() {
   }
 
   return (
-    <RequireScope scope="org:admin" level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Title>Super Admin</Page.Header.Title>
-        </Page.Header>
-        <Page.Body>
-          <Heading variant="h4" className="mb-2">
-            Organization Info
-          </Heading>
-          <Type muted small className="mb-4">
-            Details about the current organization.
-          </Type>
-          <div className="rounded-lg border border-border bg-card p-4 mb-8">
-            <Stack
-              direction="horizontal"
-              align="center"
-              gap={2}
-              className="mb-3"
-            >
-              <Building2 className="h-4 w-4 text-muted-foreground" />
-              <Type variant="body" className="font-medium">
-                Organization
-              </Type>
-            </Stack>
-            <div className="ml-6 space-y-1">
-              <div className="flex gap-3">
-                <Type variant="body" className="text-muted-foreground text-sm">
-                  Slug
-                </Type>
-                <Type variant="body" className="font-mono text-sm">
-                  {organization.slug}
-                </Type>
-              </div>
-              <div className="flex gap-3">
-                <Type variant="body" className="text-muted-foreground text-sm">
-                  ID
-                </Type>
-                <Type variant="body" className="font-mono text-sm">
-                  {organization.id}
-                </Type>
-              </div>
-            </div>
-          </div>
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Super Admin</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope="org:admin" level="page">
+          <OrgAdminSettingsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
 
-          <Heading variant="h4" className="mb-2">
-            Organization Override
-          </Heading>
-          <Type muted small className="mb-4">
-            Impersonate a different organization by switching to its slug. This
-            will log you out and redirect you to the target organization.
-          </Type>
-          <div className="rounded-lg border border-border bg-card p-4">
-            <Stack
-              direction="horizontal"
-              align="center"
-              gap={2}
-              className="mb-4"
-            >
-              <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
-              <Type variant="body" className="font-medium">
-                Switch Organization
-              </Type>
-            </Stack>
-            <form
-              onSubmit={async (e) => {
-                e.preventDefault();
-                const formData = new FormData(e.currentTarget);
-                const val = formData.get("gram_admin_override");
-                if (typeof val !== "string" || !val.trim()) {
-                  return;
-                }
+export function OrgAdminSettingsInner() {
+  const organization = useOrganization();
+  const client = useSdkClient();
 
-                document.cookie = `gram_admin_override=${val.trim()}; path=/; max-age=31536000;`;
-                await client.auth.logout();
-                window.location.href = "/login";
-              }}
-              className="ml-6 flex gap-2 max-w-md"
-            >
-              <Input
-                placeholder="organization-slug"
-                name="gram_admin_override"
-                className="flex-1"
-                required
-              />
-              <Button type="submit">Go to Org</Button>
-              <Button
-                variant="secondary"
-                type="button"
-                onClick={async () => {
-                  document.cookie = `gram_admin_override=; path=/; max-age=0;`;
-                  await client.auth.logout();
-                  window.location.href = "/login";
-                }}
-              >
-                Clear override
-              </Button>
-            </form>
+  return (
+    <>
+      <Heading variant="h4" className="mb-2">
+        Organization Info
+      </Heading>
+      <Type muted small className="mb-4">
+        Details about the current organization.
+      </Type>
+      <div className="border-border bg-card mb-8 rounded-lg border p-4">
+        <Stack direction="horizontal" align="center" gap={2} className="mb-3">
+          <Building2 className="text-muted-foreground h-4 w-4" />
+          <Type variant="body" className="font-medium">
+            Organization
+          </Type>
+        </Stack>
+        <div className="ml-6 space-y-1">
+          <div className="flex gap-3">
+            <Type variant="body" className="text-muted-foreground text-sm">
+              Slug
+            </Type>
+            <Type variant="body" className="font-mono text-sm">
+              {organization.slug}
+            </Type>
           </div>
-        </Page.Body>
-      </Page>
-    </RequireScope>
+          <div className="flex gap-3">
+            <Type variant="body" className="text-muted-foreground text-sm">
+              ID
+            </Type>
+            <Type variant="body" className="font-mono text-sm">
+              {organization.id}
+            </Type>
+          </div>
+        </div>
+      </div>
+
+      <Heading variant="h4" className="mb-2">
+        Organization Override
+      </Heading>
+      <Type muted small className="mb-4">
+        Impersonate a different organization by switching to its slug. This will
+        log you out and redirect you to the target organization.
+      </Type>
+      <div className="border-border bg-card rounded-lg border p-4">
+        <Stack direction="horizontal" align="center" gap={2} className="mb-4">
+          <ArrowRightLeft className="text-muted-foreground h-4 w-4" />
+          <Type variant="body" className="font-medium">
+            Switch Organization
+          </Type>
+        </Stack>
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const formData = new FormData(e.currentTarget);
+            const val = formData.get("gram_admin_override");
+            if (typeof val !== "string" || !val.trim()) {
+              return;
+            }
+
+            document.cookie = `gram_admin_override=${val.trim()}; path=/; max-age=31536000;`;
+            await client.auth.logout();
+            window.location.href = "/login";
+          }}
+          className="ml-6 flex max-w-md gap-2"
+        >
+          <Input
+            placeholder="organization-slug"
+            name="gram_admin_override"
+            className="flex-1"
+            required
+          />
+          <Button type="submit">Go to Org</Button>
+          <Button
+            variant="secondary"
+            type="button"
+            onClick={async () => {
+              document.cookie = `gram_admin_override=; path=/; max-age=0;`;
+              await client.auth.logout();
+              window.location.href = "/login";
+            }}
+          >
+            Clear override
+          </Button>
+        </form>
+      </div>
+    </>
   );
 }

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -23,6 +23,23 @@ import { useMemo, useState } from "react";
 import { RequireScope } from "@/components/require-scope";
 
 export default function OrgApiKeys() {
+  // We need an outer component wrapping the inner as the key fetching request
+  // will return a forbidden error if the user does not have the org:admin scope
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>API Keys</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope="org:admin" level="page">
+          <OrgApiKeysInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function OrgApiKeysInner() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [keyToRevoke, setKeyToRevoke] = useState<Key | null>(null);
   const [newlyCreatedKey, setNewlyCreatedKey] = useState<Key | null>(null);
@@ -168,213 +185,194 @@ export default function OrgApiKeys() {
   ];
 
   return (
-    <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Title>API Keys</Page.Header.Title>
-        </Page.Header>
-        <Page.Body>
-          <Heading variant="h4" className="mb-2">
-            API Keys
-          </Heading>
-          <Type muted small className="mb-6">
-            Create and manage API keys to authenticate programmatic access to
-            Gram services, including deployments, toolset management, and MCP
-            server connections.
-          </Type>
+    <>
+      <Heading variant="h4" className="mb-2">
+        API Keys
+      </Heading>
+      <Type muted small className="mb-6">
+        Create and manage API keys to authenticate programmatic access to Gram
+        services, including deployments, toolset management, and MCP server
+        connections.
+      </Type>
+      <Stack
+        direction="horizontal"
+        justify="space-between"
+        align="center"
+        className="mb-4"
+      >
+        <SearchBar
+          value={apiKeySearch}
+          onChange={setApiKeySearch}
+          placeholder="Search by key name"
+          className="w-64"
+        />
+        <RequireScope scope="org:admin" level="component">
+          <Button onClick={() => setIsCreateDialogOpen(true)}>
+            New API Key
+          </Button>
+        </RequireScope>
+      </Stack>
+      <Table
+        columns={apiKeyColumns}
+        data={filteredKeys}
+        rowKey={(row) => row.id}
+        className="max-h-[500px] overflow-y-auto"
+        noResultsMessage={
           <Stack
-            direction="horizontal"
-            justify="space-between"
+            gap={2}
+            className="bg-background h-full gap-4 p-4 py-6"
             align="center"
-            className="mb-4"
+            justify="center"
           >
-            <SearchBar
-              value={apiKeySearch}
-              onChange={setApiKeySearch}
-              placeholder="Search by key name"
-              className="w-64"
-            />
-            <RequireScope scope="org:admin" level="component">
-              <Button onClick={() => setIsCreateDialogOpen(true)}>
-                New API Key
-              </Button>
-            </RequireScope>
+            <Type variant="body">
+              {apiKeySearch ? "No matching API keys" : "No API keys yet"}
+            </Type>
+            {!apiKeySearch && (
+              <RequireScope scope="org:admin" level="component">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setIsCreateDialogOpen(true)}
+                >
+                  <Button.LeftIcon>
+                    <Icon name="key-round" className="h-4 w-4" />
+                  </Button.LeftIcon>
+                  <Button.Text>Create Key</Button.Text>
+                </Button>
+              </RequireScope>
+            )}
           </Stack>
-          <Table
-            columns={apiKeyColumns}
-            data={filteredKeys}
-            rowKey={(row) => row.id}
-            className="max-h-[500px] overflow-y-auto"
-            noResultsMessage={
-              <Stack
-                gap={2}
-                className="h-full p-4 gap-4 py-6 bg-background"
-                align="center"
-                justify="center"
-              >
-                <Type variant="body">
-                  {apiKeySearch ? "No matching API keys" : "No API keys yet"}
-                </Type>
-                {!apiKeySearch && (
-                  <RequireScope scope="org:admin" level="component">
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={() => setIsCreateDialogOpen(true)}
-                    >
-                      <Button.LeftIcon>
-                        <Icon name="key-round" className="h-4 w-4" />
-                      </Button.LeftIcon>
-                      <Button.Text>Create Key</Button.Text>
-                    </Button>
-                  </RequireScope>
-                )}
-              </Stack>
-            }
-          />
+        }
+      />
 
-          <Dialog
-            open={isCreateDialogOpen}
-            onOpenChange={handleCloseCreateDialog}
-          >
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>
-                  {newlyCreatedKey ? "API Key Created" : "Create New API Key"}
-                </Dialog.Title>
-              </Dialog.Header>
-              {newlyCreatedKey ? (
-                <div className="space-y-4 py-4">
-                  <div className="rounded-lg border border-yellow-500/50 bg-yellow-600/50 text-foreground p-4 text-sm">
-                    You will not be able to see this token value again once you
-                    close this dialog. Copy it now and store it securely.
-                  </div>
-                  <div className="flex items-center space-x-2 bg-muted p-3 rounded-md">
-                    <code className="flex-1 break-all">
-                      {newlyCreatedKey.key}
-                    </code>
-                    <Button
-                      variant="tertiary"
-                      size="sm"
-                      onClick={handleCopyToken}
-                      className="shrink-0"
-                    >
-                      {isCopied ? (
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <Copy className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                  <div className="flex justify-end">
-                    <Button onClick={handleCloseCreateDialog}>Close</Button>
-                  </div>
-                </div>
-              ) : (
-                <form className="space-y-4 py-4" onSubmit={handleCreateKey}>
-                  <InputField
-                    label="Key name"
-                    name="name"
-                    required
-                    autoFocus
-                    autoCapitalize="off"
-                    autoComplete="off"
-                    autoCorrect="off"
-                  />
-
-                  <AnyField
-                    label="Scope"
-                    optionality="hidden"
-                    render={() => {
-                      return (
-                        <RadioGroup name="scope" defaultValue="consumer">
-                          <div className="flex items-center gap-3">
-                            <RadioGroupItem value="consumer" id="r1" />
-                            <Label className="leading-normal" htmlFor="r1">
-                              Consumer: can query/modify toolsets, read data and
-                              access MCP servers.
-                            </Label>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <RadioGroupItem value="producer" id="r2" />
-                            <Label className="leading-normal" htmlFor="r2">
-                              Producer: can upload OpenAPI documents, trigger
-                              deployments, query/modify toolsets, read data and
-                              access MCP servers.
-                            </Label>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <RadioGroupItem value="chat" id="r3" />
-                            <Label className="leading-normal" htmlFor="r3">
-                              Chat: can use the chat API to interact with
-                              models.
-                            </Label>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <RadioGroupItem value="hooks" id="r4" />
-                            <Label className="leading-normal" htmlFor="r4">
-                              Hooks: can send hook events and OTEL logs from
-                              agent integrations.
-                            </Label>
-                          </div>
-                        </RadioGroup>
-                      );
-                    }}
-                  />
-                  <div className="flex justify-end space-x-2">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={handleCloseCreateDialog}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      type="submit"
-                      disabled={createKeyMutation.isPending}
-                    >
-                      Create
-                    </Button>
-                  </div>
-                </form>
-              )}
-            </Dialog.Content>
-          </Dialog>
-
-          <Dialog
-            open={!!keyToRevoke}
-            onOpenChange={(open) => !open && setKeyToRevoke(null)}
-          >
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Revoke API Key</Dialog.Title>
-              </Dialog.Header>
-              <div className="space-y-4 py-4">
-                <Type variant="body">
-                  Are you sure you want to revoke the API key{" "}
-                  <span className="italic font-bold">{keyToRevoke?.name}</span>?
-                  This action cannot be undone.
-                </Type>
-                <div className="flex justify-end space-x-2">
-                  <Button
-                    variant="secondary"
-                    onClick={() => setKeyToRevoke(null)}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="destructive-primary"
-                    onClick={handleRevokeKey}
-                    disabled={revokeKeyMutation.isPending}
-                  >
-                    Revoke Key
-                  </Button>
-                </div>
+      <Dialog open={isCreateDialogOpen} onOpenChange={handleCloseCreateDialog}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>
+              {newlyCreatedKey ? "API Key Created" : "Create New API Key"}
+            </Dialog.Title>
+          </Dialog.Header>
+          {newlyCreatedKey ? (
+            <div className="space-y-4 py-4">
+              <div className="text-foreground rounded-lg border border-yellow-500/50 bg-yellow-600/50 p-4 text-sm">
+                You will not be able to see this token value again once you
+                close this dialog. Copy it now and store it securely.
               </div>
-            </Dialog.Content>
-          </Dialog>
-        </Page.Body>
-      </Page>
-    </RequireScope>
+              <div className="bg-muted flex items-center space-x-2 rounded-md p-3">
+                <code className="flex-1 break-all">{newlyCreatedKey.key}</code>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  onClick={handleCopyToken}
+                  className="shrink-0"
+                >
+                  {isCopied ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+              <div className="flex justify-end">
+                <Button onClick={handleCloseCreateDialog}>Close</Button>
+              </div>
+            </div>
+          ) : (
+            <form className="space-y-4 py-4" onSubmit={handleCreateKey}>
+              <InputField
+                label="Key name"
+                name="name"
+                required
+                autoFocus
+                autoCapitalize="off"
+                autoComplete="off"
+                autoCorrect="off"
+              />
+
+              <AnyField
+                label="Scope"
+                optionality="hidden"
+                render={() => {
+                  return (
+                    <RadioGroup name="scope" defaultValue="consumer">
+                      <div className="flex items-center gap-3">
+                        <RadioGroupItem value="consumer" id="r1" />
+                        <Label className="leading-normal" htmlFor="r1">
+                          Consumer: can query/modify toolsets, read data and
+                          access MCP servers.
+                        </Label>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <RadioGroupItem value="producer" id="r2" />
+                        <Label className="leading-normal" htmlFor="r2">
+                          Producer: can upload OpenAPI documents, trigger
+                          deployments, query/modify toolsets, read data and
+                          access MCP servers.
+                        </Label>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <RadioGroupItem value="chat" id="r3" />
+                        <Label className="leading-normal" htmlFor="r3">
+                          Chat: can use the chat API to interact with models.
+                        </Label>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <RadioGroupItem value="hooks" id="r4" />
+                        <Label className="leading-normal" htmlFor="r4">
+                          Hooks: can send hook events and OTEL logs from agent
+                          integrations.
+                        </Label>
+                      </div>
+                    </RadioGroup>
+                  );
+                }}
+              />
+              <div className="flex justify-end space-x-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleCloseCreateDialog}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={createKeyMutation.isPending}>
+                  Create
+                </Button>
+              </div>
+            </form>
+          )}
+        </Dialog.Content>
+      </Dialog>
+
+      <Dialog
+        open={!!keyToRevoke}
+        onOpenChange={(open) => !open && setKeyToRevoke(null)}
+      >
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Revoke API Key</Dialog.Title>
+          </Dialog.Header>
+          <div className="space-y-4 py-4">
+            <Type variant="body">
+              Are you sure you want to revoke the API key{" "}
+              <span className="font-bold italic">{keyToRevoke?.name}</span>?
+              This action cannot be undone.
+            </Type>
+            <div className="flex justify-end space-x-2">
+              <Button variant="secondary" onClick={() => setKeyToRevoke(null)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive-primary"
+                onClick={handleRevokeKey}
+                disabled={revokeKeyMutation.isPending}
+              >
+                Revoke Key
+              </Button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+    </>
   );
 }

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -168,7 +168,7 @@ export default function OrgApiKeys() {
   ];
 
   return (
-    <RequireScope scope="org:admin" level="page">
+    <RequireScope scope={["org:read", "org:admin"]} level="page">
       <Page>
         <Page.Header>
           <Page.Header.Title>API Keys</Page.Header.Title>
@@ -194,9 +194,11 @@ export default function OrgApiKeys() {
               placeholder="Search by key name"
               className="w-64"
             />
-            <Button onClick={() => setIsCreateDialogOpen(true)}>
-              New API Key
-            </Button>
+            <RequireScope scope="org:admin" level="component">
+              <Button onClick={() => setIsCreateDialogOpen(true)}>
+                New API Key
+              </Button>
+            </RequireScope>
           </Stack>
           <Table
             columns={apiKeyColumns}
@@ -206,7 +208,7 @@ export default function OrgApiKeys() {
             noResultsMessage={
               <Stack
                 gap={2}
-                className="h-full p-4 bg-background"
+                className="h-full p-4 gap-4 py-6 bg-background"
                 align="center"
                 justify="center"
               >
@@ -214,16 +216,18 @@ export default function OrgApiKeys() {
                   {apiKeySearch ? "No matching API keys" : "No API keys yet"}
                 </Type>
                 {!apiKeySearch && (
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => setIsCreateDialogOpen(true)}
-                  >
-                    <Button.LeftIcon>
-                      <Icon name="key-round" className="h-4 w-4" />
-                    </Button.LeftIcon>
-                    <Button.Text>Create Key</Button.Text>
-                  </Button>
+                  <RequireScope scope="org:admin" level="component">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => setIsCreateDialogOpen(true)}
+                    >
+                      <Button.LeftIcon>
+                        <Icon name="key-round" className="h-4 w-4" />
+                      </Button.LeftIcon>
+                      <Button.Text>Create Key</Button.Text>
+                    </Button>
+                  </RequireScope>
                 )}
               </Stack>
             }

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -20,6 +20,7 @@ import { Button, Column, Icon, Stack, Table } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, Copy } from "lucide-react";
 import { useMemo, useState } from "react";
+import { RequireScope } from "@/components/require-scope";
 
 export default function OrgApiKeys() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -167,203 +168,209 @@ export default function OrgApiKeys() {
   ];
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Title>API Keys</Page.Header.Title>
-      </Page.Header>
-      <Page.Body>
-        <Heading variant="h4" className="mb-2">
-          API Keys
-        </Heading>
-        <Type muted small className="mb-6">
-          Create and manage API keys to authenticate programmatic access to Gram
-          services, including deployments, toolset management, and MCP server
-          connections.
-        </Type>
-        <Stack
-          direction="horizontal"
-          justify="space-between"
-          align="center"
-          className="mb-4"
-        >
-          <SearchBar
-            value={apiKeySearch}
-            onChange={setApiKeySearch}
-            placeholder="Search by key name"
-            className="w-64"
-          />
-          <Button onClick={() => setIsCreateDialogOpen(true)}>
-            New API Key
-          </Button>
-        </Stack>
-        <Table
-          columns={apiKeyColumns}
-          data={filteredKeys}
-          rowKey={(row) => row.id}
-          className="max-h-[500px] overflow-y-auto"
-          noResultsMessage={
-            <Stack
-              gap={2}
-              className="bg-background h-full p-4"
-              align="center"
-              justify="center"
-            >
-              <Type variant="body">
-                {apiKeySearch ? "No matching API keys" : "No API keys yet"}
-              </Type>
-              {!apiKeySearch && (
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => setIsCreateDialogOpen(true)}
-                >
-                  <Button.LeftIcon>
-                    <Icon name="key-round" className="h-4 w-4" />
-                  </Button.LeftIcon>
-                  <Button.Text>Create Key</Button.Text>
-                </Button>
-              )}
-            </Stack>
-          }
-        />
-
-        <Dialog
-          open={isCreateDialogOpen}
-          onOpenChange={handleCloseCreateDialog}
-        >
-          <Dialog.Content>
-            <Dialog.Header>
-              <Dialog.Title>
-                {newlyCreatedKey ? "API Key Created" : "Create New API Key"}
-              </Dialog.Title>
-            </Dialog.Header>
-            {newlyCreatedKey ? (
-              <div className="space-y-4 py-4">
-                <div className="text-foreground rounded-lg border border-yellow-500/50 bg-yellow-600/50 p-4 text-sm">
-                  You will not be able to see this token value again once you
-                  close this dialog. Copy it now and store it securely.
-                </div>
-                <div className="bg-muted flex items-center space-x-2 rounded-md p-3">
-                  <code className="flex-1 break-all">
-                    {newlyCreatedKey.key}
-                  </code>
+    <RequireScope scope="org:admin" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Title>API Keys</Page.Header.Title>
+        </Page.Header>
+        <Page.Body>
+          <Heading variant="h4" className="mb-2">
+            API Keys
+          </Heading>
+          <Type muted small className="mb-6">
+            Create and manage API keys to authenticate programmatic access to
+            Gram services, including deployments, toolset management, and MCP
+            server connections.
+          </Type>
+          <Stack
+            direction="horizontal"
+            justify="space-between"
+            align="center"
+            className="mb-4"
+          >
+            <SearchBar
+              value={apiKeySearch}
+              onChange={setApiKeySearch}
+              placeholder="Search by key name"
+              className="w-64"
+            />
+            <Button onClick={() => setIsCreateDialogOpen(true)}>
+              New API Key
+            </Button>
+          </Stack>
+          <Table
+            columns={apiKeyColumns}
+            data={filteredKeys}
+            rowKey={(row) => row.id}
+            className="max-h-[500px] overflow-y-auto"
+            noResultsMessage={
+              <Stack
+                gap={2}
+                className="h-full p-4 bg-background"
+                align="center"
+                justify="center"
+              >
+                <Type variant="body">
+                  {apiKeySearch ? "No matching API keys" : "No API keys yet"}
+                </Type>
+                {!apiKeySearch && (
                   <Button
-                    variant="tertiary"
                     size="sm"
-                    onClick={handleCopyToken}
-                    className="shrink-0"
+                    variant="secondary"
+                    onClick={() => setIsCreateDialogOpen(true)}
                   >
-                    {isCopied ? (
-                      <CheckCircle2 className="h-4 w-4 text-green-500" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
+                    <Button.LeftIcon>
+                      <Icon name="key-round" className="h-4 w-4" />
+                    </Button.LeftIcon>
+                    <Button.Text>Create Key</Button.Text>
                   </Button>
-                </div>
-                <div className="flex justify-end">
-                  <Button onClick={handleCloseCreateDialog}>Close</Button>
-                </div>
-              </div>
-            ) : (
-              <form className="space-y-4 py-4" onSubmit={handleCreateKey}>
-                <InputField
-                  label="Key name"
-                  name="name"
-                  required
-                  autoFocus
-                  autoCapitalize="off"
-                  autoComplete="off"
-                  autoCorrect="off"
-                />
+                )}
+              </Stack>
+            }
+          />
 
-                <AnyField
-                  label="Scope"
-                  optionality="hidden"
-                  render={() => {
-                    return (
-                      <RadioGroup name="scope" defaultValue="consumer">
-                        <div className="flex items-center gap-3">
-                          <RadioGroupItem value="consumer" id="r1" />
-                          <Label className="leading-normal" htmlFor="r1">
-                            Consumer: can query/modify toolsets, read data and
-                            access MCP servers.
-                          </Label>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          <RadioGroupItem value="producer" id="r2" />
-                          <Label className="leading-normal" htmlFor="r2">
-                            Producer: can upload OpenAPI documents, trigger
-                            deployments, query/modify toolsets, read data and
-                            access MCP servers.
-                          </Label>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          <RadioGroupItem value="chat" id="r3" />
-                          <Label className="leading-normal" htmlFor="r3">
-                            Chat: can use the chat API to interact with models.
-                          </Label>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          <RadioGroupItem value="hooks" id="r4" />
-                          <Label className="leading-normal" htmlFor="r4">
-                            Hooks: can send hook events and OTEL logs from agent
-                            integrations.
-                          </Label>
-                        </div>
-                      </RadioGroup>
-                    );
-                  }}
-                />
+          <Dialog
+            open={isCreateDialogOpen}
+            onOpenChange={handleCloseCreateDialog}
+          >
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>
+                  {newlyCreatedKey ? "API Key Created" : "Create New API Key"}
+                </Dialog.Title>
+              </Dialog.Header>
+              {newlyCreatedKey ? (
+                <div className="space-y-4 py-4">
+                  <div className="rounded-lg border border-yellow-500/50 bg-yellow-600/50 text-foreground p-4 text-sm">
+                    You will not be able to see this token value again once you
+                    close this dialog. Copy it now and store it securely.
+                  </div>
+                  <div className="flex items-center space-x-2 bg-muted p-3 rounded-md">
+                    <code className="flex-1 break-all">
+                      {newlyCreatedKey.key}
+                    </code>
+                    <Button
+                      variant="tertiary"
+                      size="sm"
+                      onClick={handleCopyToken}
+                      className="shrink-0"
+                    >
+                      {isCopied ? (
+                        <CheckCircle2 className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                  <div className="flex justify-end">
+                    <Button onClick={handleCloseCreateDialog}>Close</Button>
+                  </div>
+                </div>
+              ) : (
+                <form className="space-y-4 py-4" onSubmit={handleCreateKey}>
+                  <InputField
+                    label="Key name"
+                    name="name"
+                    required
+                    autoFocus
+                    autoCapitalize="off"
+                    autoComplete="off"
+                    autoCorrect="off"
+                  />
+
+                  <AnyField
+                    label="Scope"
+                    optionality="hidden"
+                    render={() => {
+                      return (
+                        <RadioGroup name="scope" defaultValue="consumer">
+                          <div className="flex items-center gap-3">
+                            <RadioGroupItem value="consumer" id="r1" />
+                            <Label className="leading-normal" htmlFor="r1">
+                              Consumer: can query/modify toolsets, read data and
+                              access MCP servers.
+                            </Label>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            <RadioGroupItem value="producer" id="r2" />
+                            <Label className="leading-normal" htmlFor="r2">
+                              Producer: can upload OpenAPI documents, trigger
+                              deployments, query/modify toolsets, read data and
+                              access MCP servers.
+                            </Label>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            <RadioGroupItem value="chat" id="r3" />
+                            <Label className="leading-normal" htmlFor="r3">
+                              Chat: can use the chat API to interact with
+                              models.
+                            </Label>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            <RadioGroupItem value="hooks" id="r4" />
+                            <Label className="leading-normal" htmlFor="r4">
+                              Hooks: can send hook events and OTEL logs from
+                              agent integrations.
+                            </Label>
+                          </div>
+                        </RadioGroup>
+                      );
+                    }}
+                  />
+                  <div className="flex justify-end space-x-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={handleCloseCreateDialog}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="submit"
+                      disabled={createKeyMutation.isPending}
+                    >
+                      Create
+                    </Button>
+                  </div>
+                </form>
+              )}
+            </Dialog.Content>
+          </Dialog>
+
+          <Dialog
+            open={!!keyToRevoke}
+            onOpenChange={(open) => !open && setKeyToRevoke(null)}
+          >
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>Revoke API Key</Dialog.Title>
+              </Dialog.Header>
+              <div className="space-y-4 py-4">
+                <Type variant="body">
+                  Are you sure you want to revoke the API key{" "}
+                  <span className="italic font-bold">{keyToRevoke?.name}</span>?
+                  This action cannot be undone.
+                </Type>
                 <div className="flex justify-end space-x-2">
                   <Button
-                    type="button"
                     variant="secondary"
-                    onClick={handleCloseCreateDialog}
+                    onClick={() => setKeyToRevoke(null)}
                   >
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={createKeyMutation.isPending}>
-                    Create
+                  <Button
+                    variant="destructive-primary"
+                    onClick={handleRevokeKey}
+                    disabled={revokeKeyMutation.isPending}
+                  >
+                    Revoke Key
                   </Button>
                 </div>
-              </form>
-            )}
-          </Dialog.Content>
-        </Dialog>
-
-        <Dialog
-          open={!!keyToRevoke}
-          onOpenChange={(open) => !open && setKeyToRevoke(null)}
-        >
-          <Dialog.Content>
-            <Dialog.Header>
-              <Dialog.Title>Revoke API Key</Dialog.Title>
-            </Dialog.Header>
-            <div className="space-y-4 py-4">
-              <Type variant="body">
-                Are you sure you want to revoke the API key{" "}
-                <span className="font-bold italic">{keyToRevoke?.name}</span>?
-                This action cannot be undone.
-              </Type>
-              <div className="flex justify-end space-x-2">
-                <Button
-                  variant="secondary"
-                  onClick={() => setKeyToRevoke(null)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive-primary"
-                  onClick={handleRevokeKey}
-                  disabled={revokeKeyMutation.isPending}
-                >
-                  Revoke Key
-                </Button>
               </div>
-            </div>
-          </Dialog.Content>
-        </Dialog>
-      </Page.Body>
-    </Page>
+            </Dialog.Content>
+          </Dialog>
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -72,7 +72,7 @@ function getDateKey(date: Date, mode: "utc" | "local") {
 }
 
 function StrongName({ children }: { children: ReactNode }) {
-  return <strong className="font-semibold text-foreground">{children}</strong>;
+  return <strong className="text-foreground font-semibold">{children}</strong>;
 }
 
 function getActorLabel(log: AuditLog) {
@@ -353,7 +353,7 @@ function AuditLogRow({
           <StrongName>
             {highlightMatch ? highlightMatch(actorLabel) : actorLabel}
           </StrongName>
-          <span className="mx-1.5 text-muted-foreground">
+          <span className="text-muted-foreground mx-1.5">
             {highlightMatch ? highlightMatch(verbText) : verbText}
           </span>
           {renderSubject(log, orgSlug)}
@@ -368,7 +368,7 @@ function AuditLogRow({
           </button>
         )}
       </div>
-      <span className="shrink-0 font-mono text-xs text-muted-foreground">
+      <span className="text-muted-foreground shrink-0 font-mono text-xs">
         {formatTimeOnly(log.createdAt, timestampMode)}
       </span>
     </div>
@@ -378,7 +378,7 @@ function AuditLogRow({
     return (
       <div
         ref={rowRef}
-        className={cn(isHighlighted && "border-l-4 border-l-foreground")}
+        className={cn(isHighlighted && "border-l-foreground border-l-4")}
       >
         <div
           className={cn(
@@ -388,7 +388,7 @@ function AuditLogRow({
         >
           {rowContent}
         </div>
-        <div className="rounded-b-lg border border-t-0 bg-background px-4 pb-3 pt-2">
+        <div className="bg-background rounded-b-lg border border-t-0 px-4 pt-2 pb-3">
           <StructuredDiff log={log} />
         </div>
       </div>
@@ -401,7 +401,7 @@ function AuditLogRow({
       className={cn(
         "rounded-none transition-colors",
         isOdd ? "bg-muted/30" : "bg-background",
-        isHighlighted && "border-l-4 border-l-foreground",
+        isHighlighted && "border-l-foreground border-l-4",
       )}
     >
       {rowContent}
@@ -418,10 +418,10 @@ function DateGroupHeader({
 }) {
   return (
     <div className="flex items-center gap-3 px-4 py-2">
-      <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+      <span className="text-muted-foreground shrink-0 text-[11px] font-semibold tracking-wide uppercase">
         {formatDateHeader(date, mode)}
       </span>
-      <div className="h-px flex-1 bg-border" />
+      <div className="bg-border h-px flex-1" />
     </div>
   );
 }
@@ -475,7 +475,7 @@ function FacetSelect({
         {label}
       </Type>
       <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger size="sm" className="min-w-[220px] bg-background">
+        <SelectTrigger size="sm" className="bg-background min-w-[220px]">
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>
@@ -500,6 +500,21 @@ function FacetSelect({
 }
 
 export default function OrgAuditLogs() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Audit Logs</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope="org:read" level="page">
+          <OrgAuditLogsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function OrgAuditLogsInner() {
   const organization = useOrganization();
   const { orgSlug } = useSlugs();
   const [selectedProjectSlug, setSelectedProjectSlug] = useQueryState(
@@ -692,7 +707,7 @@ export default function OrgAuditLogs() {
             part.toLowerCase() === searchQuery.toLowerCase() ? (
               <mark
                 key={i}
-                className="bg-yellow-200 dark:bg-yellow-800 text-inherit"
+                className="bg-yellow-200 text-inherit dark:bg-yellow-800"
               >
                 {part}
               </mark>
@@ -810,321 +825,296 @@ export default function OrgAuditLogs() {
   ]);
 
   return (
-    <RequireScope scope="org:read" level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Title>Audit Logs</Page.Header.Title>
-        </Page.Header>
-        <Page.Body>
-          <div className="flex w-full flex-col gap-4">
-            <div>
-              <Type className="font-medium">Recent activity across Gram</Type>
-              <Type muted small className="mt-1">
-                Review organization-wide and project-level actions in
-                chronological order.
-              </Type>
-            </div>
+    <div className="flex w-full flex-col gap-4">
+      <div>
+        <Type className="font-medium">Recent activity across Gram</Type>
+        <Type muted small className="mt-1">
+          Review organization-wide and project-level actions in chronological
+          order.
+        </Type>
+      </div>
 
-            <div className="flex flex-wrap items-end gap-3">
-              <FacetSelect
-                label="Project"
-                value={selectedProjectSlug}
-                onValueChange={setSelectedProjectSlug}
-                placeholder="All projects"
-                allLabel="All projects"
-                options={projects.map((project) => ({
-                  value: project.slug,
-                  displayName: project.slug,
-                }))}
-              />
-              <FacetSelect
-                label="Action"
-                value={selectedAction}
-                onValueChange={setSelectedAction}
-                placeholder="All actions"
-                allLabel="All actions"
-                options={actionOptions}
-              />
-              <FacetSelect
-                label="Actor"
-                value={selectedActor}
-                onValueChange={setSelectedActor}
-                placeholder="All actors"
-                allLabel="All actors"
-                options={actorOptions}
-              />
-              <div className="flex flex-col gap-1.5">
-                <Type small muted>
-                  Filters
-                </Type>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={!hasActiveFilters}
-                  onClick={() => {
-                    Promise.allSettled([
-                      setSelectedProjectSlug("all"),
-                      setSelectedAction("all"),
-                      setSelectedActor("all"),
-                    ]);
-                  }}
-                >
-                  Clear filters
-                </Button>
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Type small muted>
-                  Timestamp
-                </Type>
-                <div className="flex h-8 items-center gap-2 rounded-md border bg-background px-3">
-                  <Type
-                    small
-                    className={
-                      tsMode === "utc"
-                        ? "text-foreground"
-                        : "text-muted-foreground"
-                    }
-                  >
-                    UTC
-                  </Type>
-                  <Switch
-                    checked={tsMode === "local"}
-                    onCheckedChange={(checked) => {
-                      void setTimestampMode(checked ? "local" : "utc");
-                    }}
-                    aria-label="Toggle timestamp timezone"
-                  />
-                  <Type
-                    small
-                    className={
-                      tsMode === "local"
-                        ? "text-foreground"
-                        : "text-muted-foreground"
-                    }
-                  >
-                    Local
-                  </Type>
-                </div>
-              </div>
-            </div>
+      <div className="flex flex-wrap items-end gap-3">
+        <FacetSelect
+          label="Project"
+          value={selectedProjectSlug}
+          onValueChange={setSelectedProjectSlug}
+          placeholder="All projects"
+          allLabel="All projects"
+          options={projects.map((project) => ({
+            value: project.slug,
+            displayName: project.slug,
+          }))}
+        />
+        <FacetSelect
+          label="Action"
+          value={selectedAction}
+          onValueChange={setSelectedAction}
+          placeholder="All actions"
+          allLabel="All actions"
+          options={actionOptions}
+        />
+        <FacetSelect
+          label="Actor"
+          value={selectedActor}
+          onValueChange={setSelectedActor}
+          placeholder="All actors"
+          allLabel="All actors"
+          options={actorOptions}
+        />
+        <div className="flex flex-col gap-1.5">
+          <Type small muted>
+            Filters
+          </Type>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!hasActiveFilters}
+            onClick={() => {
+              Promise.allSettled([
+                setSelectedProjectSlug("all"),
+                setSelectedAction("all"),
+                setSelectedActor("all"),
+              ]);
+            }}
+          >
+            Clear filters
+          </Button>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Type small muted>
+            Timestamp
+          </Type>
+          <div className="bg-background flex h-8 items-center gap-2 rounded-md border px-3">
+            <Type
+              small
+              className={
+                tsMode === "utc" ? "text-foreground" : "text-muted-foreground"
+              }
+            >
+              UTC
+            </Type>
+            <Switch
+              checked={tsMode === "local"}
+              onCheckedChange={(checked) => {
+                void setTimestampMode(checked ? "local" : "utc");
+              }}
+              aria-label="Toggle timestamp timezone"
+            />
+            <Type
+              small
+              className={
+                tsMode === "local" ? "text-foreground" : "text-muted-foreground"
+              }
+            >
+              Local
+            </Type>
+          </div>
+        </div>
+      </div>
 
-            <div className="overflow-hidden rounded-lg border bg-background">
-              {/* Search toolbar */}
-              {!isLoading && !error && logs.length > 0 && (
-                <div className="flex items-center gap-2 border-b bg-surface/50 p-2">
-                  <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
-                    {searchQuery ? (
-                      <>
-                        <span className="flex items-center gap-1">
-                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                            N
-                          </kbd>
-                          <span>/</span>
-                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                            ⇧N
-                          </kbd>
-                          <span className="ml-0.5">results</span>
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                            ESC
-                          </kbd>
-                          <span>clear</span>
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <span className="flex items-center gap-1">
-                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                            J
-                          </kbd>
-                          <span>/</span>
-                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                            K
-                          </kbd>
-                          <span className="ml-0.5">navigate</span>
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                            G
-                          </kbd>
-                          <span>first</span>
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
-                            ⇧G
-                          </kbd>
-                          <span>last</span>
-                        </span>
-                      </>
-                    )}
-                  </div>
-                  <div className="ml-auto relative">
-                    <Icon
-                      name="search"
-                      className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
-                    />
-                    <Input
-                      data-audit-search-input
-                      type="text"
-                      placeholder="Search audit logs"
-                      value={searchQuery}
-                      onChange={(e) => handleSearchChange(e.target.value)}
-                      onFocus={() => setSearchInputFocused(true)}
-                      onBlur={() => setSearchInputFocused(false)}
-                      className="pl-7 pr-16 w-56 text-xs py-1 rounded-sm"
-                    />
-                    {searchQuery || searchInputFocused ? (
-                      searchMatchIndices.length > 0 ? (
-                        <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                          <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
-                            ESC
-                          </span>
-                          <span className="text-[10px] text-muted-foreground mx-0.5">
-                            {effectiveSearchIndex + 1}/
-                            {searchMatchIndices.length}
-                          </span>
-                          <div className="flex items-center">
-                            <button
-                              onClick={() => navigateToResult("prev")}
-                              className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
-                              title="Previous (Shift+N)"
-                            >
-                              <Icon name="chevron-up" className="size-2.5" />
-                            </button>
-                            <button
-                              onClick={() => navigateToResult("next")}
-                              className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
-                              title="Next (N)"
-                            >
-                              <Icon name="chevron-down" className="size-2.5" />
-                            </button>
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-                          <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
-                            ESC
-                          </span>
-                          <span className="text-[10px] text-muted-foreground ml-0.5">
-                            0/0
-                          </span>
-                        </div>
-                      )
-                    ) : (
-                      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
-                        <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm font-mono">
-                          /
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
+      <div className="bg-background overflow-hidden rounded-lg border">
+        {/* Search toolbar */}
+        {!isLoading && !error && logs.length > 0 && (
+          <div className="bg-surface/50 flex items-center gap-2 border-b p-2">
+            <div className="text-muted-foreground flex items-center gap-3 text-[11px]">
+              {searchQuery ? (
+                <>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                      N
+                    </kbd>
+                    <span>/</span>
+                    <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                      ⇧N
+                    </kbd>
+                    <span className="ml-0.5">results</span>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                      ESC
+                    </kbd>
+                    <span>clear</span>
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                      J
+                    </kbd>
+                    <span>/</span>
+                    <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                      K
+                    </kbd>
+                    <span className="ml-0.5">navigate</span>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                      G
+                    </kbd>
+                    <span>first</span>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                      ⇧G
+                    </kbd>
+                    <span>last</span>
+                  </span>
+                </>
               )}
-
-              <div
-                ref={logsContainerRef}
-                tabIndex={0}
-                className="focus:outline-none"
-              >
-                {isLoading ? (
-                  <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
-                    <Icon
-                      name="loader-circle"
-                      className="size-4 animate-spin"
-                    />
-                    <span>Loading audit logs...</span>
-                  </div>
-                ) : error ? (
-                  <div className="flex flex-col items-center gap-2 py-12 text-center">
-                    <Type className="font-medium">
-                      Error loading audit logs
-                    </Type>
-                    <Type muted small>
-                      {error.message}
-                    </Type>
-                  </div>
-                ) : logs.length === 0 ? (
-                  <div className="flex flex-col items-center gap-2 py-12 text-center">
-                    <Type className="font-medium">No audit logs found</Type>
-                    <Type muted small>
-                      {selectedProjectSlug === "all" &&
-                      selectedAction === "all" &&
-                      selectedActor === "all"
-                        ? "Activity will appear here as changes are made across your organization."
-                        : "No audit logs match the selected filters."}
-                    </Type>
+            </div>
+            <div className="relative ml-auto">
+              <Icon
+                name="search"
+                className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3 -translate-y-1/2"
+              />
+              <Input
+                data-audit-search-input
+                type="text"
+                placeholder="Search audit logs"
+                value={searchQuery}
+                onChange={(e) => handleSearchChange(e.target.value)}
+                onFocus={() => setSearchInputFocused(true)}
+                onBlur={() => setSearchInputFocused(false)}
+                className="w-56 rounded-sm py-1 pr-16 pl-7 text-xs"
+              />
+              {searchQuery || searchInputFocused ? (
+                searchMatchIndices.length > 0 ? (
+                  <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5">
+                    <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
+                      ESC
+                    </span>
+                    <span className="text-muted-foreground mx-0.5 text-[10px]">
+                      {effectiveSearchIndex + 1}/{searchMatchIndices.length}
+                    </span>
+                    <div className="flex items-center">
+                      <button
+                        onClick={() => navigateToResult("prev")}
+                        className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
+                        title="Previous (Shift+N)"
+                      >
+                        <Icon name="chevron-up" className="size-2.5" />
+                      </button>
+                      <button
+                        onClick={() => navigateToResult("next")}
+                        className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
+                        title="Next (N)"
+                      >
+                        <Icon name="chevron-down" className="size-2.5" />
+                      </button>
+                    </div>
                   </div>
                 ) : (
-                  <div>
-                    {dateGroups.map((group) => (
-                      <React.Fragment key={group.key}>
-                        <DateGroupHeader date={group.date} mode={tsMode} />
-                        {group.logs.map((log, rowIndex) => {
-                          const idx = logFlatIndices.get(log.id) ?? 0;
-                          return (
-                            <AuditLogRow
-                              key={log.id}
-                              log={log}
-                              orgSlug={orgSlug}
-                              timestampMode={tsMode}
-                              isOdd={rowIndex % 2 === 1}
-                              isHighlighted={idx === currentLogIndex}
-                              rowRef={(el) => {
-                                if (el) logRefs.current.set(idx, el);
-                                else logRefs.current.delete(idx);
-                              }}
-                              highlightMatch={
-                                searchQuery ? highlightMatch : undefined
-                              }
-                            />
-                          );
-                        })}
-                      </React.Fragment>
-                    ))}
+                  <div className="absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center gap-0.5">
+                    <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
+                      ESC
+                    </span>
+                    <span className="text-muted-foreground ml-0.5 text-[10px]">
+                      0/0
+                    </span>
                   </div>
-                )}
-              </div>
-
-              {(logs.length > 0 || isFetchingNextPage) && (
-                <div className="flex items-center justify-between border-t bg-muted/20 px-4 py-3">
-                  <Type muted small>
-                    {logs.length.toLocaleString()} audit log
-                    {logs.length === 1 ? "" : "s"}
-                  </Type>
-
-                  {hasNextPage ? (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => fetchNextPage()}
-                      disabled={isFetchingNextPage}
-                    >
-                      {isFetchingNextPage ? (
-                        <>
-                          <Icon
-                            name="loader-circle"
-                            className="size-4 animate-spin"
-                          />
-                          Loading...
-                        </>
-                      ) : (
-                        "Load more"
-                      )}
-                    </Button>
-                  ) : (
-                    <Type muted small>
-                      {isFetching
-                        ? "Refreshing..."
-                        : "End of audit log history"}
-                    </Type>
-                  )}
+                )
+              ) : (
+                <div className="absolute top-1/2 right-2 flex -translate-y-1/2 items-center">
+                  <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
+                    /
+                  </span>
                 </div>
               )}
             </div>
           </div>
-        </Page.Body>
-      </Page>
-    </RequireScope>
+        )}
+
+        <div ref={logsContainerRef} tabIndex={0} className="focus:outline-none">
+          {isLoading ? (
+            <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
+              <Icon name="loader-circle" className="size-4 animate-spin" />
+              <span>Loading audit logs...</span>
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-center">
+              <Type className="font-medium">Error loading audit logs</Type>
+              <Type muted small>
+                {error.message}
+              </Type>
+            </div>
+          ) : logs.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-center">
+              <Type className="font-medium">No audit logs found</Type>
+              <Type muted small>
+                {selectedProjectSlug === "all" &&
+                selectedAction === "all" &&
+                selectedActor === "all"
+                  ? "Activity will appear here as changes are made across your organization."
+                  : "No audit logs match the selected filters."}
+              </Type>
+            </div>
+          ) : (
+            <div>
+              {dateGroups.map((group) => (
+                <React.Fragment key={group.key}>
+                  <DateGroupHeader date={group.date} mode={tsMode} />
+                  {group.logs.map((log, rowIndex) => {
+                    const idx = logFlatIndices.get(log.id) ?? 0;
+                    return (
+                      <AuditLogRow
+                        key={log.id}
+                        log={log}
+                        orgSlug={orgSlug}
+                        timestampMode={tsMode}
+                        isOdd={rowIndex % 2 === 1}
+                        isHighlighted={idx === currentLogIndex}
+                        rowRef={(el) => {
+                          if (el) logRefs.current.set(idx, el);
+                          else logRefs.current.delete(idx);
+                        }}
+                        highlightMatch={
+                          searchQuery ? highlightMatch : undefined
+                        }
+                      />
+                    );
+                  })}
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {(logs.length > 0 || isFetchingNextPage) && (
+          <div className="bg-muted/20 flex items-center justify-between border-t px-4 py-3">
+            <Type muted small>
+              {logs.length.toLocaleString()} audit log
+              {logs.length === 1 ? "" : "s"}
+            </Type>
+
+            {hasNextPage ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? (
+                  <>
+                    <Icon
+                      name="loader-circle"
+                      className="size-4 animate-spin"
+                    />
+                    Loading...
+                  </>
+                ) : (
+                  "Load more"
+                )}
+              </Button>
+            ) : (
+              <Type muted small>
+                {isFetching ? "Refreshing..." : "End of audit log history"}
+              </Type>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -1,4 +1,5 @@
 import { useQueryState } from "nuqs";
+import { RequireScope } from "@/components/require-scope";
 import { Page } from "@/components/page-layout";
 import { Button } from "@/components/ui/button";
 import {
@@ -71,7 +72,7 @@ function getDateKey(date: Date, mode: "utc" | "local") {
 }
 
 function StrongName({ children }: { children: ReactNode }) {
-  return <strong className="text-foreground font-semibold">{children}</strong>;
+  return <strong className="font-semibold text-foreground">{children}</strong>;
 }
 
 function getActorLabel(log: AuditLog) {
@@ -352,7 +353,7 @@ function AuditLogRow({
           <StrongName>
             {highlightMatch ? highlightMatch(actorLabel) : actorLabel}
           </StrongName>
-          <span className="text-muted-foreground mx-1.5">
+          <span className="mx-1.5 text-muted-foreground">
             {highlightMatch ? highlightMatch(verbText) : verbText}
           </span>
           {renderSubject(log, orgSlug)}
@@ -367,7 +368,7 @@ function AuditLogRow({
           </button>
         )}
       </div>
-      <span className="text-muted-foreground shrink-0 font-mono text-xs">
+      <span className="shrink-0 font-mono text-xs text-muted-foreground">
         {formatTimeOnly(log.createdAt, timestampMode)}
       </span>
     </div>
@@ -377,7 +378,7 @@ function AuditLogRow({
     return (
       <div
         ref={rowRef}
-        className={cn(isHighlighted && "border-l-foreground border-l-4")}
+        className={cn(isHighlighted && "border-l-4 border-l-foreground")}
       >
         <div
           className={cn(
@@ -387,7 +388,7 @@ function AuditLogRow({
         >
           {rowContent}
         </div>
-        <div className="bg-background rounded-b-lg border border-t-0 px-4 pt-2 pb-3">
+        <div className="rounded-b-lg border border-t-0 bg-background px-4 pb-3 pt-2">
           <StructuredDiff log={log} />
         </div>
       </div>
@@ -400,7 +401,7 @@ function AuditLogRow({
       className={cn(
         "rounded-none transition-colors",
         isOdd ? "bg-muted/30" : "bg-background",
-        isHighlighted && "border-l-foreground border-l-4",
+        isHighlighted && "border-l-4 border-l-foreground",
       )}
     >
       {rowContent}
@@ -417,10 +418,10 @@ function DateGroupHeader({
 }) {
   return (
     <div className="flex items-center gap-3 px-4 py-2">
-      <span className="text-muted-foreground shrink-0 text-[11px] font-semibold tracking-wide uppercase">
+      <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
         {formatDateHeader(date, mode)}
       </span>
-      <div className="bg-border h-px flex-1" />
+      <div className="h-px flex-1 bg-border" />
     </div>
   );
 }
@@ -474,7 +475,7 @@ function FacetSelect({
         {label}
       </Type>
       <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger size="sm" className="bg-background min-w-[220px]">
+        <SelectTrigger size="sm" className="min-w-[220px] bg-background">
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>
@@ -691,7 +692,7 @@ export default function OrgAuditLogs() {
             part.toLowerCase() === searchQuery.toLowerCase() ? (
               <mark
                 key={i}
-                className="bg-yellow-200 text-inherit dark:bg-yellow-800"
+                className="bg-yellow-200 dark:bg-yellow-800 text-inherit"
               >
                 {part}
               </mark>
@@ -809,311 +810,321 @@ export default function OrgAuditLogs() {
   ]);
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Title>Audit Logs</Page.Header.Title>
-      </Page.Header>
-      <Page.Body>
-        <div className="flex w-full flex-col gap-4">
-          <div>
-            <Type className="font-medium">Recent activity across Gram</Type>
-            <Type muted small className="mt-1">
-              Review organization-wide and project-level actions in
-              chronological order.
-            </Type>
-          </div>
-
-          <div className="flex flex-wrap items-end gap-3">
-            <FacetSelect
-              label="Project"
-              value={selectedProjectSlug}
-              onValueChange={setSelectedProjectSlug}
-              placeholder="All projects"
-              allLabel="All projects"
-              options={projects.map((project) => ({
-                value: project.slug,
-                displayName: project.slug,
-              }))}
-            />
-            <FacetSelect
-              label="Action"
-              value={selectedAction}
-              onValueChange={setSelectedAction}
-              placeholder="All actions"
-              allLabel="All actions"
-              options={actionOptions}
-            />
-            <FacetSelect
-              label="Actor"
-              value={selectedActor}
-              onValueChange={setSelectedActor}
-              placeholder="All actors"
-              allLabel="All actors"
-              options={actorOptions}
-            />
-            <div className="flex flex-col gap-1.5">
-              <Type small muted>
-                Filters
+    <RequireScope scope="org:read" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Title>Audit Logs</Page.Header.Title>
+        </Page.Header>
+        <Page.Body>
+          <div className="flex w-full flex-col gap-4">
+            <div>
+              <Type className="font-medium">Recent activity across Gram</Type>
+              <Type muted small className="mt-1">
+                Review organization-wide and project-level actions in
+                chronological order.
               </Type>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!hasActiveFilters}
-                onClick={() => {
-                  Promise.allSettled([
-                    setSelectedProjectSlug("all"),
-                    setSelectedAction("all"),
-                    setSelectedActor("all"),
-                  ]);
-                }}
-              >
-                Clear filters
-              </Button>
             </div>
-            <div className="flex flex-col gap-1.5">
-              <Type small muted>
-                Timestamp
-              </Type>
-              <div className="bg-background flex h-8 items-center gap-2 rounded-md border px-3">
-                <Type
-                  small
-                  className={
-                    tsMode === "utc"
-                      ? "text-foreground"
-                      : "text-muted-foreground"
-                  }
-                >
-                  UTC
+
+            <div className="flex flex-wrap items-end gap-3">
+              <FacetSelect
+                label="Project"
+                value={selectedProjectSlug}
+                onValueChange={setSelectedProjectSlug}
+                placeholder="All projects"
+                allLabel="All projects"
+                options={projects.map((project) => ({
+                  value: project.slug,
+                  displayName: project.slug,
+                }))}
+              />
+              <FacetSelect
+                label="Action"
+                value={selectedAction}
+                onValueChange={setSelectedAction}
+                placeholder="All actions"
+                allLabel="All actions"
+                options={actionOptions}
+              />
+              <FacetSelect
+                label="Actor"
+                value={selectedActor}
+                onValueChange={setSelectedActor}
+                placeholder="All actors"
+                allLabel="All actors"
+                options={actorOptions}
+              />
+              <div className="flex flex-col gap-1.5">
+                <Type small muted>
+                  Filters
                 </Type>
-                <Switch
-                  checked={tsMode === "local"}
-                  onCheckedChange={(checked) => {
-                    void setTimestampMode(checked ? "local" : "utc");
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!hasActiveFilters}
+                  onClick={() => {
+                    Promise.allSettled([
+                      setSelectedProjectSlug("all"),
+                      setSelectedAction("all"),
+                      setSelectedActor("all"),
+                    ]);
                   }}
-                  aria-label="Toggle timestamp timezone"
-                />
-                <Type
-                  small
-                  className={
-                    tsMode === "local"
-                      ? "text-foreground"
-                      : "text-muted-foreground"
-                  }
                 >
-                  Local
+                  Clear filters
+                </Button>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Type small muted>
+                  Timestamp
                 </Type>
+                <div className="flex h-8 items-center gap-2 rounded-md border bg-background px-3">
+                  <Type
+                    small
+                    className={
+                      tsMode === "utc"
+                        ? "text-foreground"
+                        : "text-muted-foreground"
+                    }
+                  >
+                    UTC
+                  </Type>
+                  <Switch
+                    checked={tsMode === "local"}
+                    onCheckedChange={(checked) => {
+                      void setTimestampMode(checked ? "local" : "utc");
+                    }}
+                    aria-label="Toggle timestamp timezone"
+                  />
+                  <Type
+                    small
+                    className={
+                      tsMode === "local"
+                        ? "text-foreground"
+                        : "text-muted-foreground"
+                    }
+                  >
+                    Local
+                  </Type>
+                </div>
               </div>
             </div>
-          </div>
 
-          <div className="bg-background overflow-hidden rounded-lg border">
-            {/* Search toolbar */}
-            {!isLoading && !error && logs.length > 0 && (
-              <div className="bg-surface/50 flex items-center gap-2 border-b p-2">
-                <div className="text-muted-foreground flex items-center gap-3 text-[11px]">
-                  {searchQuery ? (
-                    <>
-                      <span className="flex items-center gap-1">
-                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                          N
-                        </kbd>
-                        <span>/</span>
-                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                          ⇧N
-                        </kbd>
-                        <span className="ml-0.5">results</span>
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                          ESC
-                        </kbd>
-                        <span>clear</span>
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <span className="flex items-center gap-1">
-                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                          J
-                        </kbd>
-                        <span>/</span>
-                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                          K
-                        </kbd>
-                        <span className="ml-0.5">navigate</span>
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                          G
-                        </kbd>
-                        <span>first</span>
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <kbd className="bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                          ⇧G
-                        </kbd>
-                        <span>last</span>
-                      </span>
-                    </>
-                  )}
-                </div>
-                <div className="relative ml-auto">
-                  <Icon
-                    name="search"
-                    className="text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3 -translate-y-1/2"
-                  />
-                  <Input
-                    data-audit-search-input
-                    type="text"
-                    placeholder="Search audit logs"
-                    value={searchQuery}
-                    onChange={(e) => handleSearchChange(e.target.value)}
-                    onFocus={() => setSearchInputFocused(true)}
-                    onBlur={() => setSearchInputFocused(false)}
-                    className="w-56 rounded-sm py-1 pr-16 pl-7 text-xs"
-                  />
-                  {searchQuery || searchInputFocused ? (
-                    searchMatchIndices.length > 0 ? (
-                      <div className="absolute top-1/2 right-1 flex -translate-y-1/2 items-center gap-0.5">
-                        <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
-                          ESC
+            <div className="overflow-hidden rounded-lg border bg-background">
+              {/* Search toolbar */}
+              {!isLoading && !error && logs.length > 0 && (
+                <div className="flex items-center gap-2 border-b bg-surface/50 p-2">
+                  <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+                    {searchQuery ? (
+                      <>
+                        <span className="flex items-center gap-1">
+                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                            N
+                          </kbd>
+                          <span>/</span>
+                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                            ⇧N
+                          </kbd>
+                          <span className="ml-0.5">results</span>
                         </span>
-                        <span className="text-muted-foreground mx-0.5 text-[10px]">
-                          {effectiveSearchIndex + 1}/{searchMatchIndices.length}
+                        <span className="flex items-center gap-1">
+                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                            ESC
+                          </kbd>
+                          <span>clear</span>
                         </span>
-                        <div className="flex items-center">
-                          <button
-                            onClick={() => navigateToResult("prev")}
-                            className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
-                            title="Previous (Shift+N)"
-                          >
-                            <Icon name="chevron-up" className="size-2.5" />
-                          </button>
-                          <button
-                            onClick={() => navigateToResult("next")}
-                            className="hover:bg-muted rounded-sm p-0.5 opacity-60 transition-opacity hover:opacity-100"
-                            title="Next (N)"
-                          >
-                            <Icon name="chevron-down" className="size-2.5" />
-                          </button>
-                        </div>
-                      </div>
+                      </>
                     ) : (
-                      <div className="absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center gap-0.5">
-                        <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 text-[10px]">
-                          ESC
+                      <>
+                        <span className="flex items-center gap-1">
+                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                            J
+                          </kbd>
+                          <span>/</span>
+                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                            K
+                          </kbd>
+                          <span className="ml-0.5">navigate</span>
                         </span>
-                        <span className="text-muted-foreground ml-0.5 text-[10px]">
-                          0/0
+                        <span className="flex items-center gap-1">
+                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                            G
+                          </kbd>
+                          <span>first</span>
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <kbd className="bg-muted px-1 py-0.5 rounded-sm font-mono text-[10px]">
+                            ⇧G
+                          </kbd>
+                          <span>last</span>
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  <div className="ml-auto relative">
+                    <Icon
+                      name="search"
+                      className="absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground pointer-events-none"
+                    />
+                    <Input
+                      data-audit-search-input
+                      type="text"
+                      placeholder="Search audit logs"
+                      value={searchQuery}
+                      onChange={(e) => handleSearchChange(e.target.value)}
+                      onFocus={() => setSearchInputFocused(true)}
+                      onBlur={() => setSearchInputFocused(false)}
+                      className="pl-7 pr-16 w-56 text-xs py-1 rounded-sm"
+                    />
+                    {searchQuery || searchInputFocused ? (
+                      searchMatchIndices.length > 0 ? (
+                        <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+                          <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                            ESC
+                          </span>
+                          <span className="text-[10px] text-muted-foreground mx-0.5">
+                            {effectiveSearchIndex + 1}/
+                            {searchMatchIndices.length}
+                          </span>
+                          <div className="flex items-center">
+                            <button
+                              onClick={() => navigateToResult("prev")}
+                              className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                              title="Previous (Shift+N)"
+                            >
+                              <Icon name="chevron-up" className="size-2.5" />
+                            </button>
+                            <button
+                              onClick={() => navigateToResult("next")}
+                              className="p-0.5 hover:bg-muted rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                              title="Next (N)"
+                            >
+                              <Icon name="chevron-down" className="size-2.5" />
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+                          <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm">
+                            ESC
+                          </span>
+                          <span className="text-[10px] text-muted-foreground ml-0.5">
+                            0/0
+                          </span>
+                        </div>
+                      )
+                    ) : (
+                      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
+                        <span className="text-[10px] text-muted-foreground bg-muted px-1 py-0.5 rounded-sm font-mono">
+                          /
                         </span>
                       </div>
-                    )
-                  ) : (
-                    <div className="absolute top-1/2 right-2 flex -translate-y-1/2 items-center">
-                      <span className="text-muted-foreground bg-muted rounded-sm px-1 py-0.5 font-mono text-[10px]">
-                        /
-                      </span>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
 
-            <div
-              ref={logsContainerRef}
-              tabIndex={0}
-              className="focus:outline-none"
-            >
-              {isLoading ? (
-                <div className="text-muted-foreground flex items-center justify-center gap-2 py-12">
-                  <Icon name="loader-circle" className="size-4 animate-spin" />
-                  <span>Loading audit logs...</span>
-                </div>
-              ) : error ? (
-                <div className="flex flex-col items-center gap-2 py-12 text-center">
-                  <Type className="font-medium">Error loading audit logs</Type>
+              <div
+                ref={logsContainerRef}
+                tabIndex={0}
+                className="focus:outline-none"
+              >
+                {isLoading ? (
+                  <div className="flex items-center justify-center gap-2 py-12 text-muted-foreground">
+                    <Icon
+                      name="loader-circle"
+                      className="size-4 animate-spin"
+                    />
+                    <span>Loading audit logs...</span>
+                  </div>
+                ) : error ? (
+                  <div className="flex flex-col items-center gap-2 py-12 text-center">
+                    <Type className="font-medium">
+                      Error loading audit logs
+                    </Type>
+                    <Type muted small>
+                      {error.message}
+                    </Type>
+                  </div>
+                ) : logs.length === 0 ? (
+                  <div className="flex flex-col items-center gap-2 py-12 text-center">
+                    <Type className="font-medium">No audit logs found</Type>
+                    <Type muted small>
+                      {selectedProjectSlug === "all" &&
+                      selectedAction === "all" &&
+                      selectedActor === "all"
+                        ? "Activity will appear here as changes are made across your organization."
+                        : "No audit logs match the selected filters."}
+                    </Type>
+                  </div>
+                ) : (
+                  <div>
+                    {dateGroups.map((group) => (
+                      <React.Fragment key={group.key}>
+                        <DateGroupHeader date={group.date} mode={tsMode} />
+                        {group.logs.map((log, rowIndex) => {
+                          const idx = logFlatIndices.get(log.id) ?? 0;
+                          return (
+                            <AuditLogRow
+                              key={log.id}
+                              log={log}
+                              orgSlug={orgSlug}
+                              timestampMode={tsMode}
+                              isOdd={rowIndex % 2 === 1}
+                              isHighlighted={idx === currentLogIndex}
+                              rowRef={(el) => {
+                                if (el) logRefs.current.set(idx, el);
+                                else logRefs.current.delete(idx);
+                              }}
+                              highlightMatch={
+                                searchQuery ? highlightMatch : undefined
+                              }
+                            />
+                          );
+                        })}
+                      </React.Fragment>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {(logs.length > 0 || isFetchingNextPage) && (
+                <div className="flex items-center justify-between border-t bg-muted/20 px-4 py-3">
                   <Type muted small>
-                    {error.message}
+                    {logs.length.toLocaleString()} audit log
+                    {logs.length === 1 ? "" : "s"}
                   </Type>
-                </div>
-              ) : logs.length === 0 ? (
-                <div className="flex flex-col items-center gap-2 py-12 text-center">
-                  <Type className="font-medium">No audit logs found</Type>
-                  <Type muted small>
-                    {selectedProjectSlug === "all" &&
-                    selectedAction === "all" &&
-                    selectedActor === "all"
-                      ? "Activity will appear here as changes are made across your organization."
-                      : "No audit logs match the selected filters."}
-                  </Type>
-                </div>
-              ) : (
-                <div>
-                  {dateGroups.map((group) => (
-                    <React.Fragment key={group.key}>
-                      <DateGroupHeader date={group.date} mode={tsMode} />
-                      {group.logs.map((log, rowIndex) => {
-                        const idx = logFlatIndices.get(log.id) ?? 0;
-                        return (
-                          <AuditLogRow
-                            key={log.id}
-                            log={log}
-                            orgSlug={orgSlug}
-                            timestampMode={tsMode}
-                            isOdd={rowIndex % 2 === 1}
-                            isHighlighted={idx === currentLogIndex}
-                            rowRef={(el) => {
-                              if (el) logRefs.current.set(idx, el);
-                              else logRefs.current.delete(idx);
-                            }}
-                            highlightMatch={
-                              searchQuery ? highlightMatch : undefined
-                            }
+
+                  {hasNextPage ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => fetchNextPage()}
+                      disabled={isFetchingNextPage}
+                    >
+                      {isFetchingNextPage ? (
+                        <>
+                          <Icon
+                            name="loader-circle"
+                            className="size-4 animate-spin"
                           />
-                        );
-                      })}
-                    </React.Fragment>
-                  ))}
+                          Loading...
+                        </>
+                      ) : (
+                        "Load more"
+                      )}
+                    </Button>
+                  ) : (
+                    <Type muted small>
+                      {isFetching
+                        ? "Refreshing..."
+                        : "End of audit log history"}
+                    </Type>
+                  )}
                 </div>
               )}
             </div>
-
-            {(logs.length > 0 || isFetchingNextPage) && (
-              <div className="bg-muted/20 flex items-center justify-between border-t px-4 py-3">
-                <Type muted small>
-                  {logs.length.toLocaleString()} audit log
-                  {logs.length === 1 ? "" : "s"}
-                </Type>
-
-                {hasNextPage ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => fetchNextPage()}
-                    disabled={isFetchingNextPage}
-                  >
-                    {isFetchingNextPage ? (
-                      <>
-                        <Icon
-                          name="loader-circle"
-                          className="size-4 animate-spin"
-                        />
-                        Loading...
-                      </>
-                    ) : (
-                      "Load more"
-                    )}
-                  </Button>
-                ) : (
-                  <Type muted small>
-                    {isFetching ? "Refreshing..." : "End of audit log history"}
-                  </Type>
-                )}
-              </div>
-            )}
           </div>
-        </div>
-      </Page.Body>
-    </Page>
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -28,6 +28,21 @@ import { useEffect, useState } from "react";
 import { RequireScope } from "@/components/require-scope";
 
 export default function OrgDomains() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Custom Domain</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["org:read", "org:admin"]} level="page">
+          <OrgDomainsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function OrgDomainsInner() {
   const organization = useOrganization();
   const productTier = useProductTier();
   const queryClient = useQueryClient();
@@ -136,283 +151,267 @@ export default function OrgDomains() {
   }, [domain?.isUpdating, domainRefetch]);
 
   return (
-    <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Title>Custom Domain</Page.Header.Title>
-        </Page.Header>
-        <Page.Body>
-          <Heading variant="h4" className="mb-2">
-            Custom Domain
-          </Heading>
-          <Type muted small className="mb-6">
-            Connect a custom domain to serve your MCP servers from your own
-            branded URL instead of the default Gram domain.
-          </Type>
-          {domain?.domain ? (
-            <div className="rounded-lg border border-border bg-card p-4">
-              <Stack
-                direction="horizontal"
-                justify="space-between"
-                align="start"
-              >
-                <Stack gap={1}>
-                  <Stack direction="horizontal" align="center" gap={2}>
-                    <Globe className="h-4 w-4 text-muted-foreground" />
-                    <Type variant="body" className="font-mono font-medium">
-                      {domain.domain}
-                    </Type>
-                    {domain.isUpdating ? (
-                      <SimpleTooltip tooltip="Your domain is being verified. This may take a few minutes.">
-                        <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
-                      </SimpleTooltip>
-                    ) : domain.verified ? (
-                      <SimpleTooltip tooltip="Domain verified and active">
-                        <Check className="w-4 h-4 stroke-3 text-green-500" />
-                      </SimpleTooltip>
-                    ) : (
-                      <SimpleTooltip tooltip="Domain verification failed. Ensure your DNS records are set up correctly.">
-                        <X className="w-4 h-4 stroke-3 text-red-500" />
-                      </SimpleTooltip>
-                    )}
-                  </Stack>
-                  <Type
-                    variant="body"
-                    className="text-muted-foreground text-sm ml-6"
-                  >
-                    Linked <HumanizeDateTime date={domain.createdAt} />
-                  </Type>
-                </Stack>
-                <RequireScope scope="org:admin" level="section">
-                  <Stack direction="horizontal" gap={2}>
-                    {!domain.verified && (
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => setIsAddDomainDialogOpen(true)}
-                        disabled={domain.isUpdating}
-                      >
-                        Reverify
-                      </Button>
-                    )}
-                    <Button
-                      variant="tertiary"
-                      size="sm"
-                      onClick={() => setIsDeleteDomainDialogOpen(true)}
-                      className="hover:text-destructive"
-                      disabled={deleteDomainMutation.isPending}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </Stack>
-                </RequireScope>
-              </Stack>
-            </div>
-          ) : (
-            !domainIsLoading && (
-              <div className="rounded-lg border border-dashed border-border p-6">
-                <Stack gap={2} align="center" justify="center">
-                  <Type variant="body" className="text-muted-foreground">
-                    No custom domain configured
-                  </Type>
-                  <Type
-                    variant="body"
-                    className="text-muted-foreground text-sm"
-                  >
-                    You can connect one custom domain per organization for your
-                    MCP servers.
-                  </Type>
-                  <RequireScope scope="org:admin" level="component">
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      className="mt-2"
-                      onClick={() => {
-                        if (productTier.includes("base")) {
-                          setIsCustomDomainUpgradeModalOpen(true);
-                        } else {
-                          setIsAddDomainDialogOpen(true);
-                        }
-                      }}
-                    >
-                      <Button.LeftIcon>
-                        <Globe className="h-4 w-4" />
-                      </Button.LeftIcon>
-                      <Button.Text>Add Domain</Button.Text>
-                    </Button>
-                  </RequireScope>
-                </Stack>
-              </div>
-            )
-          )}
-
-          <Dialog
-            open={isDeleteDomainDialogOpen}
-            onOpenChange={setIsDeleteDomainDialogOpen}
-          >
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Remove Custom Domain</Dialog.Title>
-              </Dialog.Header>
-              <div className="space-y-4 py-4">
-                <Type variant="body">
-                  Are you sure you want to remove{" "}
-                  <span className="italic font-bold">{domain?.domain}</span>?
-                  This will delete the associated ingress and TLS certificate.
+    <>
+      <Heading variant="h4" className="mb-2">
+        Custom Domain
+      </Heading>
+      <Type muted small className="mb-6">
+        Connect a custom domain to serve your MCP servers from your own branded
+        URL instead of the default Gram domain.
+      </Type>
+      {domain?.domain ? (
+        <div className="border-border bg-card rounded-lg border p-4">
+          <Stack direction="horizontal" justify="space-between" align="start">
+            <Stack gap={1}>
+              <Stack direction="horizontal" align="center" gap={2}>
+                <Globe className="text-muted-foreground h-4 w-4" />
+                <Type variant="body" className="font-mono font-medium">
+                  {domain.domain}
                 </Type>
-                <div className="flex justify-end space-x-2">
+                {domain.isUpdating ? (
+                  <SimpleTooltip tooltip="Your domain is being verified. This may take a few minutes.">
+                    <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+                  </SimpleTooltip>
+                ) : domain.verified ? (
+                  <SimpleTooltip tooltip="Domain verified and active">
+                    <Check className="h-4 w-4 stroke-3 text-green-500" />
+                  </SimpleTooltip>
+                ) : (
+                  <SimpleTooltip tooltip="Domain verification failed. Ensure your DNS records are set up correctly.">
+                    <X className="h-4 w-4 stroke-3 text-red-500" />
+                  </SimpleTooltip>
+                )}
+              </Stack>
+              <Type
+                variant="body"
+                className="text-muted-foreground ml-6 text-sm"
+              >
+                Linked <HumanizeDateTime date={domain.createdAt} />
+              </Type>
+            </Stack>
+            <RequireScope scope="org:admin" level="section">
+              <Stack direction="horizontal" gap={2}>
+                {!domain.verified && (
                   <Button
                     variant="secondary"
-                    onClick={() => setIsDeleteDomainDialogOpen(false)}
+                    size="sm"
+                    onClick={() => setIsAddDomainDialogOpen(true)}
+                    disabled={domain.isUpdating}
                   >
-                    Cancel
+                    Reverify
                   </Button>
-                  <RequireScope scope="org:admin" level="component">
-                    <Button
-                      variant="destructive-primary"
-                      onClick={() =>
-                        deleteDomainMutation.mutate({
-                          security: { sessionHeaderGramSession: "" },
-                        })
-                      }
-                      disabled={deleteDomainMutation.isPending}
-                    >
-                      {deleteDomainMutation.isPending
-                        ? "Removing..."
-                        : "Remove"}
-                    </Button>
-                  </RequireScope>
-                </div>
-              </div>
-            </Dialog.Content>
-          </Dialog>
+                )}
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  onClick={() => setIsDeleteDomainDialogOpen(true)}
+                  className="hover:text-destructive"
+                  disabled={deleteDomainMutation.isPending}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </Stack>
+            </RequireScope>
+          </Stack>
+        </div>
+      ) : (
+        !domainIsLoading && (
+          <div className="border-border rounded-lg border border-dashed p-6">
+            <Stack gap={2} align="center" justify="center">
+              <Type variant="body" className="text-muted-foreground">
+                No custom domain configured
+              </Type>
+              <Type variant="body" className="text-muted-foreground text-sm">
+                You can connect one custom domain per organization for your MCP
+                servers.
+              </Type>
+              <RequireScope scope="org:admin" level="component">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className="mt-2"
+                  onClick={() => {
+                    if (productTier.includes("base")) {
+                      setIsCustomDomainUpgradeModalOpen(true);
+                    } else {
+                      setIsAddDomainDialogOpen(true);
+                    }
+                  }}
+                >
+                  <Button.LeftIcon>
+                    <Globe className="h-4 w-4" />
+                  </Button.LeftIcon>
+                  <Button.Text>Add Domain</Button.Text>
+                </Button>
+              </RequireScope>
+            </Stack>
+          </div>
+        )
+      )}
 
-          <Dialog
-            open={isAddDomainDialogOpen}
-            onOpenChange={setIsAddDomainDialogOpen}
-          >
-            <Dialog.Content className="max-w-lg">
-              <Dialog.Header>
-                <Dialog.Title>Connect a Custom Domain</Dialog.Title>
-              </Dialog.Header>
-              <div className="space-y-6 py-4 min-h-[420px]">
-                <div>
-                  <Type
-                    variant="body"
-                    className="font-extrabold text-lg mb-2 block"
-                  >
-                    Step 1
+      <Dialog
+        open={isDeleteDomainDialogOpen}
+        onOpenChange={setIsDeleteDomainDialogOpen}
+      >
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Remove Custom Domain</Dialog.Title>
+          </Dialog.Header>
+          <div className="space-y-4 py-4">
+            <Type variant="body">
+              Are you sure you want to remove{" "}
+              <span className="font-bold italic">{domain?.domain}</span>? This
+              will delete the associated ingress and TLS certificate.
+            </Type>
+            <div className="flex justify-end space-x-2">
+              <Button
+                variant="secondary"
+                onClick={() => setIsDeleteDomainDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <RequireScope scope="org:admin" level="component">
+                <Button
+                  variant="destructive-primary"
+                  onClick={() =>
+                    deleteDomainMutation.mutate({
+                      security: { sessionHeaderGramSession: "" },
+                    })
+                  }
+                  disabled={deleteDomainMutation.isPending}
+                >
+                  {deleteDomainMutation.isPending ? "Removing..." : "Remove"}
+                </Button>
+              </RequireScope>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+
+      <Dialog
+        open={isAddDomainDialogOpen}
+        onOpenChange={setIsAddDomainDialogOpen}
+      >
+        <Dialog.Content className="max-w-lg">
+          <Dialog.Header>
+            <Dialog.Title>Connect a Custom Domain</Dialog.Title>
+          </Dialog.Header>
+          <div className="min-h-[420px] space-y-6 py-4">
+            <div>
+              <Type
+                variant="body"
+                className="mb-2 block text-lg font-extrabold"
+              >
+                Step 1
+              </Type>
+              <Type variant="body" className="text-muted-foreground mb-2">
+                Enter your custom domain:
+              </Type>
+              <div className="space-y-2">
+                <Input
+                  placeholder="Enter your domain (chat.yourdomain.com)"
+                  value={domainInput}
+                  onChange={handleDomainInputChange}
+                  className={cn(
+                    domainError && "border-red-500",
+                    domain?.domain &&
+                      "bg-muted text-muted-foreground cursor-not-allowed",
+                  )}
+                  readOnly={!!domain?.domain}
+                />
+                {domainError && (
+                  <Type variant="body" className="text-sm text-red-500">
+                    {domainError}
                   </Type>
-                  <Type variant="body" className="text-muted-foreground mb-2">
-                    Enter your custom domain:
-                  </Type>
-                  <div className="space-y-2">
-                    <Input
-                      placeholder="Enter your domain (chat.yourdomain.com)"
-                      value={domainInput}
-                      onChange={handleDomainInputChange}
-                      className={cn(
-                        domainError && "border-red-500",
-                        domain?.domain &&
-                          "bg-muted text-muted-foreground cursor-not-allowed",
-                      )}
-                      readOnly={!!domain?.domain}
-                    />
-                    {domainError && (
-                      <Type variant="body" className="text-red-500 text-sm">
-                        {domainError}
-                      </Type>
-                    )}
-                  </div>
-                </div>
-                <div>
-                  <Type
-                    variant="body"
-                    className="font-extrabold text-lg mb-2 block"
-                  >
-                    Step 2
-                  </Type>
-                  <Type variant="body" className="text-muted-foreground mb-2">
-                    Create a CNAME record for{" "}
-                    <span className="font-mono break-all">{subdomain}</span>{" "}
-                    pointing to the following:
-                  </Type>
-                  <div className="flex items-center space-x-2 bg-muted p-3 rounded-md mt-2">
-                    <code className="flex-1 break-all">{CNAME_VALUE}</code>
-                    <Button
-                      variant="tertiary"
-                      size="sm"
-                      onClick={handleCopyCname}
-                      className="shrink-0"
-                    >
-                      {isCnameCopied ? (
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <Copy className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-                <div>
-                  <Type
-                    variant="body"
-                    className="font-extrabold text-lg mb-2 block"
-                  >
-                    Step 3
-                  </Type>
-                  <Type variant="body" className="text-muted-foreground mb-2">
-                    Create a TXT record at{" "}
-                    <span className="font-mono break-all">{txtName}</span> with
-                    the following value:
-                  </Type>
-                  <div className="flex items-center space-x-2 bg-muted p-3 rounded-md mt-2">
-                    <code className="flex-1 break-all">{txtValue}</code>
-                    <Button
-                      variant="tertiary"
-                      size="sm"
-                      onClick={handleCopyTxt}
-                      className="shrink-0"
-                    >
-                      {isTxtCopied ? (
-                        <CheckCircle2 className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <Copy className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-                <div className="flex justify-end mt-4">
-                  <RequireScope scope="org:admin" level="component">
-                    <Button
-                      onClick={handleRegisterDomain}
-                      disabled={
-                        !domainInput.trim() ||
-                        !!domainError ||
-                        registerDomainMutation.isPending
-                      }
-                    >
-                      {registerDomainMutation.isPending
-                        ? "Registering..."
-                        : domain?.domain
-                          ? "Reverify"
-                          : "Register"}
-                    </Button>
-                  </RequireScope>
-                </div>
+                )}
               </div>
-            </Dialog.Content>
-          </Dialog>
-          <FeatureRequestModal
-            isOpen={isCustomDomainModalOpen}
-            onClose={() => setIsCustomDomainUpgradeModalOpen(false)}
-            title="Custom Domains"
-            description="Custom domains require upgrading to an enterprise plan. Someone should be in touch shortly, or feel free to book a meeting directly."
-            actionType="custom_domain"
-            icon={Globe}
-            accountUpgrade
-          />
-        </Page.Body>
-      </Page>
-    </RequireScope>
+            </div>
+            <div>
+              <Type
+                variant="body"
+                className="mb-2 block text-lg font-extrabold"
+              >
+                Step 2
+              </Type>
+              <Type variant="body" className="text-muted-foreground mb-2">
+                Create a CNAME record for{" "}
+                <span className="font-mono break-all">{subdomain}</span>{" "}
+                pointing to the following:
+              </Type>
+              <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
+                <code className="flex-1 break-all">{CNAME_VALUE}</code>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  onClick={handleCopyCname}
+                  className="shrink-0"
+                >
+                  {isCnameCopied ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+            <div>
+              <Type
+                variant="body"
+                className="mb-2 block text-lg font-extrabold"
+              >
+                Step 3
+              </Type>
+              <Type variant="body" className="text-muted-foreground mb-2">
+                Create a TXT record at{" "}
+                <span className="font-mono break-all">{txtName}</span> with the
+                following value:
+              </Type>
+              <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
+                <code className="flex-1 break-all">{txtValue}</code>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  onClick={handleCopyTxt}
+                  className="shrink-0"
+                >
+                  {isTxtCopied ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+            <div className="mt-4 flex justify-end">
+              <RequireScope scope="org:admin" level="component">
+                <Button
+                  onClick={handleRegisterDomain}
+                  disabled={
+                    !domainInput.trim() ||
+                    !!domainError ||
+                    registerDomainMutation.isPending
+                  }
+                >
+                  {registerDomainMutation.isPending
+                    ? "Registering..."
+                    : domain?.domain
+                      ? "Reverify"
+                      : "Register"}
+                </Button>
+              </RequireScope>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+      <FeatureRequestModal
+        isOpen={isCustomDomainModalOpen}
+        onClose={() => setIsCustomDomainUpgradeModalOpen(false)}
+        title="Custom Domains"
+        description="Custom domains require upgrading to an enterprise plan. Someone should be in touch shortly, or feel free to book a meeting directly."
+        actionType="custom_domain"
+        icon={Globe}
+        accountUpgrade
+      />
+    </>
   );
 }

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -136,7 +136,7 @@ export default function OrgDomains() {
   }, [domain?.isUpdating, domainRefetch]);
 
   return (
-    <RequireScope scope="org:read" level="page">
+    <RequireScope scope={["org:read", "org:admin"]} level="page">
       <Page>
         <Page.Header>
           <Page.Header.Title>Custom Domain</Page.Header.Title>
@@ -267,17 +267,21 @@ export default function OrgDomains() {
                   >
                     Cancel
                   </Button>
-                  <Button
-                    variant="destructive-primary"
-                    onClick={() =>
-                      deleteDomainMutation.mutate({
-                        security: { sessionHeaderGramSession: "" },
-                      })
-                    }
-                    disabled={deleteDomainMutation.isPending}
-                  >
-                    {deleteDomainMutation.isPending ? "Removing..." : "Remove"}
-                  </Button>
+                  <RequireScope scope="org:admin" level="component">
+                    <Button
+                      variant="destructive-primary"
+                      onClick={() =>
+                        deleteDomainMutation.mutate({
+                          security: { sessionHeaderGramSession: "" },
+                        })
+                      }
+                      disabled={deleteDomainMutation.isPending}
+                    >
+                      {deleteDomainMutation.isPending
+                        ? "Removing..."
+                        : "Remove"}
+                    </Button>
+                  </RequireScope>
                 </div>
               </div>
             </Dialog.Content>
@@ -378,20 +382,22 @@ export default function OrgDomains() {
                   </div>
                 </div>
                 <div className="flex justify-end mt-4">
-                  <Button
-                    onClick={handleRegisterDomain}
-                    disabled={
-                      !domainInput.trim() ||
-                      !!domainError ||
-                      registerDomainMutation.isPending
-                    }
-                  >
-                    {registerDomainMutation.isPending
-                      ? "Registering..."
-                      : domain?.domain
-                        ? "Reverify"
-                        : "Register"}
-                  </Button>
+                  <RequireScope scope="org:admin" level="component">
+                    <Button
+                      onClick={handleRegisterDomain}
+                      disabled={
+                        !domainInput.trim() ||
+                        !!domainError ||
+                        registerDomainMutation.isPending
+                      }
+                    >
+                      {registerDomainMutation.isPending
+                        ? "Registering..."
+                        : domain?.domain
+                          ? "Reverify"
+                          : "Register"}
+                    </Button>
+                  </RequireScope>
                 </div>
               </div>
             </Dialog.Content>

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -25,6 +25,7 @@ import {
   X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { RequireScope } from "@/components/require-scope";
 
 export default function OrgDomains() {
   const organization = useOrganization();
@@ -135,264 +136,277 @@ export default function OrgDomains() {
   }, [domain?.isUpdating, domainRefetch]);
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Title>Custom Domain</Page.Header.Title>
-      </Page.Header>
-      <Page.Body>
-        <Heading variant="h4" className="mb-2">
-          Custom Domain
-        </Heading>
-        <Type muted small className="mb-6">
-          Connect a custom domain to serve your MCP servers from your own
-          branded URL instead of the default Gram domain.
-        </Type>
-        {domain?.domain ? (
-          <div className="border-border bg-card rounded-lg border p-4">
-            <Stack direction="horizontal" justify="space-between" align="start">
-              <Stack gap={1}>
-                <Stack direction="horizontal" align="center" gap={2}>
-                  <Globe className="text-muted-foreground h-4 w-4" />
-                  <Type variant="body" className="font-mono font-medium">
-                    {domain.domain}
+    <RequireScope scope="org:read" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Title>Custom Domain</Page.Header.Title>
+        </Page.Header>
+        <Page.Body>
+          <Heading variant="h4" className="mb-2">
+            Custom Domain
+          </Heading>
+          <Type muted small className="mb-6">
+            Connect a custom domain to serve your MCP servers from your own
+            branded URL instead of the default Gram domain.
+          </Type>
+          {domain?.domain ? (
+            <div className="rounded-lg border border-border bg-card p-4">
+              <Stack
+                direction="horizontal"
+                justify="space-between"
+                align="start"
+              >
+                <Stack gap={1}>
+                  <Stack direction="horizontal" align="center" gap={2}>
+                    <Globe className="h-4 w-4 text-muted-foreground" />
+                    <Type variant="body" className="font-mono font-medium">
+                      {domain.domain}
+                    </Type>
+                    {domain.isUpdating ? (
+                      <SimpleTooltip tooltip="Your domain is being verified. This may take a few minutes.">
+                        <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
+                      </SimpleTooltip>
+                    ) : domain.verified ? (
+                      <SimpleTooltip tooltip="Domain verified and active">
+                        <Check className="w-4 h-4 stroke-3 text-green-500" />
+                      </SimpleTooltip>
+                    ) : (
+                      <SimpleTooltip tooltip="Domain verification failed. Ensure your DNS records are set up correctly.">
+                        <X className="w-4 h-4 stroke-3 text-red-500" />
+                      </SimpleTooltip>
+                    )}
+                  </Stack>
+                  <Type
+                    variant="body"
+                    className="text-muted-foreground text-sm ml-6"
+                  >
+                    Linked <HumanizeDateTime date={domain.createdAt} />
                   </Type>
-                  {domain.isUpdating ? (
-                    <SimpleTooltip tooltip="Your domain is being verified. This may take a few minutes.">
-                      <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
-                    </SimpleTooltip>
-                  ) : domain.verified ? (
-                    <SimpleTooltip tooltip="Domain verified and active">
-                      <Check className="h-4 w-4 stroke-3 text-green-500" />
-                    </SimpleTooltip>
-                  ) : (
-                    <SimpleTooltip tooltip="Domain verification failed. Ensure your DNS records are set up correctly.">
-                      <X className="h-4 w-4 stroke-3 text-red-500" />
-                    </SimpleTooltip>
-                  )}
                 </Stack>
-                <Type
-                  variant="body"
-                  className="text-muted-foreground ml-6 text-sm"
-                >
-                  Linked <HumanizeDateTime date={domain.createdAt} />
-                </Type>
+                <RequireScope scope="org:admin" level="section">
+                  <Stack direction="horizontal" gap={2}>
+                    {!domain.verified && (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => setIsAddDomainDialogOpen(true)}
+                        disabled={domain.isUpdating}
+                      >
+                        Reverify
+                      </Button>
+                    )}
+                    <Button
+                      variant="tertiary"
+                      size="sm"
+                      onClick={() => setIsDeleteDomainDialogOpen(true)}
+                      className="hover:text-destructive"
+                      disabled={deleteDomainMutation.isPending}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </Stack>
+                </RequireScope>
               </Stack>
-              <Stack direction="horizontal" gap={2}>
-                {!domain.verified && (
+            </div>
+          ) : (
+            !domainIsLoading && (
+              <div className="rounded-lg border border-dashed border-border p-6">
+                <Stack gap={2} align="center" justify="center">
+                  <Type variant="body" className="text-muted-foreground">
+                    No custom domain configured
+                  </Type>
+                  <Type
+                    variant="body"
+                    className="text-muted-foreground text-sm"
+                  >
+                    You can connect one custom domain per organization for your
+                    MCP servers.
+                  </Type>
+                  <RequireScope scope="org:admin" level="component">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="mt-2"
+                      onClick={() => {
+                        if (productTier.includes("base")) {
+                          setIsCustomDomainUpgradeModalOpen(true);
+                        } else {
+                          setIsAddDomainDialogOpen(true);
+                        }
+                      }}
+                    >
+                      <Button.LeftIcon>
+                        <Globe className="h-4 w-4" />
+                      </Button.LeftIcon>
+                      <Button.Text>Add Domain</Button.Text>
+                    </Button>
+                  </RequireScope>
+                </Stack>
+              </div>
+            )
+          )}
+
+          <Dialog
+            open={isDeleteDomainDialogOpen}
+            onOpenChange={setIsDeleteDomainDialogOpen}
+          >
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>Remove Custom Domain</Dialog.Title>
+              </Dialog.Header>
+              <div className="space-y-4 py-4">
+                <Type variant="body">
+                  Are you sure you want to remove{" "}
+                  <span className="italic font-bold">{domain?.domain}</span>?
+                  This will delete the associated ingress and TLS certificate.
+                </Type>
+                <div className="flex justify-end space-x-2">
                   <Button
                     variant="secondary"
-                    size="sm"
-                    onClick={() => setIsAddDomainDialogOpen(true)}
-                    disabled={domain.isUpdating}
+                    onClick={() => setIsDeleteDomainDialogOpen(false)}
                   >
-                    Reverify
+                    Cancel
                   </Button>
-                )}
-                <Button
-                  variant="tertiary"
-                  size="sm"
-                  onClick={() => setIsDeleteDomainDialogOpen(true)}
-                  className="hover:text-destructive"
-                  disabled={deleteDomainMutation.isPending}
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-              </Stack>
-            </Stack>
-          </div>
-        ) : (
-          !domainIsLoading && (
-            <div className="border-border rounded-lg border border-dashed p-6">
-              <Stack gap={2} align="center" justify="center">
-                <Type variant="body" className="text-muted-foreground">
-                  No custom domain configured
-                </Type>
-                <Type variant="body" className="text-muted-foreground text-sm">
-                  You can connect one custom domain per organization for your
-                  MCP servers.
-                </Type>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  className="mt-2"
-                  onClick={() => {
-                    if (productTier.includes("base")) {
-                      setIsCustomDomainUpgradeModalOpen(true);
-                    } else {
-                      setIsAddDomainDialogOpen(true);
+                  <Button
+                    variant="destructive-primary"
+                    onClick={() =>
+                      deleteDomainMutation.mutate({
+                        security: { sessionHeaderGramSession: "" },
+                      })
                     }
-                  }}
-                >
-                  <Button.LeftIcon>
-                    <Globe className="h-4 w-4" />
-                  </Button.LeftIcon>
-                  <Button.Text>Add Domain</Button.Text>
-                </Button>
-              </Stack>
-            </div>
-          )
-        )}
-
-        <Dialog
-          open={isDeleteDomainDialogOpen}
-          onOpenChange={setIsDeleteDomainDialogOpen}
-        >
-          <Dialog.Content>
-            <Dialog.Header>
-              <Dialog.Title>Remove Custom Domain</Dialog.Title>
-            </Dialog.Header>
-            <div className="space-y-4 py-4">
-              <Type variant="body">
-                Are you sure you want to remove{" "}
-                <span className="font-bold italic">{domain?.domain}</span>? This
-                will delete the associated ingress and TLS certificate.
-              </Type>
-              <div className="flex justify-end space-x-2">
-                <Button
-                  variant="secondary"
-                  onClick={() => setIsDeleteDomainDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive-primary"
-                  onClick={() =>
-                    deleteDomainMutation.mutate({
-                      security: { sessionHeaderGramSession: "" },
-                    })
-                  }
-                  disabled={deleteDomainMutation.isPending}
-                >
-                  {deleteDomainMutation.isPending ? "Removing..." : "Remove"}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog>
-
-        <Dialog
-          open={isAddDomainDialogOpen}
-          onOpenChange={setIsAddDomainDialogOpen}
-        >
-          <Dialog.Content className="max-w-lg">
-            <Dialog.Header>
-              <Dialog.Title>Connect a Custom Domain</Dialog.Title>
-            </Dialog.Header>
-            <div className="min-h-[420px] space-y-6 py-4">
-              <div>
-                <Type
-                  variant="body"
-                  className="mb-2 block text-lg font-extrabold"
-                >
-                  Step 1
-                </Type>
-                <Type variant="body" className="text-muted-foreground mb-2">
-                  Enter your custom domain:
-                </Type>
-                <div className="space-y-2">
-                  <Input
-                    placeholder="Enter your domain (chat.yourdomain.com)"
-                    value={domainInput}
-                    onChange={handleDomainInputChange}
-                    className={cn(
-                      domainError && "border-red-500",
-                      domain?.domain &&
-                        "bg-muted text-muted-foreground cursor-not-allowed",
-                    )}
-                    readOnly={!!domain?.domain}
-                  />
-                  {domainError && (
-                    <Type variant="body" className="text-sm text-red-500">
-                      {domainError}
-                    </Type>
-                  )}
-                </div>
-              </div>
-              <div>
-                <Type
-                  variant="body"
-                  className="mb-2 block text-lg font-extrabold"
-                >
-                  Step 2
-                </Type>
-                <Type variant="body" className="text-muted-foreground mb-2">
-                  Create a CNAME record for{" "}
-                  <span className="font-mono break-all">{subdomain}</span>{" "}
-                  pointing to the following:
-                </Type>
-                <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
-                  <code className="flex-1 break-all">{CNAME_VALUE}</code>
-                  <Button
-                    variant="tertiary"
-                    size="sm"
-                    onClick={handleCopyCname}
-                    className="shrink-0"
+                    disabled={deleteDomainMutation.isPending}
                   >
-                    {isCnameCopied ? (
-                      <CheckCircle2 className="h-4 w-4 text-green-500" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
-                    )}
+                    {deleteDomainMutation.isPending ? "Removing..." : "Remove"}
                   </Button>
                 </div>
               </div>
-              <div>
-                <Type
-                  variant="body"
-                  className="mb-2 block text-lg font-extrabold"
-                >
-                  Step 3
-                </Type>
-                <Type variant="body" className="text-muted-foreground mb-2">
-                  Create a TXT record at{" "}
-                  <span className="font-mono break-all">{txtName}</span> with
-                  the following value:
-                </Type>
-                <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
-                  <code className="flex-1 break-all">{txtValue}</code>
-                  <Button
-                    variant="tertiary"
-                    size="sm"
-                    onClick={handleCopyTxt}
-                    className="shrink-0"
+            </Dialog.Content>
+          </Dialog>
+
+          <Dialog
+            open={isAddDomainDialogOpen}
+            onOpenChange={setIsAddDomainDialogOpen}
+          >
+            <Dialog.Content className="max-w-lg">
+              <Dialog.Header>
+                <Dialog.Title>Connect a Custom Domain</Dialog.Title>
+              </Dialog.Header>
+              <div className="space-y-6 py-4 min-h-[420px]">
+                <div>
+                  <Type
+                    variant="body"
+                    className="font-extrabold text-lg mb-2 block"
                   >
-                    {isTxtCopied ? (
-                      <CheckCircle2 className="h-4 w-4 text-green-500" />
-                    ) : (
-                      <Copy className="h-4 w-4" />
+                    Step 1
+                  </Type>
+                  <Type variant="body" className="text-muted-foreground mb-2">
+                    Enter your custom domain:
+                  </Type>
+                  <div className="space-y-2">
+                    <Input
+                      placeholder="Enter your domain (chat.yourdomain.com)"
+                      value={domainInput}
+                      onChange={handleDomainInputChange}
+                      className={cn(
+                        domainError && "border-red-500",
+                        domain?.domain &&
+                          "bg-muted text-muted-foreground cursor-not-allowed",
+                      )}
+                      readOnly={!!domain?.domain}
+                    />
+                    {domainError && (
+                      <Type variant="body" className="text-red-500 text-sm">
+                        {domainError}
+                      </Type>
                     )}
+                  </div>
+                </div>
+                <div>
+                  <Type
+                    variant="body"
+                    className="font-extrabold text-lg mb-2 block"
+                  >
+                    Step 2
+                  </Type>
+                  <Type variant="body" className="text-muted-foreground mb-2">
+                    Create a CNAME record for{" "}
+                    <span className="font-mono break-all">{subdomain}</span>{" "}
+                    pointing to the following:
+                  </Type>
+                  <div className="flex items-center space-x-2 bg-muted p-3 rounded-md mt-2">
+                    <code className="flex-1 break-all">{CNAME_VALUE}</code>
+                    <Button
+                      variant="tertiary"
+                      size="sm"
+                      onClick={handleCopyCname}
+                      className="shrink-0"
+                    >
+                      {isCnameCopied ? (
+                        <CheckCircle2 className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+                <div>
+                  <Type
+                    variant="body"
+                    className="font-extrabold text-lg mb-2 block"
+                  >
+                    Step 3
+                  </Type>
+                  <Type variant="body" className="text-muted-foreground mb-2">
+                    Create a TXT record at{" "}
+                    <span className="font-mono break-all">{txtName}</span> with
+                    the following value:
+                  </Type>
+                  <div className="flex items-center space-x-2 bg-muted p-3 rounded-md mt-2">
+                    <code className="flex-1 break-all">{txtValue}</code>
+                    <Button
+                      variant="tertiary"
+                      size="sm"
+                      onClick={handleCopyTxt}
+                      className="shrink-0"
+                    >
+                      {isTxtCopied ? (
+                        <CheckCircle2 className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+                <div className="flex justify-end mt-4">
+                  <Button
+                    onClick={handleRegisterDomain}
+                    disabled={
+                      !domainInput.trim() ||
+                      !!domainError ||
+                      registerDomainMutation.isPending
+                    }
+                  >
+                    {registerDomainMutation.isPending
+                      ? "Registering..."
+                      : domain?.domain
+                        ? "Reverify"
+                        : "Register"}
                   </Button>
                 </div>
               </div>
-              <div className="mt-4 flex justify-end">
-                <Button
-                  onClick={handleRegisterDomain}
-                  disabled={
-                    !domainInput.trim() ||
-                    !!domainError ||
-                    registerDomainMutation.isPending
-                  }
-                >
-                  {registerDomainMutation.isPending
-                    ? "Registering..."
-                    : domain?.domain
-                      ? "Reverify"
-                      : "Register"}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog>
-        <FeatureRequestModal
-          isOpen={isCustomDomainModalOpen}
-          onClose={() => setIsCustomDomainUpgradeModalOpen(false)}
-          title="Custom Domains"
-          description="Custom domains require upgrading to an enterprise plan. Someone should be in touch shortly, or feel free to book a meeting directly."
-          actionType="custom_domain"
-          icon={Globe}
-          accountUpgrade
-        />
-      </Page.Body>
-    </Page>
+            </Dialog.Content>
+          </Dialog>
+          <FeatureRequestModal
+            isOpen={isCustomDomainModalOpen}
+            onClose={() => setIsCustomDomainUpgradeModalOpen(false)}
+            title="Custom Domains"
+            description="Custom domains require upgrading to an enterprise plan. Someone should be in touch shortly, or feel free to book a meeting directly."
+            actionType="custom_domain"
+            icon={Globe}
+            accountUpgrade
+          />
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -33,7 +33,7 @@ export default function OrgHome() {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
-    <RequireScope scope="build:read" level="page">
+    <RequireScope scope={["build:read", "org:admin"]} level="page">
       <Page>
         <Page.Header>
           <Page.Header.Title>Home</Page.Header.Title>

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -69,7 +69,11 @@ export function OrgHomeInner() {
             No projects matching &ldquo;{search}&rdquo;
           </Type>
           <div className="flex justify-center">
-            <RequireScope scope="org:admin" level="component">
+            <RequireScope
+              scope="org:admin"
+              level="component"
+              className="w-full"
+            >
               <button
                 type="button"
                 onClick={() => {
@@ -142,11 +146,11 @@ export function OrgHomeInner() {
               </DotCard>
             </Link>
           ))}
-          <RequireScope scope="org:admin" level="component">
+          <RequireScope scope="org:admin" level="component" className="w-full">
             <button
               type="button"
               onClick={() => setCreateDialogOpen(true)}
-              className="text-left hover:no-underline"
+              className="w-full text-left hover:no-underline"
             >
               <DotCard
                 icon={

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -7,6 +7,7 @@ import { SearchBar } from "@/components/ui/search-bar";
 import { Type } from "@/components/ui/type";
 import { useOrganization } from "@/contexts/Auth";
 import { useSdkClient, useSlugs } from "@/contexts/Sdk";
+import { RequireScope } from "@/components/require-scope";
 import { ArrowRight, Plus } from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
@@ -32,162 +33,168 @@ export default function OrgHome() {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Title>Home</Page.Header.Title>
-      </Page.Header>
-      <Page.Body>
-        <Heading variant="h4" className="mb-1">
-          Projects
-        </Heading>
-        <Type small muted className="mb-4">
-          Projects organize your MCP servers, tools, deployments, and
-          integrations into separate workspaces. Use them to isolate different
-          products or environments within your organization.
-        </Type>
-        <SearchBar
-          value={search}
-          onChange={setSearch}
-          placeholder="Search projects..."
-          className="mb-4"
-        />
-        {projects.length === 0 && search ? (
-          <div className="space-y-8 pt-6">
-            <Type muted className="text-center">
-              No projects matching &ldquo;{search}&rdquo;
-            </Type>
-            <div className="flex justify-center">
-              <button
-                type="button"
-                onClick={() => {
-                  setNewProjectName(search);
-                  setCreateDialogOpen(true);
-                }}
-                className="w-full max-w-md text-left hover:no-underline"
-              >
-                <DotCard
-                  icon={
-                    <Plus className="text-muted-foreground group-hover:text-primary h-10 w-10 transition-colors" />
-                  }
-                  className="!border-foreground/10 hover:!border-foreground/20 border-dashed"
-                >
-                  <Type
-                    variant="subheading"
-                    as="div"
-                    className="text-md text-muted-foreground group-hover:text-primary transition-colors"
-                  >
-                    Create &ldquo;{search}&rdquo;
-                  </Type>
-                  <Type small muted className="mb-3">
-                    Create a new project with this name
-                  </Type>
-
-                  <div className="mt-auto flex items-center justify-end pt-2">
-                    <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
-                      <span>Create</span>
-                      <Plus className="h-3.5 w-3.5" />
-                    </div>
-                  </div>
-                </DotCard>
-              </button>
-            </div>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-            {projects.map((project) => (
-              <Link
-                key={project.id}
-                to={`/${orgSlug}/projects/${project.slug}`}
-                className="hover:no-underline"
-              >
-                <DotCard
-                  icon={
-                    <ProjectAvatar
-                      project={project}
-                      className="h-10 w-10 rounded-md"
-                    />
-                  }
-                >
-                  <Type
-                    variant="subheading"
-                    as="div"
-                    className="text-md group-hover:text-primary truncate transition-colors"
-                  >
-                    {project.name}
-                  </Type>
-                  <Type small muted className="mb-3 truncate">
-                    {project.slug}
-                  </Type>
-
-                  <div className="mt-auto flex items-center justify-end pt-2">
-                    <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
-                      <span>Open</span>
-                      <ArrowRight className="h-3.5 w-3.5" />
-                    </div>
-                  </div>
-                </DotCard>
-              </Link>
-            ))}
-            <button
-              type="button"
-              onClick={() => setCreateDialogOpen(true)}
-              className="text-left hover:no-underline"
-            >
-              <DotCard
-                icon={
-                  <Plus className="text-muted-foreground group-hover:text-primary h-10 w-10 transition-colors" />
-                }
-                className="!border-foreground/10 hover:!border-foreground/20 border-dashed"
-              >
-                <Type
-                  variant="subheading"
-                  as="div"
-                  className="text-md text-muted-foreground group-hover:text-primary transition-colors"
-                >
-                  New Project
-                </Type>
-                <Type small muted className="mb-3">
-                  Create a new project for your organization
-                </Type>
-
-                <div className="mt-auto flex items-center justify-end pt-2">
-                  <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
-                    <span>Create</span>
-                    <Plus className="h-3.5 w-3.5" />
-                  </div>
-                </div>
-              </DotCard>
-            </button>
-          </div>
-        )}
-        {createDialogOpen && (
-          <InputDialog
-            open={createDialogOpen}
-            onOpenChange={setCreateDialogOpen}
-            title="Create New Project"
-            description="Create a new project to organize your MCP servers, tools, and integrations."
-            submitButtonText="Create Project"
-            onSubmit={async () => {
-              const result = await client.projects.create({
-                createProjectRequestBody: {
-                  name: newProjectName,
-                  organizationId: organization.id,
-                },
-              });
-              setNewProjectName("");
-              navigate(`/${orgSlug}/projects/${result.project.slug}`);
-            }}
-            inputs={[
-              {
-                label: "Name",
-                value: newProjectName,
-                onChange: setNewProjectName,
-                placeholder: "My Project",
-              },
-            ]}
+    <RequireScope scope="build:read" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Title>Home</Page.Header.Title>
+        </Page.Header>
+        <Page.Body>
+          <Heading variant="h4" className="mb-1">
+            Projects
+          </Heading>
+          <Type small muted className="mb-4">
+            Projects organize your MCP servers, tools, deployments, and
+            integrations into separate workspaces. Use them to isolate different
+            products or environments within your organization.
+          </Type>
+          <SearchBar
+            value={search}
+            onChange={setSearch}
+            placeholder="Search projects..."
+            className="mb-4"
           />
-        )}
-      </Page.Body>
-    </Page>
+          {projects.length === 0 && search ? (
+            <div className="space-y-8 pt-6">
+              <Type muted className="text-center">
+                No projects matching &ldquo;{search}&rdquo;
+              </Type>
+              <div className="flex justify-center">
+                <RequireScope scope="org:admin" level="component">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setNewProjectName(search);
+                      setCreateDialogOpen(true);
+                    }}
+                    className="text-left hover:no-underline w-full max-w-md"
+                  >
+                    <DotCard
+                      icon={
+                        <Plus className="h-10 w-10 text-muted-foreground group-hover:text-primary transition-colors" />
+                      }
+                      className="border-dashed !border-foreground/10 hover:!border-foreground/20"
+                    >
+                      <Type
+                        variant="subheading"
+                        as="div"
+                        className="text-md text-muted-foreground group-hover:text-primary transition-colors"
+                      >
+                        Create &ldquo;{search}&rdquo;
+                      </Type>
+                      <Type small muted className="mb-3">
+                        Create a new project with this name
+                      </Type>
+
+                      <div className="flex items-center justify-end mt-auto pt-2">
+                        <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+                          <span>Create</span>
+                          <Plus className="w-3.5 h-3.5" />
+                        </div>
+                      </div>
+                    </DotCard>
+                  </button>
+                </RequireScope>
+              </div>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+              {projects.map((project) => (
+                <Link
+                  key={project.id}
+                  to={`/${orgSlug}/projects/${project.slug}`}
+                  className="hover:no-underline"
+                >
+                  <DotCard
+                    icon={
+                      <ProjectAvatar
+                        project={project}
+                        className="h-10 w-10 rounded-md"
+                      />
+                    }
+                  >
+                    <Type
+                      variant="subheading"
+                      as="div"
+                      className="truncate text-md group-hover:text-primary transition-colors"
+                    >
+                      {project.name}
+                    </Type>
+                    <Type small muted className="truncate mb-3">
+                      {project.slug}
+                    </Type>
+
+                    <div className="flex items-center justify-end mt-auto pt-2">
+                      <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+                        <span>Open</span>
+                        <ArrowRight className="w-3.5 h-3.5" />
+                      </div>
+                    </div>
+                  </DotCard>
+                </Link>
+              ))}
+              <RequireScope scope="org:admin" level="component">
+                <button
+                  type="button"
+                  onClick={() => setCreateDialogOpen(true)}
+                  className="text-left hover:no-underline"
+                >
+                  <DotCard
+                    icon={
+                      <Plus className="h-10 w-10 text-muted-foreground group-hover:text-primary transition-colors" />
+                    }
+                    className="border-dashed !border-foreground/10 hover:!border-foreground/20"
+                  >
+                    <Type
+                      variant="subheading"
+                      as="div"
+                      className="text-md text-muted-foreground group-hover:text-primary transition-colors"
+                    >
+                      New Project
+                    </Type>
+                    <Type small muted className="mb-3">
+                      Create a new project for your organization
+                    </Type>
+
+                    <div className="flex items-center justify-end mt-auto pt-2">
+                      <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
+                        <span>Create</span>
+                        <Plus className="w-3.5 h-3.5" />
+                      </div>
+                    </div>
+                  </DotCard>
+                </button>
+              </RequireScope>
+            </div>
+          )}
+          {createDialogOpen && (
+            <InputDialog
+              open={createDialogOpen}
+              onOpenChange={setCreateDialogOpen}
+              title="Create New Project"
+              description="Create a new project to organize your MCP servers, tools, and integrations."
+              submitButtonText="Create Project"
+              onSubmit={async () => {
+                const result = await client.projects.create({
+                  createProjectRequestBody: {
+                    name: newProjectName,
+                    organizationId: organization.id,
+                  },
+                });
+                setNewProjectName("");
+                navigate(`/${orgSlug}/projects/${result.project.slug}`);
+              }}
+              inputs={[
+                {
+                  label: "Name",
+                  value: newProjectName,
+                  onChange: setNewProjectName,
+                  placeholder: "My Project",
+                },
+              ]}
+            />
+          )}
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -13,6 +13,21 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 export default function OrgHome() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Home</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["build:read", "org:admin"]} level="page">
+          <OrgHomeInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function OrgHomeInner() {
   const organization = useOrganization();
   const { orgSlug } = useSlugs();
   const client = useSdkClient();
@@ -33,168 +48,161 @@ export default function OrgHome() {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
-    <RequireScope scope={["build:read", "org:admin"]} level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Title>Home</Page.Header.Title>
-        </Page.Header>
-        <Page.Body>
-          <Heading variant="h4" className="mb-1">
-            Projects
-          </Heading>
-          <Type small muted className="mb-4">
-            Projects organize your MCP servers, tools, deployments, and
-            integrations into separate workspaces. Use them to isolate different
-            products or environments within your organization.
+    <>
+      <Heading variant="h4" className="mb-1">
+        Projects
+      </Heading>
+      <Type small muted className="mb-4">
+        Projects organize your MCP servers, tools, deployments, and integrations
+        into separate workspaces. Use them to isolate different products or
+        environments within your organization.
+      </Type>
+      <SearchBar
+        value={search}
+        onChange={setSearch}
+        placeholder="Search projects..."
+        className="mb-4"
+      />
+      {projects.length === 0 && search ? (
+        <div className="space-y-8 pt-6">
+          <Type muted className="text-center">
+            No projects matching &ldquo;{search}&rdquo;
           </Type>
-          <SearchBar
-            value={search}
-            onChange={setSearch}
-            placeholder="Search projects..."
-            className="mb-4"
-          />
-          {projects.length === 0 && search ? (
-            <div className="space-y-8 pt-6">
-              <Type muted className="text-center">
-                No projects matching &ldquo;{search}&rdquo;
-              </Type>
-              <div className="flex justify-center">
-                <RequireScope scope="org:admin" level="component">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setNewProjectName(search);
-                      setCreateDialogOpen(true);
-                    }}
-                    className="text-left hover:no-underline w-full max-w-md"
-                  >
-                    <DotCard
-                      icon={
-                        <Plus className="h-10 w-10 text-muted-foreground group-hover:text-primary transition-colors" />
-                      }
-                      className="border-dashed !border-foreground/10 hover:!border-foreground/20"
-                    >
-                      <Type
-                        variant="subheading"
-                        as="div"
-                        className="text-md text-muted-foreground group-hover:text-primary transition-colors"
-                      >
-                        Create &ldquo;{search}&rdquo;
-                      </Type>
-                      <Type small muted className="mb-3">
-                        Create a new project with this name
-                      </Type>
-
-                      <div className="flex items-center justify-end mt-auto pt-2">
-                        <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
-                          <span>Create</span>
-                          <Plus className="w-3.5 h-3.5" />
-                        </div>
-                      </div>
-                    </DotCard>
-                  </button>
-                </RequireScope>
-              </div>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-              {projects.map((project) => (
-                <Link
-                  key={project.id}
-                  to={`/${orgSlug}/projects/${project.slug}`}
-                  className="hover:no-underline"
+          <div className="flex justify-center">
+            <RequireScope scope="org:admin" level="component">
+              <button
+                type="button"
+                onClick={() => {
+                  setNewProjectName(search);
+                  setCreateDialogOpen(true);
+                }}
+                className="w-full max-w-md text-left hover:no-underline"
+              >
+                <DotCard
+                  icon={
+                    <Plus className="text-muted-foreground group-hover:text-primary h-10 w-10 transition-colors" />
+                  }
+                  className="!border-foreground/10 hover:!border-foreground/20 border-dashed"
                 >
-                  <DotCard
-                    icon={
-                      <ProjectAvatar
-                        project={project}
-                        className="h-10 w-10 rounded-md"
-                      />
-                    }
+                  <Type
+                    variant="subheading"
+                    as="div"
+                    className="text-md text-muted-foreground group-hover:text-primary transition-colors"
                   >
-                    <Type
-                      variant="subheading"
-                      as="div"
-                      className="truncate text-md group-hover:text-primary transition-colors"
-                    >
-                      {project.name}
-                    </Type>
-                    <Type small muted className="truncate mb-3">
-                      {project.slug}
-                    </Type>
+                    Create &ldquo;{search}&rdquo;
+                  </Type>
+                  <Type small muted className="mb-3">
+                    Create a new project with this name
+                  </Type>
 
-                    <div className="flex items-center justify-end mt-auto pt-2">
-                      <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
-                        <span>Open</span>
-                        <ArrowRight className="w-3.5 h-3.5" />
-                      </div>
+                  <div className="mt-auto flex items-center justify-end pt-2">
+                    <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
+                      <span>Create</span>
+                      <Plus className="h-3.5 w-3.5" />
                     </div>
-                  </DotCard>
-                </Link>
-              ))}
-              <RequireScope scope="org:admin" level="component">
-                <button
-                  type="button"
-                  onClick={() => setCreateDialogOpen(true)}
-                  className="text-left hover:no-underline"
+                  </div>
+                </DotCard>
+              </button>
+            </RequireScope>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          {projects.map((project) => (
+            <Link
+              key={project.id}
+              to={`/${orgSlug}/projects/${project.slug}`}
+              className="hover:no-underline"
+            >
+              <DotCard
+                icon={
+                  <ProjectAvatar
+                    project={project}
+                    className="h-10 w-10 rounded-md"
+                  />
+                }
+              >
+                <Type
+                  variant="subheading"
+                  as="div"
+                  className="text-md group-hover:text-primary truncate transition-colors"
                 >
-                  <DotCard
-                    icon={
-                      <Plus className="h-10 w-10 text-muted-foreground group-hover:text-primary transition-colors" />
-                    }
-                    className="border-dashed !border-foreground/10 hover:!border-foreground/20"
-                  >
-                    <Type
-                      variant="subheading"
-                      as="div"
-                      className="text-md text-muted-foreground group-hover:text-primary transition-colors"
-                    >
-                      New Project
-                    </Type>
-                    <Type small muted className="mb-3">
-                      Create a new project for your organization
-                    </Type>
+                  {project.name}
+                </Type>
+                <Type small muted className="mb-3 truncate">
+                  {project.slug}
+                </Type>
 
-                    <div className="flex items-center justify-end mt-auto pt-2">
-                      <div className="flex items-center gap-1 text-muted-foreground group-hover:text-primary transition-colors text-sm">
-                        <span>Create</span>
-                        <Plus className="w-3.5 h-3.5" />
-                      </div>
-                    </div>
-                  </DotCard>
-                </button>
-              </RequireScope>
-            </div>
-          )}
-          {createDialogOpen && (
-            <InputDialog
-              open={createDialogOpen}
-              onOpenChange={setCreateDialogOpen}
-              title="Create New Project"
-              description="Create a new project to organize your MCP servers, tools, and integrations."
-              submitButtonText="Create Project"
-              onSubmit={async () => {
-                const result = await client.projects.create({
-                  createProjectRequestBody: {
-                    name: newProjectName,
-                    organizationId: organization.id,
-                  },
-                });
-                setNewProjectName("");
-                navigate(`/${orgSlug}/projects/${result.project.slug}`);
-              }}
-              inputs={[
-                {
-                  label: "Name",
-                  value: newProjectName,
-                  onChange: setNewProjectName,
-                  placeholder: "My Project",
-                },
-              ]}
-            />
-          )}
-        </Page.Body>
-      </Page>
-    </RequireScope>
+                <div className="mt-auto flex items-center justify-end pt-2">
+                  <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
+                    <span>Open</span>
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </div>
+                </div>
+              </DotCard>
+            </Link>
+          ))}
+          <RequireScope scope="org:admin" level="component">
+            <button
+              type="button"
+              onClick={() => setCreateDialogOpen(true)}
+              className="text-left hover:no-underline"
+            >
+              <DotCard
+                icon={
+                  <Plus className="text-muted-foreground group-hover:text-primary h-10 w-10 transition-colors" />
+                }
+                className="!border-foreground/10 hover:!border-foreground/20 border-dashed"
+              >
+                <Type
+                  variant="subheading"
+                  as="div"
+                  className="text-md text-muted-foreground group-hover:text-primary transition-colors"
+                >
+                  New Project
+                </Type>
+                <Type small muted className="mb-3">
+                  Create a new project for your organization
+                </Type>
+
+                <div className="mt-auto flex items-center justify-end pt-2">
+                  <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
+                    <span>Create</span>
+                    <Plus className="h-3.5 w-3.5" />
+                  </div>
+                </div>
+              </DotCard>
+            </button>
+          </RequireScope>
+        </div>
+      )}
+      {createDialogOpen && (
+        <InputDialog
+          open={createDialogOpen}
+          onOpenChange={setCreateDialogOpen}
+          title="Create New Project"
+          description="Create a new project to organize your MCP servers, tools, and integrations."
+          submitButtonText="Create Project"
+          onSubmit={async () => {
+            const result = await client.projects.create({
+              createProjectRequestBody: {
+                name: newProjectName,
+                organizationId: organization.id,
+              },
+            });
+            setNewProjectName("");
+            navigate(`/${orgSlug}/projects/${result.project.slug}`);
+          }}
+          inputs={[
+            {
+              label: "Name",
+              value: newProjectName,
+              onChange: setNewProjectName,
+              placeholder: "My Project",
+            },
+          ]}
+        />
+      )}
+    </>
   );
 }

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -11,6 +11,21 @@ import { useState } from "react";
 import { RequireScope } from "@/components/require-scope";
 
 export default function OrgLogs() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Logging & Telemetry</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["org:read", "org:admin"]} level="page">
+          <OrgLogsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function OrgLogsInner() {
   const { data: featuresData, isLoading: featuresLoading } = useFeaturesGet();
   const [logsEnabled, setLogsEnabled] = useState<boolean | null>(null);
   const [toolIoLogsEnabled, setToolIoLogsEnabled] = useState<boolean | null>(
@@ -89,124 +104,104 @@ export default function OrgLogs() {
   };
 
   return (
-    <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Title>Logging & Telemetry</Page.Header.Title>
-        </Page.Header>
-        <Page.Body>
-          <Heading variant="h4" className="mb-2">
-            Logs
-          </Heading>
-          <Type muted small className="mb-6">
-            Configure logging and telemetry settings for your MCP servers. When
-            enabled, tool calls and traces are recorded for debugging and
-            analytics.
-          </Type>
-          <div className="rounded-lg border border-border bg-card p-4">
-            <Stack gap={4}>
-              <Stack
-                direction="horizontal"
-                justify="space-between"
-                align="center"
-              >
-                <Stack gap={1}>
-                  <Stack direction="horizontal" align="center" gap={2}>
-                    <FileText className="h-4 w-4 text-muted-foreground" />
-                    <Type variant="body" className="font-medium">
-                      Enable Logs
-                    </Type>
-                  </Stack>
-                  <Type
-                    variant="body"
-                    className="text-muted-foreground text-sm ml-6"
-                  >
-                    Record tool call traces and telemetry data
-                  </Type>
-                </Stack>
-                {!featuresLoading && (
-                  <RequireScope scope="org:admin" level="component">
-                    <Switch
-                      checked={effectiveLogsEnabled}
-                      onCheckedChange={handleSetLogs}
-                      disabled={isMutatingLogs}
-                      aria-label="Enable logs"
-                    />
-                  </RequireScope>
-                )}
+    <>
+      <Heading variant="h4" className="mb-2">
+        Logs
+      </Heading>
+      <Type muted small className="mb-6">
+        Configure logging and telemetry settings for your MCP servers. When
+        enabled, tool calls and traces are recorded for debugging and analytics.
+      </Type>
+      <div className="border-border bg-card rounded-lg border p-4">
+        <Stack gap={4}>
+          <Stack direction="horizontal" justify="space-between" align="center">
+            <Stack gap={1}>
+              <Stack direction="horizontal" align="center" gap={2}>
+                <FileText className="text-muted-foreground h-4 w-4" />
+                <Type variant="body" className="font-medium">
+                  Enable Logs
+                </Type>
               </Stack>
-
-              <div className="border-t border-border" />
-
-              <Stack
-                direction="horizontal"
-                justify="space-between"
-                align="center"
+              <Type
+                variant="body"
+                className="text-muted-foreground ml-6 text-sm"
               >
-                <Stack gap={1}>
-                  <Stack direction="horizontal" align="center" gap={2}>
-                    <Eye className="h-4 w-4 text-muted-foreground" />
-                    <Type variant="body" className="font-medium">
-                      Record Tool I/O
-                    </Type>
-                  </Stack>
-                  <Type
-                    variant="body"
-                    className="text-muted-foreground text-sm ml-6"
-                  >
-                    Store tool inputs and outputs. May expose sensitive data in
-                    logs.
-                  </Type>
-                </Stack>
-                {!featuresLoading && (
-                  <RequireScope scope="org:admin" level="component">
-                    <Switch
-                      checked={effectiveToolIoLogsEnabled}
-                      onCheckedChange={handleSetToolIoLogs}
-                      disabled={isMutatingLogs || !effectiveLogsEnabled}
-                      aria-label="Record tool inputs and outputs"
-                    />
-                  </RequireScope>
-                )}
-              </Stack>
-
-              <div className="border-t border-border" />
-
-              <Stack
-                direction="horizontal"
-                justify="space-between"
-                align="center"
-              >
-                <Stack gap={1}>
-                  <Stack direction="horizontal" align="center" gap={2}>
-                    <Monitor className="h-4 w-4 text-muted-foreground" />
-                    <Type variant="body" className="font-medium">
-                      Claude Code Session Capture
-                    </Type>
-                  </Stack>
-                  <Type
-                    variant="body"
-                    className="text-muted-foreground text-sm ml-6"
-                  >
-                    Capture user prompts and assistant responses from Claude
-                    Code sessions. Sessions appear in the Agent Sessions tab.
-                  </Type>
-                </Stack>
-                {!featuresLoading && (
-                  <RequireScope scope="org:admin" level="component">
-                    <Switch
-                      checked={effectiveSessionCaptureEnabled}
-                      onCheckedChange={handleSetSessionCapture}
-                      disabled={isMutatingLogs || !effectiveLogsEnabled}
-                      aria-label="Enable Claude Code session capture"
-                    />
-                  </RequireScope>
-                )}
-              </Stack>
+                Record tool call traces and telemetry data
+              </Type>
             </Stack>
-          </div>
-        </Page.Body>
-      </Page>
-    </RequireScope>
+            {!featuresLoading && (
+              <RequireScope scope="org:admin" level="component">
+                <Switch
+                  checked={effectiveLogsEnabled}
+                  onCheckedChange={handleSetLogs}
+                  disabled={isMutatingLogs}
+                  aria-label="Enable logs"
+                />
+              </RequireScope>
+            )}
+          </Stack>
+
+          <div className="border-border border-t" />
+
+          <Stack direction="horizontal" justify="space-between" align="center">
+            <Stack gap={1}>
+              <Stack direction="horizontal" align="center" gap={2}>
+                <Eye className="text-muted-foreground h-4 w-4" />
+                <Type variant="body" className="font-medium">
+                  Record Tool I/O
+                </Type>
+              </Stack>
+              <Type
+                variant="body"
+                className="text-muted-foreground ml-6 text-sm"
+              >
+                Store tool inputs and outputs. May expose sensitive data in
+                logs.
+              </Type>
+            </Stack>
+            {!featuresLoading && (
+              <RequireScope scope="org:admin" level="component">
+                <Switch
+                  checked={effectiveToolIoLogsEnabled}
+                  onCheckedChange={handleSetToolIoLogs}
+                  disabled={isMutatingLogs || !effectiveLogsEnabled}
+                  aria-label="Record tool inputs and outputs"
+                />
+              </RequireScope>
+            )}
+          </Stack>
+
+          <div className="border-border border-t" />
+
+          <Stack direction="horizontal" justify="space-between" align="center">
+            <Stack gap={1}>
+              <Stack direction="horizontal" align="center" gap={2}>
+                <Monitor className="text-muted-foreground h-4 w-4" />
+                <Type variant="body" className="font-medium">
+                  Claude Code Session Capture
+                </Type>
+              </Stack>
+              <Type
+                variant="body"
+                className="text-muted-foreground ml-6 text-sm"
+              >
+                Capture user prompts and assistant responses from Claude Code
+                sessions. Sessions appear in the Agent Sessions tab.
+              </Type>
+            </Stack>
+            {!featuresLoading && (
+              <RequireScope scope="org:admin" level="component">
+                <Switch
+                  checked={effectiveSessionCaptureEnabled}
+                  onCheckedChange={handleSetSessionCapture}
+                  disabled={isMutatingLogs || !effectiveLogsEnabled}
+                  aria-label="Enable Claude Code session capture"
+                />
+              </RequireScope>
+            )}
+          </Stack>
+        </Stack>
+      </div>
+    </>
   );
 }

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -89,7 +89,7 @@ export default function OrgLogs() {
   };
 
   return (
-    <RequireScope scope="org:read" level="page">
+    <RequireScope scope={["org:read", "org:admin"]} level="page">
       <Page>
         <Page.Header>
           <Page.Header.Title>Logging & Telemetry</Page.Header.Title>

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -8,6 +8,7 @@ import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet";
 import { Stack } from "@speakeasy-api/moonshine";
 import { Eye, FileText, Monitor } from "lucide-react";
 import { useState } from "react";
+import { RequireScope } from "@/components/require-scope";
 
 export default function OrgLogs() {
   const { data: featuresData, isLoading: featuresLoading } = useFeaturesGet();
@@ -88,116 +89,124 @@ export default function OrgLogs() {
   };
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Title>Logging & Telemetry</Page.Header.Title>
-      </Page.Header>
-      <Page.Body>
-        <Heading variant="h4" className="mb-2">
-          Logs
-        </Heading>
-        <Type muted small className="mb-6">
-          Configure logging and telemetry settings for your MCP servers. When
-          enabled, tool calls and traces are recorded for debugging and
-          analytics.
-        </Type>
-        <div className="border-border bg-card rounded-lg border p-4">
-          <Stack gap={4}>
-            <Stack
-              direction="horizontal"
-              justify="space-between"
-              align="center"
-            >
-              <Stack gap={1}>
-                <Stack direction="horizontal" align="center" gap={2}>
-                  <FileText className="text-muted-foreground h-4 w-4" />
-                  <Type variant="body" className="font-medium">
-                    Enable Logs
+    <RequireScope scope="org:read" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Title>Logging & Telemetry</Page.Header.Title>
+        </Page.Header>
+        <Page.Body>
+          <Heading variant="h4" className="mb-2">
+            Logs
+          </Heading>
+          <Type muted small className="mb-6">
+            Configure logging and telemetry settings for your MCP servers. When
+            enabled, tool calls and traces are recorded for debugging and
+            analytics.
+          </Type>
+          <div className="rounded-lg border border-border bg-card p-4">
+            <Stack gap={4}>
+              <Stack
+                direction="horizontal"
+                justify="space-between"
+                align="center"
+              >
+                <Stack gap={1}>
+                  <Stack direction="horizontal" align="center" gap={2}>
+                    <FileText className="h-4 w-4 text-muted-foreground" />
+                    <Type variant="body" className="font-medium">
+                      Enable Logs
+                    </Type>
+                  </Stack>
+                  <Type
+                    variant="body"
+                    className="text-muted-foreground text-sm ml-6"
+                  >
+                    Record tool call traces and telemetry data
                   </Type>
                 </Stack>
-                <Type
-                  variant="body"
-                  className="text-muted-foreground ml-6 text-sm"
-                >
-                  Record tool call traces and telemetry data
-                </Type>
+                {!featuresLoading && (
+                  <RequireScope scope="org:admin" level="component">
+                    <Switch
+                      checked={effectiveLogsEnabled}
+                      onCheckedChange={handleSetLogs}
+                      disabled={isMutatingLogs}
+                      aria-label="Enable logs"
+                    />
+                  </RequireScope>
+                )}
               </Stack>
-              {!featuresLoading && (
-                <Switch
-                  checked={effectiveLogsEnabled}
-                  onCheckedChange={handleSetLogs}
-                  disabled={isMutatingLogs}
-                  aria-label="Enable logs"
-                />
-              )}
-            </Stack>
 
-            <div className="border-border border-t" />
+              <div className="border-t border-border" />
 
-            <Stack
-              direction="horizontal"
-              justify="space-between"
-              align="center"
-            >
-              <Stack gap={1}>
-                <Stack direction="horizontal" align="center" gap={2}>
-                  <Eye className="text-muted-foreground h-4 w-4" />
-                  <Type variant="body" className="font-medium">
-                    Record Tool I/O
+              <Stack
+                direction="horizontal"
+                justify="space-between"
+                align="center"
+              >
+                <Stack gap={1}>
+                  <Stack direction="horizontal" align="center" gap={2}>
+                    <Eye className="h-4 w-4 text-muted-foreground" />
+                    <Type variant="body" className="font-medium">
+                      Record Tool I/O
+                    </Type>
+                  </Stack>
+                  <Type
+                    variant="body"
+                    className="text-muted-foreground text-sm ml-6"
+                  >
+                    Store tool inputs and outputs. May expose sensitive data in
+                    logs.
                   </Type>
                 </Stack>
-                <Type
-                  variant="body"
-                  className="text-muted-foreground ml-6 text-sm"
-                >
-                  Store tool inputs and outputs. May expose sensitive data in
-                  logs.
-                </Type>
+                {!featuresLoading && (
+                  <RequireScope scope="org:admin" level="component">
+                    <Switch
+                      checked={effectiveToolIoLogsEnabled}
+                      onCheckedChange={handleSetToolIoLogs}
+                      disabled={isMutatingLogs || !effectiveLogsEnabled}
+                      aria-label="Record tool inputs and outputs"
+                    />
+                  </RequireScope>
+                )}
               </Stack>
-              {!featuresLoading && (
-                <Switch
-                  checked={effectiveToolIoLogsEnabled}
-                  onCheckedChange={handleSetToolIoLogs}
-                  disabled={isMutatingLogs || !effectiveLogsEnabled}
-                  aria-label="Record tool inputs and outputs"
-                />
-              )}
-            </Stack>
 
-            <div className="border-border border-t" />
+              <div className="border-t border-border" />
 
-            <Stack
-              direction="horizontal"
-              justify="space-between"
-              align="center"
-            >
-              <Stack gap={1}>
-                <Stack direction="horizontal" align="center" gap={2}>
-                  <Monitor className="text-muted-foreground h-4 w-4" />
-                  <Type variant="body" className="font-medium">
-                    Claude Code Session Capture
+              <Stack
+                direction="horizontal"
+                justify="space-between"
+                align="center"
+              >
+                <Stack gap={1}>
+                  <Stack direction="horizontal" align="center" gap={2}>
+                    <Monitor className="h-4 w-4 text-muted-foreground" />
+                    <Type variant="body" className="font-medium">
+                      Claude Code Session Capture
+                    </Type>
+                  </Stack>
+                  <Type
+                    variant="body"
+                    className="text-muted-foreground text-sm ml-6"
+                  >
+                    Capture user prompts and assistant responses from Claude
+                    Code sessions. Sessions appear in the Agent Sessions tab.
                   </Type>
                 </Stack>
-                <Type
-                  variant="body"
-                  className="text-muted-foreground ml-6 text-sm"
-                >
-                  Capture user prompts and assistant responses from Claude Code
-                  sessions. Sessions appear in the Agent Sessions tab.
-                </Type>
+                {!featuresLoading && (
+                  <RequireScope scope="org:admin" level="component">
+                    <Switch
+                      checked={effectiveSessionCaptureEnabled}
+                      onCheckedChange={handleSetSessionCapture}
+                      disabled={isMutatingLogs || !effectiveLogsEnabled}
+                      aria-label="Enable Claude Code session capture"
+                    />
+                  </RequireScope>
+                )}
               </Stack>
-              {!featuresLoading && (
-                <Switch
-                  checked={effectiveSessionCaptureEnabled}
-                  onCheckedChange={handleSetSessionCapture}
-                  disabled={isMutatingLogs || !effectiveLogsEnabled}
-                  aria-label="Enable Claude Code session capture"
-                />
-              )}
             </Stack>
-          </Stack>
-        </div>
-      </Page.Body>
-    </Page>
+          </div>
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -321,7 +321,7 @@ export default function Team() {
   ];
 
   return (
-    <RequireScope scope="org:read" level="page">
+    <RequireScope scope={["org:read", "org:admin"]} level="page">
       <Page>
         <Page.Header>
           <Page.Header.Breadcrumbs />

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -24,6 +24,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Trash2, UserPlus, Users, X } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { RequireScope } from "@/components/require-scope";
 
 function getMemberColors(id: string) {
   let hash = 2166136261;
@@ -163,11 +164,11 @@ export default function Team() {
             <img
               src={member.photoUrl}
               alt={member.name}
-              className="h-8 w-8 rounded-full"
+              className="w-8 h-8 rounded-full"
             />
           ) : (
             <div
-              className="flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium text-white"
+              className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white"
               style={{
                 backgroundImage: `linear-gradient(${getMemberColors(member.id).angle}deg, ${getMemberColors(member.id).from}, ${getMemberColors(member.id).to})`,
               }}
@@ -210,17 +211,19 @@ export default function Team() {
       width: "80px",
       render: (member) =>
         member.email !== user.email ? (
-          <Button
-            variant="tertiary"
-            size="sm"
-            onClick={() => setMemberToRemove(member)}
-            className="hover:text-destructive"
-          >
-            <Button.LeftIcon>
-              <Trash2 className="h-4 w-4" />
-            </Button.LeftIcon>
-            <Button.Text className="sr-only">Remove member</Button.Text>
-          </Button>
+          <RequireScope scope="org:admin" level="component">
+            <Button
+              variant="tertiary"
+              size="sm"
+              onClick={() => setMemberToRemove(member)}
+              className="hover:text-destructive"
+            >
+              <Button.LeftIcon>
+                <Trash2 className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text className="sr-only">Remove member</Button.Text>
+            </Button>
+          </RequireScope>
         ) : (
           <Type variant="body" className="text-muted-foreground text-sm">
             You
@@ -244,7 +247,7 @@ export default function Team() {
             className={isExpired ? "opacity-50" : ""}
           >
             <div
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
+              className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white shrink-0"
               style={{
                 backgroundImage: `linear-gradient(${getMemberColors(invite.email).angle}deg, ${getMemberColors(invite.email).from}, ${getMemberColors(invite.email).to})`,
               }}
@@ -300,209 +303,218 @@ export default function Team() {
       header: "",
       width: "80px",
       render: (invite) => (
-        <Button
-          variant="tertiary"
-          size="sm"
-          onClick={() => setInviteToCancel(invite)}
-          className="hover:text-destructive"
-        >
-          <Button.LeftIcon>
-            <X className="h-4 w-4" />
-          </Button.LeftIcon>
-          <Button.Text className="sr-only">Revoke invite</Button.Text>
-        </Button>
+        <RequireScope scope="org:admin" level="component">
+          <Button
+            variant="tertiary"
+            size="sm"
+            onClick={() => setInviteToCancel(invite)}
+            className="hover:text-destructive"
+          >
+            <Button.LeftIcon>
+              <X className="h-4 w-4" />
+            </Button.LeftIcon>
+            <Button.Text className="sr-only">Revoke invite</Button.Text>
+          </Button>
+        </RequireScope>
       ),
     },
   ];
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>
-        <Stack direction="vertical" gap={8}>
-          {/* Members Section */}
-          <div>
-            <Stack
-              direction="horizontal"
-              justify="space-between"
-              align="center"
-              className="mb-4"
-            >
-              <Stack direction="vertical" gap={1}>
-                <Heading variant="h4">Team Members</Heading>
-                <Type variant="body" className="text-muted-foreground">
-                  Manage who has access to {organization.name}
-                </Type>
-              </Stack>
-              <Button onClick={() => setIsInviteDialogOpen(true)}>
-                <Button.LeftIcon>
-                  <UserPlus className="h-4 w-4" />
-                </Button.LeftIcon>
-                <Button.Text>Invite Member</Button.Text>
-              </Button>
-            </Stack>
-
-            <Table
-              columns={memberColumns}
-              data={members}
-              rowKey={(row) => row.userId}
-              className="min-h-fit"
-              noResultsMessage={
-                <Stack
-                  gap={2}
-                  className="bg-background h-full p-8"
-                  align="center"
-                  justify="center"
-                >
-                  <Users className="text-muted-foreground h-12 w-12" />
+    <RequireScope scope="org:read" level="page">
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs />
+        </Page.Header>
+        <Page.Body>
+          <Stack direction="vertical" gap={8}>
+            {/* Members Section */}
+            <div>
+              <Stack
+                direction="horizontal"
+                justify="space-between"
+                align="center"
+                className="mb-4"
+              >
+                <Stack direction="vertical" gap={1}>
+                  <Heading variant="h4">Team Members</Heading>
                   <Type variant="body" className="text-muted-foreground">
-                    No team members yet
+                    Manage who has access to {organization.name}
                   </Type>
                 </Stack>
-              }
-            />
-          </div>
-
-          {/* Pending Invites Section */}
-          {invites.length > 0 && (
-            <div>
-              <Stack direction="vertical" gap={1} className="mb-4">
-                <Heading variant="h4">Pending Invites</Heading>
-                <Type variant="body" className="text-muted-foreground">
-                  Invitations that haven't been accepted yet
-                </Type>
+                <RequireScope scope="org:admin" level="component">
+                  <Button onClick={() => setIsInviteDialogOpen(true)}>
+                    <Button.LeftIcon>
+                      <UserPlus className="h-4 w-4" />
+                    </Button.LeftIcon>
+                    <Button.Text>Invite Member</Button.Text>
+                  </Button>
+                </RequireScope>
               </Stack>
 
               <Table
-                columns={inviteColumns}
-                data={invites}
-                rowKey={(row) => row.id}
+                columns={memberColumns}
+                data={members}
+                rowKey={(row) => row.userId}
                 className="min-h-fit"
+                noResultsMessage={
+                  <Stack
+                    gap={2}
+                    className="h-full p-8 bg-background"
+                    align="center"
+                    justify="center"
+                  >
+                    <Users className="h-12 w-12 text-muted-foreground" />
+                    <Type variant="body" className="text-muted-foreground">
+                      No team members yet
+                    </Type>
+                  </Stack>
+                }
               />
             </div>
-          )}
-        </Stack>
 
-        {/* Invite Dialog */}
-        <Dialog open={isInviteDialogOpen} onOpenChange={setIsInviteDialogOpen}>
-          <Dialog.Content>
-            <Dialog.Header>
-              <Dialog.Title>Invite Team Member</Dialog.Title>
-            </Dialog.Header>
-            <form className="space-y-4 py-4" onSubmit={handleInvite}>
-              <Type variant="body" className="text-muted-foreground">
-                Enter the email address of the person you'd like to invite to{" "}
-                <span className="text-foreground font-medium">
-                  {organization.name}
-                </span>
-                .
-              </Type>
-              <InputField
-                label="Email address"
-                name="email"
-                type="email"
-                value={inviteEmail}
-                onChange={(e) => setInviteEmail(e.target.value)}
-                placeholder="colleague@company.com"
-                required
-                autoFocus
-                autoCapitalize="off"
-                autoComplete="off"
-                autoCorrect="off"
-              />
-              <div className="flex justify-end space-x-2">
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={() => setIsInviteDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="submit"
-                  disabled={inviteMutation.isPending || !inviteEmail.trim()}
-                >
-                  {inviteMutation.isPending ? "Sending..." : "Send Invite"}
-                </Button>
-              </div>
-            </form>
-          </Dialog.Content>
-        </Dialog>
+            {/* Pending Invites Section */}
+            {invites.length > 0 && (
+              <div>
+                <Stack direction="vertical" gap={1} className="mb-4">
+                  <Heading variant="h4">Pending Invites</Heading>
+                  <Type variant="body" className="text-muted-foreground">
+                    Invitations that haven't been accepted yet
+                  </Type>
+                </Stack>
 
-        {/* Remove Member Dialog */}
-        <Dialog
-          open={!!memberToRemove}
-          onOpenChange={(open) => !open && setMemberToRemove(null)}
-        >
-          <Dialog.Content>
-            <Dialog.Header>
-              <Dialog.Title>Remove Team Member</Dialog.Title>
-            </Dialog.Header>
-            <div className="space-y-4 py-4">
-              <Type variant="body">
-                Are you sure you want to remove{" "}
-                <span className="font-bold">{memberToRemove?.name}</span> from{" "}
-                {organization.name}? They will lose access to all projects and
-                resources.
-              </Type>
-              <div className="flex justify-end space-x-2">
-                <Button
-                  variant="secondary"
-                  onClick={() => setMemberToRemove(null)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="destructive-primary"
-                  onClick={handleRemoveMember}
-                  disabled={removeMemberMutation.isPending}
-                >
-                  {removeMemberMutation.isPending
-                    ? "Removing..."
-                    : "Remove Member"}
-                </Button>
+                <Table
+                  columns={inviteColumns}
+                  data={invites}
+                  rowKey={(row) => row.id}
+                  className="min-h-fit"
+                />
               </div>
-            </div>
-          </Dialog.Content>
-        </Dialog>
+            )}
+          </Stack>
 
-        {/* Cancel Invite Dialog */}
-        <Dialog
-          open={!!inviteToCancel}
-          onOpenChange={(open) => !open && setInviteToCancel(null)}
-        >
-          <Dialog.Content>
-            <Dialog.Header>
-              <Dialog.Title>Cancel Invite</Dialog.Title>
-            </Dialog.Header>
-            <div className="space-y-4 py-4">
-              <Type variant="body">
-                Are you sure you want to cancel the invite to{" "}
-                <span className="font-bold">{inviteToCancel?.email}</span>?
-              </Type>
-              <div className="flex justify-end space-x-2">
-                <Button
-                  variant="secondary"
-                  onClick={() => setInviteToCancel(null)}
-                >
-                  Keep Invite
-                </Button>
-                <Button
-                  variant="destructive-primary"
-                  onClick={handleRevokeInvite}
-                  disabled={revokeInviteMutation.isPending}
-                >
-                  {revokeInviteMutation.isPending
-                    ? "Revoking..."
-                    : "Revoke Invite"}
-                </Button>
+          {/* Invite Dialog */}
+          <Dialog
+            open={isInviteDialogOpen}
+            onOpenChange={setIsInviteDialogOpen}
+          >
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>Invite Team Member</Dialog.Title>
+              </Dialog.Header>
+              <form className="space-y-4 py-4" onSubmit={handleInvite}>
+                <Type variant="body" className="text-muted-foreground">
+                  Enter the email address of the person you'd like to invite to{" "}
+                  <span className="font-medium text-foreground">
+                    {organization.name}
+                  </span>
+                  .
+                </Type>
+                <InputField
+                  label="Email address"
+                  name="email"
+                  type="email"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  placeholder="colleague@company.com"
+                  required
+                  autoFocus
+                  autoCapitalize="off"
+                  autoComplete="off"
+                  autoCorrect="off"
+                />
+                <div className="flex justify-end space-x-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => setIsInviteDialogOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    disabled={inviteMutation.isPending || !inviteEmail.trim()}
+                  >
+                    {inviteMutation.isPending ? "Sending..." : "Send Invite"}
+                  </Button>
+                </div>
+              </form>
+            </Dialog.Content>
+          </Dialog>
+
+          {/* Remove Member Dialog */}
+          <Dialog
+            open={!!memberToRemove}
+            onOpenChange={(open) => !open && setMemberToRemove(null)}
+          >
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>Remove Team Member</Dialog.Title>
+              </Dialog.Header>
+              <div className="space-y-4 py-4">
+                <Type variant="body">
+                  Are you sure you want to remove{" "}
+                  <span className="font-bold">{memberToRemove?.name}</span> from{" "}
+                  {organization.name}? They will lose access to all projects and
+                  resources.
+                </Type>
+                <div className="flex justify-end space-x-2">
+                  <Button
+                    variant="secondary"
+                    onClick={() => setMemberToRemove(null)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="destructive-primary"
+                    onClick={handleRemoveMember}
+                    disabled={removeMemberMutation.isPending}
+                  >
+                    {removeMemberMutation.isPending
+                      ? "Removing..."
+                      : "Remove Member"}
+                  </Button>
+                </div>
               </div>
-            </div>
-          </Dialog.Content>
-        </Dialog>
-      </Page.Body>
-    </Page>
+            </Dialog.Content>
+          </Dialog>
+
+          {/* Cancel Invite Dialog */}
+          <Dialog
+            open={!!inviteToCancel}
+            onOpenChange={(open) => !open && setInviteToCancel(null)}
+          >
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>Cancel Invite</Dialog.Title>
+              </Dialog.Header>
+              <div className="space-y-4 py-4">
+                <Type variant="body">
+                  Are you sure you want to cancel the invite to{" "}
+                  <span className="font-bold">{inviteToCancel?.email}</span>?
+                </Type>
+                <div className="flex justify-end space-x-2">
+                  <Button
+                    variant="secondary"
+                    onClick={() => setInviteToCancel(null)}
+                  >
+                    Keep Invite
+                  </Button>
+                  <Button
+                    variant="destructive-primary"
+                    onClick={handleRevokeInvite}
+                    disabled={revokeInviteMutation.isPending}
+                  >
+                    {revokeInviteMutation.isPending
+                      ? "Revoking..."
+                      : "Revoke Invite"}
+                  </Button>
+                </div>
+              </div>
+            </Dialog.Content>
+          </Dialog>
+        </Page.Body>
+      </Page>
+    </RequireScope>
   );
 }

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -46,6 +46,21 @@ function getMemberColors(id: string) {
 }
 
 export default function Team() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Team</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope="org:admin" level="page">
+          <TeamInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function TeamInner() {
   const organization = useOrganization();
   const user = useUser();
   const queryClient = useQueryClient();
@@ -164,11 +179,11 @@ export default function Team() {
             <img
               src={member.photoUrl}
               alt={member.name}
-              className="w-8 h-8 rounded-full"
+              className="h-8 w-8 rounded-full"
             />
           ) : (
             <div
-              className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white"
+              className="flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium text-white"
               style={{
                 backgroundImage: `linear-gradient(${getMemberColors(member.id).angle}deg, ${getMemberColors(member.id).from}, ${getMemberColors(member.id).to})`,
               }}
@@ -247,7 +262,7 @@ export default function Team() {
             className={isExpired ? "opacity-50" : ""}
           >
             <div
-              className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white shrink-0"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
               style={{
                 backgroundImage: `linear-gradient(${getMemberColors(invite.email).angle}deg, ${getMemberColors(invite.email).from}, ${getMemberColors(invite.email).to})`,
               }}
@@ -321,200 +336,190 @@ export default function Team() {
   ];
 
   return (
-    <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <Stack direction="vertical" gap={8}>
-            {/* Members Section */}
-            <div>
-              <Stack
-                direction="horizontal"
-                justify="space-between"
-                align="center"
-                className="mb-4"
-              >
-                <Stack direction="vertical" gap={1}>
-                  <Heading variant="h4">Team Members</Heading>
-                  <Type variant="body" className="text-muted-foreground">
-                    Manage who has access to {organization.name}
-                  </Type>
-                </Stack>
-                <RequireScope scope="org:admin" level="component">
-                  <Button onClick={() => setIsInviteDialogOpen(true)}>
-                    <Button.LeftIcon>
-                      <UserPlus className="h-4 w-4" />
-                    </Button.LeftIcon>
-                    <Button.Text>Invite Member</Button.Text>
-                  </Button>
-                </RequireScope>
-              </Stack>
-
-              <Table
-                columns={memberColumns}
-                data={members}
-                rowKey={(row) => row.userId}
-                className="min-h-fit"
-                noResultsMessage={
-                  <Stack
-                    gap={2}
-                    className="h-full p-8 bg-background"
-                    align="center"
-                    justify="center"
-                  >
-                    <Users className="h-12 w-12 text-muted-foreground" />
-                    <Type variant="body" className="text-muted-foreground">
-                      No team members yet
-                    </Type>
-                  </Stack>
-                }
-              />
-            </div>
-
-            {/* Pending Invites Section */}
-            {invites.length > 0 && (
-              <div>
-                <Stack direction="vertical" gap={1} className="mb-4">
-                  <Heading variant="h4">Pending Invites</Heading>
-                  <Type variant="body" className="text-muted-foreground">
-                    Invitations that haven't been accepted yet
-                  </Type>
-                </Stack>
-
-                <Table
-                  columns={inviteColumns}
-                  data={invites}
-                  rowKey={(row) => row.id}
-                  className="min-h-fit"
-                />
-              </div>
-            )}
+    <>
+      <Stack direction="vertical" gap={8}>
+        {/* Members Section */}
+        <div>
+          <Stack
+            direction="horizontal"
+            justify="space-between"
+            align="center"
+            className="mb-4"
+          >
+            <Stack direction="vertical" gap={1}>
+              <Heading variant="h4">Team Members</Heading>
+              <Type variant="body" className="text-muted-foreground">
+                Manage who has access to {organization.name}
+              </Type>
+            </Stack>
+            <RequireScope scope="org:admin" level="component">
+              <Button onClick={() => setIsInviteDialogOpen(true)}>
+                <Button.LeftIcon>
+                  <UserPlus className="h-4 w-4" />
+                </Button.LeftIcon>
+                <Button.Text>Invite Member</Button.Text>
+              </Button>
+            </RequireScope>
           </Stack>
 
-          {/* Invite Dialog */}
-          <Dialog
-            open={isInviteDialogOpen}
-            onOpenChange={setIsInviteDialogOpen}
-          >
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Invite Team Member</Dialog.Title>
-              </Dialog.Header>
-              <form className="space-y-4 py-4" onSubmit={handleInvite}>
+          <Table
+            columns={memberColumns}
+            data={members}
+            rowKey={(row) => row.userId}
+            className="min-h-fit"
+            noResultsMessage={
+              <Stack
+                gap={2}
+                className="bg-background h-full p-8"
+                align="center"
+                justify="center"
+              >
+                <Users className="text-muted-foreground h-12 w-12" />
                 <Type variant="body" className="text-muted-foreground">
-                  Enter the email address of the person you'd like to invite to{" "}
-                  <span className="font-medium text-foreground">
-                    {organization.name}
-                  </span>
-                  .
+                  No team members yet
                 </Type>
-                <InputField
-                  label="Email address"
-                  name="email"
-                  type="email"
-                  value={inviteEmail}
-                  onChange={(e) => setInviteEmail(e.target.value)}
-                  placeholder="colleague@company.com"
-                  required
-                  autoFocus
-                  autoCapitalize="off"
-                  autoComplete="off"
-                  autoCorrect="off"
-                />
-                <div className="flex justify-end space-x-2">
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={() => setIsInviteDialogOpen(false)}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    type="submit"
-                    disabled={inviteMutation.isPending || !inviteEmail.trim()}
-                  >
-                    {inviteMutation.isPending ? "Sending..." : "Send Invite"}
-                  </Button>
-                </div>
-              </form>
-            </Dialog.Content>
-          </Dialog>
+              </Stack>
+            }
+          />
+        </div>
 
-          {/* Remove Member Dialog */}
-          <Dialog
-            open={!!memberToRemove}
-            onOpenChange={(open) => !open && setMemberToRemove(null)}
-          >
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Remove Team Member</Dialog.Title>
-              </Dialog.Header>
-              <div className="space-y-4 py-4">
-                <Type variant="body">
-                  Are you sure you want to remove{" "}
-                  <span className="font-bold">{memberToRemove?.name}</span> from{" "}
-                  {organization.name}? They will lose access to all projects and
-                  resources.
-                </Type>
-                <div className="flex justify-end space-x-2">
-                  <Button
-                    variant="secondary"
-                    onClick={() => setMemberToRemove(null)}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="destructive-primary"
-                    onClick={handleRemoveMember}
-                    disabled={removeMemberMutation.isPending}
-                  >
-                    {removeMemberMutation.isPending
-                      ? "Removing..."
-                      : "Remove Member"}
-                  </Button>
-                </div>
-              </div>
-            </Dialog.Content>
-          </Dialog>
+        {/* Pending Invites Section */}
+        {invites.length > 0 && (
+          <div>
+            <Stack direction="vertical" gap={1} className="mb-4">
+              <Heading variant="h4">Pending Invites</Heading>
+              <Type variant="body" className="text-muted-foreground">
+                Invitations that haven't been accepted yet
+              </Type>
+            </Stack>
 
-          {/* Cancel Invite Dialog */}
-          <Dialog
-            open={!!inviteToCancel}
-            onOpenChange={(open) => !open && setInviteToCancel(null)}
-          >
-            <Dialog.Content>
-              <Dialog.Header>
-                <Dialog.Title>Cancel Invite</Dialog.Title>
-              </Dialog.Header>
-              <div className="space-y-4 py-4">
-                <Type variant="body">
-                  Are you sure you want to cancel the invite to{" "}
-                  <span className="font-bold">{inviteToCancel?.email}</span>?
-                </Type>
-                <div className="flex justify-end space-x-2">
-                  <Button
-                    variant="secondary"
-                    onClick={() => setInviteToCancel(null)}
-                  >
-                    Keep Invite
-                  </Button>
-                  <Button
-                    variant="destructive-primary"
-                    onClick={handleRevokeInvite}
-                    disabled={revokeInviteMutation.isPending}
-                  >
-                    {revokeInviteMutation.isPending
-                      ? "Revoking..."
-                      : "Revoke Invite"}
-                  </Button>
-                </div>
-              </div>
-            </Dialog.Content>
-          </Dialog>
-        </Page.Body>
-      </Page>
-    </RequireScope>
+            <Table
+              columns={inviteColumns}
+              data={invites}
+              rowKey={(row) => row.id}
+              className="min-h-fit"
+            />
+          </div>
+        )}
+      </Stack>
+
+      {/* Invite Dialog */}
+      <Dialog open={isInviteDialogOpen} onOpenChange={setIsInviteDialogOpen}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Invite Team Member</Dialog.Title>
+          </Dialog.Header>
+          <form className="space-y-4 py-4" onSubmit={handleInvite}>
+            <Type variant="body" className="text-muted-foreground">
+              Enter the email address of the person you'd like to invite to{" "}
+              <span className="text-foreground font-medium">
+                {organization.name}
+              </span>
+              .
+            </Type>
+            <InputField
+              label="Email address"
+              name="email"
+              type="email"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              placeholder="colleague@company.com"
+              required
+              autoFocus
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+            />
+            <div className="flex justify-end space-x-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setIsInviteDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={inviteMutation.isPending || !inviteEmail.trim()}
+              >
+                {inviteMutation.isPending ? "Sending..." : "Send Invite"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog>
+
+      {/* Remove Member Dialog */}
+      <Dialog
+        open={!!memberToRemove}
+        onOpenChange={(open) => !open && setMemberToRemove(null)}
+      >
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Remove Team Member</Dialog.Title>
+          </Dialog.Header>
+          <div className="space-y-4 py-4">
+            <Type variant="body">
+              Are you sure you want to remove{" "}
+              <span className="font-bold">{memberToRemove?.name}</span> from{" "}
+              {organization.name}? They will lose access to all projects and
+              resources.
+            </Type>
+            <div className="flex justify-end space-x-2">
+              <Button
+                variant="secondary"
+                onClick={() => setMemberToRemove(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive-primary"
+                onClick={handleRemoveMember}
+                disabled={removeMemberMutation.isPending}
+              >
+                {removeMemberMutation.isPending
+                  ? "Removing..."
+                  : "Remove Member"}
+              </Button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+
+      {/* Cancel Invite Dialog */}
+      <Dialog
+        open={!!inviteToCancel}
+        onOpenChange={(open) => !open && setInviteToCancel(null)}
+      >
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Cancel Invite</Dialog.Title>
+          </Dialog.Header>
+          <div className="space-y-4 py-4">
+            <Type variant="body">
+              Are you sure you want to cancel the invite to{" "}
+              <span className="font-bold">{inviteToCancel?.email}</span>?
+            </Type>
+            <div className="flex justify-end space-x-2">
+              <Button
+                variant="secondary"
+                onClick={() => setInviteToCancel(null)}
+              >
+                Keep Invite
+              </Button>
+              <Button
+                variant="destructive-primary"
+                onClick={handleRevokeInvite}
+                disabled={revokeInviteMutation.isPending}
+              >
+                {revokeInviteMutation.isPending
+                  ? "Revoking..."
+                  : "Revoke Invite"}
+              </Button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Applies RBAC scope guards to all org-level dashboard pages so that users without the required grants see an access-restricted fallback rather than a mix of 403 errors and partially-rendered UI.

**All enforcement is gated on the \`gram-rbac\` feature flag.** When the flag is off, \`useRBAC\` returns \`true\` for every scope check and the grants API query never fires — existing behaviour is fully preserved.

### Pages covered (org-level only)

| Page | Scope required to view |
|------|----------------------|
| Home | \`build:read\` or \`org:admin\` |
| Billing | \`org:read\` or \`org:admin\` |
| API Keys | \`org:read\` or \`org:admin\` |
| Team | \`org:read\` or \`org:admin\` |
| Custom Domain | \`org:read\` or \`org:admin\` |
| Logging & Telemetry | \`org:read\` or \`org:admin\` |
| Audit Logs | \`org:read\` |
| Roles & Permissions (Access) | \`org:read\` or \`org:admin\` |
| Super Admin Settings | \`org:admin\` (also gates on Speakeasy \`isAdmin\`) |

Mutating actions within each page (buttons, form submits) are additionally protected with \`RequireScope scope="org:admin" level="component"\` — disabled + tooltip when the user lacks \`org:admin\`.

### Outer/inner component pattern

Each page is split into a thin outer default export (no hooks, just \`<Page>\` + \`<RequireScope level="page">\`) and an inner named export that holds all data-fetching hooks. This ensures scope-forbidden API calls never fire for unauthorised users.

### \`RequireScope\` component fix

- Added \`className\` prop to the \`component\`-level variant so callers can pass layout classes (e.g. \`w-full\`) to the disabled wrapper div.
- Fixed inner \`pointer-events-auto\` div to also carry \`w-full\` so children's own \`w-full\` resolves against the full container width rather than the shrink-wrapped flex item.


https://github.com/user-attachments/assets/d11733d3-698f-4440-a862-dbc68e2c9351



## Test plan

- [ ] With \`gram-rbac\` FF **off**: all pages render normally for all users
- [ ] With \`gram-rbac\` FF **on**, user with \`org:read\` only: Billing / Audit Logs / Team / Domains show content; mutating buttons (invite, delete, add domain) are disabled with tooltip
- [ ] With \`gram-rbac\` FF **on**, user with no org scopes: all org pages show "Access restricted" fallback
- [ ] New Project card renders full-width in both enabled and disabled states
- [ ] Dev toolbar scope overrides work in development mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)