### PR TITLE
fix: remove gradient from onboarding banner

### DIFF
--- a/.changeset/few-falcons-learn.md
+++ b/.changeset/few-falcons-learn.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+fix: remove gradient from onboarding banner

--- a/client/dashboard/src/components/project/ProjectOnboarding.tsx
+++ b/client/dashboard/src/components/project/ProjectOnboarding.tsx
@@ -5,7 +5,7 @@ export function ProjectOnboardingBanner() {
   const routes = useRoutes();
 
   return (
-    <Card className="from-background via-background bg-linear-to-tr to-blue-200 p-8 dark:to-blue-950">
+    <Card className="bg-background p-8">
       <Card.Header>
         <h2 className="text-3xl font-light">Welcome</h2>
       </Card.Header>


### PR DESCRIPTION
Replaces the gradient background in `ProjectOnboardingBanner` with `bg-background` for a more chill experience ;)
