### PR TITLE
fix: point gf bin to source .ts to avoid pnpm install warning

### DIFF
--- a/.changeset/fix-gf-bin-warning.md
+++ b/.changeset/fix-gf-bin-warning.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/functions": patch
+---
+
+Fix pnpm install warning by pointing gf bin to source .ts instead of compiled dist

--- a/ts-framework/functions/package.json
+++ b/ts-framework/functions/package.json
@@ -17,7 +17,7 @@
     "directory": "ts-framework/functions"
   },
   "bin": {
-    "gf": "./dist/bin/cli.js"
+    "gf": "./src/bin/cli.ts"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Point `bin.gf` in `@gram-ai/functions` to `./src/bin/cli.ts` instead of `./dist/bin/cli.js`
- Eliminates the `ENOENT` warning during `pnpm install` when `dist/` hasn't been built yet
- Works because the source file already has a `node --experimental-strip-types` shebang

## Test plan
- [x] `rm -rf ts-framework/functions/dist && pnpm i` — no warning
- [x] `gf --help` — CLI works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)