### PR TITLE
feat: expandable charts on Hooks analytics page

### DIFF
--- a/.changeset/loose-cups-rhyme.md
+++ b/.changeset/loose-cups-rhyme.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+charts on the Hooks analytics page can now be expanded to full-width for easier reading

--- a/client/dashboard/src/components/chart/ChartCard.test.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChartCard } from "./ChartCard";
+
+afterEach(cleanup);
+
+const defaultProps = {
+  title: "Server Usage",
+  chartId: "server-usage",
+  expandedChart: null,
+  onExpand: vi.fn(),
+};
+
+describe("ChartCard", () => {
+  it("renders the title and children", () => {
+    render(
+      <ChartCard {...defaultProps}>
+        <span>chart content</span>
+      </ChartCard>,
+    );
+    expect(screen.getByText("Server Usage")).toBeTruthy();
+    expect(screen.getByText("chart content")).toBeTruthy();
+  });
+
+  it("shows an expand button when there is data and the chart is not expanded", () => {
+    render(<ChartCard {...defaultProps}>-</ChartCard>);
+    expect(screen.getByRole("button", { name: "Expand chart" })).toBeTruthy();
+  });
+
+  it("calls onExpand with chartId when the expand button is clicked", () => {
+    const onExpand = vi.fn();
+    render(
+      <ChartCard {...defaultProps} onExpand={onExpand}>
+        -
+      </ChartCard>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Expand chart" }));
+    expect(onExpand).toHaveBeenCalledWith("server-usage");
+  });
+
+  it("shows a minimize button and calls onExpand(null) when the chart is expanded", () => {
+    const onExpand = vi.fn();
+    render(
+      <ChartCard
+        {...defaultProps}
+        expandedChart="server-usage"
+        onExpand={onExpand}
+      >
+        -
+      </ChartCard>,
+    );
+    const btn = screen.getByRole("button", { name: "Minimize chart" });
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(onExpand).toHaveBeenCalledWith(null);
+  });
+
+  it("hides the expand button when hasData is false", () => {
+    render(
+      <ChartCard {...defaultProps} hasData={false}>
+        -
+      </ChartCard>,
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("still shows a minimize button when hasData is false but the chart is expanded", () => {
+    render(
+      <ChartCard {...defaultProps} expandedChart="server-usage" hasData={false}>
+        -
+      </ChartCard>,
+    );
+    expect(screen.getByRole("button", { name: "Minimize chart" })).toBeTruthy();
+  });
+
+  it("hides the card when a different chart is expanded", () => {
+    const { container } = render(
+      <ChartCard {...defaultProps} expandedChart="other-chart">
+        -
+      </ChartCard>,
+    );
+    expect(container.firstElementChild?.classList.contains("hidden")).toBe(
+      true,
+    );
+  });
+
+  it("remains visible when it is the expanded chart", () => {
+    const { container } = render(
+      <ChartCard {...defaultProps} expandedChart="server-usage">
+        -
+      </ChartCard>,
+    );
+    expect(container.firstElementChild?.classList.contains("hidden")).toBe(
+      false,
+    );
+  });
+
+  it("remains visible when no chart is expanded", () => {
+    const { container } = render(
+      <ChartCard {...defaultProps} expandedChart={null}>
+        -
+      </ChartCard>,
+    );
+    expect(container.firstElementChild?.classList.contains("hidden")).toBe(
+      false,
+    );
+  });
+});

--- a/client/dashboard/src/components/chart/ChartCard.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.tsx
@@ -30,6 +30,7 @@ export function ChartCard({
         <h3 className="text font-semibold">{title}</h3>
         {showExpandButton && (
           <button
+            type="button"
             onClick={() => onExpand(isExpanded ? null : chartId)}
             className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors"
             aria-label={isExpanded ? "Minimize chart" : "Expand chart"}

--- a/client/dashboard/src/components/chart/ChartCard.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.tsx
@@ -18,7 +18,7 @@ export function ChartCard({
   children: ReactNode;
 }) {
   const isExpanded = expandedChart === chartId;
-  const showExpandButton = hasData || (isExpanded && !hasData);
+  const showExpandButton = hasData || isExpanded;
   return (
     <div
       className={cn(

--- a/client/dashboard/src/components/chart/ChartCard.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.tsx
@@ -1,0 +1,37 @@
+import { Maximize2, Minimize2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function ChartCard({
+  title,
+  chartId,
+  expandedChart,
+  onExpand,
+  children,
+}: {
+  title: string;
+  chartId: string;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
+  children: ReactNode;
+}) {
+  const isExpanded = expandedChart === chartId;
+  return (
+    <div className="border-border bg-card space-y-4 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text font-semibold">{title}</h3>
+        <button
+          onClick={() => onExpand(isExpanded ? null : chartId)}
+          className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors"
+          aria-label={isExpanded ? "Minimize chart" : "Expand chart"}
+        >
+          {isExpanded ? (
+            <Minimize2 className="size-4" />
+          ) : (
+            <Maximize2 className="size-4" />
+          )}
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/client/dashboard/src/components/chart/ChartCard.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.tsx
@@ -7,15 +7,18 @@ export function ChartCard({
   chartId,
   expandedChart,
   onExpand,
+  hasData = true,
   children,
 }: {
   title: string;
   chartId: string;
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
+  hasData?: boolean;
   children: ReactNode;
 }) {
   const isExpanded = expandedChart === chartId;
+  const showExpandButton = hasData || (isExpanded && !hasData);
   return (
     <div
       className={cn(
@@ -25,17 +28,19 @@ export function ChartCard({
     >
       <div className="flex items-center justify-between">
         <h3 className="text font-semibold">{title}</h3>
-        <button
-          onClick={() => onExpand(isExpanded ? null : chartId)}
-          className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors"
-          aria-label={isExpanded ? "Minimize chart" : "Expand chart"}
-        >
-          {isExpanded ? (
-            <Minimize2 className="size-4" />
-          ) : (
-            <Maximize2 className="size-4" />
-          )}
-        </button>
+        {showExpandButton && (
+          <button
+            onClick={() => onExpand(isExpanded ? null : chartId)}
+            className="text-muted-foreground hover:text-foreground rounded p-0.5 transition-colors"
+            aria-label={isExpanded ? "Minimize chart" : "Expand chart"}
+          >
+            {isExpanded ? (
+              <Minimize2 className="size-4" />
+            ) : (
+              <Maximize2 className="size-4" />
+            )}
+          </button>
+        )}
       </div>
       {children}
     </div>

--- a/client/dashboard/src/components/chart/ChartCard.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { Maximize2, Minimize2 } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -16,7 +17,12 @@ export function ChartCard({
 }) {
   const isExpanded = expandedChart === chartId;
   return (
-    <div className="border-border bg-card space-y-4 rounded-lg border p-4">
+    <div
+      className={cn(
+        "border-border bg-card space-y-4 rounded-lg border p-4 transition-all duration-200 ease-in-out",
+        expandedChart && !isExpanded && "hidden",
+      )}
+    >
       <div className="flex items-center justify-between">
         <h3 className="text font-semibold">{title}</h3>
         <button

--- a/client/dashboard/src/hooks/useExpandedChart.test.ts
+++ b/client/dashboard/src/hooks/useExpandedChart.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useExpandedChart } from "./useExpandedChart";
+
+describe("useExpandedChart", () => {
+  it("initializes with no chart expanded", () => {
+    const { result } = renderHook(() => useExpandedChart());
+    expect(result.current.expandedChart).toBeNull();
+  });
+
+  it("expands a chart when setExpandedChart is called", () => {
+    const { result } = renderHook(() => useExpandedChart());
+    act(() => {
+      result.current.setExpandedChart("server-usage");
+    });
+    expect(result.current.expandedChart).toBe("server-usage");
+  });
+
+  it("collapses the chart when Escape is pressed", () => {
+    const { result } = renderHook(() => useExpandedChart());
+    act(() => {
+      result.current.setExpandedChart("server-usage");
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(result.current.expandedChart).toBeNull();
+  });
+
+  it("does not collapse when the Escape event was already handled (e.g. a Radix dialog)", () => {
+    const { result } = renderHook(() => useExpandedChart());
+    act(() => {
+      result.current.setExpandedChart("server-usage");
+    });
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "Escape",
+        cancelable: true,
+      });
+      event.preventDefault();
+      window.dispatchEvent(event);
+    });
+    expect(result.current.expandedChart).toBe("server-usage");
+  });
+
+  it("ignores Escape when no chart is expanded", () => {
+    const { result } = renderHook(() => useExpandedChart());
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(result.current.expandedChart).toBeNull();
+  });
+});

--- a/client/dashboard/src/hooks/useExpandedChart.ts
+++ b/client/dashboard/src/hooks/useExpandedChart.ts
@@ -6,7 +6,7 @@ export function useExpandedChart() {
   useEffect(() => {
     if (!expandedChart) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpandedChart(null);
+      if (e.key === "Escape" && !e.defaultPrevented) setExpandedChart(null);
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);

--- a/client/dashboard/src/hooks/useExpandedChart.ts
+++ b/client/dashboard/src/hooks/useExpandedChart.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export function useExpandedChart() {
+  const [expandedChart, setExpandedChart] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!expandedChart) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpandedChart(null);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [expandedChart]);
+
+  return { expandedChart, setExpandedChart };
+}

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -41,6 +41,7 @@ import type {
 import { useGramContext } from "@gram/client/react-query";
 import { unwrapAsync } from "@gram/client/types/fp";
 import { Icon } from "@speakeasy-api/moonshine";
+import { ChartCard } from "@/components/chart/ChartCard";
 import { MetricCard } from "@/components/chart/MetricCard";
 import { formatChartLabel } from "@/components/chart/chartUtils";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -2068,6 +2068,7 @@ function HooksAnalytics({
   }, [summaryData]);
 
   const hasServers = (summaryData?.servers.length ?? 0) > 0;
+  const [expandedChart, setExpandedChart] = useState<string | null>(null);
 
   type FilterAxisConfig = Partial<Record<"user" | "server", "dataset" | "row">>;
 
@@ -2174,68 +2175,99 @@ function HooksAnalytics({
         <div
           className={cn(
             "grid gap-4",
-            compact ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2",
+            expandedChart
+              ? "grid-cols-1"
+              : compact
+                ? "grid-cols-1"
+                : "grid-cols-1 lg:grid-cols-2",
           )}
         >
-          {timeSeries.length > 0 && (
-            <div className="border-border bg-card space-y-4 rounded-lg border p-4">
-              <h3 className="text font-semibold">Server Usage</h3>
-              <ServerUsageTimeSeries
-                timeSeries={timeSeries}
-                from={from}
-                to={to}
+          {timeSeries.length > 0 &&
+            (!expandedChart || expandedChart === "server-usage") && (
+              <ChartCard
+                title="Server Usage"
+                chartId="server-usage"
+                expandedChart={expandedChart}
+                onExpand={setExpandedChart}
+              >
+                <ServerUsageTimeSeries
+                  timeSeries={timeSeries}
+                  from={from}
+                  to={to}
+                  serverNameMappings={serverNameMappings}
+                  expanded={expandedChart === "server-usage"}
+                />
+              </ChartCard>
+            )}
+          {hasServers &&
+            (!expandedChart || expandedChart === "users-per-server") && (
+              <UsersPerServerChart
+                title="Users per Server"
+                breakdown={breakdown}
                 serverNameMappings={serverNameMappings}
+                handleFilter={makeFilterHandler({
+                  server: "row",
+                  user: "dataset",
+                })}
+                expandedChart={expandedChart}
+                onExpand={setExpandedChart}
               />
-            </div>
-          )}
-          {hasServers && (
-            <UsersPerServerChart
-              title="Users per Server"
-              breakdown={breakdown}
-              serverNameMappings={serverNameMappings}
-              handleFilter={makeFilterHandler({
-                server: "row",
-                user: "dataset",
-              })}
-            />
-          )}
+            )}
 
-          {timeSeries.length > 0 && (
-            <div className="border-border bg-card space-y-4 rounded-lg border p-4">
-              <h3 className="text font-semibold">User Usage</h3>
-              <UserUsageTimeSeries
-                timeSeries={timeSeries}
-                from={from}
-                to={to}
+          {timeSeries.length > 0 &&
+            (!expandedChart || expandedChart === "user-usage") && (
+              <ChartCard
+                title="User Usage"
+                chartId="user-usage"
+                expandedChart={expandedChart}
+                onExpand={setExpandedChart}
+              >
+                <UserUsageTimeSeries
+                  timeSeries={timeSeries}
+                  from={from}
+                  to={to}
+                  expanded={expandedChart === "user-usage"}
+                />
+              </ChartCard>
+            )}
+          {hasServers &&
+            (!expandedChart || expandedChart === "user-event-counts") && (
+              <UserEventCountsChart
+                title="User Event Counts"
+                breakdown={breakdown}
+                handleFilter={makeFilterHandler({ user: "row" })}
+                expandedChart={expandedChart}
+                onExpand={setExpandedChart}
               />
-            </div>
-          )}
-          {hasServers && (
-            <UserEventCountsChart
-              title="User Event Counts"
-              breakdown={breakdown}
-              handleFilter={makeFilterHandler({ user: "row" })}
-            />
-          )}
+            )}
 
-          {timeSeries.length > 0 && (
-            <div className="border-border bg-card space-y-4 rounded-lg border p-4">
-              <h3 className="text font-semibold">Errors Over Time</h3>
-              <ErrorsOverTimeChart
-                timeSeries={timeSeries}
-                from={from}
-                to={to}
+          {timeSeries.length > 0 &&
+            (!expandedChart || expandedChart === "errors-over-time") && (
+              <ChartCard
+                title="Errors Over Time"
+                chartId="errors-over-time"
+                expandedChart={expandedChart}
+                onExpand={setExpandedChart}
+              >
+                <ErrorsOverTimeChart
+                  timeSeries={timeSeries}
+                  from={from}
+                  to={to}
+                  serverNameMappings={serverNameMappings}
+                  expanded={expandedChart === "errors-over-time"}
+                />
+              </ChartCard>
+            )}
+          {hasServers &&
+            (!expandedChart || expandedChart === "errors-per-server") && (
+              <ServerErrorRateChart
+                title="Errors per Server and Tool"
+                breakdown={breakdown}
                 serverNameMappings={serverNameMappings}
+                expandedChart={expandedChart}
+                onExpand={setExpandedChart}
               />
-            </div>
-          )}
-          {hasServers && (
-            <ServerErrorRateChart
-              title="Errors per Server and Tool"
-              breakdown={breakdown}
-              serverNameMappings={serverNameMappings}
-            />
-          )}
+            )}
         </div>
       )}
     </div>

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1308,6 +1308,7 @@ function HookTraceRow({
             {serverNameBadge}
             {serverName && (
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   setEditDialogOpen(true);

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -808,6 +808,9 @@ function HooksInnerContent({
   );
   const [isLogsVisible, setIsLogsVisible] = useState(false);
   const { expandedChart, setExpandedChart } = useExpandedChart();
+  useEffect(() => {
+    if (summaryPending) setExpandedChart(null);
+  }, [summaryPending, setExpandedChart]);
 
   return (
     <>

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1619,11 +1619,17 @@ function ServerErrorRateChart({
   title,
   breakdown,
   serverNameMappings,
+  expandedChart,
+  onExpand,
 }: {
   title: string;
   breakdown: HooksBreakdownRow[];
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
 }) {
+  const chartId = "errors-per-server";
+  const expanded = expandedChart === chartId;
   const { labels, datasets } = useMemo(() => {
     // Build: serverDisplay → toolName → failureCount (failures only)
     const serverMap = new Map<string, Map<string, number>>();
@@ -1677,7 +1683,9 @@ function ServerErrorRateChart({
     return { labels: chartLabels, datasets: chartDatasets };
   }, [breakdown, serverNameMappings.rawToDisplay]);
 
-  const height = Math.max(120, labels.length * (24 + 8) + 60);
+  const barHeight = expanded ? 36 : 24;
+  const spacerHeight = expanded ? 12 : 8;
+  const height = Math.max(120, labels.length * (barHeight + spacerHeight) + 60);
 
   const options: ChartOptions<"bar"> = {
     indexAxis: "y",
@@ -1698,8 +1706,12 @@ function ServerErrorRateChart({
   };
 
   return (
-    <div className="border-border bg-card space-y-4 rounded-lg border p-4">
-      <h3 className="text font-semibold">{title}</h3>
+    <ChartCard
+      title={title}
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+    >
       {labels.length === 0 ? (
         <div className="text-muted-foreground flex h-16 items-center justify-center text-sm">
           No errors in this period
@@ -1709,7 +1721,7 @@ function ServerErrorRateChart({
           <Bar data={{ labels, datasets }} options={options} />
         </div>
       )}
-    </div>
+    </ChartCard>
   );
 }
 

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1413,18 +1413,18 @@ const stackTotalPlugin = {
 const STACKED_BAR_PLUGINS = [stackTotalPlugin];
 
 function StackedBarChart({
-  title,
   labels,
   datasets,
   handleFilter,
+  expanded = false,
 }: {
-  title: string;
   labels: string[];
   datasets: StackedBarDataset[];
   handleFilter?: (datasetLabel: string, rowLabel: string) => void;
+  expanded?: boolean;
 }) {
-  const barHeight = 24;
-  const spacerHeight = 8;
+  const barHeight = expanded ? 36 : 24;
+  const spacerHeight = expanded ? 12 : 8;
   const containerHeight = Math.max(
     120,
     labels.length * (barHeight + spacerHeight) + 60,
@@ -1464,15 +1464,12 @@ function StackedBarChart({
   if (labels.length === 0) return null;
 
   return (
-    <div className="border-border bg-card space-y-4 rounded-lg border p-4">
-      <h3 className="text font-semibold">{title}</h3>
-      <div style={{ height: containerHeight }}>
-        <Bar
-          plugins={STACKED_BAR_PLUGINS}
-          data={{ labels, datasets }}
-          options={options}
-        />
-      </div>
+    <div style={{ height: containerHeight }}>
+      <Bar
+        plugins={STACKED_BAR_PLUGINS}
+        data={{ labels, datasets }}
+        options={options}
+      />
     </div>
   );
 }
@@ -1482,12 +1479,18 @@ function UsersPerServerChart({
   breakdown,
   serverNameMappings,
   handleFilter,
+  expandedChart,
+  onExpand,
 }: {
   title: string;
   breakdown: HooksBreakdownRow[];
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
   handleFilter?: (userEmail: string, serverName: string) => void;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
 }) {
+  const chartId = "users-per-server";
+  const expanded = expandedChart === chartId;
   const { labels, datasets } = useMemo(() => {
     const serverMap = new Map<string, Map<string, number>>();
     const userSet = new Set<string>();
@@ -1538,12 +1541,19 @@ function UsersPerServerChart({
   }, [breakdown, serverNameMappings.rawToDisplay]);
 
   return (
-    <StackedBarChart
+    <ChartCard
       title={title}
-      labels={labels}
-      datasets={datasets}
-      handleFilter={handleFilter}
-    />
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+    >
+      <StackedBarChart
+        labels={labels}
+        datasets={datasets}
+        handleFilter={handleFilter}
+        expanded={expanded}
+      />
+    </ChartCard>
   );
 }
 
@@ -1551,11 +1561,17 @@ function UserEventCountsChart({
   title,
   breakdown,
   handleFilter,
+  expandedChart,
+  onExpand,
 }: {
   title: string;
   breakdown: HooksBreakdownRow[];
   handleFilter?: (datasetLabel: string, userEmail: string) => void;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
 }) {
+  const chartId = "user-event-counts";
+  const expanded = expandedChart === chartId;
   const { labels, datasets } = useMemo(() => {
     const userMap = new Map<string, number>();
     for (const row of breakdown) {
@@ -1583,12 +1599,19 @@ function UserEventCountsChart({
   }, [breakdown]);
 
   return (
-    <StackedBarChart
+    <ChartCard
       title={title}
-      labels={labels}
-      datasets={datasets}
-      handleFilter={handleFilter}
-    />
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+    >
+      <StackedBarChart
+        labels={labels}
+        datasets={datasets}
+        handleFilter={handleFilter}
+        expanded={expanded}
+      />
+    </ChartCard>
   );
 }
 

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1879,14 +1879,18 @@ function ServerUsageTimeSeries({
   from,
   to,
   serverNameMappings,
-  expanded = false,
+  expandedChart,
+  onExpand,
 }: {
   timeSeries: HooksTimeSeriesPoint[];
   from: Date;
   to: Date;
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
-  expanded?: boolean;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
 }) {
+  const chartId = "server-usage";
+  const expanded = expandedChart === chartId;
   const timeRangeMs = to.getTime() - from.getTime();
   const { labels, tooltipLabels, datasets } = useMemo(
     () =>
@@ -1903,12 +1907,20 @@ function ServerUsageTimeSeries({
     [timeSeries, timeRangeMs, serverNameMappings.rawToDisplay],
   );
   return (
-    <MultiLineChart
-      labels={labels}
-      tooltipLabels={tooltipLabels}
-      datasets={datasets}
-      height={expanded ? 500 : 200}
-    />
+    <ChartCard
+      title="Server Usage"
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+      hasData={labels.length > 0}
+    >
+      <MultiLineChart
+        labels={labels}
+        tooltipLabels={tooltipLabels}
+        datasets={datasets}
+        height={expanded ? 500 : 200}
+      />
+    </ChartCard>
   );
 }
 
@@ -1916,13 +1928,17 @@ function UserUsageTimeSeries({
   timeSeries,
   from,
   to,
-  expanded = false,
+  expandedChart,
+  onExpand,
 }: {
   timeSeries: HooksTimeSeriesPoint[];
   from: Date;
   to: Date;
-  expanded?: boolean;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
 }) {
+  const chartId = "user-usage";
+  const expanded = expandedChart === chartId;
   const timeRangeMs = to.getTime() - from.getTime();
   const { labels, tooltipLabels, datasets } = useMemo(
     () =>
@@ -1930,12 +1946,20 @@ function UserUsageTimeSeries({
     [timeSeries, timeRangeMs],
   );
   return (
-    <MultiLineChart
-      labels={labels}
-      tooltipLabels={tooltipLabels}
-      datasets={datasets}
-      height={expanded ? 500 : 200}
-    />
+    <ChartCard
+      title="User Usage"
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+      hasData={labels.length > 0}
+    >
+      <MultiLineChart
+        labels={labels}
+        tooltipLabels={tooltipLabels}
+        datasets={datasets}
+        height={expanded ? 500 : 200}
+      />
+    </ChartCard>
   );
 }
 
@@ -2223,20 +2247,14 @@ function HooksAnalytics({
           )}
         >
           {timeSeries.length > 0 && (
-            <ChartCard
-              title="Server Usage"
-              chartId="server-usage"
+            <ServerUsageTimeSeries
+              timeSeries={timeSeries}
+              from={from}
+              to={to}
+              serverNameMappings={serverNameMappings}
               expandedChart={expandedChart}
               onExpand={setExpandedChart}
-            >
-              <ServerUsageTimeSeries
-                timeSeries={timeSeries}
-                from={from}
-                to={to}
-                serverNameMappings={serverNameMappings}
-                expanded={expandedChart === "server-usage"}
-              />
-            </ChartCard>
+            />
           )}
           {hasServers && (
             <UsersPerServerChart
@@ -2253,19 +2271,13 @@ function HooksAnalytics({
           )}
 
           {timeSeries.length > 0 && (
-            <ChartCard
-              title="User Usage"
-              chartId="user-usage"
+            <UserUsageTimeSeries
+              timeSeries={timeSeries}
+              from={from}
+              to={to}
               expandedChart={expandedChart}
               onExpand={setExpandedChart}
-            >
-              <UserUsageTimeSeries
-                timeSeries={timeSeries}
-                from={from}
-                to={to}
-                expanded={expandedChart === "user-usage"}
-              />
-            </ChartCard>
+            />
           )}
           {hasServers && (
             <UserEventCountsChart

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -708,7 +708,6 @@ function HooksContent() {
                   handleScroll={handleScroll}
                   hasNextPage={hasNextPage}
                   isFetchingNextPage={isFetchingNextPage}
-                  refetch={refetch}
                   dateRange={dateRange}
                   customRange={customRange}
                   customRangeLabel={urlLabel}
@@ -788,7 +787,6 @@ function HooksInnerContent({
   handleScroll: (e: React.UIEvent<HTMLDivElement>) => void;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
-  refetch: () => void;
   dateRange: DateRangePreset;
   customRange: { from: Date; to: Date } | null;
   customRangeLabel: string | null;

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1944,13 +1944,15 @@ function ErrorsOverTimeChart({
   from,
   to,
   serverNameMappings,
-  expanded = false,
+  expandedChart,
+  onExpand,
 }: {
   timeSeries: HooksTimeSeriesPoint[];
   from: Date;
   to: Date;
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
-  expanded?: boolean;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
 }) {
   const timeRangeMs = to.getTime() - from.getTime();
   const { labels, tooltipLabels, datasets, hasErrors, perServerByIndex } =
@@ -2020,26 +2022,35 @@ function ErrorsOverTimeChart({
       };
     }, [timeSeries, timeRangeMs, serverNameMappings.rawToDisplay]);
 
-  if (!hasErrors) {
-    return (
-      <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
-        No errors in this period
-      </div>
-    );
-  }
+  const chartId = "errors-over-time";
+  const expanded = expandedChart === chartId;
 
   return (
-    <MultiLineChart
-      labels={labels}
-      tooltipLabels={tooltipLabels}
-      datasets={datasets}
-      height={expanded ? 500 : 200}
-      tooltipAfterBody={(idx) => {
-        const servers = perServerByIndex[idx];
-        if (!servers || servers.length === 0) return [];
-        return servers.map((s) => `${s.name}: ${s.count}`);
-      }}
-    />
+    <ChartCard
+      title="Errors Over Time"
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+      hasData={hasErrors}
+    >
+      {!hasErrors ? (
+        <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+          No errors in this period
+        </div>
+      ) : (
+        <MultiLineChart
+          labels={labels}
+          tooltipLabels={tooltipLabels}
+          datasets={datasets}
+          height={expanded ? 500 : 200}
+          tooltipAfterBody={(idx) => {
+            const servers = perServerByIndex[idx];
+            if (!servers || servers.length === 0) return [];
+            return servers.map((s) => `${s.name}: ${s.count}`);
+          }}
+        />
+      )}
+    </ChartCard>
   );
 }
 
@@ -2267,20 +2278,14 @@ function HooksAnalytics({
           )}
 
           {timeSeries.length > 0 && (
-            <ChartCard
-              title="Errors Over Time"
-              chartId="errors-over-time"
+            <ErrorsOverTimeChart
+              timeSeries={timeSeries}
+              from={from}
+              to={to}
+              serverNameMappings={serverNameMappings}
               expandedChart={expandedChart}
               onExpand={setExpandedChart}
-            >
-              <ErrorsOverTimeChart
-                timeSeries={timeSeries}
-                from={from}
-                to={to}
-                serverNameMappings={serverNameMappings}
-                expanded={expandedChart === "errors-over-time"}
-              />
-            </ChartCard>
+            />
           )}
           {hasServers && (
             <ServerErrorRateChart

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -2142,10 +2142,11 @@ function HooksAnalytics({
       {/* KPI Cards */}
       <div
         className={cn(
-          "grid gap-3",
+          "grid gap-3 transition-all duration-200 ease-in-out",
           compact
             ? "grid-cols-2 md:grid-cols-3"
             : "grid-cols-2 md:grid-cols-3 lg:grid-cols-5",
+          expandedChart && "hidden",
         )}
       >
         {summaryIsError && !summaryData ? (

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -2200,92 +2200,86 @@ function HooksAnalytics({
                 : "grid-cols-1 lg:grid-cols-2",
           )}
         >
-          {timeSeries.length > 0 &&
-            (!expandedChart || expandedChart === "server-usage") && (
-              <ChartCard
-                title="Server Usage"
-                chartId="server-usage"
-                expandedChart={expandedChart}
-                onExpand={setExpandedChart}
-              >
-                <ServerUsageTimeSeries
-                  timeSeries={timeSeries}
-                  from={from}
-                  to={to}
-                  serverNameMappings={serverNameMappings}
-                  expanded={expandedChart === "server-usage"}
-                />
-              </ChartCard>
-            )}
-          {hasServers &&
-            (!expandedChart || expandedChart === "users-per-server") && (
-              <UsersPerServerChart
-                title="Users per Server"
-                breakdown={breakdown}
+          {timeSeries.length > 0 && (
+            <ChartCard
+              title="Server Usage"
+              chartId="server-usage"
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            >
+              <ServerUsageTimeSeries
+                timeSeries={timeSeries}
+                from={from}
+                to={to}
                 serverNameMappings={serverNameMappings}
-                handleFilter={makeFilterHandler({
-                  server: "row",
-                  user: "dataset",
-                })}
-                expandedChart={expandedChart}
-                onExpand={setExpandedChart}
+                expanded={expandedChart === "server-usage"}
               />
-            )}
+            </ChartCard>
+          )}
+          {hasServers && (
+            <UsersPerServerChart
+              title="Users per Server"
+              breakdown={breakdown}
+              serverNameMappings={serverNameMappings}
+              handleFilter={makeFilterHandler({
+                server: "row",
+                user: "dataset",
+              })}
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            />
+          )}
 
-          {timeSeries.length > 0 &&
-            (!expandedChart || expandedChart === "user-usage") && (
-              <ChartCard
-                title="User Usage"
-                chartId="user-usage"
-                expandedChart={expandedChart}
-                onExpand={setExpandedChart}
-              >
-                <UserUsageTimeSeries
-                  timeSeries={timeSeries}
-                  from={from}
-                  to={to}
-                  expanded={expandedChart === "user-usage"}
-                />
-              </ChartCard>
-            )}
-          {hasServers &&
-            (!expandedChart || expandedChart === "user-event-counts") && (
-              <UserEventCountsChart
-                title="User Event Counts"
-                breakdown={breakdown}
-                handleFilter={makeFilterHandler({ user: "row" })}
-                expandedChart={expandedChart}
-                onExpand={setExpandedChart}
+          {timeSeries.length > 0 && (
+            <ChartCard
+              title="User Usage"
+              chartId="user-usage"
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            >
+              <UserUsageTimeSeries
+                timeSeries={timeSeries}
+                from={from}
+                to={to}
+                expanded={expandedChart === "user-usage"}
               />
-            )}
+            </ChartCard>
+          )}
+          {hasServers && (
+            <UserEventCountsChart
+              title="User Event Counts"
+              breakdown={breakdown}
+              handleFilter={makeFilterHandler({ user: "row" })}
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            />
+          )}
 
-          {timeSeries.length > 0 &&
-            (!expandedChart || expandedChart === "errors-over-time") && (
-              <ChartCard
-                title="Errors Over Time"
-                chartId="errors-over-time"
-                expandedChart={expandedChart}
-                onExpand={setExpandedChart}
-              >
-                <ErrorsOverTimeChart
-                  timeSeries={timeSeries}
-                  from={from}
-                  to={to}
-                  serverNameMappings={serverNameMappings}
-                  expanded={expandedChart === "errors-over-time"}
-                />
-              </ChartCard>
-            )}
-          {hasServers &&
-            (!expandedChart || expandedChart === "errors-per-server") && (
-              <ServerErrorRateChart
-                title="Errors per Server and Tool"
-                breakdown={breakdown}
+          {timeSeries.length > 0 && (
+            <ChartCard
+              title="Errors Over Time"
+              chartId="errors-over-time"
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            >
+              <ErrorsOverTimeChart
+                timeSeries={timeSeries}
+                from={from}
+                to={to}
                 serverNameMappings={serverNameMappings}
-                expandedChart={expandedChart}
-                onExpand={setExpandedChart}
+                expanded={expandedChart === "errors-over-time"}
               />
-            )}
+            </ChartCard>
+          )}
+          {hasServers && (
+            <ServerErrorRateChart
+              title="Errors per Server and Tool"
+              breakdown={breakdown}
+              serverNameMappings={serverNameMappings}
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            />
+          )}
         </div>
       )}
     </div>

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1193,19 +1193,20 @@ function HookTraceRow({
   const timestamp = new Date(
     Number(BigInt(trace.startTimeUnixNano) / 1_000_000n),
   );
-  const timeAgo = useMemo(() => {
-    const now = new Date();
-    const diff = now.getTime() - timestamp.getTime();
-    const seconds = Math.floor(diff / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-
-    if (days > 0) return `${days}d ago`;
-    if (hours > 0) return `${hours}h ago`;
-    if (minutes > 0) return `${minutes}m ago`;
-    return `${seconds}s ago`;
-  }, [timestamp]);
+  const now = new Date();
+  const diff = now.getTime() - timestamp.getTime();
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const timeAgo =
+    days > 0
+      ? `${days}d ago`
+      : hours > 0
+        ? `${hours}h ago`
+        : minutes > 0
+          ? `${minutes}m ago`
+          : `${seconds}s ago`;
 
   const serverName = trace.toolSource;
   const toolName = trace.toolName;

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -2088,6 +2088,15 @@ function HooksAnalytics({
   const hasServers = (summaryData?.servers.length ?? 0) > 0;
   const [expandedChart, setExpandedChart] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!expandedChart) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpandedChart(null);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [expandedChart]);
+
   type FilterAxisConfig = Partial<Record<"user" | "server", "dataset" | "row">>;
 
   const makeFilterHandler = useCallback(

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -127,6 +127,12 @@ type _BarLegend = Exclude<
 type _BarTooltip = NonNullable<ChartOptions<"bar">["plugins"]>["tooltip"];
 type _BarScales = NonNullable<ChartOptions<"bar">["scales"]>;
 
+// Disable Chart.js's built-in resize animation so the CSS height transition
+// drives the visual expansion instead of triggering a full redraw animation.
+const SHARED_RESIZE_TRANSITION = {
+  resize: { animation: { duration: 0 } },
+} as const;
+
 const SHARED_LEGEND = {
   display: false,
 } satisfies NonNullable<_BarLegend>;
@@ -1447,6 +1453,7 @@ function StackedBarChart({
         if (el) el.style.cursor = elements.length ? "pointer" : "default";
       },
       scales: SHARED_BAR_SCALES,
+      transitions: SHARED_RESIZE_TRANSITION,
       plugins: {
         legend: SHARED_LEGEND,
         tooltip: {
@@ -1464,7 +1471,10 @@ function StackedBarChart({
   if (labels.length === 0) return null;
 
   return (
-    <div style={{ height: containerHeight }}>
+    <div
+      className="transition-all duration-200 ease-in-out"
+      style={{ height: containerHeight }}
+    >
       <Bar
         plugins={STACKED_BAR_PLUGINS}
         data={{ labels, datasets }}
@@ -1703,6 +1713,7 @@ function ServerErrorRateChart({
       },
     },
     scales: SHARED_BAR_SCALES,
+    transitions: SHARED_RESIZE_TRANSITION,
   };
 
   return (
@@ -1717,7 +1728,10 @@ function ServerErrorRateChart({
           No errors in this period
         </div>
       ) : (
-        <div style={{ position: "relative", height }}>
+        <div
+          className="relative transition-all duration-200 ease-in-out"
+          style={{ height }}
+        >
           <Bar data={{ labels, datasets }} options={options} />
         </div>
       )}
@@ -1840,10 +1854,14 @@ function MultiLineChart({
         ticks: { precision: 0 },
       },
     },
+    transitions: SHARED_RESIZE_TRANSITION,
   };
 
   return (
-    <div style={{ position: "relative", height }}>
+    <div
+      className="relative transition-all duration-200 ease-in-out"
+      style={{ height }}
+    >
       <Line data={{ labels, datasets }} options={options} />
     </div>
   );

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -44,6 +44,7 @@ import { Icon } from "@speakeasy-api/moonshine";
 import { ChartCard } from "@/components/chart/ChartCard";
 import { MetricCard } from "@/components/chart/MetricCard";
 import { formatChartLabel } from "@/components/chart/chartUtils";
+import { useExpandedChart } from "@/hooks/useExpandedChart";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import {
   BarElement,
@@ -806,6 +807,7 @@ function HooksInnerContent({
     [customRange, dateRange],
   );
   const [isLogsVisible, setIsLogsVisible] = useState(false);
+  const { expandedChart, setExpandedChart } = useExpandedChart();
 
   return (
     <>
@@ -925,6 +927,8 @@ function HooksInnerContent({
                   summaryData={summaryData}
                   summaryPending={summaryPending}
                   summaryIsError={summaryIsError}
+                  expandedChart={expandedChart}
+                  onExpandedChartChange={setExpandedChart}
                 />
               )}
             </div>
@@ -2046,6 +2050,8 @@ function HooksAnalytics({
   summaryData,
   summaryPending,
   summaryIsError,
+  expandedChart,
+  onExpandedChartChange: setExpandedChart,
 }: {
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
   from: Date;
@@ -2056,6 +2062,8 @@ function HooksAnalytics({
   summaryData: GetHooksSummaryResult | undefined;
   summaryPending: boolean;
   summaryIsError: boolean;
+  expandedChart: string | null;
+  onExpandedChartChange: (id: string | null) => void;
 }) {
   const breakdown = summaryData?.breakdown ?? [];
   const timeSeries = summaryData?.timeSeries ?? [];
@@ -2086,16 +2094,6 @@ function HooksAnalytics({
   }, [summaryData]);
 
   const hasServers = (summaryData?.servers.length ?? 0) > 0;
-  const [expandedChart, setExpandedChart] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!expandedChart) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpandedChart(null);
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [expandedChart]);
 
   type FilterAxisConfig = Partial<Record<"user" | "server", "dataset" | "row">>;
 

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1790,11 +1790,13 @@ function MultiLineChart({
   tooltipLabels,
   datasets,
   tooltipAfterBody,
+  height = 200,
 }: {
   labels: string[];
   tooltipLabels: string[];
   datasets: ReturnType<typeof buildTimeSeriesFromSummary>["datasets"];
   tooltipAfterBody?: (dataIndex: number) => string[];
+  height?: number;
 }) {
   if (labels.length === 0) {
     return (
@@ -1841,7 +1843,7 @@ function MultiLineChart({
   };
 
   return (
-    <div style={{ position: "relative", height: 200 }}>
+    <div style={{ position: "relative", height }}>
       <Line data={{ labels, datasets }} options={options} />
     </div>
   );
@@ -1852,11 +1854,13 @@ function ServerUsageTimeSeries({
   from,
   to,
   serverNameMappings,
+  expanded = false,
 }: {
   timeSeries: HooksTimeSeriesPoint[];
   from: Date;
   to: Date;
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
+  expanded?: boolean;
 }) {
   const timeRangeMs = to.getTime() - from.getTime();
   const { labels, tooltipLabels, datasets } = useMemo(
@@ -1878,6 +1882,7 @@ function ServerUsageTimeSeries({
       labels={labels}
       tooltipLabels={tooltipLabels}
       datasets={datasets}
+      height={expanded ? 500 : 200}
     />
   );
 }
@@ -1886,10 +1891,12 @@ function UserUsageTimeSeries({
   timeSeries,
   from,
   to,
+  expanded = false,
 }: {
   timeSeries: HooksTimeSeriesPoint[];
   from: Date;
   to: Date;
+  expanded?: boolean;
 }) {
   const timeRangeMs = to.getTime() - from.getTime();
   const { labels, tooltipLabels, datasets } = useMemo(
@@ -1902,6 +1909,7 @@ function UserUsageTimeSeries({
       labels={labels}
       tooltipLabels={tooltipLabels}
       datasets={datasets}
+      height={expanded ? 500 : 200}
     />
   );
 }
@@ -1911,11 +1919,13 @@ function ErrorsOverTimeChart({
   from,
   to,
   serverNameMappings,
+  expanded = false,
 }: {
   timeSeries: HooksTimeSeriesPoint[];
   from: Date;
   to: Date;
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
+  expanded?: boolean;
 }) {
   const timeRangeMs = to.getTime() - from.getTime();
   const { labels, tooltipLabels, datasets, hasErrors, perServerByIndex } =
@@ -1998,6 +2008,7 @@ function ErrorsOverTimeChart({
       labels={labels}
       tooltipLabels={tooltipLabels}
       datasets={datasets}
+      height={expanded ? 500 : 200}
       tooltipAfterBody={(idx) => {
         const servers = perServerByIndex[idx];
         if (!servers || servers.length === 0) return [];

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1560,6 +1560,7 @@ function UsersPerServerChart({
       chartId={chartId}
       expandedChart={expandedChart}
       onExpand={onExpand}
+      hasData={labels.length > 0}
     >
       <StackedBarChart
         labels={labels}
@@ -1618,6 +1619,7 @@ function UserEventCountsChart({
       chartId={chartId}
       expandedChart={expandedChart}
       onExpand={onExpand}
+      hasData={labels.length > 0}
     >
       <StackedBarChart
         labels={labels}
@@ -1726,6 +1728,7 @@ function ServerErrorRateChart({
       chartId={chartId}
       expandedChart={expandedChart}
       onExpand={onExpand}
+      hasData={labels.length > 0}
     >
       {labels.length === 0 ? (
         <div className="text-muted-foreground flex h-16 items-center justify-center text-sm">


### PR DESCRIPTION
## Summary

- Add `ChartCard` wrapper component with expand/minimize toggle that hides all sibling charts when one is expanded
- Grow expanded charts to fill the space: time series 200px → 500px; stacked bar charts scale bar and spacer heights proportionally
- Thread expand state through all six charts in `HooksAnalytics` (Server Usage, Users Per Server, User Usage, User Event Counts, Errors
Over Time, Errors per Server and Tool)
- Hide KPI metric cards and collapse to single-column layout when any chart is expanded
- Disable Chart.js's built-in resize animation so CSS transitions drive the expansion without a full chart redraw flicker
- Add `useExpandedChart` hook to manage the `expandedChart` state and wire up an Escape key listener to close the expanded chart

## Visual
https://github.com/user-attachments/assets/de754a62-5dbd-409b-8ebe-8dc4a9ca57e5