### PR TITLE
chore: improve dev toolbar resource picker UX

### DIFF
--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -3,7 +3,13 @@ import { useListToolsetsForOrg } from "@gram/client/react-query/listToolsetsForO
 import { Switch } from "./ui/switch";
 import { useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, ChevronUp, GripVertical, Shield } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 
 const STORAGE_KEY = "gram-rbac-dev-override";
@@ -184,7 +190,6 @@ function RBACDevToolbarInner() {
   const [state, setState] = useState<OverrideState>(loadState);
   const [collapsed, setCollapsed] = useState(true);
   const [activeTab, setActiveTab] = useState("rbac");
-  const [expandedScope, setExpandedScope] = useState<string | null>(null);
   const [pos, setPos] = useState<{ x: number; y: number } | null>(loadPosition);
   const queryClient = useQueryClient();
   const organization = useOrganization();
@@ -216,6 +221,18 @@ function RBACDevToolbarInner() {
   useEffect(() => {
     if (pos) localStorage.setItem(POSITION_KEY, JSON.stringify(pos));
   }, [pos]);
+
+  // Clamp position so the expanded toolbar stays within the viewport
+  useLayoutEffect(() => {
+    if (collapsed) return;
+    const el = rootRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom > window.innerHeight) {
+      const clampedY = Math.max(0, window.innerHeight - rect.height - 8);
+      setPos({ x: rect.left, y: clampedY });
+    }
+  }, [collapsed]);
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLButtonElement>) => {
@@ -419,7 +436,6 @@ function RBACDevToolbarInner() {
                             enabled: true,
                             resources: null,
                           };
-                          const isExpanded = expandedScope === def.scope;
                           const isRestricted =
                             scopeState.resources !== null &&
                             scopeState.resources.length > 0;
@@ -459,38 +475,18 @@ function RBACDevToolbarInner() {
                                     )}
                                   </div>
                                 </div>
-                                {scopeState.enabled &&
-                                  def.resourceType !== "org" && (
-                                    <button
-                                      type="button"
-                                      className="text-muted-foreground rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        setExpandedScope(
-                                          isExpanded ? null : def.scope,
-                                        );
-                                      }}
-                                    >
-                                      {isExpanded ? (
-                                        <ChevronUp className="h-3 w-3" />
-                                      ) : (
-                                        <ChevronDown className="h-3 w-3" />
-                                      )}
-                                    </button>
-                                  )}
                               </div>
 
-                              {/* Resource picker */}
-                              {/* TODO: verify resource-scoped overrides are enforced end-to-end (header → backend → UI) */}
-                              {isExpanded && scopeState.enabled && (
-                                <ResourcePicker
-                                  knownResources={knownResources}
-                                  selected={scopeState.resources}
-                                  onChange={(resources) =>
-                                    setScopeResources(def.scope, resources)
-                                  }
-                                />
-                              )}
+                              {scopeState.enabled &&
+                                knownResources.length > 0 && (
+                                  <ResourceDropdown
+                                    knownResources={knownResources}
+                                    selected={scopeState.resources}
+                                    onChange={(resources) =>
+                                      setScopeResources(def.scope, resources)
+                                    }
+                                  />
+                                )}
                             </div>
                           );
                         })}
@@ -528,7 +524,7 @@ function RBACDevToolbarInner() {
   );
 }
 
