### PR TITLE
fix(dashboard): unify breadcrumb format across all pages

### DIFF
--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -1,7 +1,9 @@
 import { InsightsTrigger } from "@/components/insights-sidebar";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { useOrganization, useProject } from "@/contexts/Auth.tsx";
 import { useSlugs } from "@/contexts/Sdk.tsx";
+import { useRBAC } from "@/hooks/useRBAC";
 import { capitalize, cn } from "@/lib/utils.ts";
 import React from "react";
 import { Link, useLocation, useParams } from "react-router";
@@ -65,6 +67,9 @@ const breadcrumbSubstitutions = {
   "add-function": "Add Function",
   "add-from-catalog": "Add from Catalog",
   "agent-sessions": "Agent Sessions",
+  "api-keys": "API Keys",
+  "audit-logs": "Audit Logs",
+  "admin-settings": "Admin Settings",
   // The URL segments `slack` and `clis` are preserved for backwards
   // compatibility, but the sidebar/route titles were rebranded — map them
   // here so breadcrumbs stay in sync with the rest of the UI.
@@ -85,6 +90,9 @@ function PageHeaderBreadcrumbs({
 }) {
   const params = useParams();
   const { orgSlug, projectSlug } = useSlugs();
+  const organization = useOrganization();
+  const project = useProject();
+  const { hasAnyScope } = useRBAC();
   const location = useLocation();
 
   const toPreserve = Object.values(params).filter(Boolean);
@@ -93,18 +101,24 @@ function PageHeaderBreadcrumbs({
     ...substitutions,
   };
 
-  // Build breadcrumb elements from URL segments
+  // Build page-level breadcrumb elements from URL segments
   // For project-level pages (/:orgSlug/projects/:projectSlug/...), strip 3 leading segments
   // For org-level pages (/:orgSlug/...), strip 1 leading segment (just the orgSlug)
   const segmentsToStrip = projectSlug ? 3 : 1;
-  const visibleElements = location.pathname
+  const baseUrl = projectSlug
+    ? `/${orgSlug}/projects/${projectSlug}`
+    : `/${orgSlug}`;
+
+  // Build URLs from ALL segments (so skipped segments are still in the path),
+  // then filter out the ones we don't want to display.
+  const allSegments = location.pathname
     .split("/")
     .filter(Boolean) // Remove empty strings
-    .slice(segmentsToStrip)
-    .filter((segment) => !skipSegments.includes(segment)) // Skip specified segments
-    .map((segment, index, segments) => {
-      const url = "/" + segments.slice(0, index + 1).join("/");
-      const isCurrentPage = location.pathname.endsWith(url);
+    .slice(segmentsToStrip);
+
+  const pageElements = allSegments
+    .map((segment, index) => {
+      const relativeUrl = "/" + allSegments.slice(0, index + 1).join("/");
 
       let display = segment;
       if (allSubstitutions[segment]) {
@@ -114,32 +128,66 @@ function PageHeaderBreadcrumbs({
       }
 
       return {
-        url,
+        url: baseUrl + relativeUrl,
         display,
-        isCurrentPage,
+        isCurrentPage: location.pathname.endsWith(relativeUrl),
+        skip: skipSegments.includes(segment),
       };
-    });
+    })
+    .filter((elem) => !elem.skip);
 
-  visibleElements.unshift({
-    url: "/",
-    display: "Home",
-    isCurrentPage: visibleElements.length === 0,
+  // Build full breadcrumb list: {org} > [project >] page segments
+  const canAccessOrg = hasAnyScope(["org:read", "org:admin"]);
+  const visibleElements: {
+    url: string;
+    display: string;
+    isCurrentPage: boolean;
+    disableLink?: boolean;
+  }[] = [];
+
+  // 1. Org name (always first; only clickable if user has org access)
+  visibleElements.push({
+    url: `/${orgSlug}`,
+    display: organization.name || orgSlug || "Home",
+    isCurrentPage: false,
+    disableLink: !canAccessOrg,
   });
+
+  // 2. Project name (only for project-level pages)
+  if (projectSlug) {
+    visibleElements.push({
+      url: `/${orgSlug}/projects/${projectSlug}`,
+      display: project.name || projectSlug || "Project",
+      isCurrentPage: pageElements.length === 0,
+    });
+  } else if (pageElements.length === 0) {
+    // Org root page — show "Home" as the current page
+    visibleElements.push({
+      url: `/${orgSlug}`,
+      display: "Home",
+      isCurrentPage: true,
+    });
+  }
+
+  // 3. Page segments
+  visibleElements.push(...pageElements);
 
   return (
     <PageHeader.Title className={cn(fullWidth ? "max-w-full" : "", className)}>
       <div className="ml-auto flex items-center gap-2 normal-case">
         {visibleElements.map((elem, index) => (
           <React.Fragment key={elem.url}>
-            {elem.isCurrentPage ? (
-              <span>{elem.display}</span>
+            {elem.isCurrentPage || elem.disableLink ? (
+              <span
+                className={
+                  elem.isCurrentPage ? undefined : "text-muted-foreground"
+                }
+              >
+                {elem.display}
+              </span>
             ) : (
               <Link
-                to={
-                  projectSlug
-                    ? `/${orgSlug}/projects/${projectSlug}${elem.url}`
-                    : `/${orgSlug}${elem.url}`
-                }
+                to={elem.url}
                 className="text-muted-foreground hover:text-foreground trans"
               >
                 {elem.display}

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -176,7 +176,7 @@ function PageHeaderBreadcrumbs({
     <PageHeader.Title className={cn(fullWidth ? "max-w-full" : "", className)}>
       <div className="ml-auto flex items-center gap-2 normal-case">
         {visibleElements.map((elem, index) => (
-          <React.Fragment key={elem.url}>
+          <React.Fragment key={`${elem.url}-${index}`}>
             {elem.isCurrentPage || elem.disableLink ? (
               <span
                 className={

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -27,7 +27,7 @@ export default function Billing() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Billing</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope={["org:read", "org:admin"]} level="page">

--- a/client/dashboard/src/pages/org/OrgAdminSettings.tsx
+++ b/client/dashboard/src/pages/org/OrgAdminSettings.tsx
@@ -165,7 +165,7 @@ export default function OrgAdminSettings() {
     return (
       <Page>
         <Page.Header>
-          <Page.Header.Title>Super Admin</Page.Header.Title>
+          <Page.Header.Breadcrumbs />
         </Page.Header>
         <Page.Body>
           <Type muted>You do not have access to this page.</Type>
@@ -177,7 +177,7 @@ export default function OrgAdminSettings() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Super Admin</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <OrgAdminSettingsInner />

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -28,7 +28,7 @@ export default function OrgApiKeys() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>API Keys</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope="org:admin" level="page">

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -503,7 +503,7 @@ export default function OrgAuditLogs() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Audit Logs</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope="org:read" level="page">

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -31,7 +31,7 @@ export default function OrgDomains() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Custom Domain</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope={["org:read", "org:admin"]} level="page">

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -17,7 +17,7 @@ export default function OrgHome() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Home</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -154,7 +154,7 @@ export default function OrgIdentity() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Identity</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope={["org:read", "org:admin"]} level="page">

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -14,7 +14,7 @@ export default function OrgLogs() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Logging & Telemetry</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope={["org:read", "org:admin"]} level="page">

--- a/client/dashboard/src/pages/org/OrgProjects.tsx
+++ b/client/dashboard/src/pages/org/OrgProjects.tsx
@@ -27,7 +27,7 @@ export default function OrgProjects() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Projects</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <Heading variant="h4" className="mb-2">

--- a/client/dashboard/src/pages/org/PluginDetail.tsx
+++ b/client/dashboard/src/pages/org/PluginDetail.tsx
@@ -152,7 +152,9 @@ export default function PluginDetail() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>{plugin.name}</Page.Header.Title>
+        <Page.Header.Breadcrumbs
+          substitutions={{ [pluginId ?? ""]: plugin.name }}
+        />
       </Page.Header>
       <Page.Body>
         {/* Plugin metadata */}

--- a/client/dashboard/src/pages/settings/Settings.tsx
+++ b/client/dashboard/src/pages/settings/Settings.tsx
@@ -16,7 +16,7 @@ export default function Settings() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Project Settings</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope="build:write" level="page">

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -49,7 +49,7 @@ export default function Team() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Title>Team</Page.Header.Title>
+        <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
         <RequireScope scope="org:admin" level="page">


### PR DESCRIPTION
## Summary
- Standardize breadcrumb convention across all dashboard pages:
  - **Org pages:** `{org name} > {page name}` (e.g. `Acme Corp / Billing`)
  - **Project pages:** `{org name} > {project name} > {page name}` (e.g. `Acme Corp / My API / MCP`)
- Convert 12 pages from static `<Page.Header.Title>` to `<Page.Header.Breadcrumbs />`
- Fix `skipSegments` bug where skipped URL segments were incorrectly removed from breadcrumb link paths (e.g. `/sources/http/openapi` was linking to `/sources/openapi`)
- Org breadcrumb is non-clickable for users without `org:read` or `org:admin` scope
- Add breadcrumb substitutions for hyphenated URL segments (`api-keys`, `audit-logs`, `admin-settings`)

## Changes
| File | Change |
|------|--------|
| `page-header.tsx` | Core breadcrumb engine: add org/project names, absolute URLs, RBAC guard, skipSegments fix |
| 9 org pages | Convert `<Page.Header.Title>` → `<Page.Header.Breadcrumbs />` |
| `Settings.tsx` | Convert to breadcrumbs (project-level) |
| `PluginDetail.tsx` | Convert to breadcrumbs with slug→name substitution |

## Test plan
- [ ] Navigate org-level pages (Billing, Team, API Keys, etc.) — verify breadcrumbs show `{org name} / {page name}`
- [ ] Navigate project-level pages (MCP, Sources, Deployments, etc.) — verify breadcrumbs show `{org name} / {project name} / {page name}`
- [ ] Visit org home — verify breadcrumb shows `{org name} / Home`
- [ ] Visit a source detail page (e.g. `/sources/http/openapi`) — verify the source breadcrumb links to the correct URL (including the sourceKind segment)
- [ ] Test with RBAC enabled and a user without org:read/org:admin — verify org name breadcrumb is plain text (not clickable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)