### PR TITLE
chore: suppress pnpm ignored build scripts warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,12 @@
     "overrides": {
       "react-is": "$react-is",
       "recharts": "2.15.4"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "core-js",
+      "cpu-features",
+      "msw",
+      "ssh2"
+    ]
   }
 }


### PR DESCRIPTION
## Why

Every `pnpm install` was printing a warning about four packages whose postinstall/build scripts were being blocked by our `onlyBuiltDependencies` security policy:

```
Ignored build scripts: core-js@3.47.0, cpu-features@0.0.10, msw@2.12.3, ssh2@1.17.0.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

The warning is noisy but the blocking behaviour was already correct — none of these packages need their scripts to run.

## Why each package is safe to ignore

| Package | Used by | Why it's fine without the build script |
|---|---|---|
| `core-js` | `posthog-js` (transitive) | Postinstall is optional — wraps itself in `try/catch`, pure JS polyfill |
| `msw` | Dev/test only | Postinstall is optional — wraps itself in `try/catch`, pure JS |
| `ssh2` | `@datadog/datadog-ci` (CI tool only) | Has a pure JS fallback for crypto; native binding is a perf optimisation only |
| `cpu-features` | `ssh2` (optional dep) | Marked `optional: true` by ssh2 itself; ssh2 falls back gracefully without it |

None of these affect app runtime. The native bindings for `ssh2`/`cpu-features` would only speed up crypto in the Datadog CI CLI, which isn't a hot path.

## What changed

Ran `pnpm approve-builds` and denied all four packages. This writes them to `ignoredBuiltDependencies` in `package.json` (the format pnpm manages), which tells pnpm we've consciously reviewed and rejected these scripts rather than just not noticed them.

Future packages with build scripts will still trigger the warning, so we'll continue to review them on a case-by-case basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)