### PR TITLE
chore: replace Gram brand references with Speakeasy in UI copy

### DIFF
--- a/client/dashboard/src/components/EnableLoggingOverlay.tsx
+++ b/client/dashboard/src/components/EnableLoggingOverlay.tsx
@@ -61,10 +61,10 @@ export function EnableLoggingOverlay({ onEnabled }: EnableLoggingOverlayProps) {
               className="text-muted-foreground mt-0.5 size-4 shrink-0"
             />
             <p className="text-muted-foreground text-xs">
-              When enabled, Gram will collect tool call payloads, response data,
-              and agent session logs for analysis. This data is stored securely
-              and used to generate the metrics and insights. You can disable
-              logging at any time from the Logs page.
+              When enabled, Speakeasy will collect tool call payloads, response
+              data, and agent session logs for analysis. This data is stored
+              securely and used to generate the metrics and insights. You can
+              disable logging at any time from the Logs page.
             </p>
           </div>
         </div>

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -105,7 +105,7 @@ const FreeTierExceededNotification = () => {
         <Stack direction="vertical" gap={3} className="h-full">
           <Type variant="subheading">Limits exceeded</Type>
           <Type small>
-            Free tier limits exceeded. Upgrade to continue using Gram.
+            Free tier limits exceeded. Upgrade to continue using Speakeasy.
           </Type>
           <orgRoutes.billing.Link className="mt-auto w-full">
             <Button size="sm" className="w-full">

--- a/client/dashboard/src/components/environments/ToolsetEnvironmentForm.tsx
+++ b/client/dashboard/src/components/environments/ToolsetEnvironmentForm.tsx
@@ -120,7 +120,7 @@ export function ToolsetEnvironmentForm({
           <h2 className="text-heading-xs">Environment Variables</h2>
           <p className="text-muted-foreground text-sm">
             Configure required API credentials for this toolset to use in the
-            Gram dashboard
+            Speakeasy dashboard
           </p>
           <p className="text-muted-foreground text-sm">
             View the MCP page for options on how to provide relevant credentials

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -67,7 +67,7 @@ export function InsightsSidebar({
   const sidebarWidth = `min(${SIDEBAR_MAX_WIDTH}px, ${SIDEBAR_MAX_PERCENT}vw)`;
 
   // Build system prompt with context info
-  const baseInstructions = `You are a helpful assistant for analyzing logs in Gram, an AI observability platform. Focus exclusively on log search and analysis.
+  const baseInstructions = `You are a helpful assistant for analyzing logs in Speakeasy, an AI observability platform. Focus exclusively on log search and analysis.
 
 The current date is ${new Date().toISOString().split("T")[0]}.
 

--- a/client/dashboard/src/components/sources/AddSourceDialogContent.tsx
+++ b/client/dashboard/src/components/sources/AddSourceDialogContent.tsx
@@ -39,7 +39,7 @@ export default function AddSourceDialogContent({
         <Dialog.Title>Add Source</Dialog.Title>
         <Dialog.Description>
           {isFunctionsEnabled || isExternalMCPEnabled
-            ? "Upload an OpenAPI document, add Gram Functions, or import an MCP server"
+            ? "Upload an OpenAPI document, add Speakeasy Functions, or import an MCP server"
             : "Upload an OpenAPI document to create tools"}
         </Dialog.Description>
       </Dialog.Header>
@@ -94,7 +94,7 @@ export default function AddSourceDialogContent({
                 <UploadAssetStep.Indicator />
                 <UploadAssetStep.Header
                   title="Generate Tools"
-                  description="Gram will generate tools for your API."
+                  description="Speakeasy will generate tools for your API."
                 />
                 <UploadAssetStep.Content>
                   <DeployStep />
@@ -141,7 +141,7 @@ export default function AddSourceDialogContent({
             <UploadAssetStep.Indicator />
             <UploadAssetStep.Header
               title="Generate Tools"
-              description="Gram will generate tools for your API."
+              description="Speakeasy will generate tools for your API."
             />
             <UploadAssetStep.Content>
               <DeployStep />

--- a/client/dashboard/src/components/sources/Sources.tsx
+++ b/client/dashboard/src/components/sources/Sources.tsx
@@ -254,7 +254,7 @@ export default function Sources() {
         <Page.Section.Title>Sources</Page.Section.Title>
         <Page.Section.Description className="max-w-2xl">
           {isFunctionsEnabled
-            ? "OpenAPI documents, Gram Functions, and third-party MCP servers providing tools for your project"
+            ? "OpenAPI documents, Speakeasy Functions, and third-party MCP servers providing tools for your project"
             : "OpenAPI documents and third-party MCP servers providing tools for your project"}
         </Page.Section.Description>
         <Page.Section.CTA>

--- a/client/dashboard/src/components/sources/SourcesEmptyState.tsx
+++ b/client/dashboard/src/components/sources/SourcesEmptyState.tsx
@@ -29,7 +29,7 @@ export function SourcesEmptyState() {
       <Page.Section.Title>Sources</Page.Section.Title>
       <Page.Section.Description className="max-w-2xl">
         {isFunctionsEnabled
-          ? "OpenAPI documents, Gram Functions, and third-party MCP servers providing tools for your project"
+          ? "OpenAPI documents, Speakeasy Functions, and third-party MCP servers providing tools for your project"
           : "OpenAPI documents and third-party MCP servers providing tools for your project"}
       </Page.Section.Description>
       <Page.Section.Body>

--- a/client/dashboard/src/components/upload-asset/deploy-step.tsx
+++ b/client/dashboard/src/components/upload-asset/deploy-step.tsx
@@ -162,7 +162,8 @@ export default function DeployStep() {
       <Stack direction="horizontal" gap={1} align="center">
         <Spinner />
         <Type>
-          Gram is generating tools for your API. This may take a few seconds.
+          Speakeasy is generating tools for your API. This may take a few
+          seconds.
         </Type>
       </Stack>
     );

--- a/client/dashboard/src/hooks/use-page-title.ts
+++ b/client/dashboard/src/hooks/use-page-title.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { AppRoute, AppRoutes } from "@/routes";
 
-const BASE_TITLE = "Gram";
+const BASE_TITLE = "Speakeasy";
 
 function isAppRoute(value: unknown): value is AppRoute {
   return (

--- a/client/dashboard/src/pages/deployments/DeploymentsEmptyState.tsx
+++ b/client/dashboard/src/pages/deployments/DeploymentsEmptyState.tsx
@@ -5,7 +5,7 @@ export function DeploymentsEmptyState() {
   return (
     <EmptyState
       heading="No deployments yet"
-      description="Gram tracks how your MCP server evolves over time, allowing you to see change history and roll back if necessary."
+      description="Speakeasy MCP Platform tracks how your MCP server evolves over time, allowing you to see change history and roll back if necessary."
       graphic={<ToolsetsGraphic />}
       graphicClassName="scale-90"
     />

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -79,7 +79,7 @@ export default function Environments() {
         <Page.Section>
           <Page.Section.Title>Environments</Page.Section.Title>
           <Page.Section.Description>
-            Use environments to manage API keys, allowing Gram to handle
+            Use environments to manage API keys, allowing Speakeasy to handle
             authentication for you
           </Page.Section.Description>
           <Page.Section.CTA>

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -510,7 +510,7 @@ function HooksContent() {
     <InsightsSidebar
       mcpConfig={mcpConfig}
       title="Explore Hooks"
-      subtitle="Ask me about your hooks! Powered by Elements + Gram MCP"
+      subtitle="Ask me about your hooks! Powered by Elements + Speakeasy MCP"
       hideTrigger={isLogsDisabled}
     >
       <div className="flex h-full flex-col overflow-hidden">

--- a/client/dashboard/src/pages/hooks/HooksEmptyState.tsx
+++ b/client/dashboard/src/pages/hooks/HooksEmptyState.tsx
@@ -83,7 +83,7 @@ export function HooksEmptyState() {
             <div>
               <h2 className="mb-2 text-xl font-semibold">No Hook Logs Yet</h2>
               <p className="text-muted-foreground mx-auto max-w-md text-sm">
-                Install Gram Hooks in your AI coding assistant to start
+                Install Speakeasy Hooks in your AI coding assistant to start
                 capturing tool execution logs
               </p>
             </div>

--- a/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
+++ b/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
@@ -17,7 +17,7 @@ function ClaudeInstallContent() {
       <div>
         <h3 className="mb-2 text-sm font-semibold">Test Yourself</h3>
         <p className="text-muted-foreground mb-4 text-sm">
-          Try Gram Hooks in your Claude Code instance:
+          Try Speakeasy Hooks in your Claude Code instance:
         </p>
         <div className="bg-muted/50 space-y-2 rounded-lg p-4 font-mono text-sm">
           <div className="flex items-center justify-between">
@@ -32,8 +32,8 @@ function ClaudeInstallContent() {
       <div>
         <h3 className="mb-2 text-sm font-semibold">Distribute to Your Team</h3>
         <p className="text-muted-foreground mb-4 text-sm">
-          Require your team to use Gram Hooks by configuring their Claude Code
-          settings:
+          Require your team to use Speakeasy Hooks by configuring their Claude
+          Code settings:
         </p>
 
         <div className="space-y-4">
@@ -90,8 +90,8 @@ function CursorInstallContent() {
       <div>
         <h3 className="mb-2 text-sm font-semibold">1. Publish the Plugin</h3>
         <p className="text-muted-foreground mb-4 text-sm">
-          Add the Gram hooks plugin to your Cursor team marketplace and mark it
-          as required so it auto-installs for all team members:
+          Add the Speakeasy hooks plugin to your Cursor team marketplace and
+          mark it as required so it auto-installs for all team members:
         </p>
         <div className="bg-muted/50 rounded-lg p-4 font-mono text-sm">
           <a
@@ -112,7 +112,7 @@ function CursorInstallContent() {
           <code className="bg-muted rounded px-1 py-0.5 text-xs">
             Session Start
           </code>{" "}
-          hook that injects your Gram credentials. These are automatically
+          hook that injects your Speakeasy credentials. These are automatically
           passed to all subsequent hooks in the session.
         </p>
         <p className="text-muted-foreground mb-4 text-sm">
@@ -132,7 +132,7 @@ function CursorInstallContent() {
             <span className="text-muted-foreground shrink-0 font-medium">
               Hook Name:
             </span>
-            <code>Gram Hooks</code>
+            <code>Speakeasy Hooks</code>
           </div>
           <div className="flex items-baseline gap-2">
             <span className="text-muted-foreground shrink-0 font-medium">
@@ -169,8 +169,9 @@ function CursorInstallContent() {
           Replace{" "}
           <code className="text-primary text-xs">{`<YOUR_API_KEY>`}</code> and{" "}
           <code className="text-primary text-xs">{`<YOUR_PROJECT_SLUG>`}</code>{" "}
-          with your Gram credentials. Find your API key in your project's API
-          Keys settings. This config syncs to all team members automatically.
+          with your Speakeasy credentials. Find your API key in your project's
+          API Keys settings. This config syncs to all team members
+          automatically.
         </p>
       </div>
 

--- a/client/dashboard/src/pages/integrations/Integrations.tsx
+++ b/client/dashboard/src/pages/integrations/Integrations.tsx
@@ -187,7 +187,7 @@ function CreateIntegrationDialog({
           label: "Integration Summary",
           value: summary,
           onChange: setSummary,
-          placeholder: "Access your Hubspot data in Gram.",
+          placeholder: "Access your Hubspot data in Speakeasy.",
         },
         {
           label: "Integration Keywords",

--- a/client/dashboard/src/pages/invite/AcceptInvite.tsx
+++ b/client/dashboard/src/pages/invite/AcceptInvite.tsx
@@ -119,7 +119,7 @@ function InviteDetails({ token }: { token: string }) {
         ) : (
           "an organization"
         )}{" "}
-        on Gram
+        on Speakeasy
       </p>
 
       <Button variant="brand" onClick={handleAccept}>

--- a/client/dashboard/src/pages/logs/Logs.tsx
+++ b/client/dashboard/src/pages/logs/Logs.tsx
@@ -520,7 +520,7 @@ function LogsContent() {
     <InsightsSidebar
       mcpConfig={mcpConfig}
       title="Explore Logs"
-      subtitle="Ask me about your logs! Powered by Elements + Gram MCP"
+      subtitle="Ask me about your logs! Powered by Elements + Speakeasy MCP"
       hideTrigger={isLogsDisabled}
       suggestions={[
         {

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -112,8 +112,8 @@ export function MCPOverview() {
     <Page.Section>
       <Page.Section.Title>Built-in MCP Servers</Page.Section.Title>
       <Page.Section.Description>
-        Pre-configured MCP servers provided by Gram for your project. Connect
-        from Claude Desktop, Cursor, or any MCP client.
+        Pre-configured MCP servers provided by Speakeasy for your project.
+        Connect from Claude Desktop, Cursor, or any MCP client.
       </Page.Section.Description>
       <Page.Section.Body>
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1176,7 +1176,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
             icon: "lock",
             label: "Private",
             description:
-              "Only users with a Gram API Key from this project can read the tools hosted by this server.",
+              "Only users with a Speakeasy API Key from this project can read the tools hosted by this server.",
           },
         ]}
         selectedValue={isPublic ? "public" : "private"}
@@ -1189,7 +1189,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
     <Stack className="mb-4">
       <PageSection
         heading="Visibility"
-        description="Make your MCP server visible to the world, or protected behind a Gram key."
+        description="Make your MCP server visible to the world, or protected behind a Speakeasy key."
       >
         <PublicToggle isPublic={mcpIsPublic ?? false} />
       </PageSection>
@@ -1463,7 +1463,7 @@ export function MCPJson({
                 : "italic"
             }
           >
-            Requires a Gram API key if the server is not public.
+            Requires a Speakeasy API key if the server is not public.
           </span>
         </Type>
         <CodeBlock onCopy={onCopy}>{mcpJsonPublic}</CodeBlock>
@@ -1471,9 +1471,10 @@ export function MCPJson({
       <Grid.Item>
         <Type className="font-medium">Managed Authentication</Type>
         <Type muted small className="mb-2! max-w-3xl">
-          Manage API authentication with Gram environments.
+          Manage API authentication with Speakeasy environments.
           <br />
-          Users need a single Gram API Key rather than bringing their own keys.
+          Users need a single Speakeasy API Key rather than bringing their own
+          keys.
         </Type>
         <CodeBlock onCopy={onCopy}>{mcpJsonInternal}</CodeBlock>
       </Grid.Item>
@@ -1654,7 +1655,7 @@ export function OAuthDetailsModal({
             {toolset.externalOauthServer
               ? "External OAuth Configuration"
               : isGramOAuth
-                ? "Gram OAuth Configuration"
+                ? "Speakeasy OAuth Configuration"
                 : "OAuth Proxy Configuration"}
           </Dialog.Title>
         </Dialog.Header>
@@ -1663,12 +1664,12 @@ export function OAuthDetailsModal({
             {toolset.oauthProxyServer && isGramOAuth && (
               <>
                 <div>
-                  <Type className="font-medium">Gram OAuth is Active</Type>
+                  <Type className="font-medium">Speakeasy OAuth is Active</Type>
                 </div>
                 <Stack gap={2} className="">
                   <Type className="mb-2">
-                    Gram users with access to your organization can use this MCP
-                    server.
+                    Speakeasy users with access to your organization can use
+                    this MCP server.
                   </Type>
                   {toolset.oauthProxyServer.oauthProxyProviders?.[0]
                     ?.environmentSlug && (
@@ -1946,16 +1947,18 @@ export function GramOAuthProxyModal({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <Dialog.Content className="max-h-[90vh] max-w-2xl overflow-hidden">
         <Dialog.Header>
-          <Dialog.Title>Gram OAuth</Dialog.Title>
+          <Dialog.Title>Speakeasy OAuth</Dialog.Title>
         </Dialog.Header>
 
         <div className="max-h-[60vh] space-y-4 overflow-auto">
           <div>
-            <Type className="mb-2 font-medium">Gram OAuth Configuration</Type>
+            <Type className="mb-2 font-medium">
+              Speakeasy OAuth Configuration
+            </Type>
             <Type small className="mb-4">
-              Configure Gram OAuth to let users with access to your organization
-              use this MCP server. Users will authenticate using their Gram
-              credentials.
+              Configure Speakeasy OAuth to let users with access to your
+              organization use this MCP server. Users will authenticate using
+              their Speakeasy credentials.
             </Type>
           </div>
         </div>
@@ -1967,7 +1970,7 @@ export function GramOAuthProxyModal({
           >
             {addOAuthProxyMutation.isPending
               ? "Enabling..."
-              : "Enable Gram OAuth"}
+              : "Enable Speakeasy OAuth"}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/client/dashboard/src/pages/mcp/MCPEmptyState.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEmptyState.tsx
@@ -8,7 +8,7 @@ export function MCPEmptyState({
   return (
     <EmptyState
       heading="No MCP servers yet"
-      description="Gram generates MCP-ready tools from your OpenAPI documents. Get a hosted MCP server in seconds, not days."
+      description="Speakeasy generates MCP-ready tools from your OpenAPI documents. Get a hosted MCP server in seconds, not days."
       graphic={<MCPEmptyGraphic />}
       nonEmptyProjectCTA={nonEmptyProjectCTA}
     />

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -941,7 +941,7 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
             {oauthParadigm === "external"
               ? "External OAuth"
               : oauthParadigm === "gram"
-                ? "Gram OAuth"
+                ? "Speakeasy OAuth"
                 : "OAuth Proxy"}{" "}
             is configured
           </p>
@@ -949,7 +949,7 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
             {oauthParadigm === "external"
               ? "Users will authenticate with your external OAuth server before accessing this MCP server."
               : oauthParadigm === "gram"
-                ? "Users will authenticate with Gram OAuth before accessing this MCP server."
+                ? "Users will authenticate with Speakeasy OAuth before accessing this MCP server."
                 : "The attached CLIENT_ID and CLIENT_SECRET environment variables will be used to authenticate with the OAuth provider before users can access this MCP server."}
           </p>
         </div>

--- a/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
+++ b/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
@@ -165,8 +165,8 @@ function SetupRequiredModal({
             Get Started with Insights
           </Dialog.Title>
           <Dialog.Description className="text-center">
-            Start capturing agent sessions and tool metrics by integrating Gram
-            Elements into your application.
+            Start capturing agent sessions and tool metrics by integrating
+            Speakeasy Elements into your application.
           </Dialog.Description>
         </Dialog.Header>
         <div className="space-y-4 pt-2">
@@ -1228,7 +1228,7 @@ function ObservabilityContent({
               <div className="flex flex-col items-start text-left">
                 <span className="font-medium">Chats</span>
                 <span className="text-muted-foreground text-xs font-normal">
-                  Gram Elements SDK
+                  Speakeasy Elements SDK
                 </span>
               </div>
             </div>

--- a/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
+++ b/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
@@ -98,7 +98,7 @@ export default function UploadOpenAPI() {
                 <UploadAssetStep.Indicator />
                 <UploadAssetStep.Header
                   title="Generate Tools"
-                  description="Gram will generate tools for your API."
+                  description="Speakeasy will generate tools for your API."
                 />
                 <UploadAssetStep.Content>
                   <DeployStep />
@@ -510,11 +510,12 @@ export function UploadOpenAPIContent({
     },
     {
       heading: "Generate Tools",
-      description: "Gram will generate tools for your API.",
+      description: "Speakeasy will generate tools for your API.",
       display: (
         <>
           <Type>
-            Gram is generating tools for your API. This may take a few seconds.
+            Speakeasy is generating tools for your API. This may take a few
+            seconds.
           </Type>
           <Spinner />
         </>

--- a/client/dashboard/src/pages/onboarding/Wizard.tsx
+++ b/client/dashboard/src/pages/onboarding/Wizard.tsx
@@ -433,7 +433,7 @@ export const InitialChoiceStep = ({
   return (
     <>
       <Stack gap={1}>
-        <span className="text-heading-md">Get Started with Gram</span>
+        <span className="text-heading-md">Get Started with Speakeasy</span>
         <span className="text-body-sm">What would you like to do?</span>
       </Stack>
       <div className="grid grid-cols-1 gap-4">
@@ -500,7 +500,7 @@ const ChoiceStep = ({
             onClick={() => handleChoice("cli")}
             icon={SquareFunction}
             title="Start from Code"
-            description="Deploy custom functions using the Gram CLI"
+            description="Deploy custom functions using the Speakeasy CLI"
           />
         )}
       </div>
@@ -581,7 +581,7 @@ const CliSetupStep = ({
       command: `${installCommandPrefix} build`,
     },
     {
-      label: "Push your functions to Gram",
+      label: "Push your functions to Speakeasy",
       command: `${installCommandPrefix} push`,
     },
   ];
@@ -598,7 +598,9 @@ const CliSetupStep = ({
   return (
     <>
       <Stack gap={1}>
-        <span className="text-heading-md">Get Started with Gram Functions</span>
+        <span className="text-heading-md">
+          Get Started with Speakeasy Functions
+        </span>
         <span className="text-body-sm">
           Run these commands in your terminal
         </span>
@@ -869,8 +871,8 @@ const ToolsetStep = ({
       <Stack gap={1}>
         <span className="text-heading-md">Name Your Toolset</span>
         <span className="text-body-sm">
-          This toolset will hold the tools you've added to Gram. We'll make the
-          tools it contains available in an MCP Server in the next step.
+          This toolset will hold the tools you've added to Speakeasy. We'll make
+          the tools it contains available in an MCP Server in the next step.
         </span>
       </Stack>
       <InputField

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -190,9 +190,9 @@ export function OrgApiKeysInner() {
         API Keys
       </Heading>
       <Type muted small className="mb-6">
-        Create and manage API keys to authenticate programmatic access to Gram
-        services, including deployments, toolset management, and MCP server
-        connections.
+        Create and manage API keys to authenticate programmatic access to
+        Speakeasy services, including deployments, toolset management, and MCP
+        server connections.
       </Type>
       <Stack
         direction="horizontal"

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -827,7 +827,7 @@ export function OrgAuditLogsInner() {
   return (
     <div className="flex w-full flex-col gap-4">
       <div>
-        <Type className="font-medium">Recent activity across Gram</Type>
+        <Type className="font-medium">Recent activity across Speakeasy</Type>
         <Type muted small className="mt-1">
           Review organization-wide and project-level actions in chronological
           order.

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -157,7 +157,7 @@ export function OrgDomainsInner() {
       </Heading>
       <Type muted small className="mb-6">
         Connect a custom domain to serve your MCP servers from your own branded
-        URL instead of the default Gram domain.
+        URL instead of the default Speakeasy domain.
       </Type>
       {domain?.domain ? (
         <div className="border-border bg-card rounded-lg border p-4">

--- a/client/dashboard/src/pages/prompts/PromptsEmptyState.tsx
+++ b/client/dashboard/src/pages/prompts/PromptsEmptyState.tsx
@@ -16,7 +16,7 @@ export function PromptsEmptyState({
   return (
     <EmptyState
       heading="No prompts yet"
-      description="Gram's prompt builder allows you to easily create and distribute reusable MCP prompts to your users."
+      description="Speakeasy's prompt builder allows you to easily create and distribute reusable MCP prompts to your users."
       nonEmptyProjectCTA={cta}
       graphic={<ToolsetsGraphic />}
       graphicClassName="scale-90"

--- a/client/dashboard/src/pages/sdk/SDK.tsx
+++ b/client/dashboard/src/pages/sdk/SDK.tsx
@@ -102,7 +102,8 @@ export const SdkContent = ({
   let heading = (
     <div className="flex items-end justify-between gap-4">
       <Type variant="subheading">
-        Use Gram toolsets to build agentic workflows in many popular frameworks
+        Use Speakeasy toolsets to build agentic workflows in many popular
+        frameworks
       </Type>
       {langFrameworkDropdowns}
     </div>

--- a/client/dashboard/src/pages/slackapp/SlackApp.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackApp.tsx
@@ -56,7 +56,7 @@ function SlackAppsEmptyState({ onCreate }: { onCreate: () => void }) {
         No assistants yet
       </Type>
       <Type small muted className="mb-4 max-w-md text-center">
-        Create an assistant to let your team interact with Gram toolsets
+        Create an assistant to let your team interact with Speakeasy toolsets
         directly.
       </Type>
       <Button onClick={onCreate}>
@@ -295,7 +295,7 @@ export default function SlackAppsIndex() {
           <Page.Section>
             <Page.Section.Title>Assistants</Page.Section.Title>
             <Page.Section.Description>
-              Create and manage assistants that connect your team to Gram
+              Create and manage assistants that connect your team to Speakeasy
               toolsets in Slack.
             </Page.Section.Description>
             <Page.Section.CTA>

--- a/client/dashboard/src/pages/slackapp/SlackRegister.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackRegister.tsx
@@ -106,7 +106,7 @@ export default function SlackRegister() {
           {state === "ready" && appInfo && (
             <Stack gap={4} align="center" className="w-full">
               <Stack gap={1} align="center">
-                <Type variant="subheading">Connect to Gram</Type>
+                <Type variant="subheading">Connect to Speakeasy</Type>
                 <Type muted small className="text-center">
                   <strong>{appInfo.appName}</strong> needs to verify your
                   identity to process your messages.

--- a/client/dashboard/src/pages/toolsets/resources/ResourcesEmptyState.tsx
+++ b/client/dashboard/src/pages/toolsets/resources/ResourcesEmptyState.tsx
@@ -16,7 +16,7 @@ export function ResourcesEmptyState({
   return (
     <EmptyState
       heading="No resources yet"
-      description="MCP resources can be created through Gram Functions."
+      description="MCP resources can be created through Speakeasy Functions."
       nonEmptyProjectCTA={cta}
       graphic={<ToolsetsGraphic />}
       graphicClassName="scale-90"

--- a/client/dashboard/src/pages/toolsets/resources/ResourcesTab.tsx
+++ b/client/dashboard/src/pages/toolsets/resources/ResourcesTab.tsx
@@ -88,7 +88,7 @@ export function ResourcesTabContent({
             <Dialog.Header>
               <Dialog.Title>Add Resources</Dialog.Title>
               <Dialog.Description>
-                Add Gram Functions to create resources
+                Add Speakeasy Functions to create resources
               </Dialog.Description>
             </Dialog.Header>
             <GettingStartedInstructions />

--- a/elements/.storybook/GlobalDecorator.tsx
+++ b/elements/.storybook/GlobalDecorator.tsx
@@ -53,7 +53,7 @@ const DEFAULT_ELEMENTS_CONFIG: ElementsConfig = {
     defaultOpen: true,
     expandable: true,
     defaultExpanded: true,
-    title: "Gram Elements Demo",
+    title: "Speakeasy Elements Demo",
   },
   tools: {
     expandToolGroupsByDefault: true,

--- a/elements/.storybook/manager.ts
+++ b/elements/.storybook/manager.ts
@@ -5,7 +5,7 @@ const theme = create({
   base: "dark",
 
   // Brand
-  brandTitle: "Gram Elements",
+  brandTitle: "Speakeasy Elements",
   brandUrl: "https://getgram.ai",
   brandTarget: "_blank",
 

--- a/elements/examples/bun/index.html
+++ b/elements/examples/bun/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gram Elements — Bun Example</title>
+    <title>Speakeasy Elements — Bun Example</title>
   </head>
   <body>
     <div id="root"></div>

--- a/elements/examples/express/index.html
+++ b/elements/examples/express/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gram Elements — Express Example</title>
+    <title>Speakeasy Elements — Express Example</title>
   </head>
   <body>
     <div id="root"></div>

--- a/elements/examples/fastify/index.html
+++ b/elements/examples/fastify/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gram Elements — Fastify Example</title>
+    <title>Speakeasy Elements — Fastify Example</title>
   </head>
   <body>
     <div id="root"></div>

--- a/elements/examples/hono/index.html
+++ b/elements/examples/hono/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gram Elements — Hono Example</title>
+    <title>Speakeasy Elements — Hono Example</title>
   </head>
   <body>
     <div id="root"></div>

--- a/elements/examples/nextjs/app/layout.tsx
+++ b/elements/examples/nextjs/app/layout.tsx
@@ -8,7 +8,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <title>Gram Elements — Next.js Example</title>
+        <title>Speakeasy Elements — Next.js Example</title>
       </head>
       <body>{children}</body>
     </html>

--- a/elements/examples/tanstack-start/src/routes/__root.tsx
+++ b/elements/examples/tanstack-start/src/routes/__root.tsx
@@ -12,7 +12,7 @@ export const Route = createRootRoute({
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
     ],
-    title: "Gram Elements — TanStack Start Example",
+    title: "Speakeasy Elements — TanStack Start Example",
   }),
   component: RootComponent,
 });


### PR DESCRIPTION
## Summary

- Replaces all user-visible "Gram" brand references with "Speakeasy" across the dashboard and elements package
- Updates page/browser titles (`BASE_TITLE`), empty state descriptions, dialog copy, section headings, and example HTML titles
- Covers 41 files: `client/dashboard/src/**` and `elements/**`

## Scope

**Not changed** (out of scope for this PR):
- JavaScript/TypeScript symbol names (`GramElementsProvider`, `useGramContext`, `GramError`, etc.) — API surface change requiring package version bump
- HTTP wire headers (`Gram-Project`, `Gram-Chat-ID`, `X-Gram-Source`) — protocol-breaking
- npm package names (`@gram-ai/elements`, `@gram/client`)
- Environment variable names (`GRAM_API_KEY`, `GRAM_PROJECT_SLUG`)
- Code snippet templates shown to users (package names inside code blocks)

## Test plan

- [ ] Visit dashboard pages and verify browser tab shows `[Page] | Speakeasy`
- [ ] Check MCP server detail page — OAuth dialog shows "Speakeasy OAuth"
- [ ] Check onboarding wizard — headings read "Get Started with Speakeasy"
- [ ] Check Hooks setup dialog — copy reads "Speakeasy Hooks"
- [ ] Check empty states (MCP, Prompts, Deployments, Sources) for updated copy
- [ ] Check Elements Storybook brand title shows "Speakeasy Elements"

🤖 Generated with [Claude Code](https://claude.com/claude-code)