### PR TITLE
fix: apply MOCK_IDP_USER_ADMIN flag in OIDC mode

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -104,6 +104,7 @@ OPENROUTER_DEV_KEY = "unset"
 ## MOCK_IDP_PORT is auto-remapped by `mise work:init` for parallel worktrees.
 MOCK_IDP_HOST = "localhost"
 MOCK_IDP_PORT = "35291"
+MOCK_IDP_USER_ADMIN = "unset"
 SPEAKEASY_SERVER_ADDRESS = "http://{{env.MOCK_IDP_HOST}}:{{env.MOCK_IDP_PORT}}"
 SPEAKEASY_SECRET_KEY = "test-secret"
 ## The following variables enable OIDC mode for the mock IDP, which

--- a/mise.toml
+++ b/mise.toml
@@ -104,7 +104,7 @@ OPENROUTER_DEV_KEY = "unset"
 ## MOCK_IDP_PORT is auto-remapped by `mise work:init` for parallel worktrees.
 MOCK_IDP_HOST = "localhost"
 MOCK_IDP_PORT = "35291"
-MOCK_IDP_USER_ADMIN = "unset"
+MOCK_IDP_USER_ADMIN = "true"
 SPEAKEASY_SERVER_ADDRESS = "http://{{env.MOCK_IDP_HOST}}:{{env.MOCK_IDP_PORT}}"
 SPEAKEASY_SECRET_KEY = "test-secret"
 ## The following variables enable OIDC mode for the mock IDP, which

--- a/mock-speakeasy-idp/mockidp.go
+++ b/mock-speakeasy-idp/mockidp.go
@@ -452,6 +452,7 @@ func (s *server) handleOidcCallback(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[oidc/callback] authenticated sub=%s email=%s org=%s", claims.Sub, claims.Email, claims.OrgID)
 
 	userSess := mapClaimsToSession(claims)
+	userSess.User.Admin = s.cfg.User.Admin
 
 	// Extract the WorkOS session ID from the access token (JWT) for logout.
 	var workosSessionID string
@@ -540,6 +541,7 @@ func (s *server) handleInviteAuthCallback(w http.ResponseWriter, r *http.Request
 	log.Printf("[invite/callback] authenticated sub=%s email=%s org=%s", claims.Sub, claims.Email, claims.OrgID)
 
 	userSess := mapClaimsToSession(claims)
+	userSess.User.Admin = s.cfg.User.Admin
 	var workosSessionID string
 	if sid, err := extractJWTClaim(authResp.AccessToken, "sid"); err == nil {
 		workosSessionID = sid


### PR DESCRIPTION
## Summary

- `mapClaimsToSession` hardcoded `Admin: false` for all OIDC-authenticated users
- The `MOCK_IDP_USER_ADMIN` env var (default `true`) was already read into `cfg.User.Admin` but never applied in OIDC mode
- Apply `s.cfg.User.Admin` to the session in both `handleOidcCallback` and `handleInviteAuthCallback` after `mapClaimsToSession()`

WorkOS has no concept of a Speakeasy admin flag, so this env var is the only override mechanism available. No new config is needed.

## Test plan

- [ ] Run mock IDP in OIDC mode, log in via WorkOS — verify user has `admin=true` in validate response
- [ ] Set `MOCK_IDP_USER_ADMIN=false` in `mise.local.toml`, log in — verify `admin=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)