### PR TITLE
fix: make ensureDefaultRegistryCollection truly idempotent

### DIFF
--- a/.changeset/sturdy-rocks-ensure.md
+++ b/.changeset/sturdy-rocks-ensure.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fixes a race condition where concurrent `collections.List` calls could fail with `"default registry collection already exists"` while bootstrapping the default Registry collection. The ensure routine now treats unique-constraint violations as success and re-fetches the existing rows.

--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -473,77 +473,37 @@ func (s *Service) ensureDefaultRegistryCollection(ctx context.Context, organizat
 		defaultVisibility     = "private"
 	)
 
-	collectionID, err := s.ensureDefaultCollectionRow(ctx, organizationID, defaultCollectionName, defaultVisibility)
+	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
-		return err
+		return oops.E(oops.CodeUnexpected, err, "error starting transaction for default collection").Log(ctx, s.logger)
 	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
-	return s.ensureDefaultCollectionRegistry(ctx, organizationID, collectionID, defaultRegistryNamespace(organizationSlug, organizationID))
-}
-
-func (s *Service) ensureDefaultCollectionRow(ctx context.Context, organizationID, name, visibility string) (uuid.UUID, error) {
-	getParams := repo.GetOrganizationMcpCollectionBySlugAndOrgParams{
-		Slug:           defaultCollectionSlug,
+	tx := s.repo.WithTx(dbtx)
+	collection, err := tx.EnsureOrganizationMcpCollection(ctx, repo.EnsureOrganizationMcpCollectionParams{
 		OrganizationID: organizationID,
-	}
-
-	row, err := s.repo.GetOrganizationMcpCollectionBySlugAndOrg(ctx, getParams)
-	switch {
-	case err == nil:
-		return row.ID, nil
-	case !errors.Is(err, pgx.ErrNoRows):
-		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error getting default registry collection").Log(ctx, s.logger)
-	}
-
-	created, createErr := s.repo.CreateOrganizationMcpCollection(ctx, repo.CreateOrganizationMcpCollectionParams{
-		OrganizationID: organizationID,
-		Name:           name,
+		Name:           defaultCollectionName,
 		Description:    pgtype.Text{String: "", Valid: false},
 		Slug:           defaultCollectionSlug,
-		Visibility:     visibility,
+		Visibility:     defaultVisibility,
 	})
-	if createErr == nil {
-		return created.ID, nil
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error ensuring default registry collection").Log(ctx, s.logger)
 	}
 
-	var pgErr *pgconn.PgError
-	if !errors.As(createErr, &pgErr) || pgErr.Code != pgerrcode.UniqueViolation {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, createErr, "error creating default registry collection").Log(ctx, s.logger)
-	}
-
-	row, getErr := s.repo.GetOrganizationMcpCollectionBySlugAndOrg(ctx, getParams)
-	if getErr != nil {
-		return uuid.Nil, oops.E(oops.CodeUnexpected, getErr, "error fetching default registry collection after unique violation").Log(ctx, s.logger)
-	}
-	return row.ID, nil
-}
-
-func (s *Service) ensureDefaultCollectionRegistry(ctx context.Context, organizationID string, collectionID uuid.UUID, namespace string) error {
-	_, err := s.repo.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
-		CollectionID:   collectionID,
+	if _, err := tx.EnsureOrganizationMcpCollectionRegistry(ctx, repo.EnsureOrganizationMcpCollectionRegistryParams{
+		CollectionID:   collection.ID,
 		OrganizationID: organizationID,
-	})
-	switch {
-	case err == nil:
-		return nil
-	case !errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeUnexpected, err, "error getting default registry namespace").Log(ctx, s.logger)
+		Namespace:      defaultRegistryNamespace(organizationSlug, organizationID),
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error ensuring default registry namespace").Log(ctx, s.logger)
 	}
 
-	_, createErr := s.repo.CreateOrganizationMcpCollectionRegistry(ctx, repo.CreateOrganizationMcpCollectionRegistryParams{
-		CollectionID:   collectionID,
-		OrganizationID: organizationID,
-		Namespace:      namespace,
-	})
-	if createErr == nil {
-		return nil
+	if err := dbtx.Commit(ctx); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error committing default registry collection").Log(ctx, s.logger)
 	}
 
-	var pgErr *pgconn.PgError
-	if errors.As(createErr, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-		return nil
-	}
-	return oops.E(oops.CodeUnexpected, createErr, "error creating default registry namespace").Log(ctx, s.logger)
+	return nil
 }
 
 func defaultRegistryNamespace(organizationSlug, organizationID string) string {

--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -473,87 +473,77 @@ func (s *Service) ensureDefaultRegistryCollection(ctx context.Context, organizat
 		defaultVisibility     = "private"
 	)
 
-	var existing *repo.GetOrganizationMcpCollectionBySlugAndOrgRow
-	existingRow, err := s.repo.GetOrganizationMcpCollectionBySlugAndOrg(ctx, repo.GetOrganizationMcpCollectionBySlugAndOrgParams{
+	collectionID, err := s.ensureDefaultCollectionRow(ctx, organizationID, defaultCollectionName, defaultVisibility)
+	if err != nil {
+		return err
+	}
+
+	return s.ensureDefaultCollectionRegistry(ctx, organizationID, collectionID, defaultRegistryNamespace(organizationSlug, organizationID))
+}
+
+func (s *Service) ensureDefaultCollectionRow(ctx context.Context, organizationID, name, visibility string) (uuid.UUID, error) {
+	getParams := repo.GetOrganizationMcpCollectionBySlugAndOrgParams{
 		Slug:           defaultCollectionSlug,
 		OrganizationID: organizationID,
+	}
+
+	row, err := s.repo.GetOrganizationMcpCollectionBySlugAndOrg(ctx, getParams)
+	switch {
+	case err == nil:
+		return row.ID, nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error getting default registry collection").Log(ctx, s.logger)
+	}
+
+	created, createErr := s.repo.CreateOrganizationMcpCollection(ctx, repo.CreateOrganizationMcpCollectionParams{
+		OrganizationID: organizationID,
+		Name:           name,
+		Description:    pgtype.Text{String: "", Valid: false},
+		Slug:           defaultCollectionSlug,
+		Visibility:     visibility,
 	})
-	if err == nil {
-		existing = &existingRow
-		if _, regErr := s.repo.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
-			CollectionID:   existing.ID,
-			OrganizationID: organizationID,
-		}); regErr == nil {
-			return nil
-		} else if !errors.Is(regErr, pgx.ErrNoRows) {
-			return oops.E(oops.CodeUnexpected, regErr, "error getting default registry namespace").Log(ctx, s.logger)
-		}
-	} else if !errors.Is(err, pgx.ErrNoRows) {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return oops.E(oops.CodeConflict, err, "default registry collection already exists").Log(ctx, s.logger)
-		}
-		return oops.E(oops.CodeUnexpected, err, "error getting default registry collection").Log(ctx, s.logger)
+	if createErr == nil {
+		return created.ID, nil
 	}
 
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error starting transaction for default collection").Log(ctx, s.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
-
-	tx := s.repo.WithTx(dbtx)
-	namespace := defaultRegistryNamespace(organizationSlug, organizationID)
-	var collectionID uuid.UUID
-	if existing != nil {
-		collectionID = existing.ID
-	}
-	if existing == nil {
-		created, createErr := tx.CreateOrganizationMcpCollection(ctx, repo.CreateOrganizationMcpCollectionParams{
-			OrganizationID: organizationID,
-			Name:           defaultCollectionName,
-			Description:    pgtype.Text{String: "", Valid: false},
-			Slug:           defaultCollectionSlug,
-			Visibility:     defaultVisibility,
-		})
-		if createErr != nil {
-			var pgErr *pgconn.PgError
-			if errors.As(createErr, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-				return oops.E(oops.CodeConflict, createErr, "default registry collection already exists").Log(ctx, s.logger)
-			}
-			return oops.E(oops.CodeUnexpected, createErr, "error creating default registry collection").Log(ctx, s.logger)
-		}
-
-		collectionID = created.ID
+	var pgErr *pgconn.PgError
+	if !errors.As(createErr, &pgErr) || pgErr.Code != pgerrcode.UniqueViolation {
+		return uuid.Nil, oops.E(oops.CodeUnexpected, createErr, "error creating default registry collection").Log(ctx, s.logger)
 	}
 
-	if _, regErr := tx.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
+	row, getErr := s.repo.GetOrganizationMcpCollectionBySlugAndOrg(ctx, getParams)
+	if getErr != nil {
+		return uuid.Nil, oops.E(oops.CodeUnexpected, getErr, "error fetching default registry collection after unique violation").Log(ctx, s.logger)
+	}
+	return row.ID, nil
+}
+
+func (s *Service) ensureDefaultCollectionRegistry(ctx context.Context, organizationID string, collectionID uuid.UUID, namespace string) error {
+	_, err := s.repo.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
 		CollectionID:   collectionID,
 		OrganizationID: organizationID,
-	}); regErr == nil {
+	})
+	switch {
+	case err == nil:
 		return nil
-	} else if !errors.Is(regErr, pgx.ErrNoRows) {
-		return oops.E(oops.CodeUnexpected, regErr, "error getting default registry namespace").Log(ctx, s.logger)
+	case !errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeUnexpected, err, "error getting default registry namespace").Log(ctx, s.logger)
 	}
 
