### PR TITLE
chore: filter projects by RBAC in auth.Info endpoint

### DIFF
--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -108,8 +108,7 @@ function saveState(state: OverrideState) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
-const resourcesCacheKey = (orgId: string) =>
-  `gram-rbac-dev-resources:${orgId}`;
+const resourcesCacheKey = (orgId: string) => `gram-rbac-dev-resources:${orgId}`;
 
 type CachedResources = {
   projects: { id: string; label: string }[];

--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -226,10 +226,10 @@ function RBACDevToolbarInner() {
   const orgProjects = organization?.projects;
   const toolsets = toolsetsData?.toolsets;
   useEffect(() => {
-    if (!state.enabled && orgProjects && orgProjects.length > 0) {
+    if (!state.enabled && orgProjects && orgProjects.length > 0 && toolsets) {
       saveCachedResources({
         projects: orgProjects.map((p) => ({ id: p.id, label: p.slug })),
-        mcps: (toolsets ?? []).map((t) => ({ id: t.id, label: t.name })),
+        mcps: toolsets.map((t) => ({ id: t.id, label: t.name })),
       });
     }
   }, [state.enabled, orgProjects, toolsets]);

--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -108,6 +108,27 @@ function saveState(state: OverrideState) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
+const RESOURCES_CACHE_KEY = "gram-rbac-dev-resources";
+
+type CachedResources = {
+  projects: { id: string; label: string }[];
+  mcps: { id: string; label: string }[];
+};
+
+function loadCachedResources(): CachedResources | null {
+  try {
+    const raw = localStorage.getItem(RESOURCES_CACHE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function saveCachedResources(resources: CachedResources) {
+  localStorage.setItem(RESOURCES_CACHE_KEY, JSON.stringify(resources));
+}
+
 const POSITION_KEY = "gram-rbac-dev-toolbar-pos";
 
 function loadPosition(): { x: number; y: number } | null {
@@ -188,18 +209,35 @@ function RBACDevToolbarInner() {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(loadPosition);
   const queryClient = useQueryClient();
   const organization = useOrganization();
-  const projects = organization?.projects ?? [];
-  const { data: toolsetsData } = useListToolsetsForOrg(undefined, undefined, {
-    throwOnError: false,
-  });
-  const projectResources = projects.map((project) => ({
+  const liveProjects = (organization?.projects ?? []).map((project) => ({
     id: project.id,
     label: project.slug,
   }));
-  const mcpResources = (toolsetsData?.toolsets ?? []).map((toolset) => ({
+  const { data: toolsetsData } = useListToolsetsForOrg(undefined, undefined, {
+    throwOnError: false,
+  });
+  const liveMcps = (toolsetsData?.toolsets ?? []).map((toolset) => ({
     id: toolset.id,
     label: toolset.name,
   }));
+
+  // Cache the full resource list when overrides are off so the toolbar
+  // still shows all projects/MCPs after the user restricts scopes.
+  const orgProjects = organization?.projects;
+  const toolsets = toolsetsData?.toolsets;
+  useEffect(() => {
+    if (!state.enabled && orgProjects && orgProjects.length > 0) {
+      saveCachedResources({
+        projects: orgProjects.map((p) => ({ id: p.id, label: p.slug })),
+        mcps: (toolsets ?? []).map((t) => ({ id: t.id, label: t.name })),
+      });
+    }
+  }, [state.enabled, orgProjects, toolsets]);
+
+  const cached = loadCachedResources();
+  const projectResources =
+    state.enabled && cached ? cached.projects : liveProjects;
+  const mcpResources = state.enabled && cached ? cached.mcps : liveMcps;
   const rootRef = useRef<HTMLDivElement>(null);
   const dragOffset = useRef<{
     ox: number;

--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -108,16 +108,17 @@ function saveState(state: OverrideState) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
-const RESOURCES_CACHE_KEY = "gram-rbac-dev-resources";
+const resourcesCacheKey = (orgId: string) =>
+  `gram-rbac-dev-resources:${orgId}`;
 
 type CachedResources = {
   projects: { id: string; label: string }[];
   mcps: { id: string; label: string }[];
 };
 
-function loadCachedResources(): CachedResources | null {
+function loadCachedResources(orgId: string): CachedResources | null {
   try {
-    const raw = localStorage.getItem(RESOURCES_CACHE_KEY);
+    const raw = localStorage.getItem(resourcesCacheKey(orgId));
     if (raw) return JSON.parse(raw);
   } catch {
     // ignore
@@ -125,8 +126,8 @@ function loadCachedResources(): CachedResources | null {
   return null;
 }
 
-function saveCachedResources(resources: CachedResources) {
-  localStorage.setItem(RESOURCES_CACHE_KEY, JSON.stringify(resources));
+function saveCachedResources(resources: CachedResources, orgId: string) {
+  localStorage.setItem(resourcesCacheKey(orgId), JSON.stringify(resources));
 }
 
 const POSITION_KEY = "gram-rbac-dev-toolbar-pos";
@@ -225,16 +226,26 @@ function RBACDevToolbarInner() {
   // still shows all projects/MCPs after the user restricts scopes.
   const orgProjects = organization?.projects;
   const toolsets = toolsetsData?.toolsets;
+  const orgId = organization?.id ?? "";
   useEffect(() => {
-    if (!state.enabled && orgProjects && orgProjects.length > 0 && toolsets) {
-      saveCachedResources({
-        projects: orgProjects.map((p) => ({ id: p.id, label: p.slug })),
-        mcps: toolsets.map((t) => ({ id: t.id, label: t.name })),
-      });
+    if (
+      !state.enabled &&
+      orgId &&
+      orgProjects &&
+      orgProjects.length > 0 &&
+      toolsets
+    ) {
+      saveCachedResources(
+        {
+          projects: orgProjects.map((p) => ({ id: p.id, label: p.slug })),
+          mcps: toolsets.map((t) => ({ id: t.id, label: t.name })),
+        },
+        orgId,
+      );
     }
-  }, [state.enabled, orgProjects, toolsets]);
+  }, [state.enabled, orgId, orgProjects, toolsets]);
 
-  const cached = loadCachedResources();
+  const cached = orgId ? loadCachedResources(orgId) : null;
   const projectResources =
     state.enabled && cached ? cached.projects : liveProjects;
   const mcpResources = state.enabled && cached ? cached.mcps : liveMcps;

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -723,6 +723,10 @@ func newStartCommand() *cli.Command {
 					SignInRedirectURL:      auth.FormSignInRedirectURL(c.String("site-url")),
 					Environment:            c.String("environment"),
 				},
+				accessManager,
+				func(ctx context.Context, projectIDs []string) ([]string, error) {
+					return accessManager.Filter(ctx, access.ScopeBuildRead, projectIDs)
+				},
 			))
 			organizations.Attach(mux, organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, productFeatures, accessManager))
 			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, accessManager))

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -48,16 +48,24 @@ type AuthConfigurations struct {
 	Environment            string
 }
 
+// ProjectFilterFunc filters a list of project IDs down to those the current
+// user is allowed to see. It is injected to avoid an import cycle with the
+// access package. A nil value disables filtering (all projects are returned).
+type ProjectFilterFunc func(ctx context.Context, projectIDs []string) ([]string, error)
+
 // Service for gram dashboard authentication endpoints
+
 type Service struct {
-	tracer       trace.Tracer
-	logger       *slog.Logger
-	db           *pgxpool.Pool
-	sessions     *sessions.Manager
-	cfg          AuthConfigurations
-	projectsRepo *projectsRepo.Queries
-	envRepo      *envRepo.Queries
-	orgRepo      *orgRepo.Queries
+	tracer         trace.Tracer
+	logger         *slog.Logger
+	db             *pgxpool.Pool
+	sessions       *sessions.Manager
+	cfg            AuthConfigurations
+	accessLoader   AccessLoader
+	filterProjects ProjectFilterFunc
+	projectsRepo   *projectsRepo.Queries
+	envRepo        *envRepo.Queries
+	orgRepo        *orgRepo.Queries
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -68,18 +76,22 @@ func NewService(
 	db *pgxpool.Pool,
 	sessions *sessions.Manager,
 	cfg AuthConfigurations,
+	accessLoader AccessLoader,
+	filterProjects ProjectFilterFunc,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("auth"))
 
 	return &Service{
-		tracer:       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/auth"),
-		logger:       logger,
-		db:           db,
-		sessions:     sessions,
-		cfg:          cfg,
-		projectsRepo: projectsRepo.New(db),
-		envRepo:      envRepo.New(db),
-		orgRepo:      orgRepo.New(db),
+		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/auth"),
+		logger:         logger,
+		db:             db,
+		sessions:       sessions,
+		cfg:            cfg,
+		accessLoader:   accessLoader,
+		filterProjects: filterProjects,
+		projectsRepo:   projectsRepo.New(db),
+		envRepo:        envRepo.New(db),
+		orgRepo:        orgRepo.New(db),
 	}
 }
 
@@ -98,7 +110,17 @@ func Attach(mux goahttp.Muxer, service *Service) {
 }
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {
-	return s.sessions.Authenticate(ctx, key)
+	ctx, err := s.sessions.Authenticate(ctx, key)
+	if err != nil {
+		return ctx, err
+	}
+	if s.accessLoader != nil {
+		ctx, err = s.accessLoader.PrepareContext(ctx)
+		if err != nil {
+			return ctx, oops.E(oops.CodeUnexpected, err, "load access grants").Log(ctx, s.logger)
+		}
+	}
+	return ctx, nil
 }
 
 func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (res *gen.CallbackResult, err error) {
@@ -336,8 +358,31 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 		if err != nil {
 			return nil, err
 		}
-		var orgProjects []*gen.ProjectEntry
+		// Build the full list of project IDs, then filter to only those the
+		// user is allowed to see (mirrors the projects.List endpoint).
+		projectIDs := make([]string, 0, len(projectRows))
+		for _, p := range projectRows {
+			projectIDs = append(projectIDs, p.ID.String())
+		}
+
+		allowedIDs := projectIDs
+		if s.filterProjects != nil && len(projectIDs) > 0 {
+			allowedIDs, err = s.filterProjects(ctx, projectIDs)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		allowed := make(map[string]struct{}, len(allowedIDs))
+		for _, id := range allowedIDs {
+			allowed[id] = struct{}{}
+		}
+
+		orgProjects := make([]*gen.ProjectEntry, 0, len(allowedIDs))
 		for _, project := range projectRows {
+			if _, ok := allowed[project.ID.String()]; !ok {
+				continue
+			}
 			orgProjects = append(orgProjects, &gen.ProjectEntry{
 				ID:   project.ID.String(),
 				Name: project.Name,

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -366,7 +366,7 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 		}
 
 		allowedIDs := projectIDs
-		if s.filterProjects != nil && len(projectIDs) > 0 {
+		if s.filterProjects != nil && len(projectIDs) > 0 && org.ID == authCtx.ActiveOrganizationID {
 			allowedIDs, err = s.filterProjects(ctx, projectIDs)
 			if err != nil {
 				return nil, err

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -1,8 +1,11 @@
 package auth_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
@@ -368,6 +371,180 @@ func TestService_Info_AdminOrgRelationshipUpserted(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, exists, "expected org-user relationship to be upserted by Info call")
+}
+
+// TestService_Info_ProjectFilter verifies that the ProjectFilterFunc is applied
+// to the projects returned in the Info response, matching the behaviour of
+// projects.List which uses access.Filter.
+func TestService_Info_ProjectFilter(t *testing.T) {
+	t.Parallel()
+
+	// setupInfoCtx is a small helper that creates the user, org, session and
+	// auth context needed to call Info. It returns the ready-to-use context.
+	setupInfoCtx := func(t *testing.T, instance *testInstance, userInfo *MockUserInfo) context.Context {
+		t.Helper()
+		ctx := t.Context()
+
+		err := instance.createTestUser(ctx, userInfo)
+		require.NoError(t, err)
+		err = instance.createTestOrganization(ctx, userInfo.Organizations[0])
+		require.NoError(t, err)
+
+		session := sessions.Session{
+			SessionID:            "filter-test-session",
+			UserID:               userInfo.UserID,
+			ActiveOrganizationID: userInfo.Organizations[0].ID,
+		}
+		err = instance.sessionManager.StoreSession(ctx, session)
+		require.NoError(t, err)
+
+		return contextvalues.SetAuthContext(ctx, &contextvalues.AuthContext{
+			SessionID:            &session.SessionID,
+			UserID:               session.UserID,
+			ActiveOrganizationID: session.ActiveOrganizationID,
+			AccountType:          "test",
+			Email:                &userInfo.Email,
+		})
+	}
+
+	t.Run("filter removes disallowed projects", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+
+		// Filter that only allows the first project ID it sees.
+		var seen []string
+		filter := func(_ context.Context, ids []string) ([]string, error) {
+			seen = ids
+			if len(ids) > 0 {
+				return ids[:1], nil
+			}
+			return nil, nil
+		}
+
+		_, instance := newTestAuthServiceWithFilter(t, userInfo, filter)
+		ctx := setupInfoCtx(t, instance, userInfo)
+
+		orgID := userInfo.Organizations[0].ID
+		p1, err := instance.createTestProject(ctx, orgID, "ProjectA", "project-a")
+		require.NoError(t, err)
+		_, err = instance.createTestProject(ctx, orgID, "ProjectB", "project-b")
+		require.NoError(t, err)
+
+		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
+		require.NoError(t, err)
+		require.Len(t, result.Organizations, 1)
+
+		// The filter was called with both project IDs.
+		assert.Len(t, seen, 2)
+
+		// Only the first project should survive.
+		assert.Len(t, result.Organizations[0].Projects, 1)
+		assert.Equal(t, p1.ID.String(), result.Organizations[0].Projects[0].ID)
+		assert.Equal(t, "ProjectA", result.Organizations[0].Projects[0].Name)
+	})
+
+	t.Run("filter allows all projects", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		userInfo.UserID = "filter-all-user"
+		userInfo.Email = "filterall@example.com"
+		userInfo.Organizations[0].ID = "filter-all-org"
+
+		// Pass-through filter.
+		filter := func(_ context.Context, ids []string) ([]string, error) {
+			return ids, nil
+		}
+
+		_, instance := newTestAuthServiceWithFilter(t, userInfo, filter)
+		ctx := setupInfoCtx(t, instance, userInfo)
+
+		orgID := userInfo.Organizations[0].ID
+		_, err := instance.createTestProject(ctx, orgID, "ProjX", "proj-x")
+		require.NoError(t, err)
+		_, err = instance.createTestProject(ctx, orgID, "ProjY", "proj-y")
+		require.NoError(t, err)
+
+		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
+		require.NoError(t, err)
+
+		assert.Len(t, result.Organizations[0].Projects, 2)
+	})
+
+	t.Run("filter removes all projects", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		userInfo.UserID = "filter-none-user"
+		userInfo.Email = "filternone@example.com"
+		userInfo.Organizations[0].ID = "filter-none-org"
+
+		// Deny-all filter.
+		filter := func(_ context.Context, _ []string) ([]string, error) {
+			return nil, nil
+		}
+
+		_, instance := newTestAuthServiceWithFilter(t, userInfo, filter)
+		ctx := setupInfoCtx(t, instance, userInfo)
+
+		orgID := userInfo.Organizations[0].ID
+		_, err := instance.createTestProject(ctx, orgID, "Hidden", "hidden")
+		require.NoError(t, err)
+
+		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
+		require.NoError(t, err)
+
+		assert.Empty(t, result.Organizations[0].Projects)
+	})
+
+	t.Run("filter error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		userInfo.UserID = "filter-err-user"
+		userInfo.Email = "filtererr@example.com"
+		userInfo.Organizations[0].ID = "filter-err-org"
+
+		filterErr := fmt.Errorf("access denied")
+		filter := func(_ context.Context, _ []string) ([]string, error) {
+			return nil, filterErr
+		}
+
+		_, instance := newTestAuthServiceWithFilter(t, userInfo, filter)
+		ctx := setupInfoCtx(t, instance, userInfo)
+
+		orgID := userInfo.Organizations[0].ID
+		_, err := instance.createTestProject(ctx, orgID, "Proj", "proj")
+		require.NoError(t, err)
+
+		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
+		require.ErrorIs(t, err, filterErr)
+		require.Nil(t, result)
+	})
+
+	t.Run("nil filter returns all projects", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		userInfo.UserID = "nil-filter-user"
+		userInfo.Email = "nilfilter@example.com"
+		userInfo.Organizations[0].ID = "nil-filter-org"
+
+		// Use the standard constructor (nil filter).
+		_, instance := newTestAuthService(t, userInfo)
+		ctx := setupInfoCtx(t, instance, userInfo)
+
+		orgID := userInfo.Organizations[0].ID
+		_, err := instance.createTestProject(ctx, orgID, "Visible", "visible")
+		require.NoError(t, err)
+
+		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
+		require.NoError(t, err)
+
+		assert.Len(t, result.Organizations[0].Projects, 1)
+		assert.Equal(t, "Visible", result.Organizations[0].Projects[0].Name)
+	})
 }
 
 // TestService_Info_AdminVisitingCustomerOrgDoesNotUpsertRelationship verifies that

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -428,7 +428,7 @@ func TestService_Info_ProjectFilter(t *testing.T) {
 		orgID := userInfo.Organizations[0].ID
 		p1, err := instance.createTestProject(ctx, orgID, "ProjectA", "project-a")
 		require.NoError(t, err)
-		_, err = instance.createTestProject(ctx, orgID, "ProjectB", "project-b")
+		p2, err := instance.createTestProject(ctx, orgID, "ProjectB", "project-b")
 		require.NoError(t, err)
 
 		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
@@ -438,10 +438,14 @@ func TestService_Info_ProjectFilter(t *testing.T) {
 		// The filter was called with both project IDs.
 		assert.Len(t, seen, 2)
 
-		// Only the first project should survive.
-		assert.Len(t, result.Organizations[0].Projects, 1)
-		assert.Equal(t, p1.ID.String(), result.Organizations[0].Projects[0].ID)
-		assert.Equal(t, "ProjectA", result.Organizations[0].Projects[0].Name)
+		// Only the first project (by UUID order) should survive.
+		// We cannot assume p1 sorts before p2 since UUIDs are random.
+		require.Len(t, result.Organizations[0].Projects, 1)
+		assert.Equal(t, seen[0], result.Organizations[0].Projects[0].ID)
+
+		// The surviving project must be one of the two we created.
+		validIDs := []string{p1.ID.String(), p2.ID.String()}
+		assert.Contains(t, validIDs, result.Organizations[0].Projects[0].ID)
 	})
 
 	t.Run("filter allows all projects", func(t *testing.T) {

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/pylon"
@@ -306,9 +307,52 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 		Environment:            "test",
 	}
 
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, authConfigs)
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, authConfigs, nil, nil)
 
-	return ctx, &testInstance{
+	return ctx, newTestAuthServiceResult(t, svc, conn, sessionManager, mockServer, authConfigs)
+}
+
+func newTestAuthServiceWithFilter(t *testing.T, userInfo *MockUserInfo, filterProjects auth.ProjectFilterFunc) (context.Context, *testInstance) {
+	t.Helper()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	conn, err := infra.CloneTestDatabase(t, "authtest")
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	mockServer := createMockAuthServer(userInfo)
+	t.Cleanup(mockServer.Close)
+
+	pylon, err := pylon.NewPylon(logger, "")
+	require.NoError(t, err)
+
+	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
+
+	billingClient := billing.NewStubClient(logger, tracerProvider)
+
+	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient, nil)
+
+	authConfigs := auth.AuthConfigurations{
+		SpeakeasyServerAddress: mockServer.URL,
+		GramServerURL:          "http://localhost:8080",
+		SignInRedirectURL:      "http://localhost:3000/dashboard",
+		Environment:            "test",
+	}
+
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, authConfigs, nil, filterProjects)
+
+	return ctx, newTestAuthServiceResult(t, svc, conn, sessionManager, mockServer, authConfigs)
+}
+
+func newTestAuthServiceResult(_ *testing.T, svc *auth.Service, conn *pgxpool.Pool, sessionManager *sessions.Manager, mockServer *httptest.Server, authConfigs auth.AuthConfigurations) *testInstance {
+	return &testInstance{
 		service:        svc,
 		conn:           conn,
 		sessionManager: sessionManager,
@@ -406,4 +450,14 @@ func (ti *testInstance) createTestOrganization(ctx context.Context, org MockOrga
 		return fmt.Errorf("failed to upsert organization metadata: %w", err)
 	}
 	return nil
+}
+
+// createTestProject creates a project record in the database for testing and returns its ID.
+func (ti *testInstance) createTestProject(ctx context.Context, orgID, name, slug string) (projectsRepo.Project, error) {
+	q := projectsRepo.New(ti.conn)
+	return q.CreateProject(ctx, projectsRepo.CreateProjectParams{
+		OrganizationID: orgID,
+		Name:           name,
+		Slug:           slug,
+	})
 }

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -455,9 +455,13 @@ func (ti *testInstance) createTestOrganization(ctx context.Context, org MockOrga
 // createTestProject creates a project record in the database for testing and returns its ID.
 func (ti *testInstance) createTestProject(ctx context.Context, orgID, name, slug string) (projectsRepo.Project, error) {
 	q := projectsRepo.New(ti.conn)
-	return q.CreateProject(ctx, projectsRepo.CreateProjectParams{
+	project, err := q.CreateProject(ctx, projectsRepo.CreateProjectParams{
 		OrganizationID: orgID,
 		Name:           name,
 		Slug:           slug,
 	})
+	if err != nil {
+		return project, fmt.Errorf("failed to create project: %w", err)
+	}
+	return project, nil
 }


### PR DESCRIPTION
## Summary
- The `auth.Info` endpoint returned **all** projects for an organization without RBAC filtering, while `projects.List` correctly used `access.Filter(ctx, ScopeBuildRead, ...)`. This caused the UI to show projects the user doesn't have access to.
- The `auth.Service.APIKeyAuth` method didn't call `PrepareContext` to load RBAC grants into the request context (unlike every other Goa service which delegates to `auth.Auth.Authorize`). This caused "access grants missing from prepared context" errors when the dev toolbar was active.
- The dev toolbar lost project/MCP entries from its toggle list when those scopes were restricted, since it read from the now-filtered API response.

## Changes
- **`server/internal/auth/impl.go`**: Add `ProjectFilterFunc` (injected to avoid `access→audit→auth` import cycle) and `AccessLoader` to the `Service` struct. Filter projects in `Info` response. Call `PrepareContext` in `APIKeyAuth`.
- **`server/cmd/gram/start.go`**: Wire `accessManager` as both the `AccessLoader` and the project filter (via `access.ScopeBuildRead`).
- **`client/dashboard/src/components/dev-toolbar.tsx`**: Cache full project/MCP list in localStorage when overrides are off; use the cache when overrides are on so restricted scopes don't remove items from the toggle UI.
- **`server/internal/auth/info_test.go`**: 5 new test cases covering filter subset, allow-all, deny-all, error propagation, and nil-filter backward compat.
- **`server/internal/auth/setup_test.go`**: Add `newTestAuthServiceWithFilter` and `createTestProject` test helpers.

## Test plan
- [x] All existing `TestService_Info` tests pass
- [x] New `TestService_Info_ProjectFilter` tests pass (5 subtests)
- [x] `go vet` and `go build` clean
- [x] Dashboard `tsc --noEmit` and `eslint` clean
- [ ] Manual: verify dev toolbar retains all projects when restricting `build:read`
- [ ] Manual: verify sidebar hides projects when `build:read` is restricted

🤖 Generated with [Claude Code](https://claude.com/claude-code)