### PR TITLE
fix: role member counts only show users with Gram accounts

### DIFF
--- a/server/internal/access/createrole_test.go
+++ b/server/internal/access/createrole_test.go
@@ -40,6 +40,8 @@ func TestService_CreateRole(t *testing.T) {
 	ti.roles.On("ListMembers", mock.Anything, "org_workos_test").Return([]thirdpartyworkos.Member{
 		mockMember("org_workos_test", "membership_1", "user_1", "member"),
 		mockMember("org_workos_test", "membership_2", "user_2", "member"),
+		// user_workos_only has never logged into Gram — should not be counted
+		mockMember("org_workos_test", "membership_workos_only", "user_workos_only", "member"),
 	}, nil).Once()
 	ti.roles.On("UpdateMemberRole", mock.Anything, "membership_1", "org-custom-builder").Return(&thirdpartyworkos.Member{
 		ID:             "membership_1",
@@ -55,6 +57,9 @@ func TestService_CreateRole(t *testing.T) {
 		RoleSlug:       "org-custom-builder",
 		CreatedAt:      mockMembershipTimestamp,
 	}, nil).Once()
+
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", "user2@test.com", "User 2", "user_2", "membership_2")
 
 	role, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{
 		Name:        "Custom Builder",

--- a/server/internal/access/getrole_test.go
+++ b/server/internal/access/getrole_test.go
@@ -29,6 +29,8 @@ func TestService_GetRole(t *testing.T) {
 		mockMember("org_workos_test", "membership_1", "user_1", "custom-builder"),
 		mockMember("org_workos_test", "membership_2", "user_2", "custom-builder"),
 		mockMember("org_workos_test", "membership_3", "user_3", "admin"),
+		// user_workos_only has never logged into Gram — should not be counted
+		mockMember("org_workos_test", "membership_workos_only", "user_workos_only", "custom-builder"),
 	}, nil).Once()
 
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")

--- a/server/internal/access/getrole_test.go
+++ b/server/internal/access/getrole_test.go
@@ -31,6 +31,9 @@ func TestService_GetRole(t *testing.T) {
 		mockMember("org_workos_test", "membership_3", "user_3", "admin"),
 	}, nil).Once()
 
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", "user2@test.com", "User 2", "user_2", "membership_2")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_3", "user3@test.com", "User 3", "user_3", "membership_3")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), ScopeBuildRead, "project-1")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), ScopeMCPConnect, WildcardResource)
 

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -257,7 +257,7 @@ func (s *Service) CreateRole(ctx context.Context, payload *gen.CreateRolePayload
 		return nil, oops.E(oops.CodeUnexpected, err, "sync grants for created role").Log(ctx, logger)
 	}
 
-	assignedCount := 0
+	assignedWorkosIDs := make([]string, 0, len(payload.MemberIds))
 	if len(payload.MemberIds) > 0 {
 		members, err := s.roles.ListMembers(ctx, workosOrgID)
 		if err != nil {
@@ -276,9 +276,20 @@ func (s *Service) CreateRole(ctx context.Context, payload *gen.CreateRolePayload
 				return nil, oops.E(oops.CodeUnexpected, err, "assign members to created role").Log(ctx, logger)
 			}
 
-			assignedCount++
+			assignedWorkosIDs = append(assignedWorkosIDs, userID)
 		}
 		s.access.InvalidateAllRoleCaches(ctx, ac.ActiveOrganizationID)
+	}
+
+	// Only count assigned members who have local Gram accounts, consistent with
+	// how ListRoles/GetRole/UpdateRole count members via localMemberCounts.
+	assignedCount := 0
+	if len(assignedWorkosIDs) > 0 {
+		localRows, err := usersrepo.New(s.db).GetUsersByWorkosIDs(ctx, assignedWorkosIDs)
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get users by workos ids: %w", err), "resolve local assigned members").Log(ctx, logger)
+		}
+		assignedCount = len(localRows)
 	}
 
 	createdRole, err := buildRole(ctx, logger, s.db, ac.ActiveOrganizationID, *wr, assignedCount)

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -850,7 +850,7 @@ func (s *Service) localMemberCounts(ctx context.Context, members []workos.Member
 	}
 	localRows, err := usersrepo.New(s.db).GetUsersByWorkosIDs(ctx, workosIDs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get users by workos ids: %w", err)
 	}
 	localSet := make(map[string]struct{}, len(localRows))
 	for _, u := range localRows {

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -127,7 +127,10 @@ func (s *Service) ListRoles(ctx context.Context, _ *gen.ListRolesPayload) (*gen.
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, s.logger)
 	}
