### PR TITLE
feat: make ai Insights a global, always-visible top-bar action

### DIFF
--- a/.changeset/global-ai-insights.md
+++ b/.changeset/global-ai-insights.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Surface AI Insights as a static button in the top breadcrumb bar across every project page. Pages that need a custom prompt or tool set declare it with `<InsightsConfig />`; everywhere else the global default applies.

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -1,10 +1,12 @@
 import { useIsAdmin, useOrganization, useSession } from "@/contexts/Auth.tsx";
 import { useSdkClient } from "@/contexts/Sdk.tsx";
+import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { Modal, ModalProvider } from "@speakeasy-api/moonshine";
 import { ShieldAlert } from "lucide-react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
 import { AppSidebar } from "./app-sidebar.tsx";
+import { InsightsProvider } from "./insights-sidebar.tsx";
 import { OrgSidebar } from "./org-sidebar.tsx";
 import { TopHeader } from "./top-header.tsx";
 import { SidebarInset, SidebarProvider } from "./ui/sidebar.tsx";
@@ -94,15 +96,59 @@ const AppLayoutContent = ({
       <div className="flex w-full flex-1 overflow-hidden pt-2">
         <AppSidebar variant="inset" />
         <SidebarInset>
-          <Outlet />
-          <Modal
-            closable
-            className="h-full max-h-[450px] min-h-auto w-9/12 max-w-[1100px] min-w-auto rounded-sm p-0 2xl:w-2/3 2xl:max-w-[1000px]"
-            layout="custom"
-          />
+          <GlobalInsightsWrapper>
+            <Outlet />
+            <Modal
+              closable
+              className="h-full max-h-[450px] min-h-auto w-9/12 max-w-[1100px] min-w-auto rounded-sm p-0 2xl:w-2/3 2xl:max-w-[1000px]"
+              layout="custom"
+            />
+          </GlobalInsightsWrapper>
         </SidebarInset>
       </div>
     </div>
+  );
+};
+
+/**
+ * Wraps every project-scoped page in a single InsightsProvider so the
+ * AI Insights trigger lives statically in the top breadcrumb bar across
+ * the whole project app. Pages mount <InsightsConfig /> to override the
+ * defaults (custom prompt/suggestions/MCP filter).
+ */
+const GlobalInsightsWrapper = ({ children }: { children: React.ReactNode }) => {
+  // Default config: include all observability tools (no filter), so the
+  // global assistant can answer about anything. Pages narrow this via
+  // <InsightsConfig mcpConfig={...} /> when they want a focused tool set.
+  const includeAll = useCallback(() => true, []);
+  const mcpConfig = useObservabilityMcpConfig({ toolsToInclude: includeAll });
+
+  return (
+    <InsightsProvider
+      mcpConfig={mcpConfig}
+      title="Ask AI"
+      subtitle="Your assistant for exploring Gram — logs, traces, toolsets, and more."
+      suggestions={[
+        {
+          title: "Summarize errors",
+          label: "Recent error trends",
+          prompt:
+            "Summarize the most common error patterns in the last 24 hours.",
+        },
+        {
+          title: "Top tool calls",
+          label: "Most-called tools",
+          prompt: "Which tools have been called most often this week?",
+        },
+        {
+          title: "Slow tools",
+          label: "Latency outliers",
+          prompt: "Find tools with the slowest p95 latency in the last day.",
+        },
+      ]}
+    >
+      {children}
+    </InsightsProvider>
   );
 };
 

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -2,28 +2,55 @@ import type { ElementsConfig } from "@gram-ai/elements";
 import { Chat, GramElementsProvider } from "@gram-ai/elements";
 import { useMoonshineConfig } from "@speakeasy-api/moonshine";
 import { Wand2, ChevronRight, Sparkles, Terminal } from "lucide-react";
-import { useState, useMemo, createContext, useContext } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { cn } from "@/lib/utils";
 import { devObservabilityMcpMissing } from "@/hooks/useObservabilityMcpConfig";
 
