### PR TITLE
chore: add env tags to Datadog RUM browser SDK

### DIFF
--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -75,12 +75,15 @@ export const TelemetryProvider = (props: { children: ReactNode }) => {
       return;
     }
 
-    if (getServerURL().includes("getgram.ai")) {
+    const serverURL = getServerURL();
+    if (serverURL.includes("getgram.ai")) {
+      const env = serverURL.includes("app.getgram.ai") ? "prod" : "dev";
       datadogRum.init({
         applicationId: "93afb64a-dd15-490c-a749-51b4c5c5a171",
         clientToken: "pub8358667232c624e2f91e1eaa0bd380fd",
         site: "datadoghq.com",
         service: "gram",
+        env,
         sessionSampleRate: 100,
         sessionReplaySampleRate: 100,
         trackUserInteractions: true,

--- a/elements/src/lib/errorTracking.config.ts
+++ b/elements/src/lib/errorTracking.config.ts
@@ -7,10 +7,12 @@
  * - VITE_DATADOG_APPLICATION_ID
  * - VITE_DATADOG_CLIENT_TOKEN
  * - VITE_DATADOG_SITE (optional, defaults to datadoghq.com)
+ * - VITE_DATADOG_ENV (optional, defaults to prod)
  */
 export const DATADOG_CONFIG = {
   applicationId: import.meta.env.VITE_DATADOG_APPLICATION_ID ?? "",
   clientToken: import.meta.env.VITE_DATADOG_CLIENT_TOKEN ?? "",
   site: import.meta.env.VITE_DATADOG_SITE ?? "datadoghq.com",
+  env: import.meta.env.VITE_DATADOG_ENV ?? "prod",
   service: "gram-elements",
 } as const;

--- a/elements/src/lib/errorTracking.ts
+++ b/elements/src/lib/errorTracking.ts
@@ -44,7 +44,7 @@ export function initErrorTracking(config: ErrorTrackingConfig = {}): void {
       clientToken: DATADOG_CONFIG.clientToken,
       site: DATADOG_CONFIG.site,
       service: DATADOG_CONFIG.service,
-      env: process.env.NODE_ENV || "production",
+      env: DATADOG_CONFIG.env,
       sessionSampleRate: 100,
       sessionReplaySampleRate: 100,
       trackUserInteractions: true,


### PR DESCRIPTION
## Summary

- **Dashboard**: Adds `env` tag to `datadogRum.init()` derived from the server URL at runtime — `app.getgram.ai` → `env:prod`, everything else (`dev.getgram.ai`, `pr-*.dev.getgram.ai`) → `env:dev`
- **Elements**: Replaces hardcoded `process.env.NODE_ENV` (always `"production"` in builds) with a `VITE_DATADOG_ENV` build-time env var, defaulting to `prod`
- Uses `dev`/`prod` values to match existing server-side Datadog conventions

This allows filtering Datadog RUM alerts to `env:prod` only, so dev/preview traffic doesn't trigger false alarms.

## Deployment note

The elements build pipeline needs `VITE_DATADOG_ENV=dev` set for the dev environment build. Prod builds will default to `prod` if unset.

## Test plan

- [ ] Verify `app.getgram.ai` RUM sessions are tagged `env:prod` in Datadog
- [ ] Verify `dev.getgram.ai` RUM sessions are tagged `env:dev`
- [ ] Verify preview apps (`pr-*.dev.getgram.ai`) are tagged `env:dev`
- [ ] Verify elements RUM respects the `VITE_DATADOG_ENV` build var

🤖 Generated with [Claude Code](https://claude.com/claude-code)