### PR TITLE
chore: consolidate RBAC test helpers and simplify grant internals

### DIFF
--- a/server/internal/access/context.go
+++ b/server/internal/access/context.go
@@ -7,12 +7,12 @@ type contextKey string
 const grantsContextKey contextKey = "access_grants"
 
 // GrantsToContext stores resolved grants on the request context.
-func GrantsToContext(ctx context.Context, grants *Grants) context.Context {
+func GrantsToContext(ctx context.Context, grants []Grant) context.Context {
 	return context.WithValue(ctx, grantsContextKey, grants)
 }
 
 // GrantsFromContext loads resolved grants from the request context.
-func GrantsFromContext(ctx context.Context) (*Grants, bool) {
-	grants, ok := ctx.Value(grantsContextKey).(*Grants)
+func GrantsFromContext(ctx context.Context) ([]Grant, bool) {
+	grants, ok := ctx.Value(grantsContextKey).([]Grant)
 	return grants, ok
 }

--- a/server/internal/access/context_test.go
+++ b/server/internal/access/context_test.go
@@ -27,9 +27,8 @@ func TestLoadIntoContext_LoadsUserGrants(t *testing.T) {
 	ctx, err := manager.PrepareContext(ctx)
 	require.NoError(t, err)
 
-	grants, ok := GrantsFromContext(ctx)
+	_, ok = GrantsFromContext(ctx)
 	require.True(t, ok)
-	require.NotNil(t, grants)
 	require.NoError(t, manager.Require(ctx, Check{Scope: ScopeBuildRead, ResourceID: authCtx.ProjectID.String()}))
 }
 
@@ -48,9 +47,8 @@ func TestLoadIntoContext_SkipsNonSessionAuth(t *testing.T) {
 	ctx, err := manager.PrepareContext(ctx)
 	require.NoError(t, err)
 
-	grants, ok := GrantsFromContext(ctx)
+	_, ok = GrantsFromContext(ctx)
 	require.False(t, ok)
-	require.Nil(t, grants)
 }
 
 func TestLoadIntoContext_SkipsNonEnterpriseOrgs(t *testing.T) {
@@ -69,7 +67,6 @@ func TestLoadIntoContext_SkipsNonEnterpriseOrgs(t *testing.T) {
 	ctx, err := manager.PrepareContext(ctx)
 	require.NoError(t, err)
 
-	grants, ok := GrantsFromContext(ctx)
+	_, ok = GrantsFromContext(ctx)
 	require.False(t, ok)
-	require.Nil(t, grants)
 }

--- a/server/internal/access/expand_test.go
+++ b/server/internal/access/expand_test.go
@@ -36,80 +36,80 @@ func TestCheckExpand_mcpConnect(t *testing.T) {
 func TestGrantsHasAccess_orgAdminSatisfiesOrgRead(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeOrgAdmin, Resource: "org_123"}}}
-	require.True(t, g.satisfies(Check{Scope: ScopeOrgRead, ResourceID: "org_123"}.expand()))
+	g := []Grant{{Scope: ScopeOrgAdmin, Resource: "org_123"}}
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeOrgRead, ResourceID: "org_123"}.expand()))
 }
 
 func TestGrantsHasAccess_orgReadDoesNotSatisfyOrgAdmin(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeOrgRead, Resource: "org_123"}}}
-	require.False(t, g.satisfies(Check{Scope: ScopeOrgAdmin, ResourceID: "org_123"}.expand()))
+	g := []Grant{{Scope: ScopeOrgRead, Resource: "org_123"}}
+	require.False(t, grantsSatisfy(g, Check{Scope: ScopeOrgAdmin, ResourceID: "org_123"}.expand()))
 }
 
 func TestGrantsHasAccess_buildWriteSatisfiesBuildRead(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeBuildWrite, Resource: "proj_123"}}}
-	require.True(t, g.satisfies(Check{Scope: ScopeBuildRead, ResourceID: "proj_123"}.expand()))
+	g := []Grant{{Scope: ScopeBuildWrite, Resource: "proj_123"}}
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeBuildRead, ResourceID: "proj_123"}.expand()))
 }
 
 func TestGrantsHasAccess_buildReadDoesNotSatisfyBuildWrite(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeBuildRead, Resource: "proj_123"}}}
-	require.False(t, g.satisfies(Check{Scope: ScopeBuildWrite, ResourceID: "proj_123"}.expand()))
+	g := []Grant{{Scope: ScopeBuildRead, Resource: "proj_123"}}
+	require.False(t, grantsSatisfy(g, Check{Scope: ScopeBuildWrite, ResourceID: "proj_123"}.expand()))
 }
 
 func TestGrantsHasAccess_orgAdminDoesNotSatisfyBuildRead(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeOrgAdmin, Resource: "org_123"}}}
-	require.False(t, g.satisfies(Check{Scope: ScopeBuildRead, ResourceID: "org_123"}.expand()))
+	g := []Grant{{Scope: ScopeOrgAdmin, Resource: "org_123"}}
+	require.False(t, grantsSatisfy(g, Check{Scope: ScopeBuildRead, ResourceID: "org_123"}.expand()))
 }
 
 func TestGrantsHasAccess_mcpConnectDoesNotSatisfyMCPRead(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeMCPConnect, Resource: "tool_a"}}}
-	require.False(t, g.satisfies(Check{Scope: ScopeMCPRead, ResourceID: "tool_a"}.expand()))
+	g := []Grant{{Scope: ScopeMCPConnect, Resource: "tool_a"}}
+	require.False(t, grantsSatisfy(g, Check{Scope: ScopeMCPRead, ResourceID: "tool_a"}.expand()))
 }
 
 func TestGrantsHasAccess_mcpReadSatisfiesMCPConnect(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeMCPRead, Resource: "tool_a"}}}
-	require.True(t, g.satisfies(Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
+	g := []Grant{{Scope: ScopeMCPRead, Resource: "tool_a"}}
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
 }
 
 func TestGrantsHasAccess_mcpWriteSatisfiesMCPConnect(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeMCPWrite, Resource: "tool_a"}}}
-	require.True(t, g.satisfies(Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
+	g := []Grant{{Scope: ScopeMCPWrite, Resource: "tool_a"}}
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
 }
 
 func TestGrantsHasAccess_mcpWriteSatisfiesMCPRead(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeMCPWrite, Resource: "tool_a"}}}
-	require.True(t, g.satisfies(Check{Scope: ScopeMCPRead, ResourceID: "tool_a"}.expand()))
+	g := []Grant{{Scope: ScopeMCPWrite, Resource: "tool_a"}}
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeMCPRead, ResourceID: "tool_a"}.expand()))
 }
 
 func TestGrantsHasAccess_rootWildcardSatisfiesAnyScope(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeRoot, Resource: WildcardResource}}}
