### PR TITLE
fix: resolve ResizeObserver loop errors on navigation hover

### DIFF
--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -103,6 +103,28 @@ useEffect(() => {
 }, [logs]); // or parsedLogs, depending on the component
 ```
 
+### Tooltip Usage
+
+`App.tsx` wraps the entire app in a global `TooltipProvider`. **Never add another `TooltipProvider` inside a component** — doing so creates a redundant Radix context per instance and contributes to `ResizeObserver loop completed with undelivered notifications` errors in the browser.
+
+Use `<Tooltip>`, `<TooltipTrigger>`, and `<TooltipContent>` directly — they inherit the global provider automatically. For simple cases use the existing `<SimpleTooltip tooltip="...">` wrapper from `@/components/ui/tooltip`.
+
+```tsx
+// ✅ correct
+<Tooltip>
+  <TooltipTrigger asChild>{button}</TooltipTrigger>
+  <TooltipContent>Hello</TooltipContent>
+</Tooltip>
+
+// ❌ wrong — TooltipProvider already exists at the app root
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild>{button}</TooltipTrigger>
+    <TooltipContent>Hello</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
 ### Styling and Design System
 
 - **ALWAYS use Moonshine design system utilities** from `@speakeasy-api/moonshine` instead of hardcoded Tailwind color values

--- a/.changeset/odd-poems-dig.md
+++ b/.changeset/odd-poems-dig.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+fix: resolve ResizeObserver loop errors on navigation hover

--- a/client/dashboard/src/components/require-scope.tsx
+++ b/client/dashboard/src/components/require-scope.tsx
@@ -3,12 +3,7 @@ import { useRBAC } from "@/hooks/useRBAC";
 import { cn } from "@/lib/utils";
 import { Icon } from "@speakeasy-api/moonshine";
 import React from "react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "./ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type RequireScopeProps = {
   scope: Scope | Scope[];
@@ -94,30 +89,28 @@ function ScopeDisabled({
   children: React.ReactNode;
 }) {
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className={cn(
+            "pointer-events-none inline-flex opacity-50 select-none",
+            className,
+          )}
+        >
+          {/* Wrapper div that re-enables pointer events for the tooltip to work */}
           <div
-            className={cn(
-              "pointer-events-none inline-flex opacity-50 select-none",
-              className,
-            )}
+            className="pointer-events-auto w-full cursor-not-allowed [&_*]:cursor-not-allowed"
+            onClickCapture={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
           >
-            {/* Wrapper div that re-enables pointer events for the tooltip to work */}
-            <div
-              className="pointer-events-auto w-full cursor-not-allowed [&_*]:cursor-not-allowed"
-              onClickCapture={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-            >
-              {children}
-            </div>
+            {children}
           </div>
-        </TooltipTrigger>
-        <TooltipContent>{reason}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>{reason}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/client/dashboard/src/components/ui/sidebar.tsx
+++ b/client/dashboard/src/components/ui/sidebar.tsx
@@ -529,15 +529,14 @@ function SidebarMenuButton({
     };
   }
 
+  if (state !== "collapsed" || isMobile) {
+    return button;
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent
-        side="right"
-        align="center"
-        hidden={state !== "collapsed" || isMobile}
-        {...tooltip}
-      />
+      <TooltipContent side="right" align="center" {...tooltip} />
     </Tooltip>
   );
 }

--- a/client/dashboard/src/components/ui/tooltip.tsx
+++ b/client/dashboard/src/components/ui/tooltip.tsx
@@ -67,12 +67,10 @@ function SimpleTooltip({
   children: React.ReactNode;
 }) {
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent>{tooltip}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
+++ b/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
@@ -3,7 +3,6 @@ import { Dialog } from "@/components/ui/dialog";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -264,46 +263,44 @@ export function HooksSetupDialog({
         </Dialog.Header>
 
         <div className="mb-6 flex flex-wrap gap-3">
-          <TooltipProvider>
-            {providers.map((p) => {
-              const button = (
-                <button
-                  key={p.id}
-                  onClick={() => p.available && setSelected(p.id)}
-                  disabled={!p.available}
-                  className={cn(
-                    "relative flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors",
-                    selected === p.id
-                      ? "border-primary bg-primary/5"
-                      : "border-border hover:border-primary/50 hover:bg-muted/50",
-                    !p.available &&
-                      "hover:border-border cursor-not-allowed opacity-50 hover:bg-transparent",
-                  )}
-                >
-                  <HookSourceIcon source={p.source} className="size-5" />
-                  {p.label}
-                  {!p.available && (
-                    <span className="text-muted-foreground ml-1 text-[10px] tracking-wide uppercase">
-                      Soon
-                    </span>
-                  )}
-                </button>
+          {providers.map((p) => {
+            const button = (
+              <button
+                key={p.id}
+                onClick={() => p.available && setSelected(p.id)}
+                disabled={!p.available}
+                className={cn(
+                  "relative flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors",
+                  selected === p.id
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-primary/50 hover:bg-muted/50",
+                  !p.available &&
+                    "hover:border-border cursor-not-allowed opacity-50 hover:bg-transparent",
+                )}
+              >
+                <HookSourceIcon source={p.source} className="size-5" />
+                {p.label}
+                {!p.available && (
+                  <span className="text-muted-foreground ml-1 text-[10px] tracking-wide uppercase">
+                    Soon
+                  </span>
+                )}
+              </button>
+            );
+
+            if (!p.available) {
+              return (
+                <Tooltip key={p.id}>
+                  <TooltipTrigger asChild>{button}</TooltipTrigger>
+                  <TooltipContent>
+                    <p>Coming soon</p>
+                  </TooltipContent>
+                </Tooltip>
               );
+            }
 
-              if (!p.available) {
-                return (
-                  <Tooltip key={p.id}>
-                    <TooltipTrigger asChild>{button}</TooltipTrigger>
-                    <TooltipContent>
-                      <p>Coming soon</p>
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              }
-
-              return button;
-            })}
-          </TooltipProvider>
+            return button;
+          })}
         </div>
 
         {selected === "claude" && <ClaudeInstallContent />}


### PR DESCRIPTION
## Summary

- `SidebarMenuButton` was mounting a Radix `<Tooltip>` (with its internal ResizeObserver) on every nav item even in expanded sidebar state, using
`hidden` to suppress visibility. Replaced with early return of the bare button when expanded or on mobile — no Tooltip is mounted at all when it
won't be shown.
- `ScopeDisabled`, `SimpleTooltip`, and `HooksSetupDialog` were each creating their own `TooltipProvider`, duplicating the Radix tooltip context that already exists globally in `App.tsx`. Removed all three redundant providers.

## Root Cause
Noticed this today, while being on-call secondary, and poking around in DataDog

[DataDog RUM captured](https://app.datadoghq.com/error-tracking/issue/29c2ba10-3cd8-11f1-8fed-da7ad0900002) `ResizeObserver loop completed with undelivered notifications` twice, triggered by hovering over sidebar nav items. Radix UI's floating positioning system attaches ResizeObserver to both the trigger and content elements. When those are mounted but suppressed via `hidden` (rather than unmounted), hover events still activate Radix's positioning logic, producing undeliverable resize notifications.

## Test Plan

- [x] Expand sidebar → hover over nav items → no ResizeObserver errors in console
- [x] Collapse sidebar → hover over nav items → tooltips appear correctly on the right
- [x] Org sidebar with scope-restricted items → disabled items still show "no permission" tooltip on hover
- [x] Hooks setup dialog → "Coming soon" tooltips still work on unavailable providers
