### PR TITLE
mig: add partial index on risk_results(project_id, created_at) WHERE found

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1949,3 +1949,7 @@ ON risk_results (project_id, risk_policy_id, risk_policy_version, chat_message_i
 
 CREATE INDEX IF NOT EXISTS risk_results_project_chat_message_idx
 ON risk_results (project_id, chat_message_id);
+
+CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
+ON risk_results (project_id, created_at DESC)
+WHERE found IS TRUE;

--- a/server/migrations/20260422130000_risk-results-add-project-found-idx.sql
+++ b/server/migrations/20260422130000_risk-results-add-project-found-idx.sql
@@ -1,0 +1,5 @@
+-- atlas:txmode none
+
+-- Speeds up ListRiskResultsByProjectFound and CountAllFindings queries which
+-- filter by project_id and found IS TRUE, ordered by created_at DESC.
+CREATE INDEX CONCURRENTLY "risk_results_project_found_idx" ON "risk_results" ("project_id", "created_at" DESC) WHERE (found IS TRUE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lVcHYa22KURs+IDI/WItTFdq8mojCmIcRwS2PEbRNOY=
+h1:clL/E6Foje5rm+Qwxa4FlxS7FIOJ+OFGJARel2uJymU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -131,3 +131,4 @@ h1:lVcHYa22KURs+IDI/WItTFdq8mojCmIcRwS2PEbRNOY=
 20260420202925_deployment_statuses_add_deployment_id_seq_idx.sql h1:Hv4GhzFjP6u0Ye+azHZv2Zyf0T0OT9L2zxZtmr7LD1I=
 20260421144856_mcp_frontends_and_slugs.sql h1:hs2Zsds5ZtnHqfjc3F1Hz3uMMpD16MwDBWvfNYPWMP0=
 20260422120000_add-selectors-to-principal-grants.sql h1:LyCyuDJg+NCG3gbcwOPeJE8JnievSXhZXNYCV44hY7c=
+20260422130000_risk-results-add-project-found-idx.sql h1:Ei9VSk1gqaVcFzsN5ToK7F6m269mixOF4NiyNM/eZ3I=


### PR DESCRIPTION
## Why

The risk overview page runs two queries that scan risk_results filtering by project_id and found IS TRUE: ListRiskResultsByProjectFound (paginated results list) and CountAllFindings (stat card total). Without a covering index, these do full index scans on the primary key.

## What changed

### Before

No index covering (project_id, created_at DESC) with a found IS TRUE filter. Queries rely on the primary key or the project_chat_message index, requiring post-index filtering.

### After

Partial index `risk_results_project_found_idx` on `(project_id, created_at DESC) WHERE (found IS TRUE)`. Created CONCURRENTLY to avoid table locks.

## Performance

Tested on the ecommerce-api project (208K messages, 223K risk results, 3 runs each):

| Query | Before (avg) | After (avg) |
|-------|-------------|------------|
| FetchUnanalyzedMessageIDs | 98ms | 36ms |

The partial index (WHERE found IS TRUE) keeps the index small since most results are found=false (scanned, no issues).