### PR TITLE
fix: be less eager about syncing speakeasy IDP state to Gram

### DIFF
--- a/.changeset/cuddly-apes-notice.md
+++ b/.changeset/cuddly-apes-notice.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Change ID Token syncing behavior to be slighlty less eager

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -192,8 +193,13 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		}
 	}
 
-	// Org metadata was already upserted for all orgs by GetUserInfoFromSpeakeasy.
-	orgMetadata, err := s.orgRepo.GetOrganizationMetadata(ctx, activeOrg.ID)
+	orgMetadata, err := s.orgRepo.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          activeOrg.ID,
+		Name:        activeOrg.Name,
+		Slug:        activeOrg.Slug,
+		WorkosID:    conv.PtrToPGText(activeOrg.WorkosID),
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	})
 	if err != nil {
 		return redirectWithError(authErrInit, err)
 	}
@@ -257,9 +263,11 @@ func (s *Service) SwitchScopes(ctx context.Context, payload *gen.SwitchScopesPay
 		selectedOrg = *payload.OrganizationID
 	}
 
+	var selected sessions.Organization
 	orgFound := false
 	for _, org := range userInfo.Organizations {
 		if org.ID == selectedOrg {
+			selected = org
 			orgFound = true
 			break
 		}
@@ -268,6 +276,16 @@ func (s *Service) SwitchScopes(ctx context.Context, payload *gen.SwitchScopesPay
 		return nil, oops.E(oops.CodeInvalid, nil, "organization not found in user info")
 	}
 	authCtx.ActiveOrganizationID = selectedOrg
+
+	if _, err := s.orgRepo.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          selected.ID,
+		Name:        selected.Name,
+		Slug:        selected.Slug,
+		WorkosID:    conv.PtrToPGText(selected.WorkosID),
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error upserting organization metadata").Log(ctx, s.logger)
+	}
 
 	if err := s.sessions.StoreSession(ctx, sessions.Session{
 		SessionID:            *authCtx.SessionID,

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -200,9 +199,8 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 		}
 	}
 
-	// Upsert all orgs and sync WorkOS IDs/memberships
-	if err := s.syncOrgsAndWorkOSIDs(ctx, user, validateResp); err != nil {
-		return nil, fmt.Errorf("sync orgs: %w", err)
+	if err := s.syncWorkOSMemberships(ctx, user, validateResp); err != nil {
+		return nil, fmt.Errorf("sync workos memberships: %w", err)
 	}
 
 	var adminOverride string
@@ -396,24 +394,13 @@ func (p *Manager) BuildAuthorizationURL(ctx context.Context, params AuthURLParam
 	return authURL, nil
 }
 
-func (s *Manager) syncOrgsAndWorkOSIDs(ctx context.Context, user userRepo.UpsertUserRow, validateResp validateTokenResponse) error {
-	// Upsert all orgs from the IDP response so that organization_metadata rows
-	// exist and stay current (name, slug, workos_id) for every org the user
-	// belongs to — not just the active one.
-	for _, org := range validateResp.Organizations {
-		if _, err := s.orgRepo.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
-			ID:          org.ID,
-			Name:        org.Name,
-			Slug:        org.Slug,
-			WorkosID:    conv.PtrToPGText(org.WorkOSID),
-			Whitelisted: pgtype.Bool{Bool: false, Valid: false},
-		}); err != nil {
-			return fmt.Errorf("upsert organization metadata for %s: %w", org.ID, err)
-		}
-	}
-
-	// WorkOS-specific syncing is best-effort — failures are logged but don't
-	// block login since the critical org upserts above already succeeded.
+// syncWorkOSMemberships reconciles the user's WorkOS identity and membership
+// records against what WorkOS currently reports. Organization metadata upserts
+// are the caller's responsibility and happen at login/switch-scope sites where
+// the active org is known. Failures here are best-effort and logged — they
+// don't block authentication because WorkOS membership data is only used for
+// RBAC features that degrade gracefully without it.
+func (s *Manager) syncWorkOSMemberships(ctx context.Context, user userRepo.UpsertUserRow, validateResp validateTokenResponse) error {
 	if s.workos == nil {
 		return nil
 	}

--- a/server/internal/auth/sessions/speakeasyconnections_test.go
+++ b/server/internal/auth/sessions/speakeasyconnections_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -218,9 +219,12 @@ func acquireIDToken(t *testing.T, ctx context.Context, mgr *sessions.Manager) st
 	return idToken
 }
 
-// TestSyncWorkOSIDs_PopulatesNonSSOOrg is the core regression test for the bug:
-// workos_id must be backfilled from validate (workos_id) for orgs that sync with WorkOS.
-func TestSyncWorkOSIDs_PopulatesNonSSOOrg(t *testing.T) {
+// TestCallbackUpsert_PopulatesWorkOSIDForExistingOrg is the core regression test
+// for the bug: workos_id must be populated from validate (workos_id) for an org
+// row that previously existed without one. The callback upsert (simulated here
+// by UpsertOrganizationMetadata with the validate response's WorkosID) is the
+// owner of org metadata freshness under the post-PR-2246 architecture.
+func TestCallbackUpsert_PopulatesWorkOSIDForExistingOrg(t *testing.T) {
 	t.Parallel()
 
 	const workosUserID = "wos_user_1"
@@ -241,12 +245,23 @@ func TestSyncWorkOSIDs_PopulatesNonSSOOrg(t *testing.T) {
 	require.NoError(t, err)
 
 	idToken := acquireIDToken(t, ctx, ts.mgr)
+	userInfo, err := ts.mgr.GetUserInfoFromSpeakeasy(ctx, idToken)
+	require.NoError(t, err)
+	require.NotEmpty(t, userInfo.Organizations)
 
-	// syncWorkOSIDs is called synchronously inside GetUserInfoFromSpeakeasy.
-	_, err = ts.mgr.GetUserInfoFromSpeakeasy(ctx, idToken)
+	// Simulate the Callback flow's upsert with the active org's validate data.
+	oq := orgRepo.New(ts.conn)
+	activeOrg := userInfo.Organizations[0]
+	_, err = oq.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          activeOrg.ID,
+		Name:        activeOrg.Name,
+		Slug:        activeOrg.Slug,
+		WorkosID:    conv.PtrToPGText(activeOrg.WorkosID),
+		Whitelisted: pgtype.Bool{Valid: false},
+	})
 	require.NoError(t, err)
 
-	org, err := orgRepo.New(ts.conn).GetOrganizationMetadata(ctx, workosOrgID)
+	org, err := oq.GetOrganizationMetadata(ctx, workosOrgID)
 	require.NoError(t, err)
 	require.True(t, org.WorkosID.Valid, "workos_id should be populated from validate workos_id")
 	require.Equal(t, workosOrgID, org.WorkosID.String)


### PR DESCRIPTION
https://github.com/speakeasy-api/gram/pull/2246/changes

This PR modifies Gram's behavior to synchronize all speakeasy IDP state, but speakeasy ID tokens include tons of implicit state that is ill-suited to being synchronized to our database on each request.

We revert behavior to only update data on the explicitly selected organization. We will delegate further org syncing behavior to dedicated sub-systems