### PR TITLE
chore: increase flyio request hard limit factor

### DIFF
--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -619,7 +619,7 @@ func (f *FlyRunner) reap(ctx context.Context, logger *slog.Logger, appsRepo *rep
 // triggers traffic deprioritization so the proxy can spread load before hitting
 // the hard cap.
 func concurrencyLimits(memoryMB int) (softLimit, hardLimit int) {
-	hardLimit = max(memoryMB/64, 4)
+	hardLimit = max(memoryMB/48, 4)
 	softLimit = max(hardLimit*3/4, 2)
 	return softLimit, hardLimit
 }

--- a/server/internal/functions/deploy_fly_test.go
+++ b/server/internal/functions/deploy_fly_test.go
@@ -9,29 +9,29 @@ import (
 func TestConcurrencyLimits_256MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(256)
-	require.Equal(t, 4, hard)
+	require.Equal(t, 5, hard)
 	require.Equal(t, 3, soft)
 }
 
 func TestConcurrencyLimits_512MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(512)
-	require.Equal(t, 8, hard)
-	require.Equal(t, 6, soft)
+	require.Equal(t, 10, hard)
+	require.Equal(t, 7, soft)
 }
 
 func TestConcurrencyLimits_1024MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(1024)
-	require.Equal(t, 16, hard)
-	require.Equal(t, 12, soft)
+	require.Equal(t, 21, hard)
+	require.Equal(t, 15, soft)
 }
 
 func TestConcurrencyLimits_2048MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(2048)
-	require.Equal(t, 32, hard)
-	require.Equal(t, 24, soft)
+	require.Equal(t, 42, hard)
+	require.Equal(t, 31, soft)
 }
 
 func TestConcurrencyLimits_TinyMemory(t *testing.T) {


### PR DESCRIPTION
Raise the per-machine concurrent request hard limit for deployed Fly functions by changing the memory-to-concurrency divisor from 64 to 48. This gives each machine ~33% more request headroom for the same memory allocation before the proxy starts rejecting requests. The soft limit continues to track at 75% of the hard limit, so traffic deprioritization still kicks in earlier to spread load across machines.