### PR TITLE
mig: add content_hash and generation to chat_messages

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -848,6 +848,17 @@ CREATE TABLE IF NOT EXISTS chat_messages (
   tool_outcome TEXT,
   tool_outcome_notes TEXT,
 
+  -- Canonical hash of (role, content, tool_calls, tool_call_id) used to detect
+  -- whether an incoming completion request has diverged from the stored history
+  -- (e.g., client-side conversation compaction). Nullable because existing rows
+  -- have no hash; backfilled lazily during the next capture turn.
+  content_hash BYTEA,
+
+  -- Monotonic counter per chat. Bumped when the matcher detects divergence from
+  -- the stored content chain (compaction or edit). Messages belonging to the
+  -- same logical conversation view share a generation.
+  generation INTEGER NOT NULL DEFAULT 0,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT chat_messages_pkey PRIMARY KEY (id),
@@ -856,6 +867,7 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 );
 
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_idx ON chat_messages (chat_id);
+CREATE INDEX IF NOT EXISTS chat_messages_chat_id_generation_seq_idx ON chat_messages (chat_id, generation, seq);
 
 CREATE TABLE IF NOT EXISTS chat_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/chat/repo/models.go
+++ b/server/internal/chat/repo/models.go
@@ -50,6 +50,8 @@ type ChatMessage struct {
 	ToolUrn          urn.Tool
 	ToolOutcome      pgtype.Text
 	ToolOutcomeNotes pgtype.Text
+	ContentHash      []byte
+	Generation       int32
 	CreatedAt        pgtype.Timestamptz
 }
 

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -408,7 +408,7 @@ func (q *Queries) GetLLMClientBreakdownByMessages(ctx context.Context, arg GetLL
 }
 
 const getToolCallMessages = `-- name: GetToolCallMessages :many
-SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, created_at FROM chat_messages
+SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, content_hash, generation, created_at FROM chat_messages
 WHERE chat_id = $1
   AND role = 'tool'
 ORDER BY created_at ASC
@@ -450,6 +450,8 @@ func (q *Queries) GetToolCallMessages(ctx context.Context, chatID uuid.UUID) ([]
 			&i.ToolUrn,
 			&i.ToolOutcome,
 			&i.ToolOutcomeNotes,
+			&i.ContentHash,
+			&i.Generation,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -696,7 +698,7 @@ func (q *Queries) ListAllChats(ctx context.Context, projectID uuid.UUID) ([]List
 }
 
 const listChatMessages = `-- name: ListChatMessages :many
-SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, created_at FROM chat_messages 
+SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, content_hash, generation, created_at FROM chat_messages 
 WHERE chat_id = $1 AND (project_id IS NULL OR project_id = $2::uuid) 
 ORDER BY seq ASC
 `
@@ -742,6 +744,8 @@ func (q *Queries) ListChatMessages(ctx context.Context, arg ListChatMessagesPara
 			&i.ToolUrn,
 			&i.ToolOutcome,
 			&i.ToolOutcomeNotes,
+			&i.ContentHash,
+			&i.Generation,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -116,6 +116,8 @@ type ChatMessage struct {
 	ToolUrn          urn.Tool
 	ToolOutcome      pgtype.Text
 	ToolOutcomeNotes pgtype.Text
+	ContentHash      []byte
+	Generation       int32
 	CreatedAt        pgtype.Timestamptz
 }
 

--- a/server/migrations/20260420113616_chat-messages-add-content-hash-generation.sql
+++ b/server/migrations/20260420113616_chat-messages-add-content-hash-generation.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "chat_messages" table
+ALTER TABLE "chat_messages" ADD COLUMN "content_hash" bytea NULL, ADD COLUMN "generation" integer NOT NULL DEFAULT 0;
+-- Create index "chat_messages_chat_id_generation_seq_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_chat_id_generation_seq_idx" ON "chat_messages" ("chat_id", "generation", "seq");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PM20P84ylQ4nrZ9GLIfZAJqyFPItY28gRuekUqlXSsM=
+h1:Gv4gGnAkVX2VToBdjnT+PuK1aw5rdnklIFDs7nO5tIA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -126,3 +126,4 @@ h1:PM20P84ylQ4nrZ9GLIfZAJqyFPItY28gRuekUqlXSsM=
 20260413211711_registry-type-polymorphic.sql h1:wWsYj3Wbpt09ZBIDzTIwLa9qWKE4N2/MtcPUxhnAGjY=
 20260414000001_plugins.sql h1:vlPWOWRSVYp9DahP9QbPdDxFysburvzyTs+501IkYjU=
 20260420113615_add-risk-analysis-tables.sql h1:gJRWVPfyL+HIWsvglhF10o0/SsMd+MVt5z7IDoSTQW4=
+20260420113616_chat-messages-add-content-hash-generation.sql h1:4PwJKipKdhpuXXnSMl4cCXC0SEnx3rbzLYY29+NV44s=


### PR DESCRIPTION
## Summary

Adds two columns plus a supporting index so the `/chat/completions` capture path can match incoming requests against stored history and detect divergence (client-side conversation compaction or edits).

- `content_hash BYTEA` — nullable; backfilled lazily on the next capture turn for existing rows.
- `generation INTEGER NOT NULL DEFAULT 0` — bumped when the matcher detects divergence; messages belonging to the same logical conversation view share a generation.
- `chat_messages_chat_id_generation_seq_idx` — supports the capture-time read that walks rows at the current generation in `seq` order.

Must merge and apply before the companion feature PR.

✻ Clauded...