### PR TITLE
chore: add flag to disable redis tracing

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -99,6 +99,7 @@ GRAM_REDIS_CACHE_HOST = "127.0.0.1"
 GRAM_REDIS_CACHE_PORT = "5445"
 GRAM_REDIS_CACHE_ADDR = "{{env.GRAM_REDIS_CACHE_HOST}}:{{env.GRAM_REDIS_CACHE_PORT}}"
 GRAM_REDIS_CACHE_PASSWORD = "xi9XILbY"
+GRAM_REDIS_ENABLE_TRACING = "false"
 OPENROUTER_DEV_KEY = "unset"
 ## The following variables configure the mock Speakeasy IDP for local dev.
 ## MOCK_IDP_PORT is auto-remapped by `mise work:init` for parallel worktrees.

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -254,6 +254,7 @@ func newAssetStorage(ctx context.Context, logger *slog.Logger, opts assetStorage
 type redisClientOptions struct {
 	redisAddr     string
 	redisPassword string
+	enableTracing bool
 }
 
 func newRedisClient(ctx context.Context, opts redisClientOptions) (*redis.Client, error) {
@@ -272,12 +273,14 @@ func newRedisClient(ctx context.Context, opts redisClientOptions) (*redis.Client
 		return nil, fmt.Errorf("redis connection failed: %w", err)
 	}
 
-	attrs := redisotel.WithAttributes(
-		semconv.DBSystemRedis,
-		semconv.DBRedisDBIndex(db),
-	)
-	if err := redisotel.InstrumentTracing(redisClient, redisotel.WithDBStatement(false), attrs); err != nil {
-		return nil, fmt.Errorf("failed to instrument redis client: %w", err)
+	if opts.enableTracing {
+		attrs := redisotel.WithAttributes(
+			semconv.DBSystemRedis,
+			semconv.DBRedisDBIndex(db),
+		)
+		if err := redisotel.InstrumentTracing(redisClient, redisotel.WithDBStatement(false), attrs); err != nil {
+			return nil, fmt.Errorf("failed to instrument redis client: %w", err)
+		}
 	}
 
 	return redisClient, nil

--- a/server/cmd/gram/flags_redis.go
+++ b/server/cmd/gram/flags_redis.go
@@ -1,0 +1,22 @@
+package gram
+
+import "github.com/urfave/cli/v2"
+
+var redisFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "redis-cache-addr",
+		Usage:   "Address of the redis cache server",
+		EnvVars: []string{"GRAM_REDIS_CACHE_ADDR"},
+	},
+	&cli.StringFlag{
+		Name:    "redis-cache-password",
+		Usage:   "Password for the redis cache server",
+		EnvVars: []string{"GRAM_REDIS_CACHE_PASSWORD"},
+	},
+	&cli.BoolFlag{
+		Name:    "redis-enable-tracing",
+		Usage:   "Enable tracing for the redis cache server",
+		Value:   false,
+		EnvVars: []string{"GRAM_REDIS_ENABLE_TRACING"},
+	},
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -181,16 +181,6 @@ func newStartCommand() *cli.Command {
 			Required: true,
 		},
 		&cli.StringFlag{
-			Name:    "redis-cache-addr",
-			Usage:   "Address of the redis cache server",
-			EnvVars: []string{"GRAM_REDIS_CACHE_ADDR"},
-		},
-		&cli.StringFlag{
-			Name:    "redis-cache-password",
-			Usage:   "Password for the redis cache server",
-			EnvVars: []string{"GRAM_REDIS_CACHE_PASSWORD"},
-		},
-		&cli.StringFlag{
 			Name:     "encryption-key",
 			Usage:    "Key for App level AES encryption/decyryption",
 			Required: true,
@@ -364,6 +354,7 @@ func newStartCommand() *cli.Command {
 		},
 	}
 
+	flags = append(flags, redisFlags...)
 	flags = append(flags, clickHouseFlags...)
 	flags = append(flags, functionsFlags...)
 	flags = append(flags, pulseMCPFlags...)
@@ -443,6 +434,7 @@ func newStartCommand() *cli.Command {
 			redisClient, err := newRedisClient(ctx, redisClientOptions{
 				redisAddr:     c.String("redis-cache-addr"),
 				redisPassword: c.String("redis-cache-password"),
+				enableTracing: c.Bool("redis-enable-tracing"),
 			})
 			if err != nil {
 				return fmt.Errorf("failed to connect to redis: %w", err)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -156,16 +156,6 @@ func newWorkerCommand() *cli.Command {
 			Usage:   "Provisioning key for OpenRouter to create new API keys for orgs - https://openrouter.ai/settings/provisioning-keys",
 			EnvVars: []string{"OPENROUTER_PROVISIONING_KEY"},
 		},
-		&cli.StringFlag{
-			Name:    "redis-cache-addr",
-			Usage:   "Address of the redis cache server",
-			EnvVars: []string{"GRAM_REDIS_CACHE_ADDR"},
-		},
-		&cli.StringFlag{
-			Name:    "redis-cache-password",
-			Usage:   "Password for the redis cache server",
-			EnvVars: []string{"GRAM_REDIS_CACHE_PASSWORD"},
-		},
 		&cli.StringSliceFlag{
 			Name:     "disallowed-cidr-blocks",
 			Usage:    "List of CIDR blocks to block for SSRF protection",
@@ -274,6 +264,7 @@ func newWorkerCommand() *cli.Command {
 		},
 	}
 
+	flags = append(flags, redisFlags...)
 	flags = append(flags, clickHouseFlags...)
 	flags = append(flags, functionsFlags...)
 	flags = append(flags, pulseMCPFlags...)
@@ -348,6 +339,7 @@ func newWorkerCommand() *cli.Command {
 			redisClient, err := newRedisClient(ctx, redisClientOptions{
 				redisAddr:     c.String("redis-cache-addr"),
 				redisPassword: c.String("redis-cache-password"),
+				enableTracing: c.Bool("redis-enable-tracing"),
 			})
 			if err != nil {
 				return fmt.Errorf("failed to connect to redis: %w", err)


### PR DESCRIPTION
This change introduces a new flag to toggle tracing of the Redis client used for caching in the Gram server. By default, tracing will now be disabled. This was causing a large volume of unhelpful spans and errors.