### PR TITLE
fix: support dark mode on project onboarding banner

### DIFF
--- a/.changeset/fix-onboarding-dark-mode.md
+++ b/.changeset/fix-onboarding-dark-mode.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+---
+
+Fix project onboarding banner to support dark mode by using semantic
+background tokens instead of hardcoded white.

--- a/client/dashboard/src/components/project/ProjectOnboarding.tsx
+++ b/client/dashboard/src/components/project/ProjectOnboarding.tsx
@@ -5,7 +5,7 @@ export function ProjectOnboardingBanner() {
   const routes = useRoutes();
 
   return (
-    <Card className="bg-linear-to-tr from-white via-white to-blue-200 p-8">
+    <Card className="from-background via-background bg-linear-to-tr to-blue-200 p-8 dark:to-blue-950">
       <Card.Header>
         <h2 className="text-3xl font-light">Welcome</h2>
       </Card.Header>


### PR DESCRIPTION
Replace hardcoded white gradient with semantic background token and add dark:to-blue-950 for the accent, making text legible in dark mode.

<img width="2084" height="474" alt="image" src="https://github.com/user-attachments/assets/349a8284-aae0-408c-b1d7-154540eb2009" />
