### PR TITLE
fix: pass isAdmin to scope override header in production

### DIFF
--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -26,7 +26,7 @@ import { useSessionInfo } from "@gram/client/react-query";
 import { Icon } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
-import { setFetcherIsAdmin } from "@/contexts/Sdk";
+import { useIsAdminRef } from "@/contexts/Sdk";
 import { createContext, useContext, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -224,6 +224,7 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const { session, error, status } = useSessionData();
+  const isAdminRef = useIsAdminRef();
 
   const isLoading = status === "pending";
 
@@ -231,7 +232,7 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   usePylonInAppChat(session?.user);
 
   // Sync isAdmin into the SDK fetcher so it can attach X-Gram-Scope-Override in production.
-  setFetcherIsAdmin(session?.user.isAdmin ?? false);
+  isAdminRef.current = session?.user.isAdmin ?? false;
 
   // you need something like this so you don't redirect with empty session too soon
   // isLoading is not synchronized with the session data actually being populated, so we need to wait for the session to actually finish loading

--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -26,6 +26,7 @@ import { useSessionInfo } from "@gram/client/react-query";
 import { Icon } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
+import { setFetcherIsAdmin } from "@/contexts/Sdk";
 import { createContext, useContext, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -228,6 +229,9 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
 
   useIdentifyUserForTelemetry(session?.user);
   usePylonInAppChat(session?.user);
+
+  // Sync isAdmin into the SDK fetcher so it can attach X-Gram-Scope-Override in production.
+  setFetcherIsAdmin(session?.user.isAdmin ?? false);
 
   // you need something like this so you don't redirect with empty session too soon
   // isLoading is not synchronized with the session data actually being populated, so we need to wait for the session to actually finish loading

--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -12,6 +12,14 @@ import { createContext, useContext, useEffect, useMemo, useRef } from "react";
 import { useLocation, useParams } from "react-router";
 import { useTelemetry } from "./Telemetry";
 
+// Mutable ref updated by AuthHandler once isAdmin is known from the session.
+// SdkProvider cannot call useIsAdmin() directly because it wraps AuthProvider
+// (AuthProvider needs QueryClientProvider which SdkProvider supplies).
+const _isAdminRef = { current: false };
+export function setFetcherIsAdmin(value: boolean): void {
+  _isAdminRef.current = value;
+}
+
 export const SdkContext = createContext<Gram>({} as Gram);
 
 export const useSdkClient = () => {
@@ -75,7 +83,9 @@ export const SdkProvider = ({ children }: { children: React.ReactNode }) => {
           newRequest.headers.set("gram-project", projectSlug);
         }
 
-        const scopeOverride = getRBACScopeOverrideHeader();
+        const scopeOverride = getRBACScopeOverrideHeader(
+          import.meta.env.DEV || _isAdminRef.current,
+        );
         if (scopeOverride) {
           newRequest.headers.set("X-Gram-Scope-Override", scopeOverride);
         }

--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -12,13 +12,14 @@ import { createContext, useContext, useEffect, useMemo, useRef } from "react";
 import { useLocation, useParams } from "react-router";
 import { useTelemetry } from "./Telemetry";
 
-// Mutable ref updated by AuthHandler once isAdmin is known from the session.
 // SdkProvider cannot call useIsAdmin() directly because it wraps AuthProvider
-// (AuthProvider needs QueryClientProvider which SdkProvider supplies).
-const _isAdminRef = { current: false };
-export function setFetcherIsAdmin(value: boolean): void {
-  _isAdminRef.current = value;
-}
+// (AuthProvider needs QueryClientProvider which SdkProvider supplies). Instead,
+// SdkProvider owns a ref and exposes it via context so AuthHandler can write isAdmin
+// into it, making the current value available to the fetcher on every request.
+const IsAdminContext = createContext<React.MutableRefObject<boolean>>({
+  current: false,
+});
+export const useIsAdminRef = () => useContext(IsAdminContext);
 
 export const SdkContext = createContext<Gram>({} as Gram);
 
@@ -69,6 +70,7 @@ export const SdkProvider = ({ children }: { children: React.ReactNode }) => {
   const { projectSlug } = useSlugs();
   const telemetry = useTelemetry();
 
+  const isAdminRef = useRef(false);
   const previousProjectSlug = useRef(projectSlug);
 
   // Memoize the httpClient and gram instances
@@ -84,7 +86,7 @@ export const SdkProvider = ({ children }: { children: React.ReactNode }) => {
         }
 
         const scopeOverride = getRBACScopeOverrideHeader(
-          import.meta.env.DEV || _isAdminRef.current,
+          import.meta.env.DEV || isAdminRef.current,
         );
         if (scopeOverride) {
           newRequest.headers.set("X-Gram-Scope-Override", scopeOverride);
@@ -139,11 +141,13 @@ export const SdkProvider = ({ children }: { children: React.ReactNode }) => {
   }, [projectSlug, queryClient]);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <GramProvider client={gram}>
-        <SdkContext.Provider value={gram}>{children}</SdkContext.Provider>
-      </GramProvider>
-    </QueryClientProvider>
+    <IsAdminContext.Provider value={isAdminRef}>
+      <QueryClientProvider client={queryClient}>
+        <GramProvider client={gram}>
+          <SdkContext.Provider value={gram}>{children}</SdkContext.Provider>
+        </GramProvider>
+      </QueryClientProvider>
+    </IsAdminContext.Provider>
   );
 };
 


### PR DESCRIPTION
## Summary

- \`getRBACScopeOverrideHeader()\` was called with no argument in the SDK fetcher, defaulting to \`import.meta.env.DEV\` — silently dropping \`X-Gram-Scope-Override\` for admin users in production
- \`SdkProvider\` cannot call \`useIsAdmin()\` directly because it wraps \`AuthProvider\`, which itself depends on \`QueryClientProvider\` from \`SdkProvider\` (circular dependency)
- Fix: \`SdkProvider\` owns a \`useRef(false)\` and exposes it via \`IsAdminContext\`; \`AuthHandler\` reads the ref via \`useIsAdminRef()\` and writes \`isAdmin\` into it on each render so the SDK fetcher can read the current value on every request

## Test plan

- [ ] Log in as an admin user in production (or staging)
- [ ] Enable a scope override via the RBAC dev toolbar
- [ ] Confirm \`X-Gram-Scope-Override\` header is present on API requests in devtools
- [ ] Confirm non-admin users in production still cannot set the override header

🤖 Generated with [Claude Code](https://claude.com/claude-code)