### PR TITLE
mig: add mcp_frontends and mcp_slugs tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1763,26 +1763,6 @@ CREATE INDEX IF NOT EXISTS mcp_frontends_project_id_idx
 ON mcp_frontends (project_id)
 WHERE deleted IS FALSE;
 
-CREATE INDEX IF NOT EXISTS mcp_frontends_environment_id_idx
-ON mcp_frontends (environment_id)
-WHERE deleted IS FALSE;
-
-CREATE INDEX IF NOT EXISTS mcp_frontends_external_oauth_server_id_idx
-ON mcp_frontends (external_oauth_server_id)
-WHERE deleted IS FALSE;
-
-CREATE INDEX IF NOT EXISTS mcp_frontends_oauth_proxy_server_id_idx
-ON mcp_frontends (oauth_proxy_server_id)
-WHERE deleted IS FALSE;
-
-CREATE INDEX IF NOT EXISTS mcp_frontends_remote_mcp_server_id_idx
-ON mcp_frontends (remote_mcp_server_id)
-WHERE deleted IS FALSE;
-
-CREATE INDEX IF NOT EXISTS mcp_frontends_toolset_id_idx
-ON mcp_frontends (toolset_id)
-WHERE deleted IS FALSE;
-
 -- MCP Slugs: addressable slugs for an MCP frontend. A NULL custom_domain_id
 -- represents a Gram-hosted slug (resolved by slug alone); a non-NULL
 -- custom_domain_id represents a custom-domain slug (resolved by the

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1729,6 +1729,103 @@ CREATE UNIQUE INDEX IF NOT EXISTS remote_mcp_server_headers_remote_mcp_server_id
 ON remote_mcp_server_headers (remote_mcp_server_id, name)
 WHERE deleted IS FALSE;
 
+-- MCP Frontends: user-facing MCP server configurations that link an MCP
+-- backend (either a toolset or a remote MCP server) to environment and
+-- OAuth settings. Each frontend is addressable via one or more mcp_slugs.
+CREATE TABLE IF NOT EXISTS mcp_frontends (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  environment_id uuid,
+  external_oauth_server_id uuid,
+  oauth_proxy_server_id uuid,
+  remote_mcp_server_id uuid,
+  toolset_id uuid,
+  visibility TEXT NOT NULL CHECK (visibility <> ''),
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT mcp_frontends_pkey PRIMARY KEY (id),
+  CONSTRAINT mcp_frontends_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_frontends_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_frontends_external_oauth_server_id_fkey FOREIGN KEY (external_oauth_server_id) REFERENCES external_oauth_server_metadata (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_frontends_oauth_proxy_server_id_fkey FOREIGN KEY (oauth_proxy_server_id) REFERENCES oauth_proxy_servers (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_frontends_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_frontends_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE SET NULL,
+  -- Exactly one backend must be set: either a remote MCP server or a toolset.
+  CONSTRAINT mcp_frontends_backend_exclusivity_check CHECK ((remote_mcp_server_id IS NULL) != (toolset_id IS NULL))
+);
+
+CREATE INDEX IF NOT EXISTS mcp_frontends_project_id_idx
+ON mcp_frontends (project_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_frontends_environment_id_idx
+ON mcp_frontends (environment_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_frontends_external_oauth_server_id_idx
+ON mcp_frontends (external_oauth_server_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_frontends_oauth_proxy_server_id_idx
+ON mcp_frontends (oauth_proxy_server_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_frontends_remote_mcp_server_id_idx
+ON mcp_frontends (remote_mcp_server_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_frontends_toolset_id_idx
+ON mcp_frontends (toolset_id)
+WHERE deleted IS FALSE;
+
+-- MCP Slugs: addressable slugs for an MCP frontend. A NULL custom_domain_id
+-- represents a Gram-hosted slug (resolved by slug alone); a non-NULL
+-- custom_domain_id represents a custom-domain slug (resolved by the
+-- composite (custom_domain_id, slug)).
+CREATE TABLE IF NOT EXISTS mcp_slugs (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  custom_domain_id uuid,
+  mcp_frontend_id uuid NOT NULL,
+  slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 128),
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT mcp_slugs_pkey PRIMARY KEY (id),
+  CONSTRAINT mcp_slugs_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_slugs_mcp_frontend_id_fkey FOREIGN KEY (mcp_frontend_id) REFERENCES mcp_frontends (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_slugs_custom_domain_id_fkey FOREIGN KEY (custom_domain_id) REFERENCES custom_domains (id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS mcp_slugs_project_id_idx
+ON mcp_slugs (project_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_slugs_mcp_frontend_id_idx
+ON mcp_slugs (mcp_frontend_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_slugs_custom_domain_id_idx
+ON mcp_slugs (custom_domain_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_slugs_custom_domain_id_slug_key
+ON mcp_slugs (custom_domain_id, slug)
+WHERE custom_domain_id IS NOT NULL AND deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_slugs_slug_null_custom_domain_id_key
+ON mcp_slugs (slug)
+WHERE custom_domain_id IS NULL AND deleted IS FALSE;
+
 -- Plugin definitions: project-scoped distributable bundles of MCP servers.
 -- Admins create plugins and assign them to roles for distribution.
 CREATE TABLE IF NOT EXISTS plugins (

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -492,6 +492,21 @@ type McpEnvironmentConfig struct {
 	UpdatedAt         pgtype.Timestamptz
 }
 
+type McpFrontend struct {
+	ID                    uuid.UUID
+	ProjectID             uuid.UUID
+	EnvironmentID         uuid.NullUUID
+	ExternalOauthServerID uuid.NullUUID
+	OauthProxyServerID    uuid.NullUUID
+	RemoteMcpServerID     uuid.NullUUID
+	ToolsetID             uuid.NullUUID
+	Visibility            string
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	Deleted               bool
+}
+
 type McpMetadatum struct {
 	ID                        uuid.UUID
 	ToolsetID                 uuid.UUID
@@ -515,6 +530,18 @@ type McpRegistry struct {
 	UpdatedAt pgtype.Timestamptz
 	DeletedAt pgtype.Timestamptz
 	Deleted   bool
+}
+
+type McpSlug struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	CustomDomainID uuid.NullUUID
+	McpFrontendID  uuid.UUID
+	Slug           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
 }
 
 type OauthProxyClientInfo struct {

--- a/server/migrations/20260421144856_mcp_frontends_and_slugs.sql
+++ b/server/migrations/20260421144856_mcp_frontends_and_slugs.sql
@@ -1,0 +1,63 @@
+-- Create "mcp_frontends" table
+CREATE TABLE "mcp_frontends" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "environment_id" uuid NULL,
+  "external_oauth_server_id" uuid NULL,
+  "oauth_proxy_server_id" uuid NULL,
+  "remote_mcp_server_id" uuid NULL,
+  "toolset_id" uuid NULL,
+  "visibility" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "mcp_frontends_environment_id_fkey" FOREIGN KEY ("environment_id") REFERENCES "environments" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_frontends_external_oauth_server_id_fkey" FOREIGN KEY ("external_oauth_server_id") REFERENCES "external_oauth_server_metadata" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_frontends_oauth_proxy_server_id_fkey" FOREIGN KEY ("oauth_proxy_server_id") REFERENCES "oauth_proxy_servers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_frontends_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "mcp_frontends_remote_mcp_server_id_fkey" FOREIGN KEY ("remote_mcp_server_id") REFERENCES "remote_mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_frontends_toolset_id_fkey" FOREIGN KEY ("toolset_id") REFERENCES "toolsets" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_frontends_backend_exclusivity_check" CHECK ((remote_mcp_server_id IS NULL) <> (toolset_id IS NULL)),
+  CONSTRAINT "mcp_frontends_visibility_check" CHECK (visibility <> ''::text)
+);
+-- Create index "mcp_frontends_environment_id_idx" to table: "mcp_frontends"
+CREATE INDEX "mcp_frontends_environment_id_idx" ON "mcp_frontends" ("environment_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_frontends_external_oauth_server_id_idx" to table: "mcp_frontends"
+CREATE INDEX "mcp_frontends_external_oauth_server_id_idx" ON "mcp_frontends" ("external_oauth_server_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_frontends_oauth_proxy_server_id_idx" to table: "mcp_frontends"
+CREATE INDEX "mcp_frontends_oauth_proxy_server_id_idx" ON "mcp_frontends" ("oauth_proxy_server_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_frontends_project_id_idx" to table: "mcp_frontends"
+CREATE INDEX "mcp_frontends_project_id_idx" ON "mcp_frontends" ("project_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_frontends_remote_mcp_server_id_idx" to table: "mcp_frontends"
+CREATE INDEX "mcp_frontends_remote_mcp_server_id_idx" ON "mcp_frontends" ("remote_mcp_server_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_frontends_toolset_id_idx" to table: "mcp_frontends"
+CREATE INDEX "mcp_frontends_toolset_id_idx" ON "mcp_frontends" ("toolset_id") WHERE (deleted IS FALSE);
+-- Create "mcp_slugs" table
+CREATE TABLE "mcp_slugs" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "custom_domain_id" uuid NULL,
+  "mcp_frontend_id" uuid NOT NULL,
+  "slug" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "mcp_slugs_custom_domain_id_fkey" FOREIGN KEY ("custom_domain_id") REFERENCES "custom_domains" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_slugs_mcp_frontend_id_fkey" FOREIGN KEY ("mcp_frontend_id") REFERENCES "mcp_frontends" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "mcp_slugs_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "mcp_slugs_slug_check" CHECK ((slug <> ''::text) AND (char_length(slug) <= 128))
+);
+-- Create index "mcp_slugs_custom_domain_id_idx" to table: "mcp_slugs"
+CREATE INDEX "mcp_slugs_custom_domain_id_idx" ON "mcp_slugs" ("custom_domain_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_slugs_custom_domain_id_slug_key" to table: "mcp_slugs"
+CREATE UNIQUE INDEX "mcp_slugs_custom_domain_id_slug_key" ON "mcp_slugs" ("custom_domain_id", "slug") WHERE ((custom_domain_id IS NOT NULL) AND (deleted IS FALSE));
+-- Create index "mcp_slugs_mcp_frontend_id_idx" to table: "mcp_slugs"
+CREATE INDEX "mcp_slugs_mcp_frontend_id_idx" ON "mcp_slugs" ("mcp_frontend_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_slugs_project_id_idx" to table: "mcp_slugs"
+CREATE INDEX "mcp_slugs_project_id_idx" ON "mcp_slugs" ("project_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_slugs_slug_null_custom_domain_id_key" to table: "mcp_slugs"
+CREATE UNIQUE INDEX "mcp_slugs_slug_null_custom_domain_id_key" ON "mcp_slugs" ("slug") WHERE ((custom_domain_id IS NULL) AND (deleted IS FALSE));

--- a/server/migrations/20260421144856_mcp_frontends_and_slugs.sql
+++ b/server/migrations/20260421144856_mcp_frontends_and_slugs.sql
@@ -22,18 +22,8 @@ CREATE TABLE "mcp_frontends" (
   CONSTRAINT "mcp_frontends_backend_exclusivity_check" CHECK ((remote_mcp_server_id IS NULL) <> (toolset_id IS NULL)),
   CONSTRAINT "mcp_frontends_visibility_check" CHECK (visibility <> ''::text)
 );
--- Create index "mcp_frontends_environment_id_idx" to table: "mcp_frontends"
-CREATE INDEX "mcp_frontends_environment_id_idx" ON "mcp_frontends" ("environment_id") WHERE (deleted IS FALSE);
--- Create index "mcp_frontends_external_oauth_server_id_idx" to table: "mcp_frontends"
-CREATE INDEX "mcp_frontends_external_oauth_server_id_idx" ON "mcp_frontends" ("external_oauth_server_id") WHERE (deleted IS FALSE);
--- Create index "mcp_frontends_oauth_proxy_server_id_idx" to table: "mcp_frontends"
-CREATE INDEX "mcp_frontends_oauth_proxy_server_id_idx" ON "mcp_frontends" ("oauth_proxy_server_id") WHERE (deleted IS FALSE);
 -- Create index "mcp_frontends_project_id_idx" to table: "mcp_frontends"
 CREATE INDEX "mcp_frontends_project_id_idx" ON "mcp_frontends" ("project_id") WHERE (deleted IS FALSE);
--- Create index "mcp_frontends_remote_mcp_server_id_idx" to table: "mcp_frontends"
-CREATE INDEX "mcp_frontends_remote_mcp_server_id_idx" ON "mcp_frontends" ("remote_mcp_server_id") WHERE (deleted IS FALSE);
--- Create index "mcp_frontends_toolset_id_idx" to table: "mcp_frontends"
-CREATE INDEX "mcp_frontends_toolset_id_idx" ON "mcp_frontends" ("toolset_id") WHERE (deleted IS FALSE);
 -- Create "mcp_slugs" table
 CREATE TABLE "mcp_slugs" (
   "id" uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:+jyiA/7z+ml4Ywn+05/AfjJLHukoUnlmUlO6ZRqGFjo=
+h1:4w691wH4ya+Chta8kuq/EYNkvdl7oBWrElAj0ZeW09c=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -129,3 +129,4 @@ h1:+jyiA/7z+ml4Ywn+05/AfjJLHukoUnlmUlO6ZRqGFjo=
 20260420113616_chat-messages-add-content-hash-generation.sql h1:4PwJKipKdhpuXXnSMl4cCXC0SEnx3rbzLYY29+NV44s=
 20260420143421_toolset-origins.sql h1:hsU/rOPgf/f8q2pysWDOXS45nuRzznedocFeZuimAJM=
 20260420202925_deployment_statuses_add_deployment_id_seq_idx.sql h1:Hv4GhzFjP6u0Ye+azHZv2Zyf0T0OT9L2zxZtmr7LD1I=
+20260421144856_mcp_frontends_and_slugs.sql h1:ajgpwScnyUl5G1w5cSAKuSKSer2me/oZ9WB4/sJnR4w=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4w691wH4ya+Chta8kuq/EYNkvdl7oBWrElAj0ZeW09c=
+h1:RJm188Kba4J7cfD/Zjt0b+HW4L7khaz3ZsdnZIMBXYM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -129,4 +129,4 @@ h1:4w691wH4ya+Chta8kuq/EYNkvdl7oBWrElAj0ZeW09c=
 20260420113616_chat-messages-add-content-hash-generation.sql h1:4PwJKipKdhpuXXnSMl4cCXC0SEnx3rbzLYY29+NV44s=
 20260420143421_toolset-origins.sql h1:hsU/rOPgf/f8q2pysWDOXS45nuRzznedocFeZuimAJM=
 20260420202925_deployment_statuses_add_deployment_id_seq_idx.sql h1:Hv4GhzFjP6u0Ye+azHZv2Zyf0T0OT9L2zxZtmr7LD1I=
-20260421144856_mcp_frontends_and_slugs.sql h1:ajgpwScnyUl5G1w5cSAKuSKSer2me/oZ9WB4/sJnR4w=
+20260421144856_mcp_frontends_and_slugs.sql h1:hs2Zsds5ZtnHqfjc3F1Hz3uMMpD16MwDBWvfNYPWMP0=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-1879/mcp-frontends-and-slugs-database-migration

Phase 1 schema-only migration introducing the MCP Frontend and MCP Slug tables per the Gram MCP Frontends and Slugs RFC. No SQLc queries, no application code, no data migration — those are tracked in AGE-1902 and AGE-1900.

`mcp_frontends` stores user-facing MCP server configurations linking an MCP backend (either a toolset or a remote MCP server, exactly one enforced via `CHECK`) to environment and OAuth settings.

`mcp_slugs` stores addressable slugs for an MCP frontend. Slug uniqueness is enforced via two partial unique indexes matching the existing `toolsets` precedent: one for custom-domain slugs keyed on `(custom_domain_id, slug)`, and one for Gram-hosted slugs keyed on `(slug)` where `custom_domain_id IS NULL`.