### PR TITLE
chore: upgrade madprocs to 0.1.31 and fix TTY corruption in ./zero

### DIFF
--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -4,7 +4,7 @@
 docker compose up -d || exit 1
 
 # Use psql to wait for the databases to be ready
-until docker compose exec gram-db psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT 1" > /dev/null 2>&1; do
+until docker compose exec -T gram-db psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT 1" > /dev/null 2>&1; do
     echo "Waiting for databases to be ready..."
     sleep 1
 done

--- a/.mise-tasks/start/_default
+++ b/.mise-tasks/start/_default
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 #MISE description="Start all development processes with madprocs"
+#MISE raw=true
+#MISE interactive=true
 
 #USAGE flag "--tls-cert <file>" env="GRAM_SSL_CERT_FILE" help="Path to TLS certificate file for web ui"
 #USAGE flag "--tls-key <file>" env="GRAM_SSL_KEY_FILE" help="Path to TLS key file for web ui"

--- a/.mise-tasks/zero/cleanup.sh
+++ b/.mise-tasks/zero/cleanup.sh
@@ -10,7 +10,7 @@ set -e
 if docker compose ps gram-temporal --status running -q 2>/dev/null | grep -q .; then
     echo "Restarting Temporal container..."
     docker compose restart gram-temporal
-    until docker compose exec gram-temporal temporal operator cluster health 2>/dev/null; do
+    until docker compose exec -T gram-temporal temporal operator cluster health 2>/dev/null; do
         echo "Waiting for Temporal to be healthy..."
         sleep 2
     done

--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -86,7 +86,7 @@ async function pokePostgreSQL() {
   }
 
   result =
-    await $`docker compose exec gram-db psql -U ${process.env["DB_USER"]} -d ${process.env["DB_NAME"]} -c "SELECT 1"`;
+    await $`docker compose exec -T gram-db psql -U ${process.env["DB_USER"]} -d ${process.env["DB_NAME"]} -c "SELECT 1"`;
   if (!result.ok) {
     return console.log(
       `⚪︎ Gram database: unable to connect to the database: ${result.stderr}`,
@@ -100,48 +100,4 @@ async function pokePostgreSQL() {
   );
 }
 
-async function pokeOtel() {
-  const result = await $`docker compose ps oteltui --format json`;
-  if (!result.ok) {
-    return console.log("⚪︎ otel-tui: not running.");
-  }
-
-  let parsed: unknown = {};
-  try {
-    parsed = JSON.parse(result.stdout);
-    if (
-      typeof parsed !== "object" ||
-      !parsed ||
-      !("Publishers" in parsed) ||
-      !Array.isArray(parsed.Publishers)
-    ) {
-      throw new Error("Unexpected container info");
-    }
-  } catch (e: unknown) {
-    return console.log(`⚪︎ otel-tui: unable to get info from docker: ${e}`);
-  }
-
-  const portspec = parsed.Publishers.find((p) => {
-    return (
-      typeof p === "object" &&
-      p &&
-      "TargetPort" in p &&
-      p.TargetPort === 4317 &&
-      typeof p.PublishedPort === "number"
-    );
-  });
-
-  const p =
-    typeof portspec?.PublishedPort === "number" ? portspec.PublishedPort : null;
-
-  if (p == null) {
-    return console.log(
-      "⚪︎ otel-tui: container port 4317 does not appear to be published.",
-    );
-  }
-
-  console.log(chalk.greenBright(`⚫︎ otel-tui is running on port ${p}`));
-}
-
-await pokeOtel();
 await pokePostgreSQL();

--- a/compose.yml
+++ b/compose.yml
@@ -60,6 +60,7 @@ services:
     image: ymtdzzz/otel-tui@sha256:67010920b012ee998888cf39a794f32e97ca4b01cd02681f25e8f47c261e305b
     stdin_open: true
     tty: true
+    profiles: ["tools"]
     ports:
       - "${OTLP_GRPC_PORT}:4317"
 

--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,7 @@ uv = "0.10.9"
 yq = "4.52.4"
 hk = "1.38.0"
 pkl = "0.31.0"
-"github:speakeasy-api/madprocs" = "0.1.27"
+"github:speakeasy-api/madprocs" = "0.1.31"
 "github:temporalio/cli" = "1.6.1"
 
 # ℹ️ The settings below are sensible defaults for local development. When


### PR DESCRIPTION
## Summary

- Upgrade madprocs from 0.1.27 to 0.1.31 (adds VT10x alt-buffer support for TUI apps like otel-tui)
- Fix TTY corruption that prevented madprocs VT10x rendering from working when launched via `./zero`

## What was the problem?

Running `madprocs` directly worked fine, but launching it via `./zero` broke VT10x alt-buffer rendering (otel-tui wouldn't render correctly). The root cause was the `oteltui` Docker Compose service, which has `tty: true` and `stdin_open: true`. When `docker compose up -d` ran in `infra:start`, Docker allocated a PTY for the oteltui container even in detached mode, corrupting the host terminal's TTY driver state. This corruption persisted through `exec mise run start` into madprocs, breaking its VT10x emulation.

## Changes

- **`compose.yml`**: Added `profiles: ["tools"]` to the `oteltui` service so it's excluded from `docker compose up -d` (infrastructure startup). It still starts on-demand when madprocs runs `docker compose up -d oteltui` via the `start:oteltui` task, since explicitly naming a service overrides profile restrictions.
- **`.mise-tasks/start/_default`**: Added `raw=true` and `interactive=true` mise directives so madprocs gets proper TTY access when launched via `mise run start`.
- **`.mise-tasks/infra/start.sh`**, **`.mise-tasks/zero/cleanup.sh`**, **`.mise-tasks/zero/summary.mts`**: Added `-T` flag to `docker compose exec` health-check calls. These are non-interactive queries that don't need a TTY — disabling PTY allocation avoids unnecessary terminal interaction during setup.
- **`.mise-tasks/zero/summary.mts`**: Removed the `pokeOtel()` pre-flight check. Since otel-tui is now an on-demand tool managed by madprocs (not infrastructure started by `infra:start`), checking it during setup always reported "not running".

## Test plan

- [x] `mise run start` — madprocs starts, otel-tui renders correctly with alt-buffer
- [x] `./zero` — full setup flow completes and madprocs VT10x works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
