### PR TITLE
fix: breadcrumb navigation for Plugins page

### DIFF
--- a/.changeset/plugin-ux-improvements.md
+++ b/.changeset/plugin-ux-improvements.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+---
+
+Add breadcrumb navigation to plugin pages for consistent navigation
+with the rest of the dashboard.

--- a/client/dashboard/src/pages/org/PluginDetail.tsx
+++ b/client/dashboard/src/pages/org/PluginDetail.tsx
@@ -152,7 +152,9 @@ export default function PluginDetail() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>{plugin.name}</Page.Header.Title>
+        <Page.Header.Breadcrumbs
+          substitutions={{ [pluginId!]: plugin.name }}
+        />
       </Page.Header>
       <Page.Body>
         {/* Plugin metadata */}

--- a/client/dashboard/src/pages/org/PluginDetail.tsx
+++ b/client/dashboard/src/pages/org/PluginDetail.tsx
@@ -301,7 +301,8 @@ export default function PluginDetail() {
                   </select>
                 ) : (
                   <Type muted small>
-                    No toolsets available. Create a toolset first.
+                    No toolsets available. Create a toolset in this project
+                    first.
                   </Type>
                 )}
               </div>

--- a/client/dashboard/src/pages/org/PluginDetail.tsx
+++ b/client/dashboard/src/pages/org/PluginDetail.tsx
@@ -152,9 +152,7 @@ export default function PluginDetail() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Breadcrumbs
-          substitutions={{ [pluginId!]: plugin.name }}
-        />
+        <Page.Header.Breadcrumbs substitutions={{ [pluginId!]: plugin.name }} />
       </Page.Header>
       <Page.Body>
         {/* Plugin metadata */}

--- a/client/dashboard/src/pages/org/Plugins.tsx
+++ b/client/dashboard/src/pages/org/Plugins.tsx
@@ -136,7 +136,7 @@ export default function Plugins() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Plugins</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         {(data?.plugins ?? []).length === 0 ? (

--- a/client/dashboard/src/pages/slackapp/SlackApp.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackApp.tsx
@@ -211,7 +211,7 @@ function CreateSlackAppDialog({
             </Type>
             {toolsets.length === 0 ? (
               <Type muted small>
-                No toolsets available. Create a toolset first.
+                No toolsets available. Create a toolset in this project first.
               </Type>
             ) : (
               <div className="grid max-h-60 grid-cols-2 gap-2 overflow-y-auto">


### PR DESCRIPTION
- Move to Breadcrumb based navigation for the plugins page
- Adjust text to make it more clear that toolsets need to be created within a project to use in a plugin.