### PR TITLE
fix: show skeleton loading state for toolset picker in plugin detail

### DIFF
--- a/.changeset/plugins-toolset-loading.md
+++ b/.changeset/plugins-toolset-loading.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+---
+
+Show skeleton loading state for toolset picker in plugin detail instead
+of incorrectly displaying "No toolsets available" while loading.

--- a/client/dashboard/src/pages/org/PluginDetail.tsx
+++ b/client/dashboard/src/pages/org/PluginDetail.tsx
@@ -2,6 +2,7 @@ import { InputField } from "@/components/moon/input-field";
 import { Page } from "@/components/page-layout";
 import { Dialog } from "@/components/ui/dialog";
 import { Heading } from "@/components/ui/heading";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import {
   invalidateAllPlugin,
@@ -28,7 +29,8 @@ export default function PluginDetail() {
   const { data: plugin } = usePluginSuspense({ id: pluginId! });
 
   const { fetch: authFetch } = useFetcher();
-  const { data: toolsetsData } = useListToolsetsForOrg();
+  const { data: toolsetsData, isLoading: isLoadingToolsets } =
+    useListToolsetsForOrg();
   const toolsets = toolsetsData?.toolsets ?? [];
 
   const invalidateAll = async () => {
@@ -282,7 +284,9 @@ export default function PluginDetail() {
             <form onSubmit={handleAddServer} className="flex flex-col gap-4">
               <div className="flex flex-col gap-2">
                 <label className="text-sm font-medium">Toolset</label>
-                {toolsets.length > 0 ? (
+                {isLoadingToolsets ? (
+                  <Skeleton className="h-9 w-full" />
+                ) : toolsets.length > 0 ? (
                   <select
                     name="toolsetId"
                     className="bg-background rounded-md border px-3 py-2 text-sm"
@@ -312,7 +316,9 @@ export default function PluginDetail() {
                 <Button
                   type="submit"
                   disabled={
-                    addServerMutation.isPending || toolsets.length === 0
+                    addServerMutation.isPending ||
+                    isLoadingToolsets ||
+                    toolsets.length === 0
                   }
                 >
                   Add


### PR DESCRIPTION
The toolset selector showed "No toolsets available" while the toolsets were still loading, which was misleading for orgs with many toolsets. Now shows a skeleton placeholder matching the select dimensions during fetch.