### PR TITLE
fix: update MCP install page troubleshooting link

### DIFF
--- a/server/internal/mcpmetadata/hosted_page.html.tmpl
+++ b/server/internal/mcpmetadata/hosted_page.html.tmpl
@@ -1632,7 +1632,7 @@ http_headers = { {{ range $i, $input := .SecurityInputs }}{{- if $i }}, {{ end }
           <div class="section-description">
             If you have a client that's not listed above, access the raw MCP
             configuration below. Check out
-            <a href="https://docs.getgram.ai/clients/troubleshooting">
+            <a href="https://www.speakeasy.com/docs/mcp/build/integrate/clients/troubleshooting">
               the troubleshooting documentation
             </a>
             for more help.


### PR DESCRIPTION
## Summary
- Fix broken troubleshooting link on MCP install page that was returning 404
- Updated link from `https://docs.getgram.ai/clients/troubleshooting` to `https://www.speakeasy.com/docs/mcp/build/integrate/clients/troubleshooting`

## Test plan
- [ ] Verify the new troubleshooting link resolves correctly

Slack thread: https://speakeasyapi.slack.com/archives/C093GJA5ENT/p1776372000928959?thread_ts=1776365077.537349&cid=C093GJA5ENT

https://claude.ai/code/session_016RbieMRMAkTJVrnmWFvAkz