### PR TITLE
chore: prevent dev toolbar from crashing

### DIFF
--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useIsAdmin, useOrganization } from "@/contexts/Auth";
+import { useIsAdmin, useOrganization, useSession } from "@/contexts/Auth";
 import { useListToolsetsForOrg } from "@gram/client/react-query/listToolsetsForOrg.js";
 import { Switch } from "./ui/switch";
 import { useQueryClient } from "@tanstack/react-query";
@@ -170,7 +170,11 @@ const GROUP_ORDER: { key: ResourceType; label: string }[] = [
 ];
 
 export function RBACDevToolbar() {
+  const { session } = useSession();
   const isAdmin = useIsAdmin();
+  // Don't render when unauthenticated (e.g. login page) to avoid firing
+  // API calls like toolsets.listForOrg that will 401 and trigger the error boundary.
+  if (!session) return null;
   // Always visible in dev; in other environments, restricted to superadmins.
   if (import.meta.env.DEV || isAdmin) return <RBACDevToolbarInner />;
   return null;
@@ -185,7 +189,9 @@ function RBACDevToolbarInner() {
   const queryClient = useQueryClient();
   const organization = useOrganization();
   const projects = organization?.projects ?? [];
-  const { data: toolsetsData } = useListToolsetsForOrg();
+  const { data: toolsetsData } = useListToolsetsForOrg(undefined, undefined, {
+    throwOnError: false,
+  });
   const projectResources = projects.map((project) => ({
     id: project.id,
     label: project.slug,


### PR DESCRIPTION
## Summary

- Skip rendering `RBACDevToolbar` when unauthenticated (e.g. on `/login`) to prevent `toolsets.listForOrg` from firing and returning 401
- Set `throwOnError: false` on the `useListToolsetsForOrg` query so unchecking org-level scopes in the toolbar doesn't trigger the error boundary and crash the page

## Test plan

- [ ] Navigate to `/login` while logged out — no "Something went wrong" error, no `toolsets.listForOrg` request in network tab
- [ ] Log in, open the RBAC dev toolbar, uncheck `org:read` and `org:admin` — page remains functional, toolbar shows empty MCP resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)