### PR TITLE
fix: make ensureDefaultRegistryCollection failure non-fatal

### DIFF
--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -156,7 +156,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 	}
 
 	if err := s.ensureDefaultRegistryCollection(ctx, authCtx.ActiveOrganizationID, orgSlug); err != nil {
-		s.logger.WarnContext(ctx, "failed to ensure default registry collection", "error", err, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		s.logger.WarnContext(ctx, "failed to ensure default registry collection", attr.SlogError(err), attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	collections, err := s.repo.ListOrganizationMcpCollections(ctx, authCtx.ActiveOrganizationID)

--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -156,7 +156,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 	}
 
 	if err := s.ensureDefaultRegistryCollection(ctx, authCtx.ActiveOrganizationID, orgSlug); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error ensuring default registry collection").Log(ctx, s.logger)
+		s.logger.WarnContext(ctx, "failed to ensure default registry collection", "error", err, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	}
 
 	collections, err := s.repo.ListOrganizationMcpCollections(ctx, authCtx.ActiveOrganizationID)

--- a/server/internal/collections/list_test.go
+++ b/server/internal/collections/list_test.go
@@ -178,6 +178,30 @@ func TestCollectionsService_List_DefaultRegistryConcurrent(t *testing.T) {
 	require.Equal(t, 1, registryCount, "exactly one default registry collection should exist after concurrent calls")
 }
 
+func TestCollectionsService_List_EnsureDefaultRegistryFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestCollectionsService(t)
+
+	// Create a context with an org ID that doesn't exist in organization_metadata.
+	// This causes ensureDefaultRegistryCollection to fail (FK violation), but List
+	// should still succeed and return an empty result.
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_nonexistent",
+		OrganizationSlug:     "nonexistent",
+		UserID:               "user_test",
+	})
+
+	result, err := ti.service.List(ctx, &gen.ListPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Empty(t, result.Collections)
+}
+
 func TestCollectionsService_List_DefaultRegistryBackfillsMissingNamespace(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- In local dev (and potentially prod edge cases), the `List` collections endpoint errors with "error ensuring default registry collection" when the org metadata row doesn't exist yet — the lazy `INSERT` into `organization_mcp_collections` violates the FK constraint to `organization_metadata`.
- Changed `ensureDefaultRegistryCollection` failure from a fatal error return to a `WarnContext` log. `List` now continues and returns whatever collections exist (or an empty list).
- Added `TestCollectionsService_List_EnsureDefaultRegistryFailureIsNonFatal` to verify the fix.

## Test plan
- [x] All existing `TestCollectionsService_List_*` tests pass (7/7)
- [x] New test confirms `List` succeeds with empty result when ensure fails (FK violation with non-existent org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)