### PR TITLE
fix(dashboard): improve empty states and bump madprocs

### DIFF
--- a/client/dashboard/src/pages/CLIs.tsx
+++ b/client/dashboard/src/pages/CLIs.tsx
@@ -1,5 +1,6 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import { Badge } from "@/components/ui/badge";
 import { Type } from "@/components/ui/type";
 import { Icon } from "@speakeasy-api/moonshine";
 
@@ -29,8 +30,12 @@ export default function CLIs() {
                   No skills yet
                 </Type>
                 <Type small muted className="max-w-md text-center">
-                  Coming soon
+                  Build and distribute skills to your team. Track usage, enable
+                  discovery and improve performance.
                 </Type>
+                <Badge variant="secondary" className="mt-3">
+                  Coming Soon
+                </Badge>
               </div>
             </Page.Section.Body>
           </Page.Section>

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -22,6 +22,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Type } from "@/components/ui/type";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -214,15 +215,17 @@ function PolicyCenterContent() {
           <Page.Header.Breadcrumbs />
         </Page.Header>
         <Page.Body>
-          <div className="flex flex-col items-center justify-center gap-4 py-20">
-            <div className="bg-muted flex h-14 w-14 items-center justify-center rounded-full">
-              <Shield className="text-muted-foreground h-7 w-7" />
+          <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+            <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+              <Shield className="text-muted-foreground h-6 w-6" />
             </div>
-            <h2 className="text-lg font-semibold">No Risk Policies</h2>
-            <p className="text-muted-foreground max-w-md text-center text-sm">
+            <Type variant="subheading" className="mb-1">
+              No Risk Policies
+            </Type>
+            <Type small muted className="mb-4 max-w-md text-center">
               Risk policies scan your chat messages for secrets and sensitive
               data. Create your first policy to get started.
-            </p>
+            </Type>
             <Button
               onClick={() =>
                 createMutation.mutate({

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -9,6 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Type } from "@/components/ui/type";
 import { useRoutes } from "@/routes";
 import { Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -65,13 +66,17 @@ function SecurityOverviewContent() {
           <Page.Header.Breadcrumbs />
         </Page.Header>
         <Page.Body>
-          <div className="flex flex-col items-center justify-center gap-4 py-20">
-            <Shield className="text-muted-foreground h-12 w-12" />
-            <h2 className="text-lg font-semibold">Risk Analysis</h2>
-            <p className="text-muted-foreground max-w-md text-center text-sm">
+          <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+            <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+              <Shield className="text-muted-foreground h-6 w-6" />
+            </div>
+            <Type variant="subheading" className="mb-1">
+              Risk Analysis
+            </Type>
+            <Type small muted className="mb-4 max-w-md text-center">
               Monitor your chat messages for leaked secrets and sensitive data.
               Set up a risk policy to get started.
-            </p>
+            </Type>
             <Button onClick={() => routes.policyCenter.goTo()}>
               Go to Policy Center
             </Button>

--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,7 @@ uv = "0.10.9"
 yq = "4.52.4"
 hk = "1.38.0"
 pkl = "0.31.0"
-"github:speakeasy-api/madprocs" = "0.1.31"
+"github:speakeasy-api/madprocs" = "0.1.32"
 "github:temporalio/cli" = "1.6.1"
 
 # ℹ️ The settings below are sensible defaults for local development. When


### PR DESCRIPTION
## Summary
- Unified empty state styling across Skills, Policy Center, and Security Overview pages with consistent dashed-border containers, icon circles, and `Type` components
- Moved "Coming Soon" on the Skills page from inline text to a visible `Badge` component on its own row
- Bumped madprocs from 0.1.31 to 0.1.32

## Test plan
- [ ] Verify Skills page shows the "Coming Soon" badge below the description
- [ ] Verify Policy Center empty state renders with updated styling
- [ ] Verify Security Overview empty state renders with updated styling
- [ ] Run `mise install` to confirm madprocs 0.1.32 installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)