-	memberCounts := countMembersByRoleSlug(members)
+	memberCounts, err := s.localMemberCounts(ctx, members)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, s.logger)
+	}
 
 	roles := make([]*gen.Role, 0, len(wRoles))
 	for _, wr := range wRoles {
@@ -172,7 +175,10 @@ func (s *Service) GetRole(ctx context.Context, payload *gen.GetRolePayload) (*ge
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, s.logger)
 	}
 
-	memberCounts := countMembersByRoleSlug(members)
+	memberCounts, err := s.localMemberCounts(ctx, members)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, s.logger)
+	}
 
 	return buildRole(ctx, s.logger, s.db, ac.ActiveOrganizationID, role, memberCounts[role.Slug])
 }
@@ -344,7 +350,10 @@ func (s *Service) UpdateRole(ctx context.Context, payload *gen.UpdateRolePayload
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, logger)
 	}
-	memberCountsBefore := countMembersByRoleSlug(membersBefore)
+	memberCountsBefore, err := s.localMemberCounts(ctx, membersBefore)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, logger)
+	}
 	existingRole, err := buildRole(ctx, logger, s.db, ac.ActiveOrganizationID, currentRole, memberCountsBefore[currentRole.Slug])
 	if err != nil {
 		return nil, err
@@ -387,7 +396,10 @@ func (s *Service) UpdateRole(ctx context.Context, payload *gen.UpdateRolePayload
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, logger)
 	}
 
-	memberCounts := countMembersByRoleSlug(members)
+	memberCounts, err := s.localMemberCounts(ctx, members)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, logger)
+	}
 	updatedRoleView, err := buildRole(ctx, logger, s.db, ac.ActiveOrganizationID, *updatedRole, memberCounts[updatedRole.Slug])
 	if err != nil {
 		return nil, err
@@ -828,13 +840,31 @@ func formatUserName(user workos.User) string {
 	}
 }
 
