### PR TITLE
fix(elements): fall back to supported model when requested model not in allowlist

### DIFF
--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"net/http"
 	"slices"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -68,6 +70,35 @@ var allowList = map[string]bool{
 // IsModelAllowed checks if a model is in the allowlist
 func IsModelAllowed(model string) bool {
 	return allowList[model]
+}
+
+// ResolveModel returns the model as-is if it's in the allowlist.
+// Otherwise, it returns the first allowed model (sorted alphabetically)
+// from the same provider. Returns empty string if no fallback is found.
+func ResolveModel(model string) string {
+	if allowList[model] {
+		return model
+	}
+
+	provider, _, ok := strings.Cut(model, "/")
+	if !ok || provider == "" {
+		return ""
+	}
+
+	prefix := provider + "/"
+	var candidates []string
+	for m := range allowList {
+		if strings.HasPrefix(m, prefix) {
+			candidates = append(candidates, m)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	sort.Strings(candidates)
+	return candidates[0]
 }
 
 // default credit limits per acccount type

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -116,6 +116,19 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 		model = DefaultChatModel
 	}
 
+	// Resolve unsupported models to a supported model from the same provider
+	if resolved := ResolveModel(model); resolved != "" {
+		if resolved != model {
+			c.logger.WarnContext(ctx, "requested model not in allowlist, falling back to supported model",
+				slog.String("requested_model", model),
+				slog.String("resolved_model", resolved),
+			)
+			model = resolved
+		}
+	} else {
+		return nil, fmt.Errorf("model %s is not allowed and no fallback is available for its provider", model)
+	}
+
 	// Build request body
 	reqBody := OpenAIChatRequest{
 		Model:          model,

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -120,8 +120,8 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 	if resolved := ResolveModel(model); resolved != "" {
 		if resolved != model {
 			c.logger.WarnContext(ctx, "requested model not in allowlist, falling back to supported model",
-				slog.String("requested_model", model),
-				slog.String("resolved_model", resolved),
+				attr.SlogGenAIRequestModel(model),
+				attr.SlogGenAIResponseModel(resolved),
 			)
 			model = resolved
 		}

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -1189,6 +1190,132 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 	// Verify that response_format was NOT set
 	assert.Nil(t, receivedRequestBody.ResponseFormat,
 		"response_format should not be set when JSONSchema is nil")
+}
+
+func TestResolveModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		{
+			name:     "allowed model returned as-is",
+			model:    "openai/gpt-5.4",
+			expected: "openai/gpt-5.4",
+		},
+		{
+			name:  "unsupported openai model falls back to first alphabetical openai model",
+			model: "openai/gpt-4",
+			expected: func() string {
+				// Determine expected by sorting openai models from the allowlist
+				var models []string
+				for m := range allowList {
+					if len(m) > 7 && m[:7] == "openai/" {
+						models = append(models, m)
+					}
+				}
+				sort.Strings(models)
+				return models[0]
+			}(),
+		},
+		{
+			name:  "unsupported anthropic model falls back",
+			model: "anthropic/claude-2",
+			expected: func() string {
+				var models []string
+				for m := range allowList {
+					if len(m) > 10 && m[:10] == "anthropic/" {
+						models = append(models, m)
+					}
+				}
+				sort.Strings(models)
+				return models[0]
+			}(),
+		},
+		{
+			name:     "unknown provider returns empty",
+			model:    "fakeprovider/some-model",
+			expected: "",
+		},
+		{
+			name:     "bare model name without slash returns empty",
+			model:    "gpt-4",
+			expected: "",
+		},
+		{
+			name:     "empty model returns empty",
+			model:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ResolveModel(tt.model)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
+	t.Parallel()
+
+	// Track which model the server receives
+	var receivedModel string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody OpenAIChatRequest
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
+		receivedModel = reqBody.Model
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fmt.Appendf(nil, `{
+			"id": "msg_fallback",
+			"model": "%s",
+			"choices": [{"message": {"role": "assistant", "content": "Hello"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`, reqBody.Model))
+	}))
+	defer server.Close()
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	client := NewUnifiedClient(
+		slog.Default(),
+		guardianPolicy,
+		&mockProvisioner{apiKey: "test-api-key"},
+		&mockMessageCaptureStrategy{},
+		&mockUsageTrackingStrategy{},
+		&mockChatTitleGenerator{},
+		&mockChatResolutionAnalyzer{},
+		&mockTelemetryLogger{},
+	)
+	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
+
+	projectID := uuid.New()
+	req := CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   projectID.String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("Hello")},
+		Model:       "openai/gpt-4", // unsupported model
+		ChatID:      uuid.New(),
+		UsageSource: billing.ModelUsageSourcePlayground,
+	}
+
+	resp, err := client.GetCompletion(context.Background(), req)
+	require.NoError(t, err, "unsupported model should fall back, not error")
+	require.NotNil(t, resp)
+
+	// The server should have received a supported openai model, not gpt-4
+	assert.True(t, IsModelAllowed(receivedModel),
+		"server should receive a model from the allowlist, got: %s", receivedModel)
+	assert.True(t, len(receivedModel) > 7 && receivedModel[:7] == "openai/",
+		"fallback model should be from the same provider (openai), got: %s", receivedModel)
 }
 
 // testTransport is a custom http.RoundTripper that redirects all requests to the test server

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1192,72 +1193,47 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 		"response_format should not be set when JSONSchema is nil")
 }
 
