### PR TITLE
feat: rbac lockdown for project-level dashboard pages

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.730.1
+speakeasyVersion: 1.761.5
 sources:
     Gram-Internal:
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:71196408fc1f8f2484d8f3e52c2ce91e53d638a6c2e405cf38be3b0997419e82
-        sourceBlobDigest: sha256:46848db214c1988305b3687cd43c5f0ee56f8af6ea365ca197d63aa02e7ad317
+        sourceRevisionDigest: sha256:5509c7bda46f380ef8decd893c47f50a9159f3016d379c801e1756586a9b641e
+        sourceBlobDigest: sha256:056b77259613ff1d7976a039c89f80b148566603814f1c76390850b33b42ebc4
         tags:
             - latest
             - 0.0.1

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.761.5
+speakeasyVersion: 1.730.1
 sources:
     Gram-Internal:
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:5509c7bda46f380ef8decd893c47f50a9159f3016d379c801e1756586a9b641e
-        sourceBlobDigest: sha256:056b77259613ff1d7976a039c89f80b148566603814f1c76390850b33b42ebc4
+        sourceRevisionDigest: sha256:71196408fc1f8f2484d8f3e52c2ce91e53d638a6c2e405cf38be3b0997419e82
+        sourceBlobDigest: sha256:46848db214c1988305b3687cd43c5f0ee56f8af6ea365ca197d63aa02e7ad317
         tags:
             - latest
             - 0.0.1
@@ -11,8 +11,8 @@ targets:
     gram-internal:
         source: Gram-Internal
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:5509c7bda46f380ef8decd893c47f50a9159f3016d379c801e1756586a9b641e
-        sourceBlobDigest: sha256:056b77259613ff1d7976a039c89f80b148566603814f1c76390850b33b42ebc4
+        sourceRevisionDigest: sha256:71196408fc1f8f2484d8f3e52c2ce91e53d638a6c2e405cf38be3b0997419e82
+        sourceBlobDigest: sha256:46848db214c1988305b3687cd43c5f0ee56f8af6ea365ca197d63aa02e7ad317
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: pinned

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.761.5
 sources:
     Gram-Internal:
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:5509c7bda46f380ef8decd893c47f50a9159f3016d379c801e1756586a9b641e
-        sourceBlobDigest: sha256:056b77259613ff1d7976a039c89f80b148566603814f1c76390850b33b42ebc4
+        sourceRevisionDigest: sha256:85c2c1bef9317175fbbc47a5bb77061ff167bcc374ed28e73c74265899544210
+        sourceBlobDigest: sha256:ccb1e1434f410d5308f476f2ad89f74a954a1a0d7c8b97bc9eb38f29b7ae5d19
         tags:
             - latest
             - 0.0.1
@@ -11,8 +11,8 @@ targets:
     gram-internal:
         source: Gram-Internal
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:71196408fc1f8f2484d8f3e52c2ce91e53d638a6c2e405cf38be3b0997419e82
-        sourceBlobDigest: sha256:46848db214c1988305b3687cd43c5f0ee56f8af6ea365ca197d63aa02e7ad317
+        sourceRevisionDigest: sha256:85c2c1bef9317175fbbc47a5bb77061ff167bcc374ed28e73c74265899544210
+        sourceBlobDigest: sha256:ccb1e1434f410d5308f476f2ad89f74a954a1a0d7c8b97bc9eb38f29b7ae5d19
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: pinned

--- a/client/dashboard/src/components/EnableLoggingOverlay.tsx
+++ b/client/dashboard/src/components/EnableLoggingOverlay.tsx
@@ -1,3 +1,4 @@
+import { RequireScope } from "@/components/require-scope";
 import { useState } from "react";
 import { Button, Icon } from "@speakeasy-api/moonshine";
 import { FeatureName } from "@gram/client/models/components";
