### PR TITLE
feat: add audit logging for risk policy operations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Why
+
+<!-- Explain the motivation behind this change. What problem does it solve or what need does it address? -->
+
+## What changed
+
+<!-- Describe the specific changes made in this PR. Be concrete about files, behaviors, and any new patterns introduced. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,11 @@
 ## What changed
 
 <!-- Describe the specific changes made in this PR. Be concrete about files, behaviors, and any new patterns introduced. -->
+
+### Before
+
+<!-- How did the code behave before this change? -->
+
+### After
+
+<!-- How does the code behave after this change? -->

--- a/server/internal/audit/events.go
+++ b/server/internal/audit/events.go
@@ -20,6 +20,7 @@ const (
 	subjectTypeRemoteMcpServer subjectType = "remote_mcp_server"
 	subjectTypeToolset         subjectType = "toolset"
 	subjectTypeVariation       subjectType = "variation"
+	subjectTypeRiskPolicy      subjectType = "risk_policy"
 )
 
 type Action string

--- a/server/internal/audit/risk.go
+++ b/server/internal/audit/risk.go
@@ -1,0 +1,201 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/audit/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	ActionRiskPolicyCreate  Action = "risk_policy:create"
+	ActionRiskPolicyUpdate  Action = "risk_policy:update"
+	ActionRiskPolicyDelete  Action = "risk_policy:delete"
+	ActionRiskPolicyTrigger Action = "risk_policy:trigger"
+)
+
+type LogRiskPolicyCreateEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	RiskPolicyID   uuid.UUID
+	RiskPolicyName string
+}
+
+func LogRiskPolicyCreate(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyCreateEvent) error {
+	action := ActionRiskPolicyCreate
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.RiskPolicyID.String(),
+		SubjectType:        string(subjectTypeRiskPolicy),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.RiskPolicyName),
+		SubjectSlug:        conv.ToPGTextEmpty(""),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogRiskPolicyUpdateEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	RiskPolicyID   uuid.UUID
+	RiskPolicyName string
+
+	SnapshotBefore any
+	SnapshotAfter  any
+}
+
+func LogRiskPolicyUpdate(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyUpdateEvent) error {
+	action := ActionRiskPolicyUpdate
+
+	beforeSnapshot, err := marshalAuditPayload(event.SnapshotBefore)
+	if err != nil {
+		return fmt.Errorf("marshal %s before snapshot: %w", action, err)
+	}
+
+	afterSnapshot, err := marshalAuditPayload(event.SnapshotAfter)
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.RiskPolicyID.String(),
+		SubjectType:        string(subjectTypeRiskPolicy),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.RiskPolicyName),
+		SubjectSlug:        conv.ToPGTextEmpty(""),
+
+		BeforeSnapshot: beforeSnapshot,
+		AfterSnapshot:  afterSnapshot,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogRiskPolicyDeleteEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	RiskPolicyID   uuid.UUID
+	RiskPolicyName string
+}
+
+func LogRiskPolicyDelete(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyDeleteEvent) error {
+	action := ActionRiskPolicyDelete
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.RiskPolicyID.String(),
+		SubjectType:        string(subjectTypeRiskPolicy),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.RiskPolicyName),
+		SubjectSlug:        conv.ToPGTextEmpty(""),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogRiskPolicyTriggerEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	RiskPolicyID   uuid.UUID
+	RiskPolicyName string
+}
+
+func LogRiskPolicyTrigger(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyTriggerEvent) error {
+	action := ActionRiskPolicyTrigger
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.RiskPolicyID.String(),
+		SubjectType:        string(subjectTypeRiskPolicy),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.RiskPolicyName),
+		SubjectSlug:        conv.ToPGTextEmpty(""),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -619,19 +619,22 @@ func (s *Service) policyToType(ctx context.Context, row repo.RiskPolicy) (*types
 	}, nil
 }
 
