### PR TITLE
chore: re-enable react-hooks/exhaustive-deps ESLint rule

### DIFF
--- a/client/dashboard/eslint.config.js
+++ b/client/dashboard/eslint.config.js
@@ -22,7 +22,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-hooks/exhaustive-deps": "off",
+      "react-hooks/exhaustive-deps": "error",
       "react-refresh/only-export-components": [
         "error",
         { allowConstantExport: true },

--- a/client/dashboard/src/components/ai-elements/prompt-input.tsx
+++ b/client/dashboard/src/components/ai-elements/prompt-input.tsx
@@ -460,36 +460,52 @@ export const PromptInput = ({
     [matchesAccept, maxFiles, maxFileSize, onError],
   );
 
-  const add = usingProvider
-    ? (files: File[] | FileList) => controller.attachments.add(files)
-    : addLocal;
+  const add = useMemo(
+    () =>
+      usingProvider
+        ? (files: File[] | FileList) => controller.attachments.add(files)
+        : addLocal,
+    [usingProvider, controller, addLocal],
+  );
 
-  const remove = usingProvider
-    ? (id: string) => controller.attachments.remove(id)
-    : (id: string) =>
-        setItems((prev) => {
-          const found = prev.find((file) => file.id === id);
-          if (found?.url) {
-            URL.revokeObjectURL(found.url);
-          }
-          return prev.filter((file) => file.id !== id);
-        });
+  const remove = useMemo(
+    () =>
+      usingProvider
+        ? (id: string) => controller.attachments.remove(id)
+        : (id: string) =>
+            setItems((prev) => {
+              const found = prev.find((file) => file.id === id);
+              if (found?.url) {
+                URL.revokeObjectURL(found.url);
+              }
+              return prev.filter((file) => file.id !== id);
+            }),
+    [usingProvider, controller],
+  );
 
-  const clear = usingProvider
-    ? () => controller.attachments.clear()
-    : () =>
-        setItems((prev) => {
-          for (const file of prev) {
-            if (file.url) {
-              URL.revokeObjectURL(file.url);
-            }
-          }
-          return [];
-        });
+  const clear = useMemo(
+    () =>
+      usingProvider
+        ? () => controller.attachments.clear()
+        : () =>
+            setItems((prev) => {
+              for (const file of prev) {
+                if (file.url) {
+                  URL.revokeObjectURL(file.url);
+                }
+              }
+              return [];
+            }),
+    [usingProvider, controller],
+  );
 
-  const openFileDialog = usingProvider
-    ? () => controller.attachments.openFileDialog()
-    : openFileDialogLocal;
+  const openFileDialog = useMemo(
+    () =>
+      usingProvider
+        ? () => controller.attachments.openFileDialog()
+        : openFileDialogLocal,
+    [usingProvider, controller, openFileDialogLocal],
+  );
 
   // Let provider know about our hidden file input so external menus can call openFileDialog()
   useEffect(() => {

--- a/client/dashboard/src/components/code.tsx
+++ b/client/dashboard/src/components/code.tsx
@@ -58,7 +58,7 @@ export function CodeBlock({
         },
       ],
     }).then(setHighlightedCode);
-  }, [code, language, preClassName]);
+  }, [code, language, preClassName, theme]);
 
   const baseClasses =
     "rounded-md font-mono text-sm text-wrap overflow-x-auto border break-all whitespace-pre-wrap truncate";

