### PR TITLE
feat: fire enterprise_gate_viewed when user hits in-app demo gate

### DIFF
--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -98,6 +98,31 @@ export function useCaptureUserAuthorizationEvent({
   }, [email, projectSlug, organizationSlug, telemetry]);
 }
 
+export function useCaptureEnterpriseGateViewed({
+  email,
+  organizationId,
+  organizationName,
+  organizationSlug,
+}: {
+  email: string;
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+}) {
+  const telemetry = useTelemetry();
+
+  useEffect(() => {
+    if (!email) return;
+    if (!organizationId) return;
+    telemetry.capture("enterprise_gate_viewed", {
+      email,
+      organization_id: organizationId,
+      organization_name: organizationName,
+      organization_slug: organizationSlug,
+    });
+  }, [email, organizationId, organizationName, organizationSlug, telemetry]);
+}
+
 export function useRegisterChatTelemetry({
   chatId,
   chatUrl,

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -1,9 +1,19 @@
 import { Button } from "@/components/ui/button";
+import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
+import { useCaptureEnterpriseGateViewed } from "@/contexts/Telemetry";
 import { LogOutIcon } from "lucide-react";
 
 export default function BookDemo() {
   const client = useSdkClient();
+  const { session } = useSessionData();
+
+  useCaptureEnterpriseGateViewed({
+    email: session?.user.email ?? "",
+    organizationId: session?.organization?.id ?? "",
+    organizationName: session?.organization?.name ?? "",
+    organizationSlug: session?.organization?.slug ?? "",
+  });
 
   const handleLogout = async () => {
     await client.auth.logout();


### PR DESCRIPTION
## Summary

- Adds `useCaptureEnterpriseGateViewed` telemetry hook and wires it into `BookDemo` so a `enterprise_gate_viewed` PostHog event fires whenever a signed-in user on a non-whitelisted org hits the in-app book-demo gate.
- Event carries `email`, `organization_id`, `organization_name` (user-provided), and `organization_slug` — enough context for the sales team to act on in Slack.

## Why

The in-app `BookDemo` component renders without changing the URL (see `AuthProvider.tsx:105`), so our existing `$pageview`-based Slack pipeline for `www.speakeasy.com/book-demo` (anonymous marketing leads) never fires for signed-in gated users. Instrumenting this event lets us alert `#sig-events` with the user's email + their user-provided org name, closing the gap in our lead funnel coverage.

## PostHog wiring (already shipped, no action needed in this PR)

- Destination **Gram - enterprise gate viewed → sig-events** is live and filters on the new event name. It posts to `#sig-events` (`C06LSH8B6EQ`) 

## Test plan

- [ ] After deploy, visit the dashboard with a non-whitelisted org account → confirm `<BookDemo />` renders as before
- [ ] Check PostHog activity for a new `enterprise_gate_viewed` event with the four expected properties
- [ ] Confirm `#sig-events` receives a Slack message in the format: `Gram by Gram, we build our empire! {email} just hit the in-app enterprise book demo gate. / Organization (user-provided name): *{name}* / Organization slug: \`{slug}\``
- [ ] Refresh the page within 12h → no duplicate Slack message (masking works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