@@ -68,14 +69,16 @@ export function EnableLoggingOverlay({ onEnabled }: EnableLoggingOverlayProps) {
             </p>
           </div>
         </div>
-        <Button onClick={handleEnable} disabled={isMutating}>
-          <Button.LeftIcon>
-            <Icon name="activity" className="size-4" />
-          </Button.LeftIcon>
-          <Button.Text>
-            {isMutating ? "Enabling..." : "Enable Logging"}
-          </Button.Text>
-        </Button>
+        <RequireScope scope="org:admin" level="component">
+          <Button onClick={handleEnable} disabled={isMutating}>
+            <Button.LeftIcon>
+              <Icon name="activity" className="size-4" />
+            </Button.LeftIcon>
+            <Button.Text>
+              {isMutating ? "Enabling..." : "Enable Logging"}
+            </Button.Text>
+          </Button>
+        </RequireScope>
         {mutationError && (
           <span className="text-destructive text-sm">{mutationError}</span>
         )}

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -94,7 +94,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 scope={["mcp:read", "mcp:write"]}
               />
               <ScopeGatedNavItem item={routes.clis} scope="build:read" />
-              <ScopeGatedNavItem item={routes.plugins} scope="build:read" />
               <ScopeGatedNavItem
                 item={routes.plugins}
                 scope={["build:read", "build:write"]}

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -140,6 +140,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <SidebarGroupLabel>settings</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
+              <ScopeGatedNavItem
+                item={routes.environments}
+                scope={["build:read", "build:write"]}
+              />
               <ScopeGatedNavItem item={routes.settings} scope="build:write" />
             </SidebarMenu>
           </SidebarGroupContent>

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavButton, NavMenu } from "@/components/nav-menu";
+import { NavButton } from "@/components/nav-menu";
 import {
   Sidebar,
   SidebarContent,
@@ -6,45 +6,49 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
+  SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { useSlugs } from "@/contexts/Sdk";
+import { Scope } from "@/hooks/useRBAC";
 import { useProductTier } from "@/hooks/useProductTier";
 import { AppRoute, useOrgRoutes, useRoutes } from "@/routes";
 import { useGetPeriodUsage } from "@gram/client/react-query";
 import { cn, Stack } from "@speakeasy-api/moonshine";
-import { Building2Icon, MinusIcon, TestTube2Icon } from "lucide-react";
+import { Building2Icon, MinusIcon, TestTube2Icon, Undo2 } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
+import { Link } from "react-router";
 import { RequireScope } from "./require-scope";
 import { FeatureRequestModal } from "./FeatureRequestModal";
 import { Button } from "./ui/button";
 import { Type } from "./ui/type";
 
+function ScopeGatedNavItem({
+  item,
+  scope,
+}: {
+  item: AppRoute;
+  scope: Scope | Scope[];
+}) {
+  return (
+    <SidebarMenuItem>
+      <RequireScope scope={scope} level="component" className="w-full">
+        <NavButton
+          title={item.title}
+          href={item.href()}
+          active={item.active}
+          Icon={item.Icon}
+        />
+      </RequireScope>
+    </SidebarMenuItem>
+  );
+}
+
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const routes = useRoutes();
   const { orgSlug } = useSlugs();
   const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
-
-  const settingsItems = [routes.settings] as AppRoute[];
-
-  const navGroups = {
-    connect: [routes.sources, routes.catalog, routes.playground] as AppRoute[],
-    build: [
-      routes.mcp,
-      routes.clis,
-      routes.slackApps,
-      routes.elements,
-      routes.plugins,
-    ],
-    observe: [
-      routes.observability,
-      routes.logs,
-      routes.chatSessions,
-      routes.hooks,
-    ],
-    security: [routes.riskOverview, routes.policyCenter],
-  };
 
   return (
     <Sidebar collapsible="offcanvas" {...props}>
@@ -52,33 +56,103 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupLabel>project</SidebarGroupLabel>
           <SidebarGroupContent>
-            <NavMenu items={[routes.home]} />
+            <SidebarMenu>
+              <ScopeGatedNavItem item={routes.home} scope="build:read" />
+            </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
-        {Object.entries(navGroups).map(([label, items]) => (
-          <SidebarGroup key={label}>
-            <SidebarGroupLabel>{label}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <NavMenu items={items} />
-            </SidebarGroupContent>
-          </SidebarGroup>
-        ))}
+        <SidebarGroup>
+          <SidebarGroupLabel>connect</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <ScopeGatedNavItem
+                item={routes.sources}
+                scope={["build:read", "build:write"]}
+              />
+              <ScopeGatedNavItem
+                item={routes.catalog}
+                scope={["build:read", "mcp:write"]}
+              />
+              <ScopeGatedNavItem
+                item={routes.playground}
+                scope={["mcp:read", "mcp:write", "mcp:connect"]}
+              />
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>build</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <ScopeGatedNavItem item={routes.elements} scope="build:read" />
+              <ScopeGatedNavItem
+                item={routes.mcp}
+                scope={["mcp:read", "mcp:write"]}
+              />
+              <ScopeGatedNavItem
+                item={routes.slackApps}
+                scope={["mcp:read", "mcp:write"]}
+              />
+              <ScopeGatedNavItem item={routes.clis} scope="build:read" />
+              <ScopeGatedNavItem
+                item={routes.plugins}
+                scope={["build:read", "build:write"]}
+              />
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>observe</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <ScopeGatedNavItem
+                item={routes.observability}
+                scope="build:read"
+              />
+              <ScopeGatedNavItem item={routes.logs} scope="build:read" />
+              <ScopeGatedNavItem
+                item={routes.chatSessions}
+                scope="build:read"
+              />
+              <ScopeGatedNavItem
+                item={routes.hooks}
+                scope={["build:read", "build:write"]}
+              />
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>security</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <ScopeGatedNavItem
+                item={routes.riskOverview}
+                scope="build:read"
+              />
+              <ScopeGatedNavItem
+                item={routes.policyCenter}
+                scope={["build:read", "build:write"]}
+              />
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
         <SidebarGroup>
           <SidebarGroupLabel>settings</SidebarGroupLabel>
           <SidebarGroupContent>
-            <NavMenu items={settingsItems}>
-              <RequireScope scope={["org:read", "org:admin"]} level="section">
-                <SidebarMenuItem>
-                  <NavButton
-                    title="Organization settings"
-                    href={`/${orgSlug}`}
-                    Icon={Building2Icon}
-                  />
-                </SidebarMenuItem>
-              </RequireScope>
-            </NavMenu>
+            <SidebarMenu>
+              <ScopeGatedNavItem item={routes.settings} scope="build:write" />
+            </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+        <div className="mt-auto px-2 py-3">
+          <Link
+            to={`/${orgSlug}`}
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 px-2 py-1 text-sm transition-colors hover:no-underline"
+          >
+            <Undo2 className="h-3.5 w-3.5" />
+            <span>Back to org</span>
+          </Link>
+        </div>
       </SidebarContent>
       <SidebarFooter>
         <FreeTierExceededNotification />

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -15,7 +15,7 @@ import { useProductTier } from "@/hooks/useProductTier";
 import { AppRoute, useOrgRoutes, useRoutes } from "@/routes";
 import { useGetPeriodUsage } from "@gram/client/react-query";
 import { cn, Stack } from "@speakeasy-api/moonshine";
-import { Building2Icon, MinusIcon, TestTube2Icon, Undo2 } from "lucide-react";
+import { MinusIcon, TestTube2Icon, Undo2 } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
 import { Link } from "react-router";

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -98,6 +98,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={routes.plugins}
                 scope={["build:read", "build:write"]}
               />
+              <ScopeGatedNavItem
+                item={routes.environments}
+                scope={["build:read", "build:write"]}
+              />
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -140,10 +144,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <SidebarGroupLabel>settings</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <ScopeGatedNavItem
-                item={routes.environments}
-                scope={["build:read", "build:write"]}
-              />
               <ScopeGatedNavItem item={routes.settings} scope="build:write" />
             </SidebarMenu>
           </SidebarGroupContent>

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -94,6 +94,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 scope={["mcp:read", "mcp:write"]}
               />
               <ScopeGatedNavItem item={routes.clis} scope="build:read" />
+              <ScopeGatedNavItem item={routes.plugins} scope="build:read" />
               <ScopeGatedNavItem
                 item={routes.plugins}
                 scope={["build:read", "build:write"]}

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -32,16 +32,16 @@ function ScopeGatedNavItem({
   scope: Scope | Scope[];
 }) {
   return (
-    <SidebarMenuItem>
-      <RequireScope scope={scope} level="section">
+    <RequireScope scope={scope} level="section">
+      <SidebarMenuItem>
         <NavButton
           title={item.title}
           href={item.href()}
           active={item.active}
           Icon={item.Icon}
         />
-      </RequireScope>
-    </SidebarMenuItem>
+      </SidebarMenuItem>
+    </RequireScope>
   );
 }
 

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -33,7 +33,7 @@ function ScopeGatedNavItem({
 }) {
   return (
     <SidebarMenuItem>
-      <RequireScope scope={scope} level="component" className="w-full">
+      <RequireScope scope={scope} level="section">
         <NavButton
           title={item.title}
           href={item.href()}

--- a/client/dashboard/src/components/content-error-boundary.tsx
+++ b/client/dashboard/src/components/content-error-boundary.tsx
@@ -14,6 +14,14 @@ function ContentErrorFallback({ error }: ContentErrorFallbackProps) {
   // Log error to our error handler for consistent logging
   handleError(error, { silent: true });
 
+  // Extract request URL from SDK errors (GramError / ServiceError)
+  const requestUrl =
+    "rawResponse" in error &&
+    error.rawResponse instanceof Response &&
+    error.rawResponse.url
+      ? error.rawResponse.url
+      : undefined;
+
   return (
     <Card className="m-8 w-full max-w-lg py-8">
       <Card.Header>
@@ -32,6 +40,11 @@ function ContentErrorFallback({ error }: ContentErrorFallbackProps) {
           <p className="text-muted-foreground font-mono text-sm">
             {error.message}
           </p>
+          {requestUrl && (
+            <p className="text-muted-foreground mt-2 font-mono text-xs break-all">
+              {requestUrl}
+            </p>
+          )}
         </div>
       </Card.Content>
       <Card.Footer className="justify-start">

--- a/client/dashboard/src/components/full-page-error.tsx
+++ b/client/dashboard/src/components/full-page-error.tsx
@@ -26,6 +26,13 @@ export function FullPageError({ error }: FullPageErrorProps) {
             <p className="text-muted-foreground font-mono text-xs break-all">
               {error.message}
             </p>
+            {"rawResponse" in error &&
+              error.rawResponse instanceof Response &&
+              error.rawResponse.url && (
+                <p className="text-muted-foreground mt-2 font-mono text-xs break-all">
+                  {error.rawResponse.url}
+                </p>
+              )}
           </div>
         </Stack>
 

--- a/client/dashboard/src/components/mcp_install_page/config_form.tsx
+++ b/client/dashboard/src/components/mcp_install_page/config_form.tsx
@@ -1,4 +1,5 @@
 import { CodeBlock } from "@/components/code";
+import { RequireScope } from "@/components/require-scope";
 import { Dialog } from "@/components/ui/dialog";
 import { Label as Heading } from "@/components/ui/label";
 import { Link } from "@/components/ui/link";
@@ -47,14 +48,16 @@ export function InstallPageConfigForm({
           setOpen(nextOpen);
         }}
       >
-        <Dialog.Trigger asChild>
-          <Button variant="secondary">
-            <Button.LeftIcon>
-              <Icon name="palette" />
-            </Button.LeftIcon>
-            <Button.Text>Edit Branding</Button.Text>
-          </Button>
-        </Dialog.Trigger>
+        <RequireScope scope="mcp:write" level="component">
+          <Dialog.Trigger asChild>
+            <Button variant="secondary">
+              <Button.LeftIcon>
+                <Icon name="palette" />
+              </Button.LeftIcon>
+              <Button.Text>Edit Branding</Button.Text>
+            </Button>
+          </Dialog.Trigger>
+        </RequireScope>
         <Dialog.Content>
           <Dialog.Header>
             <Dialog.Title>Install Page Configuration</Dialog.Title>

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -67,7 +67,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             <SidebarMenu>
               <ScopeGatedNavItem
                 item={orgRoutes.home}
-                scope={["build:read", "org:admin"]}
+                scope={["org:read", "build:read", "org:admin"]}
               />
             </SidebarMenu>
           </SidebarGroupContent>

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -30,16 +30,16 @@ function ScopeGatedNavItem({
   scope: Scope | Scope[];
 }) {
   return (
-    <SidebarMenuItem>
-      <RequireScope scope={scope} level="section">
+    <RequireScope scope={scope} level="section">
+      <SidebarMenuItem>
         <NavButton
           title={item.title}
           href={item.href()}
           active={item.active}
           Icon={item.Icon}
         />
-      </RequireScope>
-    </SidebarMenuItem>
+      </SidebarMenuItem>
+    </RequireScope>
   );
 }
 

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -31,7 +31,7 @@ function ScopeGatedNavItem({
 }) {
   return (
     <SidebarMenuItem>
-      <RequireScope scope={scope} level="component" className="w-full">
+      <RequireScope scope={scope} level="section">
         <NavButton
           title={item.title}
           href={item.href()}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavButton, NavMenu } from "@/components/nav-menu";
+import { NavButton } from "@/components/nav-menu";
 import { RequireScope } from "@/components/require-scope";
 import {
   Sidebar,
@@ -75,7 +75,12 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarGroup>
           <SidebarGroupLabel>explore</SidebarGroupLabel>
           <SidebarGroupContent>
-            <NavMenu items={[orgRoutes.collections]} />
+            <SidebarMenu>
+              <ScopeGatedNavItem
+                item={orgRoutes.collections}
+                scope="org:admin"
+              />
+            </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
         <SidebarGroup>

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -29,25 +29,23 @@ export function ProjectDashboard() {
     data: featuresData,
     isPending: isFeaturesPending,
     isError: isFeaturesError,
-  } = useFeaturesGet(undefined, undefined, { throwOnError: false });
+  } = useFeaturesGet();
   const logsEnabled = featuresData?.logsEnabled === true;
 
   const { data: overview, isPending: isOverviewPending } =
     useGetProjectOverview(
       { getProjectMetricsSummaryPayload: { from, to } },
       undefined,
-      { enabled: logsEnabled, throwOnError: false },
+      { enabled: logsEnabled },
     );
 
   const featuresSettled = !isFeaturesPending || isFeaturesError;
   const isOverviewLoading =
     !featuresSettled || (logsEnabled && isOverviewPending);
 
-  const { data: auditLogsData, isPending: isAuditLogsPending } = useAuditLogs(
-    { projectSlug },
-    undefined,
-    { throwOnError: false },
-  );
+  const { data: auditLogsData, isPending: isAuditLogsPending } = useAuditLogs({
+    projectSlug,
+  });
 
   const recentLogs = useMemo(
     () => (auditLogsData?.result.logs ?? []).slice(0, 10),

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -25,22 +25,29 @@ export function ProjectDashboard() {
   const to = useMemo(() => new Date(), []);
   const from = useMemo(() => subDays(to, 7), [to]);
 
-  const { data: featuresData, isPending: isFeaturesPending } = useFeaturesGet();
+  const {
+    data: featuresData,
+    isPending: isFeaturesPending,
+    isError: isFeaturesError,
+  } = useFeaturesGet(undefined, undefined, { throwOnError: false });
   const logsEnabled = featuresData?.logsEnabled === true;
 
   const { data: overview, isPending: isOverviewPending } =
     useGetProjectOverview(
       { getProjectMetricsSummaryPayload: { from, to } },
       undefined,
-      { enabled: logsEnabled },
+      { enabled: logsEnabled, throwOnError: false },
     );
 
+  const featuresSettled = !isFeaturesPending || isFeaturesError;
   const isOverviewLoading =
-    isFeaturesPending || (logsEnabled && isOverviewPending);
+    !featuresSettled || (logsEnabled && isOverviewPending);
 
-  const { data: auditLogsData, isPending: isAuditLogsPending } = useAuditLogs({
-    projectSlug,
-  });
+  const { data: auditLogsData, isPending: isAuditLogsPending } = useAuditLogs(
+    { projectSlug },
+    undefined,
+    { throwOnError: false },
+  );
 
   const recentLogs = useMemo(
     () => (auditLogsData?.result.logs ?? []).slice(0, 10),
@@ -48,14 +55,16 @@ export function ProjectDashboard() {
   );
 
   const isProjectEmpty =
-    logsEnabled &&
-    !isOverviewLoading &&
-    !isAuditLogsPending &&
-    !!overview &&
-    overview?.summary?.activeServersCount === 0 &&
-    overview?.summary?.totalToolCalls === 0;
+    isFeaturesError ||
+    (logsEnabled &&
+      !isOverviewLoading &&
+      !isAuditLogsPending &&
+      !!overview &&
+      overview?.summary?.activeServersCount === 0 &&
+      overview?.summary?.totalToolCalls === 0);
 
-  const showDisabledBanner = !isFeaturesPending && !logsEnabled;
+  const showDisabledBanner =
+    !isFeaturesPending && !isFeaturesError && !logsEnabled;
 
   return (
     <Page.Section>
@@ -81,7 +90,7 @@ export function ProjectDashboard() {
 
           {showDisabledBanner ? (
             <LoggingDisabledBanner settingsHref={orgRoutes.logs.href()} />
-          ) : (
+          ) : isFeaturesError ? null : (
             <>
               {/* Row 0: KPI Cards */}
               <div className="grid grid-cols-2 gap-4 md:grid-cols-4">

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -53,13 +53,12 @@ export function ProjectDashboard() {
   );
 
   const isProjectEmpty =
-    isFeaturesError ||
-    (logsEnabled &&
-      !isOverviewLoading &&
-      !isAuditLogsPending &&
-      !!overview &&
-      overview?.summary?.activeServersCount === 0 &&
-      overview?.summary?.totalToolCalls === 0);
+    logsEnabled &&
+    !isOverviewLoading &&
+    !isAuditLogsPending &&
+    !!overview &&
+    overview?.summary?.activeServersCount === 0 &&
+    overview?.summary?.totalToolCalls === 0;
 
   const showDisabledBanner =
     !isFeaturesPending && !isFeaturesError && !logsEnabled;
@@ -86,9 +85,11 @@ export function ProjectDashboard() {
             <ProjectOnboardingBanner />
           )}
 
-          {showDisabledBanner ? (
+          {showDisabledBanner && (
             <LoggingDisabledBanner settingsHref={orgRoutes.logs.href()} />
-          ) : isFeaturesError ? null : (
+          )}
+
+          {logsEnabled && (
             <>
               {/* Row 0: KPI Cards */}
               <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
@@ -253,13 +254,14 @@ export function ProjectDashboard() {
                   )}
                 </DashboardCard>
               </div>
-              <ActivityTimelineCard
-                logs={recentLogs}
-                isPending={isAuditLogsPending}
-                viewAllHref={orgRoutes.auditLogs.href()}
-              />
             </>
           )}
+
+          <ActivityTimelineCard
+            logs={recentLogs}
+            isPending={isAuditLogsPending}
+            viewAllHref={orgRoutes.auditLogs.href()}
+          />
         </div>
       </Page.Section.Body>
     </Page.Section>

--- a/client/dashboard/src/components/project/ProjectOnboarding.tsx
+++ b/client/dashboard/src/components/project/ProjectOnboarding.tsx
@@ -1,15 +1,14 @@
 import { useRoutes } from "@/routes";
-import { Card, Button, Icon } from "@speakeasy-api/moonshine";
+import { Button, Icon } from "@speakeasy-api/moonshine";
 
 export function ProjectOnboardingBanner() {
   const routes = useRoutes();
 
   return (
-    <Card className="bg-background p-8">
-      <Card.Header>
-        <h2 className="text-3xl font-light">Welcome</h2>
-      </Card.Header>
-      <Card.Content className="flex max-w-lg flex-col gap-8">
+    <div className="bg-background relative overflow-hidden rounded-lg border p-8">
+      <div className="bg-gradient-primary absolute inset-x-0 bottom-0 h-[3px]" />
+      <h2 className="mb-4 text-3xl font-light">Welcome</h2>
+      <div className="flex max-w-lg flex-col gap-8">
         <p className="text-muted-foreground text-base">
           Build and deploy MCP servers in minutes. Connect your APIs, browse
           popular integrations, or deploy a chat interface — all from one place.
@@ -32,7 +31,7 @@ export function ProjectOnboardingBanner() {
             </Button>
           </routes.catalog.Link>
         </div>
-      </Card.Content>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/client/dashboard/src/components/require-scope.tsx
+++ b/client/dashboard/src/components/require-scope.tsx
@@ -10,13 +10,20 @@ import {
   TooltipTrigger,
 } from "./ui/tooltip";
 
+type RenderFn = (props: { disabled: boolean }) => React.ReactNode;
+
 type RequireScopeProps = {
   scope: Scope | Scope[];
   /** When true, ALL scopes must be present. Default: false (any scope suffices). */
   all?: boolean;
   /** Optional resource ID to check scope against. */
   resourceId?: string;
-  children: React.ReactNode;
+  /**
+   * Either a React node or a render function receiving `{ disabled }`.
+   * Use the render function form when children contain portals (e.g. dropdowns,
+   * dialogs) that escape CSS containment and need to receive disabled state directly.
+   */
+  children: React.ReactNode | RenderFn;
 } & (
   | {
       /**
@@ -49,6 +56,9 @@ export function RequireScope(props: RequireScopeProps) {
     ? hasAllScopes(scopes, resourceId)
     : hasAnyScope(scopes, resourceId);
 
+  const resolveChildren = (disabled: boolean): React.ReactNode =>
+    typeof children === "function" ? children({ disabled }) : children;
+
   // While grants are loading, render nothing to avoid flash of unauthorized
   if (isLoading) {
     if (level === "page") return null;
@@ -56,13 +66,13 @@ export function RequireScope(props: RequireScopeProps) {
     // For component-level, show disabled state while loading
     return (
       <div className="pointer-events-none opacity-50 select-none">
-        {children}
+        {resolveChildren(true)}
       </div>
     );
   }
 
   if (allowed) {
-    return <>{children}</>;
+    return <>{resolveChildren(false)}</>;
   }
 
   switch (level) {
@@ -75,7 +85,7 @@ export function RequireScope(props: RequireScopeProps) {
     case "component":
       return (
         <ScopeDisabled reason={props.reason} className={props.className}>
-          {children}
+          {resolveChildren(true)}
         </ScopeDisabled>
       );
   }

--- a/client/dashboard/src/components/server-enable-dialog.tsx
+++ b/client/dashboard/src/components/server-enable-dialog.tsx
@@ -25,9 +25,7 @@ export function ServerEnableDialog({
 }: ServerEnableDialogProps) {
   const productTier = useProductTier();
   const orgRoutes = useOrgRoutes();
-  const { data: periodUsage } = useGetPeriodUsage(undefined, undefined, {
-    throwOnError: false,
-  });
+  const { data: periodUsage } = useGetPeriodUsage();
 
   const handleConfirm = () => {
     onConfirm();

--- a/client/dashboard/src/components/server-enable-dialog.tsx
+++ b/client/dashboard/src/components/server-enable-dialog.tsx
@@ -25,7 +25,9 @@ export function ServerEnableDialog({
 }: ServerEnableDialogProps) {
   const productTier = useProductTier();
   const orgRoutes = useOrgRoutes();
-  const { data: periodUsage } = useGetPeriodUsage();
+  const { data: periodUsage } = useGetPeriodUsage(undefined, undefined, {
+    throwOnError: false,
+  });
 
   const handleConfirm = () => {
     onConfirm();

--- a/client/dashboard/src/components/sources/SourceCard.tsx
+++ b/client/dashboard/src/components/sources/SourceCard.tsx
@@ -6,6 +6,7 @@ import {
 import { DotCard } from "@/components/ui/dot-card";
 import { MoreActions } from "@/components/ui/more-actions";
 import { Type } from "@/components/ui/type";
+import { useRBAC } from "@/hooks/useRBAC";
 import { sourceTypeToUrnKind } from "@/lib/sources";
 import { useRoutes } from "@/routes";
 import { Asset } from "@gram/client/models/components";
@@ -59,6 +60,8 @@ export function SourceCard({
   setChangeDocumentTargetSlug: (slug: string) => void;
 }) {
   const routes = useRoutes();
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("build:write");
   const config = sourceTypeConfig[asset.type];
 
   const sourceKind = sourceTypeToUrnKind(asset.type);
@@ -75,6 +78,7 @@ export function SourceCard({
             label: "Update",
             onClick: () => setChangeDocumentTargetSlug(asset.slug),
             icon: "upload" as const,
+            disabled: !canWrite,
           },
         ]
       : []),
@@ -92,6 +96,7 @@ export function SourceCard({
       onClick: () => handleRemove(asset.id),
       icon: "trash" as const,
       destructive: true,
+      disabled: !canWrite,
     },
   ];
 

--- a/client/dashboard/src/components/sources/SourceTableRow.tsx
+++ b/client/dashboard/src/components/sources/SourceTableRow.tsx
@@ -1,6 +1,7 @@
 import { DotRow } from "@/components/ui/dot-row";
 import { MoreActions } from "@/components/ui/more-actions";
 import { Type } from "@/components/ui/type";
+import { useRBAC } from "@/hooks/useRBAC";
 import { sourceTypeToUrnKind } from "@/lib/sources";
 import { useRoutes } from "@/routes";
 import { Badge } from "@speakeasy-api/moonshine";
@@ -40,6 +41,8 @@ export function SourceTableRow({
   setChangeDocumentTargetSlug: (slug: string) => void;
 }) {
   const routes = useRoutes();
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("build:write");
   const config = sourceTypeConfig[asset.type];
   const sourceKind = sourceTypeToUrnKind(asset.type);
 
@@ -58,6 +61,7 @@ export function SourceTableRow({
             label: "Update",
             onClick: () => setChangeDocumentTargetSlug(asset.slug),
             icon: "upload" as const,
+            disabled: !canWrite,
           },
         ]
       : []),
@@ -75,6 +79,7 @@ export function SourceTableRow({
       onClick: () => handleRemove(asset.id),
       icon: "trash" as const,
       destructive: true,
+      disabled: !canWrite,
     },
   ];
 

--- a/client/dashboard/src/components/sources/Sources.tsx
+++ b/client/dashboard/src/components/sources/Sources.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { DotTable } from "@/components/ui/dot-table";
 import { ViewToggle } from "@/components/ui/view-toggle";
 import { useViewMode } from "@/components/ui/use-view-mode";
@@ -234,65 +235,71 @@ export default function Sources() {
           <DeploymentsButton deploymentId={deployment?.id} />
         </Page.Section.CTA>
         <Page.Section.CTA>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="secondary">
-                <Button.LeftIcon>
-                  <Plus className="h-4 w-4" />
-                </Button.LeftIcon>
-                <Button.Text>Add Source</Button.Text>
-                <Button.RightIcon>
-                  <ChevronDown className="h-4 w-4" />
-                </Button.RightIcon>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-[320px] p-1">
-              <DropdownMenuItem
-                onSelect={() => routes.sources.addOpenAPI.goTo()}
-                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-              >
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 dark:bg-blue-500/20">
-                  <FileCode className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  <span className="font-medium">From your API</span>
-                  <span className="text-muted-foreground text-xs">
-                    Upload an OpenAPI spec to generate tools
-                  </span>
-                </div>
-              </DropdownMenuItem>
-              {isFunctionsEnabled && (
-                <DropdownMenuItem
-                  onSelect={() => routes.sources.addFunction.goTo()}
-                  className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-                >
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20">
-                    <Code className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-                  </div>
-                  <div className="flex flex-col gap-0.5">
-                    <span className="font-medium">Write custom code</span>
-                    <span className="text-muted-foreground text-xs">
-                      Create tools with TypeScript functions
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem
-                onSelect={() => routes.sources.addFromCatalog.goTo()}
-                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-              >
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
-                  <Server className="h-5 w-5 text-violet-600 dark:text-violet-400" />
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  <span className="font-medium">Third party server</span>
-                  <span className="text-muted-foreground text-xs">
-                    Add pre-built servers from the catalog
-                  </span>
-                </div>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <RequireScope scope="build:write" level="component">
+            {({ disabled }) => (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild disabled={disabled}>
+                  <Button variant="secondary">
+                    <Button.LeftIcon>
+                      <Plus className="h-4 w-4" />
+                    </Button.LeftIcon>
+                    <Button.Text>Add Source</Button.Text>
+                    <Button.RightIcon>
+                      <ChevronDown className="h-4 w-4" />
+                    </Button.RightIcon>
+                  </Button>
+                </DropdownMenuTrigger>
+                {!disabled && (
+                  <DropdownMenuContent align="end" className="w-[320px] p-1">
+                    <DropdownMenuItem
+                      onSelect={() => routes.sources.addOpenAPI.goTo()}
+                      className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                    >
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 dark:bg-blue-500/20">
+                        <FileCode className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">From your API</span>
+                        <span className="text-muted-foreground text-xs">
+                          Upload an OpenAPI spec to generate tools
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
+                    {isFunctionsEnabled && (
+                      <DropdownMenuItem
+                        onSelect={() => routes.sources.addFunction.goTo()}
+                        className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                      >
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20">
+                          <Code className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                        </div>
+                        <div className="flex flex-col gap-0.5">
+                          <span className="font-medium">Write custom code</span>
+                          <span className="text-muted-foreground text-xs">
+                            Create tools with TypeScript functions
+                          </span>
+                        </div>
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      onSelect={() => routes.sources.addFromCatalog.goTo()}
+                      className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                    >
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
+                        <Server className="h-5 w-5 text-violet-600 dark:text-violet-400" />
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">Third party server</span>
+                        <span className="text-muted-foreground text-xs">
+                          Add pre-built servers from the catalog
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                )}
+              </DropdownMenu>
+            )}
+          </RequireScope>
         </Page.Section.CTA>
         <Page.Section.Body>
           {isLoading ? (

--- a/client/dashboard/src/components/sources/SourcesEmptyState.tsx
+++ b/client/dashboard/src/components/sources/SourcesEmptyState.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Type } from "@/components/ui/type";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
@@ -44,63 +45,69 @@ export function SourcesEmptyState() {
             Add an OpenAPI spec, custom function, or third-party server to
             generate tools for your MCP server.
           </Type>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button>
-                <Button.LeftIcon>
-                  <Plus className="h-4 w-4" />
-                </Button.LeftIcon>
-                <Button.Text>Add Source</Button.Text>
-                <ChevronDown className="ml-1 h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="center" className="w-[320px] p-1">
-              <DropdownMenuItem
-                onSelect={() => routes.sources.addOpenAPI.goTo()}
-                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-              >
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 dark:bg-blue-500/20">
-                  <FileCode className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  <span className="font-medium">From your API</span>
-                  <span className="text-muted-foreground text-xs">
-                    Upload an OpenAPI spec to generate tools
-                  </span>
-                </div>
-              </DropdownMenuItem>
-              {isFunctionsEnabled && (
-                <DropdownMenuItem
-                  onSelect={() => routes.sources.addFunction.goTo()}
-                  className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-                >
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20">
-                    <Code className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-                  </div>
-                  <div className="flex flex-col gap-0.5">
-                    <span className="font-medium">Write custom code</span>
-                    <span className="text-muted-foreground text-xs">
-                      Create tools with TypeScript functions
-                    </span>
-                  </div>
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem
-                onSelect={() => routes.sources.addFromCatalog.goTo()}
-                className="flex cursor-pointer items-start gap-3 rounded-md p-2"
-              >
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
-                  <Server className="h-5 w-5 text-violet-600 dark:text-violet-400" />
-                </div>
-                <div className="flex flex-col gap-0.5">
-                  <span className="font-medium">Third party server</span>
-                  <span className="text-muted-foreground text-xs">
-                    Add pre-built servers from the catalog
-                  </span>
-                </div>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <RequireScope scope="build:write" level="component">
+            {({ disabled }) => (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild disabled={disabled}>
+                  <Button>
+                    <Button.LeftIcon>
+                      <Plus className="h-4 w-4" />
+                    </Button.LeftIcon>
+                    <Button.Text>Add Source</Button.Text>
+                    <ChevronDown className="ml-1 h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                {!disabled && (
+                  <DropdownMenuContent align="center" className="w-[320px] p-1">
+                    <DropdownMenuItem
+                      onSelect={() => routes.sources.addOpenAPI.goTo()}
+                      className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                    >
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10 dark:bg-blue-500/20">
+                        <FileCode className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">From your API</span>
+                        <span className="text-muted-foreground text-xs">
+                          Upload an OpenAPI spec to generate tools
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
+                    {isFunctionsEnabled && (
+                      <DropdownMenuItem
+                        onSelect={() => routes.sources.addFunction.goTo()}
+                        className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                      >
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 dark:bg-emerald-500/20">
+                          <Code className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                        </div>
+                        <div className="flex flex-col gap-0.5">
+                          <span className="font-medium">Write custom code</span>
+                          <span className="text-muted-foreground text-xs">
+                            Create tools with TypeScript functions
+                          </span>
+                        </div>
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      onSelect={() => routes.sources.addFromCatalog.goTo()}
+                      className="flex cursor-pointer items-start gap-3 rounded-md p-2"
+                    >
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 dark:bg-violet-500/20">
+                        <Server className="h-5 w-5 text-violet-600 dark:text-violet-400" />
+                      </div>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">Third party server</span>
+                        <span className="text-muted-foreground text-xs">
+                          Add pre-built servers from the catalog
+                        </span>
+                      </div>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                )}
+              </DropdownMenu>
+            )}
+          </RequireScope>
         </div>
       </Page.Section.Body>
     </Page.Section>

--- a/client/dashboard/src/components/tool-list/ToolList.tsx
+++ b/client/dashboard/src/components/tool-list/ToolList.tsx
@@ -47,6 +47,8 @@ interface ToolListProps {
   onCreateToolset?: (toolUrns: string[]) => void;
   onTestInPlayground?: () => void;
   className?: string;
+  /** When true, hides action menus and selection checkboxes for a view-only presentation. */
+  readOnly?: boolean;
   // Selection mode props for AddToolsDialog
   selectionMode?: "add" | "remove";
   selectedUrns?: string[];
@@ -266,6 +268,7 @@ function ToolRow({
   onTestInPlayground,
   onRemove,
   onToolClick,
+  readOnly,
 }: {
   tool: Tool;
   availableToolUrns?: string[];
@@ -277,6 +280,7 @@ function ToolRow({
   onTestInPlayground?: () => void;
   onRemove?: () => void;
   onToolClick?: (tool: Tool) => void;
+  readOnly?: boolean;
 }) {
   const isDisabled = false;
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -411,15 +415,19 @@ function ToolRow({
         onClick={() => onToolClick?.(tool)}
       >
         <div className="flex min-w-0 flex-[0_1_60%] items-center gap-4">
-          <Checkbox
-            checked={isSelected}
-            onCheckedChange={onCheckboxChange}
-            onClick={(e) => e.stopPropagation()}
-            className={cn(
-              "shrink-0 transition-opacity",
-              !isSelected && !isFocused && "opacity-0 group-hover:opacity-100",
-            )}
-          />
+          {!readOnly && (
+            <Checkbox
+              checked={isSelected}
+              onCheckedChange={onCheckboxChange}
+              onClick={(e) => e.stopPropagation()}
+              className={cn(
+                "shrink-0 transition-opacity",
+                !isSelected &&
+                  !isFocused &&
+                  "opacity-0 group-hover:opacity-100",
+              )}
+            />
+          )}
           <div className="flex min-w-0 flex-1 flex-col">
             <Stack direction="horizontal" gap={2} align="center">
               <p className="text-foreground truncate text-sm leading-6">
@@ -448,7 +456,7 @@ function ToolRow({
               availableToolUrns={availableToolUrns ?? []}
             />
           )}
-          <MoreActions actions={actions} />
+          {!readOnly && <MoreActions actions={actions} />}
         </div>
       </div>
 
@@ -689,6 +697,7 @@ export function ToolList({
   onCreateToolset,
   onTestInPlayground,
   className,
+  readOnly,
   selectionMode,
   selectedUrns = [],
   onSelectionChange,
@@ -1040,6 +1049,7 @@ export function ToolList({
                             : undefined
                         }
                         onToolClick={onToolClick}
+                        readOnly={readOnly}
                       />
                     );
                   })}

--- a/client/dashboard/src/components/tool-list/ToolList.tsx
+++ b/client/dashboard/src/components/tool-list/ToolList.tsx
@@ -620,6 +620,7 @@ function ToolGroupHeader({
   isFirstGroup = false,
   allSelected,
   onSelectAll,
+  readOnly,
 }: {
   group: ToolGroup;
   isExpanded: boolean;
@@ -627,6 +628,7 @@ function ToolGroupHeader({
   isFirstGroup?: boolean;
   allSelected: boolean;
   onSelectAll: () => void;
+  readOnly?: boolean;
 }) {
   const Icon = getIcon(group.icon);
 
@@ -648,25 +650,27 @@ function ToolGroupHeader({
           <Icon
             className={cn(
               "absolute inset-0 size-4 transition-opacity",
-              "group-hover/header:opacity-0",
+              !readOnly && "group-hover/header:opacity-0",
             )}
             strokeWidth={1.5}
           />
-          <SimpleTooltip
-            tooltip={`${allSelected ? "Deselect" : "Select"} ${group.tools.length} tools`}
-          >
-            <Checkbox
-              checked={allSelected}
-              onCheckedChange={onSelectAll}
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-              className={cn(
-                "absolute inset-0 opacity-0 transition-opacity",
-                "group-hover/header:opacity-100",
-              )}
-            />
-          </SimpleTooltip>
+          {!readOnly && (
+            <SimpleTooltip
+              tooltip={`${allSelected ? "Deselect" : "Select"} ${group.tools.length} tools`}
+            >
+              <Checkbox
+                checked={allSelected}
+                onCheckedChange={onSelectAll}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
+                className={cn(
+                  "absolute inset-0 opacity-0 transition-opacity",
+                  "group-hover/header:opacity-100",
+                )}
+              />
+            </SimpleTooltip>
+          )}
         </div>
         <p className="text-foreground text-sm leading-6">{group.title}</p>
       </button>
@@ -1016,6 +1020,7 @@ export function ToolList({
                 isFirstGroup={index === 0}
                 allSelected={allSelected}
                 onSelectAll={() => handleSelectAllInGroup(group)}
+                readOnly={readOnly}
               />
               {expandedGroups.has(index) && (
                 <div className="w-full">

--- a/client/dashboard/src/components/ui/sidebar.tsx
+++ b/client/dashboard/src/components/ui/sidebar.tsx
@@ -371,7 +371,11 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn(
+        "relative flex w-full min-w-0 flex-col p-2",
+        "not-has-[[data-sidebar=menu-item]]:hidden",
+        className,
+      )}
       {...props}
     />
   );

--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -1,5 +1,6 @@
 import { handleError } from "@/lib/errors";
 import { Gram } from "@gram/client";
+import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { QueryClient } from "@tanstack/react-query";
 import { createContext, useContext } from "react";
 import { useLocation, useParams } from "react-router";
@@ -25,7 +26,11 @@ const createQueryClient = () =>
   new QueryClient({
     defaultOptions: {
       queries: {
-        throwOnError: true,
+        // Suppress 403s so RBAC-restricted queries degrade gracefully
+        // instead of crashing the page. All other errors still throw to
+        // the nearest error boundary.
+        throwOnError: (error) =>
+          !(error instanceof GramError && error.statusCode === 403),
         retry: (failureCount, error: Error) => {
           // Don't retry on 4xx errors
           if (error && typeof error === "object") {

--- a/client/dashboard/src/hooks/toolTypes.ts
+++ b/client/dashboard/src/hooks/toolTypes.ts
@@ -40,7 +40,6 @@ function detectToolsetKind(tools: GeneratedTool[]): ToolsetKind {
 export function useToolset(toolsetSlug: string | undefined) {
   const result = useToolsetQuery({ slug: toolsetSlug! }, undefined, {
     enabled: !!toolsetSlug,
-    throwOnError: false,
   });
 
   const kind = detectToolsetKind(result.data?.tools ?? []);
@@ -65,10 +64,7 @@ export function useListTools(
   security?: ListToolsSecurity,
   options?: QueryHookOptions<ListToolsQueryData, ListToolsQueryError>,
 ) {
-  const result = useListToolsQuery(request, security, {
-    throwOnError: false,
-    ...options,
-  });
+  const result = useListToolsQuery(request, security, options);
 
   return {
     ...result,
@@ -112,7 +108,6 @@ export function useLatestDeployment(
 ) {
   return useLatestDeploymentQuery(undefined, undefined, {
     staleTime: 1000 * 60 * 60, // 1 hour
-    throwOnError: false,
     ...options,
   });
 }

--- a/client/dashboard/src/hooks/toolTypes.ts
+++ b/client/dashboard/src/hooks/toolTypes.ts
@@ -108,6 +108,7 @@ export function useLatestDeployment(
 ) {
   return useLatestDeploymentQuery(undefined, undefined, {
     staleTime: 1000 * 60 * 60, // 1 hour
+    throwOnError: false,
     ...options,
   });
 }

--- a/client/dashboard/src/hooks/toolTypes.ts
+++ b/client/dashboard/src/hooks/toolTypes.ts
@@ -40,6 +40,7 @@ function detectToolsetKind(tools: GeneratedTool[]): ToolsetKind {
 export function useToolset(toolsetSlug: string | undefined) {
   const result = useToolsetQuery({ slug: toolsetSlug! }, undefined, {
     enabled: !!toolsetSlug,
+    throwOnError: false,
   });
 
   const kind = detectToolsetKind(result.data?.tools ?? []);
@@ -64,7 +65,10 @@ export function useListTools(
   security?: ListToolsSecurity,
   options?: QueryHookOptions<ListToolsQueryData, ListToolsQueryError>,
 ) {
-  const result = useListToolsQuery(request, security, options);
+  const result = useListToolsQuery(request, security, {
+    throwOnError: false,
+    ...options,
+  });
 
   return {
     ...result,

--- a/client/dashboard/src/pages/CLIs.tsx
+++ b/client/dashboard/src/pages/CLIs.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Type } from "@/components/ui/type";
 import { Icon } from "@speakeasy-api/moonshine";
 
@@ -9,21 +10,23 @@ export default function CLIs() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <div className="bg-muted/20 m-8 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-24">
-          <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
-            <Icon name="terminal" className="text-muted-foreground h-6 w-6" />
+        <RequireScope scope="build:read" level="page">
+          <div className="bg-muted/20 m-8 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-24">
+            <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+              <Icon name="terminal" className="text-muted-foreground h-6 w-6" />
+            </div>
+            <Type variant="subheading" className="mb-1">
+              Skills
+            </Type>
+            <Type small muted className="mb-4 max-w-md text-center">
+              Build and distribute skills with your team. Track usage, enable
+              discovery and improve performance.
+            </Type>
+            <Type small muted>
+              Coming soon
+            </Type>
           </div>
-          <Type variant="subheading" className="mb-1">
-            Skills
-          </Type>
-          <Type small muted className="mb-4 max-w-md text-center">
-            Build and distribute skills with your team. Track usage, enable
-            discovery and improve performance.
-          </Type>
-          <Type small muted>
-            Coming soon
-          </Type>
-        </div>
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/CLIs.tsx
+++ b/client/dashboard/src/pages/CLIs.tsx
@@ -11,21 +11,29 @@ export default function CLIs() {
       </Page.Header>
       <Page.Body>
         <RequireScope scope="build:read" level="page">
-          <div className="bg-muted/20 m-8 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-24">
-            <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
-              <Icon name="terminal" className="text-muted-foreground h-6 w-6" />
-            </div>
-            <Type variant="subheading" className="mb-1">
-              Skills
-            </Type>
-            <Type small muted className="mb-4 max-w-md text-center">
+          <Page.Section>
+            <Page.Section.Title>Skills</Page.Section.Title>
+            <Page.Section.Description>
               Build and distribute skills with your team. Track usage, enable
               discovery and improve performance.
-            </Type>
-            <Type small muted>
-              Coming soon
-            </Type>
-          </div>
+            </Page.Section.Description>
+            <Page.Section.Body>
+              <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+                <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+                  <Icon
+                    name="terminal"
+                    className="text-muted-foreground h-6 w-6"
+                  />
+                </div>
+                <Type variant="subheading" className="mb-1">
+                  No skills yet
+                </Type>
+                <Type small muted className="max-w-md text-center">
+                  Coming soon
+                </Type>
+              </div>
+            </Page.Section.Body>
+          </Page.Section>
         </RequireScope>
       </Page.Body>
     </Page>

--- a/client/dashboard/src/pages/catalog/Catalog.tsx
+++ b/client/dashboard/src/pages/catalog/Catalog.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { DotTable } from "@/components/ui/dot-table";
 import { Heading } from "@/components/ui/heading";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -30,6 +31,14 @@ export function CatalogRoot() {
 }
 
 export default function Catalog() {
+  return (
+    <RequireScope scope={["build:read", "mcp:write"]} level="page">
+      <CatalogInner />
+    </RequireScope>
+  );
+}
+
+function CatalogInner() {
   const routes = useRoutes();
   const project = useProject();
   const [searchQuery, setSearchQuery] = useState("");

--- a/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
@@ -1,4 +1,5 @@
 import { InsightsConfig } from "@/components/insights-sidebar";
+import { RequireScope } from "@/components/require-scope";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { Page } from "@/components/page-layout";
@@ -124,6 +125,14 @@ function isValidPreset(value: string | null): value is DateRangePreset {
 }
 
 export default function ChatLogs() {
+  return (
+    <RequireScope scope="build:read" level="page">
+      <ChatLogsInner />
+    </RequireScope>
+  );
+}
+
+function ChatLogsInner() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedChat, setSelectedChat] =
     useState<ChatOverviewWithResolutions | null>(null);

--- a/client/dashboard/src/pages/collections/Collections.tsx
+++ b/client/dashboard/src/pages/collections/Collections.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { CreateResourceCard } from "@/components/create-resource-card";
 import { Type } from "@/components/ui/type";
 import { Input, Stack } from "@speakeasy-api/moonshine";
@@ -25,45 +26,47 @@ export default function Collections() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <Page.Section>
-          <Page.Section.Title>Collections</Page.Section.Title>
-          <Page.Section.Description>
-            Collections allow you to create reusable configurations of multiple
-            MCP servers to install into multiple projects in one go.
-          </Page.Section.Description>
-          <Page.Section.Body>
-            <Stack direction="vertical" gap={4}>
-              <div className="flex items-center gap-3">
-                <div className="relative w-64">
-                  <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-                  <Input
-                    placeholder="Search collections..."
-                    value={searchQuery}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setSearchQuery(e.target.value)
-                    }
-                    className="h-10 pr-9 pl-10"
-                  />
-                  {searchQuery && (
-                    <button
-                      onClick={() => setSearchQuery("")}
-                      className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
-                      aria-label="Clear search"
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  )}
+        <RequireScope scope="org:admin" level="page">
+          <Page.Section>
+            <Page.Section.Title>Collections</Page.Section.Title>
+            <Page.Section.Description>
+              Collections allow you to create reusable configurations of
+              multiple MCP servers to install into multiple projects in one go.
+            </Page.Section.Description>
+            <Page.Section.Body>
+              <Stack direction="vertical" gap={4}>
+                <div className="flex items-center gap-3">
+                  <div className="relative w-64">
+                    <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+                    <Input
+                      placeholder="Search collections..."
+                      value={searchQuery}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        setSearchQuery(e.target.value)
+                      }
+                      className="h-10 pr-9 pl-10"
+                    />
+                    {searchQuery && (
+                      <button
+                        onClick={() => setSearchQuery("")}
+                        className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 transition-colors"
+                        aria-label="Clear search"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    )}
+                  </div>
                 </div>
-              </div>
 
-              <CollectionGrid
-                collections={collections}
-                searchQuery={searchQuery}
-                onCreate={handleCreateCollection}
-              />
-            </Stack>
-          </Page.Section.Body>
-        </Page.Section>
+                <CollectionGrid
+                  collections={collections}
+                  searchQuery={searchQuery}
+                  onCreate={handleCreateCollection}
+                />
+              </Stack>
+            </Page.Section.Body>
+          </Page.Section>
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/collections/Collections.tsx
+++ b/client/dashboard/src/pages/collections/Collections.tsx
@@ -88,14 +88,12 @@ function CollectionGrid({
 
   if (collections.length === 0) {
     return (
-      <div className="space-y-8 pt-6">
+      <div className="space-y-4">
         {searchQuery ? (
-          <Type muted className="text-center">
-            No collections matching &ldquo;{searchQuery}&rdquo;
-          </Type>
+          <Type muted>No collections matching &ldquo;{searchQuery}&rdquo;</Type>
         ) : null}
-        <div className="flex justify-center">
-          <div className="w-full max-w-md">{createCard}</div>
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+          {createCard}
         </div>
       </div>
     );

--- a/client/dashboard/src/pages/deployments/Deployments.tsx
+++ b/client/dashboard/src/pages/deployments/Deployments.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
 import { useRoutes } from "@/routes";
 import { useListDeploymentsSuspense } from "@gram/client/react-query";
@@ -26,9 +27,11 @@ export default function DeploymentsPage() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <Suspense fallback={<div>Loading...</div>}>
-          <DeploymentsTable />
-        </Suspense>
+        <RequireScope scope={["build:read", "build:write"]} level="page">
+          <Suspense fallback={<div>Loading...</div>}>
+            <DeploymentsTable />
+          </Suspense>
+        </RequireScope>
       </Page.Body>
     </Page>
   );
@@ -94,26 +97,28 @@ function DeploymentActionsDropdown({
     : actionText;
 
   return (
-    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button variant="tertiary" size="sm" className="h-8 w-8 p-0">
-          <Button.LeftIcon>
-            <Icon name="ellipsis" className="size-4" />
-          </Button.LeftIcon>
-          <Button.Text className="sr-only">Open menu</Button.Text>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={handleRedeploy}
-          disabled={redeployMutation.isPending}
-          className="cursor-pointer"
-        >
-          <Icon name="refresh-cw" className="mr-2 size-4" />
-          {buttonText}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <RequireScope scope="build:write" level="section">
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="tertiary" size="sm" className="h-8 w-8 p-0">
+            <Button.LeftIcon>
+              <Icon name="ellipsis" className="size-4" />
+            </Button.LeftIcon>
+            <Button.Text className="sr-only">Open menu</Button.Text>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={handleRedeploy}
+            disabled={redeployMutation.isPending}
+            className="cursor-pointer"
+          >
+            <Icon name="refresh-cw" className="mr-2 size-4" />
+            {buttonText}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </RequireScope>
   );
 }
 

--- a/client/dashboard/src/pages/deployments/deployment/Deployment.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/Deployment.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { dateTimeFormatters } from "@/lib/dates";
@@ -178,7 +179,9 @@ const HeadingSection = () => {
   return (
     <div className="flex items-center justify-between">
       <Heading variant="h1">Deployment Overview</Heading>
-      <RedeployButton />
+      <RequireScope scope="build:write" level="section">
+        <RedeployButton />
+      </RequireScope>
     </div>
   );
 };

--- a/client/dashboard/src/pages/deployments/deployment/FailedSourcesSection.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/FailedSourcesSection.tsx
@@ -1,3 +1,4 @@
+import { RequireScope } from "@/components/require-scope";
 import { Checkbox } from "@/components/ui/checkbox";
 import type { FailedSource } from "@/components/sources/useFailedDeploymentSources";
 import { cn } from "@/lib/utils";
@@ -278,24 +279,26 @@ export function FailedSourcesSection({
 
         {failedSources.length > 0 && (
           <div className="flex justify-end">
-            <Button
-              variant="destructive-primary"
-              onClick={handleRemoveClick}
-              disabled={pending || selected.size === 0}
-            >
-              {pending ? (
-                <>
-                  <Button.LeftIcon>
-                    <Loader2 className="size-4 animate-spin" />
-                  </Button.LeftIcon>
-                  <Button.Text>Removing...</Button.Text>
-                </>
-              ) : (
-                <Button.Text>
-                  {`Remove ${selected.size > 0 ? selected.size : ""} source${selected.size !== 1 ? "s" : ""}`}
-                </Button.Text>
-              )}
-            </Button>
+            <RequireScope scope="build:write" level="component">
+              <Button
+                variant="destructive-primary"
+                onClick={handleRemoveClick}
+                disabled={pending || selected.size === 0}
+              >
+                {pending ? (
+                  <>
+                    <Button.LeftIcon>
+                      <Loader2 className="size-4 animate-spin" />
+                    </Button.LeftIcon>
+                    <Button.Text>Removing...</Button.Text>
+                  </>
+                ) : (
+                  <Button.Text>
+                    {`Remove ${selected.size > 0 ? selected.size : ""} source${selected.size !== 1 ? "s" : ""}`}
+                  </Button.Text>
+                )}
+              </Button>
+            </RequireScope>
           </div>
         )}
       </section>

--- a/client/dashboard/src/pages/deployments/deployment/ToolsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/ToolsTabContent.tsx
@@ -18,7 +18,7 @@ export const ToolsTabContent = ({ deploymentId }: { deploymentId: string }) => {
       <Heading variant="h2" className="mb-6">
         Tools
       </Heading>
-      <ToolList tools={toolDefinitions} />
+      <ToolList tools={toolDefinitions} readOnly />
     </div>
   );
 };

--- a/client/dashboard/src/pages/elements/Elements.tsx
+++ b/client/dashboard/src/pages/elements/Elements.tsx
@@ -3,6 +3,7 @@ import {
   CodeBlockCopyButton,
 } from "@/components/ai-elements/code-block";
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -183,6 +184,21 @@ function SwitchField({
 }
 
 export default function ChatElements() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope="build:read" level="page">
+          <ChatElementsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function ChatElementsInner() {
   const { projectSlug } = useSlugs();
   const session = useSession();
   const project = useProject();
@@ -337,449 +353,433 @@ export default function ChatElements() {
   };
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>
-        <Page.Section>
-          <Page.Section.Title>Chat Elements</Page.Section.Title>
-          <Page.Section.Description>
-            Embeddable AI chat experience for your applications
-          </Page.Section.Description>
-          <Page.Section.Body>
-            {/* Top-level tabs: Manual vs Hosted */}
-            <div className="border-border mt-3 overflow-hidden rounded-lg border p-0">
-              <Tabs
-                value={installMethod}
-                onValueChange={(v) =>
-                  setInstallMethod(v as "manual" | "hosted")
-                }
-                className="gap-0"
-              >
-                <div className="w-full rounded-t-lg bg-stone-200 px-4 py-2 dark:bg-stone-800">
-                  <TabsList className="h-auto rounded-b-none bg-transparent p-0">
-                    <TabsTrigger value="manual">
-                      Manual installation
-                    </TabsTrigger>
-                    <TabsTrigger value="hosted">Hosted</TabsTrigger>
-                  </TabsList>
-                </div>
+    <>
+      <Page.Section>
+        <Page.Section.Title>Chat Elements</Page.Section.Title>
+        <Page.Section.Description>
+          Embeddable AI chat experience for your applications
+        </Page.Section.Description>
+        <Page.Section.Body>
+          {/* Top-level tabs: Manual vs Hosted */}
+          <div className="border-border mt-3 overflow-hidden rounded-lg border p-0">
+            <Tabs
+              value={installMethod}
+              onValueChange={(v) => setInstallMethod(v as "manual" | "hosted")}
+              className="gap-0"
+            >
+              <div className="w-full rounded-t-lg bg-stone-200 px-4 py-2 dark:bg-stone-800">
+                <TabsList className="h-auto rounded-b-none bg-transparent p-0">
+                  <TabsTrigger value="manual">Manual installation</TabsTrigger>
+                  <TabsTrigger value="hosted">Hosted</TabsTrigger>
+                </TabsList>
+              </div>
 
-                {/* Manual Installation Tab Content */}
-                <div
-                  className={installMethod === "manual" ? "block" : "hidden"}
-                >
-                  <div className="flex min-h-fit gap-12 p-6">
-                    {/* Config Panel */}
+              {/* Manual Installation Tab Content */}
+              <div className={installMethod === "manual" ? "block" : "hidden"}>
+                <div className="flex min-h-fit gap-12 p-6">
+                  {/* Config Panel */}
 
-                    <div className="flex h-full w-1/3 flex-col space-y-6 overflow-y-auto pr-4">
-                      {/* Connection */}
-                      <ConfigSection
-                        title="MCP"
-                        isOpen={openSection === "connection"}
-                        onToggle={() =>
-                          setOpenSection((prev) =>
-                            prev === "connection" ? null : "connection",
-                          )
-                        }
+                  <div className="flex h-full w-1/3 flex-col space-y-6 overflow-y-auto pr-4">
+                    {/* Connection */}
+                    <ConfigSection
+                      title="MCP"
+                      isOpen={openSection === "connection"}
+                      onToggle={() =>
+                        setOpenSection((prev) =>
+                          prev === "connection" ? null : "connection",
+                        )
+                      }
+                    >
+                      <ConfigField
+                        label="Connected Server"
+                        description="The chosen server's tools will be loaded into the chat context"
                       >
-                        <ConfigField
-                          label="Connected Server"
-                          description="The chosen server's tools will be loaded into the chat context"
-                        >
-                          <div className="space-y-3">
-                            {toolsetsLoading ? (
-                              <div className="text-muted-foreground text-sm">
-                                Loading MCP servers...
-                              </div>
-                            ) : toolsets.length === 0 ? (
-                              <div className="text-muted-foreground text-sm">
-                                No MCP servers available. Add a source to create
-                                one.
-                              </div>
-                            ) : (
-                              <Select
-                                value={config.mcp}
-                                onValueChange={(v) => updateConfig("mcp", v)}
-                              >
-                                <SelectTrigger className="w-full">
-                                  <SelectValue placeholder="Select an MCP server" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {toolsets.map((toolset) => {
-                                    const mcpUrl = getMcpUrl(toolset);
-                                    return (
-                                      <SelectItem
-                                        key={toolset.id}
-                                        value={mcpUrl}
-                                        disabled={!toolset.mcpEnabled}
-                                      >
-                                        <div className="flex items-center gap-2">
-                                          <Server className="text-muted-foreground h-4 w-4" />
-                                          <span>{toolset.name}</span>
-                                          {!toolset.mcpEnabled && (
-                                            <span className="text-muted-foreground text-xs">
-                                              (disabled)
-                                            </span>
-                                          )}
-                                        </div>
-                                      </SelectItem>
-                                    );
-                                  })}
-                                </SelectContent>
-                              </Select>
-                            )}
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              className="w-full"
-                              onClick={() => routes.mcp.goTo()}
-                            >
-                              <Plus className="mr-2 h-4 w-4" />
-                              Add New MCP Server
-                            </Button>
-                          </div>
-                        </ConfigField>
-                      </ConfigSection>
-
-                      {/* Appearance */}
-                      <ConfigSection
-                        title="Appearance"
-                        isOpen={openSection === "appearance"}
-                        onToggle={() =>
-                          setOpenSection((prev) =>
-                            prev === "appearance" ? null : "appearance",
-                          )
-                        }
-                      >
-                        <ConfigField label="Variant" description="Layout style">
-                          <Select
-                            value={config.variant}
-                            onValueChange={(v) =>
-                              updateConfig("variant", v as Variant)
-                            }
-                          >
-                            <SelectTrigger className="w-full">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="standalone">
-                                Standalone
-                              </SelectItem>
-                              <SelectItem value="widget">Widget</SelectItem>
-                              <SelectItem value="sidecar">Sidecar</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </ConfigField>
-
-                        <ConfigField
-                          label="Color Scheme"
-                          description="The color scheme of the chat"
-                        >
-                          <Select
-                            value={config.colorScheme}
-                            onValueChange={(v) =>
-                              updateConfig("colorScheme", v as ColorScheme)
-                            }
-                          >
-                            <SelectTrigger className="w-full">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="system">System</SelectItem>
-                              <SelectItem value="light">Light</SelectItem>
-                              <SelectItem value="dark">Dark</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </ConfigField>
-
-                        <ConfigField
-                          label="Density"
-                          description="Spacing density"
-                        >
-                          <Select
-                            value={config.density}
-                            onValueChange={(v) =>
-                              updateConfig("density", v as Density)
-                            }
-                          >
-                            <SelectTrigger className="w-full">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="compact">Compact</SelectItem>
-                              <SelectItem value="normal">Normal</SelectItem>
-                              <SelectItem value="spacious">Spacious</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </ConfigField>
-
-                        <ConfigField
-                          label="Border Radius"
-                          description="The border radius size for UI elements within the chat"
-                        >
-                          <Select
-                            value={config.radius}
-                            onValueChange={(v) =>
-                              updateConfig("radius", v as Radius)
-                            }
-                          >
-                            <SelectTrigger className="w-full">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="round">Round</SelectItem>
-                              <SelectItem value="soft">Soft</SelectItem>
-                              <SelectItem value="sharp">Sharp</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </ConfigField>
-                      </ConfigSection>
-
-                      {/* Welcome */}
-                      <ConfigSection
-                        title="Welcome Screen"
-                        isOpen={openSection === "welcome"}
-                        onToggle={() =>
-                          setOpenSection((prev) =>
-                            prev === "welcome" ? null : "welcome",
-                          )
-                        }
-                      >
-                        <ConfigField
-                          label="Title"
-                          description="The title to show on the welcome screen"
-                        >
-                          <Input
-                            value={config.welcomeTitle}
-                            onChange={(value) =>
-                              updateConfig("welcomeTitle", value)
-                            }
-                            placeholder="Welcome"
-                          />
-                        </ConfigField>
-                        <ConfigField
-                          label="Subtitle"
-                          description="The subtitle to show on the welcome screen"
-                        >
-                          <Input
-                            value={config.welcomeSubtitle}
-                            onChange={(value) =>
-                              updateConfig("welcomeSubtitle", value)
-                            }
-                            placeholder="How can I help you today?"
-                          />
-                        </ConfigField>
-                      </ConfigSection>
-
-                      {/* Composer */}
-                      <ConfigSection
-                        title="Composer"
-                        isOpen={openSection === "composer"}
-                        onToggle={() =>
-                          setOpenSection((prev) =>
-                            prev === "composer" ? null : "composer",
-                          )
-                        }
-                      >
-                        <ConfigField
-                          label="Placeholder"
-                          description="The placeholder text for the composer input"
-                        >
-                          <Input
-                            value={config.composerPlaceholder}
-                            onChange={(value) =>
-                              updateConfig("composerPlaceholder", value)
-                            }
-                            placeholder="Send a message..."
-                          />
-                        </ConfigField>
-                      </ConfigSection>
-
-                      {/* Model */}
-                      <ConfigSection
-                        title="Model"
-                        isOpen={openSection === "model"}
-                        onToggle={() =>
-                          setOpenSection((prev) =>
-                            prev === "model" ? null : "model",
-                          )
-                        }
-                      >
-                        <SwitchField
-                          label="Show Model Picker"
-                          description="Allow users to select different models"
-                          checked={config.showModelPicker}
-                          onCheckedChange={(checked) =>
-                            updateConfig("showModelPicker", checked)
-                          }
-                        />
-                      </ConfigSection>
-
-                      {/* System Prompt */}
-                      <ConfigSection
-                        title="System Prompt"
-                        isOpen={openSection === "systemPrompt"}
-                        onToggle={() =>
-                          setOpenSection((prev) =>
-                            prev === "systemPrompt" ? null : "systemPrompt",
-                          )
-                        }
-                      >
-                        <ConfigField
-                          label="Instructions"
-                          description="Custom instructions for the AI assistant"
-                        >
-                          <TextArea
-                            value={config.systemPrompt}
-                            onChange={(value) =>
-                              updateConfig("systemPrompt", value)
-                            }
-                            placeholder="You are a helpful assistant..."
-                            rows={4}
-                          />
-                        </ConfigField>
-                      </ConfigSection>
-
-                      {/* Modal Config (only for widget variant) */}
-                      {config.variant === "widget" && (
-                        <ConfigSection
-                          title="Widget Modal"
-                          isOpen={openSection === "widgetModal"}
-                          onToggle={() =>
-                            setOpenSection((prev) =>
-                              prev === "widgetModal" ? null : "widgetModal",
-                            )
-                          }
-                        >
-                          <ConfigField label="Modal Title">
-                            <Input
-                              value={config.modalTitle}
-                              onChange={(value) =>
-                                updateConfig("modalTitle", value)
-                              }
-                              placeholder="Chat"
-                            />
-                          </ConfigField>
-                          <ConfigField label="Position">
+                        <div className="space-y-3">
+                          {toolsetsLoading ? (
+                            <div className="text-muted-foreground text-sm">
+                              Loading MCP servers...
+                            </div>
+                          ) : toolsets.length === 0 ? (
+                            <div className="text-muted-foreground text-sm">
+                              No MCP servers available. Add a source to create
+                              one.
+                            </div>
+                          ) : (
                             <Select
-                              value={config.modalPosition}
-                              onValueChange={(v) =>
-                                updateConfig(
-                                  "modalPosition",
-                                  v as ModalPosition,
-                                )
-                              }
+                              value={config.mcp}
+                              onValueChange={(v) => updateConfig("mcp", v)}
                             >
                               <SelectTrigger className="w-full">
-                                <SelectValue />
+                                <SelectValue placeholder="Select an MCP server" />
                               </SelectTrigger>
                               <SelectContent>
-                                <SelectItem value="bottom-right">
-                                  Bottom Right
-                                </SelectItem>
-                                <SelectItem value="bottom-left">
-                                  Bottom Left
-                                </SelectItem>
-                                <SelectItem value="top-right">
-                                  Top Right
-                                </SelectItem>
-                                <SelectItem value="top-left">
-                                  Top Left
-                                </SelectItem>
+                                {toolsets.map((toolset) => {
+                                  const mcpUrl = getMcpUrl(toolset);
+                                  return (
+                                    <SelectItem
+                                      key={toolset.id}
+                                      value={mcpUrl}
+                                      disabled={!toolset.mcpEnabled}
+                                    >
+                                      <div className="flex items-center gap-2">
+                                        <Server className="text-muted-foreground h-4 w-4" />
+                                        <span>{toolset.name}</span>
+                                        {!toolset.mcpEnabled && (
+                                          <span className="text-muted-foreground text-xs">
+                                            (disabled)
+                                          </span>
+                                        )}
+                                      </div>
+                                    </SelectItem>
+                                  );
+                                })}
                               </SelectContent>
                             </Select>
-                          </ConfigField>
-                          <SwitchField
-                            label="Open by Default"
-                            checked={config.modalDefaultOpen}
-                            onCheckedChange={(checked) =>
-                              updateConfig("modalDefaultOpen", checked)
-                            }
-                          />
-                        </ConfigSection>
-                      )}
+                          )}
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="w-full"
+                            onClick={() => routes.mcp.goTo()}
+                          >
+                            <Plus className="mr-2 h-4 w-4" />
+                            Add New MCP Server
+                          </Button>
+                        </div>
+                      </ConfigField>
+                    </ConfigSection>
 
-                      {/* Tools */}
+                    {/* Appearance */}
+                    <ConfigSection
+                      title="Appearance"
+                      isOpen={openSection === "appearance"}
+                      onToggle={() =>
+                        setOpenSection((prev) =>
+                          prev === "appearance" ? null : "appearance",
+                        )
+                      }
+                    >
+                      <ConfigField label="Variant" description="Layout style">
+                        <Select
+                          value={config.variant}
+                          onValueChange={(v) =>
+                            updateConfig("variant", v as Variant)
+                          }
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="standalone">
+                              Standalone
+                            </SelectItem>
+                            <SelectItem value="widget">Widget</SelectItem>
+                            <SelectItem value="sidecar">Sidecar</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </ConfigField>
+
+                      <ConfigField
+                        label="Color Scheme"
+                        description="The color scheme of the chat"
+                      >
+                        <Select
+                          value={config.colorScheme}
+                          onValueChange={(v) =>
+                            updateConfig("colorScheme", v as ColorScheme)
+                          }
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="system">System</SelectItem>
+                            <SelectItem value="light">Light</SelectItem>
+                            <SelectItem value="dark">Dark</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </ConfigField>
+
+                      <ConfigField
+                        label="Density"
+                        description="Spacing density"
+                      >
+                        <Select
+                          value={config.density}
+                          onValueChange={(v) =>
+                            updateConfig("density", v as Density)
+                          }
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="compact">Compact</SelectItem>
+                            <SelectItem value="normal">Normal</SelectItem>
+                            <SelectItem value="spacious">Spacious</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </ConfigField>
+
+                      <ConfigField
+                        label="Border Radius"
+                        description="The border radius size for UI elements within the chat"
+                      >
+                        <Select
+                          value={config.radius}
+                          onValueChange={(v) =>
+                            updateConfig("radius", v as Radius)
+                          }
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="round">Round</SelectItem>
+                            <SelectItem value="soft">Soft</SelectItem>
+                            <SelectItem value="sharp">Sharp</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </ConfigField>
+                    </ConfigSection>
+
+                    {/* Welcome */}
+                    <ConfigSection
+                      title="Welcome Screen"
+                      isOpen={openSection === "welcome"}
+                      onToggle={() =>
+                        setOpenSection((prev) =>
+                          prev === "welcome" ? null : "welcome",
+                        )
+                      }
+                    >
+                      <ConfigField
+                        label="Title"
+                        description="The title to show on the welcome screen"
+                      >
+                        <Input
+                          value={config.welcomeTitle}
+                          onChange={(value) =>
+                            updateConfig("welcomeTitle", value)
+                          }
+                          placeholder="Welcome"
+                        />
+                      </ConfigField>
+                      <ConfigField
+                        label="Subtitle"
+                        description="The subtitle to show on the welcome screen"
+                      >
+                        <Input
+                          value={config.welcomeSubtitle}
+                          onChange={(value) =>
+                            updateConfig("welcomeSubtitle", value)
+                          }
+                          placeholder="How can I help you today?"
+                        />
+                      </ConfigField>
+                    </ConfigSection>
+
+                    {/* Composer */}
+                    <ConfigSection
+                      title="Composer"
+                      isOpen={openSection === "composer"}
+                      onToggle={() =>
+                        setOpenSection((prev) =>
+                          prev === "composer" ? null : "composer",
+                        )
+                      }
+                    >
+                      <ConfigField
+                        label="Placeholder"
+                        description="The placeholder text for the composer input"
+                      >
+                        <Input
+                          value={config.composerPlaceholder}
+                          onChange={(value) =>
+                            updateConfig("composerPlaceholder", value)
+                          }
+                          placeholder="Send a message..."
+                        />
+                      </ConfigField>
+                    </ConfigSection>
+
+                    {/* Model */}
+                    <ConfigSection
+                      title="Model"
+                      isOpen={openSection === "model"}
+                      onToggle={() =>
+                        setOpenSection((prev) =>
+                          prev === "model" ? null : "model",
+                        )
+                      }
+                    >
+                      <SwitchField
+                        label="Show Model Picker"
+                        description="Allow users to select different models"
+                        checked={config.showModelPicker}
+                        onCheckedChange={(checked) =>
+                          updateConfig("showModelPicker", checked)
+                        }
+                      />
+                    </ConfigSection>
+
+                    {/* System Prompt */}
+                    <ConfigSection
+                      title="System Prompt"
+                      isOpen={openSection === "systemPrompt"}
+                      onToggle={() =>
+                        setOpenSection((prev) =>
+                          prev === "systemPrompt" ? null : "systemPrompt",
+                        )
+                      }
+                    >
+                      <ConfigField
+                        label="Instructions"
+                        description="Custom instructions for the AI assistant"
+                      >
+                        <TextArea
+                          value={config.systemPrompt}
+                          onChange={(value) =>
+                            updateConfig("systemPrompt", value)
+                          }
+                          placeholder="You are a helpful assistant..."
+                          rows={4}
+                        />
+                      </ConfigField>
+                    </ConfigSection>
+
+                    {/* Modal Config (only for widget variant) */}
+                    {config.variant === "widget" && (
                       <ConfigSection
-                        title="Tools"
-                        isOpen={openSection === "tools"}
+                        title="Widget Modal"
+                        isOpen={openSection === "widgetModal"}
                         onToggle={() =>
                           setOpenSection((prev) =>
-                            prev === "tools" ? null : "tools",
+                            prev === "widgetModal" ? null : "widgetModal",
                           )
                         }
                       >
+                        <ConfigField label="Modal Title">
+                          <Input
+                            value={config.modalTitle}
+                            onChange={(value) =>
+                              updateConfig("modalTitle", value)
+                            }
+                            placeholder="Chat"
+                          />
+                        </ConfigField>
+                        <ConfigField label="Position">
+                          <Select
+                            value={config.modalPosition}
+                            onValueChange={(v) =>
+                              updateConfig("modalPosition", v as ModalPosition)
+                            }
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="bottom-right">
+                                Bottom Right
+                              </SelectItem>
+                              <SelectItem value="bottom-left">
+                                Bottom Left
+                              </SelectItem>
+                              <SelectItem value="top-right">
+                                Top Right
+                              </SelectItem>
+                              <SelectItem value="top-left">Top Left</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </ConfigField>
                         <SwitchField
-                          label="Expand Tool Groups by Default"
-                          description="Show tool call details expanded"
-                          checked={config.expandToolGroupsByDefault}
+                          label="Open by Default"
+                          checked={config.modalDefaultOpen}
                           onCheckedChange={(checked) =>
-                            updateConfig("expandToolGroupsByDefault", checked)
+                            updateConfig("modalDefaultOpen", checked)
                           }
                         />
                       </ConfigSection>
+                    )}
 
-                      {/* Setup Button */}
-                      <div className="flex-1" />
+                    {/* Tools */}
+                    <ConfigSection
+                      title="Tools"
+                      isOpen={openSection === "tools"}
+                      onToggle={() =>
+                        setOpenSection((prev) =>
+                          prev === "tools" ? null : "tools",
+                        )
+                      }
+                    >
+                      <SwitchField
+                        label="Expand Tool Groups by Default"
+                        description="Show tool call details expanded"
+                        checked={config.expandToolGroupsByDefault}
+                        onCheckedChange={(checked) =>
+                          updateConfig("expandToolGroupsByDefault", checked)
+                        }
+                      />
+                    </ConfigSection>
+
+                    {/* Setup Button */}
+                    <div className="flex-1" />
+                    <Button
+                      className="w-full"
+                      onClick={() => setShowInstallGuide(true)}
+                    >
+                      <ArrowRight className="mr-2 h-4 w-4" />
+                      Setup
+                    </Button>
+                  </div>
+
+                  {/* Preview Panel */}
+                  <div className="flex h-[700px] w-2/3 flex-col">
+                    <div className="bg-muted/30 relative flex-1 overflow-hidden rounded-lg border">
                       <Button
-                        className="w-full"
-                        onClick={() => setShowInstallGuide(true)}
+                        variant="ghost"
+                        size="sm"
+                        onClick={refreshPreview}
+                        className={cn(
+                          "bg-foreground/[0.7] text-background hover:bg-foreground/80 hover:text-background absolute top-6 right-6 z-10 h-8 px-2 backdrop-blur-sm",
+                          config.variant === "sidecar" && "right-auto left-6",
+                        )}
                       >
-                        <ArrowRight className="mr-2 h-4 w-4" />
-                        Setup
+                        <RefreshCw className="mr-1 h-4 w-4" />
+                        Reset Preview
                       </Button>
-                    </div>
-
-                    {/* Preview Panel */}
-                    <div className="flex h-[700px] w-2/3 flex-col">
-                      <div className="bg-muted/30 relative flex-1 overflow-hidden rounded-lg border">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={refreshPreview}
-                          className={cn(
-                            "bg-foreground/[0.7] text-background hover:bg-foreground/80 hover:text-background absolute top-6 right-6 z-10 h-8 px-2 backdrop-blur-sm",
-                            config.variant === "sidecar" && "right-auto left-6",
-                          )}
-                        >
-                          <RefreshCw className="mr-1 h-4 w-4" />
-                          Reset Preview
-                        </Button>
-                        <ElementsPreview
-                          key={previewKey}
-                          config={baseElementsConfig}
-                          apiUrl={apiUrl}
-                          sessionToken={sessionToken}
-                        />
-                      </div>
+                      <ElementsPreview
+                        key={previewKey}
+                        config={baseElementsConfig}
+                        apiUrl={apiUrl}
+                        sessionToken={sessionToken}
+                      />
                     </div>
                   </div>
                 </div>
+              </div>
 
-                {/* Hosted Tab Content */}
-                <div
-                  className={
-                    installMethod === "hosted" ? "block px-4 py-4" : "hidden"
-                  }
-                >
-                  <div className="flex h-[700px] flex-col items-center justify-center text-center">
-                    <div className="bg-muted mb-4 flex h-16 w-16 items-center justify-center rounded-full">
-                      <Server className="text-muted-foreground h-8 w-8" />
-                    </div>
-                    <h3 className="mb-2 text-lg font-semibold">Coming Soon</h3>
-                    <p className="text-muted-foreground max-w-md">
-                      Hosted Elements will allow you to deploy chat experiences
-                      without any code changes. Stay tuned!
-                    </p>
+              {/* Hosted Tab Content */}
+              <div
+                className={
+                  installMethod === "hosted" ? "block px-4 py-4" : "hidden"
+                }
+              >
+                <div className="flex h-[700px] flex-col items-center justify-center text-center">
+                  <div className="bg-muted mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                    <Server className="text-muted-foreground h-8 w-8" />
                   </div>
+                  <h3 className="mb-2 text-lg font-semibold">Coming Soon</h3>
+                  <p className="text-muted-foreground max-w-md">
+                    Hosted Elements will allow you to deploy chat experiences
+                    without any code changes. Stay tuned!
+                  </p>
                 </div>
-              </Tabs>
-            </div>
-          </Page.Section.Body>
-        </Page.Section>
-      </Page.Body>
+              </div>
+            </Tabs>
+          </div>
+        </Page.Section.Body>
+      </Page.Section>
 
       {/* Installation Guide Dialog */}
       <Dialog open={showInstallGuide} onOpenChange={setShowInstallGuide}>
@@ -793,7 +793,7 @@ export default function ChatElements() {
           />
         </Dialog.Content>
       </Dialog>
-    </Page>
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/environments/Environment.tsx
+++ b/client/dashboard/src/pages/environments/Environment.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Button } from "@speakeasy-api/moonshine";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -7,6 +8,7 @@ import {
   useRegisterEnvironmentTelemetry,
   useTelemetry,
 } from "@/contexts/Telemetry";
+import { useRBAC } from "@/hooks/useRBAC";
 import {
   useDeleteEnvironmentMutation,
   useListToolsets,
@@ -159,9 +161,19 @@ function ToolsetDialog({ open, onOpenChange, onSubmit }: ToolsetDialogProps) {
 }
 
 export default function EnvironmentPage() {
+  return (
+    <RequireScope scope="build:read" level="page">
+      <EnvironmentPageInner />
+    </RequireScope>
+  );
+}
+
+function EnvironmentPageInner() {
   const environment = useEnvironment();
   const navigate = useNavigate();
   const telemetry = useTelemetry();
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("build:write");
 
   const [toolsetDialogOpen, setToolsetDialogOpen] = useState(false);
   const [selectedToolsetSlug, setSelectedToolsetSlug] = useState<string>("");
@@ -454,12 +466,14 @@ export default function EnvironmentPage() {
         <Page.Section>
           <Page.Section.Title>{environment.name}</Page.Section.Title>
           <Page.Section.CTA>
-            <Button
-              onClick={handleAddNewEntry}
-              disabled={isSaving || isAddingNew}
-            >
-              Add Variable
-            </Button>
+            <RequireScope scope="build:write" level="component">
+              <Button
+                onClick={handleAddNewEntry}
+                disabled={isSaving || isAddingNew}
+              >
+                Add Variable
+              </Button>
+            </RequireScope>
           </Page.Section.CTA>
           <MoreActions
             actions={[
@@ -467,6 +481,7 @@ export default function EnvironmentPage() {
                 label: "Fill for Toolset",
                 onClick: () => setToolsetDialogOpen(true),
                 icon: "copy-plus",
+                disabled: !canWrite,
               },
               {
                 label: "Delete Environment",
@@ -476,6 +491,7 @@ export default function EnvironmentPage() {
                   }),
                 icon: "trash",
                 destructive: true,
+                disabled: !canWrite,
               },
             ]}
           />
@@ -536,46 +552,50 @@ export default function EnvironmentPage() {
                                 : "Enter value"
                             }
                             type={
-                              visibleFields.has(entry.name)
+                              canWrite && visibleFields.has(entry.name)
                                 ? "text"
                                 : "password"
                             }
                             className={`w-full font-mono text-sm ${isEdited ? "ring-1 ring-blue-500" : ""}`}
-                            disabled={isSaving}
+                            disabled={isSaving || !canWrite}
                           />
                         </div>
-                        <Button
-                          variant="tertiary"
-                          size="sm"
-                          className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
-                          onClick={() => handleToggleVisibility(entry.name)}
-                          disabled={isSaving}
-                          aria-label={
-                            visibleFields.has(entry.name)
-                              ? `Hide ${entry.name}`
-                              : `Show ${entry.name}`
-                          }
-                        >
-                          <Button.LeftIcon>
-                            {visibleFields.has(entry.name) ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
-                          </Button.LeftIcon>
-                        </Button>
-                        <Button
-                          variant="tertiary"
-                          size="sm"
-                          className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
-                          onClick={() => handleRemoveVariable(entry.name)}
-                          disabled={isSaving}
-                          aria-label={`Remove ${entry.name}`}
-                        >
-                          <Button.LeftIcon>
-                            <Trash2 className="h-4 w-4" />
-                          </Button.LeftIcon>
-                        </Button>
+                        {canWrite && (
+                          <>
+                            <Button
+                              variant="tertiary"
+                              size="sm"
+                              className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
+                              onClick={() => handleToggleVisibility(entry.name)}
+                              disabled={isSaving}
+                              aria-label={
+                                visibleFields.has(entry.name)
+                                  ? `Hide ${entry.name}`
+                                  : `Show ${entry.name}`
+                              }
+                            >
+                              <Button.LeftIcon>
+                                {visibleFields.has(entry.name) ? (
+                                  <EyeOff className="h-4 w-4" />
+                                ) : (
+                                  <Eye className="h-4 w-4" />
+                                )}
+                              </Button.LeftIcon>
+                            </Button>
+                            <Button
+                              variant="tertiary"
+                              size="sm"
+                              className="mt-[1px] h-8 w-8 flex-shrink-0 self-start"
+                              onClick={() => handleRemoveVariable(entry.name)}
+                              disabled={isSaving}
+                              aria-label={`Remove ${entry.name}`}
+                            >
+                              <Button.LeftIcon>
+                                <Trash2 className="h-4 w-4" />
+                              </Button.LeftIcon>
+                            </Button>
+                          </>
+                        )}
                       </div>
                     </div>
                   );
@@ -668,18 +688,20 @@ export default function EnvironmentPage() {
                   <p className="text-muted-foreground text-sm">
                     No environment variables defined
                   </p>
-                  <div className="mt-4 flex flex-col items-center gap-2">
-                    <Button onClick={handleAddNewEntry}>
-                      <Plus className="mr-2 h-4 w-4" />
-                      ADD YOUR FIRST VARIABLE
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      onClick={() => setToolsetDialogOpen(true)}
-                    >
-                      FILL FOR TOOLSET
-                    </Button>
-                  </div>
+                  {canWrite && (
+                    <div className="mt-4 flex flex-col items-center gap-2">
+                      <Button onClick={handleAddNewEntry}>
+                        <Plus className="mr-2 h-4 w-4" />
+                        ADD YOUR FIRST VARIABLE
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={() => setToolsetDialogOpen(true)}
+                      >
+                        FILL FOR TOOLSET
+                      </Button>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -83,8 +83,8 @@ function EnvironmentsInner() {
           Create re-usable environment configurations and share amongst multiple
           MCP servers
         </Page.Section.Description>
-        {environments.length > 0 && (
-          <Page.Section.CTA>
+        <Page.Section.CTA>
+          {environments.length > 0 && (
             <RequireScope scope="build:write" level="component">
               <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
                 <Button.LeftIcon>
@@ -93,8 +93,8 @@ function EnvironmentsInner() {
                 <Button.Text>New Environment</Button.Text>
               </Button>
             </RequireScope>
-          </Page.Section.CTA>
-        )}
+          )}
+        </Page.Section.CTA>
         <Page.Section.Body>
           {environments.length === 0 ? (
             <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -79,8 +79,8 @@ function EnvironmentsInner() {
       <Page.Section>
         <Page.Section.Title>Environments</Page.Section.Title>
         <Page.Section.Description>
-          Use environments to manage API keys, allowing Gram to handle
-          authentication for you
+          Create re-usable environment configurations and share amongst multiple
+          MCP servers
         </Page.Section.Description>
         <Page.Section.CTA>
           <RequireScope scope="build:write" level="component">

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -83,12 +83,14 @@ function EnvironmentsInner() {
           authentication for you
         </Page.Section.Description>
         <Page.Section.CTA>
-          <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
-            <Button.LeftIcon>
-              <Plus className="h-4 w-4" />
-            </Button.LeftIcon>
-            <Button.Text>New Environment</Button.Text>
-          </Button>
+          <RequireScope scope="build:write" level="component">
+            <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
+              <Button.LeftIcon>
+                <Plus className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>New Environment</Button.Text>
+            </Button>
+          </RequireScope>
         </Page.Section.CTA>
         <Page.Section.Body>
           <Cards>

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -1,5 +1,6 @@
 import { InputDialog } from "@/components/input-dialog";
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Badge } from "@/components/ui/badge";
 import { Card, Cards } from "@/components/ui/card";
 import { UpdatedAt } from "@/components/updated-at";
@@ -19,9 +20,25 @@ export function EnvironmentsRoot() {
 }
 
 export default function Environments() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["build:read", "build:write"]} level="page">
+          <EnvironmentsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function EnvironmentsInner() {
   const session = useSession();
   const routes = useRoutes();
   const telemetry = useTelemetry();
+  const environments = useEnvironments();
 
   const [createEnvironmentDialogOpen, setCreateEnvironmentDialogOpen] =
     useState(false);
@@ -58,52 +75,44 @@ export default function Environments() {
   };
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>
-        <Page.Section>
-          <Page.Section.Title>Environments</Page.Section.Title>
-          <Page.Section.Description>
-            Use environments to manage API keys, allowing Gram to handle
-            authentication for you
-          </Page.Section.Description>
-          <Page.Section.CTA>
-            <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
-              <Button.LeftIcon>
-                <Plus className="h-4 w-4" />
-              </Button.LeftIcon>
-              <Button.Text>New Environment</Button.Text>
-            </Button>
-          </Page.Section.CTA>
-          <Page.Section.Body>
-            <Cards>
-              {useEnvironments().map((environment) => (
-                <EnvironmentCard
-                  key={environment.id}
-                  environment={environment}
-                />
-              ))}
-            </Cards>
-          </Page.Section.Body>
-        </Page.Section>
-        <InputDialog
-          open={createEnvironmentDialogOpen}
-          onOpenChange={setCreateEnvironmentDialogOpen}
-          title="Create an Environment"
-          description="Give your environment a name."
-          inputs={{
-            label: "Environment name",
-            placeholder: "Environment name",
-            value: environmentName,
-            onChange: (value) => setEnvironmentName(value),
-            onSubmit: createEnvironment,
-            validate: (value) => value.length > 0,
-          }}
-        />
-      </Page.Body>
-    </Page>
+    <>
+      <Page.Section>
+        <Page.Section.Title>Environments</Page.Section.Title>
+        <Page.Section.Description>
+          Use environments to manage API keys, allowing Gram to handle
+          authentication for you
+        </Page.Section.Description>
+        <Page.Section.CTA>
+          <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
+            <Button.LeftIcon>
+              <Plus className="h-4 w-4" />
+            </Button.LeftIcon>
+            <Button.Text>New Environment</Button.Text>
+          </Button>
+        </Page.Section.CTA>
+        <Page.Section.Body>
+          <Cards>
+            {environments.map((environment) => (
+              <EnvironmentCard key={environment.id} environment={environment} />
+            ))}
+          </Cards>
+        </Page.Section.Body>
+      </Page.Section>
+      <InputDialog
+        open={createEnvironmentDialogOpen}
+        onOpenChange={setCreateEnvironmentDialogOpen}
+        title="Create an Environment"
+        description="Give your environment a name."
+        inputs={{
+          label: "Environment name",
+          placeholder: "Environment name",
+          value: environmentName,
+          onChange: (value) => setEnvironmentName(value),
+          onSubmit: createEnvironment,
+          validate: (value) => value.length > 0,
+        }}
+      />
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -9,10 +9,11 @@ import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
 import { Environment } from "@gram/client/models/components/environment.js";
 import { useCreateEnvironmentMutation } from "@gram/client/react-query/index.js";
-import { Plus } from "lucide-react";
+import { Blocks, Plus } from "lucide-react";
 import { useState } from "react";
 import { Outlet } from "react-router";
 import { Button } from "@speakeasy-api/moonshine";
+import { Type } from "@/components/ui/type";
 import { handleAPIError } from "@/lib/errors";
 import { useEnvironments } from "./useEnvironments";
 export function EnvironmentsRoot() {
@@ -82,22 +83,50 @@ function EnvironmentsInner() {
           Create re-usable environment configurations and share amongst multiple
           MCP servers
         </Page.Section.Description>
-        <Page.Section.CTA>
-          <RequireScope scope="build:write" level="component">
-            <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
-              <Button.LeftIcon>
-                <Plus className="h-4 w-4" />
-              </Button.LeftIcon>
-              <Button.Text>New Environment</Button.Text>
-            </Button>
-          </RequireScope>
-        </Page.Section.CTA>
+        {environments.length > 0 && (
+          <Page.Section.CTA>
+            <RequireScope scope="build:write" level="component">
+              <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
+                <Button.LeftIcon>
+                  <Plus className="h-4 w-4" />
+                </Button.LeftIcon>
+                <Button.Text>New Environment</Button.Text>
+              </Button>
+            </RequireScope>
+          </Page.Section.CTA>
+        )}
         <Page.Section.Body>
-          <Cards>
-            {environments.map((environment) => (
-              <EnvironmentCard key={environment.id} environment={environment} />
-            ))}
-          </Cards>
+          {environments.length === 0 ? (
+            <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+              <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+                <Blocks className="text-muted-foreground h-6 w-6" />
+              </div>
+              <Type variant="subheading" className="mb-1">
+                No environments yet
+              </Type>
+              <Type small muted className="mb-4 max-w-md text-center">
+                Environments let you store configuration and secrets that can be
+                shared across multiple MCP servers.
+              </Type>
+              <RequireScope scope="build:write" level="component">
+                <Button onClick={() => setCreateEnvironmentDialogOpen(true)}>
+                  <Button.LeftIcon>
+                    <Plus className="h-4 w-4" />
+                  </Button.LeftIcon>
+                  <Button.Text>New Environment</Button.Text>
+                </Button>
+              </RequireScope>
+            </div>
+          ) : (
+            <Cards>
+              {environments.map((environment) => (
+                <EnvironmentCard
+                  key={environment.id}
+                  environment={environment}
+                />
+              ))}
+            </Cards>
+          )}
         </Page.Section.Body>
       </Page.Section>
       <InputDialog

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -1,8 +1,24 @@
 import { Page } from "@/components/page-layout";
 import { ProjectDashboard } from "@/components/project/ProjectDashboard";
 import { RequireScope } from "@/components/require-scope";
+import { useRBAC } from "@/hooks/useRBAC";
+import { useRoutes } from "@/routes";
+import { Navigate } from "react-router";
 
 export default function Home() {
+  const { hasAnyScope, isRbacEnabled, isLoading } = useRBAC();
+  const routes = useRoutes();
+
+  // Redirect MCP-only users (no build:read) to the MCP page
+  if (
+    isRbacEnabled &&
+    !isLoading &&
+    !hasAnyScope(["build:read"]) &&
+    hasAnyScope(["mcp:read", "mcp:write"])
+  ) {
+    return <Navigate to={routes.mcp.href()} replace />;
+  }
+
   return (
     <Page>
       <Page.Header>

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -1,5 +1,6 @@
 import { Page } from "@/components/page-layout";
 import { ProjectDashboard } from "@/components/project/ProjectDashboard";
+import { RequireScope } from "@/components/require-scope";
 
 export default function Home() {
   return (
@@ -8,7 +9,9 @@ export default function Home() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <ProjectDashboard />
+        <RequireScope scope="build:read" level="page">
+          <ProjectDashboard />
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -2,6 +2,7 @@ import { EditServerNameDialog } from "./EditServerNameDialog";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { EnterpriseGate } from "@/components/enterprise-gate";
 import { InsightsConfig } from "@/components/insights-sidebar";
+import { RequireScope } from "@/components/require-scope";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { Page } from "@/components/page-layout";
 import { ErrorAlert } from "@/components/ui/alert";
@@ -220,7 +221,11 @@ function safeBase64Decode(str: string): string | null {
 const perPage = 100;
 
 export default function HooksPage() {
-  return <HooksContent />;
+  return (
+    <RequireScope scope={["build:read", "build:write"]} level="page">
+      <HooksContent />
+    </RequireScope>
+  );
 }
 
 function HooksContent() {

--- a/client/dashboard/src/pages/logs/Logs.tsx
+++ b/client/dashboard/src/pages/logs/Logs.tsx
@@ -1,5 +1,6 @@
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { InsightsConfig } from "@/components/insights-sidebar";
+import { RequireScope } from "@/components/require-scope";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { Page } from "@/components/page-layout";
 import { Button } from "@/components/ui/button";
@@ -200,7 +201,11 @@ function MCPServerFilter({
 }
 
 export default function LogsPage() {
-  return <LogsContent />;
+  return (
+    <RequireScope scope="build:read" level="page">
+      <LogsContent />
+    </RequireScope>
+  );
 }
 
 function LogsContent() {

--- a/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
@@ -36,6 +36,7 @@ interface EnvironmentVariableRowProps {
   onEditHeaderName: (id: string) => void;
   onHeaderDisplayNameChange: (id: string, value: string) => void;
   onHeaderBlur: () => void;
+  readOnly?: boolean;
 }
 
 const MODE_OPTIONS: Array<{
@@ -75,6 +76,7 @@ export function EnvironmentVariableRow({
   onEditHeaderName,
   onHeaderDisplayNameChange,
   onHeaderBlur,
+  readOnly,
 }: EnvironmentVariableRowProps) {
   const isEditingHeader = editingHeaderId === envVar.id;
   const headerName = getHeaderDisplayName(
@@ -216,7 +218,7 @@ export function EnvironmentVariableRow({
             onValueChange={(value) =>
               onStateChange(envVar.id, value as EnvVarState)
             }
-            disabled={isDisabled}
+            disabled={isDisabled || readOnly}
           >
             <SelectTrigger
               tabIndex={-1}
@@ -270,6 +272,7 @@ export function EnvironmentVariableRow({
                 onChange={(value) => onValueChange(envVar.id, value)}
                 placeholder="Enter value..."
                 className="placeholder:text-muted-foreground h-full w-full border-0 bg-transparent px-3 pr-9 font-mono text-sm shadow-none focus:outline-none focus-visible:ring-0"
+                disabled={readOnly}
               />
             )}
           </div>

--- a/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
@@ -271,7 +271,10 @@ export function EnvironmentVariableRow({
                 value={editingValue}
                 onChange={(value) => onValueChange(envVar.id, value)}
                 placeholder="Enter value..."
-                className="placeholder:text-muted-foreground h-full w-full border-0 bg-transparent px-3 pr-9 font-mono text-sm shadow-none focus:outline-none focus-visible:ring-0"
+                className={cn(
+                  "placeholder:text-muted-foreground h-full w-full border-0 bg-transparent px-3 pr-9 font-mono text-sm shadow-none focus:outline-none focus-visible:ring-0",
+                  readOnly && "cursor-not-allowed opacity-50",
+                )}
                 disabled={readOnly}
               />
             )}

--- a/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
+++ b/client/dashboard/src/pages/mcp/EnvironmentVariableRow.tsx
@@ -36,7 +36,6 @@ interface EnvironmentVariableRowProps {
   onEditHeaderName: (id: string) => void;
   onHeaderDisplayNameChange: (id: string, value: string) => void;
   onHeaderBlur: () => void;
-  readOnly?: boolean;
 }
 
 const MODE_OPTIONS: Array<{
@@ -76,7 +75,6 @@ export function EnvironmentVariableRow({
   onEditHeaderName,
   onHeaderDisplayNameChange,
   onHeaderBlur,
-  readOnly,
 }: EnvironmentVariableRowProps) {
   const isEditingHeader = editingHeaderId === envVar.id;
   const headerName = getHeaderDisplayName(
@@ -218,7 +216,7 @@ export function EnvironmentVariableRow({
             onValueChange={(value) =>
               onStateChange(envVar.id, value as EnvVarState)
             }
-            disabled={isDisabled || readOnly}
+            disabled={isDisabled}
           >
             <SelectTrigger
               tabIndex={-1}
@@ -271,11 +269,7 @@ export function EnvironmentVariableRow({
                 value={editingValue}
                 onChange={(value) => onValueChange(envVar.id, value)}
                 placeholder="Enter value..."
-                className={cn(
-                  "placeholder:text-muted-foreground h-full w-full border-0 bg-transparent px-3 pr-9 font-mono text-sm shadow-none focus:outline-none focus-visible:ring-0",
-                  readOnly && "cursor-not-allowed opacity-50",
-                )}
-                disabled={readOnly}
+                className="placeholder:text-muted-foreground h-full w-full border-0 bg-transparent px-3 pr-9 font-mono text-sm shadow-none focus:outline-none focus-visible:ring-0"
               />
             )}
           </div>

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -1,4 +1,5 @@
 import { InputDialog } from "@/components/input-dialog";
+import { RequireScope } from "@/components/require-scope";
 import { BuiltInMCPCard } from "@/components/mcp/BuiltInMCPCard";
 import { MCPCard, MCPCardSkeleton } from "@/components/mcp/MCPCard";
 import { MCPTableRow, MCPTableRowSkeleton } from "@/components/mcp/MCPTableRow";
@@ -39,7 +40,9 @@ export const MCPPage = () => {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <MCPOverview />
+        <RequireScope scope={["mcp:read", "mcp:write"]} level="page">
+          <MCPOverview />
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -78,12 +78,14 @@ export function MCPOverview() {
   };
 
   const newMcpServerButton = (
-    <Button size="sm" onClick={() => setNewMcpDialogOpen(true)}>
-      <Button.LeftIcon>
-        <Plus />
-      </Button.LeftIcon>
-      <Button.Text>New MCP Server</Button.Text>
-    </Button>
+    <RequireScope scope="mcp:write" level="component">
+      <Button size="sm" onClick={() => setNewMcpDialogOpen(true)}>
+        <Button.LeftIcon>
+          <Plus />
+        </Button.LeftIcon>
+        <Button.Text>New MCP Server</Button.Text>
+      </Button>
+    </RequireScope>
   );
 
   const newMcpServerDialog = (

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -369,11 +369,15 @@ function MCPDetailPageInner() {
             </TabsContent>
 
             <TabsContent value="performance" className="mt-0 w-full">
-              <MCPPerformanceTab toolset={toolset} />
+              <RequireScope scope="mcp:write" level="page">
+                <MCPPerformanceTab toolset={toolset} />
+              </RequireScope>
             </TabsContent>
 
             <TabsContent value="settings" className="mt-0 w-full">
-              <MCPSettingsTab toolset={toolset} />
+              <RequireScope scope="mcp:write" level="page">
+                <MCPSettingsTab toolset={toolset} />
+              </RequireScope>
             </TabsContent>
           </div>
         </Tabs>

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -434,6 +434,7 @@ export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
   const { data: mcpMetadataData, isLoading: mcpMetadataLoading } =
     useGetMcpMetadata({ toolsetSlug: toolset.slug }, undefined, {
       retry: false,
+      throwOnError: false, // Expected 404 when no metadata exists
     });
   const mcpMetadata = mcpMetadataData?.metadata;
 

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -363,7 +363,7 @@ function MCPDetailPageInner() {
             </TabsContent>
 
             <TabsContent value="authentication" className="mt-0 w-full">
-              <RequireScope scope="mcp:write" level="section">
+              <RequireScope scope="mcp:write" level="page">
                 <MCPAuthenticationTab toolset={toolset} />
               </RequireScope>
             </TabsContent>

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1001,11 +1001,13 @@ function MCPToolsTab({ toolset }: { toolset: Toolset }) {
         >
           <Heading variant="h3">Tools</Heading>
           <Stack direction="horizontal" gap={2}>
-            <routes.customTools.Link>
-              <Button variant="secondary" size="sm">
-                <Button.Text>Custom Tools</Button.Text>
-              </Button>
-            </routes.customTools.Link>
+            {canWrite && (
+              <routes.customTools.Link>
+                <Button variant="secondary" size="sm">
+                  <Button.Text>Custom Tools</Button.Text>
+                </Button>
+              </routes.customTools.Link>
+            )}
             {canWrite && (
               <Button onClick={() => setAddToolsDialogOpen(true)} size="sm">
                 <Button.LeftIcon>

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -170,9 +170,7 @@ function MCPDetailPageInner() {
 
   // Call hooks before any conditional returns
   const { url: mcpUrl } = useMcpUrl(toolset);
-  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
-    throwOnError: false,
-  });
+  const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];
 
   // Fetch MCP metadata early to use in useMissingRequiredEnvVars
@@ -431,13 +429,10 @@ export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
   const telemetry = useTelemetry();
 
   // Fetch data needed to detect system-provided vars on the attached env.
-  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
-    throwOnError: false,
-  });
+  const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];
   const { data: mcpMetadataData, isLoading: mcpMetadataLoading } =
     useGetMcpMetadata({ toolsetSlug: toolset.slug }, undefined, {
-      throwOnError: false,
       retry: false,
     });
   const mcpMetadata = mcpMetadataData?.metadata;

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -363,7 +363,9 @@ function MCPDetailPageInner() {
             </TabsContent>
 
             <TabsContent value="authentication" className="mt-0 w-full">
-              <MCPAuthenticationTab toolset={toolset} />
+              <RequireScope scope="mcp:write" level="section">
+                <MCPAuthenticationTab toolset={toolset} />
+              </RequireScope>
             </TabsContent>
 
             <TabsContent value="performance" className="mt-0 w-full">

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -28,9 +28,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
+import { RequireScope } from "@/components/require-scope";
 import { useOrganization } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
+import { useRBAC } from "@/hooks/useRBAC";
 import { useToolset } from "@/hooks/toolTypes";
 import { FeatureRequestModal } from "@/components/FeatureRequestModal";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
@@ -153,6 +155,14 @@ function MCPLoading() {
 }
 
 export function MCPDetailPage() {
+  return (
+    <RequireScope scope={["mcp:read", "mcp:write"]} level="page">
+      <MCPDetailPageInner />
+    </RequireScope>
+  );
+}
+
+function MCPDetailPageInner() {
   const { toolsetSlug } = useParams();
   const routes = useRoutes();
 
@@ -405,6 +415,8 @@ const STATUS_OPTIONS: {
 ];
 
 export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
   const queryClient = useQueryClient();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [pendingStatus, setPendingStatus] = useState<ServerStatus | null>(null);
@@ -563,8 +575,8 @@ export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
   return (
     <>
       <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button variant="primary">
+        <DropdownMenuTrigger asChild disabled={!canWrite}>
+          <Button variant="primary" disabled={!canWrite}>
             <Button.Text>{currentLabel}</Button.Text>
             <Button.RightIcon>
               <ChevronDown className="h-4 w-4" />
@@ -711,6 +723,8 @@ function ServerInstructionsSection({
   form: UseMcpMetadataMetadataFormResult;
   isLoading: boolean;
 }) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
   const charCount = form.instructionsHandlers.value?.length ?? 0;
   const overLimit = charCount > INSTRUCTIONS_SOFT_LIMIT;
 
@@ -722,6 +736,7 @@ function ServerInstructionsSection({
           className="min-h-[150px] w-full"
           value={form.instructionsHandlers.value ?? ""}
           onChange={form.instructionsHandlers.onChange}
+          disabled={!canWrite}
         />
         {charCount > 0 && (
           <span
@@ -735,23 +750,25 @@ function ServerInstructionsSection({
           </span>
         )}
       </div>
-      <Stack direction="horizontal" gap={2} justify="end">
-        <GenerateInstructionsButton toolset={toolset} form={form} />
-        <Button
-          onClick={async () => {
-            try {
-              await form.saveAsync();
-              toast.success("Server instructions saved.");
-            } catch {
-              toast.error("Failed to save instructions.");
-            }
-          }}
-          disabled={isLoading || !form.instructionsDirty}
-          size="sm"
-        >
-          <Button.Text>Save</Button.Text>
-        </Button>
-      </Stack>
+      {canWrite && (
+        <Stack direction="horizontal" gap={2} justify="end">
+          <GenerateInstructionsButton toolset={toolset} form={form} />
+          <Button
+            onClick={async () => {
+              try {
+                await form.saveAsync();
+                toast.success("Server instructions saved.");
+              } catch {
+                toast.error("Failed to save instructions.");
+              }
+            }}
+            disabled={isLoading || !form.instructionsDirty}
+            size="sm"
+          >
+            <Button.Text>Save</Button.Text>
+          </Button>
+        </Stack>
+      )}
     </Stack>
   );
 }
@@ -827,6 +844,8 @@ Respond with ONLY the server instructions as plain text. Do not wrap in JSON or 
  * Tools Tab - Manage tools in the MCP server
  */
 function MCPToolsTab({ toolset }: { toolset: Toolset }) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
   const queryClient = useQueryClient();
   const telemetry = useTelemetry();
   const client = useSdkClient();
@@ -987,12 +1006,14 @@ function MCPToolsTab({ toolset }: { toolset: Toolset }) {
                 <Button.Text>Custom Tools</Button.Text>
               </Button>
             </routes.customTools.Link>
-            <Button onClick={() => setAddToolsDialogOpen(true)} size="sm">
-              <Button.LeftIcon>
-                <Icon name="plus" className="h-4 w-4" />
-              </Button.LeftIcon>
-              <Button.Text>Add Tools</Button.Text>
-            </Button>
+            {canWrite && (
+              <Button onClick={() => setAddToolsDialogOpen(true)} size="sm">
+                <Button.LeftIcon>
+                  <Icon name="plus" className="h-4 w-4" />
+                </Button.LeftIcon>
+                <Button.Text>Add Tools</Button.Text>
+              </Button>
+            )}
           </Stack>
         </Stack>
       )}
@@ -1026,14 +1047,15 @@ function MCPToolsTab({ toolset }: { toolset: Toolset }) {
         <ToolList
           tools={toolsToDisplay}
           toolset={fullToolset}
-          onToolUpdate={handleToolUpdate}
-          onToolsRemove={handleToolsRemove}
+          onToolUpdate={canWrite ? handleToolUpdate : undefined}
+          onToolsRemove={canWrite ? handleToolsRemove : undefined}
           onTestInPlayground={handleTestInPlayground}
+          readOnly={!canWrite}
         />
       ) : (
         <ToolsetEmptyState
           toolsetSlug={toolset.slug}
-          onAddTools={() => setAddToolsDialogOpen(true)}
+          onAddTools={canWrite ? () => setAddToolsDialogOpen(true) : undefined}
         />
       )}
 
@@ -1121,6 +1143,8 @@ function MCPPromptsTab({ toolset }: { toolset: Toolset }) {
  * Settings Tab - Visibility, Slug, Custom Domain, Actions, Danger Zone
  */
 function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
   const telemetry = useTelemetry();
   const queryClient = useQueryClient();
   const productTier = useProductTier();
@@ -1259,32 +1283,35 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
     setMcpSlug(value);
   };
 
-  const linkDomainButton = domain && domain.activated && domain.verified && (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="secondary"
-          size="sm"
-          className="mr-2"
-          disabled={updateToolsetMutation.isPending}
-          onClick={() => {
-            updateToolsetMutation.mutate({
-              request: {
-                slug: toolset.slug,
-                updateToolsetRequestBody: {
-                  customDomainId: domain.id,
-                  mcpSlug: mcpSlug,
+  const linkDomainButton = canWrite &&
+    domain &&
+    domain.activated &&
+    domain.verified && (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mr-2"
+            disabled={updateToolsetMutation.isPending}
+            onClick={() => {
+              updateToolsetMutation.mutate({
+                request: {
+                  slug: toolset.slug,
+                  updateToolsetRequestBody: {
+                    customDomainId: domain.id,
+                    mcpSlug: mcpSlug,
+                  },
                 },
-              },
-            });
-          }}
-        >
-          Link Domain
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>{domain.domain}</TooltipContent>
-    </Tooltip>
-  );
+              });
+            }}
+          >
+            Link Domain
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{domain.domain}</TooltipContent>
+      </Tooltip>
+    );
 
   // Account for legacy Pro tier which can still access custom domains
   const canAccessCustomDomain = !productTier.includes("base");
@@ -1368,6 +1395,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
                   onChange={handleMcpSlugChange}
                   maxLength={40}
                   requiredPrefix={`${orgSlug}-`}
+                  disabled={!canWrite}
                 />
               ) : (
                 <Input
@@ -1376,7 +1404,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
                   value={mcpSlug}
                   onChange={handleMcpSlugChange}
                   maxLength={40}
-                  disabled={!toolset.customDomainId}
+                  disabled={!toolset.customDomainId || !canWrite}
                 />
               )}
               <Stack
@@ -1456,17 +1484,19 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
         <Type muted small className="mb-4">
           Permanently delete this MCP server. This action cannot be undone.
         </Type>
-        <Button
-          variant="destructive-primary"
-          size="md"
-          onClick={() => setIsDeleteDialogOpen(true)}
-          disabled={isDeleteDialogOpen}
-        >
-          <Button.LeftIcon>
-            <Trash2 className="h-4 w-4" />
-          </Button.LeftIcon>
-          <Button.Text>Delete MCP Server</Button.Text>
-        </Button>
+        <RequireScope scope="mcp:write" level="component">
+          <Button
+            variant="destructive-primary"
+            size="md"
+            onClick={() => setIsDeleteDialogOpen(true)}
+            disabled={isDeleteDialogOpen}
+          >
+            <Button.LeftIcon>
+              <Trash2 className="h-4 w-4" />
+            </Button.LeftIcon>
+            <Button.Text>Delete MCP Server</Button.Text>
+          </Button>
+        </RequireScope>
       </div>
 
       <Dialog

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1328,19 +1328,21 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
     domain && canAccessCustomDomain && !toolset.customDomainId ? (
       linkDomainButton
     ) : (
-      <Button
-        variant="secondary"
-        size="sm"
-        onClick={() => {
-          if (!canAccessCustomDomain) {
-            setIsCustomDomainModalOpen(true);
-          } else {
-            routes.settings.goTo();
-          }
-        }}
-      >
-        Configure
-      </Button>
+      <RequireScope scope="build:write" level="component">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            if (!canAccessCustomDomain) {
+              setIsCustomDomainModalOpen(true);
+            } else {
+              routes.settings.goTo();
+            }
+          }}
+        >
+          Configure
+        </Button>
+      </RequireScope>
     );
 
   const anyChanges = mcpSlug !== toolset.mcpSlug;

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -170,7 +170,9 @@ function MCPDetailPageInner() {
 
   // Call hooks before any conditional returns
   const { url: mcpUrl } = useMcpUrl(toolset);
-  const { data: environmentsData } = useListEnvironments();
+  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
+    throwOnError: false,
+  });
   const environments = environmentsData?.environments ?? [];
 
   // Fetch MCP metadata early to use in useMissingRequiredEnvVars
@@ -429,7 +431,9 @@ export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
   const telemetry = useTelemetry();
 
   // Fetch data needed to detect system-provided vars on the attached env.
-  const { data: environmentsData } = useListEnvironments();
+  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
+    throwOnError: false,
+  });
   const environments = environmentsData?.environments ?? [];
   const { data: mcpMetadataData, isLoading: mcpMetadataLoading } =
     useGetMcpMetadata({ toolsetSlug: toolset.slug }, undefined, {

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -1,3 +1,4 @@
+import { RequireScope } from "@/components/require-scope";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -9,6 +10,7 @@ import {
 import { useSession } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
+import { useRBAC } from "@/hooks/useRBAC";
 import { Toolset } from "@/lib/toolTypes";
 import { useRoutes } from "@/routes";
 import type { McpEnvironmentConfigInput } from "@gram/client/models/components";
@@ -47,6 +49,8 @@ import { useEnvironmentVariables } from "./useEnvironmentVariables";
 const EMPTY_ENVIRONMENTS: never[] = [];
 
 export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
   const queryClient = useQueryClient();
   const telemetry = useTelemetry();
   const session = useSession();
@@ -712,9 +716,11 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
           ) : null
         }
         action={
-          <Button onClick={() => setIsAddingNew(true)} disabled={isAddingNew}>
-            <Button.Text>Add Variable</Button.Text>
-          </Button>
+          <RequireScope scope="mcp:write" level="component">
+            <Button onClick={() => setIsAddingNew(true)} disabled={isAddingNew}>
+              <Button.Text>Add Variable</Button.Text>
+            </Button>
+          </RequireScope>
         }
       >
         <div>
@@ -774,6 +780,7 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
                   onEditHeaderName={setEditingHeaderId}
                   onHeaderDisplayNameChange={handleHeaderDisplayNameChange}
                   onHeaderBlur={() => setEditingHeaderId(null)}
+                  readOnly={!canWrite}
                 />
               ))}
             </div>
@@ -787,12 +794,17 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
                 custom data to your backend. Environments can be shared across
                 multiple MCP servers.
               </p>
-              <Button onClick={() => setIsAddingNew(true)} variant="secondary">
-                <Button.LeftIcon>
-                  <Plus className="h-4 w-4" />
-                </Button.LeftIcon>
-                <Button.Text>Add Variable</Button.Text>
-              </Button>
+              <RequireScope scope="mcp:write" level="component">
+                <Button
+                  onClick={() => setIsAddingNew(true)}
+                  variant="secondary"
+                >
+                  <Button.LeftIcon>
+                    <Plus className="h-4 w-4" />
+                  </Button.LeftIcon>
+                  <Button.Text>Add Variable</Button.Text>
+                </Button>
+              </RequireScope>
             </div>
           )}
 
@@ -924,26 +936,28 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
       description="OAuth let's you control access to MCP servers through an identity provider."
       headingExtra={undefined}
       action={
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {!isOAuthEligible ? (
-              <span className="inline-block">
-                <Button disabled>
-                  <Button.Text>Configure</Button.Text>
+        <RequireScope scope="mcp:write" level="component">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {!isOAuthEligible ? (
+                <span className="inline-block">
+                  <Button disabled>
+                    <Button.Text>Configure</Button.Text>
+                  </Button>
+                </span>
+              ) : (
+                <Button onClick={handleConfigureClick}>
+                  <Button.Text>
+                    {isOAuthConnected ? "Manage" : "Configure"}
+                  </Button.Text>
                 </Button>
-              </span>
-            ) : (
-              <Button onClick={handleConfigureClick}>
-                <Button.Text>
-                  {isOAuthConnected ? "Manage" : "Configure"}
-                </Button.Text>
-              </Button>
+              )}
+            </TooltipTrigger>
+            {!isOAuthEligible && (
+              <TooltipContent>{disabledTooltipText}</TooltipContent>
             )}
-          </TooltipTrigger>
-          {!isOAuthEligible && (
-            <TooltipContent>{disabledTooltipText}</TooltipContent>
-          )}
-        </Tooltip>
+          </Tooltip>
+        </RequireScope>
       }
     >
       <OAuthStatusDisplay

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -1,4 +1,3 @@
-import { RequireScope } from "@/components/require-scope";
 import { Dialog } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -10,7 +9,6 @@ import {
 import { useSession } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
-import { useRBAC } from "@/hooks/useRBAC";
 import { Toolset } from "@/lib/toolTypes";
 import { useRoutes } from "@/routes";
 import type { McpEnvironmentConfigInput } from "@gram/client/models/components";
@@ -49,8 +47,6 @@ import { useEnvironmentVariables } from "./useEnvironmentVariables";
 const EMPTY_ENVIRONMENTS: never[] = [];
 
 export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
-  const { hasScope } = useRBAC();
-  const canWrite = hasScope("mcp:write");
   const queryClient = useQueryClient();
   const telemetry = useTelemetry();
   const session = useSession();
@@ -716,11 +712,9 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
           ) : null
         }
         action={
-          <RequireScope scope="mcp:write" level="component">
-            <Button onClick={() => setIsAddingNew(true)} disabled={isAddingNew}>
-              <Button.Text>Add Variable</Button.Text>
-            </Button>
-          </RequireScope>
+          <Button onClick={() => setIsAddingNew(true)} disabled={isAddingNew}>
+            <Button.Text>Add Variable</Button.Text>
+          </Button>
         }
       >
         <div>
@@ -780,7 +774,6 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
                   onEditHeaderName={setEditingHeaderId}
                   onHeaderDisplayNameChange={handleHeaderDisplayNameChange}
                   onHeaderBlur={() => setEditingHeaderId(null)}
-                  readOnly={!canWrite}
                 />
               ))}
             </div>
@@ -794,17 +787,12 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
                 custom data to your backend. Environments can be shared across
                 multiple MCP servers.
               </p>
-              <RequireScope scope="mcp:write" level="component">
-                <Button
-                  onClick={() => setIsAddingNew(true)}
-                  variant="secondary"
-                >
-                  <Button.LeftIcon>
-                    <Plus className="h-4 w-4" />
-                  </Button.LeftIcon>
-                  <Button.Text>Add Variable</Button.Text>
-                </Button>
-              </RequireScope>
+              <Button onClick={() => setIsAddingNew(true)} variant="secondary">
+                <Button.LeftIcon>
+                  <Plus className="h-4 w-4" />
+                </Button.LeftIcon>
+                <Button.Text>Add Variable</Button.Text>
+              </Button>
             </div>
           )}
 
@@ -936,28 +924,26 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
       description="OAuth let's you control access to MCP servers through an identity provider."
       headingExtra={undefined}
       action={
-        <RequireScope scope="mcp:write" level="component">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {!isOAuthEligible ? (
-                <span className="inline-block">
-                  <Button disabled>
-                    <Button.Text>Configure</Button.Text>
-                  </Button>
-                </span>
-              ) : (
-                <Button onClick={handleConfigureClick}>
-                  <Button.Text>
-                    {isOAuthConnected ? "Manage" : "Configure"}
-                  </Button.Text>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {!isOAuthEligible ? (
+              <span className="inline-block">
+                <Button disabled>
+                  <Button.Text>Configure</Button.Text>
                 </Button>
-              )}
-            </TooltipTrigger>
-            {!isOAuthEligible && (
-              <TooltipContent>{disabledTooltipText}</TooltipContent>
+              </span>
+            ) : (
+              <Button onClick={handleConfigureClick}>
+                <Button.Text>
+                  {isOAuthConnected ? "Manage" : "Configure"}
+                </Button.Text>
+              </Button>
             )}
-          </Tooltip>
-        </RequireScope>
+          </TooltipTrigger>
+          {!isOAuthEligible && (
+            <TooltipContent>{disabledTooltipText}</TooltipContent>
+          )}
+        </Tooltip>
       }
     >
       <OAuthStatusDisplay

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -1068,9 +1068,9 @@ function OAuthStatusDisplay({
   }
 
   return (
-    <div className="rounded-lg border border-dashed p-4 text-center">
-      <p className="text-muted-foreground mb-1">
-        <Shield className="text-muted-foreground mx-auto mb-1 h-5 w-5" />
+    <div className="rounded-lg border border-dashed px-6 py-8 text-center">
+      <Shield className="text-muted-foreground mx-auto mb-3 h-6 w-6" />
+      <p className="text-muted-foreground mb-2 font-medium">
         OAuth is not applicable
       </p>
       {!mcpEnabled ? (
@@ -1078,17 +1078,12 @@ function OAuthStatusDisplay({
           Enable the MCP server to configure OAuth.
         </p>
       ) : (
-        <>
-          <p className="text-muted-foreground text-sm">
-            OAuth cannot be configured because there are no tools in this server
-            that require OAuth authentication.
-          </p>
-          <p className="text-muted-foreground text-sm">
-            OAuth is available for public MCP servers that have at least one
-            tool requiring OAuth authentication, or private servers (using
-            Speakeasy as an auth provider).
-          </p>
-        </>
+        <p className="text-muted-foreground mx-auto max-w-lg text-sm">
+          OAuth cannot be configured because there are no tools in this server
+          that require OAuth authentication. OAuth is available for public MCP
+          servers that have at least one tool requiring OAuth authentication, or
+          private servers (using Speakeasy as an auth provider).
+        </p>
       )}
     </div>
   );

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -52,7 +52,9 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
   const session = useSession();
   const routes = useRoutes();
 
-  const { data: environmentsData } = useListEnvironments();
+  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
+    throwOnError: false,
+  });
   // Use stable reference for empty array to prevent infinite loops
   const environments = environmentsData?.environments ?? EMPTY_ENVIRONMENTS;
   const { data: mcpMetadataData } = useGetMcpMetadata(
@@ -888,7 +890,9 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
   const [isGramOAuthModalOpen, setIsGramOAuthModalOpen] = useState(false);
   const [isOAuthDetailsModalOpen, setIsOAuthDetailsModalOpen] = useState(false);
 
-  const { data: environmentsData } = useListEnvironments();
+  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
+    throwOnError: false,
+  });
   const environments = environmentsData?.environments ?? [];
 
   const isOAuthConnected = !!(

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -52,9 +52,7 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
   const session = useSession();
   const routes = useRoutes();
 
-  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
-    throwOnError: false,
-  });
+  const { data: environmentsData } = useListEnvironments();
   // Use stable reference for empty array to prevent infinite loops
   const environments = environmentsData?.environments ?? EMPTY_ENVIRONMENTS;
   const { data: mcpMetadataData } = useGetMcpMetadata(
@@ -890,9 +888,7 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
   const [isGramOAuthModalOpen, setIsGramOAuthModalOpen] = useState(false);
   const [isOAuthDetailsModalOpen, setIsOAuthDetailsModalOpen] = useState(false);
 
-  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
-    throwOnError: false,
-  });
+  const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];
 
   const isOAuthConnected = !!(

--- a/client/dashboard/src/pages/mcp/MCPPerformanceTab.tsx
+++ b/client/dashboard/src/pages/mcp/MCPPerformanceTab.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@/components/ui/heading";
 import { Type } from "@/components/ui/type";
 import { useTelemetry } from "@/contexts/Telemetry";
+import { useRBAC } from "@/hooks/useRBAC";
 import { Toolset } from "@/lib/toolTypes";
 import { cn } from "@/lib/utils";
 import {
@@ -82,6 +83,8 @@ function ModeCard({
 }
 
 export function MCPPerformanceTab({ toolset }: { toolset: Toolset }) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
   const queryClient = useQueryClient();
   const telemetry = useTelemetry();
 
@@ -102,7 +105,7 @@ export function MCPPerformanceTab({ toolset }: { toolset: Toolset }) {
   const toolSelectionMode = toolset.toolSelectionMode ?? "static";
 
   const onSelectMode = (mode: string) => {
-    if (mode === toolSelectionMode) return;
+    if (!canWrite || mode === toolSelectionMode) return;
     updateToolsetMutation.mutate({
       request: {
         slug: toolset.slug,

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -207,7 +207,9 @@ function OAuthWizard({
   });
 
   const createEnvironmentMutation = useCreateEnvironmentMutation();
-  const { data: environmentsData } = useListEnvironments();
+  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
+    throwOnError: false,
+  });
   const environments = environmentsData?.environments ?? [];
 
   // --- Step actions ---

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -207,9 +207,7 @@ function OAuthWizard({
   });
 
   const createEnvironmentMutation = useCreateEnvironmentMutation();
-  const { data: environmentsData } = useListEnvironments(undefined, undefined, {
-    throwOnError: false,
-  });
+  const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];
 
   // --- Step actions ---

--- a/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
+++ b/client/dashboard/src/pages/observability/ObservabilityOverview.tsx
@@ -1,6 +1,7 @@
 import { Page } from "@/components/page-layout";
 import { InsightsConfig } from "@/components/insights-sidebar";
 import { useInsightsState } from "@/components/insights-context";
+import { RequireScope } from "@/components/require-scope";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
@@ -537,6 +538,14 @@ function parseLocalDate(dateStr: string): Date {
 }
 
 export default function ObservabilityOverview() {
+  return (
+    <RequireScope scope="build:read" level="page">
+      <ObservabilityOverviewInner />
+    </RequireScope>
+  );
+}
+
+function ObservabilityOverviewInner() {
   const [searchParams, setSearchParams] = useSearchParams();
   const client = useGramContext();
 

--- a/client/dashboard/src/pages/onboarding/FunctionsOnboarding.tsx
+++ b/client/dashboard/src/pages/onboarding/FunctionsOnboarding.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { GettingStartedInstructions } from "@/components/functions/GettingStartedInstructions";
 import { Heading } from "@/components/ui/heading";
 import { Type } from "@/components/ui/type";
@@ -12,38 +13,40 @@ export default function FunctionsOnboarding() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <div className="max-w-2xl">
-          {/* Header */}
-          <Stack gap={3} className="mb-8">
-            <Stack direction="horizontal" gap={3} align="center">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
-                <CodeIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <Heading variant="h3">Add Custom Functions</Heading>
+        <RequireScope scope="build:write" level="page">
+          <div className="max-w-2xl">
+            {/* Header */}
+            <Stack gap={3} className="mb-8">
+              <Stack direction="horizontal" gap={3} align="center">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
+                  <CodeIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                </div>
+                <Heading variant="h3">Add Custom Functions</Heading>
+              </Stack>
+              <Type muted>
+                Create custom tools using TypeScript functions. Functions let
+                you extend your MCP server with custom logic and integrations.
+              </Type>
             </Stack>
-            <Type muted>
-              Create custom tools using TypeScript functions. Functions let you
-              extend your MCP server with custom logic and integrations.
+
+            {/* Instructions */}
+            <GettingStartedInstructions />
+
+            {/* Help text */}
+            <Type small muted className="mt-6">
+              Need help?{" "}
+              <a
+                href="https://www.speakeasy.com/docs/gram/getting-started/typescript"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                View the documentation
+              </a>{" "}
+              for detailed guides and examples.
             </Type>
-          </Stack>
-
-          {/* Instructions */}
-          <GettingStartedInstructions />
-
-          {/* Help text */}
-          <Type small muted className="mt-6">
-            Need help?{" "}
-            <a
-              href="https://www.speakeasy.com/docs/gram/getting-started/typescript"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary hover:underline"
-            >
-              View the documentation
-            </a>{" "}
-            for detailed guides and examples.
-          </Type>
-        </div>
+          </div>
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
+++ b/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Stepper, StepProps } from "@/components/stepper";
 import {
   Accordion,
@@ -38,77 +39,79 @@ export default function UploadOpenAPI() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <div className="max-w-2xl">
-          {/* Header */}
-          <Stack gap={3} className="mb-8">
-            <Stack direction="horizontal" gap={3} align="center">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
-                <FileTextIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-              </div>
-              <Heading variant="h3">Import OpenAPI Specification</Heading>
-            </Stack>
-            <Type muted>
-              Upload your OpenAPI spec to automatically generate tools for every
-              endpoint. Supports JSON and YAML formats.
-            </Type>
-          </Stack>
-
-          {/* Stepper */}
-          <UploadAssetStepper.Provider step={1}>
-            <UploadAssetStepper.Frame>
-              <UploadAssetStep step={1}>
-                <UploadAssetStep.Indicator />
-                <UploadAssetStep.Header
-                  title="Upload OpenAPI Specification"
-                  description="Upload your OpenAPI specification to get started."
-                />
-                <UploadAssetStep.Content>
-                  <UploadFileStep />
-                </UploadAssetStep.Content>
-              </UploadAssetStep>
-
-              <UploadAssetStep step={2}>
-                <UploadAssetStep.Indicator />
-                <UploadAssetStep.Header
-                  title="Name Your API"
-                  description="The tools generated will be scoped under this name."
-                />
-                <UploadAssetStep.Content>
-                  <NameDeploymentStep />
-                </UploadAssetStep.Content>
-              </UploadAssetStep>
-
-              <UploadAssetStep step={3}>
-                <UploadAssetStep.Indicator />
-                <UploadAssetStep.Header
-                  title="Generate Tools"
-                  description="Gram will generate tools for your API."
-                />
-                <UploadAssetStep.Content>
-                  <DeployStep />
-                </UploadAssetStep.Content>
-              </UploadAssetStep>
-
-              <Stack direction="horizontal" justify="start">
-                <FooterActions />
+        <RequireScope scope="build:write" level="page">
+          <div className="max-w-2xl">
+            {/* Header */}
+            <Stack gap={3} className="mb-8">
+              <Stack direction="horizontal" gap={3} align="center">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+                  <FileTextIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                </div>
+                <Heading variant="h3">Import OpenAPI Specification</Heading>
               </Stack>
-            </UploadAssetStepper.Frame>
-          </UploadAssetStepper.Provider>
+              <Type muted>
+                Upload your OpenAPI spec to automatically generate tools for
+                every endpoint. Supports JSON and YAML formats.
+              </Type>
+            </Stack>
 
-          {/* Help text */}
-          <Type small muted className="mt-6">
-            Don't have an OpenAPI spec?{" "}
-            <a
-              href="https://www.speakeasy.com/docs/gram"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary hover:underline"
-            >
-              Learn how to create one
-            </a>{" "}
-            or try our sample specs.
-          </Type>
-        </div>
+            {/* Stepper */}
+            <UploadAssetStepper.Provider step={1}>
+              <UploadAssetStepper.Frame>
+                <UploadAssetStep step={1}>
+                  <UploadAssetStep.Indicator />
+                  <UploadAssetStep.Header
+                    title="Upload OpenAPI Specification"
+                    description="Upload your OpenAPI specification to get started."
+                  />
+                  <UploadAssetStep.Content>
+                    <UploadFileStep />
+                  </UploadAssetStep.Content>
+                </UploadAssetStep>
+
+                <UploadAssetStep step={2}>
+                  <UploadAssetStep.Indicator />
+                  <UploadAssetStep.Header
+                    title="Name Your API"
+                    description="The tools generated will be scoped under this name."
+                  />
+                  <UploadAssetStep.Content>
+                    <NameDeploymentStep />
+                  </UploadAssetStep.Content>
+                </UploadAssetStep>
+
+                <UploadAssetStep step={3}>
+                  <UploadAssetStep.Indicator />
+                  <UploadAssetStep.Header
+                    title="Generate Tools"
+                    description="Gram will generate tools for your API."
+                  />
+                  <UploadAssetStep.Content>
+                    <DeployStep />
+                  </UploadAssetStep.Content>
+                </UploadAssetStep>
+
+                <Stack direction="horizontal" justify="start">
+                  <FooterActions />
+                </Stack>
+              </UploadAssetStepper.Frame>
+            </UploadAssetStepper.Provider>
+
+            {/* Help text */}
+            <Type small muted className="mt-6">
+              Don't have an OpenAPI spec?{" "}
+              <a
+                href="https://www.speakeasy.com/docs/gram"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                Learn how to create one
+              </a>{" "}
+              or try our sample specs.
+            </Type>
+          </div>
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -20,7 +20,10 @@ export default function OrgHome() {
         <Page.Header.Title>Home</Page.Header.Title>
       </Page.Header>
       <Page.Body>
-        <RequireScope scope={["build:read", "org:admin"]} level="page">
+        <RequireScope
+          scope={["org:read", "build:read", "org:admin"]}
+          level="page"
+        >
           <OrgHomeInner />
         </RequireScope>
       </Page.Body>

--- a/client/dashboard/src/pages/org/Plugins.tsx
+++ b/client/dashboard/src/pages/org/Plugins.tsx
@@ -146,16 +146,16 @@ export default function Plugins() {
             hooks together. Assign plugins to roles and publish them to Claude
             Code and Cursor marketplaces via GitHub.
           </Page.Section.Description>
-          {(data?.plugins ?? []).length > 0 && (
-            <Page.Section.CTA>
+          <Page.Section.CTA>
+            {(data?.plugins ?? []).length > 0 && (
               <Button onClick={() => setIsCreateDialogOpen(true)}>
                 <Button.LeftIcon>
                   <Plus className="h-4 w-4" />
                 </Button.LeftIcon>
                 <Button.Text>New Plugin</Button.Text>
               </Button>
-            </Page.Section.CTA>
-          )}
+            )}
+          </Page.Section.CTA>
           <Page.Section.Body>
             {(data?.plugins ?? []).length === 0 ? (
               <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">

--- a/client/dashboard/src/pages/org/Plugins.tsx
+++ b/client/dashboard/src/pages/org/Plugins.tsx
@@ -1,7 +1,6 @@
 import { InputField } from "@/components/moon/input-field";
 import { Page } from "@/components/page-layout";
 import { Dialog } from "@/components/ui/dialog";
-import { Heading } from "@/components/ui/heading";
 import { SearchBar } from "@/components/ui/search-bar";
 import { Type } from "@/components/ui/type";
 import { HumanizeDateTime } from "@/lib/dates";
@@ -14,6 +13,7 @@ import {
 } from "@gram/client/react-query/plugins";
 import { useDeletePluginMutation } from "@gram/client/react-query/deletePlugin";
 import { Button, Column, Icon, Stack, Table } from "@speakeasy-api/moonshine";
+import { Plus, Puzzle } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { Link, Outlet, useNavigate } from "react-router";
@@ -136,68 +136,70 @@ export default function Plugins() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Plugins</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        {(data?.plugins ?? []).length === 0 ? (
-          <div className="flex flex-col items-center justify-center px-4 py-16">
-            <div className="w-full max-w-md space-y-6 text-center">
-              <div className="flex flex-col items-center gap-4">
-                <div className="bg-muted flex size-16 items-center justify-center rounded-full">
-                  <Icon
-                    name="puzzle"
-                    className="text-muted-foreground size-8"
-                  />
+        <Page.Section>
+          <Page.Section.Title>Plugins</Page.Section.Title>
+          <Page.Section.Description>
+            Create distributable plugin bundles that package MCP servers and
+            hooks together. Assign plugins to roles and publish them to Claude
+            Code and Cursor marketplaces via GitHub.
+          </Page.Section.Description>
+          {(data?.plugins ?? []).length > 0 && (
+            <Page.Section.CTA>
+              <Button onClick={() => setIsCreateDialogOpen(true)}>
+                <Button.LeftIcon>
+                  <Plus className="h-4 w-4" />
+                </Button.LeftIcon>
+                <Button.Text>New Plugin</Button.Text>
+              </Button>
+            </Page.Section.CTA>
+          )}
+          <Page.Section.Body>
+            {(data?.plugins ?? []).length === 0 ? (
+              <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+                <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+                  <Puzzle className="text-muted-foreground h-6 w-6" />
                 </div>
-                <div>
-                  <Heading variant="h4" className="mb-2">
-                    No plugins yet
-                  </Heading>
-                  <Type muted small>
-                    Create distributable plugin bundles that package MCP servers
-                    and hooks together. Assign plugins to roles and publish them
-                    to Claude Code and Cursor marketplaces via GitHub.
-                  </Type>
-                </div>
+                <Type variant="subheading" className="mb-1">
+                  No plugins yet
+                </Type>
+                <Type small muted className="mb-4 max-w-md text-center">
+                  Add your first plugin to start distributing MCP servers and
+                  hooks to Claude Code and Cursor.
+                </Type>
+                <Button onClick={() => setIsCreateDialogOpen(true)}>
+                  <Button.LeftIcon>
+                    <Plus className="h-4 w-4" />
+                  </Button.LeftIcon>
+                  <Button.Text>New Plugin</Button.Text>
+                </Button>
               </div>
-              <Button onClick={() => setIsCreateDialogOpen(true)}>
-                Create Your First Plugin
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <>
-            <Heading variant="h4" className="mb-2">
-              Plugins
-            </Heading>
-            <Type muted small className="mb-6">
-              Create distributable plugin bundles that package MCP servers and
-              hooks together. Assign plugins to roles and publish them to Claude
-              Code and Cursor marketplaces via GitHub.
-            </Type>
-            <Stack
-              direction="horizontal"
-              justify="space-between"
-              align="center"
-              className="mb-4"
-            >
-              <SearchBar
-                value={search}
-                onChange={setSearch}
-                placeholder="Search plugins"
-                className="w-64"
-              />
-              <Button onClick={() => setIsCreateDialogOpen(true)}>
-                New Plugin
-              </Button>
-            </Stack>
-            <Table
-              columns={columns}
-              data={filteredPlugins}
-              rowKey={(row) => row.id}
-            />
-          </>
-        )}
+            ) : (
+              <>
+                <Stack
+                  direction="horizontal"
+                  justify="space-between"
+                  align="center"
+                  className="mb-4"
+                >
+                  <SearchBar
+                    value={search}
+                    onChange={setSearch}
+                    placeholder="Search plugins"
+                    className="w-64"
+                  />
+                </Stack>
+                <Table
+                  columns={columns}
+                  data={filteredPlugins}
+                  rowKey={(row) => row.id}
+                />
+              </>
+            )}
+          </Page.Section.Body>
+        </Page.Section>
 
         {/* Create Dialog */}
         <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -44,9 +45,11 @@ import { ShareChatButton } from "./ShareChatButton";
 
 export default function Playground() {
   return (
-    <ChatProvider>
-      <PlaygroundInner />
-    </ChatProvider>
+    <RequireScope scope={["mcp:read", "mcp:write", "mcp:connect"]} level="page">
+      <ChatProvider>
+        <PlaygroundInner />
+      </ChatProvider>
+    </RequireScope>
   );
 }
 

--- a/client/dashboard/src/pages/prompts/Prompts.tsx
+++ b/client/dashboard/src/pages/prompts/Prompts.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Card, Cards } from "@/components/ui/card";
 import { MoreActions } from "@/components/ui/more-actions";
 import { UpdatedAt } from "@/components/updated-at";
@@ -20,10 +21,33 @@ export function PromptsRoot() {
 }
 
 export default function Prompts() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["build:read", "build:write"]} level="page">
+          <PromptsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function PromptsInner() {
   const { prompts, isLoading } = usePrompts();
   const routes = useRoutes();
 
-  let content = (
+  if (!isLoading && prompts && prompts.length === 0) {
+    return (
+      <PromptsEmptyState
+        onCreatePrompt={() => routes.prompts.newPrompt.goTo()}
+      />
+    );
+  }
+
+  return (
     <Page.Section>
       <Page.Section.Title>Prompt Templates</Page.Section.Title>
       <Page.Section.Description>
@@ -45,23 +69,6 @@ export default function Prompts() {
         </Cards>
       </Page.Section.Body>
     </Page.Section>
-  );
-
-  if (!isLoading && prompts && prompts.length === 0) {
-    content = (
-      <PromptsEmptyState
-        onCreatePrompt={() => routes.prompts.newPrompt.goTo()}
-      />
-    );
-  }
-
-  return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>{content}</Page.Body>
-    </Page>
   );
 }
 

--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
 import { Type } from "@/components/ui/type";
 import { useIsAdmin, useOrganization, useProject } from "@/contexts/Auth";
@@ -18,36 +19,42 @@ export default function Settings() {
         <Page.Header.Title>Project Settings</Page.Header.Title>
       </Page.Header>
       <Page.Body>
-        <Heading variant="h4" className="mb-2">
-          Project Settings
-        </Heading>
-        <Type muted small className="mb-6">
-          Manage your project configuration and perform administrative actions.
-        </Type>
-        <SettingsDangerZone />
+        <RequireScope scope="build:write" level="page">
+          <Heading variant="h4" className="mb-2">
+            Project Settings
+          </Heading>
+          <Type muted small className="mb-6">
+            Manage your project configuration and perform administrative
+            actions.
+          </Type>
+          <SettingsDangerZone />
 
-        {isAdmin && (
-          <div className="mt-8 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
-            <Stack
-              direction="horizontal"
-              align="center"
-              gap={2}
-              className="mb-3"
-            >
-              <ShieldAlert className="h-5 w-5 text-red-500" />
-              <Heading variant="h4" className="text-red-600 dark:text-red-400">
-                Admin Only
-              </Heading>
-            </Stack>
-            <dl className="mb-4 grid grid-cols-[max-content_auto] gap-x-6 gap-y-2">
-              <dt className="text-end">Organization ID</dt>
-              <dd className="font-mono text-sm">{organization.id}</dd>
-              <dt className="text-end">Project ID</dt>
-              <dd className="font-mono text-sm">{project.id}</dd>
-            </dl>
-            <RegistryCacheSection />
-          </div>
-        )}
+          {isAdmin && (
+            <div className="mt-8 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
+              <Stack
+                direction="horizontal"
+                align="center"
+                gap={2}
+                className="mb-3"
+              >
+                <ShieldAlert className="h-5 w-5 text-red-500" />
+                <Heading
+                  variant="h4"
+                  className="text-red-600 dark:text-red-400"
+                >
+                  Admin Only
+                </Heading>
+              </Stack>
+              <dl className="mb-4 grid grid-cols-[max-content_auto] gap-x-6 gap-y-2">
+                <dt className="text-end">Organization ID</dt>
+                <dd className="font-mono text-sm">{organization.id}</dd>
+                <dt className="text-end">Project ID</dt>
+                <dd className="font-mono text-sm">{project.id}</dd>
+              </dl>
+              <RegistryCacheSection />
+            </div>
+          )}
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/slackapp/SlackApp.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackApp.tsx
@@ -1,6 +1,7 @@
 import { AssetImage } from "@/components/asset-image";
 import { EnterpriseGate } from "@/components/enterprise-gate";
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { CompactUpload } from "@/components/upload";
 import { useAssetImageUploadHandler } from "@/components/useAssetImageUploadHandler";
 import { Badge } from "@/components/ui/badge";
@@ -275,6 +276,21 @@ function CreateSlackAppDialog({
 }
 
 export default function SlackAppsIndex() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["mcp:read", "mcp:write"]} level="page">
+          <SlackAppsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function SlackAppsInner() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const { data, isLoading } = useListSlackApps(undefined, undefined, {
     retry: false,
@@ -284,57 +300,47 @@ export default function SlackAppsIndex() {
   const apps = data?.items ?? [];
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>
-        <EnterpriseGate
-          icon="slack"
-          description="Assistants are available on the Enterprise plan. Book a time to get started."
-        >
-          <Page.Section>
-            <Page.Section.Title>Assistants</Page.Section.Title>
-            <Page.Section.Description>
-              Create and manage assistants that connect your team to Gram
-              toolsets in Slack.
-            </Page.Section.Description>
-            <Page.Section.CTA>
-              {apps.length > 0 && (
-                <Button onClick={() => setDialogOpen(true)}>
-                  <Button.LeftIcon>
-                    <Icon name="plus" className="h-4 w-4" />
-                  </Button.LeftIcon>
-                  <Button.Text>Create new Assistant</Button.Text>
-                </Button>
-              )}
-            </Page.Section.CTA>
-            <Page.Section.Body>
-              {isLoading ? (
-                <Stack align="center" justify="center" className="py-16">
-                  <Icon
-                    name="loader-circle"
-                    className="text-muted-foreground h-6 w-6 animate-spin"
-                  />
-                </Stack>
-              ) : apps.length === 0 ? (
-                <SlackAppsEmptyState onCreate={() => setDialogOpen(true)} />
-              ) : (
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-                  {apps.map((app) => (
-                    <SlackAppCard key={app.id} app={app} />
-                  ))}
-                </div>
-              )}
-            </Page.Section.Body>
-          </Page.Section>
+    <EnterpriseGate
+      icon="slack"
+      description="Assistants are available on the Enterprise plan. Book a time to get started."
+    >
+      <Page.Section>
+        <Page.Section.Title>Assistants</Page.Section.Title>
+        <Page.Section.Description>
+          Create and manage assistants that connect your team to Gram toolsets
+          in Slack.
+        </Page.Section.Description>
+        <Page.Section.CTA>
+          {apps.length > 0 && (
+            <Button onClick={() => setDialogOpen(true)}>
+              <Button.LeftIcon>
+                <Icon name="plus" className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>Create new Assistant</Button.Text>
+            </Button>
+          )}
+        </Page.Section.CTA>
+        <Page.Section.Body>
+          {isLoading ? (
+            <Stack align="center" justify="center" className="py-16">
+              <Icon
+                name="loader-circle"
+                className="text-muted-foreground h-6 w-6 animate-spin"
+              />
+            </Stack>
+          ) : apps.length === 0 ? (
+            <SlackAppsEmptyState onCreate={() => setDialogOpen(true)} />
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {apps.map((app) => (
+                <SlackAppCard key={app.id} app={app} />
+              ))}
+            </div>
+          )}
+        </Page.Section.Body>
+      </Page.Section>
 
-          <CreateSlackAppDialog
-            open={dialogOpen}
-            onOpenChange={setDialogOpen}
-          />
-        </EnterpriseGate>
-      </Page.Body>
-    </Page>
+      <CreateSlackAppDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </EnterpriseGate>
   );
 }

--- a/client/dashboard/src/pages/sources/SourceSettingsTab.tsx
+++ b/client/dashboard/src/pages/sources/SourceSettingsTab.tsx
@@ -13,6 +13,7 @@ import {
   useLatestDeployment,
   useListAssets,
 } from "@gram/client/react-query/index.js";
+import { RequireScope } from "@/components/require-scope";
 import { Button, Dialog, Stack } from "@speakeasy-api/moonshine";
 import { Download, Eye, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -131,16 +132,18 @@ export function SourceSettingsTab({
             Removing this source will remove it from the current deployment.
             This action cannot be undone.
           </Type>
-          <Button
-            variant="destructive-primary"
-            size="md"
-            onClick={() => setDeleteDialogOpen(true)}
-          >
-            <Button.LeftIcon>
-              <Trash2 className="h-4 w-4" />
-            </Button.LeftIcon>
-            <Button.Text>Delete Source</Button.Text>
-          </Button>
+          <RequireScope scope="build:write" level="component">
+            <Button
+              variant="destructive-primary"
+              size="md"
+              onClick={() => setDeleteDialogOpen(true)}
+            >
+              <Button.LeftIcon>
+                <Trash2 className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>Delete Source</Button.Text>
+            </Button>
+          </RequireScope>
         </div>
       </div>
 

--- a/client/dashboard/src/pages/sources/Sources.tsx
+++ b/client/dashboard/src/pages/sources/Sources.tsx
@@ -7,6 +7,15 @@ export function SourcesRoot() {
   return <Outlet />;
 }
 
+/** Gates the shared Catalog behind build:write when accessed via sources/add-from-catalog. */
+export function AddFromCatalogGate() {
+  return (
+    <RequireScope scope="build:write" level="page">
+      <Outlet />
+    </RequireScope>
+  );
+}
+
 export function SourcesPage() {
   return (
     <Page>

--- a/client/dashboard/src/pages/sources/Sources.tsx
+++ b/client/dashboard/src/pages/sources/Sources.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router";
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import SourcesComponent from "@/components/sources/Sources";
 
 export function SourcesRoot() {
@@ -13,7 +14,9 @@ export function SourcesPage() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <SourcesComponent />
+        <RequireScope scope={["build:read", "build:write"]} level="page">
+          <SourcesComponent />
+        </RequireScope>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/sources/external-mcp/ExternalMCPDetails.tsx
+++ b/client/dashboard/src/pages/sources/external-mcp/ExternalMCPDetails.tsx
@@ -12,6 +12,7 @@ import {
   useListToolsets,
 } from "@gram/client/react-query/index.js";
 import { ToolsetEntry } from "@gram/client/models/components";
+import { RequireScope } from "@/components/require-scope";
 import { Badge, Button, Dialog, Stack } from "@speakeasy-api/moonshine";
 import { ChevronRight, Globe, Lock, Power, Server, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -279,16 +280,18 @@ export default function ExternalMCPDetails() {
                   Removing this source will remove it from the current
                   deployment. This action cannot be undone.
                 </Type>
-                <Button
-                  variant="destructive-primary"
-                  size="md"
-                  onClick={() => setDeleteDialogOpen(true)}
-                >
-                  <Button.LeftIcon>
-                    <Trash2 className="h-4 w-4" />
-                  </Button.LeftIcon>
-                  <Button.Text>Delete Source</Button.Text>
-                </Button>
+                <RequireScope scope="build:write" level="component">
+                  <Button
+                    variant="destructive-primary"
+                    size="md"
+                    onClick={() => setDeleteDialogOpen(true)}
+                  >
+                    <Button.LeftIcon>
+                      <Trash2 className="h-4 w-4" />
+                    </Button.LeftIcon>
+                    <Button.Text>Delete Source</Button.Text>
+                  </Button>
+                </RequireScope>
               </div>
             </div>
           </TabsContent>

--- a/client/dashboard/src/pages/toolBuilder/CustomTools.tsx
+++ b/client/dashboard/src/pages/toolBuilder/CustomTools.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { ToolCollectionBadge } from "@/components/tool-collection-badge";
 import { Card, Cards } from "@/components/ui/card";
 import { MoreActions } from "@/components/ui/more-actions";
@@ -28,6 +29,21 @@ export function CustomToolsRoot() {
 }
 
 export default function CustomTools() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["build:read", "build:write"]} level="page">
+          <CustomToolsInner />
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function CustomToolsInner() {
   const { customTools, isLoading } = useCustomTools();
   const [newToolDialogOpen, setNewToolDialogOpen] = useState(false);
 
@@ -35,42 +51,36 @@ export default function CustomTools() {
     setNewToolDialogOpen(true);
   };
 
-  let content = (
-    <Page.Section>
-      <Page.Section.Title>Custom Tools</Page.Section.Title>
-      <Page.Section.Description>
-        Create higher-order tools by sequencing together tools and instructions
-      </Page.Section.Description>
-      <Page.Section.CTA>
-        <Button onClick={onNewCustomTool}>
-          <Button.LeftIcon>
-            <Plus className="h-4 w-4" />
-          </Button.LeftIcon>
-          <Button.Text>New Custom Tool</Button.Text>
-        </Button>
-      </Page.Section.CTA>
-      <Page.Section.Body>
-        <Cards isLoading={isLoading}>
-          {customTools?.map((template) => {
-            return <CustomToolCard key={template.id} template={template} />;
-          })}
-        </Cards>
-      </Page.Section.Body>
-    </Page.Section>
-  );
-
-  if (!isLoading && (!customTools || customTools.length === 0)) {
-    content = <CustomToolsEmptyState onCreateCustomTool={onNewCustomTool} />;
-  }
-
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>{content}</Page.Body>
+    <>
+      {!isLoading && (!customTools || customTools.length === 0) ? (
+        <CustomToolsEmptyState onCreateCustomTool={onNewCustomTool} />
+      ) : (
+        <Page.Section>
+          <Page.Section.Title>Custom Tools</Page.Section.Title>
+          <Page.Section.Description>
+            Create higher-order tools by sequencing together tools and
+            instructions
+          </Page.Section.Description>
+          <Page.Section.CTA>
+            <Button onClick={onNewCustomTool}>
+              <Button.LeftIcon>
+                <Plus className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>New Custom Tool</Button.Text>
+            </Button>
+          </Page.Section.CTA>
+          <Page.Section.Body>
+            <Cards isLoading={isLoading}>
+              {customTools?.map((template) => {
+                return <CustomToolCard key={template.id} template={template} />;
+              })}
+            </Cards>
+          </Page.Section.Body>
+        </Page.Section>
+      )}
       <ToolifyDialog open={newToolDialogOpen} setOpen={setNewToolDialogOpen} />
-    </Page>
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/toolsets/PromptsTab.tsx
+++ b/client/dashboard/src/pages/toolsets/PromptsTab.tsx
@@ -1,13 +1,16 @@
 import { CreateThingCard } from "@/components/create-thing-card";
+import { EmptyState } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Cards } from "@/components/ui/card";
 import { Type } from "@/components/ui/type";
 import { Toolset } from "@/lib/toolTypes";
 import { useRoutes } from "@/routes";
 import { PromptTemplate } from "@gram/client/models/components";
 import { useUpdateToolsetMutation } from "@gram/client/react-query";
-import { Stack } from "@speakeasy-api/moonshine";
+import { Button, Stack } from "@speakeasy-api/moonshine";
 import { useState } from "react";
 import { PromptTemplateCard } from "../prompts/Prompts";
+import { ToolsetsGraphic } from "./ToolsetsEmptyState";
 import { usePrompts } from "../prompts/usePrompts";
 import { PromptSelectPopover } from "../prompts/PromptSelectPopover";
 
@@ -53,6 +56,28 @@ export function PromptsTabContent({
     });
   };
 
+  const hasPrompts = toolsetPrompts && toolsetPrompts.length > 0;
+
+  if (!hasPrompts) {
+    return (
+      <EmptyState
+        heading="No prompts yet"
+        description="Add prompt templates to this MCP server."
+        nonEmptyProjectCTA={
+          <RequireScope scope="mcp:write" level="section">
+            <Stack gap={2} direction="horizontal">
+              <routes.prompts.newPrompt.Link>
+                <Button size="sm">Create Prompt</Button>
+              </routes.prompts.newPrompt.Link>
+            </Stack>
+          </RequireScope>
+        }
+        graphic={<ToolsetsGraphic />}
+        graphicClassName="scale-90"
+      />
+    );
+  }
+
   return (
     <>
       <Cards isLoading={!toolset}>
@@ -65,35 +90,38 @@ export function PromptsTabContent({
           />
         ))}
       </Cards>
-      <Stack
-        gap={3}
-        direction={"horizontal"}
-        align={"center"}
-        className="w-full max-w-4xl"
-      >
-        {allPrompts && allPrompts?.length > 0 && (
-          <>
-            <PromptSelectPopover
-              open={promptSelectPopoverOpen}
-              setOpen={setPromptSelectPopoverOpen}
-              onSelect={(prompt) => addPromptToToolset(prompt)}
-            >
-              {/* For some reason the popover doesnt show up in the right place without this div */}
-              <div className="w-full">
-                <CreateThingCard className="mb-0!">
-                  + Add Prompt
-                </CreateThingCard>
-              </div>
-            </PromptSelectPopover>
-            <Type muted>or</Type>
-          </>
-        )}
-        <div className="w-full">
-          <routes.prompts.newPrompt.Link>
-            <CreateThingCard className="mb-0!">+ Create Prompt</CreateThingCard>
-          </routes.prompts.newPrompt.Link>
-        </div>
-      </Stack>
+      <RequireScope scope="mcp:write" level="section">
+        <Stack
+          gap={3}
+          direction={"horizontal"}
+          align={"center"}
+          className="w-full max-w-4xl"
+        >
+          {allPrompts && allPrompts?.length > 0 && (
+            <>
+              <PromptSelectPopover
+                open={promptSelectPopoverOpen}
+                setOpen={setPromptSelectPopoverOpen}
+                onSelect={(prompt) => addPromptToToolset(prompt)}
+              >
+                <div className="w-full">
+                  <CreateThingCard className="mb-0!">
+                    + Add Prompt
+                  </CreateThingCard>
+                </div>
+              </PromptSelectPopover>
+              <Type muted>or</Type>
+            </>
+          )}
+          <div className="w-full">
+            <routes.prompts.newPrompt.Link>
+              <CreateThingCard className="mb-0!">
+                + Create Prompt
+              </CreateThingCard>
+            </routes.prompts.newPrompt.Link>
+          </div>
+        </Stack>
+      </RequireScope>
     </>
   );
 }

--- a/client/dashboard/src/pages/toolsets/PromptsTab.tsx
+++ b/client/dashboard/src/pages/toolsets/PromptsTab.tsx
@@ -64,7 +64,7 @@ export function PromptsTabContent({
         heading="No prompts yet"
         description="Add prompt templates to this MCP server."
         nonEmptyProjectCTA={
-          <RequireScope scope="mcp:write" level="section">
+          <RequireScope scope="mcp:write" level="component">
             <Stack gap={2} direction="horizontal">
               <routes.prompts.newPrompt.Link>
                 <Button size="sm">Create Prompt</Button>

--- a/client/dashboard/src/pages/toolsets/ToolsetEmptyState.tsx
+++ b/client/dashboard/src/pages/toolsets/ToolsetEmptyState.tsx
@@ -6,13 +6,13 @@ export function ToolsetEmptyState({
   onAddTools,
 }: {
   toolsetSlug: string;
-  onAddTools: () => void;
+  onAddTools?: () => void;
 }) {
-  const cta = (
+  const cta = onAddTools ? (
     <Button size="sm" onClick={onAddTools}>
       ADD TOOLS
     </Button>
-  );
+  ) : undefined;
 
   return (
     <EmptyState

--- a/client/dashboard/src/pages/toolsets/resources/ResourcesEmptyState.tsx
+++ b/client/dashboard/src/pages/toolsets/resources/ResourcesEmptyState.tsx
@@ -9,7 +9,7 @@ export function ResourcesEmptyState({
   onAddResources: () => void;
 }) {
   const cta = (
-    <RequireScope scope="mcp:write" level="section">
+    <RequireScope scope="mcp:write" level="component">
       <Button size="sm" onClick={onAddResources}>
         ADD RESOURCES
       </Button>

--- a/client/dashboard/src/pages/toolsets/resources/ResourcesEmptyState.tsx
+++ b/client/dashboard/src/pages/toolsets/resources/ResourcesEmptyState.tsx
@@ -1,4 +1,5 @@
 import { EmptyState } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
 import { Button } from "@speakeasy-api/moonshine";
 import { ToolsetsGraphic } from "../ToolsetsEmptyState";
 
@@ -8,9 +9,11 @@ export function ResourcesEmptyState({
   onAddResources: () => void;
 }) {
   const cta = (
-    <Button size="sm" onClick={onAddResources}>
-      ADD RESOURCES
-    </Button>
+    <RequireScope scope="mcp:write" level="section">
+      <Button size="sm" onClick={onAddResources}>
+        ADD RESOURCES
+      </Button>
+    </RequireScope>
   );
 
   return (

--- a/client/dashboard/src/pages/toolsets/resources/ResourcesTab.tsx
+++ b/client/dashboard/src/pages/toolsets/resources/ResourcesTab.tsx
@@ -1,3 +1,4 @@
+import { RequireScope } from "@/components/require-scope";
 import { Card, Cards } from "@/components/ui/card";
 import {
   Command,
@@ -14,6 +15,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Type } from "@/components/ui/type";
+import { useRBAC } from "@/hooks/useRBAC";
 import { useLatestDeployment, useListResources } from "@/hooks/toolTypes";
 import { Resource, Toolset } from "@/lib/toolTypes";
 import { useUpdateToolsetMutation } from "@gram/client/react-query";
@@ -114,11 +116,13 @@ export function ResourcesTabContent({
           );
         })}
       {allResources && allResources.length > 0 && (
-        <ResourceSelectPopover
-          allResources={allResources}
-          currentResourceUrns={currentResourceUrns}
-          onSelect={(resourceUrn) => addResourceToToolset(resourceUrn)}
-        />
+        <RequireScope scope="mcp:write" level="section">
+          <ResourceSelectPopover
+            allResources={allResources}
+            currentResourceUrns={currentResourceUrns}
+            onSelect={(resourceUrn) => addResourceToToolset(resourceUrn)}
+          />
+        </RequireScope>
       )}
     </Cards>
   );
@@ -133,12 +137,15 @@ function ResourceCard({
   functionName?: string;
   onDelete: () => void;
 }) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
   const actions = [
     {
       label: "Remove from toolset",
       onClick: onDelete,
       icon: "trash" as const,
       destructive: true,
+      disabled: !canWrite,
     },
   ];
 

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -1,7 +1,7 @@
 import { McpIcon } from "@/components/ui/mcp-icon";
 import { Icon, IconName, IconProps } from "@speakeasy-api/moonshine";
 import React, { useMemo } from "react";
-import { Link, useLocation, useNavigate } from "react-router";
+import { Link, Outlet, useLocation, useNavigate } from "react-router";
 import { useSlugs } from "./contexts/Sdk";
 import { cn } from "./lib/utils";
 import Billing from "./pages/billing/Billing";
@@ -57,6 +57,7 @@ import SecurityOverview from "./pages/security/SecurityOverview";
 import PolicyCenter from "./pages/security/PolicyCenter";
 import Team from "./pages/team/Team";
 import AcceptInvite from "./pages/invite/AcceptInvite";
+import { RequireScope } from "./components/require-scope";
 import SourceDetails from "./pages/sources/SourceDetails";
 import { SourcesPage, SourcesRoot } from "./pages/sources/Sources";
 import CustomTools, { CustomToolsRoot } from "./pages/toolBuilder/CustomTools";
@@ -64,6 +65,15 @@ import {
   ToolBuilderNew,
   ToolBuilderPage,
 } from "./pages/toolBuilder/ToolBuilder";
+
+/** Wrapper that gates the shared Catalog behind build:write when accessed via sources/add-from-catalog. */
+function AddFromCatalogGate() {
+  return (
+    <RequireScope scope="build:write" level="page">
+      <Outlet />
+    </RequireScope>
+  );
+}
 
 type AppRouteBasic = {
   title: string;
@@ -236,7 +246,7 @@ const ROUTE_STRUCTURE = {
       addFromCatalog: {
         title: "Add from Catalog",
         url: "add-from-catalog",
-        component: CatalogRoot,
+        component: AddFromCatalogGate,
         indexComponent: Catalog,
       },
     },

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -1,7 +1,7 @@
 import { McpIcon } from "@/components/ui/mcp-icon";
 import { Icon, IconName, IconProps } from "@speakeasy-api/moonshine";
 import React, { useMemo } from "react";
-import { Link, Outlet, useLocation, useNavigate } from "react-router";
+import { Link, useLocation, useNavigate } from "react-router";
 import { useSlugs } from "./contexts/Sdk";
 import { cn } from "./lib/utils";
 import Billing from "./pages/billing/Billing";
@@ -57,23 +57,17 @@ import SecurityOverview from "./pages/security/SecurityOverview";
 import PolicyCenter from "./pages/security/PolicyCenter";
 import Team from "./pages/team/Team";
 import AcceptInvite from "./pages/invite/AcceptInvite";
-import { RequireScope } from "./components/require-scope";
 import SourceDetails from "./pages/sources/SourceDetails";
-import { SourcesPage, SourcesRoot } from "./pages/sources/Sources";
+import {
+  AddFromCatalogGate,
+  SourcesPage,
+  SourcesRoot,
+} from "./pages/sources/Sources";
 import CustomTools, { CustomToolsRoot } from "./pages/toolBuilder/CustomTools";
 import {
   ToolBuilderNew,
   ToolBuilderPage,
 } from "./pages/toolBuilder/ToolBuilder";
-
-/** Wrapper that gates the shared Catalog behind build:write when accessed via sources/add-from-catalog. */
-function AddFromCatalogGate() {
-  return (
-    <RequireScope scope="build:write" level="page">
-      <Outlet />
-    </RequireScope>
-  );
-}
 
 type AppRouteBasic = {
   title: string;

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -309,7 +309,7 @@ const ROUTE_STRUCTURE = {
   environments: {
     title: "Environments",
     url: "environments",
-    icon: "key",
+    icon: "blocks",
     component: EnvironmentsRoot,
     indexComponent: Environments,
     subPages: {

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -309,6 +309,7 @@ const ROUTE_STRUCTURE = {
   environments: {
     title: "Environments",
     url: "environments",
+    icon: "key",
     component: EnvironmentsRoot,
     indexComponent: Environments,
     subPages: {

--- a/client/sdk/.speakeasy/gen.lock
+++ b/client/sdk/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 0.0.1
   speakeasyVersion: 1.761.5
   generationVersion: 2.879.13
-  releaseVersion: 0.32.69
-  configChecksum: 4e2d9341101d344e26de615c5275f2a6
+  releaseVersion: 0.32.70
+  configChecksum: cfc96886f6a717b254973c2177af2b21
 persistentEdits:
   generation_id: bb7e101e-7ad4-46ab-85f8-4945a377ddd8
   pristine_commit_hash: 8f637eb1797d8010346278d429048da266e99c54
@@ -2063,11 +2063,11 @@ trackedFiles:
     pristine_git_object: bf1f7d6d396e43fdddcc27f74052233f952ed602
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:fe5ae39e34614a23e0762549e6691930de9327ed
+    last_write_checksum: sha1:5b9b3f426aaea6e15d71349dc50720f6da865f0d
     pristine_git_object: 37015b45d10dbc89a9a32f9f2230620a633c7af5
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:9ec668ca16c232dbd30a5247af509bc1077cca1b
+    last_write_checksum: sha1:161943275f93ea1941e7ef23c85fb4a92fa4df21
     pristine_git_object: efd88030fdaeb4cfabe39268b1f7e684dda63c7e
   src/core.ts:
     id: f431fdbcd144
@@ -2667,7 +2667,7 @@ trackedFiles:
     pristine_git_object: b9f82967e336f398ea542003dc4b7b2508bc4e76
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:585e1b3c396be97b8c26b7c6fdcfa4233f3938ac
+    last_write_checksum: sha1:1b20eb39ff36369a4863a577ddf7c3d62b333f99
     pristine_git_object: 582b9fc70b7ac2bf3e01969f3ea9b751959bbd2b
   src/lib/dlv.ts:
     id: b1988214835a

--- a/client/sdk/.speakeasy/gen.yaml
+++ b/client/sdk/.speakeasy/gen.yaml
@@ -34,7 +34,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.32.69
+  version: 0.32.70
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies: {}

--- a/client/sdk/jsr.json
+++ b/client/sdk/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@gram/client",
-  "version": "0.32.69",
+  "version": "0.32.70",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/client/sdk/package.json
+++ b/client/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gram/client",
-  "version": "0.32.69",
+  "version": "0.32.70",
   "author": "Speakeasy",
   "private": true,
   "type": "module",

--- a/client/sdk/src/lib/config.ts
+++ b/client/sdk/src/lib/config.ts
@@ -56,7 +56,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "0.0.1",
-  sdkVersion: "0.32.69",
+  sdkVersion: "0.32.70",
   genVersion: "2.879.13",
-  userAgent: "speakeasy-sdk/typescript 0.32.69 2.879.13 0.0.1 @gram/client",
+  userAgent: "speakeasy-sdk/typescript 0.32.70 2.879.13 0.0.1 @gram/client",
 } as const;

--- a/elements/examples/tanstack-start/src/routeTree.gen.ts
+++ b/elements/examples/tanstack-start/src/routeTree.gen.ts
@@ -8,125 +8,125 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ChatRouteImport } from "./routes/chat";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as ChatServerFnRouteImport } from "./routes/chat_.server-fn";
-import { Route as ApiLoginRouteImport } from "./routes/api/login";
-import { Route as ApiChatSessionRouteImport } from "./routes/api/chat.session";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ChatRouteImport } from './routes/chat'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as ChatServerFnRouteImport } from './routes/chat_.server-fn'
+import { Route as ApiLoginRouteImport } from './routes/api/login'
+import { Route as ApiChatSessionRouteImport } from './routes/api/chat.session'
 
 const ChatRoute = ChatRouteImport.update({
-  id: "/chat",
-  path: "/chat",
+  id: '/chat',
+  path: '/chat',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ChatServerFnRoute = ChatServerFnRouteImport.update({
-  id: "/chat_/server-fn",
-  path: "/chat/server-fn",
+  id: '/chat_/server-fn',
+  path: '/chat/server-fn',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiLoginRoute = ApiLoginRouteImport.update({
-  id: "/api/login",
-  path: "/api/login",
+  id: '/api/login',
+  path: '/api/login',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiChatSessionRoute = ApiChatSessionRouteImport.update({
-  id: "/api/chat/session",
-  path: "/api/chat/session",
+  id: '/api/chat/session',
+  path: '/api/chat/session',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/chat": typeof ChatRoute;
-  "/api/login": typeof ApiLoginRoute;
-  "/chat/server-fn": typeof ChatServerFnRoute;
-  "/api/chat/session": typeof ApiChatSessionRoute;
+  '/': typeof IndexRoute
+  '/chat': typeof ChatRoute
+  '/api/login': typeof ApiLoginRoute
+  '/chat/server-fn': typeof ChatServerFnRoute
+  '/api/chat/session': typeof ApiChatSessionRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/chat": typeof ChatRoute;
-  "/api/login": typeof ApiLoginRoute;
-  "/chat/server-fn": typeof ChatServerFnRoute;
-  "/api/chat/session": typeof ApiChatSessionRoute;
+  '/': typeof IndexRoute
+  '/chat': typeof ChatRoute
+  '/api/login': typeof ApiLoginRoute
+  '/chat/server-fn': typeof ChatServerFnRoute
+  '/api/chat/session': typeof ApiChatSessionRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/chat": typeof ChatRoute;
-  "/api/login": typeof ApiLoginRoute;
-  "/chat_/server-fn": typeof ChatServerFnRoute;
-  "/api/chat/session": typeof ApiChatSessionRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/chat': typeof ChatRoute
+  '/api/login': typeof ApiLoginRoute
+  '/chat_/server-fn': typeof ChatServerFnRoute
+  '/api/chat/session': typeof ApiChatSessionRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/chat"
-    | "/api/login"
-    | "/chat/server-fn"
-    | "/api/chat/session";
-  fileRoutesByTo: FileRoutesByTo;
-  to: "/" | "/chat" | "/api/login" | "/chat/server-fn" | "/api/chat/session";
+    | '/'
+    | '/chat'
+    | '/api/login'
+    | '/chat/server-fn'
+    | '/api/chat/session'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/chat' | '/api/login' | '/chat/server-fn' | '/api/chat/session'
   id:
-    | "__root__"
-    | "/"
-    | "/chat"
-    | "/api/login"
-    | "/chat_/server-fn"
-    | "/api/chat/session";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/chat'
+    | '/api/login'
+    | '/chat_/server-fn'
+    | '/api/chat/session'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  ChatRoute: typeof ChatRoute;
-  ApiLoginRoute: typeof ApiLoginRoute;
-  ChatServerFnRoute: typeof ChatServerFnRoute;
-  ApiChatSessionRoute: typeof ApiChatSessionRoute;
+  IndexRoute: typeof IndexRoute
+  ChatRoute: typeof ChatRoute
+  ApiLoginRoute: typeof ApiLoginRoute
+  ChatServerFnRoute: typeof ChatServerFnRoute
+  ApiChatSessionRoute: typeof ApiChatSessionRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/chat": {
-      id: "/chat";
-      path: "/chat";
-      fullPath: "/chat";
-      preLoaderRoute: typeof ChatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/chat_/server-fn": {
-      id: "/chat_/server-fn";
-      path: "/chat/server-fn";
-      fullPath: "/chat/server-fn";
-      preLoaderRoute: typeof ChatServerFnRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/login": {
-      id: "/api/login";
-      path: "/api/login";
-      fullPath: "/api/login";
-      preLoaderRoute: typeof ApiLoginRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/chat/session": {
-      id: "/api/chat/session";
-      path: "/api/chat/session";
-      fullPath: "/api/chat/session";
-      preLoaderRoute: typeof ApiChatSessionRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/chat': {
+      id: '/chat'
+      path: '/chat'
+      fullPath: '/chat'
+      preLoaderRoute: typeof ChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/chat_/server-fn': {
+      id: '/chat_/server-fn'
+      path: '/chat/server-fn'
+      fullPath: '/chat/server-fn'
+      preLoaderRoute: typeof ChatServerFnRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/login': {
+      id: '/api/login'
+      path: '/api/login'
+      fullPath: '/api/login'
+      preLoaderRoute: typeof ApiLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/chat/session': {
+      id: '/api/chat/session'
+      path: '/api/chat/session'
+      fullPath: '/api/chat/session'
+      preLoaderRoute: typeof ApiChatSessionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -136,16 +136,16 @@ const rootRouteChildren: RootRouteChildren = {
   ApiLoginRoute: ApiLoginRoute,
   ChatServerFnRoute: ChatServerFnRoute,
   ApiChatSessionRoute: ApiChatSessionRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }


### PR DESCRIPTION
## Summary

- Enforces RBAC scope gates across all project-level dashboard pages using `RequireScope` at page, section, and component levels
- Hides sidebar nav items (instead of disabling them) when the user lacks required scopes, and auto-hides group labels when all items in a group are hidden
- Gates write actions (create, edit, delete) behind appropriate scopes (`build:write`, `mcp:write`, `org:admin`) while keeping read-only views accessible
- Handles 403 errors gracefully across queries (environments, deployments, toolsets, usage) to prevent page crashes for restricted users
- Adds proper empty states for restricted views (prompts, resources, custom tools)

## Scope mapping

| Scope | Access |
|-------|--------|
| `build:read` | Project home, sources (view), deployments (view), environments (view), observability, logs, elements, skills |
| `build:write` | Sources (edit), deployments (create/redeploy), environments (manage), hooks, custom tools, prompts, settings |
| `mcp:read` | MCP servers (view), Slack apps (view), playground (view) |
| `mcp:write` | MCP servers (manage), Slack apps (manage), catalog (add), playground (configure) |
| `mcp:connect` | Playground (execute tool calls) |

## Test plan

- [ ] With RBAC dev toolbar, toggle scopes on/off and verify sidebar items hide/show correctly
- [ ] Verify group labels disappear when all items in a group are hidden
- [ ] Verify page-level gates show "Access restricted" for unauthorized pages
- [ ] Verify write actions (buttons, forms) are disabled for read-only users
- [ ] Verify 403 errors from backend don't crash pages
- [ ] Verify non-RBAC users (feature flag off) see everything as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)