### PR TITLE
fix: upsert org-user relationship for admin users on auth.info

### DIFF
--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -321,15 +321,25 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 		}
 	}
 
-	// on auth info write through data for user/org relationship as a backfill mechanism
-	// user and org both will have been created by now
-	// admin is only exception where there is not a single user-org relationship written
+	// Write through the user-org relationship as a backfill mechanism.
+	// For admins, only upsert when the active org is one they actually belong to.
+	// Admins can override their active org to visit customer orgs via the admin
+	// override feature, and we must not insert a relationship row in those cases.
+	belongsToActiveOrg := !userInfo.Admin
+	for _, org := range userInfo.Organizations {
+		if org.ID == authCtx.ActiveOrganizationID {
+			belongsToActiveOrg = true
+			break
+		}
+	}
 
-	if _, err := s.orgRepo.UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
-		OrganizationID: authCtx.ActiveOrganizationID,
-		UserID:         authCtx.UserID,
-	}); err != nil {
-		s.logger.ErrorContext(ctx, "error upserting organization user relationship", attr.SlogError(err))
+	if belongsToActiveOrg {
+		if _, err := s.orgRepo.UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			UserID:         authCtx.UserID,
+		}); err != nil {
+			s.logger.ErrorContext(ctx, "error upserting organization user relationship", attr.SlogError(err))
+		}
 	}
 
 	// Fully unpack the userInfo object

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -324,13 +324,12 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 	// on auth info write through data for user/org relationship as a backfill mechanism
 	// user and org both will have been created by now
 	// admin is only exception where there is not a single user-org relationship written
