### PR TITLE
feat: add placeholder Identity page under secure nav

### DIFF
--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -143,6 +143,10 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={orgRoutes.auditLogs}
                 scope={["org:read", "org:admin"]}
               />
+              <ScopeGatedNavItem
+                item={orgRoutes.identity}
+                scope={["org:read", "org:admin"]}
+              />
               {isRbacEnabled && (
                 <ScopeGatedNavItem
                   item={orgRoutes.access}

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -135,18 +135,18 @@ function IdentityCard({
   );
 }
 
-function RequireSamlRow() {
-  const [requireSaml, setRequireSaml] = useState(false);
+function RequireSsoRow() {
+  const [requireSso, setRequireSso] = useState(false);
   return (
     <div className="border-border bg-muted/30 flex items-center justify-between gap-4 border-t p-4">
       <Type variant="body" className="font-medium">
-        Require workspace members to login with SAML to access this workspace
+        Require workspace members to login with SSO to access this workspace
       </Type>
       <Switch
-        checked={requireSaml}
-        onCheckedChange={setRequireSaml}
+        checked={requireSso}
+        onCheckedChange={setRequireSso}
         disabled
-        aria-label="Require workspace members to login with SAML"
+        aria-label="Require workspace members to login with SSO"
       />
     </div>
   );
@@ -180,7 +180,7 @@ function OrgIdentityInner() {
         learnMoreText="Learn more about SAML SSO"
         learnMoreHref="https://www.speakeasy.com/docs"
       >
-        <RequireSamlRow />
+        <RequireSsoRow />
       </IdentityCard>
       <IdentityCard
         heading="Directory Sync"

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -1,0 +1,196 @@
+import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
+import { Heading } from "@/components/ui/heading";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
+import { Type } from "@/components/ui/type";
+import { Button } from "@speakeasy-api/moonshine";
+import { FolderSync, Lock } from "lucide-react";
+import { useRef, useState } from "react";
+
+const CONTACT_SALES_URL = "https://www.speakeasy.com/book-demo";
+const UPSELL_COPY =
+  "SAML SSO is only available on Enterprise plans. Upgrade to get started.";
+
+type IdentityCardProps = {
+  heading: string;
+  description: string;
+  providerIcon: React.ReactNode;
+  providerTitle: string;
+  providerSubtitle: string;
+  learnMoreText: string;
+  learnMoreHref: string;
+  children?: React.ReactNode;
+};
+
+function ConfigureButton() {
+  const [open, setOpen] = useState(false);
+  const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const show = () => {
+    if (hideTimeout.current) clearTimeout(hideTimeout.current);
+    setOpen(true);
+  };
+
+  const scheduleHide = () => {
+    if (hideTimeout.current) clearTimeout(hideTimeout.current);
+    hideTimeout.current = setTimeout(() => setOpen(false), 150);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="secondary"
+          size="sm"
+          aria-disabled="true"
+          className="cursor-not-allowed opacity-60"
+          onMouseEnter={show}
+          onMouseLeave={scheduleHide}
+          onFocus={show}
+          onBlur={scheduleHide}
+          onClick={(e) => e.preventDefault()}
+        >
+          Configure
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={8}
+        className="w-72"
+        onMouseEnter={show}
+        onMouseLeave={scheduleHide}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="flex flex-col items-center gap-3 text-center">
+          <Type small>{UPSELL_COPY}</Type>
+          <Button variant="brand" size="sm" asChild>
+            <a
+              href={CONTACT_SALES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Contact sales
+            </a>
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function IdentityCard({
+  heading,
+  description,
+  providerIcon,
+  providerTitle,
+  providerSubtitle,
+  learnMoreText,
+  learnMoreHref,
+  children,
+}: IdentityCardProps) {
+  return (
+    <section className="border-border bg-card overflow-hidden rounded-lg border">
+      <div className="p-6">
+        <Heading variant="h5" className="mb-1">
+          {heading}
+        </Heading>
+        <Type muted small className="mb-4">
+          {description}
+        </Type>
+        <div className="border-border overflow-hidden rounded-lg border">
+          <div className="flex items-center gap-4 p-4">
+            <div className="bg-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-full">
+              {providerIcon}
+            </div>
+            <div className="min-w-0 flex-1">
+              <Type variant="body" className="font-medium">
+                {providerTitle}
+              </Type>
+              <Type muted small>
+                {providerSubtitle}
+              </Type>
+            </div>
+            <ConfigureButton />
+          </div>
+          {children}
+        </div>
+      </div>
+      <div className="border-border bg-muted/30 border-t px-6 py-3">
+        <a
+          href={learnMoreHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4 transition-colors"
+        >
+          {learnMoreText}
+        </a>
+      </div>
+    </section>
+  );
+}
+
+function RequireSamlRow() {
+  const [requireSaml, setRequireSaml] = useState(false);
+  return (
+    <div className="border-border bg-muted/30 flex items-center justify-between gap-4 border-t p-4">
+      <Type variant="body" className="font-medium">
+        Require workspace members to login with SAML to access this workspace
+      </Type>
+      <Switch
+        checked={requireSaml}
+        onCheckedChange={setRequireSaml}
+        disabled
+        aria-label="Require workspace members to login with SAML"
+      />
+    </div>
+  );
+}
+
+export default function OrgIdentity() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Title>Identity</Page.Header.Title>
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["org:read", "org:admin"]} level="page">
+          <OrgIdentityInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function OrgIdentityInner() {
+  return (
+    <div className="flex flex-col gap-6">
+      <Heading variant="h4">Security</Heading>
+      <IdentityCard
+        heading="SAML Single Sign-On"
+        description="Set up SAML Single Sign-On (SSO) to allow your team to sign in to Speakeasy with your identity provider."
+        providerIcon={<Lock className="text-muted-foreground h-5 w-5" />}
+        providerTitle="SAML"
+        providerSubtitle="Choose an identity provider to get started."
+        learnMoreText="Learn more about SAML SSO"
+        learnMoreHref="https://www.speakeasy.com/docs"
+      >
+        <RequireSamlRow />
+      </IdentityCard>
+      <IdentityCard
+        heading="Directory Sync"
+        description="Automatically provision and deprovision users from your identity provider."
+        providerIcon={<FolderSync className="text-muted-foreground h-5 w-5" />}
+        providerTitle="SCIM"
+        providerSubtitle="Choose an identity provider to get started."
+        learnMoreText="Learn more about SCIM Directory Sync"
+        learnMoreHref="https://www.speakeasy.com/docs"
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -41,6 +41,7 @@ import PluginDetail from "./pages/org/PluginDetail";
 import OrgAuditLogs from "./pages/org/OrgAuditLogs";
 import OrgDomains from "./pages/org/OrgDomains";
 import OrgHome from "./pages/org/OrgHome";
+import OrgIdentity from "./pages/org/OrgIdentity";
 import OrgLogs from "./pages/org/OrgLogs";
 import Playground from "./pages/playground/Playground";
 import NewPromptPage from "./pages/prompts/NewPrompt";
@@ -601,6 +602,12 @@ const ORG_ROUTE_STRUCTURE = {
     url: "audit-logs",
     icon: "history",
     component: OrgAuditLogs,
+  },
+  identity: {
+    title: "Identity",
+    url: "identity",
+    icon: "fingerprint",
+    component: OrgIdentity,
   },
   access: {
     title: "Roles & Permissions",


### PR DESCRIPTION
## Summary

Adds a placeholder **Identity** page to the org-level **Secure** nav group, laying out the shell UI for SAML SSO and SCIM Directory Sync gating (no backend wiring yet).

- New `OrgIdentity` page at `/identity` with two cards: **SAML Single Sign-On** and **Directory Sync**
- Each card has a disabled-looking `Configure` button that opens a hover popover reading _"SAML SSO is only available on Enterprise plans. Upgrade to get started."_ with a `Contact sales` CTA linking to `https://www.speakeasy.com/book-demo` (matching the existing `EnterpriseGate` pattern)
- SAML card includes a _"Require workspace members to login with SAML"_ toggle row (disabled, UI-only)
- Sidebar gating uses the same `org:read`/`org:admin` scopes as the sibling Audit Logs / Access entries
- Design replicates a Dub reference screenshot, with copy re-branded to Speakeasy
- 
<img width="3012" height="1700" alt="CleanShot 2026-04-20 at 17 10 40@2x" src="https://github.com/user-attachments/assets/968f99a1-ffd5-4de4-bbc7-fef4205e4f20" />

## Implementation notes

- **Popover over HoverCard**: the shared `ui/hover-card.tsx` primitive does not wrap content in `Portal`, which broke positioning under the app's transformed sidebar ancestor (transforms re-base the containing block for `position: fixed`, a CSS spec quirk). `Popover` already portals to `document.body`, so the popover anchors correctly against the trigger's viewport coordinates.
- **Disabled appearance without `disabled` attribute**: `aria-disabled="true"` + `cursor-not-allowed opacity-60` + no-op `onClick` — this keeps the button as a first-class interactive target so Radix's hover handlers fire reliably (Chromium strips pointer events from truly-disabled buttons).

## Test plan

- [ ] Navigate to **Secure → Identity** in the org sidebar
- [ ] Hover **Configure** on the SAML card → popover appears above-right of the button with "Contact sales" CTA
- [ ] Move cursor into the popover → it stays open; click "Contact sales" → opens book-demo in a new tab
- [ ] Hover **Configure** on the SCIM card → same behavior
- [ ] Verify page is gated by `org:read` / `org:admin` scopes (non-privileged users see no nav entry)
- [ ] Confirm "Learn more about SAML SSO" and "Learn more about SCIM Directory Sync" footer links render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
