### PR TITLE
chore: rename timestamp slog attribute for better compatibility

### DIFF
--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -87,6 +87,11 @@ func NewLogHandler(opts *LogHandlerOptions) slog.Handler {
 						return a
 					}
 
+					if a.Key == slog.TimeKey {
+						a.Key = "timestamp"
+						return a
+					}
+
 					replace, ok := temporalKeys[a.Key]
 					if !ok {
 						return a


### PR DESCRIPTION
Log aggregators like Datadog expect the timestamp to be in a field named "timestamp". This change renames the slog attribute for time from `"time"` to `"timestamp"` to improve compatibility with these aggregators.