-// Context for sidebar state. `available` lets descendants detect whether
-// they're inside an InsightsSidebar provider — so a page-header-level
-// trigger can self-hide on pages that aren't wrapped.
-const InsightsContext = createContext<{
+/**
+ * Per-page overrides for the global AI Insights panel. Pages mount
+ * <InsightsConfig {...} /> to register custom title/subtitle/suggestions
+ * /context/mcpConfig; on unmount, the global defaults take over again.
+ */
+export interface InsightsConfigOptions {
+  mcpConfig?: Omit<ElementsConfig, "variant" | "welcome" | "theme">;
+  title?: string;
+  subtitle?: string;
+  suggestions?: Array<{
+    title: string;
+    label: string;
+    prompt: string;
+  }>;
+  contextInfo?: string;
+  /** Hide the trigger button (e.g., when logs are disabled on this page). */
+  hideTrigger?: boolean;
+}
+
+interface InsightsContextValue {
   available: boolean;
   isExpanded: boolean;
   setIsExpanded: (expanded: boolean) => void;
-}>({
+  /** Pages call this to register a per-page config override. Pass null to
+   *  clear (typically on unmount of <InsightsConfig />). */
+  setOverride: (override: InsightsConfigOptions | null) => void;
+}
+
+const InsightsContext = createContext<InsightsContextValue>({
   available: false,
   isExpanded: false,
   setIsExpanded: () => {},
+  setOverride: () => {},
 });
 
 /**
- * Hook to access the insights sidebar state.
- * Returns { available, isExpanded, setIsExpanded } to allow pages to adapt
- * their layout and control the sidebar. `available` is false when no
- * InsightsSidebar ancestor exists.
+ * Hook to access the insights sidebar state. `available` is false when no
+ * InsightsProvider ancestor exists.
  */
 export function useInsightsState() {
   return useContext(InsightsContext);
@@ -31,9 +58,9 @@ export function useInsightsState() {
 
 /**
  * Header-bar trigger for opening the AI Insights sidebar. Renders only
- * when inside an InsightsSidebar provider so it can be slotted globally
- * (e.g. into PageHeaderBreadcrumbs) without appearing on pages that don't
- * use insights.
+ * when inside an InsightsProvider so it can be slotted globally (e.g. into
+ * PageHeaderBreadcrumbs) without appearing on pages that opt out via
+ * hideTrigger.
  */
 export function InsightsTrigger({ className }: { className?: string }) {
   const { available, isExpanded, setIsExpanded } = useInsightsState();
@@ -56,49 +83,68 @@ export function InsightsTrigger({ className }: { className?: string }) {
   );
 }
 
-interface InsightsSidebarProps {
-  /** Base MCP config from useObservabilityMcpConfig */
+/**
+ * Page-level config override. Mount this anywhere inside an InsightsProvider
+ * to swap in a custom prompt/suggestions/MCP filter. Cleans up on unmount,
+ * restoring the provider's defaults.
+ */
+export function InsightsConfig(options: InsightsConfigOptions) {
+  const { setOverride } = useInsightsState();
+  // Stringify the options so the effect re-fires only when content changes,
+  // not on every parent render that creates a fresh object identity.
+  const key = JSON.stringify(options);
+  useEffect(() => {
+    setOverride(options);
+    return () => setOverride(null);
+  }, [key, setOverride, options]);
+  return null;
+}
+
+interface InsightsProviderProps {
+  /** Default MCP config used when no <InsightsConfig> override is mounted. */
   mcpConfig: Omit<ElementsConfig, "variant" | "welcome" | "theme">;
-  /** Title shown in the chat welcome screen */
+  /** Default welcome title. */
   title: string;
-  /** Subtitle shown in the chat welcome screen */
+  /** Default welcome subtitle. */
   subtitle: string;
-  /** Suggestion prompts for quick actions */
+  /** Default suggestion prompts. */
   suggestions?: Array<{
     title: string;
     label: string;
     prompt: string;
   }>;
-  /** Default expanded state */
+  /** Default expanded state. */
   defaultExpanded?: boolean;
-  /** Context information to pass to the chat (like current date range) */
-  contextInfo?: string;
-  /** Hide the trigger button (e.g., when logs are disabled) */
-  hideTrigger?: boolean;
-  /** Main content to render alongside the sidebar */
+  /** Children rendered alongside the sidebar (page content). */
   children: React.ReactNode;
 }
 
 const SIDEBAR_MAX_WIDTH = 670;
 const SIDEBAR_MAX_PERCENT = 40; // Never more than 40% of viewport
 
-export function InsightsSidebar({
-  mcpConfig,
-  title,
-  subtitle,
-  suggestions = [],
+export function InsightsProvider({
+  mcpConfig: defaultMcpConfig,
+  title: defaultTitle,
+  subtitle: defaultSubtitle,
+  suggestions: defaultSuggestions = [],
   defaultExpanded = false,
-  contextInfo,
-  hideTrigger = false,
   children,
-}: InsightsSidebarProps) {
+}: InsightsProviderProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const [override, setOverride] = useState<InsightsConfigOptions | null>(null);
   const { theme } = useMoonshineConfig();
 
-  // Calculate responsive sidebar width (min of fixed width or 40% of viewport)
+  // Resolve effective values: per-page override wins, fall back to defaults.
+  const mcpConfig = override?.mcpConfig ?? defaultMcpConfig;
+  const title = override?.title ?? defaultTitle;
+  const subtitle = override?.subtitle ?? defaultSubtitle;
+  const suggestions = override?.suggestions ?? defaultSuggestions;
+  const contextInfo = override?.contextInfo;
+  const hideTrigger = override?.hideTrigger ?? false;
+
   const sidebarWidth = `min(${SIDEBAR_MAX_WIDTH}px, ${SIDEBAR_MAX_PERCENT}vw)`;
 
-  // Build system prompt with context info
+  // Build system prompt with optional context info.
   const baseInstructions = `You are a helpful assistant for analyzing logs in Gram, an AI observability platform. Focus exclusively on log search and analysis.
 
 The current date is ${new Date().toISOString().split("T")[0]}.
@@ -141,9 +187,19 @@ When the user asks about "current period", "selected period", "this timeframe", 
     [mcpConfig, title, subtitle, suggestions, theme, systemPrompt],
   );
 
-  const contextValue = useMemo(
-    () => ({ available: !hideTrigger, isExpanded, setIsExpanded }),
-    [hideTrigger, isExpanded],
+  const handleSetOverride = useCallback(
+    (next: InsightsConfigOptions | null) => setOverride(next),
+    [],
+  );
+
+  const contextValue = useMemo<InsightsContextValue>(
+    () => ({
+      available: !hideTrigger,
+      isExpanded,
+      setIsExpanded,
+      setOverride: handleSetOverride,
+    }),
+    [hideTrigger, isExpanded, handleSetOverride],
   );
 
   return (
@@ -169,8 +225,7 @@ When the user asks about "current period", "selected period", "this timeframe", 
         )}
 
         {/* Sidebar panel - fixed position that slides in.
-            Note: the trigger for opening this panel now lives in the top
-            breadcrumb bar via <InsightsTrigger />, rendered by PageHeader. */}
+            Trigger lives in the top breadcrumb bar via <InsightsTrigger />. */}
         <div
           className={cn(
             "bg-background border-border fixed top-0 right-0 bottom-0 z-30 flex flex-col border-l shadow-xl transition-transform duration-300 ease-in-out",
@@ -218,3 +273,10 @@ When the user asks about "current period", "selected period", "this timeframe", 
     </InsightsContext.Provider>
   );
 }
+
+/**
+ * @deprecated Use <InsightsProvider> at the app shell level + <InsightsConfig>
+ * on individual pages that need custom prompts. This alias is kept temporarily
+ * to avoid breaking out-of-tree consumers; remove after migration.
+ */
+export const InsightsSidebar = InsightsProvider;

--- a/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
@@ -1,4 +1,4 @@
-import { InsightsSidebar } from "@/components/insights-sidebar";
+import { InsightsConfig } from "@/components/insights-sidebar";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { Page } from "@/components/page-layout";
@@ -327,33 +327,34 @@ export default function ChatLogs() {
   }, [timeRange.from, timeRange.to, resolutionStatus, searchQuery]);
 
   return (
-    <InsightsSidebar
-      mcpConfig={mcpConfig}
-      title="How can I help you debug?"
-      subtitle="Search agent sessions, analyze failures, or explore logs"
-      contextInfo={dateRangeContext}
-      hideTrigger={isLogsDisabled}
-      suggestions={[
-        {
-          title: "Failed Chats",
-          label: "Analyze failed chats",
-          prompt:
-            "Show me recent agent sessions that failed. What patterns do you see in the failures?",
-        },
-        {
-          title: "Search Logs",
-          label: "Search raw logs",
-          prompt:
-            "Search the raw telemetry logs for errors or warnings in the current period",
-        },
-        {
-          title: "Debug Session",
-          label: "Debug a specific chat",
-          prompt:
-            "Help me debug an agent session. Search both the chat data and raw logs to understand what happened.",
-        },
-      ]}
-    >
+    <>
+      <InsightsConfig
+        mcpConfig={mcpConfig}
+        title="How can I help you debug?"
+        subtitle="Search agent sessions, analyze failures, or explore logs"
+        contextInfo={dateRangeContext}
+        hideTrigger={isLogsDisabled}
+        suggestions={[
+          {
+            title: "Failed Chats",
+            label: "Analyze failed chats",
+            prompt:
+              "Show me recent agent sessions that failed. What patterns do you see in the failures?",
+          },
+          {
+            title: "Search Logs",
+            label: "Search raw logs",
+            prompt:
+              "Search the raw telemetry logs for errors or warnings in the current period",
+          },
+          {
+            title: "Debug Session",
+            label: "Debug a specific chat",
+            prompt:
+              "Help me debug an agent session. Search both the chat data and raw logs to understand what happened.",
+          },
+        ]}
+      />
       <ChatLogsContent
         dateRange={dateRange}
         setDateRangeParam={setDateRangeParam}
@@ -382,7 +383,7 @@ export default function ChatLogs() {
         total={total}
         onDeleteChat={handleDeleteChat}
       />
-    </InsightsSidebar>
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1,7 +1,7 @@
 import { EditServerNameDialog } from "./EditServerNameDialog";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { EnterpriseGate } from "@/components/enterprise-gate";
-import { InsightsSidebar } from "@/components/insights-sidebar";
+import { InsightsConfig } from "@/components/insights-sidebar";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { Page } from "@/components/page-layout";
 import { ErrorAlert } from "@/components/ui/alert";
@@ -570,12 +570,13 @@ function HooksContent() {
   const isLoading = isFetching && groupedTraces.length === 0;
 
   return (
-    <InsightsSidebar
-      mcpConfig={mcpConfig}
-      title="Explore Hooks"
-      subtitle="Ask me about your hooks! Powered by Elements + Gram MCP"
-      hideTrigger={isLogsDisabled}
-    >
+    <>
+      <InsightsConfig
+        mcpConfig={mcpConfig}
+        title="Explore Hooks"
+        subtitle="Ask me about your hooks! Powered by Elements + Gram MCP"
+        hideTrigger={isLogsDisabled}
+      />
       <div className="flex h-full flex-col overflow-hidden">
         <Page>
           <Page.Header>
@@ -644,7 +645,7 @@ function HooksContent() {
           )}
         </Page>
       </div>
-    </InsightsSidebar>
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/logs/Logs.tsx
+++ b/client/dashboard/src/pages/logs/Logs.tsx
@@ -1,5 +1,5 @@
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
-import { InsightsSidebar } from "@/components/insights-sidebar";
+import { InsightsConfig } from "@/components/insights-sidebar";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { Page } from "@/components/page-layout";
 import { Button } from "@/components/ui/button";
@@ -534,29 +534,31 @@ function LogsContent() {
     !!selectedServer || !!searchQuery || logFilters.length > 0;
 
   return (
-    <InsightsSidebar
-      mcpConfig={mcpConfig}
-      title="Explore Logs"
-      subtitle="Ask me about your logs! Powered by Elements + Gram MCP"
-      hideTrigger={isLogsDisabled}
-      suggestions={[
-        {
-          title: "Failing Tool Calls",
-          label: "Summarize failing tool calls",
-          prompt: "Summarize failing tool calls",
-        },
-        {
-          title: "Visualize top tool calls",
-          label: "Plot tool call counts",
-          prompt: "Plot a chart of the top tool calls and their counts",
-        },
-        {
-          title: "Recent Errors",
-          label: "Find recent errors",
-          prompt: "Search for recent error logs and summarize what's happening",
-        },
-      ]}
-    >
+    <>
+      <InsightsConfig
+        mcpConfig={mcpConfig}
+        title="Explore Logs"
+        subtitle="Ask me about your logs! Powered by Elements + Gram MCP"
+        hideTrigger={isLogsDisabled}
+        suggestions={[
+          {
+            title: "Failing Tool Calls",
+            label: "Summarize failing tool calls",
+            prompt: "Summarize failing tool calls",
+          },
+          {
+            title: "Visualize top tool calls",
+            label: "Plot tool call counts",
+            prompt: "Plot a chart of the top tool calls and their counts",
+          },
+          {
+            title: "Recent Errors",
+            label: "Find recent errors",
+            prompt:
+              "Search for recent error logs and summarize what's happening",
+          },
+        ]}
+      />
       <LogsInnerContent
         isLogsDisabled={isLogsDisabled}
         isLoading={isLoading}
@@ -596,7 +598,7 @@ function LogsContent() {
         isLoadingAttributeKeys={isLoadingAttributeKeys}
         hasActiveFilters={hasActiveFilters}
       />
-    </InsightsSidebar>
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
+++ b/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
@@ -1,6 +1,6 @@
 import { Page } from "@/components/page-layout";
 import {
-  InsightsSidebar,
+  InsightsConfig,
   useInsightsState,
 } from "@/components/insights-sidebar";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
@@ -800,33 +800,34 @@ export default function ObservabilityOverview() {
   }, [from, to]);
 
   return (
-    <InsightsSidebar
-      mcpConfig={mcpConfig}
-      title="What would you like to know?"
-      subtitle="Ask about metrics, trends, or performance insights"
-      contextInfo={dateRangeContext}
-      hideTrigger={isLogsDisabled}
-      suggestions={[
-        {
-          title: "Resolution Summary",
-          label: "Summarize chat resolutions",
-          prompt:
-            "Summarize the chat resolution metrics for the current period. What's the success rate?",
-        },
-        {
-          title: "Tool Failures",
-          label: "Analyze failing tools",
-          prompt:
-            "Which tools have the highest failure rates? What might be causing the failures?",
-        },
-        {
-          title: "Performance Trends",
-          label: "Analyze trends",
-          prompt:
-            "What trends do you see in the metrics? Are things improving or declining?",
-        },
-      ]}
-    >
+    <>
+      <InsightsConfig
+        mcpConfig={mcpConfig}
+        title="What would you like to know?"
+        subtitle="Ask about metrics, trends, or performance insights"
+        contextInfo={dateRangeContext}
+        hideTrigger={isLogsDisabled}
+        suggestions={[
+          {
+            title: "Resolution Summary",
+            label: "Summarize chat resolutions",
+            prompt:
+              "Summarize the chat resolution metrics for the current period. What's the success rate?",
+          },
+          {
+            title: "Tool Failures",
+            label: "Analyze failing tools",
+            prompt:
+              "Which tools have the highest failure rates? What might be causing the failures?",
+          },
+          {
+            title: "Performance Trends",
+            label: "Analyze trends",
+            prompt:
+              "What trends do you see in the metrics? Are things improving or declining?",
+          },
+        ]}
+      />
       <Page>
         <Page.Header>
           <Page.Header.Breadcrumbs fullWidth />
@@ -871,7 +872,7 @@ export default function ObservabilityOverview() {
           />
         </Page.Body>
       </Page>
-    </InsightsSidebar>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

Make the AI Insights trigger a static, always-visible button in the top breadcrumb bar across every project-scoped page — not just the four that previously wrapped themselves with `<InsightsSidebar>`.

## How

**New architecture in `insights-sidebar.tsx`**:

- `<InsightsProvider>` — wraps the app shell, owns state + default config
- `<InsightsConfig />` — declarative per-page override; mounts to register a custom prompt/suggestions/MCP filter, cleans up on unmount
- `<InsightsTrigger />` — header button (unchanged behavior; auto-renders now that the global provider is always present)
- Old `InsightsSidebar` export retained as a deprecated alias

**Wrap point**: `<GlobalInsightsWrapper>` inside `AppLayout` → `SidebarInset` → `<Outlet />`. Uses `useObservabilityMcpConfig({ toolsToInclude: () => true })` for the project-scoped default; safe because `AppLayout` only mounts on `:orgSlug/projects/:projectSlug`.

**Page refactor**: Logs, ChatLogs, ObservabilityOverview, Hooks dropped their `<InsightsSidebar>` wrappers and now place `<InsightsConfig {...sameProps} />` as a sibling above their content — same custom prompts, no layout responsibility.

## Tradeoff

`OrgLayout` (org-level pages: billing, members, etc.) is **not** wrapped — `useObservabilityMcpConfig` requires a project slug. Org pages won't show the trigger. Acceptable for now; if AI assistance is wanted there too, the hook needs a no-project fallback.

## Test plan

- [x] `tsc --noEmit`, `oxfmt --check`, `eslint` all pass
- [ ] Navigate to any project page (Toolsets, Sources, Settings, etc.) → AI Insights button visible top-right of breadcrumb bar
- [ ] Click → global panel opens with default "Ask AI" prompt and 3 generic suggestions
- [ ] Navigate to Logs → panel content updates to "Explore Logs" + log-specific suggestions (per-page override taking effect)
- [ ] Navigate away from Logs → defaults restored
- [ ] Navigate to ObservabilityOverview, ChatLogs, Hooks → each shows its own customized prompt
- [ ] Disable logs on a page that uses `hideTrigger={isLogsDisabled}` → trigger hides while that page is mounted
- [ ] Visit an org-level page (e.g. `/org/billing`) → trigger does NOT render (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
