### PR TITLE
chore: add mise task to rebuild local clickhouse image

### DIFF
--- a/.mise-tasks/clickhouse/rebuild.sh
+++ b/.mise-tasks/clickhouse/rebuild.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="Rebuild the local ClickHouse image to pick up config changes (users.d, config.d)"
+
+set -e
+
+docker compose up -d --build clickhouse
+
+until curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${CLICKHOUSE_HTTP_PORT}/?user=${CLICKHOUSE_USERNAME}&password=${CLICKHOUSE_PASSWORD}&query=SELECT+1" | grep -q 200; do
+    echo "Waiting for ClickHouse to be ready..."
+    sleep 1
+done
+
+echo "ClickHouse rebuilt and ready."


### PR DESCRIPTION
## Summary

- Adds `mise run clickhouse:rebuild` which runs `docker compose up -d --build clickhouse` and waits for the HTTP port to return 200.
- Lets devs pick up changes under `local/clickhouse/users.d/` and `config.d/` without remembering the docker compose flags.

## Why

`local/clickhouse/users.d/dev_profile.xml` was bumped to `max_concurrent_queries_for_user=30` in #1905, but pre-existing local ClickHouse images
keep the stale `=2` limit baked in. That surfaces as `Code 202: Too many simultaneous queries` for any endpoint that fans out queries (e.g. the
hooks summary endpoint fires six parallel CH queries). A one-shot task makes the recovery obvious.

## Test plan

- [x] `shellcheck .mise-tasks/clickhouse/rebuild.sh` clean
- [x] `mise tasks` lists `clickhouse:rebuild` with description
- [x] `mise run clickhouse:rebuild` rebuilds the image, recreates the container, and exits cleanly once CH responds
- [x] Verified `system.settings` shows `max_concurrent_queries_for_user=30` after rebuild
