### PR TITLE
fix(elements): resume turn after client-side frontend tools via sendAutomaticallyWhen

### DIFF
--- a/.changeset/elements-frontend-tool-executable.md
+++ b/.changeset/elements-frontend-tool-executable.md
@@ -2,4 +2,4 @@
 "@gram-ai/elements": patch
 ---
 
-Keep frontend tools executable inside streamText's multi-step loop. Build the AI SDK `ToolSet` directly from `FrontendTool` definitions so `execute` survives, and stop double-approval-wrapping them (`defineFrontendTool` already self-wraps).
+fix: resume the chat turn after a client-side frontend tool completes. `useChatRuntime` now wires `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls`, so Skip/Save clicks on frontend-tool forms no longer leave the conversation stuck with an unresolved tool-call.

--- a/.changeset/elements-frontend-tool-executable.md
+++ b/.changeset/elements-frontend-tool-executable.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Keep frontend tools executable inside streamText's multi-step loop. Build the AI SDK `ToolSet` directly from `FrontendTool` definitions so `execute` survives, and stop double-approval-wrapping them (`defineFrontendTool` already self-wraps).

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -1,3 +1,4 @@
+import { FrontendTools } from "@/components/FrontendTools";
 import { ROOT_SELECTOR } from "@/constants/tailwind";
 import {
   isLocalThreadId,
@@ -10,8 +11,9 @@ import { initErrorTracking, trackError } from "@/lib/errorTracking";
 import { MODELS } from "@/lib/models";
 import {
   clearFrontendToolApprovalConfig,
-  frontendToolsToExecutableAISDKTools,
+  getEnabledTools,
   setFrontendToolApprovalConfig,
+  toAISDKTools,
   wrapToolsWithApproval,
   type ApprovalHelpers,
   type FrontendTool,
@@ -22,15 +24,20 @@ import { ElementsConfig, Model } from "@/types";
 import { Plugin } from "@/types/plugins";
 import {
   AssistantRuntimeProvider,
+  AssistantTool,
   useAssistantState,
   unstable_useRemoteThreadListRuntime as useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  frontendTools as convertFrontendToolsToAISDKTools,
+  useChatRuntime,
+} from "@assistant-ui/react-ai-sdk";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   convertToModelMessages,
   createUIMessageStream,
+  lastAssistantMessageIsCompleteWithToolCalls,
   LanguageModel,
   smoothStream,
   stepCountIs,
@@ -317,6 +324,11 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
           setCurrentChatId(chatId);
         }
 
+        const context = runtimeRef.current?.thread.getModelContext();
+        const frontendTools = toAISDKTools(
+          getEnabledTools(context?.tools ?? {}),
+        );
+
         // Include Gram-Chat-ID header for chat persistence and Gram-Environment for environment selection
         const headersWithChatId = {
           ...validHeaders,
@@ -348,20 +360,18 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
           console.log("Using custom language model", config.languageModel);
         }
 
-        // Frontend tools self-wrap approval inside `defineFrontendTool`, so we
-        // route MCP tools through `wrapToolsWithApproval` and merge the frontend
-        // tools (with execute attached) afterwards. This keeps streamText's
-        // multi-step loop alive after a frontend tool call.
-        const wrappedMCPTools = wrapToolsWithApproval(
-          (mcpTools ?? {}) as ToolSet,
+        // Combine tools - MCP tools only available when not using custom model
+        const combinedTools: ToolSet = {
+          ...mcpTools,
+          ...convertFrontendToolsToAISDKTools(frontendTools),
+        } as ToolSet;
+
+        // Wrap tools that require approval
+        const tools = wrapToolsWithApproval(
+          combinedTools,
           config.tools?.toolsRequiringApproval,
           getApprovalHelpers(),
         );
-
-        const tools: ToolSet = {
-          ...wrappedMCPTools,
-          ...frontendToolsToExecutableAISDKTools(config.tools?.frontendTools),
-        };
 
         // Stream the response
         const modelToUse = config.languageModel
@@ -447,7 +457,6 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     [
       config.languageModel,
       config.tools?.toolsRequiringApproval,
-      config.tools?.frontendTools,
       model,
       systemPrompt,
       mcpTools,
@@ -475,6 +484,8 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     }),
     [config, model, isExpanded, isOpen, plugins, mcpTools],
   );
