### PR TITLE
mig: move plugins from project-scoped to org-scoped

### DIFF
--- a/.changeset/plugins-org-scoped.md
+++ b/.changeset/plugins-org-scoped.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+---
+
+Move plugins from project-scoped to org-scoped. Drops project_id from
+the plugins table and updates the unique slug index to (organization_id, slug).

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1690,12 +1690,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS remote_mcp_server_headers_remote_mcp_server_id
 ON remote_mcp_server_headers (remote_mcp_server_id, name)
 WHERE deleted IS FALSE;
 
--- Plugin definitions: project-scoped distributable bundles of MCP servers.
+-- Plugin definitions: org-scoped distributable bundles of MCP servers.
 -- Admins create plugins and assign them to roles for distribution.
 CREATE TABLE IF NOT EXISTS plugins (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,
-  project_id uuid NOT NULL,
   name TEXT NOT NULL CHECK (name <> ''),
   slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 60),
   description TEXT,
@@ -1706,12 +1705,11 @@ CREATE TABLE IF NOT EXISTS plugins (
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
 
   CONSTRAINT plugins_pkey PRIMARY KEY (id),
-  CONSTRAINT plugins_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT plugins_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+  CONSTRAINT plugins_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS plugins_organization_id_project_id_slug_key
-  ON plugins (organization_id, project_id, slug)
+CREATE UNIQUE INDEX IF NOT EXISTS plugins_organization_id_slug_key
+  ON plugins (organization_id, slug)
   WHERE deleted IS FALSE;
 
 -- Links a plugin to a toolset-backed MCP server.

--- a/server/migrations/20260420142710_plugins-org-scoped.sql
+++ b/server/migrations/20260420142710_plugins-org-scoped.sql
@@ -1,6 +1,22 @@
 -- atlas:txmode none
 
+-- Deduplicate slugs that would collide under org-only uniqueness.
+-- Appends a UUID prefix to duplicates, keeping the oldest per (org, slug).
+UPDATE "plugins" p
+SET "slug" = p."slug" || '-' || LEFT(p."id"::text, 8)
+WHERE p."id" NOT IN (
+  SELECT DISTINCT ON (organization_id, slug) id
+  FROM "plugins"
+  WHERE deleted IS FALSE
+  ORDER BY organization_id, slug, created_at ASC
+)
+AND p.deleted IS FALSE;
+
+-- Drop the old project-scoped unique index concurrently to avoid ACCESS EXCLUSIVE lock.
+DROP INDEX CONCURRENTLY IF EXISTS "plugins_organization_id_project_id_slug_key";
+
 -- Modify "plugins" table
 ALTER TABLE "plugins" DROP COLUMN "project_id";
--- Create index "plugins_organization_id_slug_key" to table: "plugins"
+
+-- Create new org-scoped unique index concurrently.
 CREATE UNIQUE INDEX CONCURRENTLY "plugins_organization_id_slug_key" ON "plugins" ("organization_id", "slug") WHERE (deleted IS FALSE);

--- a/server/migrations/20260420142710_plugins-org-scoped.sql
+++ b/server/migrations/20260420142710_plugins-org-scoped.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "plugins" table
+ALTER TABLE "plugins" DROP COLUMN "project_id";
+-- Create index "plugins_organization_id_slug_key" to table: "plugins"
+CREATE UNIQUE INDEX CONCURRENTLY "plugins_organization_id_slug_key" ON "plugins" ("organization_id", "slug") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PM20P84ylQ4nrZ9GLIfZAJqyFPItY28gRuekUqlXSsM=
+h1:M0KZfGcgWmBgqv++I79+jIhrn28a8pmaAsFJAKbvl3Q=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -126,3 +126,4 @@ h1:PM20P84ylQ4nrZ9GLIfZAJqyFPItY28gRuekUqlXSsM=
 20260413211711_registry-type-polymorphic.sql h1:wWsYj3Wbpt09ZBIDzTIwLa9qWKE4N2/MtcPUxhnAGjY=
 20260414000001_plugins.sql h1:vlPWOWRSVYp9DahP9QbPdDxFysburvzyTs+501IkYjU=
 20260420113615_add-risk-analysis-tables.sql h1:gJRWVPfyL+HIWsvglhF10o0/SsMd+MVt5z7IDoSTQW4=
+20260420142710_plugins-org-scoped.sql h1:DZxu/f0iiQQ0zijWSp0LlltxXL6SvKRuU+LoB35rfg0=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:M0KZfGcgWmBgqv++I79+jIhrn28a8pmaAsFJAKbvl3Q=
+h1:m8JI06urplnG260fbxQ1yCctv89yzrhLrxRkG8hPPaQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -126,4 +126,4 @@ h1:M0KZfGcgWmBgqv++I79+jIhrn28a8pmaAsFJAKbvl3Q=
 20260413211711_registry-type-polymorphic.sql h1:wWsYj3Wbpt09ZBIDzTIwLa9qWKE4N2/MtcPUxhnAGjY=
 20260414000001_plugins.sql h1:vlPWOWRSVYp9DahP9QbPdDxFysburvzyTs+501IkYjU=
 20260420113615_add-risk-analysis-tables.sql h1:gJRWVPfyL+HIWsvglhF10o0/SsMd+MVt5z7IDoSTQW4=
-20260420142710_plugins-org-scoped.sql h1:DZxu/f0iiQQ0zijWSp0LlltxXL6SvKRuU+LoB35rfg0=
+20260420142710_plugins-org-scoped.sql h1:ULh+DtSqG3WHnV/bCWQbjA1pITa6E/vsGjZ6mRUpkEU=


### PR DESCRIPTION
Drops project_id from the plugins table and updates the unique slug index from (organization_id, project_id, slug) to (organization_id, slug).

Plugins are now org-scoped to enable org-wide distribution managed by admins, rather than being tied to individual projects.