--- a/client/dashboard/src/components/environments/useAttachedEnvironmentForm.ts
+++ b/client/dashboard/src/components/environments/useAttachedEnvironmentForm.ts
@@ -119,7 +119,7 @@ export function useAttachedEnvironmentForm({
 
   useEffect(() => {
     serverDataReceived(attachedEnvironmentQuery.data ?? null);
-  }, [attachedEnvironmentQuery.data]);
+  }, [attachedEnvironmentQuery.data, serverDataReceived]);
 
   const mutation = useMutation<ToolsetEnvironmentLink | null, Error, void>({
     mutationFn: async (): Promise<ToolsetEnvironmentLink | null> => {

--- a/client/dashboard/src/components/mcp_install_page/useMcpMetadataForm.tsx
+++ b/client/dashboard/src/components/mcp_install_page/useMcpMetadataForm.tsx
@@ -120,7 +120,8 @@ export function useMcpMetadataMetadataForm(
         instructions: currentMetadata?.instructions,
       });
     }
-  }, [currentMetadata, metadataParams]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- syncs server→local only on server change; including metadataParams would overwrite user edits
+  }, [currentMetadata]);
 
   useEffect(() => {
     if (!metadataParams.externalDocumentationUrl) {

--- a/client/dashboard/src/components/mcp_install_page/useMcpMetadataForm.tsx
+++ b/client/dashboard/src/components/mcp_install_page/useMcpMetadataForm.tsx
@@ -120,7 +120,7 @@ export function useMcpMetadataMetadataForm(
         instructions: currentMetadata?.instructions,
       });
     }
-  }, [currentMetadata]);
+  }, [currentMetadata, metadataParams]);
 
   useEffect(() => {
     if (!metadataParams.externalDocumentationUrl) {

--- a/client/dashboard/src/components/tool-list/ToolList.tsx
+++ b/client/dashboard/src/components/tool-list/ToolList.tsx
@@ -19,7 +19,7 @@ import {
   PencilRuler,
   SquareFunction,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AnnotationBadges } from "./AnnotationBadges";
 import { ToolVariationBadge } from "../tool-variation-badge";
 import { McpIcon } from "../ui/mcp-icon";
@@ -737,7 +737,7 @@ export function ToolList({
 
   useEffect(() => {
     setExpandedGroups(new Set(groups.map((_, i) => i)));
-  }, [groups.length]);
+  }, [groups]);
 
   // For normal mode (remove tools from toolset)
   const [selectedForRemoval, setSelectedForRemoval] = useState<Set<string>>(
@@ -830,7 +830,15 @@ export function ToolList({
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [hasChanges, focusedToolIndex, visibleTools.length]);
+  }, [
+    hasChanges,
+    focusedToolIndex,
+    visibleTools,
+    selectionMode,
+    selectedSet,
+    selectedForRemoval,
+    handleCheckboxChange,
+  ]);
 
   // Register command palette actions and context badge when tools are selected
   // Skip this in selection mode - the dialog handles its own UI
@@ -908,8 +916,6 @@ export function ToolList({
       removeActions(toolActionIds);
       setContextBadge(null);
     };
-    // addActions, removeActions, and setContextBadge are memoized in CommandPaletteContext
-    // with empty deps so they're stable and don't need to be in the dependency array
   }, [
     selectionMode,
     hasChanges,
@@ -917,6 +923,9 @@ export function ToolList({
     onAddToToolset,
     onCreateToolset,
     onToolsRemove,
+    addActions,
+    removeActions,
+    setContextBadge,
   ]);
 
   const toggleGroup = (index: number) => {
@@ -931,29 +940,32 @@ export function ToolList({
     });
   };
 
-  const handleCheckboxChange = (toolId: string, checked: boolean) => {
-    if (selectionMode === "add" && onSelectionChange) {
-      // For selection mode, update parent state
-      const next = new Set(selectedUrns);
-      if (checked) {
-        next.add(toolId);
-      } else {
-        next.delete(toolId);
-      }
-      onSelectionChange(Array.from(next));
-    } else {
-      // For normal mode, update local state
-      setSelectedForRemoval((prev) => {
-        const next = new Set(prev);
+  const handleCheckboxChange = useCallback(
+    (toolId: string, checked: boolean) => {
+      if (selectionMode === "add" && onSelectionChange) {
+        // For selection mode, update parent state
+        const next = new Set(selectedUrns);
         if (checked) {
           next.add(toolId);
         } else {
           next.delete(toolId);
         }
-        return next;
-      });
-    }
-  };
+        onSelectionChange(Array.from(next));
+      } else {
+        // For normal mode, update local state
+        setSelectedForRemoval((prev) => {
+          const next = new Set(prev);
+          if (checked) {
+            next.add(toolId);
+          } else {
+            next.delete(toolId);
+          }
+          return next;
+        });
+      }
+    },
+    [selectionMode, onSelectionChange, selectedUrns],
+  );
 
   const handleCancel = () => {
     setSelectedForRemoval(new Set());

--- a/client/dashboard/src/components/tool-list/ToolList.tsx
+++ b/client/dashboard/src/components/tool-list/ToolList.tsx
@@ -737,7 +737,8 @@ export function ToolList({
 
   useEffect(() => {
     setExpandedGroups(new Set(groups.map((_, i) => i)));
-  }, [groups]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset expanded state when group count changes, not when tools within groups change
+  }, [groups.length]);
 
   // For normal mode (remove tools from toolset)
   const [selectedForRemoval, setSelectedForRemoval] = useState<Set<string>>(

--- a/client/dashboard/src/components/tool-list/ToolList.tsx
+++ b/client/dashboard/src/components/tool-list/ToolList.tsx
@@ -781,6 +781,33 @@ export function ToolList({
     return map;
   }, [visibleTools]);
 
+  const handleCheckboxChange = useCallback(
+    (toolId: string, checked: boolean) => {
+      if (selectionMode === "add" && onSelectionChange) {
+        // For selection mode, update parent state
+        const next = new Set(selectedUrns);
+        if (checked) {
+          next.add(toolId);
+        } else {
+          next.delete(toolId);
+        }
+        onSelectionChange(Array.from(next));
+      } else {
+        // For normal mode, update local state
+        setSelectedForRemoval((prev) => {
+          const next = new Set(prev);
+          if (checked) {
+            next.add(toolId);
+          } else {
+            next.delete(toolId);
+          }
+          return next;
+        });
+      }
+    },
+    [selectionMode, onSelectionChange, selectedUrns],
+  );
+
   // Handle keyboard navigation
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -939,33 +966,6 @@ export function ToolList({
       return next;
     });
   };
-
-  const handleCheckboxChange = useCallback(
-    (toolId: string, checked: boolean) => {
-      if (selectionMode === "add" && onSelectionChange) {
-        // For selection mode, update parent state
-        const next = new Set(selectedUrns);
-        if (checked) {
-          next.add(toolId);
-        } else {
-          next.delete(toolId);
-        }
-        onSelectionChange(Array.from(next));
-      } else {
-        // For normal mode, update local state
-        setSelectedForRemoval((prev) => {
-          const next = new Set(prev);
-          if (checked) {
-            next.add(toolId);
-          } else {
-            next.delete(toolId);
-          }
-          return next;
-        });
-      }
-    },
-    [selectionMode, onSelectionChange, selectedUrns],
-  );
 
   const handleCancel = () => {
     setSelectedForRemoval(new Set());

--- a/client/dashboard/src/components/upload-asset/deploy-step.tsx
+++ b/client/dashboard/src/components/upload-asset/deploy-step.tsx
@@ -56,7 +56,7 @@ export default function DeployStep() {
       toolCount: matchingTools.length,
       toolUrns: matchingTools.map((tool) => tool.toolUrn),
     };
-  }, [toolsList.data]);
+  }, [toolsList.data, stepper.meta]);
 
   // Auto-create toolset after tools are loaded (regardless of overall deployment status)
   // The deployment may fail due to unrelated issues (e.g., external MCP), but if tools
@@ -109,7 +109,7 @@ export default function DeployStep() {
     };
 
     createToolset();
-  }, [step.state, toolUrns.length]);
+  }, [step.state, toolUrns, client.toolsets, stepper.meta, telemetry]);
 
   const deploymentLogs = useDeploymentLogs(
     {
@@ -153,7 +153,14 @@ export default function DeployStep() {
         step.setState("failed");
         stepper.setState("error");
       });
-  }, [step.isCurrentStep, step.state]);
+  }, [
+    step.isCurrentStep,
+    step.state,
+    createOrEvolveDeployment,
+    step,
+    stepper,
+    telemetry,
+  ]);
 
   if (!step.isCurrentStep) return null;
 
