### PR TITLE
feat: collapse bar charts beyond N rows with expand-to-view-all

### DIFF
--- a/.changeset/whole-symbols-speak.md
+++ b/.changeset/whole-symbols-speak.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Hooks dashboard bar charts now collapse to the top 6 rows with a "show more" link to expand the full dataset.

--- a/client/dashboard/src/components/chart/ChartCard.tsx
+++ b/client/dashboard/src/components/chart/ChartCard.tsx
@@ -22,11 +22,11 @@ export function ChartCard({
   return (
     <div
       className={cn(
-        "border-border bg-card space-y-4 rounded-lg border p-4 transition-all duration-200 ease-in-out",
+        "border-border bg-card rounded-lg border p-4 transition-all duration-200 ease-in-out",
         expandedChart && !isExpanded && "hidden",
       )}
     >
-      <div className="flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between">
         <h3 className="text font-semibold">{title}</h3>
         {showExpandButton && (
           <button

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -116,6 +116,10 @@ const BRAND_RED_COLORS = [
 ];
 
 const COLLAPSED_BAR_CHART_MAX_ROWS = 6;
+const BAR_THICKNESS = { collapsed: 18, expanded: 24 };
+const BAR_ROW_HEIGHT = { collapsed: 18, expanded: 24 };
+const BAR_ROW_SPACER = { collapsed: 8, expanded: 12 };
+const LINE_CHART_HEIGHT = { collapsed: 250, expanded: 600 };
 
 // ---------------------------------------------------------------------------
 // Shared Chart.js config building blocks
@@ -1442,21 +1446,23 @@ function StackedBarChart({
   maxRows?: number;
   onShowAll?: () => void;
 }) {
+  const thickness = expanded ? BAR_THICKNESS.expanded : BAR_THICKNESS.collapsed;
   const hiddenCount =
     !expanded && maxRows && labels.length > maxRows
       ? labels.length - maxRows
       : 0;
   const visibleLabels = hiddenCount > 0 ? labels.slice(0, maxRows) : labels;
-  const visibleDatasets =
+  const visibleDatasets = (
     hiddenCount > 0
       ? datasets.map((ds) => ({ ...ds, data: ds.data.slice(0, maxRows) }))
-      : datasets;
+      : datasets
+  ).map((ds) => ({ ...ds, barThickness: thickness }));
 
-  const barHeight = expanded ? 36 : 24;
-  const spacerHeight = expanded ? 12 : 8;
+  const rowH = expanded ? BAR_ROW_HEIGHT.expanded : BAR_ROW_HEIGHT.collapsed;
+  const rowS = expanded ? BAR_ROW_SPACER.expanded : BAR_ROW_SPACER.collapsed;
   const containerHeight = Math.max(
     120,
-    visibleLabels.length * (barHeight + spacerHeight) + 60,
+    visibleLabels.length * (rowH + rowS) + 60,
   );
 
   const options = useMemo<ChartOptions<"bar">>(
@@ -1727,7 +1733,7 @@ function ServerErrorRateChart({
     const chartLabels = sortedServers.map((s) => s.displayName);
     const chartDatasets = sortedTools.map((tool, i) => ({
       label: tool,
-      barThickness: 16,
+      barThickness: BAR_THICKNESS.collapsed,
       data: sortedServers.map((s) => s.toolCounts.get(tool) ?? 0),
       backgroundColor: BRAND_RED_COLORS[i % BRAND_RED_COLORS.length],
       hoverBackgroundColor:
@@ -1743,20 +1749,19 @@ function ServerErrorRateChart({
       : 0;
   const visibleLabels =
     hiddenCount > 0 ? labels.slice(0, COLLAPSED_BAR_CHART_MAX_ROWS) : labels;
-  const visibleDatasets =
+  const thickness = expanded ? BAR_THICKNESS.expanded : BAR_THICKNESS.collapsed;
+  const visibleDatasets = (
     hiddenCount > 0
       ? datasets.map((ds) => ({
           ...ds,
           data: ds.data.slice(0, COLLAPSED_BAR_CHART_MAX_ROWS),
         }))
-      : datasets;
+      : datasets
+  ).map((ds) => ({ ...ds, barThickness: thickness }));
 
-  const barHeight = expanded ? 36 : 24;
-  const spacerHeight = expanded ? 12 : 8;
-  const height = Math.max(
-    120,
-    visibleLabels.length * (barHeight + spacerHeight) + 60,
-  );
+  const rowH = expanded ? BAR_ROW_HEIGHT.expanded : BAR_ROW_HEIGHT.collapsed;
+  const rowS = expanded ? BAR_ROW_SPACER.expanded : BAR_ROW_SPACER.collapsed;
+  const height = Math.max(120, visibleLabels.length * (rowH + rowS) + 60);
 
   const options: ChartOptions<"bar"> = {
     indexAxis: "y",
@@ -1987,7 +1992,9 @@ function ServerUsageTimeSeries({
         labels={labels}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
-        height={expanded ? 600 : 260}
+        height={
+          expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
+        }
       />
     </ChartCard>
   );
@@ -2026,7 +2033,9 @@ function UserUsageTimeSeries({
         labels={labels}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
-        height={expanded ? 600 : 260}
+        height={
+          expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
+        }
       />
     </ChartCard>
   );
@@ -2135,7 +2144,9 @@ function ErrorsOverTimeChart({
           labels={labels}
           tooltipLabels={tooltipLabels}
           datasets={datasets}
-          height={expanded ? 600 : 260}
+          height={
+            expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
+          }
           tooltipAfterBody={(idx) => {
             const servers = perServerByIndex[idx];
             if (!servers || servers.length === 0) return [];

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1987,7 +1987,7 @@ function ServerUsageTimeSeries({
         labels={labels}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
-        height={expanded ? 500 : 200}
+        height={expanded ? 600 : 260}
       />
     </ChartCard>
   );
@@ -2026,7 +2026,7 @@ function UserUsageTimeSeries({
         labels={labels}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
-        height={expanded ? 500 : 200}
+        height={expanded ? 600 : 260}
       />
     </ChartCard>
   );
@@ -2135,7 +2135,7 @@ function ErrorsOverTimeChart({
           labels={labels}
           tooltipLabels={tooltipLabels}
           datasets={datasets}
-          height={expanded ? 500 : 200}
+          height={expanded ? 600 : 260}
           tooltipAfterBody={(idx) => {
             const servers = perServerByIndex[idx];
             if (!servers || servers.length === 0) return [];

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -115,7 +115,7 @@ const BRAND_RED_COLORS = [
   "#7f1d1d", // red-900
 ];
 
-const COLLAPSED_BAR_CHART_MAX_ROWS = 10;
+const COLLAPSED_BAR_CHART_MAX_ROWS = 6;
 
 // ---------------------------------------------------------------------------
 // Shared Chart.js config building blocks
@@ -1506,13 +1506,17 @@ function StackedBarChart({
         />
       </div>
       {hiddenCount > 0 && onShowAll && (
-        <button
-          type="button"
-          onClick={onShowAll}
-          className="text-muted-foreground hover:text-foreground mt-1 w-full text-center text-xs underline-offset-2 hover:underline"
-        >
-          Show {hiddenCount} more
-        </button>
+        <div className="mt-2 flex w-full">
+          <Button
+            variant="ghost"
+            size="sm"
+            icon="chevron-down"
+            iconAfter={true}
+            onClick={onShowAll}
+          >
+            Show {hiddenCount} more
+          </Button>
+        </div>
       )}
     </>
   );

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -115,6 +115,8 @@ const BRAND_RED_COLORS = [
   "#7f1d1d", // red-900
 ];
 
+const COLLAPSED_BAR_CHART_MAX_ROWS = 10;
+
 // ---------------------------------------------------------------------------
 // Shared Chart.js config building blocks
 // ---------------------------------------------------------------------------
@@ -1430,17 +1432,31 @@ function StackedBarChart({
   datasets,
   handleFilter,
   expanded = false,
+  maxRows,
+  onShowAll,
 }: {
   labels: string[];
   datasets: StackedBarDataset[];
   handleFilter?: (datasetLabel: string, rowLabel: string) => void;
   expanded?: boolean;
+  maxRows?: number;
+  onShowAll?: () => void;
 }) {
+  const hiddenCount =
+    !expanded && maxRows && labels.length > maxRows
+      ? labels.length - maxRows
+      : 0;
+  const visibleLabels = hiddenCount > 0 ? labels.slice(0, maxRows) : labels;
+  const visibleDatasets =
+    hiddenCount > 0
+      ? datasets.map((ds) => ({ ...ds, data: ds.data.slice(0, maxRows) }))
+      : datasets;
+
   const barHeight = expanded ? 36 : 24;
   const spacerHeight = expanded ? 12 : 8;
   const containerHeight = Math.max(
     120,
-    labels.length * (barHeight + spacerHeight) + 60,
+    visibleLabels.length * (barHeight + spacerHeight) + 60,
   );
 
   const options = useMemo<ChartOptions<"bar">>(
@@ -1452,7 +1468,7 @@ function StackedBarChart({
         if (!elements.length || !handleFilter) return;
         const { datasetIndex, index } = elements[0];
         const datasetLabel = datasets[datasetIndex]?.label;
-        const rowLabel = labels[index];
+        const rowLabel = visibleLabels[index];
         if (datasetLabel && rowLabel) handleFilter(datasetLabel, rowLabel);
       },
       onHover(event, elements) {
@@ -1472,22 +1488,33 @@ function StackedBarChart({
         },
       },
     }),
-    [datasets, labels, handleFilter],
+    [datasets, visibleLabels, handleFilter],
   );
 
-  if (labels.length === 0) return null;
+  if (visibleLabels.length === 0) return null;
 
   return (
-    <div
-      className="transition-all duration-200 ease-in-out"
-      style={{ height: containerHeight }}
-    >
-      <Bar
-        plugins={STACKED_BAR_PLUGINS}
-        data={{ labels, datasets }}
-        options={options}
-      />
-    </div>
+    <>
+      <div
+        className="transition-all duration-200 ease-in-out"
+        style={{ height: containerHeight }}
+      >
+        <Bar
+          plugins={STACKED_BAR_PLUGINS}
+          data={{ labels: visibleLabels, datasets: visibleDatasets }}
+          options={options}
+        />
+      </div>
+      {hiddenCount > 0 && onShowAll && (
+        <button
+          type="button"
+          onClick={onShowAll}
+          className="text-muted-foreground hover:text-foreground mt-1 w-full text-center text-xs underline-offset-2 hover:underline"
+        >
+          Show {hiddenCount} more
+        </button>
+      )}
+    </>
   );
 }
 
@@ -1570,6 +1597,8 @@ function UsersPerServerChart({
         datasets={datasets}
         handleFilter={handleFilter}
         expanded={expanded}
+        maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
+        onShowAll={() => onExpand(chartId)}
       />
     </ChartCard>
   );
@@ -1629,6 +1658,8 @@ function UserEventCountsChart({
         datasets={datasets}
         handleFilter={handleFilter}
         expanded={expanded}
+        maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
+        onShowAll={() => onExpand(chartId)}
       />
     </ChartCard>
   );
@@ -1702,9 +1733,26 @@ function ServerErrorRateChart({
     return { labels: chartLabels, datasets: chartDatasets };
   }, [breakdown, serverNameMappings.rawToDisplay]);
 
+  const hiddenCount =
+    !expanded && labels.length > COLLAPSED_BAR_CHART_MAX_ROWS
+      ? labels.length - COLLAPSED_BAR_CHART_MAX_ROWS
+      : 0;
+  const visibleLabels =
+    hiddenCount > 0 ? labels.slice(0, COLLAPSED_BAR_CHART_MAX_ROWS) : labels;
+  const visibleDatasets =
+    hiddenCount > 0
+      ? datasets.map((ds) => ({
+          ...ds,
+          data: ds.data.slice(0, COLLAPSED_BAR_CHART_MAX_ROWS),
+        }))
+      : datasets;
+
   const barHeight = expanded ? 36 : 24;
   const spacerHeight = expanded ? 12 : 8;
-  const height = Math.max(120, labels.length * (barHeight + spacerHeight) + 60);
+  const height = Math.max(
+    120,
+    visibleLabels.length * (barHeight + spacerHeight) + 60,
+  );
 
   const options: ChartOptions<"bar"> = {
     indexAxis: "y",
@@ -1738,12 +1786,26 @@ function ServerErrorRateChart({
           No errors in this period
         </div>
       ) : (
-        <div
-          className="relative transition-all duration-200 ease-in-out"
-          style={{ height }}
-        >
-          <Bar data={{ labels, datasets }} options={options} />
-        </div>
+        <>
+          <div
+            className="relative transition-all duration-200 ease-in-out"
+            style={{ height }}
+          >
+            <Bar
+              data={{ labels: visibleLabels, datasets: visibleDatasets }}
+              options={options}
+            />
+          </div>
+          {hiddenCount > 0 && (
+            <button
+              type="button"
+              onClick={() => onExpand(chartId)}
+              className="text-muted-foreground hover:text-foreground mt-1 w-full text-center text-xs underline-offset-2 hover:underline"
+            >
+              Show {hiddenCount} more
+            </button>
+          )}
+        </>
       )}
     </ChartCard>
   );


### PR DESCRIPTION
## Summary
- Bar charts (Users per Server, User Event Counts, Errors per Server) now cap at `COLLAPSED_BAR_CHART_MAX_ROWS` (6) rows in the default
  view, with a "Show N more" link that triggers the existing full-expand
- Time series chart height increased to 250px collapsed / 600px expanded for better data density
- Extracted `BAR_THICKNESS`, `BAR_ROW_HEIGHT`, `BAR_ROW_SPACER`, and `LINE_CHART_HEIGHT` constants so all chart dimensions are
controlled from a single place

## Root cause
Bar charts with large datasets (50+ servers or users) made the dashboard cards very tall and hard to scan. The existing expand
mechanism was already in place but wasn't being leveraged to hide excess rows — charts simply rendered everything at full height
regardless of how many entries there were.

## Test plan
- [ ] Charts with ≤6 rows show no "Show N more" link and render as before
- [ ] Charts with >6 rows show the top 6 entries and a "Show N more" link at the bottom
- [ ] Clicking "Show N more" triggers full-expand (other charts hide, all rows visible)
- [ ] Minimizing the expanded chart returns it to the collapsed 6-row view
- [ ] All bar charts have visually consistent row heights
- [ ] Time series charts render at the new 250px / 600px heights

## Visual

https://github.com/user-attachments/assets/5e1f6e6c-19c7-4ba6-beeb-1bf455c61a78
