### PR TITLE
fix: claude desktop install instructions for header-auth MCP servers

### DIFF
--- a/server/internal/mcpmetadata/hosted_page.html.tmpl
+++ b/server/internal/mcpmetadata/hosted_page.html.tmpl
@@ -1026,6 +1026,73 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
     >
       <div class="modal-content">
         <h1>Instructions</h1>
+        {{- if .SecurityInputs }}
+        <ol>
+          <li class="instruction-item">
+            In Claude Desktop, navigate to
+            <strong
+              >Settings &gt; Developer &gt; Local MCP Servers &gt; Edit
+              config</strong
+            >. This opens your <code>claude_desktop_config.json</code> file in
+            your operating system's file browser.
+          </li>
+          <li class="instruction-item">
+            Open <code>claude_desktop_config.json</code> in your editor of
+            choice and merge in the following configuration. Replace each
+            <code>your-*-value</code> placeholder with your actual credential.
+            <div class="card code-container">
+              <button class="copy-button waiting">
+                <svg
+                  class="icon icon-copy"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy"></use>
+                </svg>
+                <svg
+                  class="icon icon-copy-success"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy-check"></use>
+                </svg>
+              </button>
+              <!-- prettier-ignore -->
+              <code class="code-snippet language-json">{
+  "mcpServers": {
+    "{{ .MCPSlug }}": {
+      "command": "npx",
+      "args": [
+        "mcp-remote@0.1.25",
+        "{{ .MCPURL }}"{{- range .SecurityInputs }},
+        "--header",
+        "{{ .SystemName | asHTTPHeader }}:${{ "{" }}{{ .DisplayName | asPosixName }}{{ "}" }}"{{- end }}
+      ],
+      "env": {
+        {{- range $i, $input := .SecurityInputs }}{{- if $i }},{{ end }}
+        "{{ $input.DisplayName | asPosixName }}": "your-{{ $input.DisplayName | asPosixName }}-value"{{- end }}
+      }
+    }
+  }
+}</code>
+            </div>
+          </li>
+          <li class="instruction-item">
+            Save <code>claude_desktop_config.json</code> and restart Claude
+            Desktop to load the new configuration.
+          </li>
+        </ol>
+        <p>
+          These steps are longer than the
+          <strong>Add custom connector</strong> flow because Claude Desktop
+          does not yet support custom HTTP headers in remote MCP server
+          connectors. Configuring a local MCP server entry that proxies to the
+          remote server (via <code>mcp-remote</code>) is the current
+          workaround.
+        </p>
+        {{- else }}
         <ol>
           <li class="instruction-item">
             In Claude Desktop, navigate to
@@ -1077,6 +1144,7 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
           page. Once added, team members can connect from
           <strong>Settings &gt; Connectors</strong>.
         </p>
+        {{- end }}
       </div>
     </template>
     <template class="install-target-template" data-install-target="codex-cli">

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -823,6 +823,98 @@ func TestServeInstallPage_CustomDomain_DeletedToolsetReturnsNotFound(t *testing.
 	assert.Contains(t, rr.Body.String(), "Server Not Found")
 }
 
+// TestServeInstallPage_ClaudeDesktop_NoSecurityInputs verifies that a public
+// MCP server with no required HTTP headers renders the simple "Add custom
+// connector" Claude Desktop install flow, including the Teams & Enterprise
+// admin connector footer.
+func TestServeInstallPage_ClaudeDesktop_NoSecurityInputs(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "claude-desktop-public-" + uuid.New().String()[:8]
+	toolset, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Public Claude Desktop Toolset",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("public toolset with no security inputs"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	_, err = testInstance.conn.Exec(ctx,
+		"UPDATE toolsets SET mcp_is_public = true WHERE id = $1", toolset.ID)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(context.Background(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = testInstance.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.Contains(t, body, `"Add custom connector"`, "should render the simple Add custom connector flow")
+	assert.Contains(t, body, "For Teams &amp; Enterprise", "should render the Teams & Enterprise admin connector footer")
+	assert.NotContains(t, body, "Settings &gt; Developer &gt; Local MCP Servers", "should not render the claude_desktop_config.json workaround flow")
+	assert.NotContains(t, body, "Claude Desktop does not yet support custom HTTP headers", "should not render the workaround explanation")
+}
+
+// TestServeInstallPage_ClaudeDesktop_WithSecurityInputs verifies that an MCP
+// server requiring HTTP-header credentials renders the claude_desktop_config.json
+// workaround flow (because Claude Desktop's custom connector UI does not yet
+// support custom HTTP headers) and hides the simple Add custom connector flow
+// and the Teams & Enterprise footer (which has the same UI limitation).
+func TestServeInstallPage_ClaudeDesktop_WithSecurityInputs(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "claude-desktop-private-" + uuid.New().String()[:8]
+	_, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Private Claude Desktop Toolset",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("private toolset producing security inputs via gram security mode"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = testInstance.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.Contains(t, body, "Settings &gt; Developer &gt; Local MCP Servers", "should render the claude_desktop_config.json edit instructions")
+	assert.Contains(t, body, `"mcpServers"`, "should render the claude_desktop_config.json snippet")
+	assert.Contains(t, body, `"mcp-remote@0.1.25"`, "should render the mcp-remote command in the snippet")
+	assert.Contains(t, body, `"--header"`, "should render the --header argument in the snippet")
+	assert.Contains(t, body, "does not yet support custom HTTP headers", "should explain why the workaround is needed")
+	assert.NotContains(t, body, `"Add custom connector"`, "should not render the simple Add custom connector flow")
+	assert.NotContains(t, body, "For Teams &amp; Enterprise", "should not render the Teams & Enterprise admin connector footer")
+}
+
 // TestServeInstallPage_NoDomain_AuthedUserWithOrgDomain verifies that a toolset
 // WITHOUT a custom domain can still be loaded via the platform domain when the
 // logged-in user's organization happens to have a custom domain configured. This


### PR DESCRIPTION
[AGE-1841](https://linear.app/speakeasy/issue/AGE-1841/feature-claude-desktop-install-instructions-missing-environment)

When the MCP server requires HTTP-header credentials, the Claude Desktop install steps now walk users through editing `claude_desktop_config.json` with an `mcp-remote` + `--header` + `env` block, instead of the simple **Add custom connector** flow which silently fails because Claude Desktop's connector UI does not yet support custom HTTP headers.

The original 4-step connector flow (and the **For Teams & Enterprise** admin connector footer, which has the same UI limitation) is still shown for MCP servers with no security inputs.