@@ -286,9 +293,9 @@ function DeploymentDetailsCollapsible({
  * deployment state.
  */
 const useCreateDeployment = (): (() => Promise<Deployment>) => {
-  const latestDeployment = useLatestDeployment();
+  const _latestDeployment = useLatestDeployment();
   const stepper = useStepper();
-  const step = useStep();
+  const _step = useStep();
   const client = useSdkClient();
 
   const _do = React.useCallback(async () => {
@@ -334,7 +341,7 @@ const useCreateDeployment = (): (() => Promise<Deployment>) => {
     }
 
     return deployment;
-  }, [latestDeployment.data, step.isCurrentStep]);
+  }, [client.deployments, stepper.meta]);
 
   return _do;
 };

--- a/client/dashboard/src/components/upload-asset/name-deployment-step.tsx
+++ b/client/dashboard/src/components/upload-asset/name-deployment-step.tsx
@@ -19,7 +19,7 @@ export default function NameDeploymentStep() {
       const name = stepper.meta.current.file.name.replace(/\.[^/.]+$/, "");
       setValue(slugify(name));
     }
-  }, [step.isCurrentStep]);
+  }, [step.isCurrentStep, stepper.meta]);
 
   const validation = React.useMemo<string | null>(() => {
     if (!value) return "API name is required";

--- a/client/dashboard/src/components/upload-asset/stepper/context.tsx
+++ b/client/dashboard/src/components/upload-asset/stepper/context.tsx
@@ -48,9 +48,10 @@ export const StepperContextProvider: React.FC<StepperContextProviderProps> = ({
 
   React.useEffect(() => {
     isMounted.current = true;
+    const subs = subscribers.current;
     return () => {
       isMounted.current = false;
-      subscribers.current.clear();
+      subs.clear();
     };
   }, []);
 

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -75,6 +75,7 @@ export const SdkProvider = ({ children }: { children: React.ReactNode }) => {
     }
 
     return gram;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- telemetry is stable context value; including it would recreate the SDK client unnecessarily
   }, [projectSlug]);
 
   // Invalidate all queries when projectSlug changes
@@ -83,7 +84,7 @@ export const SdkProvider = ({ children }: { children: React.ReactNode }) => {
       queryClient.invalidateQueries();
       previousProjectSlug.current = projectSlug;
     }
-  }, [projectSlug, queryClient]);
+  }, [projectSlug]);
 
   return (
     <IsAdminContext.Provider value={isAdminRef}>

--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -95,7 +95,7 @@ export function useCaptureUserAuthorizationEvent({
       organization_slug: organizationSlug,
       slug: `${organizationSlug}/${projectSlug}`,
     });
-  }, [email, projectSlug, organizationSlug, telemetry]);
+  }, [email, projectId, projectSlug, organizationSlug, telemetry]);
 }
 
 export function useCaptureEnterpriseGateViewed({
@@ -204,5 +204,5 @@ export function useRegisterProjectForTelemetry({
       organization_slug: organizationSlug,
       slug: `${organizationSlug}/${projectSlug}`,
     });
-  }, [projectSlug, organizationSlug, telemetry]);
+  }, [projectId, projectSlug, organizationSlug, telemetry]);
 }

