### PR TITLE
fix: scope toolset picker in plugins to current project

### DIFF
--- a/.changeset/plugins-project-scoped-toolsets.md
+++ b/.changeset/plugins-project-scoped-toolsets.md
@@ -1,0 +1,7 @@
+---
+"dashboard": patch
+---
+
+Fix plugin toolset picker to show project-scoped toolsets instead of all
+org toolsets. Uses useListToolsets (project-scoped) instead of
+useListToolsetsForOrg.

--- a/client/dashboard/src/pages/org/PluginDetail.tsx
+++ b/client/dashboard/src/pages/org/PluginDetail.tsx
@@ -12,7 +12,7 @@ import { invalidateAllPlugins } from "@gram/client/react-query/plugins";
 import { useUpdatePluginMutation } from "@gram/client/react-query/updatePlugin";
 import { useAddPluginServerMutation } from "@gram/client/react-query/addPluginServer";
 import { useRemovePluginServerMutation } from "@gram/client/react-query/removePluginServer";
-import { useListToolsetsForOrg } from "@gram/client/react-query/listToolsetsForOrg";
+import { useListToolsets } from "@gram/client/react-query/listToolsets";
 import { Button, Column, Icon, Stack, Table } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -30,7 +30,7 @@ export default function PluginDetail() {
 
   const { fetch: authFetch } = useFetcher();
   const { data: toolsetsData, isLoading: isLoadingToolsets } =
-    useListToolsetsForOrg();
+    useListToolsets();
   const toolsets = toolsetsData?.toolsets ?? [];
 
   const invalidateAll = async () => {


### PR DESCRIPTION
Was using useListToolsetsForOrg which showed all org toolsets. Now uses useListToolsets which respects the project header, matching the server-side validation that rejects cross-project toolset references.