-	_, err = tx.CreateOrganizationMcpCollectionRegistry(ctx, repo.CreateOrganizationMcpCollectionRegistryParams{
+	_, createErr := s.repo.CreateOrganizationMcpCollectionRegistry(ctx, repo.CreateOrganizationMcpCollectionRegistryParams{
 		CollectionID:   collectionID,
 		OrganizationID: organizationID,
 		Namespace:      namespace,
 	})
-	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return oops.E(oops.CodeConflict, err, "default registry namespace already exists").Log(ctx, s.logger)
-		}
-		return oops.E(oops.CodeUnexpected, err, "error creating default registry namespace").Log(ctx, s.logger)
+	if createErr == nil {
+		return nil
 	}
 
-	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "error committing default registry collection").Log(ctx, s.logger)
+	var pgErr *pgconn.PgError
+	if errors.As(createErr, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+		return nil
 	}
-
-	return nil
+	return oops.E(oops.CodeUnexpected, createErr, "error creating default registry namespace").Log(ctx, s.logger)
 }
 
 func defaultRegistryNamespace(organizationSlug, organizationID string) string {

--- a/server/internal/collections/list_test.go
+++ b/server/internal/collections/list_test.go
@@ -2,8 +2,10 @@ package collections_test
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
 	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
@@ -128,4 +130,86 @@ func TestCollectionsService_List_DefaultRegistryNotDuplicatedWhenAlreadyExists(t
 		}
 	}
 	require.Equal(t, 1, registryCount, "should not duplicate the registry collection")