--- a/client/dashboard/src/hooks/useRBAC.ts
+++ b/client/dashboard/src/hooks/useRBAC.ts
@@ -31,7 +31,7 @@ export function useRBAC() {
     (featureFlagEnabled && productTier === "enterprise") || devOverrideActive;
 
   // Re-render when the toolbar changes scopes in localStorage.
-  const [overrideVersion, setOverrideVersion] = useState(0);
+  const [, setOverrideVersion] = useState(0);
   useEffect(() => {
     if (!import.meta.env.DEV && !isAdmin) return;
     const handler = () => setOverrideVersion((v) => v + 1);
@@ -48,11 +48,11 @@ export function useRBAC() {
     throwOnError: false,
   });
 
-  // overrideVersion triggers a re-render (and therefore a re-read of devOverrideActive)
+  // setOverrideVersion triggers a re-render (and therefore a re-read of devOverrideActive)
   // when the dev toolbar changes; the query invalidation handles the actual refetch.
   const grants = useMemo(() => {
     return data?.grants;
-  }, [data?.grants, overrideVersion]);
+  }, [data?.grants]);
 
   /**
    * Check if the user has a given scope, optionally scoped to a resource ID.

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -437,7 +437,10 @@ function ToolSelectionPanel({
   );
   const [search, setSearch] = useState("");
   const selectedServer = allServers.find((s) => s.id === selectedServerId);
-  const tools = selectedServer?.tools ?? [];
+  const tools = useMemo(
+    () => selectedServer?.tools ?? [],
+    [selectedServer?.tools],
+  );
   const filteredTools = useMemo(
     () =>
       (search
@@ -790,7 +793,10 @@ function CollectionGroupPanel({
   // Fetch org-level collections
   const { data: collectionsData, isLoading: collectionsLoading } =
     useListCollections({}, undefined);
-  const collections = collectionsData?.collections ?? [];
+  const collections = useMemo(
+    () => collectionsData?.collections ?? [],
+    [collectionsData?.collections],
+  );
 
   // Fetch servers for each collection in parallel
   const serverQueries = useQueries({

--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -307,6 +307,7 @@ export function AddServerDialog({
     if (!open) {
       releaseState.reset();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset when dialog open/close state changes, not on every releaseState update
   }, [open]);
 
   // Clean up Radix body scroll-lock on unmount (e.g. when navigating away mid-dialog)
@@ -332,7 +333,7 @@ export function AddServerDialog({
     if (!allToolsetsDone) {
       prevAllDoneRef.current = false;
     }
-  }, [allToolsetsDone]);
+  }, [allToolsetsDone, onServersAdded]);
 
   if (servers.length === 0) return null;
 
@@ -759,6 +760,7 @@ function ConfigurePhaseContent({
     if (!hasOnlySingleRemote && releaseState.canDeploy && needsDeployment) {
       releaseState.startDeployment();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only trigger on deploy readiness changes, not on every releaseState update
   }, [hasOnlySingleRemote, needsDeployment, releaseState.canDeploy]);
 
   // If all servers were multi-remote, show loading state while auto-deploying

--- a/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts
@@ -413,6 +413,7 @@ export function useExternalMcpReleaseWorkflow({
     }
 
     createToolsets();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- toolset creation should only trigger on phase transition to "complete", not when serverConfigs/toolsetStatuses change mid-creation
   }, [phase]);
 
   const updateServerConfig = useCallback(

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -608,7 +608,7 @@ export function ChatDetailPanel({
     });
   }, [chatId, searchLogs]);
 
-  const logs = logsData?.logs || [];
+  const logs = useMemo(() => logsData?.logs || [], [logsData?.logs]);
   const toolLogs = useMemo(() => filterToolLogs(logs), [logs]);
 
   // Fetch risk findings for this chat

--- a/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogs.tsx
@@ -322,7 +322,7 @@ function ChatLogsInner() {
     );
 
   // Chats are sorted server-side via sortBy/sortOrder params
-  const chats = data?.chats ?? [];
+  const chats = useMemo(() => data?.chats ?? [], [data?.chats]);
   // Keep total stable across page changes to avoid flickering
   const lastTotalRef = useRef(0);
   if (data?.total !== undefined && data.total > 0) {

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -63,7 +63,7 @@ export default function CliCallback(props: CliCallbackProps) {
           err instanceof Error ? err.message : "Failed to create API key",
         );
       });
-  }, [createKey, session, localCallbackUrl]);
+  }, [createKey, session, localCallbackUrl, validCallback]);
 
   if (error) {
     return <FailedScreen error={error} />;

--- a/client/dashboard/src/pages/collections/CollectionDetail.tsx
+++ b/client/dashboard/src/pages/collections/CollectionDetail.tsx
@@ -83,7 +83,10 @@ export default function CollectionDetail() {
   );
 
   // Fetch toolsets from all projects for the inline server picker
-  const projects = organization.projects ?? [];
+  const projects = useMemo(
+    () => organization.projects ?? [],
+    [organization.projects],
+  );
   const toolsetQueries = useQueries({
     queries: projects.map((project) => ({
       queryKey: ["toolsets", "list", project.slug],

--- a/client/dashboard/src/pages/collections/CreateCollection.tsx
+++ b/client/dashboard/src/pages/collections/CreateCollection.tsx
@@ -30,7 +30,10 @@ export default function CreateCollection() {
   const orgRoutes = useOrgRoutes();
   const client = useSdkClient();
   const organization = useOrganization();
-  const projects = organization.projects ?? [];
+  const projects = useMemo(
+    () => organization.projects ?? [],
+    [organization.projects],
+  );
 
   const orgSlug = organization.slug ?? "";
   const baseNamespace = `com.speakeasy.${orgSlug}`;

--- a/client/dashboard/src/pages/deployments/ToolsList.tsx
+++ b/client/dashboard/src/pages/deployments/ToolsList.tsx
@@ -107,7 +107,7 @@ export function ToolsList(props: { deploymentId?: string }) {
       }),
     }));
     return filteredGroups.filter((g) => g.tools.length > 0);
-  }, [tools, search, tagFilters]);
+  }, [groupedTools, search, tagFilters]);
 
   const toolGroups = useMemo(() => {
     const toolGroups = filteredGroups.map((group) => ({

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -194,9 +194,11 @@ export const LogsTabContent = ({
   const { searchParams, setSearchParams } = useDeploymentSearchParams();
   const [localGrouping, setLocalGrouping] = useState(false);
 
-  const setGroupBySource = embeddedMode
-    ? (value: boolean) => setLocalGrouping(value)
-    : (value: boolean) => {
+  const setGroupBySource = useCallback(
+    (value: boolean) => {
+      if (embeddedMode) {
+        setLocalGrouping(value);
+      } else {
         setSearchParams((prev) => {
           if (prev.tab !== "logs") return prev;
           const next = { ...prev };
@@ -204,7 +206,10 @@ export const LogsTabContent = ({
           else next.grouping = undefined;
           return next;
         });
-      };
+      }
+    },
+    [embeddedMode, setSearchParams],
+  );
 
   const groupBySource = React.useMemo(() => {
     if (embeddedMode) return localGrouping;
@@ -360,28 +365,31 @@ export const LogsTabContent = ({
     [effectiveSearchIndex, filteredIndices, scrollToLog],
   );
 
-  const handleFocusChange = (newFocus: LogFocus) => {
-    setFocus(newFocus);
-    setCurrentSearchIndex(0);
+  const handleFocusChange = useCallback(
+    (newFocus: LogFocus) => {
+      setFocus(newFocus);
+      setCurrentSearchIndex(0);
 
-    if (newFocus !== "all") {
-      const indices = parsedLogs
-        .map((log, index) =>
-          (newFocus === "warns" && log.level === "WARN") ||
-          (newFocus === "errors" && log.level === "ERROR") ||
-          (newFocus === "skipped" && log.level === "SKIP")
-            ? index
-            : -1,
-        )
-        .filter((i) => i !== -1);
+      if (newFocus !== "all") {
+        const indices = parsedLogs
+          .map((log, index) =>
+            (newFocus === "warns" && log.level === "WARN") ||
+            (newFocus === "errors" && log.level === "ERROR") ||
+            (newFocus === "skipped" && log.level === "SKIP")
+              ? index
+              : -1,
+          )
+          .filter((i) => i !== -1);
 
-      if (indices.length > 0 && indices[0] !== undefined) {
-        scrollToLog(indices[0]);
+        if (indices.length > 0 && indices[0] !== undefined) {
+          scrollToLog(indices[0]);
+        }
+      } else {
+        setCurrentLogIndex(null);
       }
-    } else {
-      setCurrentLogIndex(null);
-    }
-  };
+    },
+    [parsedLogs, scrollToLog],
+  );
 
   const handleSearchChange = (query: string) => {
     setSearchQuery(query);
@@ -539,7 +547,15 @@ export const LogsTabContent = ({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [currentLogIndex, parsedLogs.length, navigateToResult, groupBySource]);
+  }, [
+    currentLogIndex,
+    parsedLogs.length,
+    navigateToResult,
+    groupBySource,
+    handleFocusChange,
+    scrollToLog,
+    setGroupBySource,
+  ]);
 
   const searchRegex = useMemo(() => {
     if (!searchQuery) return null;

--- a/client/dashboard/src/pages/elements/Elements.tsx
+++ b/client/dashboard/src/pages/elements/Elements.tsx
@@ -259,6 +259,7 @@ function ChatElementsInner() {
         updateConfig("mcp", getMcpUrl(firstEnabledToolset));
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-run when toolsets or URL param change, not when config.mcp updates (would cause loop)
   }, [toolsets, toolsetSlugFromUrl]);
 
   const updateConfig = <K extends keyof ElementsFormConfig>(
@@ -304,7 +305,8 @@ function ChatElementsInner() {
     };
 
     createSession();
-  }, [previewKey, project.slug, session.session]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- createSessionMutation is unstable; trigger on previewKey, auth, and user identity changes only
+  }, [previewKey, project.slug, session.session, session.user.id]);
 
   // Build config object (memoized) - excludes api since sessionToken changes independently
   const baseElementsConfig = useMemo(
@@ -920,7 +922,7 @@ function InstallationGuide({
       framework: selectedFramework,
       product: selectedProduct,
     });
-  }, [projectSlug, selectedFramework, selectedProduct]);
+  }, [projectSlug, selectedFramework, selectedProduct, telemetry]);
 
   const { data: existingKeys } = useListAPIKeys(
     {},
@@ -972,7 +974,14 @@ function InstallationGuide({
         },
       );
     }
-  }, [currentStep, existingKeys]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- createApiKeyMutation is unstable; only trigger on step changes and when existing keys load
+  }, [
+    currentStep,
+    existingKeys,
+    generatedApiKey,
+    keyCreationAttempted,
+    projectSlug,
+  ]);
 
   const mcpUrl = config.mcp || `https://app.getgram.ai/mcp/${projectSlug}`;
 

--- a/client/dashboard/src/pages/environments/Environment.tsx
+++ b/client/dashboard/src/pages/environments/Environment.tsx
@@ -412,6 +412,7 @@ function EnvironmentPageInner() {
     newEntryValue,
     deletedFields,
     updateEnvironment,
+    validateEntryName,
   ]);
 
   const handleAddNewEntry = useCallback(() => {
@@ -425,14 +426,17 @@ function EnvironmentPageInner() {
     setNewEntryVisible(false);
   }, []);
 
-  const validateEntryName = (name: string) => {
-    return (
-      name.length > 0 &&
-      !environment?.entries.some((entry) => entry.name === name) &&
-      !Object.keys(envValues).includes(name) &&
-      /^[-_.a-zA-Z][-_.a-zA-Z0-9]*$/.test(name)
-    );
-  };
+  const validateEntryName = useCallback(
+    (name: string) => {
+      return (
+        name.length > 0 &&
+        !environment?.entries.some((entry) => entry.name === name) &&
+        !Object.keys(envValues).includes(name) &&
+        /^[-_.a-zA-Z][-_.a-zA-Z0-9]*$/.test(name)
+      );
+    },
+    [environment?.entries, envValues],
+  );
 
   const handleToolsetSubmit = (toolsetSlug: string) => {
     setSelectedToolsetSlug(toolsetSlug);

--- a/client/dashboard/src/pages/environments/Environment.tsx
+++ b/client/dashboard/src/pages/environments/Environment.tsx
@@ -371,6 +371,18 @@ function EnvironmentPageInner() {
     [saveError],
   );
 
+  const validateEntryName = useCallback(
+    (name: string) => {
+      return (
+        name.length > 0 &&
+        !environment?.entries.some((entry) => entry.name === name) &&
+        !Object.keys(envValues).includes(name) &&
+        /^[-_.a-zA-Z][-_.a-zA-Z0-9]*$/.test(name)
+      );
+    },
+    [environment?.entries, envValues],
+  );
+
   const handleSave = useCallback(() => {
     if (!environment) return;
 
@@ -425,18 +437,6 @@ function EnvironmentPageInner() {
     setNewEntryValue("");
     setNewEntryVisible(false);
   }, []);
-
-  const validateEntryName = useCallback(
-    (name: string) => {
-      return (
-        name.length > 0 &&
-        !environment?.entries.some((entry) => entry.name === name) &&
-        !Object.keys(envValues).includes(name) &&
-        /^[-_.a-zA-Z][-_.a-zA-Z0-9]*$/.test(name)
-      );
-    },
-    [environment?.entries, envValues],
-  );
 
   const handleToolsetSubmit = (toolsetSlug: string) => {
     setSelectedToolsetSlug(toolsetSlug);

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1259,7 +1259,7 @@ function HookTraceRow({
         {displayServerName || "local"}
       </span>
     );
-  }, [displayServerName, toolName, skillName]);
+  }, [displayServerName, serverName, toolName, skillName]);
 
   const statusConfig = useMemo(() => {
     if (trace.hookStatus === "failure") {

--- a/client/dashboard/src/pages/integrations/Integrations.tsx
+++ b/client/dashboard/src/pages/integrations/Integrations.tsx
@@ -38,7 +38,7 @@ export default function Integrations() {
     if (!createIntegrationDialogOpen) {
       refetch();
     }
-  }, [createIntegrationDialogOpen]);
+  }, [createIntegrationDialogOpen, refetch]);
 
   return (
     <Page>

--- a/client/dashboard/src/pages/login/Login.tsx
+++ b/client/dashboard/src/pages/login/Login.tsx
@@ -20,7 +20,7 @@ export default function Login() {
         routes.home.goTo();
       }
     }
-  }, [session.session, searchParams, navigate, routes.home]);
+  }, [session.session, redirectTo, navigate, routes.home]);
 
   return (
     <main className="flex min-h-screen flex-col md:flex-row">

--- a/client/dashboard/src/pages/logs/LogFilterBar.tsx
+++ b/client/dashboard/src/pages/logs/LogFilterBar.tsx
@@ -147,12 +147,15 @@ export function LogFilterBar({
     focusMainInput();
   };
 
-  const handleOpSelect = (op: Op) => {
-    setSelectedOp(op);
-    setStep("value");
-    setFilterValue("");
-    onSearchInputChange("");
-  };
+  const handleOpSelect = useCallback(
+    (op: Op) => {
+      setSelectedOp(op);
+      setStep("value");
+      setFilterValue("");
+      onSearchInputChange("");
+    },
+    [onSearchInputChange],
+  );
 
   // Wraps the parent onSearchInputChange. During the operator step, if the
   // user types a recognised operator followed by a space (e.g. "!= ") we

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
@@ -49,7 +49,7 @@ export function AddVariableSheet({
   const [entries, setEntries] = useState([{ ...emptyEntry }]);
 
   const resetForm = useCallback(() => {
-    setEntries([{ ...emptyEntry }]);
+    setEntries([{ key: "", value: "" }]);
   }, []);
 
   const handleSave = () => {

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -953,11 +953,12 @@ function MCPToolsTab({ toolset }: { toolset: Toolset }) {
     grouped.map((group) => group.key),
   );
 
-  const groupKeys = grouped.map((group) => group.key);
+  const groupKeysJoined = grouped.map((group) => group.key).join(",");
   // Set initial selected groups when the tool list resolves
   useEffect(() => {
-    setSelectedGroups(groupKeys);
-  }, [groupKeys.join(",")]);
+    setSelectedGroups(grouped.map((group) => group.key));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- recalculate only when the set of group keys changes
+  }, [groupKeysJoined]);
 
   const handleToolUpdate = async (
     tool: Tool,

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -512,9 +512,13 @@ export function MCPAuthenticationTab({ toolset }: { toolset: Toolset }) {
   };
 
   // Check if there are any unsaved changes (including unmapped required vars and user edits)
-  const hasAnyUnsavedChanges = useMemo(() => {
-    return envVars.some(hasUnsavedChanges);
-  }, [envVars, editingState, environmentConfigs, selectedEnvironmentView]);
+  const hasAnyUnsavedChanges = useMemo(
+    () => {
+      return envVars.some(hasUnsavedChanges);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- hasUnsavedChanges is an inline fn; its reactive deps are listed explicitly
+    [envVars, editingState, environmentConfigs, selectedEnvironmentView],
+  );
 
   // Save all variables with unsaved changes
   const handleSaveAll = async () => {

--- a/client/dashboard/src/pages/mcp/MCPHostedPage.tsx
+++ b/client/dashboard/src/pages/mcp/MCPHostedPage.tsx
@@ -72,7 +72,7 @@ export function MCPPagePreview({
         setError(err.message);
         setIsLoading(false);
       });
-  }, [toolset?.mcpSlug, session.session, project.slug]);
+  }, [installPageUrl, session.session, project.slug]);
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -127,7 +127,7 @@ export function MCPPagePreview({
 
       updateScale();
     }
-  }, [rawHtml]);
+  }, [rawHtml, height]);
 
   if (error) {
     return <div className="text-red-600">Error loading page: {error}</div>;

--- a/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
+++ b/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
@@ -194,12 +194,12 @@ export function MCPTeamAccessTab({ toolset }: { toolset: Toolset }) {
   const orgRoutes = useOrgRoutes();
   const { data: membersData, isLoading: membersLoading } = useMembers();
   const { data: rolesData, isLoading: rolesLoading } = useRoles();
-  const members = membersData?.members ?? [];
-  const roles = rolesData?.roles ?? [];
 
   const [sheetData, setSheetData] = useState<ToolDetailSheet | null>(null);
 
   const memberAccess = useMemo((): MemberAccess[] => {
+    const members = membersData?.members ?? [];
+    const roles = rolesData?.roles ?? [];
     const roleMap = new Map(roles.map((r) => [r.id, r]));
     return members
       .map((member) => {
@@ -220,7 +220,7 @@ export function MCPTeamAccessTab({ toolset }: { toolset: Toolset }) {
           m.scopes.connect !== "none",
       )
       .sort((a, b) => a.member.name.localeCompare(b.member.name));
-  }, [members, roles, toolset.slug]);
+  }, [membersData?.members, rolesData?.roles, toolset.slug]);
 
   const openToolSheet = (
     row: MemberAccess,

--- a/client/dashboard/src/pages/mcp/mcp-details-utils.ts
+++ b/client/dashboard/src/pages/mcp/mcp-details-utils.ts
@@ -133,7 +133,7 @@ export function useMcpSlugValidation(
           }
         });
     }
-  }, [mcpSlug]);
+  }, [mcpSlug, currentSlug, client.toolsets]);
 
   return slugError;
 }

--- a/client/dashboard/src/pages/mcp/useEnvironmentVariables.ts
+++ b/client/dashboard/src/pages/mcp/useEnvironmentVariables.ts
@@ -252,5 +252,12 @@ export function useEnvironmentVariables(
     });
 
     return existingVars;
-  }, [toolset.slug, environments, mcpMetadata]);
+  }, [
+    toolset.securityVariables,
+    toolset.serverVariables,
+    toolset.functionEnvironmentVariables,
+    toolset.externalMcpHeaderDefinitions,
+    environments,
+    mcpMetadata,
+  ]);
 }

--- a/client/dashboard/src/pages/onboarding/Wizard.tsx
+++ b/client/dashboard/src/pages/onboarding/Wizard.tsx
@@ -1128,18 +1128,19 @@ const DefaultLogo = () => (
   </motion.div>
 );
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 const TerminalSpinner = () => {
-  const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
   const [frame, setFrame] = useState(0);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setFrame((prev) => (prev + 1) % spinnerFrames.length);
+      setFrame((prev) => (prev + 1) % SPINNER_FRAMES.length);
     }, 80);
     return () => clearInterval(interval);
   }, []);
 
-  return <span className="text-primary">{spinnerFrames[frame]}</span>;
+  return <span className="text-primary">{SPINNER_FRAMES[frame]}</span>;
 };
 
 const TerminalAnimationWithLogs = () => {
@@ -1209,6 +1210,7 @@ export default gram;`;
   // Initialize editor with MCP code
   useEffect(() => {
     setEditorCode(mcpCode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
   }, []);
 
   // Animate logs appearing one by one
@@ -1273,6 +1275,7 @@ export default gram;`;
     });
 
     return () => timers.forEach(clearTimeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mcpCode and greetCode are stable string constants defined in the component
   }, [animationKey, hasMoved]);
 
   // Check for actual tools deployment

--- a/client/dashboard/src/pages/playground/Agentify.tsx
+++ b/client/dashboard/src/pages/playground/Agentify.tsx
@@ -54,7 +54,7 @@ export const AgentifyProvider = ({
     if (!Object.keys(FRAMEWORKS[lang]).includes(framework)) {
       setFramework(FRAMEWORKS[lang][0]);
     }
-  }, [lang]);
+  }, [lang, framework]);
 
   const agentify = async (toolsetSlug: string, environmentSlug: string) => {
     telemetry.capture("agentify_event", {
@@ -223,7 +223,8 @@ export const AgentifyButton = ({
       );
       setSuggestionNumMessages(messages.length);
     });
-  }, [agentifyModalOpen]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only trigger when modal opens or message count changes
+  }, [agentifyModalOpen, messages.length, suggestionNumMessages]);
 
   const agentifyFn = async () => {
     agentify(toolsetSlug, environmentSlug);

--- a/client/dashboard/src/pages/playground/ChatWindow.tsx
+++ b/client/dashboard/src/pages/playground/ChatWindow.tsx
@@ -306,7 +306,8 @@ function ChatInner({
     });
 
     return tools;
-  }, [instance.data, client]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- configRef is a stable ref; createToolExecutor is defined inline and depends on stable refs
+  }, [instance.data, client, configRef]);
 
   // Create a list of tools for the mention system
   const mentionTools: MentionTool[] = useMemo(() => {
@@ -424,7 +425,7 @@ function ChatInner({
   }, [
     openrouterChat,
     _temperature,
-    allTools,
+    maxTokens,
     isToolTaggingEnabled,
     mentionTools,
     appendDisplayOnlyMessage,
@@ -499,7 +500,13 @@ function ChatInner({
         setUseChatMessages(initialMessagesInner);
       }
     }
-  }, [currentChatId, isChatHistoryLoading]);
+  }, [
+    currentChatId,
+    isChatHistoryLoading,
+    chatHistory,
+    _initialMessages,
+    setUseChatMessages,
+  ]);
 
   const handleSend = useCallback(
     async (msg: string) => {
@@ -525,18 +532,25 @@ function ChatInner({
       sendMessage({ text: msg });
       setInputText("");
     },
-    [chatMessages, telemetry, model, mentionTools, sendMessage],
+    [
+      chatMessages,
+      telemetry,
+      model,
+      mentionTools,
+      sendMessage,
+      isToolTaggingEnabled,
+    ],
   );
 
   useEffect(() => {
     chat.setAppendMessage((message) => {
       sendMessage({ text: message.content as string });
     });
-  }, [sendMessage]);
+  }, [sendMessage, chat]);
 
   useEffect(() => {
     setMessages(chatMessages);
-  }, [chatMessages]);
+  }, [chatMessages, setMessages]);
 
   useEffect(() => {
     setDisplayOnlyMessages([]);

--- a/client/dashboard/src/pages/playground/EditToolDialog.tsx
+++ b/client/dashboard/src/pages/playground/EditToolDialog.tsx
@@ -115,6 +115,7 @@ export function EditToolDialog({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleSave reads current state; listing all state values ensures fresh closure
   }, [
     open,
     name,

--- a/client/dashboard/src/pages/playground/ToolMentions.tsx
+++ b/client/dashboard/src/pages/playground/ToolMentions.tsx
@@ -130,6 +130,7 @@ export function ToolMentionAutocomplete({
 
     textarea.addEventListener("keydown", handleKeyDown);
     return () => textarea.removeEventListener("keydown", handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleKeyDown is intentionally omitted; its captured values (showSuggestions, filteredTools, selectedIndex) are listed explicitly
   }, [showSuggestions, filteredTools, selectedIndex, textareaRef]);
 
   // Get position for suggestions dropdown

--- a/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
+++ b/client/dashboard/src/pages/playground/usePlaygroundEnvironment.ts
@@ -64,11 +64,11 @@ export function usePlaygroundEnvironment(
     .replace(/-+$/, "");
 
   const { data: environmentsData } = useListEnvironments();
-  const environments = environmentsData?.environments ?? [];
 
   const existingEnvironment = useMemo(
-    () => environments.find((env) => env.slug === slug),
-    [environments, slug],
+    () =>
+      (environmentsData?.environments ?? []).find((env) => env.slug === slug),
+    [environmentsData?.environments, slug],
   );
 
   const storedEntries = useMemo(

--- a/client/dashboard/src/pages/toolBuilder/ToolBuilder.tsx
+++ b/client/dashboard/src/pages/toolBuilder/ToolBuilder.tsx
@@ -247,6 +247,7 @@ function ToolBuilder({ initial }: { initial: ToolBuilderState }) {
     setPurpose(initial.purpose);
     setInputs(initial.inputs);
     setSteps(initial.steps.map(makeStep));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- makeStep depends on tools/setStep which are derived from initial; re-running on initial change is correct
   }, [initial]);
 
   const insertTool = (
@@ -284,15 +285,17 @@ function ToolBuilder({ initial }: { initial: ToolBuilderState }) {
   useEffect(() => {
     const allInputs = steps.flatMap((step) => parseInputs(step.instructions));
     allInputs.push(...parseInputs(purpose));
-    const currentInputs = inputs.map((input) => input.name);
 
-    const curFiltered = inputs.filter((input) =>
-      allInputs.includes(input.name),
-    );
-    const toInsert = allInputs.filter(
-      (input) => !currentInputs.includes(input),
-    );
-    setInputs([...curFiltered, ...toInsert.map((input) => ({ name: input }))]);
+    setInputs((prevInputs) => {
+      const currentInputs = prevInputs.map((input) => input.name);
+      const curFiltered = prevInputs.filter((input) =>
+        allInputs.includes(input.name),
+      );
+      const toInsert = allInputs.filter(
+        (input) => !currentInputs.includes(input),
+      );
+      return [...curFiltered, ...toInsert.map((input) => ({ name: input }))];
+    });
   }, [steps, purpose]);
 
   const validateName = (v: string) => {

--- a/client/dashboard/src/pages/toolsets/Toolset.tsx
+++ b/client/dashboard/src/pages/toolsets/Toolset.tsx
@@ -222,6 +222,7 @@ export function ToolsetView({
     if (newTab !== activeTab) {
       setActiveTab(newTab);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- getTabFromHash reads location.hash; activeTab excluded to avoid loop
   }, [location.hash]);
 
   // Redirect to appropriate default tab based on toolset kind
@@ -242,6 +243,7 @@ export function ToolsetView({
       setActiveTab("tools");
       navigate("#tools", { replace: true });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only redirect on toolset kind change; activeTab/navigate/isExternalMcpProxy excluded to avoid loops
   }, [toolset?.kind]);
 
   // Update URL hash when tab changes
@@ -300,9 +302,8 @@ export function ToolsetView({
     return () => {
       removeActions(pageActions.map((a) => a.id));
     };
-    // addActions and removeActions are memoized in CommandPaletteContext with empty deps
-    // so they're stable and don't need to be in the dependency array
-  }, [toolsetSlug, toolset?.kind]); // Re-run when toolset slug or kind changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- routes changes every render; addActions/removeActions/cloneToolset are stable
+  }, [toolsetSlug, toolset?.kind]);
 
   // Refetch any loaded instances of this toolset on update (primarily for the playground)
   const refetchInstance = () => {
@@ -410,12 +411,13 @@ export function ToolsetView({
         },
       );
     },
-    [toolset?.toolUrns, toolsetSlug],
+    [toolset?.toolUrns, toolsetSlug, telemetry, updateToolsetMutation],
   );
 
   const handleTestInPlayground = useCallback(() => {
     routes.playground.goTo(toolsetSlug);
-  }, [toolsetSlug]); // routes changes every render but is used in closure
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- routes changes every render but goTo is stable
+  }, [toolsetSlug]);
 
   const handleCreateToolset = useCallback((toolUrns: string[]) => {
     setSelectedToolUrns(toolUrns);

--- a/client/dashboard/src/pages/toolsets/ToolsetDropown.tsx
+++ b/client/dashboard/src/pages/toolsets/ToolsetDropown.tsx
@@ -3,7 +3,7 @@ import { Combobox } from "@/components/ui/combobox";
 import { capitalize } from "@/lib/utils";
 import { ToolsetEntry } from "@gram/client/models/components";
 import { useListToolsets } from "@gram/client/react-query";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 export function ToolsetDropdown({
   selectedToolset,
@@ -22,15 +22,16 @@ export function ToolsetDropdown({
 }) {
   const { data: toolsets } = useListToolsets();
 
-  const toolsetDropdownItems =
-    toolsets?.toolsets?.map((toolset) => ({
-      ...toolset,
-      label: toolset.name,
-      value: toolset.slug,
-    })) ?? [];
-
-  toolsetDropdownItems.sort(
-    (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+  const toolsetDropdownItems = useMemo(
+    () =>
+      (
+        toolsets?.toolsets?.map((toolset) => ({
+          ...toolset,
+          label: toolset.name,
+          value: toolset.slug,
+        })) ?? []
+      ).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()),
+    [toolsets?.toolsets],
   );
 
   // Set the default selection if no selection is made
@@ -42,7 +43,12 @@ export function ToolsetDropdown({
     ) {
       setSelectedToolset(toolsetDropdownItems[0]!);
     }
-  }, [toolsetDropdownItems, defaultSelection, setSelectedToolset]);
+  }, [
+    toolsetDropdownItems,
+    defaultSelection,
+    setSelectedToolset,
+    selectedToolset,
+  ]);
 
   return (
     <Combobox

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -571,7 +571,8 @@ export const useRoutes = (overrides?: {
 
   const routes: RoutesWithGoTo = useMemo(
     () => addGoToToRoutes(ROUTE_STRUCTURE),
-    [location.pathname],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- addGoToToRoutes is stable in behavior; recompute only when pathname or slugs change
+    [location.pathname, orgSlug, projectSlug, navigate],
   );
 
   return routes;
@@ -807,7 +808,8 @@ export const useOrgRoutes = (): OrgRoutesWithGoTo => {
 
   const routes: OrgRoutesWithGoTo = useMemo(
     () => addGoToToRoutes(ORG_ROUTE_STRUCTURE),
-    [location.pathname],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- addGoToToRoutes is stable in behavior; recompute only when pathname or slug change
+    [location.pathname, orgSlug, navigate],
   );
 
   return routes;


### PR DESCRIPTION
## Summary

- Re-enable `react-hooks/exhaustive-deps` at `"error"` level (was `"off"`)
- Fix all 81 violations across 44 files
- Prevents stale closure bugs and infinite re-render loops from missing hook dependencies

## Fix strategies used

- **Added missing deps** — stable values (slugs, IDs, library hooks like `navigate`)
- **Wrapped in `useMemo`** — for `data?.items ?? []` patterns creating new array refs each render
- **Wrapped in `useCallback`** — for inline function deps that change every render
- **`eslint-disable` with reason** — for intentional omissions (run-once effects, mutation objects that would loop)
- **Moved logic inside callback** — for conditionals that destabilize dep arrays

## Test plan

- [x] ESLint passes with zero `exhaustive-deps` violations
- [x] TypeScript type-check passes
- [ ] Smoke test dashboard in browser — key flows: playground, MCP details, toolsets, catalog, onboarding
- [ ] Verify no infinite re-render loops introduced

Closes AGE-1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)