### PR TITLE
feat(glint): add enforce-o11y-conventions rule

### DIFF
--- a/.mise-tasks/lint/server.sh
+++ b/.mise-tasks/lint/server.sh
@@ -14,6 +14,7 @@ fi
 
 if [ ! -x ./bin/gcl ] || [ -n "$(find ../glint .custom-gcl.yml ../go.mod ../go.sum -newer ./bin/gcl -type f 2>/dev/null)" ]; then
     golangci-lint custom --destination ./bin --name gcl
+    ./bin/gcl cache clean
 fi
 
 exec ./bin/gcl run --max-issues-per-linter=0 "${args[@]}" ./...

--- a/glint/enforce_o11y_conventions.go
+++ b/glint/enforce_o11y_conventions.go
@@ -1,0 +1,79 @@
+package glint
+
+import (
+	"go/ast"
+	"go/types"
+	"slices"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	enforceO11yConventionsAnalyzer       = "enforceo11yconventions"
+	enforceO11yConventionsDefaultMessage = "avoid direct slog attribute constructors"
+)
+
+var bannedSlogFuncs = []string{
+	"Any",
+	"Bool",
+	"Duration",
+	"Float64",
+	"Group",
+	"GroupAttrs",
+	"Int",
+	"Int64",
+	"String",
+	"Time",
+	"Uint64",
+}
+
+type enforceO11yConventionsSettings struct {
+	Disabled bool   `json:"disabled"`
+	Message  string `json:"message"`
+}
+
+func newEnforceO11yConventionsAnalyzer(rule enforceO11yConventionsSettings) *analysis.Analyzer {
+	message := enforceO11yConventionsDefaultMessage
+	if rule.Message != "" {
+		message += ": " + rule.Message
+	}
+
+	return &analysis.Analyzer{
+		Name: enforceO11yConventionsAnalyzer,
+		Doc:  enforceO11yConventionsDefaultMessage,
+		Run: func(pass *analysis.Pass) (any, error) {
+			for _, file := range pass.Files {
+				ast.Inspect(file, func(node ast.Node) bool {
+					callExpr, ok := node.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+
+					selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+
+					called, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
+					if !ok || called.Pkg() == nil {
+						return true
+					}
+
+					if called.Signature().Recv() != nil {
+						return true
+					}
+
+					if called.Pkg().Path() != "log/slog" || !slices.Contains(bannedSlogFuncs, called.Name()) {
+						return true
+					}
+
+					pass.ReportRangef(callExpr, "%s", message)
+
+					return true
+				})
+			}
+
+			return nil, nil
+		},
+	}
+}

