### PR TITLE
chore: nav tweaks reorder build, add secure section to org sidebar

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -31,11 +31,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const navGroups = {
     connect: [routes.sources, routes.catalog, routes.playground] as AppRoute[],
     build: [
-      routes.elements,
       routes.mcp,
-      routes.plugins,
-      routes.slackApps,
       routes.clis,
+      routes.slackApps,
+      routes.elements,
+      routes.plugins,
     ],
     observe: [
       routes.observability,

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -122,16 +122,6 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={orgRoutes.logs}
                 scope={["org:read", "org:admin"]}
               />
-              <ScopeGatedNavItem
-                item={orgRoutes.auditLogs}
-                scope={["org:read", "org:admin"]}
-              />
-              {isRbacEnabled && (
-                <ScopeGatedNavItem
-                  item={orgRoutes.access}
-                  scope={["org:read", "org:admin"]}
-                />
-              )}
               {isAdmin && (
                 <SidebarMenuItem>
                   <NavButton
@@ -141,6 +131,23 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     Icon={orgRoutes.adminSettings.Icon}
                   />
                 </SidebarMenuItem>
+              )}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>secure</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <ScopeGatedNavItem
+                item={orgRoutes.auditLogs}
+                scope={["org:read", "org:admin"]}
+              />
+              {isRbacEnabled && (
+                <ScopeGatedNavItem
+                  item={orgRoutes.access}
+                  scope={["org:read", "org:admin"]}
+                />
               )}
             </SidebarMenu>
           </SidebarGroupContent>


### PR DESCRIPTION
## Summary

Two small dashboard navigation tweaks:

**1. Build sidebar — reorder the Build group**

New order in `app-sidebar.tsx`: MCP → Skills → Assistants → Chat Elements → Plugins.

**2. Org sidebar — add a "secure" group**

Moves `Audit Logs` and `Roles & Permissions` (RBAC-gated) out of the **settings** group into a new **secure** group below it in `org-sidebar.tsx`. All scope gating (`org:read`/`org:admin`) and the `isRbacEnabled` flag are preserved.

No behavior changes — pure ordering and grouping.

## Test plan

- [x] `pnpm dev` in `client/dashboard` and confirm the sidebar order under **build**
- [x] On the org page, confirm a new **secure** section appears below **settings** with Audit Logs (and Roles & Permissions when RBAC is enabled)
- [x] Verify items are hidden for users without `org:read`/`org:admin`
