### PR TITLE
feat(dashboard): blank MCP server CTA + trigger events label

### DIFF
--- a/.changeset/mcp-blank-server-trigger-events.md
+++ b/.changeset/mcp-blank-server-trigger-events.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a "blank MCP server" CTA on the empty-project MCP page (create empty server, add built-in tools, connect a data source later). Relabel `TriggerLogRow` counts from "N attempts" to "N events".

--- a/client/dashboard/src/pages/logs/TriggerLogRow.tsx
+++ b/client/dashboard/src/pages/logs/TriggerLogRow.tsx
@@ -56,7 +56,7 @@ export function TriggerLogRow({ trace, onLogClick }: TriggerLogRowProps) {
 
         {trace.logCount > 1 && (
           <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
-            {trace.logCount} attempts
+            {trace.logCount} events
           </span>
         )}
 

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -130,10 +130,22 @@ export function MCPOverview() {
     return (
       <>
         {isProjectEmpty ? (
-          <InitialChoiceStep
-            routes={routes}
-            isFunctionsEnabled={isFunctionsEnabled}
-          />
+          <>
+            <InitialChoiceStep
+              routes={routes}
+              isFunctionsEnabled={isFunctionsEnabled}
+            />
+            <Page.Section>
+              <Page.Section.Title>
+                Or start with a blank MCP server
+              </Page.Section.Title>
+              <Page.Section.Description>
+                Create an empty MCP server and add built-in tools like MCP Logs
+                to it. You can connect a data source later.
+              </Page.Section.Description>
+              <Page.Section.CTA>{newMcpServerButton}</Page.Section.CTA>
+            </Page.Section>
+          </>
         ) : (
           <MCPEmptyState nonEmptyProjectCTA={newMcpServerButton} />
         )}


### PR DESCRIPTION
## Summary
- MCP empty-state now also offers a `Page.Section` CTA to create a blank server (add built-in tools, connect a data source later), alongside the existing `InitialChoiceStep`.
- Rename the `TriggerLogRow` count label from "N attempts" to "N events" to reflect what's actually counted.

Linear: https://linear.app/speakeasy/issue/AGE-1894/choredashboard-blank-mcp-server-cta-trigger-events-label

✻ Clauded...