### PR TITLE
mig: add selectors column to principal grants

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1614,21 +1614,29 @@ CREATE TABLE IF NOT EXISTS principal_grants (
   principal_type TEXT NOT NULL GENERATED ALWAYS AS (split_part(principal_urn, ':', 1)) STORED,
   scope TEXT NOT NULL,
   resource TEXT NOT NULL DEFAULT '*',
+  selectors JSONB,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT principal_grants_pkey PRIMARY KEY (id),
   CONSTRAINT principal_grants_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT principal_grants_selectors_check CHECK (selectors IS NULL OR jsonb_typeof(selectors) = 'object'),
   CONSTRAINT principal_grants_org_principal_scope_resource_key UNIQUE (organization_id, principal_urn, scope, resource)
 );
 
-COMMENT ON TABLE principal_grants IS 'RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource=''*'' means unrestricted.';
+COMMENT ON TABLE principal_grants IS 'RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource=''*'' means unrestricted. Selectors can further constrain applicability.';
 COMMENT ON COLUMN principal_grants.organization_id IS 'The organization this grant belongs to. Grants are always org-scoped.';
 COMMENT ON COLUMN principal_grants.principal_urn IS 'URN identifying the principal, e.g. "user:user_abc", "role:admin". Format is type:id.';
 COMMENT ON COLUMN principal_grants.principal_type IS 'Derived from principal_urn. The type prefix, e.g. "user", "role".';
 COMMENT ON COLUMN principal_grants.scope IS 'The scope being granted, e.g. "build:read". Validated in application code, not via FK.';
 COMMENT ON COLUMN principal_grants.resource IS '''*'' = unrestricted (scope applies to all resources in the org). Any other value = a specific resource ID this scope is granted on.';
+COMMENT ON COLUMN principal_grants.selectors IS 'Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.';
+
+CREATE INDEX IF NOT EXISTS principal_grants_selectors_idx
+ON principal_grants
+USING GIN (selectors)
+WHERE selectors IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS audit_logs (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/access/repo/models.go
+++ b/server/internal/access/repo/models.go
@@ -3,26 +3,3 @@
 //   sqlc v1.29.0
 
 package repo
-
-import (
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/speakeasy-api/gram/server/internal/urn"
-)
-
-// RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource='*' means unrestricted.
-type PrincipalGrant struct {
-	ID uuid.UUID
-	// The organization this grant belongs to. Grants are always org-scoped.
-	OrganizationID string
-	// URN identifying the principal, e.g. "user:user_abc", "role:admin". Format is type:id.
-	PrincipalUrn urn.Principal
-	// Derived from principal_urn. The type prefix, e.g. "user", "role".
-	PrincipalType string
-	// The scope being granted, e.g. "build:read". Validated in application code, not via FK.
-	Scope string
-	// '*' = unrestricted (scope applies to all resources in the org). Any other value = a specific resource ID this scope is granted on.
-	Resource  string
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-}

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -135,18 +136,29 @@ type ListPrincipalGrantsByOrgParams struct {
 	PrincipalUrn   string
 }
 
+type ListPrincipalGrantsByOrgRow struct {
+	ID             uuid.UUID
+	OrganizationID string
+	PrincipalUrn   urn.Principal
+	PrincipalType  string
+	Scope          string
+	Resource       string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
 // Queries for managing principal grants (RBAC).
 // principal_grants is org-scoped (no project_id); every query is scoped to organization_id.
 // Returns all grant rows for an organization, optionally filtered by principal URN.
-func (q *Queries) ListPrincipalGrantsByOrg(ctx context.Context, arg ListPrincipalGrantsByOrgParams) ([]PrincipalGrant, error) {
+func (q *Queries) ListPrincipalGrantsByOrg(ctx context.Context, arg ListPrincipalGrantsByOrgParams) ([]ListPrincipalGrantsByOrgRow, error) {
 	rows, err := q.db.Query(ctx, listPrincipalGrantsByOrg, arg.OrganizationID, arg.PrincipalUrn)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []PrincipalGrant
+	var items []ListPrincipalGrantsByOrgRow
 	for rows.Next() {
-		var i PrincipalGrant
+		var i ListPrincipalGrantsByOrgRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.OrganizationID,
@@ -203,16 +215,27 @@ type UpsertPrincipalGrantParams struct {
 	Resource       string
 }
 
+type UpsertPrincipalGrantRow struct {
+	ID             uuid.UUID
+	OrganizationID string
+	PrincipalUrn   urn.Principal
+	PrincipalType  string
+	Scope          string
+	Resource       string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
 // Creates or updates a single grant row. On conflict (same org/principal/scope/resource),
 // the updated_at timestamp is refreshed. Returns the full row.
-func (q *Queries) UpsertPrincipalGrant(ctx context.Context, arg UpsertPrincipalGrantParams) (PrincipalGrant, error) {
+func (q *Queries) UpsertPrincipalGrant(ctx context.Context, arg UpsertPrincipalGrantParams) (UpsertPrincipalGrantRow, error) {
 	row := q.db.QueryRow(ctx, upsertPrincipalGrant,
 		arg.OrganizationID,
 		arg.PrincipalUrn,
 		arg.Scope,
 		arg.Resource,
 	)
-	var i PrincipalGrant
+	var i UpsertPrincipalGrantRow
 	err := row.Scan(
 		&i.ID,
 		&i.OrganizationID,

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -140,7 +140,7 @@ func seedGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizati
 	require.NoError(t, err)
 }
 
-func listPrincipalGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, principal urn.Principal) []accessrepo.PrincipalGrant {
+func listPrincipalGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, principal urn.Principal) []accessrepo.ListPrincipalGrantsByOrgRow {
 	t.Helper()
 
 	grants, err := accessrepo.New(conn).ListPrincipalGrantsByOrg(ctx, accessrepo.ListPrincipalGrantsByOrgParams{

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -745,7 +745,7 @@ type PluginServer struct {
 	Deleted     bool
 }
 
-// RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource='*' means unrestricted.
+// RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource='*' means unrestricted. Selectors can further constrain applicability.
 type PrincipalGrant struct {
 	ID uuid.UUID
 	// The organization this grant belongs to. Grants are always org-scoped.
@@ -757,7 +757,9 @@ type PrincipalGrant struct {
 	// The scope being granted, e.g. "build:read". Validated in application code, not via FK.
 	Scope string
 	// '*' = unrestricted (scope applies to all resources in the org). Any other value = a specific resource ID this scope is granted on.
-	Resource  string
+	Resource string
+	// Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.
+	Selectors []byte
 	CreatedAt pgtype.Timestamptz
 	UpdatedAt pgtype.Timestamptz
 }

--- a/server/migrations/20260422120000_add-selectors-to-principal-grants.sql
+++ b/server/migrations/20260422120000_add-selectors-to-principal-grants.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "principal_grants"
+  ADD COLUMN "selectors" jsonb NULL,
+  ADD CONSTRAINT "principal_grants_selectors_check" CHECK ("selectors" IS NULL OR jsonb_typeof("selectors") = 'object');
+
+-- Set comment to table: "principal_grants"
+COMMENT ON TABLE "principal_grants" IS 'RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource=''*'' means unrestricted. Selectors can further constrain applicability.';
+
+-- Set comment to column: "selectors" on table: "principal_grants"
+COMMENT ON COLUMN "principal_grants"."selectors" IS 'Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.';
+
+CREATE INDEX "principal_grants_selectors_idx"
+  ON "principal_grants"
+  USING GIN ("selectors")
+  WHERE "selectors" IS NOT NULL;

--- a/server/migrations/20260422120000_add-selectors-to-principal-grants.sql
+++ b/server/migrations/20260422120000_add-selectors-to-principal-grants.sql
@@ -1,6 +1,11 @@
+-- atlas:txmode none
+
 ALTER TABLE "principal_grants"
   ADD COLUMN "selectors" jsonb NULL,
-  ADD CONSTRAINT "principal_grants_selectors_check" CHECK ("selectors" IS NULL OR jsonb_typeof("selectors") = 'object');
+  ADD CONSTRAINT "principal_grants_selectors_check" CHECK ("selectors" IS NULL OR jsonb_typeof("selectors") = 'object') NOT VALID;
+
+ALTER TABLE "principal_grants"
+  VALIDATE CONSTRAINT "principal_grants_selectors_check";
 
 -- Set comment to table: "principal_grants"
 COMMENT ON TABLE "principal_grants" IS 'RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource=''*'' means unrestricted. Selectors can further constrain applicability.';
@@ -8,7 +13,7 @@ COMMENT ON TABLE "principal_grants" IS 'RBAC grants. Normalized: one row per (or
 -- Set comment to column: "selectors" on table: "principal_grants"
 COMMENT ON COLUMN "principal_grants"."selectors" IS 'Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.';
 
-CREATE INDEX "principal_grants_selectors_idx"
+CREATE INDEX CONCURRENTLY "principal_grants_selectors_idx"
   ON "principal_grants"
   USING GIN ("selectors")
   WHERE "selectors" IS NOT NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4+UlohHMqJC8EVBJrNl87I9j//IIlbaIafqP1iahe/U=
+h1:lVcHYa22KURs+IDI/WItTFdq8mojCmIcRwS2PEbRNOY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -130,4 +130,4 @@ h1:4+UlohHMqJC8EVBJrNl87I9j//IIlbaIafqP1iahe/U=
 20260420143421_toolset-origins.sql h1:hsU/rOPgf/f8q2pysWDOXS45nuRzznedocFeZuimAJM=
 20260420202925_deployment_statuses_add_deployment_id_seq_idx.sql h1:Hv4GhzFjP6u0Ye+azHZv2Zyf0T0OT9L2zxZtmr7LD1I=
 20260421144856_mcp_frontends_and_slugs.sql h1:hs2Zsds5ZtnHqfjc3F1Hz3uMMpD16MwDBWvfNYPWMP0=
-20260422120000_add-selectors-to-principal-grants.sql h1:deq/xxB9GyhrnBhMXz1TaeU8pQkJ2d4kZhySyZFQSvM=
+20260422120000_add-selectors-to-principal-grants.sql h1:LyCyuDJg+NCG3gbcwOPeJE8JnievSXhZXNYCV44hY7c=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:RJm188Kba4J7cfD/Zjt0b+HW4L7khaz3ZsdnZIMBXYM=
+h1:4+UlohHMqJC8EVBJrNl87I9j//IIlbaIafqP1iahe/U=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -130,3 +130,4 @@ h1:RJm188Kba4J7cfD/Zjt0b+HW4L7khaz3ZsdnZIMBXYM=
 20260420143421_toolset-origins.sql h1:hsU/rOPgf/f8q2pysWDOXS45nuRzznedocFeZuimAJM=
 20260420202925_deployment_statuses_add_deployment_id_seq_idx.sql h1:Hv4GhzFjP6u0Ye+azHZv2Zyf0T0OT9L2zxZtmr7LD1I=
 20260421144856_mcp_frontends_and_slugs.sql h1:hs2Zsds5ZtnHqfjc3F1Hz3uMMpD16MwDBWvfNYPWMP0=
+20260422120000_add-selectors-to-principal-grants.sql h1:deq/xxB9GyhrnBhMXz1TaeU8pQkJ2d4kZhySyZFQSvM=


### PR DESCRIPTION
## Why

We need to start storing selector constraints on principal grants so the RBAC model can evolve beyond simple scope/resource tuples.

## What Changed

- added a nullable `selectors jsonb` column to `principal_grants`
- added a check constraint to ensure `selectors`, when present, is a JSON object
- added a partial GIN index on `selectors` for future JSON containment/path queries
- updated the table and column comments
- added the migration and regenerated `atlas.sum`

## Notes

- We intentionally did not add selector-aware uniqueness yet. The current access code still treats grants as `(organization_id, principal_urn, scope, resource)`, so widening uniqueness before the runtime becomes selector-aware would let the database distinguish rows that the auth layer still treats as equivalent.
- The `principal_grants_selectors_check` constraint is there to keep the payload shape to JSON objects only, since selectors are expected to be keyed fields rather than arrays or scalar JSON values.
- We also stayed away from changing the existing `resource`-based uniqueness because `resource` is expected to go away later; doing uniqueness now would likely force another index rewrite once that happens.