### PR TITLE
fix(dashboard): use DotCard style for environment page cards

### DIFF
--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -1,18 +1,16 @@
 import { InputDialog } from "@/components/input-dialog";
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
-import { Badge } from "@/components/ui/badge";
-import { Card, Cards } from "@/components/ui/card";
-import { UpdatedAt } from "@/components/updated-at";
+import { DotCard } from "@/components/ui/dot-card";
 import { useSession } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
 import { Environment } from "@gram/client/models/components/environment.js";
 import { useCreateEnvironmentMutation } from "@gram/client/react-query/index.js";
-import { Blocks, Plus } from "lucide-react";
+import { ArrowRight, Blocks, Plus } from "lucide-react";
 import { useState } from "react";
 import { Outlet } from "react-router";
-import { Button } from "@speakeasy-api/moonshine";
+import { Badge, Button } from "@speakeasy-api/moonshine";
 import { Type } from "@/components/ui/type";
 import { handleAPIError } from "@/lib/errors";
 import { useEnvironments } from "./useEnvironments";
@@ -118,14 +116,14 @@ function EnvironmentsInner() {
               </RequireScope>
             </div>
           ) : (
-            <Cards>
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
               {environments.map((environment) => (
                 <EnvironmentCard
                   key={environment.id}
                   environment={environment}
                 />
               ))}
-            </Cards>
+            </div>
           )}
         </Page.Section.Body>
       </Page.Section>
@@ -155,22 +153,31 @@ function EnvironmentCard({ environment }: { environment: Environment }) {
       params={[environment.slug]}
       className="hover:no-underline"
     >
-      <Card>
-        <Card.Header>
-          <Card.Title>{environment.name}</Card.Title>
-        </Card.Header>
-        <Card.Content>
-          <Card.Description>
-            {environment.description || "No description provided"}
-          </Card.Description>
-        </Card.Content>
-        <Card.Footer>
-          <Badge variant="outline">
-            {environment.entries.length || "No"} Entries
+      <DotCard icon={<Blocks className="text-muted-foreground h-8 w-8" />}>
+        <div className="mb-2 flex items-start justify-between gap-2">
+          <Type
+            variant="subheading"
+            as="div"
+            className="text-md group-hover:text-primary flex-1 truncate transition-colors"
+            title={environment.name}
+          >
+            {environment.name}
+          </Type>
+        </div>
+        <Type small muted className="truncate">
+          {environment.description || "No description provided"}
+        </Type>
+        <div className="mt-auto flex items-center justify-between gap-2 pt-2">
+          <Badge variant="neutral">
+            {environment.entries.length}{" "}
+            {environment.entries.length === 1 ? "Entry" : "Entries"}
           </Badge>
-          <UpdatedAt date={new Date(environment.updatedAt)} />
-        </Card.Footer>
-      </Card>
+          <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
+            <span>Open</span>
+            <ArrowRight className="h-3.5 w-3.5" />
+          </div>
+        </div>
+      </DotCard>
     </routes.environments.environment.Link>
   );
 }


### PR DESCRIPTION
## Summary
- Switch environments page cards from generic `Card`/`Cards` to `DotCard` with dot-pattern sidebar, matching the sources page card style
- Show entries count badge instead of "Updated at" timestamp in the card footer
- Use the same 2-column grid layout (`grid-cols-1 xl:grid-cols-2`) as the sources page

## Test plan
- [ ] Navigate to Environments page and verify cards display with the dot-pattern sidebar and Blocks icon
- [ ] Verify entry count badge shows correct singular/plural ("1 Entry" vs "3 Entries")
- [ ] Verify "Open →" hover indicator appears on card hover
- [ ] Verify empty state is unchanged
- [ ] Compare visually with Sources page to confirm consistent card styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)