### PR TITLE
fix: use workos_id from registry validate response instead of sso connection id

### DIFF
--- a/mock-speakeasy-idp/claims.go
+++ b/mock-speakeasy-idp/claims.go
@@ -39,6 +39,7 @@ func deriveOrgs(claims *OidcClaims) []organization {
 				UpdatedAt:          now,
 				AccountType:        "free",
 				SSOConnectionID:    &workosOrgID,
+				WorkOSID:           &workosOrgID,
 				UserWorkspaceSlugs: []string{},
 			},
 		}
@@ -55,6 +56,7 @@ func deriveOrgs(claims *OidcClaims) []organization {
 				CreatedAt:          now,
 				UpdatedAt:          now,
 				AccountType:        "free",
+				WorkOSID:           nil,
 				UserWorkspaceSlugs: []string{},
 			})
 		}
@@ -78,6 +80,7 @@ func deriveOrgs(claims *OidcClaims) []organization {
 			CreatedAt:          now,
 			UpdatedAt:          now,
 			AccountType:        "free",
+			WorkOSID:           nil,
 			UserWorkspaceSlugs: []string{},
 		},
 	}

--- a/mock-speakeasy-idp/mockidp.go
+++ b/mock-speakeasy-idp/mockidp.go
@@ -60,11 +60,15 @@ type OrgConfig struct {
 	Name        string
 	Slug        string
 	AccountType string
+	// WorkOSID is the WorkOS organization id included in /validate (json workos_id).
+	// Nil means omit the field so Gram's syncWorkOSIDs skips SetOrgWorkosID for that org.
+	WorkOSID *string
 }
 
 // NewConfig returns a Config with hardcoded test defaults (no env var lookup).
 // Use this in tests for deterministic behavior. Always runs in mock mode.
 func NewConfig() Config {
+	mockOrgWorkOSID := MockOrgID
 	return Config{
 		SecretKey: MockSecretKey,
 		User: UserConfig{
@@ -79,6 +83,7 @@ func NewConfig() Config {
 			Name:        MockOrgName,
 			Slug:        MockOrgSlug,
 			AccountType: "free",
+			WorkOSID:    &mockOrgWorkOSID,
 		},
 	}
 }
@@ -87,6 +92,7 @@ func NewConfig() Config {
 // When OIDC env vars are set, OIDC mode is enabled and the mock user/org
 // config is ignored (real identity comes from the OIDC provider).
 func DefaultConfig() Config {
+	orgID := envStr("MOCK_IDP_ORG_ID", "550e8400-e29b-41d4-a716-446655440000")
 	cfg := Config{
 		SecretKey: envStr("SPEAKEASY_SECRET_KEY", MockSecretKey),
 		User: UserConfig{
@@ -97,10 +103,11 @@ func DefaultConfig() Config {
 			Whitelisted: envBool("MOCK_IDP_USER_WHITELISTED", true),
 		},
 		Organization: OrgConfig{
-			ID:          envStr("MOCK_IDP_ORG_ID", "550e8400-e29b-41d4-a716-446655440000"),
+			ID:          orgID,
 			Name:        envStr("MOCK_IDP_ORG_NAME", "Local Dev Org"),
 			Slug:        envStr("MOCK_IDP_ORG_SLUG", "local-dev-org"),
 			AccountType: envStr("MOCK_IDP_ORG_ACCOUNT_TYPE", "free"),
+			WorkOSID:    &orgID,
 		},
 		Oidc: OidcConfig{
 			Issuer:       envStrNoUnset("OIDC_ISSUER"),
@@ -179,6 +186,7 @@ type organization struct {
 	UpdatedAt          string   `json:"updated_at"`
 	AccountType        string   `json:"account_type"`
 	SSOConnectionID    *string  `json:"sso_connection_id"`
+	WorkOSID           *string  `json:"workos_id,omitempty"`
 	UserWorkspaceSlugs []string `json:"user_workspaces_slugs"`
 }
 
@@ -726,6 +734,7 @@ func (s *server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		UpdatedAt:          now,
 		AccountType:        accountType,
 		SSOConnectionID:    nil,
+		WorkOSID:           nil,
 		UserWorkspaceSlugs: []string{slug},
 	}
 
@@ -894,6 +903,7 @@ func (s *server) buildOrg() organization {
 		UpdatedAt:          fixedTime,
 		AccountType:        s.cfg.Organization.AccountType,
 		SSOConnectionID:    nil,
+		WorkOSID:           s.cfg.Organization.WorkOSID,
 		UserWorkspaceSlugs: []string{s.cfg.Organization.Slug},
 	}
 }

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -39,7 +39,6 @@ type speakeasyProviderOrganization struct {
 	CreatedAt          time.Time `json:"created_at"`
 	UpdatedAt          time.Time `json:"updated_at"`
 	AccountType        string    `json:"account_type"`
-	SSOConnectionID    *string   `json:"sso_connection_id,omitempty"`
 	WorkOSID           *string   `json:"workos_id,omitempty"`   //nolint:tagliatelle // workos_id is correct snake_case
 	UserWorkspaceSlugs []string  `json:"user_workspaces_slugs"` // speakeasy-registry side is user_workspaces_slugs
 }
@@ -215,10 +214,11 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 	var nonFreeOrganizations []auth.OrganizationEntry
 	for i, org := range validateResp.Organizations {
 		authOrg := auth.OrganizationEntry{
-			ID:                 org.ID,
-			Name:               org.Name,
-			Slug:               org.Slug,
-			SsoConnectionID:    org.SSOConnectionID,
+			ID:   org.ID,
+			Name: org.Name,
+			Slug: org.Slug,
+			// will be removed
+			SsoConnectionID:    nil,
 			UserWorkspaceSlugs: org.UserWorkspaceSlugs,
 			Projects:           []*auth.ProjectEntry{}, // filled in from gram server
 		}
@@ -315,10 +315,11 @@ func (s *Manager) CreateOrgFromSpeakeasy(ctx context.Context, idToken string, or
 	organizations := make([]auth.OrganizationEntry, len(validateResp.Organizations))
 	for i, org := range validateResp.Organizations {
 		authOrg := auth.OrganizationEntry{
-			ID:                 org.ID,
-			Name:               org.Name,
-			Slug:               org.Slug,
-			SsoConnectionID:    org.SSOConnectionID,
+			ID:   org.ID,
+			Name: org.Name,
+			Slug: org.Slug,
+			// will be removed
+			SsoConnectionID:    nil,
 			UserWorkspaceSlugs: org.UserWorkspaceSlugs,
 			Projects:           []*auth.ProjectEntry{},
 		}

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -40,6 +40,7 @@ type speakeasyProviderOrganization struct {
 	UpdatedAt          time.Time `json:"updated_at"`
 	AccountType        string    `json:"account_type"`
 	SSOConnectionID    *string   `json:"sso_connection_id,omitempty"`
+	WorkOSID           *string   `json:"workos_id,omitempty"`   //nolint:tagliatelle // workos_id is correct snake_case
 	UserWorkspaceSlugs []string  `json:"user_workspaces_slugs"` // speakeasy-registry side is user_workspaces_slugs
 }
 
@@ -434,11 +435,11 @@ func (s *Manager) syncWorkOSIDs(ctx context.Context, user userRepo.UpsertUserRow
 	// Ensure that all orgs in the response with WorkOS syncing have been
 	// upserted into the database.
 	for _, org := range validateResp.Organizations {
-		if org.SSOConnectionID == nil {
+		if org.WorkOSID == nil {
 			continue
 		}
 		if _, err := s.orgRepo.SetOrgWorkosID(ctx, orgRepo.SetOrgWorkosIDParams{
-			WorkosID:       conv.ToPGText(*org.SSOConnectionID),
+			WorkosID:       conv.ToPGText(*org.WorkOSID),
 			OrganizationID: org.ID,
 		}); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			s.logger.ErrorContext(ctx, "failed to set org workos ID", attr.SlogError(err))

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -214,9 +214,10 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 	var nonFreeOrganizations []auth.OrganizationEntry
 	for i, org := range validateResp.Organizations {
 		authOrg := auth.OrganizationEntry{
-			ID:                 org.ID,
-			Name:               org.Name,
-			Slug:               org.Slug,
+			ID:   org.ID,
+			Name: org.Name,
+			Slug: org.Slug,
+			// will be removed
 			UserWorkspaceSlugs: org.UserWorkspaceSlugs,
 			Projects:           []*auth.ProjectEntry{}, // filled in from gram server
 		}
@@ -313,9 +314,11 @@ func (s *Manager) CreateOrgFromSpeakeasy(ctx context.Context, idToken string, or
 	organizations := make([]auth.OrganizationEntry, len(validateResp.Organizations))
 	for i, org := range validateResp.Organizations {
 		authOrg := auth.OrganizationEntry{
-			ID:                 org.ID,
-			Name:               org.Name,
-			Slug:               org.Slug,
+			ID:   org.ID,
+			Name: org.Name,
+			Slug: org.Slug,
+			// will be removed
+			SsoConnectionID:    nil,
 			UserWorkspaceSlugs: org.UserWorkspaceSlugs,
 			Projects:           []*auth.ProjectEntry{},
 		}

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -218,6 +218,7 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 			Name: org.Name,
 			Slug: org.Slug,
 			// will be removed
+			SsoConnectionID:    nil,
 			UserWorkspaceSlugs: org.UserWorkspaceSlugs,
 			Projects:           []*auth.ProjectEntry{}, // filled in from gram server
 		}

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -214,11 +214,9 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 	var nonFreeOrganizations []auth.OrganizationEntry
 	for i, org := range validateResp.Organizations {
 		authOrg := auth.OrganizationEntry{
-			ID:   org.ID,
-			Name: org.Name,
-			Slug: org.Slug,
-			// will be removed
-			SsoConnectionID:    nil,
+			ID:                 org.ID,
+			Name:               org.Name,
+			Slug:               org.Slug,
 			UserWorkspaceSlugs: org.UserWorkspaceSlugs,
 			Projects:           []*auth.ProjectEntry{}, // filled in from gram server
 		}
@@ -315,11 +313,9 @@ func (s *Manager) CreateOrgFromSpeakeasy(ctx context.Context, idToken string, or
 	organizations := make([]auth.OrganizationEntry, len(validateResp.Organizations))
 	for i, org := range validateResp.Organizations {
 		authOrg := auth.OrganizationEntry{
-			ID:   org.ID,
-			Name: org.Name,
-			Slug: org.Slug,
-			// will be removed
-			SsoConnectionID:    nil,
+			ID:                 org.ID,
+			Name:               org.Name,
+			Slug:               org.Slug,
 			UserWorkspaceSlugs: org.UserWorkspaceSlugs,
 			Projects:           []*auth.ProjectEntry{},
 		}

--- a/server/internal/auth/sessions/speakeasyconnections_test.go
+++ b/server/internal/auth/sessions/speakeasyconnections_test.go
@@ -140,6 +140,13 @@ type testSetup struct {
 // and a fake WorkOS server. The mock IDP org is seeded into organization_metadata.
 func newManagerWithFakeWorkOS(t *testing.T, fake *fakeWorkOSServer) *testSetup {
 	t.Helper()
+	return newManagerWithFakeWorkOSConfig(t, fake, mockidp.NewConfig())
+}
+
+// newManagerWithFakeWorkOSConfig is like newManagerWithFakeWorkOS but uses the
+// given mock IDP config (e.g. to omit workos_id from /validate).
+func newManagerWithFakeWorkOSConfig(t *testing.T, fake *fakeWorkOSServer, idpCfg mockidp.Config) *testSetup {
+	t.Helper()
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -147,7 +154,6 @@ func newManagerWithFakeWorkOS(t *testing.T, fake *fakeWorkOSServer) *testSetup {
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	idpCfg := mockidp.NewConfig()
 	idpSrv := httptest.NewServer(mockidp.Handler(idpCfg))
 	t.Cleanup(idpSrv.Close)
 
@@ -213,7 +219,7 @@ func acquireIDToken(t *testing.T, ctx context.Context, mgr *sessions.Manager) st
 }
 
 // TestSyncWorkOSIDs_PopulatesNonSSOOrg is the core regression test for the bug:
-// workos_id must be backfilled for orgs without an SSO connection.
+// workos_id must be backfilled from validate (workos_id) for orgs that sync with WorkOS.
 func TestSyncWorkOSIDs_PopulatesNonSSOOrg(t *testing.T) {
 	t.Parallel()
 
@@ -229,16 +235,52 @@ func TestSyncWorkOSIDs_PopulatesNonSSOOrg(t *testing.T) {
 
 	ts := newManagerWithFakeWorkOS(t, fake)
 	ctx := t.Context()
+
+	// Simulate an org row that has not yet been linked to WorkOS in Gram.
+	_, err := ts.conn.Exec(ctx, `UPDATE organization_metadata SET workos_id = NULL WHERE id = $1`, workosOrgID)
+	require.NoError(t, err)
+
 	idToken := acquireIDToken(t, ctx, ts.mgr)
 
 	// syncWorkOSIDs is called synchronously inside GetUserInfoFromSpeakeasy.
-	_, err := ts.mgr.GetUserInfoFromSpeakeasy(ctx, idToken)
+	_, err = ts.mgr.GetUserInfoFromSpeakeasy(ctx, idToken)
 	require.NoError(t, err)
 
 	org, err := orgRepo.New(ts.conn).GetOrganizationMetadata(ctx, workosOrgID)
 	require.NoError(t, err)
-	require.True(t, org.WorkosID.Valid, "workos_id should be populated for non-SSO org")
+	require.True(t, org.WorkosID.Valid, "workos_id should be populated from validate workos_id")
 	require.Equal(t, workosOrgID, org.WorkosID.String)
+}
+
+// TestSyncWorkOSIDs_SkipsSetOrgWorkosIDWhenValidateOmitsWorkOSID verifies that when
+// the Speakeasy validate response omits workos_id, Gram does not set organization_metadata.workos_id.
+func TestSyncWorkOSIDs_SkipsSetOrgWorkosIDWhenValidateOmitsWorkOSID(t *testing.T) {
+	t.Parallel()
+
+	cfg := mockidp.NewConfig()
+	cfg.Organization.WorkOSID = nil
+
+	const workosUserID = "wos_user_skip_validate_wos"
+
+	fake := newFakeWorkOSServer()
+	fake.users = []fakeWOSUser{{ID: workosUserID, Email: mockidp.MockUserEmail}}
+	fake.memberships = []fakeWOSMembership{
+		{ID: "mem_skip_v", UserID: workosUserID, OrganizationID: mockidp.MockOrgID, RoleSlug: "member"},
+	}
+
+	ts := newManagerWithFakeWorkOSConfig(t, fake, cfg)
+	ctx := t.Context()
+
+	_, err := ts.conn.Exec(ctx, `UPDATE organization_metadata SET workos_id = NULL WHERE id = $1`, mockidp.MockOrgID)
+	require.NoError(t, err)
+
+	idToken := acquireIDToken(t, ctx, ts.mgr)
+	_, err = ts.mgr.GetUserInfoFromSpeakeasy(ctx, idToken)
+	require.NoError(t, err)
+
+	org, err := orgRepo.New(ts.conn).GetOrganizationMetadata(ctx, mockidp.MockOrgID)
+	require.NoError(t, err)
+	require.False(t, org.WorkosID.Valid, "workos_id must remain unset when validate omits workos_id")
 }
 
 // TestSyncWorkOSIDs_UserWorkosIDSet verifies the user's workos_id is recorded


### PR DESCRIPTION
Update sync code to gate on work os id being populated when upserting org metadata. The registry populates this field more reliably than the sso id