### PR TITLE
fix: add hard limits to fly runners to avoid OOM errors

### DIFF
--- a/.changeset/long-ghosts-lie.md
+++ b/.changeset/long-ghosts-lie.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Set a hard limit on concurrent HTTP requests to Gram Function runners deployed on Fly. This prevents OOM errors when a large number of tool calls are made in a short period of time. This can cause memory exhaustion and crashes.

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -642,7 +642,7 @@ func (f *FlyRunner) newMachineConfig(req RunnerDeployRequest, image string, file
 		Guest: &fly.MachineGuest{
 			CPUKind:       "shared",
 			CPUs:          2,
-			MemoryMB:      2048,
+			MemoryMB:      memoryMB,
 			GPUs:          0,
 			PersistRootfs: fly.MachinePersistRootfsNever,
 		},

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -613,9 +613,23 @@ func (f *FlyRunner) reap(ctx context.Context, logger *slog.Logger, appsRepo *rep
 	return nil
 }
 
+// concurrencyLimits derives Fly proxy concurrency soft and hard limits from the
+// machine's memory allocation. The hard limit caps the maximum concurrent
+// connections the Fly proxy will route to a single machine; the soft limit
+// triggers traffic deprioritization so the proxy can spread load before hitting
+// the hard cap.
+func concurrencyLimits(memoryMB int) (softLimit, hardLimit int) {
+	hardLimit = max(memoryMB/64, 4)
+	softLimit = max(hardLimit*3/4, 2)
+	return softLimit, hardLimit
+}
+
 func (f *FlyRunner) newMachineConfig(req RunnerDeployRequest, image string, files []*fly.File, baseMetadata map[string]string) *fly.MachineConfig {
 	machineMeta := maps.Clone(baseMetadata)
 	machineMeta[fly.MachineConfigMetadataKeyFlyProcessGroup] = "gram_functions_runner"
+
+	memoryMB := 2048
+	softLimit, hardLimit := concurrencyLimits(memoryMB)
 
 	return &fly.MachineConfig{
 		Image: image,
@@ -659,8 +673,9 @@ func (f *FlyRunner) newMachineConfig(req RunnerDeployRequest, image string, file
 					},
 				},
 				Concurrency: &fly.MachineServiceConcurrency{
-					Type:      "connections",
-					SoftLimit: 20,
+					Type:      "requests",
+					SoftLimit: softLimit,
+					HardLimit: hardLimit,
 				},
 			},
 		},

--- a/server/internal/functions/deploy_fly_test.go
+++ b/server/internal/functions/deploy_fly_test.go
@@ -1,0 +1,49 @@
+package functions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrencyLimits_256MB(t *testing.T) {
+	t.Parallel()
+	soft, hard := concurrencyLimits(256)
+	require.Equal(t, 4, hard)
+	require.Equal(t, 3, soft)
+}
+
+func TestConcurrencyLimits_512MB(t *testing.T) {
+	t.Parallel()
+	soft, hard := concurrencyLimits(512)
+	require.Equal(t, 8, hard)
+	require.Equal(t, 6, soft)
+}
+
+func TestConcurrencyLimits_1024MB(t *testing.T) {
+	t.Parallel()
+	soft, hard := concurrencyLimits(1024)
+	require.Equal(t, 16, hard)
+	require.Equal(t, 12, soft)
+}
+
+func TestConcurrencyLimits_2048MB(t *testing.T) {
+	t.Parallel()
+	soft, hard := concurrencyLimits(2048)
+	require.Equal(t, 32, hard)
+	require.Equal(t, 24, soft)
+}
+
+func TestConcurrencyLimits_TinyMemory(t *testing.T) {
+	t.Parallel()
+	soft, hard := concurrencyLimits(64)
+	require.Equal(t, 4, hard, "hard limit floors at 4")
+	require.Equal(t, 3, soft)
+}
+
+func TestConcurrencyLimits_ZeroMemory(t *testing.T) {
+	t.Parallel()
+	soft, hard := concurrencyLimits(0)
+	require.Equal(t, 4, hard, "hard limit floors at 4")
+	require.Equal(t, 3, soft, "soft limit floors at 2 but 3/4 of 4 = 3")
+}


### PR DESCRIPTION
Closes AGE-1834

This change sets a hard limit on concurrent HTTP requests to Gram Function runners deployed on Fly. This prevents OOM errors when a large number of tool calls are made in a short period of time. This can cause memory exhaustion and crashes.