### PR TITLE
fix(openrouter): split assistant messages with text + tool_calls

### DIFF
--- a/.changeset/openrouter-sanitize-assistant-content.md
+++ b/.changeset/openrouter-sanitize-assistant-content.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Null out assistant-message `content` when `tool_calls` are present before sending to OpenRouter. Fixes the Azure-path OpenAI→Anthropic converter dropping `tool_calls` and producing a dangling `tool_result` on the next turn.

--- a/.changeset/openrouter-sanitize-assistant-content.md
+++ b/.changeset/openrouter-sanitize-assistant-content.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Null out assistant-message `content` when `tool_calls` are present before sending to OpenRouter. Fixes the Azure-path OpenAI→Anthropic converter dropping `tool_calls` and producing a dangling `tool_result` on the next turn.
+Fix chats breaking when switching providers mid-conversation. Assistant turns that contained both a text reply and a tool call could cause the next turn to fail with a validation error on some provider routes, leaving the conversation unrecoverable. Affected chats now continue to work seamlessly across providers.

--- a/.changeset/openrouter-sanitize-assistant-content.md
+++ b/.changeset/openrouter-sanitize-assistant-content.md
@@ -1,5 +1,5 @@
 ---
-"dashboard": patch
+"server": patch
 ---
 
 Fix chats breaking when switching providers mid-conversation. Assistant turns that contained both a text reply and a tool call could cause the next turn to fail with a validation error on some provider routes, leaving the conversation unrecoverable. Affected chats now continue to work seamlessly across providers.

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
@@ -364,7 +365,15 @@ func buildAssistantRows(
 	parentHash []byte,
 	generation int32,
 ) []repo.CreateChatMessageParams {
-	hasText := response.Content != ""
+	// Whitespace-only content is treated as "no text" to stay in sync with
+	// NormalizeAssistantMessages, which trims before deciding whether to split
+	// a replayed combined message. Any divergence here would hash the stored
+	// rows against a different incoming shape and bump generation every turn.
+	content := response.Content
+	if strings.TrimSpace(content) == "" {
+		content = ""
+	}
+	hasText := content != ""
 	hasTools := len(toolCallsJSON) > 0
 
 	base := repo.CreateChatMessageParams{
@@ -400,8 +409,8 @@ func buildAssistantRows(
 
 	if hasText && hasTools {
 		text := base
-		text.Content = response.Content
-		text.ContentHash = hashAssistantResponse(parentHash, response.Content)
+		text.Content = content
+		text.ContentHash = hashAssistantResponse(parentHash, content)
 
 		tools := base
 		tools.ToolCalls = toolCallsJSON
@@ -415,13 +424,13 @@ func buildAssistantRows(
 	}
 
 	only := base
-	only.Content = response.Content
+	only.Content = content
 	only.ToolCalls = toolCallsJSON
 	only.FinishReason = finishReason
 	only.PromptTokens = promptTokens
 	only.CompletionTokens = completionTokens
 	only.TotalTokens = totalTokens
-	only.ContentHash = hashAssistantResponse(parentHash, response.Content)
+	only.ContentHash = hashAssistantResponse(parentHash, content)
 
 	return []repo.CreateChatMessageParams{only}
 }

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -327,34 +327,10 @@ func (s *ChatMessageCaptureStrategy) CaptureMessage(
 		return err
 	}
 
-	assistantParams := repo.CreateChatMessageParams{
-		ChatID:           request.ChatID,
-		Role:             "assistant",
-		ProjectID:        projectID,
-		Content:          response.Content,
-		ContentRaw:       nil,
-		ContentAssetUrl:  conv.ToPGTextEmpty(""),
-		StorageError:     conv.ToPGTextEmpty(""),
-		Model:            conv.ToPGText(response.Model),
-		MessageID:        conv.ToPGText(response.MessageID),
-		ToolCallID:       conv.ToPGTextEmpty(""), // Empty for assistant messages
-		UserID:           conv.ToPGText(request.UserID),
-		ExternalUserID:   conv.ToPGText(request.ExternalUserID),
-		FinishReason:     conv.PtrToPGText(response.FinishReason),
-		ToolCalls:        toolCallsJSON,
-		PromptTokens:     int64(response.Usage.PromptTokens),
-		CompletionTokens: int64(response.Usage.CompletionTokens),
-		TotalTokens:      int64(response.Usage.TotalTokens),
-		Origin:           conv.ToPGText(origin),
-		UserAgent:        conv.ToPGText(userAgent),
-		IpAddress:        conv.ToPGText(ipAddress),
-		Source:           conv.ToPGText(string(request.UsageSource)),
-		ContentHash:      hashAssistantResponse(session.parentHash, response.Content),
-		Generation:       session.generation,
-	}
+	assistantRows := buildAssistantRows(request, response, projectID, toolCallsJSON, origin, userAgent, ipAddress, session.parentHash, session.generation)
 
 	if len(session.pendingRows) == 0 {
-		if _, err := s.repo.CreateChatMessage(ctx, []repo.CreateChatMessageParams{assistantParams}); err != nil {
+		if _, err := s.repo.CreateChatMessage(ctx, assistantRows); err != nil {
 			s.logger.ErrorContext(ctx, "failed to store chat message", attr.SlogError(err))
 			return fmt.Errorf("store chat message: %w", err)
 		}
@@ -366,11 +342,88 @@ func (s *ChatMessageCaptureStrategy) CaptureMessage(
 	// assistant row atomically so either the whole turn lands or none of it
 	// does. A partial write would orphan the assistant and force divergence
 	// detection to open a new generation on the next turn.
-	if err := s.flushTurnAtomically(ctx, session.pendingRows, assistantParams); err != nil {
+	if err := s.flushTurnAtomically(ctx, session.pendingRows, assistantRows); err != nil {
 		return err
 	}
 	s.notifyObservers(ctx, projectID)
 	return nil
+}
+
+// buildAssistantRows turns a single completion response into 1 or 2 chained
+// assistant rows. When the response carries both text content and tool_calls,
+// it splits into a text-only row followed by a tool-calls-only row so the
+// stored shape matches what NormalizeAssistantMessages produces on replay.
+// Tokens and finish_reason land on the final row to keep per-turn accounting
+// on a single row.
+func buildAssistantRows(
+	request openrouter.CompletionRequest,
+	response openrouter.CompletionResponse,
+	projectID uuid.UUID,
+	toolCallsJSON []byte,
+	origin, userAgent, ipAddress string,
+	parentHash []byte,
+	generation int32,
+) []repo.CreateChatMessageParams {
+	hasText := response.Content != ""
+	hasTools := len(toolCallsJSON) > 0
+
+	base := repo.CreateChatMessageParams{
+		ChatID:           request.ChatID,
+		Role:             "assistant",
+		ProjectID:        projectID,
+		Content:          "",
+		ContentRaw:       nil,
+		ContentAssetUrl:  conv.ToPGTextEmpty(""),
+		StorageError:     conv.ToPGTextEmpty(""),
+		Model:            conv.ToPGText(response.Model),
+		MessageID:        conv.ToPGText(response.MessageID),
+		ToolCallID:       conv.ToPGTextEmpty(""),
+		UserID:           conv.ToPGText(request.UserID),
+		ExternalUserID:   conv.ToPGText(request.ExternalUserID),
+		FinishReason:     conv.ToPGTextEmpty(""),
+		ToolCalls:        nil,
+		PromptTokens:     0,
+		CompletionTokens: 0,
+		TotalTokens:      0,
+		Origin:           conv.ToPGText(origin),
+		UserAgent:        conv.ToPGText(userAgent),
+		IpAddress:        conv.ToPGText(ipAddress),
+		Source:           conv.ToPGText(string(request.UsageSource)),
+		ContentHash:      nil,
+		Generation:       generation,
+	}
+
+	finishReason := conv.PtrToPGText(response.FinishReason)
+	promptTokens := int64(response.Usage.PromptTokens)
+	completionTokens := int64(response.Usage.CompletionTokens)
+	totalTokens := int64(response.Usage.TotalTokens)
+
+	if hasText && hasTools {
+		text := base
+		text.Content = response.Content
+		text.ContentHash = hashAssistantResponse(parentHash, response.Content)
+
+		tools := base
+		tools.ToolCalls = toolCallsJSON
+		tools.FinishReason = finishReason
+		tools.PromptTokens = promptTokens
+		tools.CompletionTokens = completionTokens
+		tools.TotalTokens = totalTokens
+		tools.ContentHash = hashAssistantResponse(text.ContentHash, "")
+
+		return []repo.CreateChatMessageParams{text, tools}
+	}
+
+	only := base
+	only.Content = response.Content
+	only.ToolCalls = toolCallsJSON
+	only.FinishReason = finishReason
+	only.PromptTokens = promptTokens
+	only.CompletionTokens = completionTokens
+	only.TotalTokens = totalTokens
+	only.ContentHash = hashAssistantResponse(parentHash, response.Content)
+
+	return []repo.CreateChatMessageParams{only}
 }
 
 // resolveSession returns the session produced by StartOrResumeChat. If the
@@ -407,9 +460,9 @@ func (s *ChatMessageCaptureStrategy) resolveSession(ctx context.Context, raw ope
 }
 
 // flushTurnAtomically writes the pending user rows (via storeMessages, which
-// also handles asset-storage upload) and the assistant row inside a single
+// also handles asset-storage upload) and the assistant rows inside a single
 // Postgres transaction.
-func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, pending []chatMessageRow, assistant repo.CreateChatMessageParams) error {
+func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, pending []chatMessageRow, assistants []repo.CreateChatMessageParams) error {
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to begin transaction for catch-up flush", attr.SlogError(err))
@@ -422,7 +475,7 @@ func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, pe
 	}
 
 	txRepo := repo.New(dbtx)
-	if _, err := txRepo.CreateChatMessage(ctx, []repo.CreateChatMessageParams{assistant}); err != nil {
+	if _, err := txRepo.CreateChatMessage(ctx, assistants); err != nil {
 		s.logger.ErrorContext(ctx, "failed to store assistant chat message", attr.SlogError(err))
 		return fmt.Errorf("store assistant chat message: %w", err)
 	}

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -202,3 +202,56 @@ func roles(rows []repo.ChatMessage) []string {
 	}
 	return out
 }
+
+// An assistant response that carries both narrative text and tool_calls must
+// land as two chained rows — text-only then tool-calls-only — so the stored
+// shape matches what NormalizeAssistantMessages produces on replay.
+func TestCaptureMessage_SplitsAssistantResponseWithBothTextAndToolCalls(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	req := makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("Check weather"))
+	resp := openrouter.CompletionResponse{
+		Content:   "I'll check the weather.",
+		Model:     "test-model",
+		MessageID: "msg-split",
+		ToolCalls: []openrouter.ToolCall{{
+			Index: 0,
+			ID:    "tool_abc",
+			Type:  "function",
+			Function: openrouter.ToolCallFunction{
+				Name:      "get_weather",
+				Arguments: `{"city":"SF"}`,
+			},
+		}},
+		Usage: openrouter.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+
+	runTurn(t, ctx, s, req, resp)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Len(t, rows, 3)
+	require.Equal(t, []string{"user", "assistant", "assistant"}, roles(rows))
+
+	text := rows[1]
+	require.Equal(t, "I'll check the weather.", text.Content)
+	require.Empty(t, text.ToolCalls, "text-only row carries no tool_calls")
+	require.Equal(t, int64(0), text.PromptTokens)
+	require.Equal(t, int64(0), text.CompletionTokens)
+
+	tools := rows[2]
+	require.Empty(t, tools.Content)
+	require.NotEmpty(t, tools.ToolCalls, "tool-only row carries tool_calls JSON")
+	require.Equal(t, int64(10), tools.PromptTokens)
+	require.Equal(t, int64(5), tools.CompletionTokens)
+	require.Equal(t, int64(15), tools.TotalTokens)
+
+	require.NotEqual(t, text.ContentHash, tools.ContentHash, "chained hashes differ")
+}

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -255,3 +255,46 @@ func TestCaptureMessage_SplitsAssistantResponseWithBothTextAndToolCalls(t *testi
 
 	require.NotEqual(t, text.ContentHash, tools.ContentHash, "chained hashes differ")
 }
+
+// Whitespace-only content must be treated as "no text" on both sides of the
+// normalize/capture boundary. Storing 2 rows for whitespace + tools would make
+// the replay match (which sees 1 tool-only message after normalization) diverge
+// and bump generation every turn.
+func TestCaptureMessage_WhitespaceOnlyContentWithToolCallsStoresSingleRow(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	req := makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("Check weather"))
+	resp := openrouter.CompletionResponse{
+		Content:   "   \n\t",
+		Model:     "test-model",
+		MessageID: "msg-ws",
+		ToolCalls: []openrouter.ToolCall{{
+			Index: 0,
+			ID:    "tool_abc",
+			Type:  "function",
+			Function: openrouter.ToolCallFunction{
+				Name:      "get_weather",
+				Arguments: `{"city":"SF"}`,
+			},
+		}},
+		Usage: openrouter.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+
+	runTurn(t, ctx, s, req, resp)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Len(t, rows, 2, "whitespace-only content collapses into the tool row")
+	require.Equal(t, []string{"user", "assistant"}, roles(rows))
+
+	tools := rows[1]
+	require.Empty(t, tools.Content, "stored Content is empty, not the whitespace")
+	require.NotEmpty(t, tools.ToolCalls)
+}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -116,6 +116,8 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 		model = DefaultChatModel
 	}
 
+	SanitizeAssistantContent(req.Messages)
+
 	// Build request body
 	reqBody := OpenAIChatRequest{
 		Model:          model,

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -86,6 +87,11 @@ type initializeRequestResult struct {
 
 // initializeRequest creates the OpenAI-compatible request body with defaults applied.
 func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionRequest) (*initializeRequestResult, error) {
+	// Normalize before anything else so hashing, persistence, and the forwarded
+	// request all see the same canonical shape. Combined assistant messages
+	// (content + tool_calls on the same object) become two sequential messages.
+	req.Messages = slices.Collect(NormalizeAssistantMessages(req.Messages))
+
 	var captureSession CaptureSession
 	if c.messageCaptureStrategy != nil {
 		sess, err := c.messageCaptureStrategy.StartOrResumeChat(ctx, req)
@@ -115,8 +121,6 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 	if model == "" {
 		model = DefaultChatModel
 	}
-
-	SanitizeAssistantContent(req.Messages)
 
 	// Build request body
 	reqBody := OpenAIChatRequest{

--- a/server/internal/thirdparty/openrouter/utils.go
+++ b/server/internal/thirdparty/openrouter/utils.go
@@ -1,25 +1,91 @@
 package openrouter
 
 import (
+	"iter"
+	"strings"
+
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
 )
 
-// SanitizeAssistantContent nulls out the content string on any assistant
-// message that also carries tool_calls. OpenRouter's OpenAI→Anthropic
-// converter on the Azure path drops tool_calls when content is a non-null
-// string, producing a tool_result with no matching tool_use on the next turn.
-// The known-good shape across providers is content:null + tool_calls populated.
-func SanitizeAssistantContent(msgs []or.ChatMessages) {
-	for i := range msgs {
-		if msgs[i].Type != or.ChatMessagesTypeAssistant {
-			continue
+// NormalizeAssistantMessages yields assistant messages in a canonical shape
+// where content and tool_calls never coexist on the same message. An assistant
+// message with both text content and tool_calls is emitted as two sequential
+// messages: text-only, then tool-calls-only. All other messages pass through
+// unchanged. Idempotent.
+//
+// Rationale: some OpenAI->Anthropic converters (Azure path) reject a single
+// assistant message that carries both content and tool_calls. Splitting into
+// two sequential assistant messages maps 1:1 to Anthropic's native multi-block
+// content shape (text block followed by tool_use block) without losing the
+// narrative text.
+func NormalizeAssistantMessages(msgs []or.ChatMessages) iter.Seq[or.ChatMessages] {
+	return func(yield func(or.ChatMessages) bool) {
+		for _, msg := range msgs {
+			if msg.Type != or.ChatMessagesTypeAssistant || msg.ChatAssistantMessage == nil {
+				if !yield(msg) {
+					return
+				}
+				continue
+			}
+
+			asst := msg.ChatAssistantMessage
+			if len(asst.ToolCalls) == 0 {
+				if !yield(msg) {
+					return
+				}
+				continue
+			}
+
+			if !assistantHasContent(asst) {
+				normalized := *asst
+				normalized.Content = optionalnullable.From[or.ChatAssistantMessageContent](nil)
+				if !yield(or.CreateChatMessagesAssistant(normalized)) {
+					return
+				}
+				continue
+			}
+
+			textOnly := *asst
+			textOnly.ToolCalls = nil
+
+			toolOnly := or.ChatAssistantMessage{
+				Role:             asst.Role,
+				Content:          optionalnullable.From[or.ChatAssistantMessageContent](nil),
+				Name:             nil,
+				ToolCalls:        asst.ToolCalls,
+				Refusal:          nil,
+				Reasoning:        nil,
+				ReasoningDetails: nil,
+				Images:           nil,
+				Audio:            nil,
+			}
+
+			if !yield(or.CreateChatMessagesAssistant(textOnly)) {
+				return
+			}
+			if !yield(or.CreateChatMessagesAssistant(toolOnly)) {
+				return
+			}
 		}
-		asst := msgs[i].ChatAssistantMessage
-		if asst == nil || len(asst.ToolCalls) == 0 {
-			continue
+	}
+}
+
+func assistantHasContent(asst *or.ChatAssistantMessage) bool {
+	content, ok := asst.Content.GetOrZero()
+	if !ok {
+		return false
+	}
+	switch content.Type {
+	case or.ChatAssistantMessageContentTypeStr:
+		if content.Str == nil {
+			return false
 		}
-		asst.Content = optionalnullable.From[or.ChatAssistantMessageContent](nil)
+		return strings.TrimSpace(*content.Str) != ""
+	case or.ChatAssistantMessageContentTypeArrayOfChatContentItems:
+		return len(content.ArrayOfChatContentItems) > 0
+	default:
+		return false
 	}
 }
 

--- a/server/internal/thirdparty/openrouter/utils.go
+++ b/server/internal/thirdparty/openrouter/utils.go
@@ -5,6 +5,24 @@ import (
 	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
 )
 
+// SanitizeAssistantContent nulls out the content string on any assistant
+// message that also carries tool_calls. OpenRouter's OpenAI→Anthropic
+// converter on the Azure path drops tool_calls when content is a non-null
+// string, producing a tool_result with no matching tool_use on the next turn.
+// The known-good shape across providers is content:null + tool_calls populated.
+func SanitizeAssistantContent(msgs []or.ChatMessages) {
+	for i := range msgs {
+		if msgs[i].Type != or.ChatMessagesTypeAssistant {
+			continue
+		}
+		asst := msgs[i].ChatAssistantMessage
+		if asst == nil || len(asst.ToolCalls) == 0 {
+			continue
+		}
+		asst.Content = optionalnullable.From[or.ChatAssistantMessageContent](nil)
+	}
+}
+
 func CreateMessageUser(content string) or.ChatMessages {
 	return or.CreateChatMessagesUser(or.ChatUserMessage{
 		Role:    or.ChatUserMessageRoleUser,

--- a/server/internal/thirdparty/openrouter/utils_test.go
+++ b/server/internal/thirdparty/openrouter/utils_test.go
@@ -2,6 +2,7 @@ package openrouter
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
@@ -9,28 +10,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSanitizeAssistantContent_NullsContentWhenToolCallsPresent(t *testing.T) {
+func combinedAssistant(text string, toolID string) or.ChatMessages {
+	c := or.CreateChatAssistantMessageContentStr(text)
+	return or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
+		Role:    or.ChatAssistantMessageRoleAssistant,
+		Content: optionalnullable.From(&c),
+		Name:    nil,
+		ToolCalls: []or.ChatToolCall{{
+			ID:       toolID,
+			Type:     or.ChatToolCallTypeFunction,
+			Function: or.ChatToolCallFunction{Name: "do_thing", Arguments: "{}"},
+		}},
+		Refusal:          nil,
+		Reasoning:        nil,
+		ReasoningDetails: nil,
+		Images:           nil,
+		Audio:            nil,
+	})
+}
+
+func toolOnlyAssistant(toolID string) or.ChatMessages {
+	return or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
+		Role:    or.ChatAssistantMessageRoleAssistant,
+		Content: optionalnullable.From[or.ChatAssistantMessageContent](nil),
+		Name:    nil,
+		ToolCalls: []or.ChatToolCall{{
+			ID:       toolID,
+			Type:     or.ChatToolCallTypeFunction,
+			Function: or.ChatToolCallFunction{Name: "do_thing", Arguments: "{}"},
+		}},
+		Refusal:          nil,
+		Reasoning:        nil,
+		ReasoningDetails: nil,
+		Images:           nil,
+		Audio:            nil,
+	})
+}
+
+func TestNormalizeAssistantMessages_SplitsCombinedIntoTextThenToolOnly(t *testing.T) {
 	t.Parallel()
 
-	c := or.CreateChatAssistantMessageContentStr("narrative text")
 	msgs := []or.ChatMessages{
 		CreateMessageUser("hi"),
-		or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
-			Role:    or.ChatAssistantMessageRoleAssistant,
-			Content: optionalnullable.From(&c),
-			ToolCalls: []or.ChatToolCall{{
-				ID:       "toolu_bdrk_abc",
-				Type:     or.ChatToolCallTypeFunction,
-				Function: or.ChatToolCallFunction{Name: "do_thing", Arguments: "{}"},
-			}},
-		}),
+		combinedAssistant("I'll check the weather.", "toolu_bdrk_abc"),
 	}
 
-	SanitizeAssistantContent(msgs)
+	out := slices.Collect(NormalizeAssistantMessages(msgs))
+	require.Len(t, out, 3)
 
-	body, err := json.Marshal(msgs[1])
+	require.Equal(t, or.ChatMessagesTypeUser, out[0].Type)
+
+	require.Equal(t, or.ChatMessagesTypeAssistant, out[1].Type)
+	require.Equal(t, "I'll check the weather.", GetText(out[1]))
+	require.Empty(t, out[1].ChatAssistantMessage.ToolCalls)
+
+	require.Equal(t, or.ChatMessagesTypeAssistant, out[2].Type)
+	body, err := json.Marshal(out[2])
 	require.NoError(t, err)
-
 	var decoded struct {
 		Role      string          `json:"role"`
 		Content   json.RawMessage `json:"content"`
@@ -45,22 +81,103 @@ func TestSanitizeAssistantContent_NullsContentWhenToolCallsPresent(t *testing.T)
 	require.Equal(t, "toolu_bdrk_abc", decoded.ToolCalls[0].ID)
 }
 
-func TestSanitizeAssistantContent_LeavesToolCallFreeAssistantAlone(t *testing.T) {
+func TestNormalizeAssistantMessages_NullsContentOnToolOnlyWhenTextBlank(t *testing.T) {
+	t.Parallel()
+
+	blank := or.CreateChatAssistantMessageContentStr("   ")
+	msgs := []or.ChatMessages{
+		or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
+			Role:    or.ChatAssistantMessageRoleAssistant,
+			Content: optionalnullable.From(&blank),
+			Name:    nil,
+			ToolCalls: []or.ChatToolCall{{
+				ID:       "t1",
+				Type:     or.ChatToolCallTypeFunction,
+				Function: or.ChatToolCallFunction{Name: "do_thing", Arguments: "{}"},
+			}},
+			Refusal:          nil,
+			Reasoning:        nil,
+			ReasoningDetails: nil,
+			Images:           nil,
+			Audio:            nil,
+		}),
+	}
+
+	out := slices.Collect(NormalizeAssistantMessages(msgs))
+	require.Len(t, out, 1)
+
+	body, err := json.Marshal(out[0])
+	require.NoError(t, err)
+	var decoded struct {
+		Content json.RawMessage `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	require.Equal(t, "null", string(decoded.Content))
+}
+
+func TestNormalizeAssistantMessages_PassesThroughToolCallFreeAssistant(t *testing.T) {
 	t.Parallel()
 
 	msgs := []or.ChatMessages{CreateMessageAssistant("plain reply")}
-	SanitizeAssistantContent(msgs)
-	require.Equal(t, "plain reply", GetText(msgs[0]))
+
+	out := slices.Collect(NormalizeAssistantMessages(msgs))
+	require.Len(t, out, 1)
+	require.Equal(t, "plain reply", GetText(out[0]))
 }
 
-func TestSanitizeAssistantContent_LeavesNonAssistantAlone(t *testing.T) {
+func TestNormalizeAssistantMessages_PassesThroughNonAssistant(t *testing.T) {
 	t.Parallel()
 
 	msgs := []or.ChatMessages{
 		CreateMessageUser("user text"),
 		CreateMessageSystem("sys text"),
 	}
-	SanitizeAssistantContent(msgs)
-	require.Equal(t, "user text", GetText(msgs[0]))
-	require.Equal(t, "sys text", GetText(msgs[1]))
+
+	out := slices.Collect(NormalizeAssistantMessages(msgs))
+	require.Len(t, out, 2)
+	require.Equal(t, "user text", GetText(out[0]))
+	require.Equal(t, "sys text", GetText(out[1]))
+}
+
+func TestNormalizeAssistantMessages_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	msgs := []or.ChatMessages{
+		CreateMessageUser("hi"),
+		combinedAssistant("text", "t1"),
+	}
+
+	first := slices.Collect(NormalizeAssistantMessages(msgs))
+	second := slices.Collect(NormalizeAssistantMessages(first))
+
+	require.Len(t, second, len(first))
+	for i := range first {
+		a, err := json.Marshal(first[i])
+		require.NoError(t, err)
+		b, err := json.Marshal(second[i])
+		require.NoError(t, err)
+		require.JSONEq(t, string(a), string(b))
+	}
+}
+
+func TestNormalizeAssistantMessages_PreservesOrderAndPassThroughShapes(t *testing.T) {
+	t.Parallel()
+
+	msgs := []or.ChatMessages{
+		CreateMessageUser("u1"),
+		combinedAssistant("a1", "t1"),
+		toolOnlyAssistant("t2"),
+		CreateMessageAssistant("a2"),
+	}
+
+	out := slices.Collect(NormalizeAssistantMessages(msgs))
+	require.Len(t, out, 5)
+	require.Equal(t, or.ChatMessagesTypeUser, out[0].Type)
+	require.Equal(t, "a1", GetText(out[1]))
+	require.Empty(t, out[1].ChatAssistantMessage.ToolCalls)
+	require.Empty(t, GetText(out[2]))
+	require.Len(t, out[2].ChatAssistantMessage.ToolCalls, 1)
+	require.Empty(t, GetText(out[3]))
+	require.Len(t, out[3].ChatAssistantMessage.ToolCalls, 1)
+	require.Equal(t, "a2", GetText(out[4]))
 }

--- a/server/internal/thirdparty/openrouter/utils_test.go
+++ b/server/internal/thirdparty/openrouter/utils_test.go
@@ -1,0 +1,66 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"testing"
+
+	or "github.com/OpenRouterTeam/go-sdk/models/components"
+	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeAssistantContent_NullsContentWhenToolCallsPresent(t *testing.T) {
+	t.Parallel()
+
+	c := or.CreateChatAssistantMessageContentStr("narrative text")
+	msgs := []or.ChatMessages{
+		CreateMessageUser("hi"),
+		or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
+			Role:    or.ChatAssistantMessageRoleAssistant,
+			Content: optionalnullable.From(&c),
+			ToolCalls: []or.ChatToolCall{{
+				ID:       "toolu_bdrk_abc",
+				Type:     or.ChatToolCallTypeFunction,
+				Function: or.ChatToolCallFunction{Name: "do_thing", Arguments: "{}"},
+			}},
+		}),
+	}
+
+	SanitizeAssistantContent(msgs)
+
+	body, err := json.Marshal(msgs[1])
+	require.NoError(t, err)
+
+	var decoded struct {
+		Role      string          `json:"role"`
+		Content   json.RawMessage `json:"content"`
+		ToolCalls []struct {
+			ID string `json:"id"`
+		} `json:"tool_calls"`
+	}
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	require.Equal(t, "assistant", decoded.Role)
+	require.Equal(t, "null", string(decoded.Content))
+	require.Len(t, decoded.ToolCalls, 1)
+	require.Equal(t, "toolu_bdrk_abc", decoded.ToolCalls[0].ID)
+}
+
+func TestSanitizeAssistantContent_LeavesToolCallFreeAssistantAlone(t *testing.T) {
+	t.Parallel()
+
+	msgs := []or.ChatMessages{CreateMessageAssistant("plain reply")}
+	SanitizeAssistantContent(msgs)
+	require.Equal(t, "plain reply", GetText(msgs[0]))
+}
+
+func TestSanitizeAssistantContent_LeavesNonAssistantAlone(t *testing.T) {
+	t.Parallel()
+
+	msgs := []or.ChatMessages{
+		CreateMessageUser("user text"),
+		CreateMessageSystem("sys text"),
+	}
+	SanitizeAssistantContent(msgs)
+	require.Equal(t, "user text", GetText(msgs[0]))
+	require.Equal(t, "sys text", GetText(msgs[1]))
+}


### PR DESCRIPTION
## Summary
- An assistant turn with both narrative text and `tool_calls` is valid for Anthropic (native multi-block content) but the OpenAI→Anthropic converter on OpenRouter's Azure path rejects it, breaking the next turn with a dangling `tool_result`. Once a chat contains such a turn, switching the backing provider mid-conversation makes it unrecoverable.
- Introduce `NormalizeAssistantMessages(msgs) iter.Seq[or.ChatMessages]`: splits a combined assistant message into two sequential messages — text-only, then tool-calls-only. Idempotent. Maps 1:1 to Anthropic's native shape on the way out, so no data loss.
- Apply at the OpenRouter boundary in `initializeRequest` **before** `StartOrResumeChat`, so hashing, persistence, and the forwarded OpenAI request all see the same canonical shape.
- Capture emits chained rows: when the upstream response carries both text and tool_calls, it lands as a text row followed by a tool-calls row (hashes chained, tokens/finish-reason on the final row).
- Whitespace-only content is treated as no-text on both sides of the boundary, so stored rows and replayed messages hash identically and don't spuriously bump generation.

## Why split instead of null-out
The original PR nulled `content` when `tool_calls` were present — unblocks Azure but drops the model's narrative text. The split preserves it and matches what Anthropic models natively emit (text block + tool_use block in one message). OpenAI allows multiple consecutive same-role messages, so the wire is spec-compliant.

## Migration
Chats that already contain combined assistant rows will bump generation once on the next turn as the matcher sees a normalized incoming prefix diverge from stored rows. Old rows stay as audit history.

Linear: https://linear.app/speakeasy/issue/AGE-1890

✻ Clauded...