### PR TITLE
fix: prevent Page.Body from overflowing past PageLayout (AGE-1840)

### DIFF
--- a/client/dashboard/src/components/page-layout.tsx
+++ b/client/dashboard/src/components/page-layout.tsx
@@ -40,7 +40,11 @@ function PageBody({
     // Nest the max-width container inside another div so that the entire page area remains scrollable
     <div
       className={cn(
-        "h-full w-full",
+        // flex-1 + min-h-0 ensures this pane occupies exactly the remaining
+        // space in PageLayout's flex column (after PageHeader). Using h-full
+        // here would resolve to 100% of PageLayout and overflow past the
+        // header, clipping content at the bottom.
+        "min-h-0 w-full flex-1",
         overflowHidden ? "flex flex-col overflow-hidden" : "overflow-y-auto",
       )}
     >


### PR DESCRIPTION
## Summary

- The outer `Page.Body` wrapper used `h-full w-full`, which resolves to 100% of `PageLayout` — the same height `PageHeader` already partly consumes. Under tall content (e.g. the Playground's resizable panels with a long tools list), the body's bottom pixels spilled past `PageLayout` and got clipped by its `overflow-hidden`.
- Switched the wrapper to `min-h-0 w-full flex-1` so it occupies exactly the remaining space in `PageLayout`'s flex column after `PageHeader` — the canonical CSS pattern for a scrollable flex-column child.

Fixes [AGE-1840](https://linear.app/speakeasy/issue/AGE-1840/bug-playground-ui-cut-off).

## Test plan

- [ ] Open the Playground with a toolset that has many tools and confirm the tools list and chat composer both render within the viewport, with the tools list scrolling internally rather than the bottom items being cut off.
- [ ] Open other pages that use `Page.Body` (Home, Toolsets, ToolBuilder, Hooks, ChatLogs, etc.) and confirm layout is unchanged.
- [ ] Resize the window to narrower and shorter dimensions and confirm the Playground bottom (tools list and chat input) remains inside the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)