-func countMembersByRoleSlug(members []workos.Member) map[string]int {
-	counts := make(map[string]int, len(members))
-	for _, member := range members {
-		counts[member.RoleSlug]++
+// localMemberCounts counts WorkOS members per role slug, but only for members
+// who have a local Gram account. This ensures counts match what ListMembers
+// returns — users in WorkOS who have never logged into Gram are excluded.
+func (s *Service) localMemberCounts(ctx context.Context, members []workos.Member) (map[string]int, error) {
+	workosIDs := make([]string, 0, len(members))
+	for _, m := range members {
+		workosIDs = append(workosIDs, m.UserID)
 	}
-
-	return counts
+	localRows, err := usersrepo.New(s.db).GetUsersByWorkosIDs(ctx, workosIDs)
+	if err != nil {
+		return nil, err
+	}
+	localSet := make(map[string]struct{}, len(localRows))
+	for _, u := range localRows {
+		if u.WorkosID.Valid {
+			localSet[u.WorkosID.String] = struct{}{}
+		}
+	}
+	counts := make(map[string]int)
+	for _, m := range members {
+		if _, ok := localSet[m.UserID]; ok {
+			counts[m.RoleSlug]++
+		}
+	}
+	return counts, nil
 }
 
 func membershipsByUserID(members []workos.Member) map[string]string {

--- a/server/internal/access/listroles_test.go
+++ b/server/internal/access/listroles_test.go
@@ -28,6 +28,8 @@ func TestService_ListRoles(t *testing.T) {
 		mockMember("org_workos_test", "membership_1", "user_1", "admin"),
 		mockMember("org_workos_test", "membership_2", "user_2", "custom-builder"),
 		mockMember("org_workos_test", "membership_3", "user_3", "custom-builder"),
+		// user_workos_only has never logged into Gram — should not be counted
+		mockMember("org_workos_test", "membership_workos_only", "user_workos_only", "custom-builder"),
 	}, nil).Once()
 
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")

--- a/server/internal/access/listroles_test.go
+++ b/server/internal/access/listroles_test.go
@@ -30,6 +30,9 @@ func TestService_ListRoles(t *testing.T) {
 		mockMember("org_workos_test", "membership_3", "user_3", "custom-builder"),
 	}, nil).Once()
 
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", "user2@test.com", "User 2", "user_2", "membership_2")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_3", "user3@test.com", "User 3", "user_3", "membership_3")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "admin"), ScopeOrgAdmin, WildcardResource)
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), ScopeBuildRead, "project-1")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), ScopeBuildRead, "project-2")

--- a/server/internal/access/updaterole_test.go
+++ b/server/internal/access/updaterole_test.go
@@ -62,6 +62,8 @@ func TestService_UpdateRole(t *testing.T) {
 		mockMember("org_workos_test", "membership_1", "user_1", "custom-builder"),
 		mockMember("org_workos_test", "membership_2", "user_2", "custom-builder"),
 		mockMember("org_workos_test", "membership_3", "user_3", "custom-builder"),
+		// user_workos_only has never logged into Gram — should not be counted
+		mockMember("org_workos_test", "membership_workos_only", "user_workos_only", "custom-builder"),
 	}, nil).Once()
 
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")
@@ -152,6 +154,8 @@ func TestService_UpdateRole_AuditLog(t *testing.T) {
 		mockMember("org_workos_test", "membership_2", "user_2", "custom-builder"),
 	}, nil).Once()
 
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", "user2@test.com", "User 2", "user_2", "membership_2")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), ScopeBuildRead, "project-old")
 
 	updated, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
@@ -165,6 +169,7 @@ func TestService_UpdateRole_AuditLog(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, updated)
+	require.Equal(t, 2, updated.MemberCount)
 
 	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionAccessRoleUpdate)
 	require.NoError(t, err)

--- a/server/internal/access/updaterole_test.go
+++ b/server/internal/access/updaterole_test.go
@@ -64,6 +64,9 @@ func TestService_UpdateRole(t *testing.T) {
 		mockMember("org_workos_test", "membership_3", "user_3", "custom-builder"),
 	}, nil).Once()
 
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_2", "user2@test.com", "User 2", "user_2", "membership_2")
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_3", "user3@test.com", "User 3", "user_3", "membership_3")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), ScopeBuildRead, "project-old")
 	role, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{
 		ID:          "role_custom",


### PR DESCRIPTION
## Summary

- Role member counts in the Roles & Permissions table were showing inflated numbers (e.g. 55) because they counted all WorkOS org members, including users who have never logged into Gram
- The Members tab correctly showed 18 (only users with local Gram accounts) but role counts did not apply the same filter
- Replaced `countMembersByRoleSlug` with a `localMemberCounts` service method that cross-references the WorkOS member list against the local users table, matching the existing filter already used by `ListMembers`
- Fixes `ListRoles`, `GetRole`, `CreateRole` and `UpdateRole` responses — all three return a `MemberCount` field that was affected

## Test plan

- [ ] Existing unit tests updated to seed local users matching mock WorkOS member IDs — all pass
- [ ] Verify roles table member counts match the Members tab count in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)