-	require.True(t, g.satisfies(Check{Scope: ScopeBuildRead, ResourceID: "proj_123"}.expand()))
-	require.True(t, g.satisfies(Check{Scope: ScopeOrgAdmin, ResourceID: "org_456"}.expand()))
-	require.True(t, g.satisfies(Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
+	g := []Grant{{Scope: ScopeRoot, Resource: WildcardResource}}
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeBuildRead, ResourceID: "proj_123"}.expand()))
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeOrgAdmin, ResourceID: "org_456"}.expand()))
+	require.True(t, grantsSatisfy(g, Check{Scope: ScopeMCPConnect, ResourceID: "tool_a"}.expand()))
 }
 
 func TestGrantsHasAccess_wrongResourceNotSatisfied(t *testing.T) {
 	t.Parallel()
 
-	g := &Grants{rows: []Grant{{Scope: ScopeOrgAdmin, Resource: "org_123"}}}
-	require.False(t, g.satisfies(Check{Scope: ScopeOrgRead, ResourceID: "org_999"}.expand()))
+	g := []Grant{{Scope: ScopeOrgAdmin, Resource: "org_123"}}
+	require.False(t, grantsSatisfy(g, Check{Scope: ScopeOrgRead, ResourceID: "org_999"}.expand()))
 }
 
 func TestScopeExpansions_isDAG(t *testing.T) {

--- a/server/internal/access/grants.go
+++ b/server/internal/access/grants.go
@@ -15,6 +15,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+const WildcardResource = "*"
+
 type RoleGrant struct {
 	Scope     string
 	Resources []string
@@ -51,30 +53,19 @@ func SeedSystemRoleGrants(ctx context.Context, logger *slog.Logger, db *pgxpool.
 	return nil
 }
 
-const WildcardResource = "*"
-
 type Grant struct {
 	Scope    Scope
 	Resource string
 }
 
-type Grants struct {
-	rows []Grant
-}
-
-func (g *Grants) satisfies(checks []Check) bool {
-	if g == nil {
-		return false
-	}
-
-	for _, row := range g.rows {
+func grantsSatisfy(grants []Grant, checks []Check) bool {
+	for _, row := range grants {
 		for _, check := range checks {
 			if row.Scope == check.Scope && row.Resource == check.ResourceID {
 				return true
 			}
 		}
 	}
-
 	return false
 }
 

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -609,7 +609,7 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 	// Return override scopes when active so the frontend sees the same restricted
 	// set as the enforcement layer.
 	if overrides, ok := s.access.getScopeOverrides(ctx); ok {
-		return &gen.ListUserGrantsResult{Grants: grantsFromRows(grantsFromOverrides(overrides).rows)}, nil
+		return &gen.ListUserGrantsResult{Grants: grantsFromRows(grantsFromOverrides(overrides))}, nil
 	}
 
 	enforce, err := s.access.shouldEnforce(ctx)
@@ -661,7 +661,7 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 		return nil, oops.E(oops.CodeUnexpected, err, "load effective user grants").Log(ctx, logger)
 	}
 
-	return &gen.ListUserGrantsResult{Grants: grantsFromRows(grants.rows)}, nil
+	return &gen.ListUserGrantsResult{Grants: grantsFromRows(grants)}, nil
 }
 
 // UpdateMemberRole is intentionally stricter than member listing: it only

--- a/server/internal/access/integration_test.go
+++ b/server/internal/access/integration_test.go
@@ -37,7 +37,9 @@ func TestRequire_withLoadedGrantsFromContext(t *testing.T) {
 	require.NoError(t, err)
 
 	err = manager.Require(ctx, Check{Scope: ScopeMCPConnect, ResourceID: "toolB"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestFilter_withLoadedGrantsFromContext(t *testing.T) {

--- a/server/internal/access/load.go
+++ b/server/internal/access/load.go
@@ -9,7 +9,7 @@ import (
 )
 
 // LoadGrants loads and normalizes grants for the given organization and principals.
-func LoadGrants(ctx context.Context, db accessrepo.DBTX, organizationID string, principals []urn.Principal) (*Grants, error) {
+func LoadGrants(ctx context.Context, db accessrepo.DBTX, organizationID string, principals []urn.Principal) ([]Grant, error) {
 	if organizationID == "" {
 		return nil, fmt.Errorf("organization id is required")
 	}
@@ -35,11 +35,7 @@ func LoadGrants(ctx context.Context, db accessrepo.DBTX, organizationID string, 
 		})
 	}
 
-	if len(grantRows) == 0 {
-		return &Grants{rows: nil}, nil
-	}
-
-	return &Grants{rows: grantRows}, nil
+	return grantRows, nil
 }
 
 func parsePrincipalURNs(principals []urn.Principal) ([]string, error) {

--- a/server/internal/access/manager.go
+++ b/server/internal/access/manager.go
@@ -102,7 +102,7 @@ func (m *Manager) getScopeOverrides(ctx context.Context) ([]RoleGrant, bool) {
 }
 
 func (m *Manager) PrepareContext(ctx context.Context) (context.Context, error) {
-	if grants, ok := GrantsFromContext(ctx); ok && grants != nil {
+	if _, ok := GrantsFromContext(ctx); ok {
 		return ctx, nil
 	}
 
@@ -112,8 +112,7 @@ func (m *Manager) PrepareContext(ctx context.Context) (context.Context, error) {
 	}
 
 	if overrides, ok := m.getScopeOverrides(ctx); ok {
-		grants := grantsFromOverrides(overrides)
-		return GrantsToContext(ctx, grants), nil
+		return GrantsToContext(ctx, grantsFromOverrides(overrides)), nil
 	}
 
 	if authCtx.AccountType != "enterprise" {
@@ -250,7 +249,7 @@ func (m *Manager) Require(ctx context.Context, checks ...Check) error {
 	}
 
 	grants, ok := GrantsFromContext(ctx)
-	if !ok || grants == nil {
+	if !ok {
 		return m.mapError(ctx, ErrMissingGrants)
 	}
 
@@ -259,7 +258,7 @@ func (m *Manager) Require(ctx context.Context, checks ...Check) error {
 			return m.mapError(ctx, err)
 		}
 
-		if !grants.satisfies(check.expand()) {
+		if !grantsSatisfy(grants, check.expand()) {
 			return m.mapError(ctx, Denied(check.Scope, check.ResourceID))
 		}
 	}
@@ -280,7 +279,7 @@ func (m *Manager) RequireAny(ctx context.Context, checks ...Check) error {
 	}
 
 	grants, ok := GrantsFromContext(ctx)
-	if !ok || grants == nil {
+	if !ok {
 		return m.mapError(ctx, ErrMissingGrants)
 	}
 
@@ -290,7 +289,7 @@ func (m *Manager) RequireAny(ctx context.Context, checks ...Check) error {
 		}
 	}
 
-	if slices.ContainsFunc(checks, func(c Check) bool { return grants.satisfies(c.expand()) }) {
+	if slices.ContainsFunc(checks, func(c Check) bool { return grantsSatisfy(grants, c.expand()) }) {
 		return nil
 	}
 
@@ -307,7 +306,7 @@ func (m *Manager) Filter(ctx context.Context, scope Scope, resourceIDs []string)
 	}
 
 	grants, ok := GrantsFromContext(ctx)
-	if !ok || grants == nil {
+	if !ok {
 		return nil, m.mapError(ctx, ErrMissingGrants)
 	}
 
@@ -317,7 +316,7 @@ func (m *Manager) Filter(ctx context.Context, scope Scope, resourceIDs []string)
 			return nil, m.mapError(ctx, err)
 		}
 
-		if grants.satisfies(Check{Scope: scope, ResourceID: resourceID}.expand()) {
+		if grantsSatisfy(grants, Check{Scope: scope, ResourceID: resourceID}.expand()) {
 			allowed = append(allowed, resourceID)
 		}
 	}

--- a/server/internal/access/manager_test.go
+++ b/server/internal/access/manager_test.go
@@ -38,7 +38,9 @@ func TestManagerRequire_requiresAuthContext(t *testing.T) {
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{enabled: true}, workos.NewStubClient(), cache.NoopCache)
 
 	err := manager.Require(t.Context(), Check{Scope: ScopeBuildRead, ResourceID: "proj_123"})
-	requireOopsCode(t, err, oops.CodeUnauthorized)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
 func TestManagerRequire_skipsWhenRBACFeatureDisabled(t *testing.T) {
@@ -54,10 +56,12 @@ func TestManagerRequire_mapsDeniedToForbidden(t *testing.T) {
 	t.Parallel()
 
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{enabled: true}, workos.NewStubClient(), cache.NoopCache)
-	ctx := GrantsToContext(enterpriseSessionCtx(t), &Grants{rows: nil})
+	ctx := GrantsToContext(enterpriseSessionCtx(t), nil)
 
 	err := manager.Require(ctx, Check{Scope: ScopeBuildRead, ResourceID: "proj_123"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestManagerRequire_mapsMissingGrantsToUnexpected(t *testing.T) {
@@ -66,7 +70,9 @@ func TestManagerRequire_mapsMissingGrantsToUnexpected(t *testing.T) {
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{enabled: true}, workos.NewStubClient(), cache.NoopCache)
 
 	err := manager.Require(enterpriseSessionCtx(t), Check{Scope: ScopeBuildRead, ResourceID: "proj_123"})
-	requireOopsCode(t, err, oops.CodeUnexpected)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
 	require.ErrorIs(t, err, ErrMissingGrants)
 }
 
@@ -76,7 +82,9 @@ func TestManagerRequire_returnsUnexpectedWhenFeatureCheckFails(t *testing.T) {
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{err: errors.New("boom")}, workos.NewStubClient(), cache.NoopCache)
 
 	err := manager.Require(enterpriseSessionCtx(t), Check{Scope: ScopeBuildRead, ResourceID: "proj_123"})
-	requireOopsCode(t, err, oops.CodeUnexpected)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
 }
 
 func TestResolveRoleSlug_cachesEmptyMembershipResult(t *testing.T) {
@@ -106,20 +114,22 @@ func TestManagerRequireAny_mapsDeniedToForbidden(t *testing.T) {
 	t.Parallel()
 
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{enabled: true}, workos.NewStubClient(), cache.NoopCache)
-	ctx := GrantsToContext(enterpriseSessionCtx(t), &Grants{rows: []Grant{{Scope: ScopeMCPConnect, Resource: "tool_a"}}})
+	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{{Scope: ScopeMCPConnect, Resource: "tool_a"}})
 
 	err := manager.RequireAny(ctx,
 		Check{Scope: ScopeMCPConnect, ResourceID: "tool_b"},
 		Check{Scope: ScopeMCPConnect, ResourceID: "tool_c"},
 	)
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestManagerFilter_returnsAllowedSubset(t *testing.T) {
 	t.Parallel()
 
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{enabled: true}, workos.NewStubClient(), cache.NoopCache)
-	ctx := GrantsToContext(enterpriseSessionCtx(t), &Grants{rows: []Grant{{Scope: ScopeBuildRead, Resource: "proj_123"}}})
+	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{{Scope: ScopeBuildRead, Resource: "proj_123"}})
 
 	resourceIDs, err := manager.Filter(ctx, ScopeBuildRead, []string{"proj_123", "proj_456"})
 	require.NoError(t, err)
@@ -130,10 +140,12 @@ func TestManagerRequire_rejectsInvalidCheck(t *testing.T) {
 	t.Parallel()
 
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{enabled: true}, workos.NewStubClient(), cache.NoopCache)
-	ctx := GrantsToContext(enterpriseSessionCtx(t), &Grants{rows: []Grant{{Scope: ScopeBuildRead, Resource: WildcardResource}}})
+	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{{Scope: ScopeBuildRead, Resource: WildcardResource}})
 
 	err := manager.Require(ctx, Check{Scope: ScopeBuildRead, ResourceID: ""})
-	requireOopsCode(t, err, oops.CodeUnexpected)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
 	require.ErrorIs(t, err, ErrInvalidCheck)
 }
 
@@ -141,10 +153,12 @@ func TestManagerRequire_requiresChecks(t *testing.T) {
 	t.Parallel()
 
 	manager := NewManager(testLogger(t), nil, stubFeatureChecker{enabled: true}, workos.NewStubClient(), cache.NoopCache)
-	ctx := GrantsToContext(enterpriseSessionCtx(t), &Grants{rows: []Grant{{Scope: ScopeBuildRead, Resource: WildcardResource}}})
+	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{{Scope: ScopeBuildRead, Resource: WildcardResource}})
 
 	err := manager.Require(ctx)
-	requireOopsCode(t, err, oops.CodeUnexpected)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
 	require.ErrorIs(t, err, ErrNoChecks)
 }
 
@@ -354,14 +368,6 @@ func TestCanUseOverride_prodPlusNonAdmin(t *testing.T) {
 	enforce, err := manager.shouldEnforce(ctx)
 	require.NoError(t, err)
 	require.False(t, enforce)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var shareableErr *oops.ShareableError
-	require.ErrorAs(t, err, &shareableErr)
-	require.Equal(t, code, shareableErr.Code)
 }
 
 func testLogger(t *testing.T) *slog.Logger {

--- a/server/internal/access/override.go
+++ b/server/internal/access/override.go
@@ -22,18 +22,18 @@ func readScopeOverrides(ctx context.Context) ([]RoleGrant, bool) {
 // grantsFromOverrides builds a Grants object from parsed scope overrides.
 // Scopes with no resources get wildcard access; scopes with resources get
 // one grant per resource ID.
-func grantsFromOverrides(overrides []RoleGrant) *Grants {
-	var rows []Grant
+func grantsFromOverrides(overrides []RoleGrant) []Grant {
+	var grants []Grant
 	for _, o := range overrides {
 		if len(o.Resources) == 0 {
-			rows = append(rows, Grant{Scope: Scope(o.Scope), Resource: WildcardResource})
+			grants = append(grants, Grant{Scope: Scope(o.Scope), Resource: WildcardResource})
 			continue
 		}
 		for _, r := range o.Resources {
-			rows = append(rows, Grant{Scope: Scope(o.Scope), Resource: r})
+			grants = append(grants, Grant{Scope: Scope(o.Scope), Resource: r})
 		}
 	}
-	return &Grants{rows: rows}
+	return grants
 }
 
 func parseOverrideHeader(value string) []RoleGrant {

--- a/server/internal/access/rbac_test.go
+++ b/server/internal/access/rbac_test.go
@@ -1,8 +1,8 @@
 package access
 
 import (
-	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 	"context"
+	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -22,7 +22,9 @@ func TestService_ListRoles_ForbiddenWithoutOrgReadGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	_, err := ti.service.ListRoles(ctx, &gen.ListRolesPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_ListRoles_AllowsOrgReadGrant(t *testing.T) {
@@ -50,7 +52,9 @@ func TestService_GetRole_ForbiddenWithoutOrgReadGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	_, err := ti.service.GetRole(ctx, &gen.GetRolePayload{ID: "role_custom"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_GetRole_AllowsOrgReadGrant(t *testing.T) {
@@ -80,7 +84,9 @@ func TestService_ListScopes_ForbiddenWithoutOrgReadGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	_, err := ti.service.ListScopes(ctx, &gen.ListScopesPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_ListScopes_AllowsOrgReadGrant(t *testing.T) {
@@ -101,7 +107,9 @@ func TestService_ListMembers_ForbiddenWithoutOrgReadGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	_, err := ti.service.ListMembers(ctx, &gen.ListMembersPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_ListMembers_AllowsOrgReadGrant(t *testing.T) {
@@ -135,7 +143,9 @@ func TestService_CreateRole_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	_, err := ti.service.CreateRole(ctx, &gen.CreateRolePayload{Name: "Denied", Description: "Denied"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_CreateRole_AllowsOrgAdminGrant(t *testing.T) {
@@ -169,7 +179,9 @@ func TestService_UpdateRole_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	_, err := ti.service.UpdateRole(ctx, &gen.UpdateRolePayload{ID: "role_custom"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_UpdateRole_AllowsOrgAdminGrant(t *testing.T) {
@@ -206,7 +218,9 @@ func TestService_DeleteRole_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: "role_custom"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_DeleteRole_AllowsOrgAdminGrant(t *testing.T) {
@@ -233,7 +247,9 @@ func TestService_UpdateMemberRole_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	ctx = withRBACGrants(t, ctx)
 
 	_, err := ti.service.UpdateMemberRole(ctx, &gen.UpdateMemberRolePayload{UserID: "user_1", RoleID: "role_builder"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_UpdateMemberRole_AllowsOrgAdminGrant(t *testing.T) {
@@ -274,7 +290,7 @@ func withRBACGrants(t *testing.T, ctx context.Context, grants ...Grant) context.
 	authCtx.AccountType = "enterprise"
 	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
-	return GrantsToContext(ctx, &Grants{rows: grants})
+	return GrantsToContext(ctx, grants)
 }
 
 func testAccessAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthContext {

--- a/server/internal/customdomains/rbac_test.go
+++ b/server/internal/customdomains/rbac_test.go
@@ -11,16 +11,19 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	cdrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestCustomDomainsService_GetDomain_ForbiddenWithoutOrgReadGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestCustomDomainsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.GetDomain(ctx, &gen.GetDomainPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestCustomDomainsService_GetDomain_AllowsOrgReadGrant(t *testing.T) {
@@ -31,7 +34,7 @@ func TestCustomDomainsService_GetDomain_AllowsOrgReadGrant(t *testing.T) {
 	_, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{OrganizationID: authCtx.ActiveOrganizationID, Domain: "docs.example.com"})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgRead, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgRead, Resource: authCtx.ActiveOrganizationID})
 
 	domain, err := ti.service.GetDomain(ctx, &gen.GetDomainPayload{})
 	require.NoError(t, err)
@@ -46,7 +49,7 @@ func TestCustomDomainsService_GetDomain_AllowsOrgAdminGrantViaScopeHierarchy(t *
 	_, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{OrganizationID: authCtx.ActiveOrganizationID, Domain: "hierarchy.example.com"})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 
 	domain, err := ti.service.GetDomain(ctx, &gen.GetDomainPayload{})
 	require.NoError(t, err)
@@ -61,20 +64,24 @@ func TestCustomDomainsService_GetDomain_ForbiddenWithGrantForDifferentOrganizati
 	_, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{OrganizationID: authCtx.ActiveOrganizationID, Domain: "docs.example.com"})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 
 	_, err = ti.service.GetDomain(ctx, &gen.GetDomainPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestCustomDomainsService_CreateDomain_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestCustomDomainsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	err := ti.service.CreateDomain(ctx, &gen.CreateDomainPayload{Domain: "create.example.com"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestCustomDomainsService_CreateDomain_AllowsOrgAdminGrant(t *testing.T) {
@@ -82,7 +89,7 @@ func TestCustomDomainsService_CreateDomain_AllowsOrgAdminGrant(t *testing.T) {
 
 	ctx, ti := newTestCustomDomainsService(t)
 	authCtx := testAuthContext(t, ctx)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 
 	err := ti.service.CreateDomain(ctx, &gen.CreateDomainPayload{Domain: "create.example.com"})
 	require.NoError(t, err)
@@ -94,10 +101,12 @@ func TestCustomDomainsService_CreateDomain_ForbiddenWithGrantForDifferentOrganiz
 	t.Parallel()
 
 	ctx, ti := newTestCustomDomainsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 
 	err := ti.service.CreateDomain(ctx, &gen.CreateDomainPayload{Domain: "create.example.com"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestCustomDomainsService_DeleteDomain_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
@@ -108,9 +117,11 @@ func TestCustomDomainsService_DeleteDomain_ForbiddenWithoutOrgAdminGrant(t *test
 	_, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{OrganizationID: authCtx.ActiveOrganizationID, Domain: "delete.example.com"})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 	err = ti.service.DeleteDomain(ctx, &gen.DeleteDomainPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestCustomDomainsService_DeleteDomain_AllowsOrgAdminGrant(t *testing.T) {
@@ -121,7 +132,7 @@ func TestCustomDomainsService_DeleteDomain_AllowsOrgAdminGrant(t *testing.T) {
 	_, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{OrganizationID: authCtx.ActiveOrganizationID, Domain: "delete.example.com"})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 	err = ti.service.DeleteDomain(ctx, &gen.DeleteDomainPayload{})
 	require.NoError(t, err)
 }
@@ -134,9 +145,11 @@ func TestCustomDomainsService_DeleteDomain_ForbiddenWithGrantForDifferentOrganiz
 	_, err := ti.repo.CreateCustomDomain(ctx, cdrepo.CreateCustomDomainParams{OrganizationID: authCtx.ActiveOrganizationID, Domain: "delete.example.com"})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 	err = ti.service.DeleteDomain(ctx, &gen.DeleteDomainPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestCustomDomainsService_GetDomain_UnauthorizedWithEmptyOrgID(t *testing.T) {
@@ -148,7 +161,9 @@ func TestCustomDomainsService_GetDomain_UnauthorizedWithEmptyOrgID(t *testing.T)
 	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	_, err := ti.service.GetDomain(ctx, &gen.GetDomainPayload{})
-	requireOopsCode(t, err, oops.CodeUnauthorized)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
 func TestCustomDomainsService_CreateDomain_UnauthorizedWithEmptyOrgID(t *testing.T) {
@@ -160,7 +175,9 @@ func TestCustomDomainsService_CreateDomain_UnauthorizedWithEmptyOrgID(t *testing
 	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	err := ti.service.CreateDomain(ctx, &gen.CreateDomainPayload{Domain: "create.example.com"})
-	requireOopsCode(t, err, oops.CodeUnauthorized)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
 func TestCustomDomainsService_DeleteDomain_UnauthorizedWithEmptyOrgID(t *testing.T) {
@@ -172,15 +189,9 @@ func TestCustomDomainsService_DeleteDomain_UnauthorizedWithEmptyOrgID(t *testing
 	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	err := ti.service.DeleteDomain(ctx, &gen.DeleteDomainPayload{})
-	requireOopsCode(t, err, oops.CodeUnauthorized)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
 func testAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthContext {

--- a/server/internal/customdomains/setup_test.go
+++ b/server/internal/customdomains/setup_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/workflowservice/v1"
@@ -12,11 +11,9 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	cdrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -88,30 +85,4 @@ func newTestCustomDomainsService(t *testing.T) (context.Context, *serviceTestIns
 	svc := customdomains.NewService(logger, tracerProvider, conn, sessionManager, temporal, accessManager)
 
 	return ctx, &serviceTestInstance{service: svc, conn: conn, sessionManager: sessionManager, temporal: temporal, repo: cdrepo.New(conn)}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "customdomains-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }

--- a/server/internal/deployments/rbac_test.go
+++ b/server/internal/deployments/rbac_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -23,7 +24,7 @@ func TestDeployments_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	assetStorage := assetstest.NewTestBlobStore(t)
 	ctx, ti := newTestDeploymentService(t, assetStorage)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListDeployments(ctx, &gen.ListDeploymentsPayload{
 		Cursor:           nil,
@@ -31,7 +32,9 @@ func TestDeployments_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 
 	_, err = ti.service.GetDeployment(ctx, &gen.GetDeploymentPayload{
 		ID:               uuid.NewString(),
@@ -39,21 +42,24 @@ func TestDeployments_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 
 	_, err = ti.service.GetLatestDeployment(ctx, &gen.GetLatestDeploymentPayload{
 		ApikeyToken:      nil,
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 
 	_, err = ti.service.GetActiveDeployment(ctx, &gen.GetActiveDeploymentPayload{
 		ApikeyToken:      nil,
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestDeployments_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
@@ -67,7 +73,7 @@ func TestDeployments_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.NotNil(t, authCtx)
 
 	projectID := authCtx.ProjectID.String()
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: projectID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: projectID})
 
 	_, err := ti.service.ListDeployments(ctx, &gen.ListDeploymentsPayload{
 		Cursor:           nil,
@@ -103,7 +109,7 @@ func TestDeployments_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.NotNil(t, authCtx)
 
 	projectID := authCtx.ProjectID.String()
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: projectID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: projectID})
 
 	_, err := ti.service.ListDeployments(ctx, &gen.ListDeploymentsPayload{
 		Cursor:           nil,
@@ -120,7 +126,7 @@ func TestDeployments_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	assetStorage := assetstest.NewTestBlobStore(t)
 	ctx, ti := newTestDeploymentService(t, assetStorage)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.ListDeployments(ctx, &gen.ListDeploymentsPayload{
 		Cursor:           nil,
@@ -128,7 +134,9 @@ func TestDeployments_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestDeployments_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
@@ -137,7 +145,7 @@ func TestDeployments_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	assetStorage := assetstest.NewTestBlobStore(t)
 	ctx, ti := newTestDeploymentService(t, assetStorage)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.CreateDeployment(ctx, &gen.CreateDeploymentPayload{
 		IdempotencyKey:   "rbac-test-create",
@@ -155,7 +163,9 @@ func TestDeployments_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 		ExternalURL:      nil,
 		NonBlocking:      nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 
 	_, err = ti.service.Evolve(ctx, &gen.EvolvePayload{
 		ApikeyToken:            nil,
@@ -172,7 +182,8 @@ func TestDeployments_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 		ExcludeExternalMcps:    []string{},
 		NonBlocking:            nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 
 	_, err = ti.service.Redeploy(ctx, &gen.RedeployPayload{
 		DeploymentID:     uuid.NewString(),
@@ -180,7 +191,8 @@ func TestDeployments_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestDeployments_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
@@ -194,7 +206,7 @@ func TestDeployments_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	require.NotNil(t, authCtx)
 
 	projectID := authCtx.ProjectID.String()
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: projectID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: projectID})
 
 	_, err := ti.service.CreateDeployment(ctx, &gen.CreateDeploymentPayload{
 		IdempotencyKey:   "rbac-test-create-readonly",
@@ -212,7 +224,9 @@ func TestDeployments_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 		ExternalURL:      nil,
 		NonBlocking:      nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestDeployments_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
@@ -226,7 +240,7 @@ func TestDeployments_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.NotNil(t, authCtx)
 
 	projectID := authCtx.ProjectID.String()
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: projectID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: projectID})
 
 	bs := bytes.NewBuffer(testenv.ReadFixture(t, "fixtures/todo-valid.yaml"))
 	ares, err := ti.assets.UploadOpenAPIv3(ctx, &agen.UploadOpenAPIv3Form{

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -6,30 +6,25 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -119,40 +114,4 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 		temporalEnv:    temporalEnv,
 		sessionManager: sessionManager,
 	}
-}
-
-// withExactAccessGrants sets AccountType to "enterprise" and seeds the given grants
-// into the database, returning a context with those grants loaded.
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "deployments-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/environments/rbac_test.go
+++ b/server/internal/environments/rbac_test.go
@@ -10,19 +10,22 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestEnvironments_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestEnvironmentService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListEnvironments(ctx, &gen.ListEnvironmentsPayload{
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestEnvironments_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
@@ -34,7 +37,7 @@ func TestEnvironments_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListEnvironments(ctx, &gen.ListEnvironmentsPayload{
 		SessionToken:     nil,
@@ -52,7 +55,7 @@ func TestEnvironments_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListEnvironments(ctx, &gen.ListEnvironmentsPayload{
 		SessionToken:     nil,
@@ -65,20 +68,22 @@ func TestEnvironments_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestEnvironmentService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.ListEnvironments(ctx, &gen.ListEnvironmentsPayload{
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestEnvironments_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestEnvironmentService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.CreateEnvironment(ctx, &gen.CreateEnvironmentPayload{
 		SessionToken:     nil,
@@ -88,7 +93,9 @@ func TestEnvironments_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 		Description:      nil,
 		Entries:          []*gen.EnvironmentEntryInput{},
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestEnvironments_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
@@ -100,7 +107,7 @@ func TestEnvironments_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CreateEnvironment(ctx, &gen.CreateEnvironmentPayload{
 		SessionToken:     nil,
@@ -110,7 +117,9 @@ func TestEnvironments_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 		Description:      nil,
 		Entries:          []*gen.EnvironmentEntryInput{},
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestEnvironments_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
@@ -122,7 +131,7 @@ func TestEnvironments_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CreateEnvironment(ctx, &gen.CreateEnvironmentPayload{
 		SessionToken:     nil,

--- a/server/internal/environments/setup_test.go
+++ b/server/internal/environments/setup_test.go
@@ -6,23 +6,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -85,38 +80,4 @@ func newTestEnvironmentService(t *testing.T) (context.Context, *testInstance) {
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "environments-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/externalmcp/rbac_test.go
+++ b/server/internal/externalmcp/rbac_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestExternalMCP_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestExternalMCPService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListCatalog(ctx, &gen.ListCatalogPayload{
 		SessionToken:     nil,
@@ -40,7 +41,7 @@ func TestExternalMCP_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListCatalog(ctx, &gen.ListCatalogPayload{
 		SessionToken:     nil,
@@ -62,7 +63,7 @@ func TestExternalMCP_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListCatalog(ctx, &gen.ListCatalogPayload{
 		SessionToken:     nil,
@@ -79,7 +80,7 @@ func TestExternalMCP_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestExternalMCPService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.ListCatalog(ctx, &gen.ListCatalogPayload{
 		SessionToken:     nil,

--- a/server/internal/externalmcp/setup_test.go
+++ b/server/internal/externalmcp/setup_test.go
@@ -6,22 +6,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -86,30 +82,4 @@ func newTestExternalMCPService(t *testing.T) (context.Context, *testInstance) {
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "externalmcp-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }

--- a/server/internal/hooks/rbac_test.go
+++ b/server/internal/hooks/rbac_test.go
@@ -10,20 +10,23 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestHooks_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestHooksService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.List(ctx, &gen.ListPayload{
 		ApikeyToken:      nil,
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestHooks_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
@@ -35,7 +38,7 @@ func TestHooks_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.List(ctx, &gen.ListPayload{
 		ApikeyToken:      nil,
@@ -54,7 +57,7 @@ func TestHooks_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.List(ctx, &gen.ListPayload{
 		ApikeyToken:      nil,
@@ -68,21 +71,23 @@ func TestHooks_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestHooksService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.List(ctx, &gen.ListPayload{
 		ApikeyToken:      nil,
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestHooks_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestHooksService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.Upsert(ctx, &gen.UpsertPayload{
 		ApikeyToken:      nil,
@@ -91,7 +96,9 @@ func TestHooks_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 		RawServerName:    "test-server",
 		DisplayName:      "Test Server",
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestHooks_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
@@ -103,7 +110,7 @@ func TestHooks_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.Upsert(ctx, &gen.UpsertPayload{
 		ApikeyToken:      nil,
@@ -112,7 +119,9 @@ func TestHooks_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 		RawServerName:    "test-server",
 		DisplayName:      "Test Server",
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestHooks_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
@@ -124,7 +133,7 @@ func TestHooks_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.Upsert(ctx, &gen.UpsertPayload{
 		ApikeyToken:      nil,

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -11,19 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
-	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -89,38 +84,4 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 		redisClient:    redisClient,
 		sessionManager: sessionManager,
 	}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "hooks-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/keys/rbac_test.go
+++ b/server/internal/keys/rbac_test.go
@@ -4,33 +4,32 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/keys"
 	"github.com/speakeasy-api/gram/server/internal/access"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestKeysService_CreateKey_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-denied-create", Scopes: []string{"consumer"}})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestKeysService_CreateKey_AllowsOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
 
 	key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-allow-create", Scopes: []string{"consumer"}})
 	require.NoError(t, err)
@@ -41,17 +40,19 @@ func TestKeysService_ListKeys_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListKeys(ctx, &gen.ListKeysPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestKeysService_ListKeys_AllowsOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
 	_, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-allow-list", Scopes: []string{"consumer"}})
 	require.NoError(t, err)
 
@@ -64,49 +65,27 @@ func TestKeysService_RevokeKey_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
 	key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-denied-revoke", Scopes: []string{"consumer"}})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 	err = ti.service.RevokeKey(ctx, &gen.RevokeKeyPayload{ID: key.ID})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestKeysService_RevokeKey_AllowsOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestKeysService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: testAuthContext(t, ctx).ActiveOrganizationID})
 	key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rbac-allow-revoke", Scopes: []string{"consumer"}})
 	require.NoError(t, err)
 
 	err = ti.service.RevokeKey(ctx, &gen.RevokeKeyPayload{ID: key.ID})
 	require.NoError(t, err)
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx := testAuthContext(t, ctx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "keys-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }
 
 func testAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthContext {
@@ -116,12 +95,4 @@ func testAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthConte
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 	return authCtx
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/mcp/rbac_test.go
+++ b/server/internal/mcp/rbac_test.go
@@ -11,14 +11,13 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestServePublic_RBAC_PrivateMCP_DeniedWithNoGrants(t *testing.T) {
@@ -28,7 +27,7 @@ func TestServePublic_RBAC_PrivateMCP_DeniedWithNoGrants(t *testing.T) {
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-denied-"+uuid.NewString()[:8])
 
 	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{}, workos.NewStubClient(), cache.NoopCache)
-	ctx = withExactAccessGrants(t, ctx, ti)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
 	var oopsErr *oops.ShareableError
@@ -43,7 +42,7 @@ func TestServePublic_RBAC_PrivateMCP_DeniedWithUnrelatedGrant(t *testing.T) {
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-unrelated-"+uuid.NewString()[:8])
 
 	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{}, workos.NewStubClient(), cache.NoopCache)
-	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPConnect, Resource: uuid.NewString()})
 
 	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
 	var oopsErr *oops.ShareableError
@@ -58,7 +57,7 @@ func TestServePublic_RBAC_PrivateMCP_AllowedWithWriteGrant(t *testing.T) {
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-write-implies-connect-"+uuid.NewString()[:8])
 
 	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{}, workos.NewStubClient(), cache.NoopCache)
-	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID.String()})
 
 	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
 	require.NoError(t, err)
@@ -71,7 +70,7 @@ func TestServePublic_RBAC_PrivateMCP_AllowedWithConnectGrant(t *testing.T) {
 	toolset := createPrivateMCPToolset(t, ctx, ti, "rbac-allowed-"+uuid.NewString()[:8])
 
 	accessManager := access.NewManager(ti.logger, ti.conn, accesstest.AlwaysEnabledFeatureChecker{}, workos.NewStubClient(), cache.NoopCache)
-	ctx = withExactAccessGrants(t, ctx, ti, access.Grant{Scope: access.ScopeMCPConnect, Resource: toolset.ID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPConnect, Resource: toolset.ID.String()})
 
 	err := accessManager.Require(ctx, access.Check{Scope: access.ScopeMCPConnect, ResourceID: toolset.ID.String()})
 	require.NoError(t, err)
@@ -88,37 +87,11 @@ func TestServePublic_RBAC_PublicMCP_AllowedWithoutGrants(t *testing.T) {
 	toolsetsRepo := toolsets_repo.New(ti.conn)
 	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "rbac-public-"+uuid.NewString()[:8])
 
-	ctx = withExactAccessGrants(t, ctx, ti)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, ti *testInstance, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "mcp-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(ti.conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, ti.conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }
 
 func createPrivateMCPToolset(t *testing.T, ctx context.Context, ti *testInstance, slug string) toolsets_repo.Toolset {

--- a/server/internal/organizations/listinvites_test.go
+++ b/server/internal/organizations/listinvites_test.go
@@ -1,15 +1,17 @@
 package organizations_test
 
 import (
-	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 	"testing"
 	"time"
+
+	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 
 	gen "github.com/speakeasy-api/gram/server/gen/organizations"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/mock"
@@ -85,7 +87,7 @@ func TestService_ListInvites_AllowsOrgReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgRead, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgRead, Resource: authCtx.ActiveOrganizationID})
 
 	ti.orgs.On("ListInvitations", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Invitation{}, nil).Once()
 
@@ -102,7 +104,7 @@ func TestService_ListInvites_AllowsOrgAdminGrantViaScopeHierarchy(t *testing.T) 
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 
 	ti.orgs.On("ListInvitations", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Invitation{}, nil).Once()
 
@@ -115,10 +117,12 @@ func TestService_ListInvites_ForbiddenWithoutOrgReadGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	res, err := ti.service.ListInvites(ctx, &gen.ListInvitesPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 	require.Nil(t, res)
 }
 
@@ -126,10 +130,12 @@ func TestService_ListInvites_ForbiddenWithGrantForDifferentOrganization(t *testi
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 
 	res, err := ti.service.ListInvites(ctx, &gen.ListInvitesPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 	require.Nil(t, res)
 }
 
@@ -140,6 +146,8 @@ func TestService_ListInvites_ForbiddenWhenNotOrgAdmin(t *testing.T) {
 	expectWorkOSOrgNonAdminRole(t, ti.orgs)
 
 	res, err := ti.service.ListInvites(ctx, &gen.ListInvitesPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 	require.Nil(t, res)
 }

--- a/server/internal/organizations/listusers_test.go
+++ b/server/internal/organizations/listusers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,7 +62,7 @@ func TestService_ListUsers_AllowsOrgReadGrant(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgRead, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgRead, Resource: authCtx.ActiveOrganizationID})
 
 	res, err := ti.service.ListUsers(ctx, &gen.ListUsersPayload{})
 	require.NoError(t, err)
@@ -82,7 +83,7 @@ func TestService_ListUsers_AllowsOrgAdminGrantViaScopeHierarchy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 
 	res, err := ti.service.ListUsers(ctx, &gen.ListUsersPayload{})
 	require.NoError(t, err)
@@ -93,10 +94,12 @@ func TestService_ListUsers_ForbiddenWithoutOrgReadGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	res, err := ti.service.ListUsers(ctx, &gen.ListUsersPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 	require.Nil(t, res)
 }
 
@@ -104,10 +107,12 @@ func TestService_ListUsers_ForbiddenWithGrantForDifferentOrganization(t *testing
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 
 	res, err := ti.service.ListUsers(ctx, &gen.ListUsersPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 	require.Nil(t, res)
 }
 
@@ -118,6 +123,8 @@ func TestService_ListUsers_ForbiddenWhenNotOrgAdmin(t *testing.T) {
 	expectWorkOSOrgNonAdminRole(t, ti.orgs)
 
 	res, err := ti.service.ListUsers(ctx, &gen.ListUsersPayload{})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 	require.Nil(t, res)
 }

--- a/server/internal/organizations/removeuser_test.go
+++ b/server/internal/organizations/removeuser_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -119,9 +120,9 @@ func TestService_RemoveUser_NotAMember(t *testing.T) {
 	err := ti.service.RemoveUser(ctx, &gen.RemoveUserPayload{
 		UserID: "non-member-user-id",
 	})
-	requireOopsCode(t, err, oops.CodeNotFound)
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 	require.Equal(t, "user is not a member of this organization", oopsErr.Error())
 
 	ti.orgs.AssertExpectations(t)
@@ -139,7 +140,9 @@ func TestService_RemoveUser_CannotRemoveSelf(t *testing.T) {
 	err := ti.service.RemoveUser(ctx, &gen.RemoveUserPayload{
 		UserID: authCtx.UserID,
 	})
-	requireOopsCode(t, err, oops.CodeBadRequest)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
 }
 
 func TestService_RemoveUser_AllowsOrgAdminGrant(t *testing.T) {
@@ -160,7 +163,7 @@ func TestService_RemoveUser_AllowsOrgAdminGrant(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 
 	ti.orgs.On("DeleteOrganizationMembership", mock.Anything, mock.Anything).Return(nil).Maybe()
 
@@ -172,20 +175,24 @@ func TestService_RemoveUser_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	err := ti.service.RemoveUser(ctx, &gen.RemoveUserPayload{UserID: "any-user-id"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_RemoveUser_ForbiddenWithGrantForDifferentOrganization(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 
 	err := ti.service.RemoveUser(ctx, &gen.RemoveUserPayload{UserID: "any-user-id"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_RemoveUser_ForbiddenWhenNotOrgAdmin(t *testing.T) {
@@ -195,5 +202,7 @@ func TestService_RemoveUser_ForbiddenWhenNotOrgAdmin(t *testing.T) {
 	expectWorkOSOrgNonAdminRole(t, ti.orgs)
 
 	err := ti.service.RemoveUser(ctx, &gen.RemoveUserPayload{UserID: "any-user-id"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }

--- a/server/internal/organizations/revokeinvite_test.go
+++ b/server/internal/organizations/revokeinvite_test.go
@@ -1,14 +1,16 @@
 package organizations_test
 
 import (
-	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 	"testing"
 	"time"
+
+	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 
 	gen "github.com/speakeasy-api/gram/server/gen/organizations"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -65,7 +67,9 @@ func TestService_RevokeInvite_NotFound(t *testing.T) {
 	err := ti.service.RevokeInvite(ctx, &gen.RevokeInvitePayload{
 		InvitationID: "test-invitation-id",
 	})
-	requireOopsCode(t, err, oops.CodeNotFound)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 }
 
 func TestService_RevokeInvite_WrongOrganization(t *testing.T) {
@@ -87,7 +91,9 @@ func TestService_RevokeInvite_WrongOrganization(t *testing.T) {
 	err := ti.service.RevokeInvite(ctx, &gen.RevokeInvitePayload{
 		InvitationID: "other-org-invitation-id",
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_RevokeInvite_AllowsOrgAdminGrant(t *testing.T) {
@@ -98,7 +104,7 @@ func TestService_RevokeInvite_AllowsOrgAdminGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 
 	ti.orgs.On("GetInvitation", mock.Anything, "test-invitation-id").Return(&thirdpartyworkos.Invitation{
 		ID:             "test-invitation-id",
@@ -119,20 +125,24 @@ func TestService_RevokeInvite_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	err := ti.service.RevokeInvite(ctx, &gen.RevokeInvitePayload{InvitationID: "any-invitation-id"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_RevokeInvite_ForbiddenWithGrantForDifferentOrganization(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 
 	err := ti.service.RevokeInvite(ctx, &gen.RevokeInvitePayload{InvitationID: "any-invitation-id"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_RevokeInvite_ForbiddenWhenNotOrgAdmin(t *testing.T) {
@@ -142,5 +152,7 @@ func TestService_RevokeInvite_ForbiddenWhenNotOrgAdmin(t *testing.T) {
 	expectWorkOSOrgNonAdminRole(t, ti.orgs)
 
 	err := ti.service.RevokeInvite(ctx, &gen.RevokeInvitePayload{InvitationID: "any-invitation-id"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }

--- a/server/internal/organizations/sendinvite_test.go
+++ b/server/internal/organizations/sendinvite_test.go
@@ -1,14 +1,16 @@
 package organizations_test
 
 import (
-	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 	"testing"
 	"time"
+
+	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 
 	gen "github.com/speakeasy-api/gram/server/gen/organizations"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -110,7 +112,7 @@ func TestService_SendInvite_AllowsOrgAdminGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: authCtx.ActiveOrganizationID})
 
 	expiresAt := time.Now().UTC().Add(7 * 24 * time.Hour).Format(time.RFC3339)
 	createdAt := time.Now().UTC().Format(time.RFC3339)
@@ -135,20 +137,24 @@ func TestService_SendInvite_ForbiddenWithoutOrgAdminGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.SendInvite(ctx, &gen.SendInvitePayload{Email: "x@example.com"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_SendInvite_ForbiddenWithGrantForDifferentOrganization(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeOrgAdmin, Resource: "org_other"})
 
 	_, err := ti.service.SendInvite(ctx, &gen.SendInvitePayload{Email: "x@example.com"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestService_SendInvite_ForbiddenWhenNotOrgAdmin(t *testing.T) {
@@ -158,5 +164,7 @@ func TestService_SendInvite_ForbiddenWhenNotOrgAdmin(t *testing.T) {
 	expectWorkOSOrgNonAdminRole(t, ti.orgs)
 
 	_, err := ti.service.SendInvite(ctx, &gen.SendInvitePayload{Email: "x@example.com"})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -6,24 +6,20 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	mockidp "github.com/speakeasy-api/gram/mock-speakeasy-idp"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/organizations"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -173,38 +169,4 @@ func expectWorkOSOrgAdminRole(t *testing.T, orgs *MockOrganizationProvider) {
 func expectWorkOSOrgNonAdminRole(t *testing.T, orgs *MockOrganizationProvider) {
 	t.Helper()
 	orgs.On("GetOrgMembership", mock.Anything, testAuthUserWorkOSID, mockidp.MockOrgID).Return(&thirdpartyworkos.Member{RoleSlug: "member"}, nil).Once()
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "organizations-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/packages/rbac_test.go
+++ b/server/internal/packages/rbac_test.go
@@ -10,20 +10,23 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestPackages_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestPackagesService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListPackages(ctx, &gen.ListPackagesPayload{
 		ApikeyToken:      nil,
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestPackages_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
@@ -35,7 +38,7 @@ func TestPackages_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListPackages(ctx, &gen.ListPackagesPayload{
 		ApikeyToken:      nil,
@@ -54,7 +57,7 @@ func TestPackages_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListPackages(ctx, &gen.ListPackagesPayload{
 		ApikeyToken:      nil,
@@ -68,21 +71,23 @@ func TestPackages_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestPackagesService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.ListPackages(ctx, &gen.ListPackagesPayload{
 		ApikeyToken:      nil,
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestPackages_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestPackagesService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.CreatePackage(ctx, &gen.CreatePackagePayload{
 		ApikeyToken:      nil,
@@ -96,7 +101,9 @@ func TestPackages_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 		Keywords:         []string{},
 		ImageAssetID:     nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestPackages_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
@@ -108,7 +115,7 @@ func TestPackages_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CreatePackage(ctx, &gen.CreatePackagePayload{
 		ApikeyToken:      nil,
@@ -122,7 +129,9 @@ func TestPackages_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 		Keywords:         []string{},
 		ImageAssetID:     nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestPackages_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
@@ -134,7 +143,7 @@ func TestPackages_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CreatePackage(ctx, &gen.CreatePackagePayload{
 		ApikeyToken:      nil,

--- a/server/internal/packages/setup_test.go
+++ b/server/internal/packages/setup_test.go
@@ -6,23 +6,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -83,38 +78,4 @@ func newTestPackagesService(t *testing.T) (context.Context, *testInstance) {
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "packages-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
-}
-
-func requireOopsCode(t *testing.T, err error, code oops.Code) {
-	t.Helper()
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, code, oopsErr.Code)
 }

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -50,7 +50,7 @@ func TestPluginsService_CreatePlugin_ForbiddenWithoutOrgAdmin(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestPluginsService(t)
-	ctx = access.GrantsToContext(ctx, &access.Grants{})
+	ctx = access.GrantsToContext(ctx, nil)
 
 	_, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{
 		Name: "Forbidden Plugin",

--- a/server/internal/projects/createproject_test.go
+++ b/server/internal/projects/createproject_test.go
@@ -72,7 +72,7 @@ func TestProjectsService_CreateProject_ForbiddenWithoutOrgAdminGrant(t *testing.
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, true)
-	ctx = access.GrantsToContext(ctx, &access.Grants{})
+	ctx = access.GrantsToContext(ctx, nil)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -95,7 +95,7 @@ func TestProjectsService_CreateProject_SkipsRBACWhenDisabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, false)
-	ctx = access.GrantsToContext(ctx, &access.Grants{})
+	ctx = access.GrantsToContext(ctx, nil)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 

--- a/server/internal/projects/deleteproject_test.go
+++ b/server/internal/projects/deleteproject_test.go
@@ -93,7 +93,7 @@ func TestProjectsService_DeleteProject_SkipsRBACWhenDisabled(t *testing.T) {
 
 	ctx, ti := newTestProjectsService(t, false)
 	project := createProjectForDeletion(t, ctx, ti, "rbac-disabled-"+uuid.NewString()[:8])
-	ctx = access.GrantsToContext(ctx, &access.Grants{})
+	ctx = access.GrantsToContext(ctx, nil)
 
 	err := ti.service.DeleteProject(ctx, &gen.DeleteProjectPayload{
 		ID: project.ID.String(),

--- a/server/internal/projects/getproject_test.go
+++ b/server/internal/projects/getproject_test.go
@@ -65,7 +65,7 @@ func TestProjectsService_GetProject(t *testing.T) {
 		t.Parallel()
 
 		ctx, ti := newTestProjectsService(t, true)
-		ctx = access.GrantsToContext(ctx, &access.Grants{})
+		ctx = access.GrantsToContext(ctx, nil)
 
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
 		require.True(t, ok)

--- a/server/internal/projects/listprojects_test.go
+++ b/server/internal/projects/listprojects_test.go
@@ -27,7 +27,7 @@ func TestProjectsService_ListProjects_SkipsRBACWhenDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// Clear grants so no project would be visible if RBAC were enforced.
-	ctx = access.GrantsToContext(ctx, &access.Grants{})
+	ctx = access.GrantsToContext(ctx, nil)
 
 	result, err := ti.service.ListProjects(ctx, &gen.ListProjectsPayload{
 		OrganizationID: authCtx.ActiveOrganizationID,

--- a/server/internal/projects/setlogo_test.go
+++ b/server/internal/projects/setlogo_test.go
@@ -191,7 +191,7 @@ func TestSetLogo_ForbiddenWithoutBuildWriteGrant(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, true)
-	ctx = access.GrantsToContext(ctx, &access.Grants{})
+	ctx = access.GrantsToContext(ctx, nil)
 
 	result, err := ti.service.SetLogo(ctx, &projects.SetLogoPayload{
 		ApikeyToken:      nil,
@@ -212,7 +212,7 @@ func TestSetLogo_SkipsRBACWhenDisabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, false)
-	ctx = access.GrantsToContext(ctx, &access.Grants{})
+	ctx = access.GrantsToContext(ctx, nil)
 
 	assetID := uuid.New()
 	result, err := ti.service.SetLogo(ctx, &projects.SetLogoPayload{

--- a/server/internal/rbactest/grants.go
+++ b/server/internal/rbactest/grants.go
@@ -1,0 +1,25 @@
+// Package rbactest provides test helpers for RBAC grant setup in integration tests.
+package rbactest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+)
+
+// WithExactAccessGrants marks the context as enterprise and loads the given grants
+// directly into the context. Pass no grants to simulate RBAC active with no permissions.
+func WithExactAccessGrants(t *testing.T, ctx context.Context, grants ...access.Grant) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	return access.GrantsToContext(ctx, grants)
+}

--- a/server/internal/resources/rbac_test.go
+++ b/server/internal/resources/rbac_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestResources_RBAC_List_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestResourcesService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
 		SessionToken:     nil,
@@ -38,7 +39,7 @@ func TestResources_RBAC_List_DeniedWithUnrelatedGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: "other-project-id"})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: "other-project-id"})
 
 	_, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
 		SessionToken:     nil,
@@ -61,7 +62,7 @@ func TestResources_RBAC_List_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	result, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
 		SessionToken:     nil,
@@ -83,7 +84,7 @@ func TestResources_RBAC_List_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	result, err := ti.service.ListResources(ctx, &gen.ListResourcesPayload{
 		SessionToken:     nil,

--- a/server/internal/resources/setup_test.go
+++ b/server/internal/resources/setup_test.go
@@ -6,20 +6,16 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/resources"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,30 +78,4 @@ func newTestResourcesService(t *testing.T) (context.Context, *testInstance) {
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "resources-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }

--- a/server/internal/telemetry/rbac_test.go
+++ b/server/internal/telemetry/rbac_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestTelemetry_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestLogsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
 		Limit:            10,
@@ -44,7 +45,7 @@ func TestTelemetry_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
 		Limit:            10,
@@ -70,7 +71,7 @@ func TestTelemetry_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
 		Limit:            10,
@@ -91,7 +92,7 @@ func TestTelemetry_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestLogsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.SearchLogs(ctx, &telem_gen.SearchLogsPayload{
 		Limit:            10,

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -27,7 +26,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -129,32 +127,6 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 		disabledLogsOrgID:  disabledLogsOrgID,
 		enabledToolIOOrgID: enabledToolIOOrgID,
 	}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "telemetry-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }
 
 func switchOrganizationInCtx(t *testing.T, ctx context.Context, newOrgID string) context.Context {

--- a/server/internal/templates/rbac_test.go
+++ b/server/internal/templates/rbac_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestTemplates_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestTemplateService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
 		SessionToken:     nil,
@@ -37,7 +38,7 @@ func TestTemplates_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
 		SessionToken:     nil,
@@ -56,7 +57,7 @@ func TestTemplates_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
 		SessionToken:     nil,
@@ -70,7 +71,7 @@ func TestTemplates_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestTemplateService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.ListTemplates(ctx, &gen.ListTemplatesPayload{
 		SessionToken:     nil,
@@ -86,7 +87,7 @@ func TestTemplates_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestTemplateService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.CreateTemplate(ctx, &gen.CreateTemplatePayload{
 		SessionToken:     nil,
@@ -115,7 +116,7 @@ func TestTemplates_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CreateTemplate(ctx, &gen.CreateTemplatePayload{
 		SessionToken:     nil,
@@ -144,7 +145,7 @@ func TestTemplates_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	name := "nonexistent-template"
 	err := ti.service.DeleteTemplate(ctx, &gen.DeleteTemplatePayload{

--- a/server/internal/templates/setup_test.go
+++ b/server/internal/templates/setup_test.go
@@ -12,11 +12,9 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/templates"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -98,30 +96,4 @@ type toolsetsServiceStub struct {
 
 func (s *toolsetsServiceStub) InvalidateCacheByTool(ctx context.Context, toolURN urn.Tool, projectID uuid.UUID) error {
 	return s.InvalidateCacheByToolFunc(ctx, toolURN, projectID)
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "templates-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }

--- a/server/internal/tools/rbac_test.go
+++ b/server/internal/tools/rbac_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestTools_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsService(t, assetstest.NewTestBlobStore(t))
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListTools(ctx, &gen.ListToolsPayload{
 		SessionToken:     nil,
@@ -41,7 +42,7 @@ func TestTools_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListTools(ctx, &gen.ListToolsPayload{
 		SessionToken:     nil,
@@ -63,7 +64,7 @@ func TestTools_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListTools(ctx, &gen.ListToolsPayload{
 		SessionToken:     nil,
@@ -80,7 +81,7 @@ func TestTools_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsService(t, assetstest.NewTestBlobStore(t))
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.ListTools(ctx, &gen.ListToolsPayload{
 		SessionToken:     nil,

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -11,21 +11,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	agen "github.com/speakeasy-api/gram/server/gen/assets"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -37,7 +34,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/tools"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -205,30 +201,4 @@ func uploadFunctionsWithManifest(t *testing.T, ctx context.Context, assetsServic
 	require.NoError(t, err, "failed to upload functions")
 
 	return result
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "tools-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }

--- a/server/internal/toolsets/rbac_test.go
+++ b/server/internal/toolsets/rbac_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestToolsets_RBAC_List_ReturnsEmptyWithNoGrants(t *testing.T) {
@@ -19,7 +20,7 @@ func TestToolsets_RBAC_List_ReturnsEmptyWithNoGrants(t *testing.T) {
 	ctx, ti := newTestToolsetsService(t)
 	_ = createMinimalPrivateToolset(t, ctx, ti, "rbac-list-empty-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	result, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
 		SessionToken:     nil,
@@ -36,7 +37,7 @@ func TestToolsets_RBAC_List_FiltersToGrantedToolsets(t *testing.T) {
 	ctx, ti := newTestToolsetsService(t)
 	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-filter-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
 
 	result, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
 		SessionToken:     nil,
@@ -54,7 +55,7 @@ func TestToolsets_RBAC_List_ReturnsEmptyWithWrongResourceGrant(t *testing.T) {
 	ctx, ti := newTestToolsetsService(t)
 	_ = createMinimalPrivateToolset(t, ctx, ti, "rbac-excluded-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPRead, Resource: uuid.NewString()})
 
 	result, err := ti.service.ListToolsets(ctx, &gen.ListToolsetsPayload{
 		SessionToken:     nil,
@@ -69,7 +70,7 @@ func TestToolsets_RBAC_Create_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
 		SessionToken:           nil,
@@ -95,7 +96,7 @@ func TestToolsets_RBAC_Create_DeniedWithReadOnlyGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
 		SessionToken:           nil,
@@ -121,7 +122,7 @@ func TestToolsets_RBAC_Create_AllowedWithProjectWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
 		SessionToken:           nil,
@@ -146,7 +147,7 @@ func TestToolsets_RBAC_CloneToolset_DeniedWithProjectWriteButNoSourceRead(t *tes
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.CloneToolset(ctx, &gen.CloneToolsetPayload{
 		SessionToken:     nil,
@@ -165,7 +166,7 @@ func TestToolsets_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	ctx, ti := newTestToolsetsService(t)
 	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-write-denied-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
 		SessionToken:           nil,
@@ -194,7 +195,7 @@ func TestToolsets_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	ctx, ti := newTestToolsetsService(t)
 	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-write-readonly-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
 
 	_, err := ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
 		SessionToken:           nil,
@@ -223,7 +224,7 @@ func TestToolsets_RBAC_WriteOps_AllowedWithToolsetWriteGrant(t *testing.T) {
 	ctx, ti := newTestToolsetsService(t)
 	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-write-allowed-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPWrite, Resource: toolset.ID})
 
 	name := "updated-name"
 	_, err := ti.service.UpdateToolset(ctx, &gen.UpdateToolsetPayload{
@@ -251,7 +252,7 @@ func TestToolsets_RBAC_UpdateOAuthProxyServer_DeniedWithNoGrants(t *testing.T) {
 	ctx, ti := newTestToolsetsService(t)
 	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-update-oauth-proxy-denied-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	audience := "https://api.example.com"
 	_, err := ti.service.UpdateOAuthProxyServer(ctx, &gen.UpdateOAuthProxyServerPayload{
@@ -274,7 +275,7 @@ func TestToolsets_RBAC_UpdateOAuthProxyServer_DeniedWithReadOnlyGrant(t *testing
 	ctx, ti := newTestToolsetsService(t)
 	toolset := createMinimalPrivateToolset(t, ctx, ti, "rbac-update-oauth-proxy-readonly-test")
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeMCPRead, Resource: toolset.ID})
 
 	audience := "https://api.example.com"
 	_, err := ti.service.UpdateOAuthProxyServer(ctx, &gen.UpdateOAuthProxyServerPayload{
@@ -303,7 +304,7 @@ func TestToolsets_RBAC_UpdateOAuthProxyServer_EmptyForm_DeniedWithNoGrants(t *te
 		"rbac-empty-form-proxy",
 	)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.UpdateOAuthProxyServer(ctx, &gen.UpdateOAuthProxyServerPayload{
 		SessionToken:     nil,

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -21,7 +20,6 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
@@ -40,7 +38,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/toolsets"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -378,30 +375,4 @@ func createMinimalPublicToolset(t *testing.T, ctx context.Context, ti *testInsta
 	require.True(t, *updated.McpIsPublic)
 
 	return updated
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "toolsets-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }

--- a/server/internal/variations/rbac_test.go
+++ b/server/internal/variations/rbac_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rbactest"
 )
 
 func TestVariations_RBAC_ReadOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestVariationsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
 		SessionToken:     nil,
@@ -37,7 +38,7 @@ func TestVariations_RBAC_ReadOps_AllowedWithBuildReadGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
 		SessionToken:     nil,
@@ -56,7 +57,7 @@ func TestVariations_RBAC_ReadOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
 		SessionToken:     nil,
@@ -70,7 +71,7 @@ func TestVariations_RBAC_ReadOps_DeniedWithWrongResourceID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestVariationsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: uuid.NewString()})
 
 	_, err := ti.service.ListGlobal(ctx, &gen.ListGlobalPayload{
 		SessionToken:     nil,
@@ -86,7 +87,7 @@ func TestVariations_RBAC_WriteOps_DeniedWithNoGrants(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestVariationsService(t)
-	ctx = withExactAccessGrants(t, ctx, ti.conn)
+	ctx = rbactest.WithExactAccessGrants(t, ctx)
 
 	_, err := ti.service.UpsertGlobal(ctx, &gen.UpsertGlobalPayload{
 		SessionToken:     nil,
@@ -109,7 +110,7 @@ func TestVariations_RBAC_WriteOps_DeniedWithReadOnlyGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildRead, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.UpsertGlobal(ctx, &gen.UpsertGlobalPayload{
 		SessionToken:     nil,
@@ -132,7 +133,7 @@ func TestVariations_RBAC_WriteOps_AllowedWithBuildWriteGrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
 
-	ctx = withExactAccessGrants(t, ctx, ti.conn, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
+	ctx = rbactest.WithExactAccessGrants(t, ctx, access.Grant{Scope: access.ScopeBuildWrite, Resource: authCtx.ProjectID.String()})
 
 	_, err := ti.service.UpsertGlobal(ctx, &gen.UpsertGlobalPayload{
 		SessionToken:     nil,

--- a/server/internal/variations/setup_test.go
+++ b/server/internal/variations/setup_test.go
@@ -6,19 +6,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/access/accesstest"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/variations"
 	"github.com/stretchr/testify/require"
 )
@@ -81,30 +77,4 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 		conn:           conn,
 		sessionManager: sessionManager,
 	}
-}
-
-func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, grants ...access.Grant) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
-
-	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "variations-rbac-grants-"+uuid.NewString())
-	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PrincipalUrn:   principal,
-			Scope:          string(grant.Scope),
-			Resource:       grant.Resource,
-		})
-		require.NoError(t, err)
-	}
-
-	loadedGrants, err := access.LoadGrants(ctx, conn, authCtx.ActiveOrganizationID, []urn.Principal{principal})
-	require.NoError(t, err)
-
-	return access.GrantsToContext(ctx, loadedGrants)
 }


### PR DESCRIPTION
A needed cleanup post RBAC which refactors some of the test setup and gets rid of a useless `Grants` struct. 

## Summary

- Extracts a shared `rbactest.WithExactAccessGrants` helper into `server/internal/rbactest`, replacing ~16 copy-pasted `withExactAccessGrants` functions across domain `setup_test.go` files
- Inlines all `requireOopsCode` helper call sites (was duplicated across 8+ packages) using `require.ErrorAs` + `require.Equal` directly
- Simplifies the `access` package internals: removes the `Grants` struct wrapper entirely, storing `[]Grant` directly in context; `GrantsToContext` now accepts `[]Grant`, `GrantsFromContext` returns `[]Grant`; `LoadGrants` returns `[]Grant`; satisfaction check is a plain `grantsSatisfy` function