-func TestResolveModel(t *testing.T) {
+func firstAllowedModelForProvider(prefix string) string {
+	var models []string
+	for m := range allowList {
+		if strings.HasPrefix(m, prefix) {
+			models = append(models, m)
+		}
+	}
+	sort.Strings(models)
+	return models[0]
+}
+
+func TestResolveModel_AllowedModelReturnedAsIs(t *testing.T) {
 	t.Parallel()
+	require.Equal(t, "openai/gpt-5.4", ResolveModel("openai/gpt-5.4"))
+}
 
-	tests := []struct {
-		name     string
-		model    string
-		expected string
-	}{
-		{
-			name:     "allowed model returned as-is",
-			model:    "openai/gpt-5.4",
-			expected: "openai/gpt-5.4",
-		},
-		{
-			name:  "unsupported openai model falls back to first alphabetical openai model",
-			model: "openai/gpt-4",
-			expected: func() string {
-				// Determine expected by sorting openai models from the allowlist
-				var models []string
-				for m := range allowList {
-					if len(m) > 7 && m[:7] == "openai/" {
-						models = append(models, m)
-					}
-				}
-				sort.Strings(models)
-				return models[0]
-			}(),
-		},
-		{
-			name:  "unsupported anthropic model falls back",
-			model: "anthropic/claude-2",
-			expected: func() string {
-				var models []string
-				for m := range allowList {
-					if len(m) > 10 && m[:10] == "anthropic/" {
-						models = append(models, m)
-					}
-				}
-				sort.Strings(models)
-				return models[0]
-			}(),
-		},
-		{
-			name:     "unknown provider returns empty",
-			model:    "fakeprovider/some-model",
-			expected: "",
-		},
-		{
-			name:     "bare model name without slash returns empty",
-			model:    "gpt-4",
-			expected: "",
-		},
-		{
-			name:     "empty model returns empty",
-			model:    "",
-			expected: "",
-		},
-	}
+func TestResolveModel_UnsupportedOpenAIFallback(t *testing.T) {
+	t.Parallel()
+	expected := firstAllowedModelForProvider("openai/")
+	require.Equal(t, expected, ResolveModel("openai/gpt-4"))
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := ResolveModel(tt.model)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+func TestResolveModel_UnsupportedAnthropicFallback(t *testing.T) {
+	t.Parallel()
+	expected := firstAllowedModelForProvider("anthropic/")
+	require.Equal(t, expected, ResolveModel("anthropic/claude-2"))
+}
+
+func TestResolveModel_UnknownProviderReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", ResolveModel("fakeprovider/some-model"))
+}
+
+func TestResolveModel_BareModelNameReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", ResolveModel("gpt-4"))
+}
+
+func TestResolveModel_EmptyModelReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "", ResolveModel(""))
 }
 
 func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
@@ -1307,14 +1283,14 @@ func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
 		UsageSource: billing.ModelUsageSourcePlayground,
 	}
 
-	resp, err := client.GetCompletion(context.Background(), req)
+	resp, err := client.GetCompletion(t.Context(), req)
 	require.NoError(t, err, "unsupported model should fall back, not error")
 	require.NotNil(t, resp)
 
 	// The server should have received a supported openai model, not gpt-4
-	assert.True(t, IsModelAllowed(receivedModel),
+	require.True(t, IsModelAllowed(receivedModel),
 		"server should receive a model from the allowlist, got: %s", receivedModel)
-	assert.True(t, len(receivedModel) > 7 && receivedModel[:7] == "openai/",
+	require.True(t, strings.HasPrefix(receivedModel, "openai/"),
 		"fallback model should be from the same provider (openai), got: %s", receivedModel)
 }
 

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -1223,17 +1223,17 @@ func TestResolveModel_UnsupportedAnthropicFallback(t *testing.T) {
 
 func TestResolveModel_UnknownProviderReturnsEmpty(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "", ResolveModel("fakeprovider/some-model"))
+	require.Empty(t, ResolveModel("fakeprovider/some-model"))
 }
 
 func TestResolveModel_BareModelNameReturnsEmpty(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "", ResolveModel("gpt-4"))
+	require.Empty(t, ResolveModel("gpt-4"))
 }
 
 func TestResolveModel_EmptyModelReturnsEmpty(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "", ResolveModel(""))
+	require.Empty(t, ResolveModel(""))
 }
 
 func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {


### PR DESCRIPTION
## Summary
- Elements consumers on older library versions may request unsupported models (e.g. `openai/gpt-4`), causing a hard 502 error
- Instead of rejecting the request, `ResolveModel()` now finds the first alphabetically-sorted supported model from the same provider and uses it as a fallback
- A `WARN`-level log is emitted with both the requested and resolved model for observability

## Context
Triggered by a production 502 from `audn.ai` using `ai/5.0.90` SDK with an unsupported model:
```
86.153.87.80 - [21/Apr/2026:13:56:25 +0000] "POST /chat/completions HTTP/2.0" 502
```

## Changes
- `openrouter.go`: Added `ResolveModel()` — extracts provider prefix, finds fallback from allowlist
- `unified_client.go`: Model resolution in `initializeRequest()` with warn log, before the request is built
- `unified_client_test.go`: Table-driven `TestResolveModel` (6 cases) + integration `TestChatClient_GetCompletion_UnsupportedModelFallback`

## Test plan
- [x] All 19 existing + 2 new tests pass (`go test ./server/internal/thirdparty/openrouter/ -v`)
- [ ] Verify in staging that `openai/gpt-4` requests get resolved to `openai/gpt-4.1` with a warn log
- [ ] Confirm `audn.ai` traffic no longer 502s after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)