### PR TITLE
chore: propagate X-Request-ID into logs and traces

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -23,6 +23,7 @@ const (
 	FilePathKey                       = semconv.FilePathKey
 	HostNameKey                       = semconv.HostNameKey
 	HTTPRefererHostKey                = attribute.Key("http.request.referer_host")
+	HTTPRequestIDKey                  = attribute.Key("http.request_id")
 	HTTPRequestHeaderRefererKey       = attribute.Key("http.request.header.referer")
 	HTTPRequestHeaderContentTypeKey   = attribute.Key("http.request.header.content_type")
 	HTTPRequestHeaderUserAgentKey     = attribute.Key("http.request.header.user_agent")
@@ -313,6 +314,13 @@ func SlogHostName(v string) slog.Attr      { return slog.String(string(HostNameK
 
 func HTTPReferrerHost(v string) attribute.KeyValue { return HTTPRefererHostKey.String(v) }
 func SlogHTTPReferrerHost(v string) slog.Attr      { return slog.String(string(HTTPRefererHostKey), v) }
+
+func HTTPRequestID(v string) attribute.KeyValue {
+	return HTTPRequestIDKey.String(v)
+}
+func SlogHTTPRequestID(v string) slog.Attr {
+	return slog.String(string(HTTPRequestIDKey), v)
+}
 
 func HTTPRequestHeaderReferer(v string) attribute.KeyValue {
 	return HTTPRequestHeaderRefererKey.String(v)

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -26,6 +26,7 @@ type AuthContext struct {
 }
 
 type RequestContext struct {
+	ReqID       string
 	ReqURL      string
 	Host        string
 	Method      string

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -49,9 +49,15 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+			requestID := r.Header.Get("X-Request-ID")
+
 			spanCtx := trace.SpanContextFromContext(ctx)
 			if spanCtx.HasTraceID() {
 				w.Header().Set("x-trace-id", spanCtx.TraceID().String())
+			}
+
+			if requestID != "" {
+				trace.SpanFromContext(ctx).SetAttributes(attr.HTTPRequestID(requestID))
 			}
 
 			start := time.Now()
@@ -63,6 +69,7 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 			}
 
 			requestContext := &contextvalues.RequestContext{
+				ReqID:       requestID,
 				ReqURL:      r.URL.String(),
 				Host:        r.Host,
 				Method:      r.Method,
@@ -78,6 +85,9 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 				attr.SlogHTTPRequestMethod(r.Method),
 				attr.SlogURLOriginal(r.URL.String()),
 				attr.SlogHostName(r.Host),
+			}
+			if requestContext.ReqID != "" {
+				attrs = append(attrs, attr.SlogHTTPRequestID(requestContext.ReqID))
 			}
 			if requestContext.Referer != "" {
 				attrs = append(attrs, attr.SlogHTTPRequestHeaderReferer(requestContext.Referer))

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -49,7 +49,7 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			requestID := r.Header.Get("X-Request-ID")
+			requestID := conv.TruncateString(r.Header.Get("X-Request-ID"), 64)
 
 			spanCtx := trace.SpanContextFromContext(ctx)
 			if spanCtx.HasTraceID() {

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -57,6 +57,7 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 			}
 
 			if requestID != "" {
+				w.Header().Set("x-request-id", requestID)
 				trace.SpanFromContext(ctx).SetAttributes(attr.HTTPRequestID(requestID))
 			}
 


### PR DESCRIPTION
Capture the X-Request-ID header in the HTTP logging middleware and attach it as http.request_id on request logs and the active span, and thread it through RequestContext for downstream consumers.
