### PR TITLE
fix(chat): scope CountChatMessages by project_id

### DIFF
--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -152,7 +152,11 @@ WHERE chat_id = @chat_id AND (project_id IS NULL OR project_id = @project_id::uu
 ORDER BY seq ASC;
 
 -- name: CountChatMessages :one
-SELECT COUNT(*) FROM chat_messages WHERE chat_id = @chat_id;
+-- Must match ListChatMessages' project_id filter, otherwise count and the
+-- list drift and the client hits "chat history mismatch" at
+-- message_capture_strategy.go.
+SELECT COUNT(*) FROM chat_messages
+WHERE chat_id = @chat_id AND (project_id IS NULL OR project_id = @project_id::uuid);
 
 -- name: GetMaxGenerationForChat :one
 SELECT COALESCE(MAX(generation), 0)::integer AS generation FROM chat_messages WHERE chat_id = @chat_id;

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -43,11 +43,20 @@ func (q *Queries) BackfillChatMessageHash(ctx context.Context, arg BackfillChatM
 }
 
 const countChatMessages = `-- name: CountChatMessages :one
-SELECT COUNT(*) FROM chat_messages WHERE chat_id = $1
+SELECT COUNT(*) FROM chat_messages
+WHERE chat_id = $1 AND (project_id IS NULL OR project_id = $2::uuid)
 `
 
-func (q *Queries) CountChatMessages(ctx context.Context, chatID uuid.UUID) (int64, error) {
-	row := q.db.QueryRow(ctx, countChatMessages, chatID)
+type CountChatMessagesParams struct {
+	ChatID    uuid.UUID
+	ProjectID uuid.UUID
+}
+
+// Must match ListChatMessages' project_id filter, otherwise count and the
+// list drift and the client hits "chat history mismatch" at
+// message_capture_strategy.go.
+func (q *Queries) CountChatMessages(ctx context.Context, arg CountChatMessagesParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countChatMessages, arg.ChatID, arg.ProjectID)
 	var count int64
 	err := row.Scan(&count)
 	return count, err


### PR DESCRIPTION
## Summary
- `CountChatMessages` lacked the `project_id` filter that `ListChatMessages` applies, so count and list could drift and trip `chat history mismatch` in message_capture_strategy.go.
- Add the matching `project_id IS NULL OR project_id = @project_id::uuid` clause and regenerate sqlc.
- No production callers of `CountChatMessages` exist today; only the query + generated code change.

Linear: https://linear.app/speakeasy/issue/AGE-1891/fixchat-scope-countchatmessages-by-project-id

✻ Clauded...