### PR TITLE
feat: add ai insights exploration and tooltips to project overview

### DIFF
--- a/.changeset/project-overview-ai-insights.md
+++ b/.changeset/project-overview-ai-insights.md
@@ -1,0 +1,9 @@
+---
+"dashboard": patch
+---
+
+Add info tooltips to every KPI and chart card on the Project Overview
+dashboard, plus an "Explore with AI" wand on each chart that opens the
+Insights sidebar and auto-submits a chart-specific question through the
+thread runtime. The nav-bar AI Insights trigger also gains a brand
+gradient border on hover.

--- a/client/dashboard/src/components/chart/MetricCard.tsx
+++ b/client/dashboard/src/components/chart/MetricCard.tsx
@@ -1,4 +1,5 @@
 import { cn, Icon, type IconName } from "@speakeasy-api/moonshine";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { getValueColor, ThresholdConfig } from "./chartUtils";
 
 type AccentColor = "red" | "orange" | "yellow" | "green" | "blue" | "purple";
@@ -14,6 +15,7 @@ export type MetricCardProps = {
   comparisonLabel?: string;
   accentColor?: AccentColor;
   subtext?: string;
+  tooltip?: string;
 };
 
 const accentColorsMap: Record<AccentColor, string> = {
@@ -36,6 +38,7 @@ export function MetricCard({
   comparisonLabel,
   accentColor,
   subtext,
+  tooltip,
 }: MetricCardProps) {
   const formatValue = (v: number) => {
     switch (format) {
@@ -74,7 +77,20 @@ export function MetricCard({
       )}
     >
       <div className="mb-3 flex items-center justify-between">
-        <span className="text-sm font-semibold">{title}</span>
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-semibold">{title}</span>
+          {tooltip && (
+            <SimpleTooltip tooltip={tooltip}>
+              <button
+                type="button"
+                aria-label={`About ${title}`}
+                className="text-muted-foreground hover:text-foreground inline-flex cursor-help items-center"
+              >
+                <Icon name="info" className="size-3.5" />
+              </button>
+            </SimpleTooltip>
+          )}
+        </div>
         {icon && (
           <div className="bg-muted/50 rounded-lg p-2">
             <Icon name={icon} className="text-muted-foreground size-4" />

--- a/client/dashboard/src/components/insights-context.ts
+++ b/client/dashboard/src/components/insights-context.ts
@@ -27,6 +27,10 @@ export interface InsightsContextValue {
   /** Pages call this to register a per-page config override. Pass null to
    *  clear (typically on unmount of <InsightsConfig />). */
   setOverride: (override: InsightsConfigOptions | null) => void;
+  /** Queue a prompt to be auto-appended to the Insights chat thread.
+   *  Fires once per call — intended for "Explore with AI" CTAs that should
+   *  drop the user straight into a running conversation. */
+  sendPrompt: (prompt: string) => void;
 }
 
 export const InsightsContext = createContext<InsightsContextValue>({
@@ -34,6 +38,7 @@ export const InsightsContext = createContext<InsightsContextValue>({
   isExpanded: false,
   setIsExpanded: () => {},
   setOverride: () => {},
+  sendPrompt: () => {},
 });
 
 /**

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -192,6 +192,13 @@ ${contextInfo}
 When the user asks about "current period", "selected period", "this timeframe", or similar, use the date range from the context above. Do not ask the user to specify a date range if it's already provided in the context.`
     : baseInstructions;
 
+  // New config identity on every override change is intentional: clicking
+  // "Explore with AI" on a different chart should drop the user into a fresh,
+  // focused conversation with the new contextInfo, not splice a new system
+  // prompt into an in-flight thread from a different chart. If we ever want
+  // to preserve threads across Explore clicks, split transport config
+  // (mcpConfig/model/theme) from presentation config (systemPrompt/welcome)
+  // inside GramElementsProvider so only the transport piece is stable.
   const elementsConfig = useMemo<ElementsConfig>(
     () => ({
       ...mcpConfig,

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -1,8 +1,9 @@
 import type { ElementsConfig } from "@gram-ai/elements";
 import { Chat, GramElementsProvider } from "@gram-ai/elements";
+import { useThreadRuntime } from "@assistant-ui/react";
 import { useMoonshineConfig } from "@speakeasy-api/moonshine";
 import { Wand2, ChevronRight, Sparkles, Terminal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { devObservabilityMcpMissing } from "@/hooks/useObservabilityMcpConfig";
 import { InsightsContext, useInsightsState } from "./insights-context";
@@ -10,6 +11,34 @@ import type { InsightsConfigOptions } from "./insights-context";
 
 // Types-only re-export (erased at compile time, won't break Fast Refresh)
 export type { InsightsConfigOptions } from "./insights-context";
+
+/**
+ * Shared hover-animation class for any "AI Insights" CTA (the nav trigger,
+ * per-chart Explore buttons, etc.). Cycles the element's `color` through the
+ * Speakeasy brand rainbow — same palette as the login page's brand bar.
+ * Must be used inside an <InsightsProvider> so <InsightsRainbowStyles /> is
+ * mounted.
+ */
+export const INSIGHTS_AI_RAINBOW_CLASS = "insights-ai-rainbow";
+
+function InsightsRainbowStyles() {
+  return (
+    <style>{`
+      @keyframes insights-ai-rainbow {
+        0%   { color: #C83228; }
+        16%  { color: #FB873F; }
+        33%  { color: #D2DC91; }
+        50%  { color: #5A8250; }
+        66%  { color: #2873D7; }
+        83%  { color: #9BC3FF; }
+        100% { color: #C83228; }
+      }
+      .${INSIGHTS_AI_RAINBOW_CLASS}:hover {
+        animation: insights-ai-rainbow 2.5s linear infinite;
+      }
+    `}</style>
+  );
+}
 
 /**
  * Header-bar trigger for opening the AI Insights sidebar. Renders only
@@ -27,8 +56,9 @@ export function InsightsTrigger({ className }: { className?: string }) {
       aria-label={isExpanded ? "Close AI Insights" : "Open AI Insights"}
       aria-pressed={isExpanded}
       className={cn(
-        "border-border hover:bg-accent hover:text-accent-foreground inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors",
+        "border-border hover:bg-accent inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors",
         isExpanded && "bg-accent text-accent-foreground",
+        INSIGHTS_AI_RAINBOW_CLASS,
         className,
       )}
     >
@@ -87,6 +117,10 @@ export function InsightsProvider({
 }: InsightsProviderProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const [override, setOverride] = useState<InsightsConfigOptions | null>(null);
+  const [pendingPrompt, setPendingPrompt] = useState<{
+    text: string;
+    nonce: number;
+  } | null>(null);
   const { theme } = useMoonshineConfig();
 
   // Resolve effective values: per-page override wins, fall back to defaults.
@@ -147,18 +181,29 @@ When the user asks about "current period", "selected period", "this timeframe", 
     [],
   );
 
+  const handleSendPrompt = useCallback((text: string) => {
+    // Nonce lets the bridge detect repeat clicks on the same prompt (same
+    // chart twice in a row); reference-equal objects would otherwise be
+    // skipped by the bridge's useEffect.
+    setPendingPrompt({ text, nonce: Date.now() });
+  }, []);
+
+  const consumePendingPrompt = useCallback(() => setPendingPrompt(null), []);
+
   const contextValue = useMemo(
     () => ({
       available: !hideTrigger,
       isExpanded,
       setIsExpanded,
       setOverride: handleSetOverride,
+      sendPrompt: handleSendPrompt,
     }),
-    [hideTrigger, isExpanded, handleSetOverride],
+    [hideTrigger, isExpanded, handleSetOverride, handleSendPrompt],
   );
 
   return (
     <InsightsContext.Provider value={contextValue}>
+      <InsightsRainbowStyles />
       <div className="flex h-full w-full">
         {/* Main content area - shrinks when sidebar opens */}
         <div
@@ -220,6 +265,10 @@ When the user asks about "current period", "selected period", "this timeframe", 
           {/* Chat content */}
           <div className="flex-1 overflow-hidden">
             <GramElementsProvider config={elementsConfig}>
+              <PendingPromptBridge
+                pending={pendingPrompt}
+                onConsume={consumePendingPrompt}
+              />
               <Chat />
             </GramElementsProvider>
           </div>
@@ -235,3 +284,31 @@ When the user asks about "current period", "selected period", "this timeframe", 
  * to avoid breaking out-of-tree consumers; remove after migration.
  */
 export const InsightsSidebar = InsightsProvider;
+
+/**
+ * Lives inside GramElementsProvider so it can access useThreadRuntime().
+ * When a pending prompt is queued via InsightsContext.sendPrompt, this bridge
+ * appends it to the current thread as a user message, triggering the
+ * assistant to respond. It fires once per nonce so repeat clicks on the
+ * same CTA still work.
+ */
+function PendingPromptBridge({
+  pending,
+  onConsume,
+}: {
+  pending: { text: string; nonce: number } | null;
+  onConsume: () => void;
+}) {
+  const runtime = useThreadRuntime();
+  const firedNonceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!pending || !runtime) return;
+    if (firedNonceRef.current === pending.nonce) return;
+    firedNonceRef.current = pending.nonce;
+    runtime.append(pending.text);
+    onConsume();
+  }, [pending, runtime, onConsume]);
+
+  return null;
+}

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -92,7 +92,7 @@ export function InsightsTrigger({ className }: { className?: string }) {
       aria-label={isExpanded ? "Close AI Insights" : "Open AI Insights"}
       aria-pressed={isExpanded}
       className={cn(
-        "border-border hover:bg-accent inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors",
+        "border-border hover:bg-accent hover:text-accent-foreground inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors",
         isExpanded && "bg-accent text-accent-foreground",
         INSIGHTS_AI_RAINBOW_BORDER_CLASS,
         className,

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -13,13 +13,20 @@ import type { InsightsConfigOptions } from "./insights-context";
 export type { InsightsConfigOptions } from "./insights-context";
 
 /**
- * Shared hover-animation class for any "AI Insights" CTA (the nav trigger,
- * per-chart Explore buttons, etc.). Cycles the element's `color` through the
- * Speakeasy brand rainbow — same palette as the login page's brand bar.
- * Must be used inside an <InsightsProvider> so <InsightsRainbowStyles /> is
- * mounted.
+ * Cycles an element's `color` through the Speakeasy brand rainbow on hover —
+ * used for small icon-only "Explore with AI" CTAs where a border treatment
+ * would be invisible. Requires <InsightsRainbowStyles /> in the tree.
  */
 export const INSIGHTS_AI_RAINBOW_CLASS = "insights-ai-rainbow";
+
+/**
+ * Reveals a full-spectrum Speakeasy brand gradient border on hover — same
+ * 9-stop palette as the login page's BrandGradientBar. Used for the nav-bar
+ * AI Insights trigger where the button shape can host a real border.
+ * Requires <InsightsRainbowStyles /> in the tree. Works best on elements
+ * with a 1px border and a border-radius.
+ */
+export const INSIGHTS_AI_RAINBOW_BORDER_CLASS = "insights-ai-rainbow-border";
 
 function InsightsRainbowStyles() {
   return (
@@ -35,6 +42,35 @@ function InsightsRainbowStyles() {
       }
       .${INSIGHTS_AI_RAINBOW_CLASS}:hover {
         animation: insights-ai-rainbow 2.5s linear infinite;
+      }
+
+      /* Gradient border via a masked pseudo-element. Mask cuts the interior
+         so only the 1px ring shows; border-radius is inherited so rounded
+         corners stay intact. Fades in on hover; the underlying border goes
+         transparent so we don't double up. */
+      .${INSIGHTS_AI_RAINBOW_BORDER_CLASS} {
+        position: relative;
+      }
+      .${INSIGHTS_AI_RAINBOW_BORDER_CLASS}::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        padding: 1px;
+        border-radius: inherit;
+        background: linear-gradient(90deg, #320F1E 0%, #C83228 12.5%, #FB873F 25%, #D2DC91 37.5%, #5A8250 50%, #002314 62%, #00143C 74%, #2873D7 86%, #9BC3FF 100%);
+        -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+        -webkit-mask-composite: xor;
+        mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+        mask-composite: exclude;
+        opacity: 0;
+        transition: opacity 200ms ease;
+        pointer-events: none;
+      }
+      .${INSIGHTS_AI_RAINBOW_BORDER_CLASS}:hover::before {
+        opacity: 1;
+      }
+      .${INSIGHTS_AI_RAINBOW_BORDER_CLASS}:hover {
+        border-color: transparent;
       }
     `}</style>
   );
@@ -58,7 +94,7 @@ export function InsightsTrigger({ className }: { className?: string }) {
       className={cn(
         "border-border hover:bg-accent inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors",
         isExpanded && "bg-accent text-accent-foreground",
-        INSIGHTS_AI_RAINBOW_CLASS,
+        INSIGHTS_AI_RAINBOW_BORDER_CLASS,
         className,
       )}
     >

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -1,6 +1,6 @@
 import type { ElementsConfig } from "@gram-ai/elements";
 import { Chat, GramElementsProvider } from "@gram-ai/elements";
-import { useThreadRuntime } from "@assistant-ui/react";
+import { useAssistantRuntime } from "@assistant-ui/react";
 import { useMoonshineConfig } from "@speakeasy-api/moonshine";
 import { Wand2, ChevronRight, Sparkles, Terminal } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -342,16 +342,34 @@ function PendingPromptBridge({
   pending: { text: string; nonce: number } | null;
   onConsume: () => void;
 }) {
-  const runtime = useThreadRuntime();
+  const assistantRuntime = useAssistantRuntime();
   const firedNonceRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!pending || !runtime) return;
+    if (!pending || !assistantRuntime) return;
     if (firedNonceRef.current === pending.nonce) return;
     firedNonceRef.current = pending.nonce;
-    runtime.append(pending.text);
+
+    const { text } = pending;
+    // Switch to a brand-new thread before appending. This sidesteps the
+    // assistant-ui MessageRepository id-collision error
+    // ("A message with the same id already exists in the parent tree")
+    // that triggers when a second Explore click tries to append into a
+    // thread that still holds messages from the previous chart's
+    // conversation. It also matches the intended product UX: each Explore
+    // CTA starts a fresh focused chat with the new contextInfo.
+    assistantRuntime.threads
+      .switchToNewThread()
+      .then(() => {
+        assistantRuntime.thread.append(text);
+      })
+      .catch((err: unknown) => {
+        // eslint-disable-next-line no-console
+        console.error("Failed to send Explore prompt:", err);
+      });
+
     onConsume();
-  }, [pending, runtime, onConsume]);
+  }, [pending, assistantRuntime, onConsume]);
 
   return null;
 }

--- a/client/dashboard/src/components/project/ActivityTimelineCard.tsx
+++ b/client/dashboard/src/components/project/ActivityTimelineCard.tsx
@@ -33,6 +33,7 @@ export function ActivityTimelineCard({ logs, isPending, viewAllHref }: Props) {
   return (
     <DashboardCard
       title="Activity Timeline"
+      tooltip="Recent administrative activity in this project — deployments, toolset changes, API key rotations, environment edits, and access role updates. Grouped by day, most recent first."
       action={
         <Link
           to={viewAllHref}

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -100,11 +100,7 @@ export function ProjectDashboard() {
     return () => setInsightsOverride(null);
   }, [setInsightsOverride]);
 
-  const timeWindowContext = useMemo(
-    () =>
-      `The user is on the Project Overview dashboard. The selected period is the last 7 days (from ${from.toISOString()} to ${to.toISOString()}).`,
-    [from, to],
-  );
+  const timeWindowContext = `The user is on the Project Overview dashboard. The selected period is the last 7 days (from ${from.toISOString()} to ${to.toISOString()}).`;
 
   return (
     <Page.Section>

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -11,8 +11,21 @@ import { useAuditLogs, useGetProjectOverview } from "@gram/client/react-query";
 import { useFeaturesGet } from "@gram/client/react-query/featuresGet";
 import { cn } from "@/lib/utils";
 import { subDays } from "date-fns";
-import { useMemo } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { Badge, Button, Card, Icon } from "@speakeasy-api/moonshine";
+import { Wand2 } from "lucide-react";
+import {
+  InsightsConfig,
+  INSIGHTS_AI_RAINBOW_CLASS,
+  type InsightsConfigOptions,
+} from "@/components/insights-sidebar";
+import { useInsightsState } from "@/components/insights-context";
 import { ActivityTimelineCard } from "./ActivityTimelineCard";
 import { ProjectOnboardingBanner } from "./ProjectOnboarding";
 
@@ -57,8 +70,42 @@ export function ProjectDashboard() {
 
   const showDisabledBanner = !isFeaturesPending && !logsEnabled;
 
+  const {
+    isExpanded: isInsightsExpanded,
+    setIsExpanded: setInsightsExpanded,
+    sendPrompt: sendInsightsPrompt,
+  } = useInsightsState();
+  const [exploreConfig, setExploreConfig] =
+    useState<InsightsConfigOptions | null>(null);
+
+  const exploreWithAI = useCallback(
+    (opts: InsightsConfigOptions) => {
+      setExploreConfig(opts);
+      setInsightsExpanded(true);
+      // Auto-send the chart's canonical question so the user lands in a
+      // running conversation — the welcome-screen suggestion fallback alone
+      // isn't shown once the thread has prior messages.
+      const firstPrompt = opts.suggestions?.[0]?.prompt;
+      if (firstPrompt) sendInsightsPrompt(firstPrompt);
+    },
+    [setInsightsExpanded, sendInsightsPrompt],
+  );
+
+  // Clear the per-chart override when the panel is closed so the next opening
+  // (e.g. via the header trigger) falls back to the page defaults.
+  useEffect(() => {
+    if (!isInsightsExpanded) setExploreConfig(null);
+  }, [isInsightsExpanded]);
+
+  const timeWindowContext = useMemo(
+    () =>
+      `The user is on the Project Overview dashboard. The selected period is the last 7 days (from ${from.toISOString()} to ${to.toISOString()}).`,
+    [from, to],
+  );
+
   return (
     <Page.Section>
+      {exploreConfig && <InsightsConfig {...exploreConfig} />}
       <Page.Section.Title>Project Overview</Page.Section.Title>
       <Page.Section.Description>
         <Badge variant="neutral">
@@ -92,6 +139,7 @@ export function ProjectDashboard() {
                     title="Active Servers"
                     value={overview?.summary.activeServersCount ?? 0}
                     icon="server"
+                    tooltip="Unique MCP servers that received at least one tool call via hook telemetry in the selected period. Servers with no activity in the window are not counted."
                   />
                 )}
                 {isOverviewPending ? (
@@ -101,6 +149,7 @@ export function ProjectDashboard() {
                     title="Tool Calls"
                     value={overview?.summary.totalToolCalls ?? 0}
                     icon="wrench"
+                    tooltip="Total tool invocations recorded across all servers and sources (Elements, MCP, hooks, and the Gram SDK) in the selected period."
                   />
                 )}
                 {isOverviewPending ? (
@@ -110,6 +159,7 @@ export function ProjectDashboard() {
                     title="End Users"
                     value={overview?.summary.activeUsersCount ?? 0}
                     icon="users"
+                    tooltip="Unique end users identified during the selected period. When chat sessions exist they are counted from chat messages; otherwise they are counted from tool-call hook events."
                   />
                 )}
                 {isOverviewPending ? (
@@ -119,6 +169,7 @@ export function ProjectDashboard() {
                     title="Sessions"
                     value={overview?.summary.totalChats ?? 0}
                     icon="message-circle"
+                    tooltip="Chat sessions started in the selected period across Elements, MCP clients, hooks, and any other source that opens a Gram chat."
                   />
                 )}
               </div>
@@ -127,7 +178,30 @@ export function ProjectDashboard() {
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <DashboardCard
                   title="Top Users"
-                  action={<ViewAllLink to={routes.hooks.href()} />}
+                  tooltip="End users ranked by activity in the selected period. Activity is measured in tool calls, skill invocations or in chat messages when agent sessions exist."
+                  action={
+                    <CardActions>
+                      <ExploreWithAIButton
+                        onClick={() =>
+                          exploreWithAI({
+                            title: "Analyze your top users",
+                            subtitle:
+                              "Dig into who is driving the most activity.",
+                            contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Top Users chart.`,
+                            suggestions: [
+                              {
+                                title: "Top users & usage patterns",
+                                label: "Last 7 days",
+                                prompt:
+                                  "Who are my top 5 end users in the last 7 days, and what is each user's main usage pattern — tool calls, skill invocations, agent sessions, or a mix?",
+                              },
+                            ],
+                          })
+                        }
+                      />
+                      <ViewAllLink to={routes.hooks.href()} />
+                    </CardActions>
+                  }
                 >
                   {isOverviewPending ? (
                     <SkeletonList />
@@ -148,7 +222,30 @@ export function ProjectDashboard() {
 
                 <DashboardCard
                   title="Top Servers"
-                  action={<ViewAllLink to={routes.hooks.href()} />}
+                  tooltip="MCP servers ranked by the number of tool calls they served in the selected period, based on hook telemetry."
+                  action={
+                    <CardActions>
+                      <ExploreWithAIButton
+                        onClick={() =>
+                          exploreWithAI({
+                            title: "Analyze your top servers",
+                            subtitle:
+                              "See which MCP servers are driving the most traffic.",
+                            contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Top Servers chart.`,
+                            suggestions: [
+                              {
+                                title: "Top servers & hot tools",
+                                label: "Last 7 days",
+                                prompt:
+                                  "Which MCP servers received the most tool calls in the last 7 days, and which specific tools on each server are driving that volume?",
+                              },
+                            ],
+                          })
+                        }
+                      />
+                      <ViewAllLink to={routes.hooks.href()} />
+                    </CardActions>
+                  }
                 >
                   {isOverviewPending ? (
                     <SkeletonList />
@@ -172,19 +269,40 @@ export function ProjectDashboard() {
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <DashboardCard
                   title="Most Agent Sessions by User"
+                  tooltip="End users ranked by agent activity in the selected period. When chat sessions exist, activity counts chat messages; otherwise it counts tool calls from hook events."
                   action={
-                    <ViewAllLink
-                      to={
-                        // no hooks data and no chat sessions
-                        isProjectEmpty && overview?.summary.totalChats === 0
-                          ? routes.hooks.href()
-                          : // has hooks data but no chat sessions
-                            !isProjectEmpty &&
-                              overview?.summary.totalChats === 0
-                            ? routes.observability.href()
-                            : routes.chatSessions.href()
-                      }
-                    />
+                    <CardActions>
+                      <ExploreWithAIButton
+                        onClick={() =>
+                          exploreWithAI({
+                            title: "Analyze agent sessions",
+                            subtitle:
+                              "Understand how your power users interact with agents.",
+                            contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Most Agent Sessions by User chart.`,
+                            suggestions: [
+                              {
+                                title: "Power users & agent behavior",
+                                label: "Last 7 days",
+                                prompt:
+                                  "For the users with the most agent sessions in the last 7 days, what are the common prompts they send and which tools get invoked most often?",
+                              },
+                            ],
+                          })
+                        }
+                      />
+                      <ViewAllLink
+                        to={
+                          // no hooks data and no chat sessions
+                          isProjectEmpty && overview?.summary.totalChats === 0
+                            ? routes.hooks.href()
+                            : // has hooks data but no chat sessions
+                              !isProjectEmpty &&
+                                overview?.summary.totalChats === 0
+                              ? routes.observability.href()
+                              : routes.chatSessions.href()
+                        }
+                      />
+                    </CardActions>
                   }
                 >
                   {isOverviewPending ? (
@@ -226,7 +344,30 @@ export function ProjectDashboard() {
 
                 <DashboardCard
                   title="Most Used LLM Clients"
-                  action={<ViewAllLink to={routes.hooks.href()} />}
+                  tooltip="LLM clients (e.g. Claude, Cursor, Windsurf) ranked by activity volume in the selected period, identified from client metadata sent with each call."
+                  action={
+                    <CardActions>
+                      <ExploreWithAIButton
+                        onClick={() =>
+                          exploreWithAI({
+                            title: "Analyze LLM client usage",
+                            subtitle:
+                              "Compare how different LLM clients exercise your tools.",
+                            contextInfo: `${timeWindowContext} The user clicked "Explore with AI" on the Most Used LLM Clients chart.`,
+                            suggestions: [
+                              {
+                                title: "LLM clients & reliability",
+                                label: "Last 7 days",
+                                prompt:
+                                  "Break down tool-call activity by LLM client in the last 7 days and highlight any clients with unusually high error rates or latency.",
+                              },
+                            ],
+                          })
+                        }
+                      />
+                      <ViewAllLink to={routes.hooks.href()} />
+                    </CardActions>
+                  }
                 >
                   {isOverviewPending ? (
                     <SkeletonList />
@@ -268,6 +409,27 @@ function ViewAllLink({ to }: { to: string }) {
       View all
       <Icon name="arrow-right" />
     </Link>
+  );
+}
+
+function CardActions({ children }: { children: ReactNode }) {
+  return <div className="flex items-center gap-3">{children}</div>;
+}
+
+function ExploreWithAIButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Explore with AI"
+      title="Explore with AI"
+      className={cn(
+        "text-muted-foreground inline-flex items-center justify-center rounded-md p-1 transition-colors",
+        INSIGHTS_AI_RAINBOW_CLASS,
+      )}
+    >
+      <Wand2 className="size-3.5" />
+    </button>
   );
 }
 

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -91,6 +91,15 @@ export function ProjectDashboard() {
     if (!isInsightsExpanded) setInsightsOverride(null);
   }, [isInsightsExpanded, setInsightsOverride]);
 
+  // Also clear on unmount: otherwise navigating away with the sidebar still
+  // open leaves a stale chart-specific override in InsightsProvider state,
+  // which would leak into pages that don't mount their own <InsightsConfig>.
+  // Kept as a separate effect so the cleanup fires only on unmount, not on
+  // every isInsightsExpanded transition.
+  useEffect(() => {
+    return () => setInsightsOverride(null);
+  }, [setInsightsOverride]);
+
   const timeWindowContext = useMemo(
     () =>
       `The user is on the Project Overview dashboard. The selected period is the last 7 days (from ${from.toISOString()} to ${to.toISOString()}).`,

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -11,17 +11,10 @@ import { useAuditLogs, useGetProjectOverview } from "@gram/client/react-query";
 import { useFeaturesGet } from "@gram/client/react-query/featuresGet";
 import { cn } from "@/lib/utils";
 import { subDays } from "date-fns";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { Badge, Button, Card, Icon } from "@speakeasy-api/moonshine";
 import { Wand2 } from "lucide-react";
 import {
-  InsightsConfig,
   INSIGHTS_AI_RAINBOW_CLASS,
   type InsightsConfigOptions,
 } from "@/components/insights-sidebar";
@@ -73,29 +66,30 @@ export function ProjectDashboard() {
   const {
     isExpanded: isInsightsExpanded,
     setIsExpanded: setInsightsExpanded,
+    setOverride: setInsightsOverride,
     sendPrompt: sendInsightsPrompt,
   } = useInsightsState();
-  const [exploreConfig, setExploreConfig] =
-    useState<InsightsConfigOptions | null>(null);
 
   const exploreWithAI = useCallback(
     (opts: InsightsConfigOptions) => {
-      setExploreConfig(opts);
+      // Apply the override synchronously so it lands in the same commit as
+      // setIsExpanded + sendPrompt. Routing through <InsightsConfig> adds a
+      // useEffect-deferred setOverride, which (a) loses the chart contextInfo
+      // on the first runtime.append call and (b) triggered a click-outside
+      // crash via the unmount→cleanup chain.
+      setInsightsOverride(opts);
       setInsightsExpanded(true);
-      // Auto-send the chart's canonical question so the user lands in a
-      // running conversation — the welcome-screen suggestion fallback alone
-      // isn't shown once the thread has prior messages.
       const firstPrompt = opts.suggestions?.[0]?.prompt;
       if (firstPrompt) sendInsightsPrompt(firstPrompt);
     },
-    [setInsightsExpanded, sendInsightsPrompt],
+    [setInsightsOverride, setInsightsExpanded, sendInsightsPrompt],
   );
 
   // Clear the per-chart override when the panel is closed so the next opening
   // (e.g. via the header trigger) falls back to the page defaults.
   useEffect(() => {
-    if (!isInsightsExpanded) setExploreConfig(null);
-  }, [isInsightsExpanded]);
+    if (!isInsightsExpanded) setInsightsOverride(null);
+  }, [isInsightsExpanded, setInsightsOverride]);
 
   const timeWindowContext = useMemo(
     () =>
@@ -105,7 +99,6 @@ export function ProjectDashboard() {
 
   return (
     <Page.Section>
-      {exploreConfig && <InsightsConfig {...exploreConfig} />}
       <Page.Section.Title>Project Overview</Page.Section.Title>
       <Page.Section.Description>
         <Badge variant="neutral">

--- a/client/dashboard/src/components/ui/dashboard-card.tsx
+++ b/client/dashboard/src/components/ui/dashboard-card.tsx
@@ -1,16 +1,37 @@
 import { type ReactNode } from "react";
+import { Icon } from "@speakeasy-api/moonshine";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 
 type DashboardCardProps = {
   title: string;
   action?: ReactNode;
   children: ReactNode;
+  tooltip?: string;
 };
 
-export function DashboardCard({ title, action, children }: DashboardCardProps) {
+export function DashboardCard({
+  title,
+  action,
+  children,
+  tooltip,
+}: DashboardCardProps) {
   return (
     <div className="bg-card text-card-foreground relative flex h-full w-full flex-col rounded-lg border">
       <div className="flex w-full flex-row items-center justify-between gap-4 border-b px-6 py-4">
-        <h3 className="text-sm font-semibold">{title}</h3>
+        <div className="flex items-center gap-1.5">
+          <h3 className="text-sm font-semibold">{title}</h3>
+          {tooltip && (
+            <SimpleTooltip tooltip={tooltip}>
+              <button
+                type="button"
+                aria-label={`About ${title}`}
+                className="text-muted-foreground hover:text-foreground inline-flex cursor-help items-center"
+              >
+                <Icon name="info" className="size-3.5" />
+              </button>
+            </SimpleTooltip>
+          )}
+        </div>
         {action}
       </div>
       <div className="px-6 py-5">{children}</div>


### PR DESCRIPTION
## Summary
- Every KPI and dashboard card on Project Overview now carries an info tooltip explaining what the number actually measures, so customers don't have to guess or read docs.
- Each chart card gets an "Explore with AI" wand button alongside "View all". Clicking it opens the Insights sidebar and auto-submits a chart-specific question (top users, top servers, agent sessions, LLM clients) through the thread runtime — dropping the user straight into a running conversation.
- The nav-bar **AI Insights** trigger and the per-chart wand buttons share a new `INSIGHTS_AI_RAINBOW_CLASS` that cycles their icon/text color through the Speakeasy brand palette on hover (same stops as the login page's `BrandGradientBar`).

<img width="1472" height="452" alt="CleanShot 2026-04-20 at 15 14 11@2x" src="https://github.com/user-attachments/assets/e859b67c-8978-403d-bc74-c8bc5a2d4b11" />

<img width="3068" height="1496" alt="CleanShot 2026-04-20 at 15 14 40@2x" src="https://github.com/user-attachments/assets/97ac0b09-8f6e-446b-9460-43b2a5b4a634" />

## Why auto-send instead of welcome suggestions
`ThreadWelcome` (and therefore `config.welcome.suggestions`) only renders when the thread has zero messages. Once a user has chatted once, suggestions are hidden forever. So passing suggestions via `InsightsConfig` alone produced the "clicking does nothing visible" bug. The fix bypasses the welcome path entirely: `InsightsContext.sendPrompt(text)` queues a nonce'd prompt; a new `PendingPromptBridge` mounted inside `GramElementsProvider` calls `useThreadRuntime().append(text)` whenever the nonce changes. Same API `Replay.tsx` uses.

## Test plan
- [ ] Open Project Overview with an empty project → tooltip icons render on every KPI and card; hovering shows the correct copy.
- [ ] Click the wand button on "Top Users" → Insights sidebar opens, a user message appears with the chart-specific prompt, assistant begins streaming a response.
- [ ] Close the sidebar, open it from the nav-bar AI Insights trigger → defaults come back (no stale per-chart override).
- [ ] Click wand on one chart, wait for response, click wand on a different chart → second prompt appends as a new user message in the same thread.
- [ ] Click wand on the same chart twice in a row → both clicks fire (nonce makes repeat clicks distinct).
- [ ] Hover the nav-bar AI Insights button and each chart's wand button → brand rainbow color cycle runs on hover, reverts on mouseout.
- [ ] Verify `pnpm tsc -p tsconfig.app.json --noEmit` and `pnpm lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)