### PR TITLE
fix: probe rfc 8414 compliant urls during oauth discovery

### DIFF
--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -133,32 +133,29 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 		}
 	}
 
-	// Strategy 3: Probe well-known locations at the server origin
+	// Strategy 3: Probe well-known locations derived from the remote URL
 	if authServerMeta == nil {
-		origin, err := getOrigin(remoteURL)
-		if err == nil {
-			// Try OAuth Protected Resource metadata first
-			prURL := origin + "/.well-known/oauth-protected-resource"
-			meta, err := fetchJSON[protectedResourceMetadata](ctx, logger, guardianPolicy, prURL)
-			if err == nil && meta != nil {
-				resourceMeta = meta
-				// Follow the chain
-				if len(meta.AuthorizationServers) > 0 {
-					asURL := buildWellKnownURL(meta.AuthorizationServers[0])
-					asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
-					if asMeta != nil {
-						authServerMeta = asMeta
-					}
-				}
-			}
-
-			// Try OAuth Authorization Server metadata directly
-			if authServerMeta == nil {
-				asURL := origin + "/.well-known/oauth-authorization-server"
+		// Try OAuth Protected Resource metadata first
+		prURL := buildWellKnownResourceURL(remoteURL)
+		meta, err := fetchJSON[protectedResourceMetadata](ctx, logger, guardianPolicy, prURL)
+		if err == nil && meta != nil {
+			resourceMeta = meta
+			// Follow the chain
+			if len(meta.AuthorizationServers) > 0 {
+				asURL := buildWellKnownURL(meta.AuthorizationServers[0])
 				asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
 				if asMeta != nil {
 					authServerMeta = asMeta
 				}
+			}
+		}
+
+		// Try OAuth Authorization Server metadata directly
+		if authServerMeta == nil {
+			asURL := buildWellKnownURL(remoteURL)
+			asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
+			if asMeta != nil {
+				authServerMeta = asMeta
 			}
 		}
 	}
@@ -220,19 +217,27 @@ func parseWWWAuthenticate(header string) map[string]string {
 	return params
 }
 
-// getOrigin extracts the origin (scheme + host) from a URL.
-func getOrigin(rawURL string) (string, error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return "", fmt.Errorf("parse URL: %w", err)
-	}
-	return fmt.Sprintf("%s://%s", u.Scheme, u.Host), nil
+// buildWellKnownURL constructs the well-known OAuth Authorization Server metadata URL.
+// Per RFC 8414 Section 3, the well-known suffix is inserted between the host and the path.
+// e.g. https://example.com/path → https://example.com/.well-known/oauth-authorization-server/path
+func buildWellKnownURL(baseURL string) string {
+	return buildWellKnownSuffixURL(baseURL, "oauth-authorization-server")
 }
 
-// buildWellKnownURL constructs the well-known OAuth Authorization Server metadata URL.
-func buildWellKnownURL(baseURL string) string {
-	baseURL = strings.TrimSuffix(baseURL, "/")
-	return baseURL + "/.well-known/oauth-authorization-server"
+// buildWellKnownResourceURL constructs the well-known OAuth Protected Resource metadata URL.
+// Per RFC 9728, the well-known suffix is inserted between the host and the path.
+// e.g. https://example.com/path → https://example.com/.well-known/oauth-protected-resource/path
+func buildWellKnownResourceURL(baseURL string) string {
+	return buildWellKnownSuffixURL(baseURL, "oauth-protected-resource")
+}
+
+// buildWellKnownSuffixURL inserts a /.well-known/<suffix> between the host and path of a URL.
+func buildWellKnownSuffixURL(baseURL, suffix string) string {
+	u, err := url.Parse(strings.TrimSuffix(baseURL, "/"))
+	if err != nil {
+		return baseURL + "/.well-known/" + suffix
+	}
+	return fmt.Sprintf("%s://%s/.well-known/%s%s", u.Scheme, u.Host, suffix, u.Path)
 }
 
 // fetchJSON fetches JSON from a URL and decodes it into the target.

--- a/server/internal/externalmcp/oauthdiscovery_test.go
+++ b/server/internal/externalmcp/oauthdiscovery_test.go
@@ -14,14 +14,14 @@ func TestBuildWellKnownURL_OriginOnly(t *testing.T) {
 
 func TestBuildWellKnownURL_WithPath(t *testing.T) {
 	t.Parallel()
-	result := buildWellKnownURL("https://app.getgram.ai/mcp/speakeasy-team-snowflake")
-	require.Equal(t, "https://app.getgram.ai/.well-known/oauth-authorization-server/mcp/speakeasy-team-snowflake", result)
+	result := buildWellKnownURL("https://example.com/mcp/my-server")
+	require.Equal(t, "https://example.com/.well-known/oauth-authorization-server/mcp/my-server", result)
 }
 
 func TestBuildWellKnownURL_WithTrailingSlash(t *testing.T) {
 	t.Parallel()
-	result := buildWellKnownURL("https://app.getgram.ai/mcp/speakeasy-team-snowflake/")
-	require.Equal(t, "https://app.getgram.ai/.well-known/oauth-authorization-server/mcp/speakeasy-team-snowflake", result)
+	result := buildWellKnownURL("https://example.com/mcp/my-server/")
+	require.Equal(t, "https://example.com/.well-known/oauth-authorization-server/mcp/my-server", result)
 }
 
 func TestBuildWellKnownResourceURL_OriginOnly(t *testing.T) {
@@ -32,8 +32,8 @@ func TestBuildWellKnownResourceURL_OriginOnly(t *testing.T) {
 
 func TestBuildWellKnownResourceURL_WithPath(t *testing.T) {
 	t.Parallel()
-	result := buildWellKnownResourceURL("https://app.getgram.ai/mcp/speakeasy-team-snowflake")
-	require.Equal(t, "https://app.getgram.ai/.well-known/oauth-protected-resource/mcp/speakeasy-team-snowflake", result)
+	result := buildWellKnownResourceURL("https://example.com/mcp/my-server")
+	require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/my-server", result)
 }
 
 func TestParseWWWAuthenticate_Empty(t *testing.T) {

--- a/server/internal/externalmcp/oauthdiscovery_test.go
+++ b/server/internal/externalmcp/oauthdiscovery_test.go
@@ -1,0 +1,51 @@
+package externalmcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildWellKnownURL_OriginOnly(t *testing.T) {
+	t.Parallel()
+	result := buildWellKnownURL("https://auth.example.com")
+	require.Equal(t, "https://auth.example.com/.well-known/oauth-authorization-server", result)
+}
+
+func TestBuildWellKnownURL_WithPath(t *testing.T) {
+	t.Parallel()
+	result := buildWellKnownURL("https://app.getgram.ai/mcp/speakeasy-team-snowflake")
+	require.Equal(t, "https://app.getgram.ai/.well-known/oauth-authorization-server/mcp/speakeasy-team-snowflake", result)
+}
+
+func TestBuildWellKnownURL_WithTrailingSlash(t *testing.T) {
+	t.Parallel()
+	result := buildWellKnownURL("https://app.getgram.ai/mcp/speakeasy-team-snowflake/")
+	require.Equal(t, "https://app.getgram.ai/.well-known/oauth-authorization-server/mcp/speakeasy-team-snowflake", result)
+}
+
+func TestBuildWellKnownResourceURL_OriginOnly(t *testing.T) {
+	t.Parallel()
+	result := buildWellKnownResourceURL("https://auth.example.com")
+	require.Equal(t, "https://auth.example.com/.well-known/oauth-protected-resource", result)
+}
+
+func TestBuildWellKnownResourceURL_WithPath(t *testing.T) {
+	t.Parallel()
+	result := buildWellKnownResourceURL("https://app.getgram.ai/mcp/speakeasy-team-snowflake")
+	require.Equal(t, "https://app.getgram.ai/.well-known/oauth-protected-resource/mcp/speakeasy-team-snowflake", result)
+}
+
+func TestParseWWWAuthenticate_Empty(t *testing.T) {
+	t.Parallel()
+	params := parseWWWAuthenticate("")
+	require.Empty(t, params)
+}
+
+func TestParseWWWAuthenticate_WithParams(t *testing.T) {
+	t.Parallel()
+	header := `Bearer realm="OAuth", resource_metadata="https://example.com/.well-known/oauth-protected-resource/mcp/test"`
+	params := parseWWWAuthenticate(header)
+	require.Equal(t, "OAuth", params["realm"])
+	require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/test", params["resource_metadata"])
+}


### PR DESCRIPTION
##  Summary

  - Fix RFC 8414 non-compliance in buildWellKnownURL — the well-known suffix was appended to the end of the URL instead of inserted between host and path
  - This caused OAuth AS metadata discovery to fail for servers with path-bearing URLs (e.g. https://app.getgram.ai/mcp/speakeasy-team-snowflake), resulting in empty OAuth endpoint fields in the DB
  - Also fix Strategy 3 well-known probing to use the same RFC-compliant URL construction

  Resolves https://linear.app/speakeasy/issue/AGE-1831

##  Test plan

  - Unit tests for buildWellKnownURL and buildWellKnownResourceURL with origin-only and path-bearing URLs
  - Linter passes
  - Deploy and verify Snowflake MCP server discovers OAuth endpoints correctly