+}
+
+func TestCollectionsService_List_DefaultRegistryConcurrent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	start := make(chan struct{})
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := ti.service.List(ctx, &gen.ListPayload{
+				SessionToken:     nil,
+				ApikeyToken:      nil,
+				ProjectSlugInput: nil,
+			})
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err, "concurrent ensure of default registry collection must not fail")
+	}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	cRepo := collectionsRepo.New(ti.conn)
+	rows, err := cRepo.ListOrganizationMcpCollections(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+
+	var registryCount int
+	for _, r := range rows {
+		if r.Slug == "registry" {
+			registryCount++
+		}
+	}
+	require.Equal(t, 1, registryCount, "exactly one default registry collection should exist after concurrent calls")
+}
+
+func TestCollectionsService_List_DefaultRegistryBackfillsMissingNamespace(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	cRepo := collectionsRepo.New(ti.conn)
+	_, err := cRepo.CreateOrganizationMcpCollection(ctx, collectionsRepo.CreateOrganizationMcpCollectionParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Name:           "Registry",
+		Description:    pgtype.Text{String: "", Valid: false},
+		Slug:           "registry",
+		Visibility:     "private",
+	})
+	require.NoError(t, err)
+
+	result, err := ti.service.List(ctx, &gen.ListPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	var found bool
+	for _, c := range result.Collections {
+		if c.Slug == "registry" {
+			found = true
+			require.NotNil(t, c.McpRegistryNamespace)
+			require.Equal(t, fmt.Sprintf("com.speakeasy.%s.registry", mockidp.MockOrgSlug), *c.McpRegistryNamespace)
+		}
+	}
+	require.True(t, found, "default registry collection should be present with a backfilled namespace")
 }

--- a/server/internal/collections/queries.sql
+++ b/server/internal/collections/queries.sql
@@ -4,6 +4,14 @@ VALUES
   (@organization_id, @name, @description, @slug, @visibility)
 RETURNING id, organization_id, name, description, slug, visibility, created_at, updated_at;
 
+-- name: EnsureOrganizationMcpCollection :one
+INSERT INTO organization_mcp_collections (organization_id, name, description, slug, visibility)
+VALUES
+  (@organization_id, @name, @description, @slug, @visibility)
+ON CONFLICT (slug, organization_id) WHERE deleted IS FALSE
+DO UPDATE SET updated_at = organization_mcp_collections.updated_at
+RETURNING id, organization_id, name, description, slug, visibility, created_at, updated_at;
+
 -- name: GetOrganizationMcpCollectionByID :one
 SELECT id, organization_id, name, description, slug, visibility, created_at, updated_at
 FROM organization_mcp_collections
