### PR TITLE
fix: properly check for session capture enabled

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -580,6 +580,7 @@ func newStartCommand() *cli.Command {
 
 			logsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureLogs)
 			toolIOLogsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureToolIOLogs)
+			sessionCaptureEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureSessionCapture)
 			roleClient, err := newAccessRoleProvider(ctx, logger, guardianPolicy, c)
 			if err != nil {
 				return fmt.Errorf("failed to create access role provider: %w", err)
@@ -596,7 +597,7 @@ func newStartCommand() *cli.Command {
 			telemLogger, shutdown := newTelemetryLogger(ctx, logger, chDB, logsEnabled, toolIOLogsEnabled)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
-			telemSvc := tm.NewService(logger, tracerProvider, db, chDB, sessionManager, chatSessionsManager, logsEnabled, posthogClient, accessManager)
+			telemSvc := tm.NewService(logger, tracerProvider, db, chDB, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, accessManager)
 
 			// Wrap cache for hooks service in local development
 			var hooksCache cache.Cache = cache.NewRedisCacheAdapter(redisClient)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -425,6 +425,7 @@ func newWorkerCommand() *cli.Command {
 
 			logsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureLogs)
 			toolIOLogsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureToolIOLogs)
+			sessionCaptureEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureSessionCapture)
 
 			// Create ClickHouse client and telemetry service for resolution events
 			chDB, chShutdown, err := newClickhouseClient(ctx, logger, c)
@@ -446,7 +447,7 @@ func newWorkerCommand() *cli.Command {
 			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, chDB, logsEnabled, toolIOLogsEnabled)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
-			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, posthogClient, accessManager)
+			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, sessionCaptureEnabled, posthogClient, accessManager)
 
 			/**
 			 * BEGIN -- MCP service setup for agent client

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -119,6 +119,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	featClient := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return false, nil }
+	sessionCaptureEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
@@ -133,6 +134,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 		sessionManager,
 		chatSessions,
 		logsEnabled,
+		sessionCaptureEnabled,
 		posthog,
 		accessManager,
 	)

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -37,18 +37,19 @@ import (
 const logsDisabledMsg = "logs are not enabled for this organization"
 
 type Service struct {
-	auth         *auth.Auth
-	db           *pgxpool.Pool
-	chatRepo     *chatRepo.Queries
-	hooksRepo    *hooksRepo.Queries
-	chConn       clickhouse.Conn
-	chRepo       *repo.Queries
-	logger       *slog.Logger
-	tracer       trace.Tracer
-	posthog      PosthogClient
-	chatSessions *chatsessions.Manager
-	logsEnabled  FeatureChecker
-	access       *access.Manager
+	auth                  *auth.Auth
+	db                    *pgxpool.Pool
+	chatRepo              *chatRepo.Queries
+	hooksRepo             *hooksRepo.Queries
+	chConn                clickhouse.Conn
+	chRepo                *repo.Queries
+	logger                *slog.Logger
+	tracer                trace.Tracer
+	posthog               PosthogClient
+	chatSessions          *chatsessions.Manager
+	logsEnabled           FeatureChecker
+	sessionCaptureEnabled FeatureChecker
+	access                *access.Manager
 }
 
 var _ telem_gen.Service = (*Service)(nil)
@@ -63,6 +64,7 @@ func NewService(
 	sessions *sessions.Manager,
 	chatSessions *chatsessions.Manager,
 	logsEnabled FeatureChecker,
+	sessionCaptureEnabled FeatureChecker,
 	posthogClient PosthogClient,
 	accessManager *access.Manager,
 ) *Service {
@@ -78,18 +80,19 @@ func NewService(
 	}
 
 	return &Service{
-		auth:         a,
-		db:           db,
-		chatRepo:     chatRepo.New(db),
-		hooksRepo:    hooksRepo.New(db),
-		chConn:       chConn,
-		chRepo:       chRepo,
-		logger:       logger,
-		logsEnabled:  logsEnabled,
-		tracer:       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/telemetry"),
-		posthog:      posthogClient,
-		chatSessions: chatSessions,
-		access:       accessManager,
+		auth:                  a,
+		db:                    db,
+		chatRepo:              chatRepo.New(db),
+		hooksRepo:             hooksRepo.New(db),
+		chConn:                chConn,
+		chRepo:                chRepo,
+		logger:                logger,
+		logsEnabled:           logsEnabled,
+		sessionCaptureEnabled: sessionCaptureEnabled,
+		tracer:                tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/telemetry"),
+		posthog:               posthogClient,
+		chatSessions:          chatSessions,
+		access:                accessManager,
 	}
 }
 
@@ -944,17 +947,13 @@ func (s *Service) GetProjectOverview(ctx context.Context, payload *telem_gen.Get
 	comparisonStartPG := pgtype.Timestamptz{Time: time.Unix(0, comparisonStart), Valid: true, InfinityModifier: pgtype.Finite}
 	comparisonEndPG := pgtype.Timestamptz{Time: time.Unix(0, comparisonEnd), Valid: true, InfinityModifier: pgtype.Finite}
 
-	// Determine metrics mode: Check if there are chat sessions in PostgreSQL
-	sessionCount, err := s.chatRepo.GetChatSessionCount(ctx, chatRepo.GetChatSessionCountParams{
-		ProjectID: *authCtx.ProjectID,
-		TimeStart: timeStartPG,
-		TimeEnd:   timeEndPG,
-	})
+	// Determine metrics mode: Check if session capture is enabled
+	sessionCaptureEnabled, err := s.sessionCaptureEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error checking session count")
+		return nil, oops.E(oops.CodeUnexpected, err, "unable to check if session capture is enabled")
 	}
 
-	sessionMode := sessionCount > 0
+	sessionMode := sessionCaptureEnabled
 	metricsMode := "tool_call"
 	if sessionMode {
 		metricsMode = "session"

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -111,10 +111,14 @@ func newTestLogsService(t *testing.T) (context.Context, *testInstance) {
 		return false, nil
 	}
 
+	sessionCaptureEnabled := func(_ context.Context, orgID string) (bool, error) {
+		return true, nil
+	}
+
 	posthogClient := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
 	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled)
-	svc := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, posthogClient, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}, workos.NewStubClient(), cache.NoopCache))
+	svc := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, access.NewManager(logger, conn, accesstest.AlwaysEnabledFeatureChecker{}, workos.NewStubClient(), cache.NoopCache))
 
 	return ctx, &testInstance{
 		service:            svc,


### PR DESCRIPTION
A small fix to how we determine which metrics to pull for the project overview endpoint for the home page