-	if !userInfo.Admin {
-		if _, err := s.orgRepo.UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			UserID:         authCtx.UserID,
-		}); err != nil {
-			s.logger.ErrorContext(ctx, "error upserting organization user relationship", attr.SlogError(err))
-		}
+
+	if _, err := s.orgRepo.UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         authCtx.UserID,
+	}); err != nil {
+		s.logger.ErrorContext(ctx, "error upserting organization user relationship", attr.SlogError(err))
 	}
 
 	// Fully unpack the userInfo object

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -238,11 +238,25 @@ func TestService_Info(t *testing.T) {
 
 // TestService_Info_AdminOrgRelationshipUpserted verifies that an admin user who has no
 // pre-existing record in organization_user_relationships gets one created when Info is
-// called for one of their own organizations.
+// called for their speakeasy-team org.
 func TestService_Info_AdminOrgRelationshipUpserted(t *testing.T) {
 	t.Parallel()
 
-	userInfo := adminMockUserInfo()
+	userInfo := &MockUserInfo{
+		UserID:          "admin-user-speakeasy",
+		Email:           "admin@speakeasyapi.dev",
+		Admin:           true,
+		UserWhitelisted: true,
+		Organizations: []MockOrganizationEntry{
+			{
+				ID:                 "speakeasy-team-org-id",
+				Name:               "Speakeasy Team",
+				Slug:               "speakeasy-team",
+				SsoConnectionID:    nil,
+				UserWorkspaceSlugs: []string{"speakeasy-workspace"},
+			},
+		},
+	}
 	ctx, instance := newTestAuthService(t, userInfo)
 
 	err := instance.createTestUser(ctx, userInfo)

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -238,8 +238,7 @@ func TestService_Info(t *testing.T) {
 
 // TestService_Info_AdminOrgRelationshipUpserted verifies that an admin user who has no
 // pre-existing record in organization_user_relationships gets one created when Info is
-// called. Previously, admins were excluded from the upsert; this test guards against
-// that regression.
+// called for one of their own organizations.
 func TestService_Info_AdminOrgRelationshipUpserted(t *testing.T) {
 	t.Parallel()
 
@@ -295,4 +294,60 @@ func TestService_Info_AdminOrgRelationshipUpserted(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, exists, "expected org-user relationship to be upserted by Info call")
+}
+
+// TestService_Info_AdminVisitingCustomerOrgDoesNotUpsertRelationship verifies that
+// when an admin uses the org override to view a customer org, no relationship row is
+// written for that customer org. Only the admin's own orgs should be upserted.
+func TestService_Info_AdminVisitingCustomerOrgDoesNotUpsertRelationship(t *testing.T) {
+	t.Parallel()
+
+	// adminMockUserInfo gives the admin a single own org: admin-org-123.
+	userInfo := adminMockUserInfo()
+	ctx, instance := newTestAuthService(t, userInfo)
+
+	err := instance.createTestUser(ctx, userInfo)
+	require.NoError(t, err)
+
+	// Create the admin's own org so the projects loop in Info can resolve it.
+	err = instance.createTestOrganization(ctx, userInfo.Organizations[0])
+	require.NoError(t, err)
+
+	// Simulate the admin override: the session's active org is a customer org that
+	// does not appear in the admin's userInfo.Organizations list.
+	const customerOrgID = "customer-org-override-456"
+	session := sessions.Session{
+		SessionID:            "admin-customer-session-id",
+		UserID:               userInfo.UserID,
+		ActiveOrganizationID: customerOrgID,
+	}
+	err = instance.sessionManager.StoreSession(ctx, session)
+	require.NoError(t, err)
+
+	authCtx := &contextvalues.AuthContext{
+		SessionID:            &session.SessionID,
+		UserID:               session.UserID,
+		ActiveOrganizationID: session.ActiveOrganizationID,
+		AccountType:          "test",
+		ProjectID:            nil,
+		OrganizationSlug:     "",
+		Email:                &userInfo.Email,
+		ProjectSlug:          nil,
+		APIKeyScopes:         nil,
+	}
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	result, err := instance.service.Info(ctx, &gen.InfoPayload{SessionToken: nil})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsAdmin)
+
+	// No relationship row must be created for the customer org.
+	queries := orgRepo.New(instance.conn)
+	exists, err := queries.HasOrganizationUserRelationship(ctx, orgRepo.HasOrganizationUserRelationshipParams{
+		OrganizationID: customerOrgID,
+		UserID:         userInfo.UserID,
+	})
+	require.NoError(t, err)
+	require.False(t, exists, "admin must not be upserted into a customer org's relationship table")
 }

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 )
 
 func TestService_Info(t *testing.T) {
@@ -233,4 +234,65 @@ func TestService_Info(t *testing.T) {
 		require.Equal(t, "Default", project.Name)
 		require.Equal(t, "default", string(project.Slug))
 	})
+}
+
+// TestService_Info_AdminOrgRelationshipUpserted verifies that an admin user who has no
+// pre-existing record in organization_user_relationships gets one created when Info is
+// called. Previously, admins were excluded from the upsert; this test guards against
+// that regression.
+func TestService_Info_AdminOrgRelationshipUpserted(t *testing.T) {
+	t.Parallel()
+
+	userInfo := adminMockUserInfo()
+	ctx, instance := newTestAuthService(t, userInfo)
+
+	err := instance.createTestUser(ctx, userInfo)
+	require.NoError(t, err)
+
+	err = instance.createTestOrganization(ctx, userInfo.Organizations[0])
+	require.NoError(t, err)
+
+	queries := orgRepo.New(instance.conn)
+
+	// Confirm no relationship exists before the Info call.
+	exists, err := queries.HasOrganizationUserRelationship(ctx, orgRepo.HasOrganizationUserRelationshipParams{
+		OrganizationID: userInfo.Organizations[0].ID,
+		UserID:         userInfo.UserID,
+	})
+	require.NoError(t, err)
+	require.False(t, exists, "expected no org-user relationship before Info call")
+
+	session := sessions.Session{
+		SessionID:            "admin-session-id",
+		UserID:               userInfo.UserID,
+		ActiveOrganizationID: userInfo.Organizations[0].ID,
+	}
+	err = instance.sessionManager.StoreSession(ctx, session)
+	require.NoError(t, err)
+
+	authCtx := &contextvalues.AuthContext{
+		SessionID:            &session.SessionID,
+		UserID:               session.UserID,
+		ActiveOrganizationID: session.ActiveOrganizationID,
+		AccountType:          "test",
+		ProjectID:            nil,
+		OrganizationSlug:     "",
+		Email:                &userInfo.Email,
+		ProjectSlug:          nil,
+		APIKeyScopes:         nil,
+	}
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	result, err := instance.service.Info(ctx, &gen.InfoPayload{SessionToken: nil})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsAdmin)
+
+	// The upsert must have created the relationship.
+	exists, err = queries.HasOrganizationUserRelationship(ctx, orgRepo.HasOrganizationUserRelationshipParams{
+		OrganizationID: userInfo.Organizations[0].ID,
+		UserID:         userInfo.UserID,
+	})
+	require.NoError(t, err)
+	require.True(t, exists, "expected org-user relationship to be upserted by Info call")
 }

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -236,6 +236,66 @@ func TestService_Info(t *testing.T) {
 	})
 }
 