+
+  const frontendTools = config.tools?.frontendTools ?? {};
 
   // Create combined executable tools for direct tool execution (ActionButton)
   // Uses a simplified type that focuses on the execute function
@@ -504,6 +515,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
         headers={auth.headers}
         contextValue={contextValue}
         runtimeRef={runtimeRef}
+        frontendTools={frontendTools}
         localIdToUuidMap={localIdToUuidMapRef.current}
         currentRemoteIdRef={currentRemoteIdRef}
         executableTools={executableTools}
@@ -520,6 +532,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
       transport={transport}
       contextValue={contextValue}
       runtimeRef={runtimeRef}
+      frontendTools={frontendTools}
       executableTools={executableTools}
       currentChatId={currentChatId}
     >
@@ -543,6 +556,8 @@ interface ElementsProviderWithHistoryProps {
   headers: Record<string, string>;
   contextValue: React.ContextType<typeof ElementsContext>;
   runtimeRef: React.RefObject<ReturnType<typeof useChatRuntime> | null>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  frontendTools: Record<string, AssistantTool | FrontendTool<any, any>>;
   localIdToUuidMap: Map<string, string>;
   currentRemoteIdRef: React.RefObject<string | null>;
   executableTools: ExecutableToolSet;
@@ -578,6 +593,7 @@ const ElementsProviderWithHistory = ({
   headers,
   contextValue,
   runtimeRef,
+  frontendTools,
   localIdToUuidMap,
   currentRemoteIdRef,
   executableTools,
@@ -591,9 +607,14 @@ const ElementsProviderWithHistory = ({
   });
   const initialThreadId = contextValue?.config.history?.initialThreadId;
 
-  // Hook factory for creating the base chat runtime
+  // Without `sendAutomaticallyWhen`, client-side frontend tools leave the turn
+  // half-finished: the tool-result is patched in but the agent never resumes,
+  // so the next user message lands on top of an unresolved tool-call sequence.
   const useChatRuntimeHook = useCallback(() => {
-    return useChatRuntime({ transport });
+    return useChatRuntime({
+      transport,
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    });
   }, [transport]);
 
   const runtime = useRemoteThreadListRuntime({
@@ -646,6 +667,7 @@ const ElementsProviderWithHistory = ({
               >
                 {children}
               </div>
+              <FrontendTools tools={frontendTools} />
             </ToolExecutionProvider>
           </ElementsContext.Provider>
         </ChatIdContext.Provider>
@@ -660,6 +682,8 @@ interface ElementsProviderWithoutHistoryProps {
   transport: ChatTransport<UIMessage>;
   contextValue: React.ContextType<typeof ElementsContext>;
   runtimeRef: React.RefObject<ReturnType<typeof useChatRuntime> | null>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  frontendTools: Record<string, AssistantTool | FrontendTool<any, any>>;
   executableTools: ExecutableToolSet;
   currentChatId: string | null;
 }
@@ -669,10 +693,14 @@ const ElementsProviderWithoutHistory = ({
   transport,
   contextValue,
   runtimeRef,
+  frontendTools,
   executableTools,
   currentChatId,
 }: ElementsProviderWithoutHistoryProps) => {
-  const runtime = useChatRuntime({ transport });
+  const runtime = useChatRuntime({
+    transport,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  });
 
   // Populate runtimeRef so transport can access thread context
   useEffect(() => {
@@ -694,6 +722,7 @@ const ElementsProviderWithoutHistory = ({
             >
               {children}
             </div>
+            <FrontendTools tools={frontendTools} />
           </ToolExecutionProvider>
         </ElementsContext.Provider>
       </ChatIdContext.Provider>

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -1,4 +1,3 @@
-import { FrontendTools } from "@/components/FrontendTools";
 import { ROOT_SELECTOR } from "@/constants/tailwind";
 import {
   isLocalThreadId,
@@ -11,9 +10,8 @@ import { initErrorTracking, trackError } from "@/lib/errorTracking";
 import { MODELS } from "@/lib/models";
 import {
   clearFrontendToolApprovalConfig,
-  getEnabledTools,
+  frontendToolsToExecutableAISDKTools,
   setFrontendToolApprovalConfig,
-  toAISDKTools,
   wrapToolsWithApproval,
   type ApprovalHelpers,
   type FrontendTool,
@@ -24,14 +22,10 @@ import { ElementsConfig, Model } from "@/types";
 import { Plugin } from "@/types/plugins";
 import {
   AssistantRuntimeProvider,
-  AssistantTool,
   useAssistantState,
   unstable_useRemoteThreadListRuntime as useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
-import {
-  frontendTools as convertFrontendToolsToAISDKTools,
-  useChatRuntime,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -323,11 +317,6 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
           setCurrentChatId(chatId);
         }
 
-        const context = runtimeRef.current?.thread.getModelContext();
-        const frontendTools = toAISDKTools(
-          getEnabledTools(context?.tools ?? {}),
-        );
-
         // Include Gram-Chat-ID header for chat persistence and Gram-Environment for environment selection
         const headersWithChatId = {
           ...validHeaders,
@@ -359,18 +348,20 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
           console.log("Using custom language model", config.languageModel);
         }
 
-        // Combine tools - MCP tools only available when not using custom model
-        const combinedTools: ToolSet = {
-          ...mcpTools,
-          ...convertFrontendToolsToAISDKTools(frontendTools),
-        } as ToolSet;
-
-        // Wrap tools that require approval
-        const tools = wrapToolsWithApproval(
-          combinedTools,
+        // Frontend tools self-wrap approval inside `defineFrontendTool`, so we
+        // route MCP tools through `wrapToolsWithApproval` and merge the frontend
+        // tools (with execute attached) afterwards. This keeps streamText's
+        // multi-step loop alive after a frontend tool call.
+        const wrappedMCPTools = wrapToolsWithApproval(
+          (mcpTools ?? {}) as ToolSet,
           config.tools?.toolsRequiringApproval,
           getApprovalHelpers(),
         );
+
+        const tools: ToolSet = {
+          ...wrappedMCPTools,
+          ...frontendToolsToExecutableAISDKTools(config.tools?.frontendTools),
+        };
 
         // Stream the response
         const modelToUse = config.languageModel
@@ -456,6 +447,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     [
       config.languageModel,
       config.tools?.toolsRequiringApproval,
+      config.tools?.frontendTools,
       model,
       systemPrompt,
       mcpTools,
@@ -483,8 +475,6 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     }),
     [config, model, isExpanded, isOpen, plugins, mcpTools],
   );
-
-  const frontendTools = config.tools?.frontendTools ?? {};
 
   // Create combined executable tools for direct tool execution (ActionButton)
   // Uses a simplified type that focuses on the execute function
@@ -514,7 +504,6 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
         headers={auth.headers}
         contextValue={contextValue}
         runtimeRef={runtimeRef}
-        frontendTools={frontendTools}
         localIdToUuidMap={localIdToUuidMapRef.current}
         currentRemoteIdRef={currentRemoteIdRef}
         executableTools={executableTools}
@@ -531,7 +520,6 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
       transport={transport}
       contextValue={contextValue}
       runtimeRef={runtimeRef}
-      frontendTools={frontendTools}
       executableTools={executableTools}
       currentChatId={currentChatId}
     >
@@ -555,8 +543,6 @@ interface ElementsProviderWithHistoryProps {
   headers: Record<string, string>;
   contextValue: React.ContextType<typeof ElementsContext>;
   runtimeRef: React.RefObject<ReturnType<typeof useChatRuntime> | null>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  frontendTools: Record<string, AssistantTool | FrontendTool<any, any>>;
   localIdToUuidMap: Map<string, string>;
   currentRemoteIdRef: React.RefObject<string | null>;
   executableTools: ExecutableToolSet;
@@ -592,7 +578,6 @@ const ElementsProviderWithHistory = ({
   headers,
   contextValue,
   runtimeRef,
-  frontendTools,
   localIdToUuidMap,
   currentRemoteIdRef,
   executableTools,
@@ -661,7 +646,6 @@ const ElementsProviderWithHistory = ({
               >
                 {children}
               </div>
-              <FrontendTools tools={frontendTools} />
             </ToolExecutionProvider>
           </ElementsContext.Provider>
         </ChatIdContext.Provider>
@@ -676,8 +660,6 @@ interface ElementsProviderWithoutHistoryProps {
   transport: ChatTransport<UIMessage>;
   contextValue: React.ContextType<typeof ElementsContext>;
   runtimeRef: React.RefObject<ReturnType<typeof useChatRuntime> | null>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  frontendTools: Record<string, AssistantTool | FrontendTool<any, any>>;
   executableTools: ExecutableToolSet;
   currentChatId: string | null;
 }
@@ -687,7 +669,6 @@ const ElementsProviderWithoutHistory = ({
   transport,
   contextValue,
   runtimeRef,
-  frontendTools,
   executableTools,
   currentChatId,
 }: ElementsProviderWithoutHistoryProps) => {
@@ -713,7 +694,6 @@ const ElementsProviderWithoutHistory = ({
             >
               {children}
             </div>
-            <FrontendTools tools={frontendTools} />
           </ToolExecutionProvider>
         </ElementsContext.Provider>
       </ChatIdContext.Provider>

--- a/elements/src/lib/tools.test.ts
+++ b/elements/src/lib/tools.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import {
+  convertToModelMessages,
+  isToolUIPart,
+  jsonSchema,
+  lastAssistantMessageIsCompleteWithToolCalls,
+  readUIMessageStream,
+  stepCountIs,
+  streamText,
+  type ToolSet,
+  type UIMessage,
+  type UIMessagePart,
+} from "ai";
+import { MockLanguageModelV2 } from "ai/test";
+
+type MockStream = Extract<
+  NonNullable<
+    NonNullable<
+      ConstructorParameters<typeof MockLanguageModelV2>[0]
+    >["doStream"]
+  >,
+  (...a: never[]) => PromiseLike<{ stream: ReadableStream<unknown> }>
+>;
+type StreamPart =
+  Awaited<ReturnType<MockStream>>["stream"] extends ReadableStream<infer T>
+    ? T
+    : never;
+
+/**
+ * Repro for the assistants-onboarding "Skip bugged state":
+ *
+ * 1. Assistant calls a frontend tool (e.g. `request_environment_secrets`) that
+ *    renders a form with a Skip button.
+ * 2. User clicks Skip. The form calls `draft.resolvePending(toolCallId, { cancelled: true })`.
+ * 3. Expected: tool-result is patched onto the message, the agent continues,
+ *    chat returns to a ready state.
+ * 4. Observed (pre-fix): the chat stayed stuck — the next user message landed
+ *    with an invalid tool sequence and the provider rejected it with a
+ *    "message needing to be sent with role: assistant"-shaped error.
+ *
+ * `streamText` runs without an `execute` for frontend tools: AI-SDK's
+ * `frontendTools()` helper strips execute so client-side logic can take over.
+ * The missing link on main was that the runtime patched in the tool result
+ * but nothing resumed the turn. The fix wires `sendAutomaticallyWhen:
+ * lastAssistantMessageIsCompleteWithToolCalls` into `useChatRuntime`, which
+ * flips that resume on.
+ */
+
+function toolCallChunks(opts: {
+  toolCallId: string;
+  toolName: string;
+  input: string;
+}): StreamPart[] {
+  return [
+    { type: "stream-start", warnings: [] },
+    {
+      type: "response-metadata",
+      id: "resp-1",
+      modelId: "m",
+      timestamp: new Date(0),
+    },
+    { type: "tool-input-start", id: opts.toolCallId, toolName: opts.toolName },
+    { type: "tool-input-delta", id: opts.toolCallId, delta: opts.input },
+    { type: "tool-input-end", id: opts.toolCallId },
+    {
+      type: "tool-call",
+      toolCallId: opts.toolCallId,
+      toolName: opts.toolName,
+      input: opts.input,
+    },
+    {
+      type: "finish",
+      finishReason: "tool-calls",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    },
+  ];
+}
+
+function makeStream<T>(chunks: T[]): ReadableStream<T> {
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(c);
+      controller.close();
+    },
+  });
+}
+
+async function collectUIMessages(
+  stream: AsyncIterable<UIMessage>,
+): Promise<UIMessage[]> {
+  const out: UIMessage[] = [];
+  for await (const msg of stream) {
+    const idx = out.findIndex((m) => m.id === msg.id);
+    if (idx >= 0) out[idx] = msg;
+    else out.push(msg);
+  }
+  return out;
+}
+
+async function streamToolCallOnly(toolCallId: string): Promise<UIMessage[]> {
+  const toolsNoExecute = {
+    request_environment_secrets: {
+      description: "Ask the user to enter secrets for an env.",
+      inputSchema: jsonSchema({
+        type: "object",
+        properties: {
+          keys: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { name: { type: "string" } },
+              required: ["name"],
+            },
+          },
+        },
+        required: ["keys"],
+      }),
+    },
+  } as unknown as ToolSet;
+
+  const model = new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: makeStream([
+        ...toolCallChunks({
+          toolCallId,
+          toolName: "request_environment_secrets",
+          input: JSON.stringify({ keys: [{ name: "SLACK_BOT_TOKEN" }] }),
+        }),
+      ]),
+    }),
+  });
+
+  const result = streamText({
+    model,
+    messages: [{ role: "user", content: "Set up Slack" }],
+    tools: toolsNoExecute,
+    stopWhen: stepCountIs(5),
+  });
+  return collectUIMessages(
+    readUIMessageStream({ stream: result.toUIMessageStream() }),
+  );
+}
+
+describe("frontend tool Skip flow (sendAutomaticallyWhen fix)", () => {
+  it("without a tool-result, the message sequence is invalid — this is the bug we are fixing", async () => {
+    // Mirrors the elements flow on main: frontend tool has no execute inside
+    // streamText (it's run client-side by useToolInvocations). If nothing
+    // patches a tool-result onto the message, sending a follow-up user
+    // message produces an invalid sequence.
+    const toolCallId = "call_unresolved";
+    const messages = await streamToolCallOnly(toolCallId);
+
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const toolParts = (assistant.parts as UIMessagePart<never, never>[]).filter(
+      (p) => isToolUIPart(p),
+    );
+    expect(toolParts).toHaveLength(1);
+    expect((toolParts[0] as unknown as { state: string }).state).toBe(
+      "input-available",
+    );
+
+    const follow: UIMessage[] = [
+      ...messages,
+      {
+        id: "u2",
+        role: "user",
+        parts: [{ type: "text", text: "skip" }],
+      } as unknown as UIMessage,
+    ];
+
+    // Also: `lastAssistantMessageIsCompleteWithToolCalls` must return `false`
+    // here — there is no tool result, so the runtime should NOT auto-resume.
+    expect(lastAssistantMessageIsCompleteWithToolCalls({ messages })).toBe(
+      false,
+    );
+
+    // And the resulting model-message sequence contains a bogus `role: "tool"`
+    // with empty content — the provider will reject this as an invalid tool
+    // message, surfacing to the user as the "needs role: assistant" error.
+    const modelMsgs = convertToModelMessages(follow);
+    const assistantIdx = modelMsgs.findIndex(
+      (m) =>
+        m.role === "assistant" &&
+        Array.isArray(m.content) &&
+        (m.content as Array<{ type: string }>).some(
+          (c) => c.type === "tool-call",
+        ),
+    );
+    expect(assistantIdx).toBeGreaterThanOrEqual(0);
+    expect(modelMsgs[assistantIdx + 1]?.role).toBe("tool");
+    expect(modelMsgs[assistantIdx + 1]?.content).toEqual([]);
+  });
+
+  it("once the tool-result is patched onto the message, sendAutomaticallyWhen fires and the sequence is valid", async () => {
+    // Simulates the full post-fix behaviour: `useToolInvocations` ran execute
+    // client-side and called `addToolResult`, which flips the tool part to
+    // `output-available`. With the result in place:
+    //   - `lastAssistantMessageIsCompleteWithToolCalls` returns true, so the
+    //     runtime re-issues the model turn (this is the 1-line fix).
+    //   - `convertToModelMessages` produces a real `role: "tool"` message
+    //     with the result, which the provider accepts.
+    const toolCallId = "call_resolved";
+    const rawMessages = await streamToolCallOnly(toolCallId);
+
+    // Patch in the tool-output-available state — this is the shape
+    // `chatHelpers.addToolResult` produces under the hood.
+    const patched: UIMessage[] = rawMessages.map((m) => {
+      if (m.role !== "assistant") return m;
+      return {
+        ...m,
+        parts: (m.parts as Array<Record<string, unknown>>).map((p) =>
+          isToolUIPart(p as UIMessagePart<never, never>)
+            ? {
+                ...p,
+                state: "output-available",
+                output: { ok: true, cancelled: true },
+              }
+            : p,
+        ),
+      } as UIMessage;
+    });
+
+    const toolPart = (
+      (
+        patched.find((m) => m.role === "assistant")!.parts as UIMessagePart<
+          never,
+          never
+        >[]
+      ).filter((p) => isToolUIPart(p))[0] as unknown as { state: string }
+    ).state;
+    expect(toolPart).toBe("output-available");
+
+    // Pre-condition for the fix: the runtime auto-resumes the turn.
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({ messages: patched }),
+    ).toBe(true);
+
+    // And the sequence handed to the model is well-formed (assistant
+    // tool-call is followed by a real role:"tool" message with a result).
+    const modelMsgs = convertToModelMessages(patched);
+    const assistantIdx = modelMsgs.findIndex(
+      (m) =>
+        m.role === "assistant" &&
+        Array.isArray(m.content) &&
+        (m.content as Array<{ type: string }>).some(
+          (c) => c.type === "tool-call",
+        ),
+    );
+    const next = modelMsgs[assistantIdx + 1];
+    expect(next?.role).toBe("tool");
+    expect(Array.isArray(next?.content) && next.content.length).toBeGreaterThan(
+      0,
+    );
+    const toolResult = (
+      next?.content as Array<{ type: string; output?: { type?: string } }>
+    )[0];
+    expect(toolResult?.type).toBe("tool-result");
+  });
+});

--- a/elements/src/lib/tools.ts
+++ b/elements/src/lib/tools.ts
@@ -4,7 +4,7 @@ import {
   Tool,
   makeAssistantTool,
 } from "@assistant-ui/react";
-import { JSONSchema7, ToolSet, type ToolCallOptions } from "ai";
+import { jsonSchema, JSONSchema7, ToolSet, type ToolCallOptions } from "ai";
 import { FC } from "react";
 import z from "zod";
 
@@ -34,6 +34,50 @@ export const getEnabledTools = (tools: Record<string, Tool>) => {
       ([, tool]) => !tool.disabled && tool.type !== "backend",
     ),
   );
+};
+
+/**
+ * Builds an AI SDK ToolSet from FrontendTool definitions, preserving the
+ * `execute` function so streamText can run the tool inline. This lets the
+ * AI SDK's multi-step loop (`stopWhen: stepCountIs(...)`) continue after a
+ * frontend tool call instead of returning control to the runtime.
+ *
+ * Approval is handled inside the wrapped execute (see `defineFrontendTool`),
+ * so callers should NOT pass the result through `wrapToolsWithApproval` —
+ * doing so would prompt the user twice.
+ */
+export const frontendToolsToExecutableAISDKTools = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  frontendTools: Record<string, FrontendTool<any, any>> | undefined,
+): ToolSet => {
+  if (!frontendTools) return {} as ToolSet;
+  return Object.fromEntries(
+    Object.entries(frontendTools).flatMap(([name, tool]) => {
+      const def = tool.unstable_tool as unknown as {
+        description?: string;
+        parameters?: unknown;
+        disabled?: boolean;
+        type?: string;
+        execute?: (...args: unknown[]) => unknown;
+      };
+      if (!def?.execute) return [];
+      if (def.disabled || def.type === "backend") return [];
+      const schema =
+        def.parameters instanceof z.ZodType
+          ? z.toJSONSchema(def.parameters)
+          : def.parameters;
+      return [
+        [
+          name,
+          {
+            ...(def.description ? { description: def.description } : {}),
+            inputSchema: jsonSchema(schema as JSONSchema7),
+            execute: def.execute,
+          },
+        ],
+      ];
+    }),
+  ) as unknown as ToolSet;
 };
 
 /**

--- a/elements/src/lib/tools.ts
+++ b/elements/src/lib/tools.ts
@@ -4,7 +4,7 @@ import {
   Tool,
   makeAssistantTool,
 } from "@assistant-ui/react";
-import { jsonSchema, JSONSchema7, ToolSet, type ToolCallOptions } from "ai";
+import { JSONSchema7, ToolSet, type ToolCallOptions } from "ai";
 import { FC } from "react";
 import z from "zod";
 
@@ -34,50 +34,6 @@ export const getEnabledTools = (tools: Record<string, Tool>) => {
       ([, tool]) => !tool.disabled && tool.type !== "backend",
     ),
   );
-};
-
-/**
- * Builds an AI SDK ToolSet from FrontendTool definitions, preserving the
- * `execute` function so streamText can run the tool inline. This lets the
- * AI SDK's multi-step loop (`stopWhen: stepCountIs(...)`) continue after a
- * frontend tool call instead of returning control to the runtime.
- *
- * Approval is handled inside the wrapped execute (see `defineFrontendTool`),
- * so callers should NOT pass the result through `wrapToolsWithApproval` —
- * doing so would prompt the user twice.
- */
-export const frontendToolsToExecutableAISDKTools = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  frontendTools: Record<string, FrontendTool<any, any>> | undefined,
-): ToolSet => {
-  if (!frontendTools) return {} as ToolSet;
-  return Object.fromEntries(
-    Object.entries(frontendTools).flatMap(([name, tool]) => {
-      const def = tool.unstable_tool as unknown as {
-        description?: string;
-        parameters?: unknown;
-        disabled?: boolean;
-        type?: string;
-        execute?: (...args: unknown[]) => unknown;
-      };
-      if (!def?.execute) return [];
-      if (def.disabled || def.type === "backend") return [];
-      const schema =
-        def.parameters instanceof z.ZodType
-          ? z.toJSONSchema(def.parameters)
-          : def.parameters;
-      return [
-        [
-          name,
-          {
-            ...(def.description ? { description: def.description } : {}),
-            inputSchema: jsonSchema(schema as JSONSchema7),
-            execute: def.execute,
-          },
-        ],
-      ];
-    }),
-  ) as unknown as ToolSet;
 };
 
 /**


### PR DESCRIPTION
## Summary

Previously, a user clicking Skip on a frontend-tool form (e.g. `request_environment_secrets` in the assistants onboarding Slack flow) left the chat stuck: `useToolInvocations` patched the tool-result onto the message, but nothing resumed the model turn. The next user message landed on top of an unresolved tool-call and the provider bounced it with a "message needing to be sent with role: assistant"-shaped error.

Fix: wire `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls` into `useChatRuntime`. Once the client-side tool result is added, the runtime re-issues the turn, the LLM responds, and the chat returns to ready.

## Why not the original approach

The first iteration of this PR pulled `execute` inline into `streamText` via a new `frontendToolsToExecutableAISDKTools` helper, removed the `<FrontendTools>` mount, etc. That works for the happy path, but:

- breaks external `@gram-ai/elements` npm consumers who set `render:` on `defineFrontendTool` (no `useAssistantTool` registration);
- leaks on stream abort: if the user hits Stop while `execute` is awaiting the resolver, the promise hangs and the tool-call stays `input-available`;
- tightly couples `streamText` to the tool's React state lifecycle.

The canonical AI SDK pattern handles all of this out of the box. Using `sendAutomaticallyWhen` is a one-liner that keeps the existing architecture intact.

## Changes

- `elements/src/contexts/ElementsProvider.tsx`: import `lastAssistantMessageIsCompleteWithToolCalls`, pass `sendAutomaticallyWhen` to both `useChatRuntime` call sites.
- `elements/src/lib/tools.ts`: reverted to `main` (no `frontendToolsToExecutableAISDKTools`).
- `elements/src/lib/tools.test.ts`: new vitest coverage — the without-patch sequence is invalid and `lastAssistantMessageIsCompleteWithToolCalls` returns `false`; with an `output-available` patch it returns `true` and `convertToModelMessages` produces a well-formed tool message.

Linear: https://linear.app/speakeasy/issue/AGE-1895/fixelements-keep-frontend-tools-executable-in-streamtext-loop

✻ Clauded...