### PR TITLE
chore(mv): log missing active-deployment at debug severity

### DIFF
--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -357,8 +357,10 @@ func DescribeToolset(
 	// TODO: It would be better if every query below accepted a deployment ID as a parameter to guarantee cache consistency.
 	activeDeploymentID, err := deploymentRepo.GetActiveDeploymentID(ctx, pid)
 	if err != nil {
-		// We only log this because we only need to know this for the cache
-		logger.ErrorContext(ctx, "failed to get active deployment id", attr.SlogError(err))
+		// Informational: only used to scope the cache key. Missing on a project
+		// with no deployments yet, which is fine — tools still resolve from the
+		// toolset version below.
+		logger.DebugContext(ctx, "no active deployment id", attr.SlogError(err))
 	}
 
 	// Get tool URNs and resource URNs from latest toolset version

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -356,11 +356,11 @@ func DescribeToolset(
 
 	// TODO: It would be better if every query below accepted a deployment ID as a parameter to guarantee cache consistency.
 	activeDeploymentID, err := deploymentRepo.GetActiveDeploymentID(ctx, pid)
-	if err != nil {
-		// Informational: only used to scope the cache key. Missing on a project
-		// with no deployments yet, which is fine — tools still resolve from the
-		// toolset version below.
-		logger.DebugContext(ctx, "no active deployment id", attr.SlogError(err))
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		logger.WarnContext(ctx, "no active deployment id", attr.SlogError(err))
+	case err != nil:
+		logger.ErrorContext(ctx, "failed to get active deployment id", attr.SlogError(err))
 	}
 
 	// Get tool URNs and resource URNs from latest toolset version


### PR DESCRIPTION
## Summary

- `DescribeToolset` uses `GetActiveDeploymentID` purely to scope a cache key. A missing deployment on a fresh project is a benign, expected condition — not an error.
- Downgrade the log from `ErrorContext` to `DebugContext` and reword the comment to explain the cache-scoping intent so it stops emitting spurious alerts.

Linear: [AGE-1909](https://linear.app/speakeasy/issue/AGE-1909)

✻ Clauded...