-function ResourcePicker({
+function ResourceDropdown({
   knownResources,
   selected,
   onChange,
@@ -537,84 +533,143 @@ function ResourcePicker({
   selected: string[] | null;
   onChange: (resources: string[] | null) => void;
 }) {
+  const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const isAll = selected === null;
+  const selectedSet = new Set(selected ?? []);
 
-  const alreadySelected = new Set(selected ?? []);
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        !triggerRef.current?.contains(target) &&
+        !panelRef.current?.contains(target)
+      )
+        setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
 
-  // Filter known resources by query
-  const suggestions = knownResources.filter((r) => {
+  const filtered = knownResources.filter((r) => {
     if (!query) return true;
     const q = query.toLowerCase();
     return r.label.toLowerCase().includes(q) || r.id.toLowerCase().includes(q);
   });
 
   const toggleResource = (id: string) => {
-    if (alreadySelected.has(id)) {
-      removeResource(id);
+    if (selectedSet.has(id)) {
+      const next = (selected ?? []).filter((s) => s !== id);
+      onChange(next.length === 0 ? null : next);
     } else {
       onChange([...(selected ?? []), id]);
     }
-    setQuery("");
   };
 
-  const removeResource = (id: string) => {
-    const next = (selected ?? []).filter((s) => s !== id);
-    onChange(next.length === 0 ? null : next);
-  };
+  const label = isAll
+    ? "All resources"
+    : `${selectedSet.size} of ${knownResources.length} selected`;
+
+  // Compute position from trigger rect so the portal panel aligns correctly
+  const triggerRect = triggerRef.current?.getBoundingClientRect();
 
   return (
-    <div className="border-border bg-muted/30 mr-2 mb-1.5 ml-7 space-y-1.5 rounded-lg border border-dashed p-2">
-      <div className="flex items-center justify-between">
-        <span className="text-muted-foreground text-[10px] font-medium">
-          Resources
+    <div className="mr-2 mb-1.5 ml-7">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="border-border bg-background hover:bg-muted/50 flex w-full items-center justify-between rounded-md border px-2 py-1 text-left"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(!open);
+        }}
+      >
+        <span className="text-muted-foreground truncate text-[11px]">
+          {label}
         </span>
-        <button
-          type="button"
-          className={`text-[10px] transition-colors ${isAll ? "text-foreground font-medium" : "text-muted-foreground hover:text-foreground"}`}
-          onClick={() => {
-            onChange(null);
-            setQuery("");
-          }}
-        >
-          All (wildcard)
-        </button>
-      </div>
-
-      {/* Filter input (only shown when there are many resources) */}
-      {knownResources.length > 5 && (
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="filter…"
-          className="bg-background border-border text-foreground placeholder:text-muted-foreground/50 focus:border-foreground/30 w-full rounded border px-1.5 py-0.5 font-mono text-[11px] outline-none"
+        <ChevronDown
+          className={`text-muted-foreground h-3 w-3 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
         />
-      )}
+      </button>
 
-      {/* Resource list */}
-      <div className="max-h-[140px] space-y-0.5 overflow-y-auto">
-        {suggestions.map((r) => {
-          const isChecked = alreadySelected.has(r.id);
-          return (
+      {open &&
+        triggerRect &&
+        createPortal(
+          <div
+            ref={panelRef}
+            className="border-border bg-background fixed z-[999999] rounded-md border shadow-lg"
+            style={{
+              top: triggerRect.bottom + 4,
+              left: triggerRect.left,
+              width: triggerRect.width,
+            }}
+          >
+            {/* All wildcard option */}
             <button
-              key={r.id}
               type="button"
-              className={`hover:bg-muted/50 flex w-full items-center gap-1.5 rounded px-1.5 py-0.5 text-left transition-colors ${isChecked ? "bg-muted/30" : ""}`}
-              onClick={() => toggleResource(r.id)}
+              className="hover:bg-muted/50 flex w-full items-center gap-1.5 border-b border-inherit px-2 py-1.5 text-left transition-colors"
+              onClick={() => {
+                onChange(null);
+                setQuery("");
+              }}
             >
               <div
-                className={`flex h-3 w-3 shrink-0 items-center justify-center rounded-sm border text-[8px] transition-all ${isChecked ? "bg-foreground border-foreground text-background" : "border-muted-foreground/30"}`}
+                className={`flex h-3 w-3 shrink-0 items-center justify-center rounded-sm border text-[8px] transition-all ${isAll ? "bg-foreground border-foreground text-background" : "border-muted-foreground/30"}`}
               >
-                {isChecked && "✓"}
+                {isAll && "✓"}
               </div>
-              <span className="text-foreground truncate font-mono text-[11px]">
-                {r.label}
+              <span className="text-foreground text-[11px] font-medium">
+                All (wildcard)
               </span>
             </button>
-          );
-        })}
-      </div>
+
+            {/* Filter input */}
+            {knownResources.length > 5 && (
+              <div className="border-b border-inherit px-2 py-1">
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Filter…"
+                  className="text-foreground placeholder:text-muted-foreground/50 w-full bg-transparent text-[11px] outline-none"
+                />
+              </div>
+            )}
+
+            {/* Resource list */}
+            <div className="max-h-[160px] overflow-y-auto py-0.5">
+              {filtered.map((r) => {
+                const isChecked = selectedSet.has(r.id);
+                return (
+                  <button
+                    key={r.id}
+                    type="button"
+                    className="hover:bg-muted/50 flex w-full items-center gap-1.5 px-2 py-1 text-left transition-colors"
+                    onClick={() => toggleResource(r.id)}
+                  >
+                    <div
+                      className={`flex h-3 w-3 shrink-0 items-center justify-center rounded-sm border text-[8px] transition-all ${isChecked ? "bg-foreground border-foreground text-background" : "border-muted-foreground/30"}`}
+                    >
+                      {isChecked && "✓"}
+                    </div>
+                    <span className="text-foreground truncate font-mono text-[11px]">
+                      {r.label}
+                    </span>
+                  </button>
+                );
+              })}
+              {filtered.length === 0 && (
+                <p className="text-muted-foreground px-2 py-1.5 text-center text-[11px]">
+                  No matches
+                </p>
+              )}
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace inline checkbox list for resource scoping with a compact multi-select dropdown — scales better when there are many projects or MCP servers
- Dropdown panel portals to `document.body` so it floats above the toolbar's `overflow-y-auto` container
- Clamp toolbar position when expanding near the bottom of the viewport to prevent overflow
<img width="932" height="1372" alt="CleanShot 2026-04-17 at 12 52 51@2x" src="https://github.com/user-attachments/assets/c0dc5e3d-9be2-4349-9263-58eb86c4f5ea" />



## Test plan
- [ ] Open dev toolbar near bottom of viewport, expand — should clamp upward
- [ ] Enable `build:read` or `mcp:connect`, click resource dropdown — should float outside toolbar
- [ ] Select/deselect resources, verify "scoped" badge and header value update
- [ ] Verify "All (wildcard)" toggle works
- [ ] Drag toolbar, collapse/expand — position persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)