### PR TITLE
chore: improve ci-gate failure messages with named job results

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1170,14 +1170,42 @@ jobs:
     steps:
       - name: Check results
         run: |
-          results="${{ join(needs.*.result, ' ') }}"
-          for result in $results; do
+          failed=()
+
+          check() {
+            local name="$1"
+            local result="$2"
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-              echo "CI failed: found job with result '$result'"
-              exit 1
+              failed+=("❌ $name ($result)")
             fi
-          done
-          echo "All CI checks passed or were skipped."
+          }
+
+          check "server-build-lint"    "${{ needs.server-build-lint.result }}"
+          check "server-test"          "${{ needs.server-test.result }}"
+          check "docker-build-server"  "${{ needs.docker-build-server.result }}"
+          check "docker-build-client"  "${{ needs.docker-build-client.result }}"
+          check "client-build-lint"    "${{ needs.client-build-lint.result }}"
+          check "ts-sdk-build-lint"    "${{ needs.ts-sdk-build-lint.result }}"
+          check "cli-build-lint"       "${{ needs.cli-build-lint.result }}"
+          check "plog-build-lint"      "${{ needs.plog-build-lint.result }}"
+          check "functions-build-host" "${{ needs.functions-build-host.result }}"
+          check "functions-image"      "${{ needs.functions-image.result }}"
+          check "ts-framework-test"    "${{ needs.ts-framework-test.result }}"
+          check "elements-build-lint"  "${{ needs.elements-build-lint.result }}"
+          check "elements-test"        "${{ needs.elements-test.result }}"
+          check "elements-examples"    "${{ needs.elements-examples.result }}"
+          check "atlas-lint"           "${{ needs.atlas-lint.result }}"
+          check "atlas-push"           "${{ needs.atlas-push.result }}"
+
+          if [[ ${#failed[@]} -gt 0 ]]; then
+            echo "CI failed. The following checks did not pass:"
+            for item in "${failed[@]}"; do
+              echo "  $item"
+            done
+            exit 1
+          fi
+
+          echo "✅ All CI checks passed or were skipped."
 
   dispatch-release:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1171,32 +1171,9 @@ jobs:
       - name: Check results
         run: |
           failed=()
-
-          check() {
-            local name="$1"
-            local result="$2"
-            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-              failed+=("❌ $name ($result)")
-            fi
-          }
-
-          check "changes"              "${{ needs.changes.result }}"
-          check "server-build-lint"    "${{ needs.server-build-lint.result }}"
-          check "server-test"          "${{ needs.server-test.result }}"
-          check "docker-build-server"  "${{ needs.docker-build-server.result }}"
-          check "docker-build-client"  "${{ needs.docker-build-client.result }}"
-          check "client-build-lint"    "${{ needs.client-build-lint.result }}"
-          check "ts-sdk-build-lint"    "${{ needs.ts-sdk-build-lint.result }}"
-          check "cli-build-lint"       "${{ needs.cli-build-lint.result }}"
-          check "plog-build-lint"      "${{ needs.plog-build-lint.result }}"
-          check "functions-build-host" "${{ needs.functions-build-host.result }}"
-          check "functions-image"      "${{ needs.functions-image.result }}"
-          check "ts-framework-test"    "${{ needs.ts-framework-test.result }}"
-          check "elements-build-lint"  "${{ needs.elements-build-lint.result }}"
-          check "elements-test"        "${{ needs.elements-test.result }}"
-          check "elements-examples"    "${{ needs.elements-examples.result }}"
-          check "atlas-lint"           "${{ needs.atlas-lint.result }}"
-          check "atlas-push"           "${{ needs.atlas-push.result }}"
+          while IFS= read -r line; do
+            failed+=("$line")
+          done < <(echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | "❌ \(.key) (\(.value.result))"')
 
           if [[ ${#failed[@]} -gt 0 ]]; then
             echo "CI failed. The following checks did not pass:"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1169,11 +1169,14 @@ jobs:
       - atlas-push
     steps:
       - name: Check results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
+          failed_output=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | "❌ \(.key) (\(.value.result))"') || { echo "Error: jq command failed"; exit 1; }
           failed=()
           while IFS= read -r line; do
-            failed+=("$line")
-          done < <(echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | "❌ \(.key) (\(.value.result))"')
+            [[ -n "$line" ]] && failed+=("$line")
+          done <<< "$failed_output"
 
           if [[ ${#failed[@]} -gt 0 ]]; then
             echo "CI failed. The following checks did not pass:"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1180,6 +1180,7 @@ jobs:
             fi
           }
 
+          check "changes"              "${{ needs.changes.result }}"
           check "server-build-lint"    "${{ needs.server-build-lint.result }}"
           check "server-test"          "${{ needs.server-test.result }}"
           check "docker-build-server"  "${{ needs.docker-build-server.result }}"

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -1,5 +1,3 @@
-// TEST: deliberate type error to verify ci-gate failure message
-const _ciGateTest: number = "this is not a number";
 import { MCPCard } from "@/components/mcp/MCPCard";
 import { Page } from "@/components/page-layout";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -1,3 +1,5 @@
+// TEST: deliberate type error to verify ci-gate failure message
+const _ciGateTest: number = "this is not a number";
 import { MCPCard } from "@/components/mcp/MCPCard";
 import { Page } from "@/components/page-layout";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -1,3 +1,5 @@
+// TEST: deliberate type error to verify ci-gate dynamic check output
+const _ciGateTest: number = "this is not a number";
 import { MCPCard } from "@/components/mcp/MCPCard";
 import { Page } from "@/components/page-layout";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -1,5 +1,3 @@
-// TEST: deliberate type error to verify ci-gate dynamic check output
-const _ciGateTest: number = "this is not a number";
 import { MCPCard } from "@/components/mcp/MCPCard";
 import { Page } from "@/components/page-layout";
 import { Skeleton } from "@/components/ui/skeleton";


### PR DESCRIPTION
## Summary

- Replaces `join(needs.*.result, ' ')` anonymous list with per-job named checks in the `ci-gate` step
- On failure, the gate now prints each failing job by name with a ❌ cross, e.g.:
  ```
  CI failed. The following checks did not pass:
    ❌ client-build-lint (failure)
    ❌ elements-test (cancelled)
  ```
- On success, prints `✅ All CI checks passed or were skipped.`


Example screenshot:
<img width="1814" height="360" alt="CleanShot 2026-04-15 at 10 14 18@2x" src="https://github.com/user-attachments/assets/ec6ff1a7-a2d3-4984-93e1-4a9bf72b2770" />


## Test plan

- [ ] This PR intentionally includes a deliberate TypeScript type error in `Home.tsx` to trigger `client-build-lint` failure
- [ ] Verify the CI Gate step output shows `❌ client-build-lint (failure)` (not an anonymous list)
- [ ] After confirming the message format, the test commit will be reverted before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)