-// policyRowSnapshot returns a lightweight representation of a risk policy row
-// suitable for audit log snapshots. Unlike policyToType it avoids extra DB
-// queries for message counts, keeping transactions short.
-func policyRowSnapshot(row repo.RiskPolicy) map[string]any {
-	return map[string]any{
-		"id":         row.ID.String(),
-		"project_id": row.ProjectID.String(),
-		"name":       row.Name,
-		"sources":    row.Sources,
-		"enabled":    row.Enabled,
-		"version":    row.Version,
-		"created_at": row.CreatedAt.Time.Format(time.RFC3339),
-		"updated_at": row.UpdatedAt.Time.Format(time.RFC3339),
+// policyRowSnapshot returns a *types.RiskPolicy suitable for audit log
+// snapshots. Unlike policyToType it skips the extra DB queries for message
+// counts, keeping transactions short. Count fields are set to -1 to indicate
+// they were not computed.
+func policyRowSnapshot(row repo.RiskPolicy) *types.RiskPolicy {
+	return &types.RiskPolicy{
+		ID:              row.ID.String(),
+		ProjectID:       row.ProjectID.String(),
+		Name:            row.Name,
+		Sources:         row.Sources,
+		Enabled:         row.Enabled,
+		Version:         row.Version,
+		CreatedAt:       row.CreatedAt.Time.Format(time.RFC3339),
+		UpdatedAt:       row.UpdatedAt.Time.Format(time.RFC3339),
+		PendingMessages: -1,
+		TotalMessages:   -1,
 	}
 }
 

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -151,7 +152,13 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		return nil, oops.E(oops.CodeUnexpected, err, "generate policy id").Log(ctx, s.logger)
 	}
 
-	row, err := s.repo.CreateRiskPolicy(ctx, repo.CreateRiskPolicyParams{
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	row, err := repo.New(dbtx).CreateRiskPolicy(ctx, repo.CreateRiskPolicyParams{
 		ID:             id,
 		ProjectID:      *authCtx.ProjectID,
 		OrganizationID: authCtx.ActiveOrganizationID,
@@ -163,7 +170,7 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogRiskPolicyCreate(ctx, s.db, audit.LogRiskPolicyCreateEvent{
+	if err := audit.LogRiskPolicyCreate(ctx, dbtx, audit.LogRiskPolicyCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -173,6 +180,10 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		RiskPolicyName:   row.Name,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy create").Log(ctx, s.logger)
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy create").Log(ctx, s.logger)
 	}
 
 	// Trigger the drain workflow for the new policy.
@@ -279,7 +290,13 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 
 	snapshotBefore, _ := s.policyToType(ctx, current)
 
-	row, err := s.repo.UpdateRiskPolicy(ctx, repo.UpdateRiskPolicyParams{
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	row, err := repo.New(dbtx).UpdateRiskPolicy(ctx, repo.UpdateRiskPolicyParams{
 		ID:        id,
 		ProjectID: *authCtx.ProjectID,
 		Name:      payload.Name,
@@ -292,7 +309,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 
 	snapshotAfter, _ := s.policyToType(ctx, row)
 
-	if err := audit.LogRiskPolicyUpdate(ctx, s.db, audit.LogRiskPolicyUpdateEvent{
+	if err := audit.LogRiskPolicyUpdate(ctx, dbtx, audit.LogRiskPolicyUpdateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -304,6 +321,10 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		SnapshotAfter:    snapshotAfter,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy update").Log(ctx, s.logger)
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy update").Log(ctx, s.logger)
 	}
 
 	// Signal the drain workflow — it reads the current enabled/version
@@ -340,16 +361,22 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		return oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
 	}
 
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
 	// Soft-delete only — list queries already filter out results for deleted
 	// policies via the risk_policies join, so orphaned rows are harmless.
-	if err := s.repo.DeleteRiskPolicy(ctx, repo.DeleteRiskPolicyParams{
+	if err := repo.New(dbtx).DeleteRiskPolicy(ctx, repo.DeleteRiskPolicyParams{
 		ID:        id,
 		ProjectID: *authCtx.ProjectID,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "delete risk policy").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogRiskPolicyDelete(ctx, s.db, audit.LogRiskPolicyDeleteEvent{
+	if err := audit.LogRiskPolicyDelete(ctx, dbtx, audit.LogRiskPolicyDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -359,6 +386,10 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		RiskPolicyName:   existing.Name,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "log risk policy delete").Log(ctx, s.logger)
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "commit risk policy delete").Log(ctx, s.logger)
 	}
 
 	return nil

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -288,7 +288,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		enabled = *payload.Enabled
 	}
 
-	snapshotBefore, _ := s.policyToType(ctx, current)
+	snapshotBefore := policyRowSnapshot(current)
 
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -307,8 +307,6 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		return nil, oops.E(oops.CodeUnexpected, err, "update risk policy").Log(ctx, s.logger)
 	}
 
-	snapshotAfter, _ := s.policyToType(ctx, row)
-
 	if err := audit.LogRiskPolicyUpdate(ctx, dbtx, audit.LogRiskPolicyUpdateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
@@ -318,7 +316,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		RiskPolicyID:     row.ID,
 		RiskPolicyName:   row.Name,
 		SnapshotBefore:   snapshotBefore,
-		SnapshotAfter:    snapshotAfter,
+		SnapshotAfter:    policyRowSnapshot(row),
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy update").Log(ctx, s.logger)
 	}
@@ -619,6 +617,22 @@ func (s *Service) policyToType(ctx context.Context, row repo.RiskPolicy) (*types
 		PendingMessages: pendingMessages,
 		TotalMessages:   totalMessages,
 	}, nil
+}
+
+// policyRowSnapshot returns a lightweight representation of a risk policy row
+// suitable for audit log snapshots. Unlike policyToType it avoids extra DB
+// queries for message counts, keeping transactions short.
+func policyRowSnapshot(row repo.RiskPolicy) map[string]any {
+	return map[string]any{
+		"id":         row.ID.String(),
+		"project_id": row.ProjectID.String(),
+		"name":       row.Name,
+		"sources":    row.Sources,
+		"enabled":    row.Enabled,
+		"version":    row.Version,
+		"created_at": row.CreatedAt.Time.Format(time.RFC3339),
+		"updated_at": row.UpdatedAt.Time.Format(time.RFC3339),
+	}
 }
 
 func validatePolicyName(name string) error {

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/background"
@@ -28,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var _ gen.Service = (*Service)(nil)
@@ -161,6 +163,18 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy").Log(ctx, s.logger)
 	}
 
+	if err := audit.LogRiskPolicyCreate(ctx, s.db, audit.LogRiskPolicyCreateEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		ProjectID:        *authCtx.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		RiskPolicyID:     row.ID,
+		RiskPolicyName:   row.Name,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy create").Log(ctx, s.logger)
+	}
+
 	// Trigger the drain workflow for the new policy.
 	if enabled {
 		_ = s.signaler.SignalNewMessages(ctx, background.DrainRiskAnalysisParams{
@@ -263,6 +277,8 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		enabled = *payload.Enabled
 	}
 
+	snapshotBefore, _ := s.policyToType(ctx, current)
+
 	row, err := s.repo.UpdateRiskPolicy(ctx, repo.UpdateRiskPolicyParams{
 		ID:        id,
 		ProjectID: *authCtx.ProjectID,
@@ -272,6 +288,22 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "update risk policy").Log(ctx, s.logger)
+	}
+
+	snapshotAfter, _ := s.policyToType(ctx, row)
+
+	if err := audit.LogRiskPolicyUpdate(ctx, s.db, audit.LogRiskPolicyUpdateEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		ProjectID:        *authCtx.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		RiskPolicyID:     row.ID,
+		RiskPolicyName:   row.Name,
+		SnapshotBefore:   snapshotBefore,
+		SnapshotAfter:    snapshotAfter,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy update").Log(ctx, s.logger)
 	}
 
 	// Signal the drain workflow — it reads the current enabled/version
@@ -299,6 +331,15 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		return oops.C(oops.CodeInvalid)
 	}
 
+	// Fetch before delete so we can log the policy name.
+	existing, err := s.repo.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{
+		ID:        id,
+		ProjectID: *authCtx.ProjectID,
+	})
+	if err != nil {
+		return oops.E(oops.CodeNotFound, err, "risk policy not found").Log(ctx, s.logger)
+	}
+
 	// Soft-delete only — list queries already filter out results for deleted
 	// policies via the risk_policies join, so orphaned rows are harmless.
 	if err := s.repo.DeleteRiskPolicy(ctx, repo.DeleteRiskPolicyParams{
@@ -306,6 +347,18 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		ProjectID: *authCtx.ProjectID,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "delete risk policy").Log(ctx, s.logger)
+	}
+
+	if err := audit.LogRiskPolicyDelete(ctx, s.db, audit.LogRiskPolicyDeleteEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		ProjectID:        *authCtx.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		RiskPolicyID:     id,
+		RiskPolicyName:   existing.Name,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "log risk policy delete").Log(ctx, s.logger)
 	}
 
 	return nil
@@ -482,6 +535,18 @@ func (s *Service) TriggerRiskAnalysis(ctx context.Context, payload *gen.TriggerR
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "bump policy version").Log(ctx, s.logger)
+	}
+
+	if err := audit.LogRiskPolicyTrigger(ctx, s.db, audit.LogRiskPolicyTriggerEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		ProjectID:        *authCtx.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		RiskPolicyID:     policy.ID,
+		RiskPolicyName:   policy.Name,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "log risk policy trigger").Log(ctx, s.logger)
 	}
 
 	if err := s.signaler.SignalNewMessages(ctx, background.DrainRiskAnalysisParams{


### PR DESCRIPTION
## Why

The risk policy service (introduced in #2297) was missing audit logging. All other mutating services in the codebase (toolsets, projects, environments, etc.) log create/update/delete actions to the audit trail, but risk policy operations were not covered. This was flagged during PR review.

## What changed

### Before

- `CreateRiskPolicy`, `UpdateRiskPolicy`, `DeleteRiskPolicy`, and `TriggerRiskAnalysis` performed their mutations without writing any audit log entries. There was no record of who created, modified, or deleted a risk policy.
- Mutations and any future audit logging would not be atomic — a failed audit insert after a successful mutation would leave the database in an inconsistent state (policy changed but no audit trail).

### After

- All four mutating risk policy operations now write audit log entries (`risk_policy:create`, `risk_policy:update`, `risk_policy:delete`, `risk_policy:trigger`), following the same pattern used by toolsets, projects, and other services.
- `CreateRiskPolicy`, `UpdateRiskPolicy`, and `DeleteRiskPolicy` wrap the mutation + audit insert in a database transaction, so they either both succeed or both roll back. The drain workflow signal and `policyToType` enrichment happen *after* the commit to keep transactions tight.
- Audit snapshots for updates use a lightweight `policyRowSnapshot()` helper that maps row fields directly, avoiding the extra `CountTotalMessages`/`CountAnalyzedMessages` DB queries that `policyToType` runs. This keeps the transaction free of unnecessary reads.
- A new `risk_policy` subject type is registered in `server/internal/audit/events.go`.
- A new file `server/internal/audit/risk.go` contains the audit event types and logging functions.
- A PR template (`.github/pull_request_template.md`) is introduced with "Why" and "What changed" (with before/after) sections.