### PR TITLE
mig: add risk analysis tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1764,3 +1764,64 @@ CREATE TABLE IF NOT EXISTS plugin_assignments (
 
 CREATE UNIQUE INDEX IF NOT EXISTS plugin_assignments_plugin_id_principal_urn_key
   ON plugin_assignments (plugin_id, principal_urn);
+
+-- Risk analysis policies for scanning chat messages against configurable rules.
+-- One workflow per policy drains unanalyzed messages and produces risk_results.
+CREATE TABLE IF NOT EXISTS risk_policies (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  organization_id TEXT NOT NULL,
+
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  name TEXT NOT NULL,
+  sources TEXT[] NOT NULL,
+  version BIGINT NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT risk_policies_pkey PRIMARY KEY (id),
+  CONSTRAINT risk_policies_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+  CONSTRAINT risk_policies_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS risk_policies_project_id_idx
+ON risk_policies (project_id)
+WHERE deleted IS FALSE;
+
+-- Individual findings produced by scanning a chat message against a risk policy.
+-- No soft delete: results are regenerated when the policy version changes.
+CREATE TABLE IF NOT EXISTS risk_results (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  organization_id TEXT NOT NULL,
+  risk_policy_id uuid NOT NULL,
+  risk_policy_version BIGINT NOT NULL,
+  chat_message_id uuid NOT NULL,
+  source TEXT NOT NULL,
+
+  found BOOLEAN NOT NULL,
+  rule_id TEXT,
+  description TEXT,
+  match TEXT,
+  start_pos INT,
+  end_pos INT,
+  confidence DOUBLE PRECISION,
+  tags TEXT[],
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT risk_results_pkey PRIMARY KEY (id),
+  CONSTRAINT risk_results_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+  CONSTRAINT risk_results_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE,
+  CONSTRAINT risk_results_risk_policy_id_fkey FOREIGN KEY (risk_policy_id) REFERENCES risk_policies(id) ON DELETE CASCADE,
+  CONSTRAINT risk_results_chat_message_id_fkey FOREIGN KEY (chat_message_id) REFERENCES chat_messages(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS risk_results_project_policy_version_message_idx
+ON risk_results (project_id, risk_policy_id, risk_policy_version, chat_message_id);
+
+CREATE INDEX IF NOT EXISTS risk_results_project_chat_message_idx
+ON risk_results (project_id, chat_message_id);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -809,6 +809,39 @@ type RemoteMcpServerHeader struct {
 	Deleted                bool
 }
 
+type RiskPolicy struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	Enabled        bool
+	Name           string
+	Sources        []string
+	Version        int64
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
+}
+
+type RiskResult struct {
+	ID                uuid.UUID
+	ProjectID         uuid.UUID
+	OrganizationID    string
+	RiskPolicyID      uuid.UUID
+	RiskPolicyVersion int64
+	ChatMessageID     uuid.UUID
+	Source            string
+	Found             bool
+	RuleID            pgtype.Text
+	Description       pgtype.Text
+	Match             pgtype.Text
+	StartPos          pgtype.Int4
+	EndPos            pgtype.Int4
+	Confidence        pgtype.Float8
+	Tags              []string
+	CreatedAt         pgtype.Timestamptz
+}
+
 type SlackApp struct {
 	CreatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz

--- a/server/migrations/20260420113615_add-risk-analysis-tables.sql
+++ b/server/migrations/20260420113615_add-risk-analysis-tables.sql
@@ -1,0 +1,47 @@
+-- Create "risk_policies" table
+CREATE TABLE "risk_policies" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "name" text NOT NULL,
+  "sources" text[] NOT NULL,
+  "version" bigint NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_policies_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_policies_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "risk_policies_project_id_idx" to table: "risk_policies"
+CREATE INDEX "risk_policies_project_id_idx" ON "risk_policies" ("project_id") WHERE (deleted IS FALSE);
+-- Create "risk_results" table
+CREATE TABLE "risk_results" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "risk_policy_id" uuid NOT NULL,
+  "risk_policy_version" bigint NOT NULL,
+  "chat_message_id" uuid NOT NULL,
+  "source" text NOT NULL,
+  "found" boolean NOT NULL,
+  "rule_id" text NULL,
+  "description" text NULL,
+  "match" text NULL,
+  "start_pos" integer NULL,
+  "end_pos" integer NULL,
+  "confidence" double precision NULL,
+  "tags" text[] NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_results_chat_message_id_fkey" FOREIGN KEY ("chat_message_id") REFERENCES "chat_messages" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_results_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_results_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_results_risk_policy_id_fkey" FOREIGN KEY ("risk_policy_id") REFERENCES "risk_policies" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "risk_results_project_chat_message_idx" to table: "risk_results"
+CREATE INDEX "risk_results_project_chat_message_idx" ON "risk_results" ("project_id", "chat_message_id");
+-- Create index "risk_results_project_policy_version_message_idx" to table: "risk_results"
+CREATE INDEX "risk_results_project_policy_version_message_idx" ON "risk_results" ("project_id", "risk_policy_id", "risk_policy_version", "chat_message_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:1C6rVyiPu5pavQCmnjIEoqQdVVVXpTcCP+Xpk1mSImI=
+h1:PM20P84ylQ4nrZ9GLIfZAJqyFPItY28gRuekUqlXSsM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -125,3 +125,4 @@ h1:1C6rVyiPu5pavQCmnjIEoqQdVVVXpTcCP+Xpk1mSImI=
 20260413142758_remote-mcp-servers.sql h1:V4dXOc4auWQbkecnpDDg8iLrgyCCd+3f/a1uX5dQyH8=
 20260413211711_registry-type-polymorphic.sql h1:wWsYj3Wbpt09ZBIDzTIwLa9qWKE4N2/MtcPUxhnAGjY=
 20260414000001_plugins.sql h1:vlPWOWRSVYp9DahP9QbPdDxFysburvzyTs+501IkYjU=
+20260420113615_add-risk-analysis-tables.sql h1:gJRWVPfyL+HIWsvglhF10o0/SsMd+MVt5z7IDoSTQW4=


### PR DESCRIPTION
## Summary
- Add `risk_policies` table for configurable risk detection rules per project
- Add `risk_results` table for storing findings from scanning chat messages
- Includes indexes for efficient querying by project, policy, and message

## Test plan
- [x] Migration applies cleanly (verified locally)
- [x] Rollback is safe (new tables only, no existing table modifications)