+// TestService_Info_RegularUserOrgRelationshipUpserted verifies that a standard (non-admin)
+// user who belongs to a non-speakeasy org gets an organization_user_relationships row
+// created when Info is called. This is the common path for all real customers.
+func TestService_Info_RegularUserOrgRelationshipUpserted(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	ctx, instance := newTestAuthService(t, userInfo)
+
+	err := instance.createTestUser(ctx, userInfo)
+	require.NoError(t, err)
+
+	err = instance.createTestOrganization(ctx, userInfo.Organizations[0])
+	require.NoError(t, err)
+
+	queries := orgRepo.New(instance.conn)
+
+	// Confirm no relationship exists before the Info call.
+	exists, err := queries.HasOrganizationUserRelationship(ctx, orgRepo.HasOrganizationUserRelationshipParams{
+		OrganizationID: userInfo.Organizations[0].ID,
+		UserID:         userInfo.UserID,
+	})
+	require.NoError(t, err)
+	require.False(t, exists, "expected no org-user relationship before Info call")
+
+	session := sessions.Session{
+		SessionID:            "regular-user-session-id",
+		UserID:               userInfo.UserID,
+		ActiveOrganizationID: userInfo.Organizations[0].ID,
+	}
+	err = instance.sessionManager.StoreSession(ctx, session)
+	require.NoError(t, err)
+
+	authCtx := &contextvalues.AuthContext{
+		SessionID:            &session.SessionID,
+		UserID:               session.UserID,
+		ActiveOrganizationID: session.ActiveOrganizationID,
+		AccountType:          "test",
+		ProjectID:            nil,
+		OrganizationSlug:     "",
+		Email:                &userInfo.Email,
+		ProjectSlug:          nil,
+		APIKeyScopes:         nil,
+	}
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	result, err := instance.service.Info(ctx, &gen.InfoPayload{SessionToken: nil})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsAdmin)
+
+	// The upsert must have created the relationship.
+	exists, err = queries.HasOrganizationUserRelationship(ctx, orgRepo.HasOrganizationUserRelationshipParams{
+		OrganizationID: userInfo.Organizations[0].ID,
+		UserID:         userInfo.UserID,
+	})
+	require.NoError(t, err)
+	require.True(t, exists, "expected org-user relationship to be upserted by Info call")
+}
+
 // TestService_Info_AdminOrgRelationshipUpserted verifies that an admin user who has no
 // pre-existing record in organization_user_relationships gets one created when Info is
 // called for their speakeasy-team org.


### PR DESCRIPTION
## Summary

- Removes the \`!userInfo.Admin\` guard that was preventing admin users from getting a row in \`organization_user_relationships\` when visiting their own org (e.g. speakeasy-team)
- Adds a \`belongsToActiveOrg\` check so the upsert is **skipped when an admin is visiting a customer org** via the org override feature — preventing admin user records from being written into customer orgs
- Non-admin users are unaffected (upsert always runs for them)

| User type | Active org | Upserted? |
|---|---|---|
| Regular user | their own org | ✅ always |
| Admin | own org (speakeasy-team) | ✅ yes |
| Admin | customer org via override | ❌ no |

## Test plan

- [ ] \`TestService_Info_AdminOrgRelationshipUpserted\` — admin with speakeasy-team as active org gets a relationship row created
- [ ] \`TestService_Info_AdminVisitingCustomerOrgDoesNotUpsertRelationship\` — admin visiting a customer org via override does **not** get a relationship row written for that org

🤖 Generated with [Claude Code](https://claude.com/claude-code)