@@ -71,6 +79,18 @@ WITH org_collection AS (
 INSERT INTO organization_mcp_collection_registries (collection_id, namespace)
 SELECT id, @namespace
 FROM org_collection
+RETURNING *;
+
+-- name: EnsureOrganizationMcpCollectionRegistry :one
+WITH org_collection AS (
+  SELECT omc.id FROM organization_mcp_collections omc
+  WHERE omc.id = @collection_id AND omc.organization_id = @organization_id AND omc.deleted IS FALSE
+)
+INSERT INTO organization_mcp_collection_registries (collection_id, namespace)
+SELECT id, @namespace
+FROM org_collection
+ON CONFLICT (collection_id) WHERE deleted IS FALSE
+DO UPDATE SET updated_at = organization_mcp_collection_registries.updated_at
 RETURNING *;
 
 -- name: GetOrganizationMcpCollectionRegistryByID :one

--- a/server/internal/collections/repo/queries.sql.go
+++ b/server/internal/collections/repo/queries.sql.go
@@ -213,6 +213,90 @@ func (q *Queries) DetachServerFromOrganizationMcpCollection(ctx context.Context,
 	return err
 }
 
+const ensureOrganizationMcpCollection = `-- name: EnsureOrganizationMcpCollection :one
+INSERT INTO organization_mcp_collections (organization_id, name, description, slug, visibility)
+VALUES
+  ($1, $2, $3, $4, $5)
+ON CONFLICT (slug, organization_id) WHERE deleted IS FALSE
+DO UPDATE SET updated_at = organization_mcp_collections.updated_at
+RETURNING id, organization_id, name, description, slug, visibility, created_at, updated_at
+`
+
+type EnsureOrganizationMcpCollectionParams struct {
+	OrganizationID string
+	Name           string
+	Description    pgtype.Text
+	Slug           string
+	Visibility     string
+}
+
+type EnsureOrganizationMcpCollectionRow struct {
+	ID             uuid.UUID
+	OrganizationID string
+	Name           string
+	Description    pgtype.Text
+	Slug           string
+	Visibility     string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
+func (q *Queries) EnsureOrganizationMcpCollection(ctx context.Context, arg EnsureOrganizationMcpCollectionParams) (EnsureOrganizationMcpCollectionRow, error) {
+	row := q.db.QueryRow(ctx, ensureOrganizationMcpCollection,
+		arg.OrganizationID,
+		arg.Name,
+		arg.Description,
+		arg.Slug,
+		arg.Visibility,
+	)
+	var i EnsureOrganizationMcpCollectionRow
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.Name,
+		&i.Description,
+		&i.Slug,
+		&i.Visibility,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const ensureOrganizationMcpCollectionRegistry = `-- name: EnsureOrganizationMcpCollectionRegistry :one
+WITH org_collection AS (
+  SELECT omc.id FROM organization_mcp_collections omc
+  WHERE omc.id = $2 AND omc.organization_id = $3 AND omc.deleted IS FALSE
+)
+INSERT INTO organization_mcp_collection_registries (collection_id, namespace)
+SELECT id, $1
+FROM org_collection
+ON CONFLICT (collection_id) WHERE deleted IS FALSE
+DO UPDATE SET updated_at = organization_mcp_collection_registries.updated_at
+RETURNING id, collection_id, namespace, created_at, updated_at, deleted_at, deleted
+`
+
+type EnsureOrganizationMcpCollectionRegistryParams struct {
+	Namespace      string
+	CollectionID   uuid.UUID
+	OrganizationID string
+}
+
+func (q *Queries) EnsureOrganizationMcpCollectionRegistry(ctx context.Context, arg EnsureOrganizationMcpCollectionRegistryParams) (OrganizationMcpCollectionRegistry, error) {
+	row := q.db.QueryRow(ctx, ensureOrganizationMcpCollectionRegistry, arg.Namespace, arg.CollectionID, arg.OrganizationID)
+	var i OrganizationMcpCollectionRegistry
+	err := row.Scan(
+		&i.ID,
+		&i.CollectionID,
+		&i.Namespace,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getOrganizationMcpCollectionByID = `-- name: GetOrganizationMcpCollectionByID :one
 SELECT id, organization_id, name, description, slug, visibility, created_at, updated_at
 FROM organization_mcp_collections


### PR DESCRIPTION
## Summary

`ensureDefaultRegistryCollection` treated "already exists" as a failure — when two `List` calls raced through the bootstrap, one would lose the `UniqueViolation` on `INSERT` and surface a `Conflict` error, the opposite of "ensure" semantics.

## Changes

- Split `ensureDefaultRegistryCollection` into `ensureDefaultCollectionRow` / `ensureDefaultCollectionRegistry`.
- Drop the surrounding transaction; on `UniqueViolation`, re-fetch the existing row and continue instead of returning `Conflict`.
- Remove the dead `UniqueViolation` branch on the initial `SELECT`.

## Tests

- `TestCollectionsService_List_DefaultRegistryConcurrent` — 16 goroutines racing through `List`; reliably reproduces the old bug at `impl.go:522`, passes after the fix.
- `TestCollectionsService_List_DefaultRegistryBackfillsMissingNamespace` — collection row exists without its registry namespace row; `ensure` backfills.
