### PR TITLE
chore(skills): add gram-audit-logging, gram-management-api, and gram-rbac skills

### DIFF
--- a/.agents/skills/gram-audit-logging/SKILL.md
+++ b/.agents/skills/gram-audit-logging/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: gram-audit-logging
+description: Concepts, external interfaces, and conventions for Gram's audit logging subsystem — the internal Go API for recording actor/action/subject events and the `/rpc/auditlogs.*` management API that exposes them. Activate whenever the task involves recording or exposing audit events (adding or changing audit coverage on a service, introducing a new audited subject or action, writing tests that assert an event was recorded, changing how entries are displayed or filtered).
+metadata:
+  relevant_files:
+    - "server/internal/audit/**/*.go"
+    - "server/internal/audit/**/*.sql"
+    - "server/design/auditlogs/**"
+---
+
+Audit logging is how Gram records _who did what to which resource_. Every meaningful mutation on a project- or org-scoped resource is expected to produce one audit entry, written inside the same database transaction as the mutation so events can't drift from the state they describe. Entries are exposed to Gram users through the `auditlogs` management API.
+
+## Concepts and terminology
+
+**Actor.** The principal that caused the event — a `urn.Principal` carrying a type (user, role, service account) and an id, with optional display name and slug for human rendering.
+
+**Subject.** The resource the event is about — identified by a subject type (e.g. `remote_mcp_server`, `access_role`) and a subject id.
+
+**Action.** What happened to the subject. Each subject declares its own set of actions, typically one per mutating verb on the subject's life cycle.
+
+**Before/after snapshot.** Optional opaque JSON payloads describing the subject's state. Populated on updates, left empty on creates and deletes unless the snapshot is independently useful.
+
+**Metadata.** Optional JSON bag for contextual fields that are not part of the subject's state.
+
+**Scoping.** Every entry belongs to exactly one organization and zero or one projects. Org-scoped subjects (roles, members) carry no project id; project-scoped subjects carry the project UUID.
+
+**Atomicity.** Audit entries are written inside the same database transaction as the mutation they describe, so the state and the record of the state commit together or not at all.
+
+## Server
+
+Audit logging lives in `server/internal/audit/` with its management-API surface defined in `server/design/auditlogs/`. Callers are other services whose handlers emit events; the `auditlogs` Goa service reads them back.
+
+### Conventions
+
+**Where types live.** The package-private `subjectType` string type and every `subjectType*` constant live in `server/internal/audit/events.go`. The public `Action` string type and the `marshalAuditPayload` snapshot helper live in the same file. The subject-type const block is kept alphabetised.
+
+**Subject type naming.** Subject type values are short snake_case strings (e.g. `remote_mcp_server`, `access_role`). Constants follow the `subjectType<Name>` pattern.
+
+**Action naming.** Values follow `<subject-slug>:<verb>` (e.g. `remote-mcp:create`, `access_role:update`). Verbs are typically `create` / `update` / `delete`; subjects may add feature-specific verbs (`toolset:attach_oauth_proxy`).
+
+**Subject files.** One Go file per subject under `server/internal/audit/`, named after the subject in plural form (e.g. `remotemcpservers.go`, `toolsets.go`). Each file owns that subject's `Action*` constants, its `Log*Event` payload structs, and its `Log*` functions. Do not merge subjects into a shared file.
+
+**`Log*Event` and `Log*` naming.** One `Log<Verb>Event` struct plus one `Log<Verb>` function per action, declared in the subject file. `Log*` functions take `(ctx, dbtx repo.DBTX, event Log*Event) error` so the audit insert is atomic with the caller's mutation.
+
+### Non-generated files
+
+| File                                                              | Purpose                                                                                                                                     |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/design/auditlogs/design.go`                               | Goa design for the `auditlogs` service. Regenerates `server/gen/auditlogs/` and `server/gen/http/auditlogs/` via `mise run gen:goa-server`. |
+| `server/internal/audit/<subject>.go`                              | One file per subject (e.g. `access.go`, `remotemcpservers.go`, `toolsets.go`).                                                              |
+| `server/internal/audit/audittest/helpers.go`                      | Test helpers other packages use to assert audit events.                                                                                     |
+| `server/internal/audit/audittest/queries.sql`                     | SQLc queries backing the test helpers. Regenerates `server/internal/audit/audittest/repo/` via `mise run gen:sqlc-server`.                  |
+| `server/internal/audit/events.go`                                 | Top-level declarations shared across every subject.                                                                                         |
+| `server/internal/audit/impl.go`                                   | Implementation of the `/rpc/auditlogs.*` Goa service (reads).                                                                               |
+| `server/internal/audit/queries.sql`                               | SQLc queries for the audit log table. Regenerates `server/internal/audit/repo/` via `mise run gen:sqlc-server`.                             |
+| `server/internal/audit/{setup_test,list_test,listfacets_test}.go` | Tests for the `auditlogs` management API.                                                                                                   |
+
+### Generated files
+
+Files under `server/gen/**` and any `repo/` subdirectory carry a `DO NOT EDIT` header.
+
+| Path                                                  | Generator                                                                                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `server/gen/auditlogs/`, `server/gen/http/auditlogs/` | `mise run gen:goa-server` from `server/design/auditlogs/design.go`.                                                             |
+| `server/internal/audit/audittest/repo/`               | `mise run gen:sqlc-server` from `server/internal/audit/audittest/queries.sql` (separate stanza in `server/database/sqlc.yaml`). |
+| `server/internal/audit/repo/`                         | `mise run gen:sqlc-server` from `server/internal/audit/queries.sql` (via the `audit` stanza in `server/database/sqlc.yaml`).    |
+
+## Server-client contract
+
+Audit entries are surfaced to Gram users through a small, fixed set of endpoints. New actions and subject types appear automatically — facets are computed from the rows that exist, so there is no registration step outside the Go code.
+
+**HTTP routes** (design: `server/design/auditlogs/design.go`):
+
+- `GET /rpc/auditlogs.list` — paginated list; supports cursor, `project_slug`, `actor_id`, and `action` filters.
+- `GET /rpc/auditlogs.listFacets` — returns the set of actors and actions that actually appear, for UI facet pickers.
+
+**Generated client surfaces** — regenerated by `mise run gen:goa-server` then `mise run gen:sdk`:
+
+- TypeScript SDK: `client/sdk/src/funcs/auditlogs*.ts`, `client/sdk/src/react-query/auditlogs*.ts`, plus models under `client/sdk/src/models/`.
+- CLI bindings: `server/gen/http/cli/gram/cli.go`.
+
+## Jobs to be done
+
+### How to audit a handler in a service
+
+When a handler mutates a resource whose subject already has `Action*`/`Log*` definitions, the handler opts in by calling the existing `Log*` function. The call has to happen inside the same `dbtx` as the mutation so the audit row and the state it describes commit together.
+
+1. Open the service's `impl.go` and locate the handler. Confirm the handler already uses a transaction; if not, wrap the repo calls in `s.db.Begin(ctx)` → `defer o11y.NoLogDefer(rollback)` → `dbtx.Commit(ctx)`.
+2. After the primary repo writes succeed and before `Commit`, call the subject's `audit.Log<Verb>` with a populated `Log<Verb>Event`. Pass the same `dbtx` the repo writes used so the audit row commits atomically with them.
+3. Build the actor from `contextvalues.GetAuthContext(ctx)` — typically `urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)`, plus `authCtx.Email` for `ActorDisplayName`. Principal types live in `server/internal/urn`. Fill in the subject-specific identifier fields (subject id, display name, slug) from the repo row you just wrote.
+4. For updates, populate `SnapshotBefore` and `SnapshotAfter` with the pre- and post-mutation state. For creates and deletes, leave them nil unless the snapshot is independently useful.
+5. Treat audit-log failures as `oops.CodeUnexpected`. Audit logging is not optional — if it fails, fail the request.
+6. Add a test that asserts the event was recorded (see "How to assert audit events in tests" below).
+
+### How to add a new action to an existing subject
+
+Use this when the subject already has a file but you're introducing a new verb.
+
+1. In the subject's file, add an `Action<Subject><Verb>` constant alongside the existing ones.
+2. Add a `Log<Subject><Verb>Event` struct with the fields the caller needs to supply. At minimum: `OrganizationID`, `ProjectID` (zero value for org-scoped subjects), `Actor`, `ActorDisplayName`, `ActorSlug`, plus subject-specific identifier fields (`<Subject>ID`, display name, slug). Updates additionally carry `SnapshotBefore any` and `SnapshotAfter any`.
+3. Add a `Log<Subject><Verb>` function that translates the event into `repo.InsertAuditLogParams`, passes any snapshots through `marshalAuditPayload` (which handles nil internally), calls `repo.New(dbtx).InsertAuditLog`, and wraps errors with `fmt.Errorf("log %s: %w", action, err)`.
+4. Call the new function from the handler as described under "How to audit a handler in a service".
+
+No schema change, no codegen step — facet queries pick up the new action automatically.
+
+### How to add a new audited subject
+
+Use this when introducing an entirely new kind of resource that doesn't map onto any existing subject file.
+
+1. Add a `subjectType<Name>` constant to `events.go`.
+2. Create `server/internal/audit/<subject>.go` following the subject-file convention, and populate it with the `Action*` constants, `Log*Event` structs, and `Log*` functions.
+3. Call the new `Log*` functions from the owning service's handlers.
+
+### How to update an existing action or subject
+
+1. **Renaming an `Action` value is a breaking change** for consumers of `auditlogs.list` that filter on action strings. Avoid it; add a new action and dual-write if a behaviour rename is needed.
+2. Adding a new field to a `Log*Event` struct is safe — update every call site (`exhaustruct` will flag missed ones).
+3. Changing the shape of `SnapshotBefore`/`SnapshotAfter` is safe for new rows only; old rows retain the old shape. If consumers parse snapshots, version the payload inside the JSON.
+4. Do not edit the string values of `subjectType*` constants; the same breakage argument as action renames applies.
+
+### How to assert audit events in tests
+
+Use `audittest` helpers in the service's test package — do not query the audit tables directly.
+
+1. Capture a baseline count with `audittest.AuditLogCountByAction(ctx, conn, audit.Action<Foo>)`.
+2. Exercise the handler.
+3. Assert `after == before + 1` (or the expected delta).
+4. For snapshot correctness, fetch the row with `audittest.LatestAuditLogByAction` and decode `Metadata`, `BeforeSnapshot`, or `AfterSnapshot` with `audittest.DecodeAuditData`.
+
+## Relevant mise tasks
+
+| Task                       | Purpose                                                                                                                        |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `mise run gen:goa-server`  | Regenerate `server/gen/auditlogs/**` whenever you edit `server/design/auditlogs/design.go`.                                    |
+| `mise run gen:sdk`         | Regenerate the TypeScript SDK and CLI bindings after a Goa design change.                                                      |
+| `mise run gen:sqlc-server` | Regenerate `server/internal/audit/repo/` and `audittest/repo/`. Run whenever you change `queries.sql` in either place.         |
+| `mise run lint:server`     | `golangci-lint` including `exhaustruct` — keep struct literals complete when adding fields to `Log*Event`.                     |
+| `mise run test:server`     | Runs the full server test suite. Takes the same arguments as `go test` (e.g. `./internal/audit/... ./internal/remotemcp/...`). |
+
+## Maintaining this skill
+
+This file documents conventions that evolve over time. Adding a new action, subject, or filter is already covered by "Jobs to be done" — those don't require skill edits. Structural changes do. Update this skill in the same commit when you make any of the following kinds of changes:
+
+- Reorganising per-subject files (moving away from one-file-per-subject, merging subjects, renaming the plural convention).
+- Renaming or reshaping `Log*Event` fields, or changing the `Log*` function signature.
+- Replacing `marshalAuditPayload` or changing how snapshots are encoded.
+- Moving audit code out of `server/internal/audit/`.
+- Changing how facets are computed — today they derive from row data with no registration; if that changes, the "no registration step" claim stops being true.
+- Adding a new audit-relevant mise task that belongs on the cheat sheet.
+- Introducing a new top-level concept (a new principal type for actors, a new kind of subject scoping beyond org/project, etc.).
+
+## Cross-references
+
+- `gram-management-api` — the `auditlogs` service is itself a management API; adding a new endpoint or filter follows that skill's flow.
+- `gram-rbac` — `access_role`, `access_member`, and other RBAC mutations are audited via `server/internal/audit/access.go`.
+- `golang` — `oops` error wrapping, `slog` logging, transaction patterns, and the black-box `setup_test.go` convention used by audit tests and service tests.
+- `postgresql` — when adding or changing SQLc queries in `audit/queries.sql` or `audittest/queries.sql`.
+- `mise-tasks` — when modifying the generator scripts under `.mise-tasks/gen/`.

--- a/.agents/skills/gram-management-api/SKILL.md
+++ b/.agents/skills/gram-management-api/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: gram-management-api
+description: Concepts, external interfaces, and conventions for Gram's management API — the Goa-designed HTTP-RPC surface under `/rpc/<service>.<method>` that powers the dashboard, CLI, and public SDK. Activate whenever the task involves designing, implementing, or modifying a management endpoint (new service, new method, payload/result changes, OpenAPI/SDK surface changes, CLI changes, wiring a new service into the server).
+metadata:
+  relevant_files:
+    - "server/design/**/*.go"
+    - "server/internal/*/impl.go"
+    - "server/internal/*/queries.sql"
+    - "server/internal/*/setup_test.go"
+    - "server/internal/mv/**/*.go"
+    - "server/cmd/gram/start.go"
+    - ".changeset/**/*.md"
+---
+
+Gram's management API is the internal HTTP-RPC surface that the dashboard, CLI, and SDK use to administer projects, toolsets, deployments, access, and related resources. Every endpoint lives at `/rpc/<service>.<method>`, is authored in Goa DSL under `server/design/`, implemented in a single `Service` struct per package under `server/internal/<service>/`, and exposed through generated server stubs, OpenAPI, CLI bindings, and a TypeScript SDK.
+
+## Concepts and terminology
+
+**Service.** A named collection of related endpoints (e.g. `remoteMcp`, `access`, `auditlogs`). Each service maps one-to-one to a Go package of the same name.
+
+**Method.** A single endpoint on a service. Exposed as `/rpc/<service>.<method>`.
+
+**Payload / Result.** The input and output types for a method. Payloads are composed from shared security payloads plus method-specific form attributes.
+
+**Security scheme.** The authentication mechanism a method accepts. Gram's management endpoints use three schemes: **Session** (browser cookie), **ByKey** (API key header), and **ProjectSlug** (project-selector header). Additional schemes exist for non-management surfaces and are out of scope here.
+
+**Model views (`mv`).** Stateless functions that convert database row types into API response types. Keep database types out of the API boundary — handlers always return a view, never a `repo` struct.
+
+**Handler.** One method implementation on the `Service` struct.
+
+**Management API vs public SDK.** The same Goa design produces two OpenAPI outputs: an internal spec used to generate the TypeScript SDK that powers the dashboard and CLI, and a public spec derived from it via redaction overlays. Only the internal SDK sees every endpoint.
+
+**Changeset.** A short changelog file written alongside a change that identifies which package bumps (server, dashboard, sdk) and by how much (`patch`, `minor`, `major`).
+
+## Server
+
+The design, implementation, tests, and per-service generated code for every management endpoint live under `server/`.
+
+### Conventions
+
+**Naming.** Goa service names (e.g. `remoteMcp`, `auditlogs`) and method names (e.g. `createServer`) are camelCase. DSL types (e.g. `CreateServerForm`, `RemoteMcpServer`) are PascalCase. Go package names under `server/internal/` and `server/design/` are lowercase with no separators (e.g. `remotemcp`).
+
+**Design layout.** Service DSL lives at `server/design/<svc>/design.go`. The service package must be blank-imported in `server/design/gram.go` (alphabetised) for the generator to pick it up.
+
+**HTTP methods.** Read methods use `GET`; mutations use `POST`. Deletes that carry only an id query parameter use `DELETE`.
+
+**Security DSL helpers.** `server/design/security/` exports the `Session`, `ByKey`, and `ProjectSlug` schemes plus paired helpers — `SessionPayload()`/`SessionHeader()`, `ByKeyPayload()`/`ByKeyHeader()`, `ProjectPayload()`/`ProjectHeader()` — that attach the right payload field and HTTP header to a method.
+
+**Security composition.** Most management endpoints advertise `Session` and `ByKey` side-by-side via repeated `Security(...)` calls on the service so the dashboard and API-key clients can both reach them. Project-scoped endpoints additionally layer `ProjectSlug` via `ProjectPayload()` / `ProjectHeader()` so the caller must name a project.
+
+**Shared errors.** Every service calls `shared.DeclareErrorResponses()` (from `server/design/shared/errors.go`) exactly once so the standard Gram error envelope applies to every method.
+
+**Shared types.** When a payload or result type is reused across services, add `Meta("struct:pkg:path", "types")` so the generator emits it under `server/gen/types/` instead of the per-service package.
+
+**OpenAPI meta keys.** Every method has three metadata keys that control the downstream SDK/CLI names:
+
+- `Meta("openapi:operationId", "verbNounSubject")` — OpenAPI operation id.
+- `Meta("openapi:extension:x-speakeasy-name-override", "methodName")` — method name on the SDK service class.
+- `Meta("openapi:extension:x-speakeasy-react-hook", '{"name": "HookName"}')` — React Query hook name.
+
+**`impl.go` layout.** Lives at `server/internal/<svc>/impl.go`. Contains the `Service` struct (injected dependencies — tracer, logger, database pool, `*auth.Auth`, `*access.Manager`, plus feature-specific fields), compile-time assertions (`var _ gen.Service = (*Service)(nil)`, and `var _ gen.Auther = (*Service)(nil)` when `ByKey` is advertised), a `NewService(...)` constructor, an `Attach(mux, service)` wiring function, `APIKeyAuth` when `ByKey` is advertised, and one method per Goa `Method` declaration.
+
+**Model view files.** `server/internal/mv/<svc>.go` (singular or per-resource — e.g. `remotemcpserver.go`). Exported functions are named `Build<Subject>View` and `Build<Subject>ListView`. The package doc calls these "model views", which is where the package name comes from.
+
+**Wiring.** New services are attached in `server/cmd/gram/start.go` with `<svc>.Attach(mux, <svc>.NewService(...))` near the other service attachments.
+
+**SQLc.** Per-service queries live in `server/internal/<svc>/queries.sql`. Every new service requires a stanza in `server/database/sqlc.yaml` pointing at its queries file and writing to `server/internal/<svc>/repo/`.
+
+**Test layout.** Tests live in `package <svc>_test` (black-box). A single `setup_test.go` per service defines `TestMain` (calling `testenv.Launch`) and a `newTestService(t)` factory that clones a fresh test database, seeds an auth context, and returns the live `*Service`. Package-local helpers typically include `withExactAccessGrants` for scope setup and `requireOopsCode` for error-shape assertions. One `<method>_test.go` per handler.
+
+### Common code flows
+
+**Handler skeleton.** Inside each method: extract `authCtx` from context → `s.access.Require(...)` → validate inputs → repo work → return `mv.Build<Subject>View(...)`. Handlers never return `repo` types directly. For mutation handlers, wrap the repo work in a transaction — `s.db.Begin(ctx)` → `defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })` → repo writes → `audit.Log*` → `dbtx.Commit(ctx)` — so the audit row and the state it describes commit atomically. Read handlers typically don't need a transaction or audit call.
+
+**`Attach` wiring.** `func Attach(mux goahttp.Muxer, service *Service)` constructs `gen.NewEndpoints(service)`, layers the `middleware.MapErrors()` and `middleware.TraceMethods(tracer)` middleware, and mounts the endpoints via `srv.Mount(mux, srv.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, nil, nil))`.
+
+### Non-generated files
+
+Substitute the service name for `<svc>` and the method name for `<method>`.
+
+| Path                                           | Purpose                                                                                                               |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `server/.golangci.yaml`                        | Per-file linter exceptions.                                                                                           |
+| `server/cmd/gram/start.go`                     | Wires every service into the HTTP mux.                                                                                |
+| `server/design/<svc>/design.go`                | The service's Goa design. Regenerates `server/gen/<svc>/` and `server/gen/http/<svc>/` via `mise run gen:goa-server`. |
+| `server/design/gram.go`                        | Root Goa import graph. Regenerates the aggregate `server/gen/**` tree via `mise run gen:goa-server`.                  |
+| `server/design/security/`                      | Shared security schemes and helpers.                                                                                  |
+| `server/design/shared/`                        | Design types shared across services.                                                                                  |
+| `server/internal/<svc>/<method>_test.go`       | Black-box test file, one per method.                                                                                  |
+| `server/internal/<svc>/impl.go`                | The service implementation.                                                                                           |
+| `server/internal/<svc>/queries.sql`            | The service's SQLc queries. Regenerates `server/internal/<svc>/repo/` via `mise run gen:sqlc-server`.                 |
+| `server/internal/<svc>/setup_test.go`          | Shared test harness for the service.                                                                                  |
+| `server/internal/<svc>/shared.go` (or similar) | Non-trivial helpers specific to the service.                                                                          |
+| `server/internal/mv/<svc>.go`                  | View builders for the service's response types.                                                                       |
+
+### Generated files
+
+Files under `server/gen/**` and any `repo/` subdirectory carry a `DO NOT EDIT` header.
+
+| Path                                                                                                         | Generator                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `server/gen/<svc>/{service.go, client.go, endpoints.go}`                                                     | `mise run gen:goa-server` from `server/design/<svc>/design.go`.                                                                |
+| `server/gen/http/<svc>/{server,client}/{server.go, client.go, cli.go, encode_decode.go, paths.go, types.go}` | `mise run gen:goa-server` from `server/design/<svc>/design.go`.                                                                |
+| `server/gen/types/`                                                                                          | `mise run gen:goa-server` — aggregates types across services that mark `Meta("struct:pkg:path", "types")`.                     |
+| `server/internal/<svc>/repo/{db.go, models.go, queries.sql.go}`                                              | `mise run gen:sqlc-server` from `server/internal/<svc>/queries.sql` (via the service's stanza in `server/database/sqlc.yaml`). |
+
+## Server-client contract
+
+The server's design authors the contract; clients receive it through generated OpenAPI, a TypeScript SDK, and CLI bindings. The contract is versioned through changesets.
+
+**HTTP routes.** `/rpc/<service>.<method>`. Method names are derived from the Goa `Service`/`Method` names — renaming them is a breaking change for CLI and any direct HTTP callers.
+
+**OpenAPI.** `server/gen/http/openapi3.yaml` and `openapi3.json` are the raw Goa outputs. `.speakeasy/workflow.yaml` defines two sources (`Gram-Internal`, `Gram-Public`) that apply overlays from `.speakeasy/overlays/` to produce `.speakeasy/out.openapi.yaml` and `.speakeasy/openapi-public.yaml`. The TypeScript SDK is generated from the internal spec.
+
+**TypeScript SDK.** `client/sdk/` — per-operation modules under `src/funcs/`, a per-service class under `src/sdk/`, React Query hooks under `src/react-query/`, and model types under `src/models/{components,operations}/`.
+
+**CLI bindings.** `server/gen/http/cli/gram/cli.go` provides command bindings over the same endpoints.
+
+**Changesets.** `.changeset/<kebab-slug>.md` with YAML frontmatter of the form `"server": minor` (or `"dashboard": patch`, etc.) and a one-paragraph body. A new endpoint is usually `"server": minor`; a bug fix or dashboard-only change is `patch`.
+
+**Regeneration.** After any design change, run `mise run gen:goa-server` (server stubs, OpenAPI, CLI), then `mise run gen:sdk` (Speakeasy overlays, TypeScript SDK, the public OpenAPI output). `gen:sdk` accepts `--check` (fail if outputs drift), `--skip-versioning` (no version bump during iteration), and `--skip-upload-spec` (skip the Speakeasy registry upload).
+
+## Jobs to be done
+
+### How to add a new method to an existing service
+
+1. Edit the service's `server/design/<svc>/design.go` — add a `Method("<method>", ...)` block with `Payload`, `Result`, `HTTP(...)`, and the three OpenAPI meta keys.
+2. Run `mise run gen:goa-server` to regenerate the service interface and HTTP server code.
+3. Implement the new method on the service in `server/internal/<svc>/impl.go`, following the handler skeleton.
+4. Add any required SQLc queries to `server/internal/<svc>/queries.sql` and run `mise run gen:sqlc-server`.
+5. Add a view builder in `server/internal/mv/<svc>.go` if the response introduces a new shape.
+6. Gate the handler with an existing RBAC scope (see `gram-rbac` skill) and emit audit events for mutations (see `gram-audit-logging` skill).
+7. Write a `<method>_test.go` file covering the happy path plus the RBAC-deny and not-found / bad-request paths.
+8. Run `mise run lint:server` and `mise run test:server ./internal/<svc>/...`.
+9. Run `mise run gen:sdk` to propagate the change into the TypeScript SDK and OpenAPI outputs.
+10. Add `.changeset/<kebab-slug>.md` with `"server": minor`.
+
+### How to add a brand-new management API service
+
+1. Add a blank import for the new package in `server/design/gram.go` (alphabetised).
+2. Create `server/design/<svc>/design.go` with the service declaration, `Security(...)` calls, `shared.DeclareErrorResponses()`, and the initial set of methods.
+3. Add a stanza in `server/database/sqlc.yaml` pointing at `server/internal/<svc>/queries.sql` and writing to `server/internal/<svc>/repo`.
+4. Author `server/internal/<svc>/queries.sql`.
+5. Run `mise run gen:goa-server` and `mise run gen:sqlc-server` (or `mise run gen:server` which runs both).
+6. Implement `server/internal/<svc>/impl.go`: `Service` struct, compile-time assertions, `NewService`, `Attach`, `APIKeyAuth` (when `ByKey` is advertised), and each method handler.
+7. Add view builders in `server/internal/mv/<svc>.go`.
+8. Wire the service into `server/cmd/gram/start.go` with `<svc>.Attach(mux, <svc>.NewService(...))` near the other attachments.
+9. Add `server/internal/<svc>/setup_test.go` plus one `<method>_test.go` per handler.
+10. Add any new RBAC scopes (`gram-rbac`) and audit subjects (`gram-audit-logging`) the service needs.
+11. Run `mise run lint:server`, `mise run test:server`, and `mise run gen:sdk`.
+12. Add `.changeset/<kebab-slug>.md` with `"server": minor`.
+13. Run `mise run go:tidy` if imports changed.
+
+### How to change a payload or result type
+
+1. Edit the type in `server/design/<svc>/design.go`. Prefer additive changes: new `Attribute` calls on existing types are backwards compatible; `Required("...")` additions and attribute removals are not.
+2. Run `mise run gen:goa-server`.
+3. Update the handler in `server/internal/<svc>/impl.go` to populate or consume the new fields. `exhaustruct` will flag missed struct fields at lint time.
+4. Update the view builder in `server/internal/mv/<svc>.go` if the response type changed.
+5. Run `mise run gen:sdk` to propagate to the SDK surface, then update any dashboard consumers (see `frontend` skill).
+6. Update tests to cover the new shape.
+7. Add `.changeset/<kebab-slug>.md` — `"server": patch` for additive changes, `minor` for anything consumers would notice.
+
+### How to rename an endpoint or override its SDK / hook name
+
+SDK surface names are controlled by OpenAPI metadata, not by renaming Go symbols.
+
+1. Change `Meta("openapi:operationId", ...)`, `x-speakeasy-name-override`, and/or `x-speakeasy-react-hook` on the `Method` in the design file.
+2. Run `mise run gen:goa-server` then `mise run gen:sdk` to regenerate the SDK and hook names.
+3. Update dashboard consumers to use the new names (see `frontend` skill).
+4. Note that the HTTP path is derived from the Goa `Service`/`Method` names — changing those is a breaking change for CLI and any direct HTTP callers. Prefer adding a new method and deprecating the old.
+
+### How to regenerate outputs after a design change
+
+Order matters because each step's output is the next step's input.
+
+1. `mise run gen:goa-server` — after any edit under `server/design/**`.
+2. `mise run gen:sqlc-server` — after any edit under `server/internal/*/queries.sql` or `server/database/sqlc.yaml`. (Or use `mise run gen:server` to run both.)
+3. `mise run lint:server` and `mise run test:server` — catch struct-field drift early.
+4. `mise run gen:sdk` — regenerate the TypeScript SDK and the public/internal OpenAPI files.
+5. `mise run go:tidy` if imports changed.
+
+## Relevant mise tasks
+
+| Task                       | Purpose                                                                                                                                                         |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mise run build:server`    | Build the server binary.                                                                                                                                        |
+| `mise run gen:goa-server`  | Regenerate everything under `server/gen/**` from the Goa design files.                                                                                          |
+| `mise run gen:sdk`         | Apply Speakeasy overlays and regenerate the TypeScript SDK and both public/internal OpenAPI files. Flags: `--check`, `--skip-versioning`, `--skip-upload-spec`. |
+| `mise run gen:server`      | Convenience: runs `gen:sqlc-server` then `gen:goa-server`.                                                                                                      |
+| `mise run gen:sqlc-server` | Regenerate every `repo/` package from every `queries.sql`.                                                                                                      |
+| `mise run go:tidy`         | `go mod tidy` across the workspace.                                                                                                                             |
+| `mise run lint:server`     | `golangci-lint` over the server tree including `exhaustruct`.                                                                                                   |
+| `mise run test:server`     | Runs `go test` across the server tree; accepts `go test` arguments.                                                                                             |
+
+## Maintaining this skill
+
+This file documents conventions that evolve over time. Adding a new endpoint or service using the patterns above is already covered by "Jobs to be done" — those don't require skill edits. Structural changes do. Update this skill in the same commit when you make any of the following kinds of changes:
+
+- Changing the `/rpc/<service>.<method>` HTTP route convention, or introducing a second route convention alongside it.
+- Adding, removing, or renaming a security scheme (`Session`, `ByKey`, `ProjectSlug`).
+- Changing the required OpenAPI meta keys or their semantics.
+- Replacing `mv/` with a different view pattern, or changing the `Build<Subject>View` naming convention.
+- Changing the `impl.go` anatomy — new required struct fields, new middleware layer in `Attach`, a different `NewService` contract.
+- Changing the black-box test convention (`package <svc>_test`, `testenv.Launch`, `newTestService`) or moving shared helpers out of per-service `setup_test.go`.
+- Changing the Speakeasy workflow — new overlay stages, different source definitions in `.speakeasy/workflow.yaml`, a third OpenAPI output alongside internal/public.
+- Changing the changeset format or adding a new package target.
+- Adding a new API-relevant mise task that belongs on the cheat sheet.
+
+## Cross-references
+
+- `golang` — Go code style, error handling (`oops`), logging, testing, dependency injection, and the `conv` / `o11y` helpers referenced in the handler skeleton.
+- `postgresql` — schema design, migrations, SQLc query rules, and the `project_id` scoping requirement.
+- `gram-rbac` — scope declaration and `access.Require(ctx, access.Check{...})` enforcement inside handlers.
+- `gram-audit-logging` — emitting `audit.Log*` calls inside handler transactions.
+- `frontend` — consuming endpoints from the dashboard via the generated SDK and React Query hooks.
+- `mise-tasks` — modifying any of the `.mise-tasks/gen/*.sh` scripts referenced above.

--- a/.agents/skills/gram-rbac/SKILL.md
+++ b/.agents/skills/gram-rbac/SKILL.md
@@ -47,6 +47,8 @@ The server-side RBAC implementation lives in `server/internal/access/` and the `
 
 **`access.Check`.** `{Scope, ResourceID}` — the thing a handler asks `Require` to enforce. `ResourceID` is typically `authCtx.ProjectID.String()` for project-scoped scopes.
 
+**`access.Filter` for list endpoints.** When a handler lists resources the caller might only partially own, `s.access.Filter(ctx, scope, candidateIDs) ([]string, error)` returns the subset of IDs the caller holds the scope for. The standard pattern is: gather candidate IDs from the repo, call `Filter`, then rebuild the response from the allowed IDs. Prefer this over a post-hoc per-item `Require` loop. Canonical call sites: `server/internal/projects/impl.go` (projects list) and `server/internal/toolsets/impl.go` (toolsets list).
+
 **Auth context accessor.** `contextvalues.GetAuthContext(ctx)` returns the current `*AuthContext`. RBAC-relevant fields: `ActiveOrganizationID`, `ProjectID`, `UserID`, `Email`, `AccountType`, `IsAdmin`.
 
 ### Non-generated files
@@ -94,17 +96,31 @@ Scope and resource-type changes on the server must be accompanied by a matching 
 
 ## Client
 
-The dashboard pages under `client/dashboard/src/pages/access/` render membership and role management on top of the generated SDK and the `listScopes` response.
+The dashboard pages under `client/dashboard/src/pages/access/` render membership and role management on top of the generated SDK and the `listScopes` response. RBAC-aware UI across the rest of the dashboard gates itself through a shared hook and component.
+
+### Conventions
+
+**`useRBAC` hook.** `client/dashboard/src/hooks/useRBAC.ts` wraps the generated `useGrants` React Query hook and exposes `hasScope(scope, resourceId?)`, `hasAllScopes(scopes, resourceId?)`, `hasAnyScope(scopes, resourceId?)`, plus `isRbacEnabled`, `isLoading`, `grants`, and `error`. Returns `false` from the `has*` checks while loading and `true` when RBAC is disabled.
+
+**`RequireScope` component.** `client/dashboard/src/components/require-scope.tsx` is the primary rendering gate. Props: `scope: Scope | Scope[]`, `all?: boolean` (AND vs OR when multiple scopes), `resourceId?: string`, `level: "page" | "section" | "component"`, `children`, and level-specific extras (`fallback` for page/section, `reason`/`className` for component).
+
+- `level="page"` — renders a full Unauthorized fallback page when the scope is missing.
+- `level="section"` — hides the children entirely.
+- `level="component"` — renders disabled with a tooltip explaining why (good for buttons and inputs).
+
+**Scope vocabulary import.** `useRBAC` and `RequireScope` both consume the `Scope` union from `client/dashboard/src/pages/access/types.ts` (covered under "Server-client contract"). Keeping that file in lockstep with the server is what makes the client gates work.
 
 ### Non-generated files
 
-| File                                                                   | Purpose                                                                                         |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `Access.tsx`                                                           | Top-level page shell.                                                                           |
-| `ChangeRoleDialog.tsx`, `CreateRoleDialog.tsx`, `DeleteRoleDialog.tsx` | Role and member-role mutation dialogs.                                                          |
-| `MembersTab.tsx`, `RolesTab.tsx`                                       | The two tabs of the access page.                                                                |
-| `ScopePickerPopover.tsx`                                               | Scope selection UI.                                                                             |
-| `types.ts`                                                             | Hand-maintained client mirror of the server's scope vocabulary. (See "Server-client contract".) |
+| File                                                                                                     | Purpose                                                                                         |
+| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `client/dashboard/src/components/require-scope.tsx`                                                      | `RequireScope` gating component — page, section, and component-level rendering gates.           |
+| `client/dashboard/src/hooks/useRBAC.ts`                                                                  | `useRBAC` hook — scope checks and raw grants for the dashboard.                                 |
+| `client/dashboard/src/pages/access/Access.tsx`                                                           | Top-level access page shell.                                                                    |
+| `client/dashboard/src/pages/access/ChangeRoleDialog.tsx`, `CreateRoleDialog.tsx`, `DeleteRoleDialog.tsx` | Role and member-role mutation dialogs.                                                          |
+| `client/dashboard/src/pages/access/MembersTab.tsx`, `RolesTab.tsx`                                       | The two tabs of the access page.                                                                |
+| `client/dashboard/src/pages/access/ScopePickerPopover.tsx`                                               | Scope selection UI.                                                                             |
+| `client/dashboard/src/pages/access/types.ts`                                                             | Hand-maintained client mirror of the server's scope vocabulary. (See "Server-client contract".) |
 
 ## Jobs to be done
 
@@ -148,11 +164,49 @@ Use this when adjusting what `admin` or `member` gets out of the box. Prefer add
 3. Consider whether existing orgs' grant tables need a migration to reflect the new defaults; new orgs pick up defaults automatically via seeding.
 4. Run `mise run lint:server` and `mise run test:server`.
 
-### How to inspect the caller's grants or filter resources
+### How to filter a list handler to the caller's accessible resources
 
-- To get the caller's full grant set (e.g. to gate UI): call `/rpc/access.listUserGrants` from the frontend, or inspect `access.GrantsFromContext(ctx)` in Go.
-- To enforce a single scope inline: `s.access.Require(ctx, access.Check{...})`.
-- To filter a list of candidate resource ids down to the ones the caller has access to: `s.access.Filter(ctx, scope, resourceIDs)` returns only the ids that satisfy the scope. Use this for `list*` handlers that would otherwise return resources the caller isn't allowed to see.
+Use this whenever a `list*` handler would otherwise return resources the caller has no grant for. `projects.List` and `toolsets.List` are the canonical examples.
+
+1. Query the repo for the full candidate set the org/project contains.
+2. Collect the candidate IDs into `[]string`.
+3. Call `allowedIDs, err := s.access.Filter(ctx, access.Scope<Name>, candidateIDs)`. Return the error as-is.
+4. Build a set from `allowedIDs` and rebuild the response by walking the original rows, keeping only the ones whose ID is in the set. Preserves repo ordering without a second query.
+5. Do not fall back to a per-item `Require` loop — `Filter` exists specifically to avoid N authorization round-trips.
+
+### How to gate dashboard UI with RBAC
+
+Dashboard code should never hand-roll scope checks — use the shared primitives so a change to `useRBAC` or `<RequireScope>` flows through the whole app.
+
+1. **Rendering gates — use `<RequireScope>`.** Pick the level that matches what you want the un-entitled user to see:
+   - `level="page"` around a full route component renders an Unauthorized fallback page.
+   - `level="section"` around a block hides it entirely.
+   - `level="component"` around a button or input renders disabled with a tooltip reason.
+
+   ```tsx
+   <RequireScope scope="org:admin" level="component" reason="Admin only">
+     <Button onClick={() => setDialogOpen(true)}>New API key</Button>
+   </RequireScope>
+   ```
+
+2. **Multi-scope gates.** Pass an array and set `all` to switch between OR (default) and AND logic: `<RequireScope scope={["org:read", "org:admin"]} level="page">`.
+
+3. **Resource-specific gates.** Pass `resourceId` when the scope only applies to a specific resource: `<RequireScope scope="mcp:write" resourceId={toolsetId} level="component">`.
+
+4. **Imperative checks — use `useRBAC`.** When you need the scope result as a value (to compute a class name, skip an effect, pick a label), pull from the hook instead of wrapping markup:
+
+   ```tsx
+   const { hasScope, isLoading } = useRBAC();
+   const canEdit = hasScope("mcp:write", toolsetId);
+   ```
+
+5. **The `Scope` string you pass must match the server.** Import from `client/dashboard/src/pages/access/types.ts` (re-exported via `useRBAC` for convenience). If TypeScript complains about an unknown scope, you're missing the union update from the server scope add (see "How to add a new scope to an existing resource type").
+
+### How to inspect the caller's grants
+
+- **In the dashboard**: `const { grants } = useRBAC();` returns the raw `RoleGrant[]`. Prefer `hasScope` for gating; reach for `grants` only when you need to render them (the access page itself, diagnostics, dev overlays).
+- **In Go handlers**: `access.GrantsFromContext(ctx)` returns the grants on the request context after the access middleware has run.
+- **Over the API**: `GET /rpc/access.listUserGrants` returns the caller's effective grants.
 
 ## Role hierarchy at a glance
 
@@ -182,6 +236,7 @@ This file documents conventions that evolve over time. Adding a new scope, resou
 - Changing how `fullAccessGrantPayloads` or `ListScopes` is populated (e.g. moving the scope catalogue out of `impl.go`).
 - Moving the hand-maintained client scope vocabulary out of `client/dashboard/src/pages/access/types.ts`, or changing the three-place-enum-lockstep count in the design file.
 - Changing the auth context invariant — e.g. if `ActiveOrganizationID` becomes optional, or a new invariant field is added.
+- Changing or replacing the dashboard's RBAC primitives — `useRBAC` return shape, `<RequireScope>` levels/props, or the SDK hook the dashboard reads grants from.
 - Adding a new RBAC-relevant mise task that belongs on the cheat sheet.
 
 ## Cross-references

--- a/.agents/skills/gram-rbac/SKILL.md
+++ b/.agents/skills/gram-rbac/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: gram-rbac
+description: Concepts, external interfaces, and conventions for Gram's role-based access control (RBAC) subsystem — scopes, grants, principals, system roles, and the `access.Manager.Require` enforcement path used inside handlers. Activate whenever the task involves authorization (adding or modifying a scope or resource type, declaring a new role or grant, gating a handler, changing scope inheritance, exposing RBAC state through the dashboard).
+metadata:
+  relevant_files:
+    - "server/internal/access/**/*.go"
+    - "server/internal/access/**/*.sql"
+    - "server/design/access/**"
+    - "client/dashboard/src/pages/access/**"
+---
+
+Gram's RBAC is a scope-and-grant model. The server ships with a fixed set of **scopes** grouped into **system roles** (admin, member). A **grant** binds a scope to an optional resource id for a given **principal** (user or custom role). Handlers enforce scopes by calling `access.Manager.Require(ctx, access.Check{Scope, ResourceID})`; the dashboard renders the same scope vocabulary through a matching TypeScript union that is hand-maintained in lockstep with the server.
+
+## Concepts and terminology
+
+**Scope.** A named permission that authorizes an operation on a particular kind of resource.
+
+**Resource type.** The kind of resource a scope protects — currently `org`, `project`, `mcp`, or `remote-mcp`. Every scope has exactly one resource type.
+
+**Scope expansion.** Higher-privilege scopes satisfy lower-privilege ones, so a handler that needs `mcp:read` is also reachable by callers who hold `mcp:write` or `mcp:connect`. For a typical read/write/connect triple the wiring is: write satisfies read; connect satisfies both read and write.
+
+**Grant.** A tuple of `{Scope, Resource}` held by a principal. `Resource` is either a specific id or the wildcard `"*"` (unrestricted). The API-visible forms are `RoleGrant` and `ListRoleGrant` (which also carries the transitively-implied `sub_scopes`).
+
+**Principal.** Who holds a grant — a `urn.Principal` with a type (user, role, service account) and an id.
+
+**System role.** A built-in role shipped with the server. Gram defines two: **admin** (every scope) and **member** (the read-and-connect subset).
+
+**Enforcement.** Inside a handler, authorization is an explicit one-line check: the handler names the scope (and resource, if project-scoped) it needs, and the RBAC manager either allows the call or returns a forbidden error.
+
+**Auth context invariant.** By the time a handler runs, the auth context's `ActiveOrganizationID` is always populated — RBAC does not defensively check for an empty org id.
+
+## Server
+
+The server-side RBAC implementation lives in `server/internal/access/` and the `access` Goa service design lives in `server/design/access/`.
+
+### Conventions
+
+**Scope declarations.** `Scope` type and every `Scope*` constant live in `server/internal/access/scopes.go`. Constants follow the `Scope<Name>` pattern; string values follow `<resource>:<verb>` (e.g. `mcp:read`, `org:admin`). `root` is reserved for service-internal superadmin overrides. The file also holds the `scopeExpansions` map and computes the inverse `scopeSubScopes` in `init()`.
+
+**System role grants.** `SystemRoleGrants` in `server/internal/access/grants.go` — admin and member defaults. Adding a scope usually means adding it to admin, and optionally to member if end users should get it by default.
+
+**Scope metadata.** `ListScopes` in `server/internal/access/impl.go` returns one `{Slug, Description, ResourceType}` entry per scope; this is what the dashboard consumes to render the scope picker.
+
+**`fullAccessGrantPayloads` helper.** A helper at the bottom of `server/internal/access/impl.go` that returns every admin-equivalent grant payload. Consumed by `listUserGrants`, so it must grow whenever a new scope is added or an admin-equivalent user would be missing it.
+
+**`access.Manager`.** The central enforcer. Methods: `PrepareContext`, `Require(ctx, checks...)`, `RequireAny(ctx, checks...)`, `Filter(ctx, scope, ids)`, `InvalidateRoleCache`. Constructed in `server/cmd/gram/start.go` and injected into every service that gates on RBAC.
+
+**`access.Check`.** `{Scope, ResourceID}` — the thing a handler asks `Require` to enforce. `ResourceID` is typically `authCtx.ProjectID.String()` for project-scoped scopes.
+
+**Auth context accessor.** `contextvalues.GetAuthContext(ctx)` returns the current `*AuthContext`. RBAC-relevant fields: `ActiveOrganizationID`, `ProjectID`, `UserID`, `Email`, `AccountType`, `IsAdmin`.
+
+### Non-generated files
+
+| File                                 | Purpose                                                                                                                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `server/design/access/design.go`     | Goa design for the `access` service. Regenerates `server/gen/access/` and `server/gen/http/access/` via `mise run gen:goa-server`.                           |
+| `server/internal/access/*_test.go`   | Black-box tests for the service (`listscopes_test.go`, `rbac_test.go`, `listusergrants_test.go`, `manager_test.go`, `expand_test.go`, and per-method tests). |
+| `server/internal/access/access.go`   | The `Check` type and its expansion logic.                                                                                                                    |
+| `server/internal/access/accesstest/` | Test helpers other packages reuse for RBAC setup.                                                                                                            |
+| `server/internal/access/context.go`  | Request-context helpers for grants.                                                                                                                          |
+| `server/internal/access/errors.go`   | The package's sentinel errors.                                                                                                                               |
+| `server/internal/access/grants.go`   | System role defaults.                                                                                                                                        |
+| `server/internal/access/impl.go`     | Implementation of the `/rpc/access.*` Goa service.                                                                                                           |
+| `server/internal/access/load.go`     | Principal grant loading from the database.                                                                                                                   |
+| `server/internal/access/manager.go`  | The central RBAC enforcer.                                                                                                                                   |
+| `server/internal/access/override.go` | Scope override plumbing.                                                                                                                                     |
+| `server/internal/access/queries.sql` | SQLc queries for principals, grants, roles, and members. Regenerates `server/internal/access/repo/` via `mise run gen:sqlc-server`.                          |
+| `server/internal/access/scopes.go`   | Scope type, constants, and expansion rules.                                                                                                                  |
+
+### Generated files
+
+| Path                                            | Generator                                                                                                                      |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `server/gen/access/`, `server/gen/http/access/` | `mise run gen:goa-server` from `server/design/access/design.go`.                                                               |
+| `server/internal/access/repo/`                  | `mise run gen:sqlc-server` from `server/internal/access/queries.sql` (via the `access` stanza in `server/database/sqlc.yaml`). |
+
+## Server-client contract
+
+Scope and resource-type changes on the server must be accompanied by a matching edit to a hand-maintained client file — adding a scope is not purely a server change.
+
+**HTTP routes** (design: `server/design/access/design.go`):
+
+- `/rpc/access.listScopes` — every scope the server knows about, with `resource_type` and description.
+- `/rpc/access.listRoles`, `getRole`, `createRole`, `updateRole`, `deleteRole` — custom role CRUD.
+- `/rpc/access.listMembers`, `updateMemberRole` — org membership and role assignment.
+- `/rpc/access.listUserGrants` — the caller's effective grants.
+- `/rpc/access.disableRBAC` — feature flag hook.
+
+**Three-place enum lockstep.** `server/design/access/design.go` repeats the scope slug enum in three places — `RoleGrantModel.scope`, `ListRoleGrantModel.scope`, and its `sub_scopes` element — plus `ScopeModel.slug` for the listing endpoint. All three must stay synchronized with `scopes.go`, and `ScopeModel.resource_type` must contain every resource type in use.
+
+**Generated SDK types.** `client/sdk/src/models/components/scopedefinition.ts`, `rolegrant.ts`, `listrolegrant.ts`, etc. Regenerated by `mise run gen:sdk` after every design change.
+
+**Hand-maintained client mirror.** `client/dashboard/src/pages/access/types.ts` exports a `Scope` string-literal union, a `ResourceType` string-literal union, and the `RoleGrant` interface. These must be updated in the same commit as a scope or resource-type change on the server.
+
+## Client
+
+The dashboard pages under `client/dashboard/src/pages/access/` render membership and role management on top of the generated SDK and the `listScopes` response.
+
+### Non-generated files
+
+| File                                                                   | Purpose                                                                                         |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `Access.tsx`                                                           | Top-level page shell.                                                                           |
+| `ChangeRoleDialog.tsx`, `CreateRoleDialog.tsx`, `DeleteRoleDialog.tsx` | Role and member-role mutation dialogs.                                                          |
+| `MembersTab.tsx`, `RolesTab.tsx`                                       | The two tabs of the access page.                                                                |
+| `ScopePickerPopover.tsx`                                               | Scope selection UI.                                                                             |
+| `types.ts`                                                             | Hand-maintained client mirror of the server's scope vocabulary. (See "Server-client contract".) |
+
+## Jobs to be done
+
+### How to gate a handler with an existing scope
+
+1. Inject `*access.Manager` into the service struct (if it isn't already) and keep it on `s.access`.
+2. At the top of the handler — before any database work — call `s.access.Require(ctx, access.Check{Scope: access.Scope<Name>, ResourceID: authCtx.ProjectID.String()})` and return the error as-is.
+3. Choose the narrowest scope for the operation: `*:read` for GET/list, `*:write` for mutations, `*:connect` for runtime usage. Scope expansions mean write callers are still permitted to read.
+4. Use `RequireAny` instead of `Require` when a single handler legitimately satisfies multiple equivalent scopes.
+5. In the handler's test, add one case that builds the context without the scope and asserts an `oops.CodeForbidden` response, and one case that builds the context with the scope via `withExactAccessGrants`.
+
+### How to add a new scope to an existing resource type
+
+Use this when the resource type is already represented (e.g. adding a new verb on `mcp`).
+
+1. Add the `Scope<Name>` constant in `server/internal/access/scopes.go`.
+2. Add the new scope to `scopeExpansions` in the same file. Usually: the new scope is the upper or lower end of an existing read/write/connect triple.
+3. Extend `SystemRoleGrants` in `grants.go`: admin always receives the new scope. Member receives it if and only if end users should have it by default (read and connect, yes; write, no).
+4. Add a `{Slug, Description, ResourceType}` entry to `ListScopes` in `impl.go`.
+5. Extend `fullAccessGrantPayloads` at the bottom of `impl.go`.
+6. Update the three enums in `server/design/access/design.go` that have to stay in lockstep.
+7. Add the new slug to the `Scope` union in `client/dashboard/src/pages/access/types.ts`.
+8. Bump the `require.Len(t, result.Scopes, N)` assertions in both `listscopes_test.go` and `rbac_test.go`.
+9. Run `mise run gen:goa-server`, then `mise run gen:sdk`.
+10. Run `mise run lint:server` and `mise run test:server`.
+
+### How to add a new resource type
+
+Use this when introducing a resource type that doesn't exist yet (e.g. the first `foo:*` scopes).
+
+1. Follow every step under "How to add a new scope to an existing resource type" for each scope on the new type.
+2. Additionally, add the new resource type string to `ScopeModel.resource_type` in `server/design/access/design.go`.
+3. Additionally, add the new resource type to the `ResourceType` union in `client/dashboard/src/pages/access/types.ts`.
+
+### How to change system role defaults
+
+Use this when adjusting what `admin` or `member` gets out of the box. Prefer additive changes — removing a grant from a shipped role is an observable permissions change for existing users.
+
+1. Edit `SystemRoleGrants` in `grants.go`.
+2. Update `listusergrants_test.go` — its `expectedFullAccessScopes` list captures the admin set.
+3. Consider whether existing orgs' grant tables need a migration to reflect the new defaults; new orgs pick up defaults automatically via seeding.
+4. Run `mise run lint:server` and `mise run test:server`.
+
+### How to inspect the caller's grants or filter resources
+
+- To get the caller's full grant set (e.g. to gate UI): call `/rpc/access.listUserGrants` from the frontend, or inspect `access.GrantsFromContext(ctx)` in Go.
+- To enforce a single scope inline: `s.access.Require(ctx, access.Check{...})`.
+- To filter a list of candidate resource ids down to the ones the caller has access to: `s.access.Filter(ctx, scope, resourceIDs)` returns only the ids that satisfy the scope. Use this for `list*` handlers that would otherwise return resources the caller isn't allowed to see.
+
+## Role hierarchy at a glance
+
+- `admin` — every scope. Write implies read via `scopeExpansions`, so admins can exercise every read operation transitively.
+- `member` — the read-and-connect subset.
+- Resource scoping — a grant's `Resource` either names a specific id or is the wildcard `"*"`. Checks against the wildcard always succeed for their scope.
+- `root` — held only by service-internal overrides; satisfies every check.
+
+## Relevant mise tasks
+
+| Task                       | Purpose                                                                                             |
+| -------------------------- | --------------------------------------------------------------------------------------------------- |
+| `mise run gen:goa-server`  | Regenerate `server/gen/access/**` after editing `server/design/access/design.go`.                   |
+| `mise run gen:sdk`         | Regenerate the SDK and OpenAPI so dashboard/CLI consumers see the new scope vocabulary.             |
+| `mise run gen:sqlc-server` | Regenerate `server/internal/access/repo/` when `queries.sql` changes.                               |
+| `mise run lint:server`     | Catches `exhaustruct` violations in the scope/grant structs.                                        |
+| `mise run test:server`     | Runs the scope-count assertions and RBAC tests. Filter with `./internal/access/...` when iterating. |
+
+## Maintaining this skill
+
+This file documents conventions that evolve over time. Adding a new scope, resource type, or tweaking system-role defaults is already covered by "Jobs to be done" — those don't require skill edits. Structural changes do. Update this skill in the same commit when you make any of the following kinds of changes:
+
+- Changing the `<resource>:<verb>` scope naming convention.
+- Adding or removing a system role beyond `admin` and `member`.
+- Replacing `access.Manager` as the central enforcer, or changing its method set (`Require`, `RequireAny`, `Filter`, etc.).
+- Changing scope-expansion semantics (e.g. how `scopeSubScopes` is computed from `scopeExpansions`, or introducing transitive expansion).
+- Changing how `fullAccessGrantPayloads` or `ListScopes` is populated (e.g. moving the scope catalogue out of `impl.go`).
+- Moving the hand-maintained client scope vocabulary out of `client/dashboard/src/pages/access/types.ts`, or changing the three-place-enum-lockstep count in the design file.
+- Changing the auth context invariant — e.g. if `ActiveOrganizationID` becomes optional, or a new invariant field is added.
+- Adding a new RBAC-relevant mise task that belongs on the cheat sheet.
+
+## Cross-references
+
+- `gram-management-api` — the `access` service itself, and every service that gates handlers with `access.Require`, follows that skill's flow.
+- `gram-audit-logging` — role and member mutations emit audit events via `server/internal/audit/access.go`; subjects are `access_role` and `access_member`.
+- `golang` — error handling through `oops`, the no-defensive-checks rule for `ActiveOrganizationID`, the `setup_test.go` / black-box test conventions used by RBAC tests.
+- `frontend` — everything under `client/dashboard/src/pages/access/` (component structure, `cn()`/Moonshine styling, React Query usage).
+- `postgresql` — the `principal_grants`, `roles`, and related tables backing `accessrepo`.
+- `mise-tasks` — when modifying the `.mise-tasks/gen/*.sh` scripts referenced above.

--- a/.claude/skills/gram-audit-logging
+++ b/.claude/skills/gram-audit-logging
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-audit-logging

--- a/.claude/skills/gram-management-api
+++ b/.claude/skills/gram-management-api
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-management-api

--- a/.claude/skills/gram-rbac
+++ b/.claude/skills/gram-rbac
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-rbac

--- a/.codex/skills/datadog
+++ b/.codex/skills/datadog
@@ -1,0 +1,1 @@
+../../.agents/skills/datadog

--- a/.codex/skills/gram-audit-logging
+++ b/.codex/skills/gram-audit-logging
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-audit-logging

--- a/.codex/skills/gram-management-api
+++ b/.codex/skills/gram-management-api
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-management-api

--- a/.codex/skills/gram-rbac
+++ b/.codex/skills/gram-rbac
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-rbac

--- a/.cursor/skills/datadog
+++ b/.cursor/skills/datadog
@@ -1,0 +1,1 @@
+../../.agents/skills/datadog

--- a/.cursor/skills/gram-audit-logging
+++ b/.cursor/skills/gram-audit-logging
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-audit-logging

--- a/.cursor/skills/gram-management-api
+++ b/.cursor/skills/gram-management-api
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-management-api

--- a/.cursor/skills/gram-rbac
+++ b/.cursor/skills/gram-rbac
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-rbac

--- a/.opencode/skills/datadog
+++ b/.opencode/skills/datadog
@@ -1,0 +1,1 @@
+../../.agents/skills/datadog

--- a/.opencode/skills/gram-audit-logging
+++ b/.opencode/skills/gram-audit-logging
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-audit-logging

--- a/.opencode/skills/gram-management-api
+++ b/.opencode/skills/gram-management-api
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-management-api

--- a/.opencode/skills/gram-rbac
+++ b/.opencode/skills/gram-rbac
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-rbac


### PR DESCRIPTION
Introduce three concept-level agent skills that document the audit logging subsystem, the management API surface, and the RBAC subsystem. Each skill follows the same layout: overview, concepts, server conventions and files, server-client contract (HTTP routes, generated OpenAPI, SDK, CLI), a client section where applicable, common code flows, jobs-to-be-done recipes, a relevant mise tasks cheat sheet, guidance on when structural changes require a skill update, and cross-references into the existing `golang`, `postgresql`, `frontend`, and `mise-tasks` skills.