--- a/glint/enforce_o11y_conventions_test.go
+++ b/glint/enforce_o11y_conventions_test.go
@@ -4,12 +4,32 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-// disabledAllRulesPlugin returns a plugin instance with every rule disabled.
-// Tests can flip individual rules back on to assert per-rule registration.
-func disabledAllRulesPlugin() *plugin {
-	return &plugin{
+func TestEnforceO11yConventions(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newEnforceO11yConventionsAnalyzer(enforceO11yConventionsSettings{}), "enforceo11yconventions")
+}
+
+func TestEnforceO11yConventionsCustomMessage(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(
+		t,
+		testdata,
+		newEnforceO11yConventionsAnalyzer(enforceO11yConventionsSettings{Message: "use attr.Slog* helpers instead"}),
+		"enforceo11yconventionscustommessage",
+	)
+}
+
+func TestBuildAnalyzersSkipsDisabledEnforceO11yConventions(t *testing.T) {
+	t.Parallel()
+
+	p := &plugin{
 		settings: settings{
 			Rules: ruleSettings{
 				NoAnonymousDefer:           noAnonymousDeferSettings{Disabled: true},
@@ -21,22 +41,8 @@ func disabledAllRulesPlugin() *plugin {
 			},
 		},
 	}
-}
 
-func TestBuildAnalyzersAllDisabled(t *testing.T) {
-	t.Parallel()
-
-	p := disabledAllRulesPlugin()
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
 	require.Empty(t, analyzers)
-}
-
-func TestBuildAnalyzersAllEnabled(t *testing.T) {
-	t.Parallel()
-
-	p := &plugin{}
-	analyzers, err := p.BuildAnalyzers()
-	require.NoError(t, err)
-	require.Len(t, analyzers, 6)
 }

--- a/glint/no_anonymous_defer_test.go
+++ b/glint/no_anonymous_defer_test.go
@@ -33,6 +33,7 @@ func TestBuildAnalyzersSkipsDisabledNoAnonymousDefer(t *testing.T) {
 		settings: settings{
 			Rules: ruleSettings{
 				NoAnonymousDefer:           noAnonymousDeferSettings{Disabled: true},
+				EnforceO11yConventions:     enforceO11yConventionsSettings{Disabled: true},
 				ServiceHasServiceAssertion: serviceHasServiceAssertionSettings{Disabled: true},
 				ServiceHasAutherAssertion:  serviceHasAutherAssertionSettings{Disabled: true},
 				ServiceHasAttachFunc:       serviceHasAttachFuncSettings{Disabled: true},

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -21,6 +21,7 @@ type settings struct {
 
 type ruleSettings struct {
 	NoAnonymousDefer           noAnonymousDeferSettings           `json:"no-anonymous-defer"`
+	EnforceO11yConventions     enforceO11yConventionsSettings     `json:"enforce-o11y-conventions"`
 	ServiceHasServiceAssertion serviceHasServiceAssertionSettings `json:"service-has-service-assertion"`
 	ServiceHasAutherAssertion  serviceHasAutherAssertionSettings  `json:"service-has-auther-assertion"`
 	ServiceHasAttachFunc       serviceHasAttachFuncSettings       `json:"service-has-attach-func"`
@@ -44,6 +45,9 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	analyzers := []*analysis.Analyzer{}
 	if !p.settings.Rules.NoAnonymousDefer.Disabled {
 		analyzers = append(analyzers, newNoAnonymousDeferAnalyzer(p.settings.Rules.NoAnonymousDefer))
+	}
+	if !p.settings.Rules.EnforceO11yConventions.Disabled {
+		analyzers = append(analyzers, newEnforceO11yConventionsAnalyzer(p.settings.Rules.EnforceO11yConventions))
 	}
 	if !p.settings.Rules.ServiceHasServiceAssertion.Disabled {
 		analyzers = append(analyzers, newServiceHasServiceAssertionAnalyzer(p.settings.Rules.ServiceHasServiceAssertion))

--- a/glint/testdata/src/enforceo11yconventions/enforceo11yconventions.go
+++ b/glint/testdata/src/enforceo11yconventions/enforceo11yconventions.go
@@ -1,0 +1,39 @@
+package enforceo11yconventions
+
+import stdslog "log/slog"
+import "time"
+
+type logger struct{}
+
+func (logger) String(string, string) {}
+
+func bad() {
+	_ = stdslog.String("key", "value")          // want "avoid direct slog attribute constructors"
+	_ = stdslog.Int64("count", 1)               // want "avoid direct slog attribute constructors"
+	_ = stdslog.Group("group")                  // want "avoid direct slog attribute constructors"
+	_ = stdslog.GroupAttrs("group")             // want "avoid direct slog attribute constructors"
+	_ = stdslog.Duration("timeout", 0)          // want "avoid direct slog attribute constructors"
+	_ = stdslog.Float64("ratio", 1)             // want "avoid direct slog attribute constructors"
+	_ = stdslog.Bool("enabled", true)           // want "avoid direct slog attribute constructors"
+	_ = stdslog.Uint64("size", 1)               // want "avoid direct slog attribute constructors"
+	_ = stdslog.Time("created_at", time.Time{}) // want "avoid direct slog attribute constructors"
+	_ = stdslog.Any("payload", struct{}{})      // want "avoid direct slog attribute constructors"
+	_ = stdslog.Int("answer", 42)               // want "avoid direct slog attribute constructors"
+}
+
+func good() {
+	local := logger{}
+	local.String("key", "value")
+	String("key", "value")
+	v := stdslog.StringValue("value")
+	_ = v.String()
+	_ = stdslog.Attr{}
+
+	a := stdslog.Attr{}
+	_ = a.Value.String()
+
+	r := stdslog.Record{}
+	_ = r.Level.String()
+}
+
+func String(string, string) {}

--- a/glint/testdata/src/enforceo11yconventionscustommessage/enforceo11yconventionscustommessage.go
+++ b/glint/testdata/src/enforceo11yconventionscustommessage/enforceo11yconventionscustommessage.go
@@ -1,0 +1,7 @@
+package enforceo11yconventionscustommessage
+
+import "log/slog"
+
+func bad() {
+	_ = slog.String("key", "value") // want "avoid direct slog attribute constructors: use attr[.]Slog[*] helpers instead"
+}

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -89,6 +89,21 @@ linters:
         linters:
           - forbidigo
         text: GG002
+      # This is the only sanctioned place to use slog attribute builders to establish conventions.
+      - path: internal/attr/conventions\.go
+        linters:
+          - glint
+        text: enforceo11yconventions
+      # This is forwarding log events from within pgx library that we have no control over.
+      - path: internal/o11y/slog\.go
+        linters:
+          - glint
+        text: enforceo11yconventions
+      # Not interesting to enforce this in tests
+      - path: _test\.go|internal/testenv/
+        linters:
+          - glint
+        text: enforceo11yconventions
   settings:
     custom:
       glint:
@@ -97,6 +112,9 @@ linters:
         original-url: github.com/speakeasy-api/gram/glint
         settings:
           rules:
+            enforce-o11y-conventions:
+              disabled: false
+              message: Use the attribute builders in `github.com/speakeasy-api/gram/server/internal/attr` instead.
             no-anonymous-defer:
               disabled: true
             no-repo-fields-in-service:

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -215,10 +215,11 @@ const (
 	VisibilityKey                  = attribute.Key("gram.visibility")
 
 	// Hooks
-	HookEventKey       = attribute.Key("gram.hook.event")
-	HookErrorKey       = attribute.Key("gram.hook.error")
-	HookIsInterruptKey = attribute.Key("gram.hook.is_interrupt")
-	HookSourceKey      = attribute.Key("gram.hook.source")
+	HookEventKey                = attribute.Key("gram.hook.event")
+	HookErrorKey                = attribute.Key("gram.hook.error")
+	HookIsInterruptKey          = attribute.Key("gram.hook.is_interrupt")
+	HookSourceKey               = attribute.Key("gram.hook.source")
+	HookServerNameOverrideIDKey = attribute.Key("gram.hook.server_name_override_id")
 
 	PaginationTsStartKey     = attribute.Key("gram.pagination.ts_start")
 	PaginationTsEndKey       = attribute.Key("gram.pagination.ts_end")
@@ -275,6 +276,9 @@ const (
 	GenAIEvaluationScoreValueKey  = attribute.Key("gen_ai.evaluation.score.value") // Numeric score (0-100)
 	GenAIEvaluationScoreLabelKey  = attribute.Key("gen_ai.evaluation.score.label") // Low cardinality label (success, failure, partial, abandoned)
 	GenAIEvaluationExplanationKey = attribute.Key("gen_ai.evaluation.explanation") // Free-form explanation
+
+	StatsToolCallCountKey  = attribute.Key("gram.stats.tool_call_count")
+	StatsMCPServerCountKey = attribute.Key("gram.stats.mcp_server_count")
 )
 
 const (
@@ -374,6 +378,13 @@ func HTTPServerRequestDuration(v float64) attribute.KeyValue {
 }
 func SlogHTTPServerRequestDuration(v float64) slog.Attr {
 	return slog.Float64(string(HTTPServerRequestDurationKey), v)
+}
+
+func HookServerNameOverrideID(v string) attribute.KeyValue {
+	return HookServerNameOverrideIDKey.String(v)
+}
+func SlogHookServerNameOverrideID(v string) slog.Attr {
+	return slog.String(string(HookServerNameOverrideIDKey), v)
 }
 
 func ServerAddress(v string) attribute.KeyValue { return ServerAddressKey.String(v) }
@@ -1178,3 +1189,9 @@ func SlogLogSeverityText(v string) slog.Attr      { return slog.String(string(Lo
 
 func LogBody(v string) attribute.KeyValue { return LogBodyKey.String(v) }
 func SlogLogBody(v string) slog.Attr      { return slog.String(string(LogBodyKey), v) }
+
+func StatsToolCallCount(v int) attribute.KeyValue { return StatsToolCallCountKey.Int(v) }
+func SlogStatsToolCallCount(v int) slog.Attr      { return slog.Int(string(StatsToolCallCountKey), v) }
+
+func StatsMCPServerCount(v int) attribute.KeyValue { return StatsMCPServerCountKey.Int(v) }
+func SlogStatsMCPServerCount(v int) slog.Attr      { return slog.Int(string(StatsMCPServerCountKey), v) }

--- a/server/internal/background/activities/platform_usage_metrics.go
+++ b/server/internal/background/activities/platform_usage_metrics.go
@@ -17,13 +17,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 )
 
-const (
-	logKeyOrgID     = "org_id"
-	logKeyOrgName   = "org_name"
-	logKeyToolCalls = "tool_calls"
-	logKeyServers   = "servers"
-)
-
 type CollectPlatformUsageMetrics struct {
 	logger *slog.Logger
 	db     *pgxpool.Pool
@@ -156,10 +149,10 @@ func (f *FreeTierReportingUsageMetrics) Do(ctx context.Context, orgIDs []string)
 			}
 
 			f.logger.InfoContext(ctx, "billing usage report",
-				slog.String(logKeyOrgID, org.ID),
-				slog.String(logKeyOrgName, org.Name),
-				slog.Int(logKeyToolCalls, usage.ToolCalls),
-				slog.Int(logKeyServers, usage.Servers),
+				attr.SlogOrganizationID(org.ID),
+				attr.SlogOrganizationSlug(org.Slug),
+				attr.SlogStatsToolCallCount(usage.ToolCalls),
+				attr.SlogStatsMCPServerCount(usage.Servers),
 			)
 
 			anyOverage := usage.ToolCalls > usage.IncludedToolCalls || usage.Servers > usage.IncludedServers || usage.Credits > usage.IncludedCredits

--- a/server/internal/hooks/server_names_impl.go
+++ b/server/internal/hooks/server_names_impl.go
@@ -2,7 +2,6 @@ package hooks
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/google/uuid"
 	goahttp "goa.design/goa/v3/http"
@@ -134,7 +133,7 @@ func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error 
 			oops.CodeUnexpected,
 			err,
 			"failed to delete hooks server name override",
-		).Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()), slog.String("override_id", payload.OverrideID))
+		).Log(ctx, s.logger, attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogHookServerNameOverrideID(payload.OverrideID))
 	}
 
 	return nil

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -218,9 +218,9 @@ func (s *Service) GetMcpMetadata(ctx context.Context, payload *gen.GetMcpMetadat
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeBadRequest, err, "toolset not found").Log(ctx, s.logger, slog.String("toolset_slug", string(payload.ToolsetSlug)))
+		return nil, oops.E(oops.CodeBadRequest, err, "toolset not found").Log(ctx, s.logger, attr.SlogToolsetSlug(string(payload.ToolsetSlug)))
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch toolset").Log(ctx, s.logger, slog.String("toolset_slug", string(payload.ToolsetSlug)))
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch toolset").Log(ctx, s.logger, attr.SlogToolsetSlug(string(payload.ToolsetSlug)))
 	}
 
 	record, err := s.repo.GetMetadataForToolset(ctx, toolset.ID)
@@ -267,9 +267,9 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, oops.E(oops.CodeBadRequest, err, "toolset not found").Log(ctx, logger, slog.String("toolset_slug", string(payload.ToolsetSlug)))
+		return nil, oops.E(oops.CodeBadRequest, err, "toolset not found").Log(ctx, logger, attr.SlogToolsetSlug(string(payload.ToolsetSlug)))
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch toolset").Log(ctx, logger, slog.String("toolset_slug", string(payload.ToolsetSlug)))
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch toolset").Log(ctx, logger, attr.SlogToolsetSlug(string(payload.ToolsetSlug)))
 	}
 
 	logger = logger.With(


### PR DESCRIPTION
Adds a new glint analyzer that flags direct use of `log/slog` attribute constructors (`slog.String`, `slog.Int`, `slog.Bool`, `slog.Group`, `slog.Any`, etc.). These call sites must route through the helpers in `server/internal/attr` so observability attribute keys and values stay consistent across traces, metrics, and logs.

The rule supports a configurable `message` setting so the golangci-lint config can point contributors at the sanctioned helpers. It is wired into the plugin alongside the existing analyzers and is toggled on in `server/.golangci.yaml` with carve-outs for the conventions package itself, the pgx slog forwarder, and tests.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>