### PR TITLE
fix: access grants when RBAC is disabled

### DIFF
--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -612,6 +612,21 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 		return &gen.ListUserGrantsResult{Grants: grantsFromRows(grantsFromOverrides(overrides).rows)}, nil
 	}
 
+	ac, err := s.authContext(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+	}
+	if ac.AccountType != "enterprise" {
+		return &gen.ListUserGrantsResult{Grants: fullAccessGrantPayloads()}, nil
+	}
+	enabled, err := s.access.features.IsFeatureEnabled(ctx, ac.ActiveOrganizationID, productfeatures.FeatureRBAC)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "check RBAC feature").Log(ctx, s.logger)
+	}
+	if !enabled {
+		return &gen.ListUserGrantsResult{Grants: fullAccessGrantPayloads()}, nil
+	}
+
 	ac, workosOrgID, err := s.roleOrgContext(ctx)
 	if err != nil {
 		return nil, err
@@ -951,6 +966,18 @@ func roleGrantsFromListRoleGrants(grants []*gen.ListRoleGrant) []*gen.RoleGrant 
 		out = append(out, &gen.RoleGrant{Scope: grant.Scope, Resources: grant.Resources})
 	}
 	return out
+}
+
+func fullAccessGrantPayloads() []*gen.ListRoleGrant {
+	return []*gen.ListRoleGrant{
+		{Scope: string(ScopeOrgRead), Resources: nil},
+		{Scope: string(ScopeOrgAdmin), Resources: nil},
+		{Scope: string(ScopeBuildRead), Resources: nil},
+		{Scope: string(ScopeBuildWrite), Resources: nil},
+		{Scope: string(ScopeMCPRead), Resources: nil},
+		{Scope: string(ScopeMCPWrite), Resources: nil},
+		{Scope: string(ScopeMCPConnect), Resources: nil},
+	}
 }
 
 func connectedUser(ctx context.Context, db *pgxpool.Pool, organizationID string, userID string) (usersrepo.User, error) {

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -612,18 +612,11 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 		return &gen.ListUserGrantsResult{Grants: grantsFromRows(grantsFromOverrides(overrides).rows)}, nil
 	}
 
-	ac, err := s.authContext(ctx)
+	enforce, err := s.access.shouldEnforce(ctx)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").Log(ctx, s.logger)
+		return nil, err
 	}
-	if ac.AccountType != "enterprise" {
-		return &gen.ListUserGrantsResult{Grants: fullAccessGrantPayloads()}, nil
-	}
-	enabled, err := s.access.features.IsFeatureEnabled(ctx, ac.ActiveOrganizationID, productfeatures.FeatureRBAC)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "check RBAC feature").Log(ctx, s.logger)
-	}
-	if !enabled {
+	if !enforce {
 		return &gen.ListUserGrantsResult{Grants: fullAccessGrantPayloads()}, nil
 	}
 

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+var expectedFullAccessScopes = []string{
+	string(ScopeOrgRead),
+	string(ScopeOrgAdmin),
+	string(ScopeBuildRead),
+	string(ScopeBuildWrite),
+	string(ScopeMCPRead),
+	string(ScopeMCPWrite),
+	string(ScopeMCPConnect),
+}
+
 func TestService_ListGrants(t *testing.T) {
 	t.Parallel()
 
@@ -20,6 +30,8 @@ func TestService_ListGrants(t *testing.T) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, authCtx.UserID, "member@example.com", "Member User", "workos_user_member", "membership_1")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID), ScopeBuildRead, "project_123")
@@ -45,6 +57,8 @@ func TestService_ListGrants_MultipleRoles(t *testing.T) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, authCtx.UserID, "member@example.com", "Member User", "workos_user_member", "membership_1")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), ScopeBuildRead, "project_123")
@@ -68,10 +82,70 @@ func TestService_ListGrants_NotConnected(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	_, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "current user has not joined this organization")
+}
+
+func TestService_ListGrants_NonEnterpriseReturnsFullAccess(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	authCtx.AccountType = "pro"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
+	require.NoError(t, err)
+	require.Len(t, result.Grants, len(expectedFullAccessScopes))
+
+	byScope := make(map[string]*gen.ListRoleGrant, len(result.Grants))
+	for _, grant := range result.Grants {
+		byScope[grant.Scope] = grant
+	}
+
+	for _, scope := range expectedFullAccessScopes {
+		grant, ok := byScope[scope]
+		require.True(t, ok)
+		require.Nil(t, grant.Resources)
+	}
+}
+
+func TestService_ListGrants_RBACDisabledReturnsFullAccess(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	ti.service.access.features = stubFeatureChecker{enabled: false}
+
+	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
+	require.NoError(t, err)
+	require.Len(t, result.Grants, len(expectedFullAccessScopes))
+
+	byScope := make(map[string]*gen.ListRoleGrant, len(result.Grants))
+	for _, grant := range result.Grants {
+		byScope[grant.Scope] = grant
+	}
+
+	for _, scope := range expectedFullAccessScopes {
+		grant, ok := byScope[scope]
+		require.True(t, ok)
+		require.Nil(t, grant.Resources)
+	}
 }
 
 func TestService_ListGrants_WorkOSMembersFailure(t *testing.T) {
@@ -81,6 +155,8 @@ func TestService_ListGrants_WorkOSMembersFailure(t *testing.T) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, authCtx.UserID, "member@example.com", "Member User", "workos_user_member", "membership_1")
 

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -148,6 +148,34 @@ func TestService_ListGrants_RBACDisabledReturnsFullAccess(t *testing.T) {
 	}
 }
 
+func TestService_ListGrants_EnterpriseWithoutSessionReturnsFullAccess(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	authCtx.AccountType = "enterprise"
+	authCtx.SessionID = nil
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
+	require.NoError(t, err)
+	require.Len(t, result.Grants, len(expectedFullAccessScopes))
+
+	byScope := make(map[string]*gen.ListRoleGrant, len(result.Grants))
+	for _, grant := range result.Grants {
+		byScope[grant.Scope] = grant
+	}
+
+	for _, scope := range expectedFullAccessScopes {
+		grant, ok := byScope[scope]
+		require.True(t, ok)
+		require.Nil(t, grant.Resources)
+	}
+}
+
 func TestService_ListGrants_WorkOSMembersFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Prevents issues when orgs are not properly linked in WorkOS and RBAC is disabled.

## Summary
- bypass WorkOS membership and organization linkage lookups in `ListGrants` when RBAC is disabled
- return full-access grant payloads when grants are not being enforced
- add regression coverage for non-enterprise and RBAC-disabled access grant responses
