### PR TITLE
fix: add structured logging to risk analysis signal chain and flush on shutdown

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -772,10 +772,7 @@ func newStartCommand() *cli.Command {
 				30*time.Second,
 				logger,
 			)
-			shutdownFuncs = append(shutdownFuncs, func(_ context.Context) error {
-				riskSignaler.Shutdown()
-				return nil
-			})
+			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
 			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, accessManager, riskSignaler)
 			captureStrategy.AddObserver(riskService)
 			risk.Attach(mux, riskService)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -768,10 +768,14 @@ func newStartCommand() *cli.Command {
 			functions.Attach(mux, functions.NewService(logger, tracerProvider, db, encryptionClient, tigrisStore))
 
 			riskSignaler := background.NewThrottledSignaler(
-				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv},
+				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},
 				30*time.Second,
 				logger,
 			)
+			shutdownFuncs = append(shutdownFuncs, func(_ context.Context) error {
+				riskSignaler.Shutdown()
+				return nil
+			})
 			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, accessManager, riskSignaler)
 			captureStrategy.AddObserver(riskService)
 			risk.Attach(mux, riskService)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -459,10 +459,14 @@ func newWorkerCommand() *cli.Command {
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
 			riskSignaler := background.NewThrottledSignaler(
-				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv},
+				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},
 				30*time.Second,
 				logger,
 			)
+			shutdownFuncs = append(shutdownFuncs, func(_ context.Context) error {
+				riskSignaler.Shutdown()
+				return nil
+			})
 			captureStrategy.AddObserver(risk.NewObserver(logger, db, riskSignaler))
 
 			completionsClient := openrouter.NewUnifiedClient(

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -463,10 +463,7 @@ func newWorkerCommand() *cli.Command {
 				30*time.Second,
 				logger,
 			)
-			shutdownFuncs = append(shutdownFuncs, func(_ context.Context) error {
-				riskSignaler.Shutdown()
-				return nil
-			})
+			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
 			captureStrategy.AddObserver(risk.NewObserver(logger, db, riskSignaler))
 
 			completionsClient := openrouter.NewUnifiedClient(

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -167,6 +167,7 @@ const (
 	OAuthConnectedKey              = attribute.Key("gram.oauth.connected")
 	OAuthExpiredKey                = attribute.Key("gram.oauth.expired")
 	OAuthProxyServerIDKey          = attribute.Key("gram.oauth.proxy_server_id")
+	ObserverCountKey               = attribute.Key("gram.observer.count")
 	OAuthProviderCountKey          = attribute.Key("gram.oauth.provider_count")
 	OpenAPIMethodKey               = attribute.Key("gram.openapi.method")
 	OpenAPIOperationIDKey          = attribute.Key("gram.openapi.operation_id")
@@ -190,6 +191,8 @@ const (
 	ProjectIDKey                   = attribute.Key("gram.project.id")
 	ProjectNameKey                 = attribute.Key("gram.project.name")
 	ProjectSlugKey                 = attribute.Key("gram.project.slug")
+	RiskPolicyCountKey             = attribute.Key("gram.risk.policy_count")
+	RiskPolicyIDKey                = attribute.Key("gram.risk.policy_id")
 	RiskRuleIDKey                  = attribute.Key("gram.risk.rule_id")
 	SecretNameKey                  = attribute.Key("gram.secret.name")
 	SecurityPlacementKey           = attribute.Key("gram.security.placement")
@@ -775,6 +778,9 @@ func SlogOAuthProxyServerID(v string) slog.Attr {
 	return slog.String(string(OAuthProxyServerIDKey), v)
 }
 
+func ObserverCount(v int) attribute.KeyValue { return ObserverCountKey.Int(v) }
+func SlogObserverCount(v int) slog.Attr      { return slog.Int(string(ObserverCountKey), v) }
+
 func OAuthProviderCount(v int) attribute.KeyValue { return OAuthProviderCountKey.Int(v) }
 func SlogOAuthProviderCount(v int) slog.Attr      { return slog.Int(string(OAuthProviderCountKey), v) }
 
@@ -856,11 +862,20 @@ func SlogProjectSlug(v string) slog.Attr      { return slog.String(string(Projec
 func ProjectName(v string) attribute.KeyValue { return ProjectNameKey.String(v) }
 func SlogProjectName(v string) slog.Attr      { return slog.String(string(ProjectNameKey), v) }
 
+func RiskPolicyCount(v int) attribute.KeyValue { return RiskPolicyCountKey.Int(v) }
+func SlogRiskPolicyCount(v int) slog.Attr      { return slog.Int(string(RiskPolicyCountKey), v) }
+
+func RiskPolicyID(v string) attribute.KeyValue { return RiskPolicyIDKey.String(v) }
+func SlogRiskPolicyID(v string) slog.Attr      { return slog.String(string(RiskPolicyIDKey), v) }
+
 func RiskRuleID(v string) attribute.KeyValue { return RiskRuleIDKey.String(v) }
 func SlogRiskRuleID(v string) slog.Attr      { return slog.String(string(RiskRuleIDKey), v) }
 
 func SecretName(v string) attribute.KeyValue { return SecretNameKey.String(v) }
 func SlogSecretName(v string) slog.Attr      { return slog.String(string(SecretNameKey), v) }
+
+func TemporalWorkflowID(v string) attribute.KeyValue { return TemporalWorkflowIDKey.String(v) }
+func SlogTemporalWorkflowID(v string) slog.Attr      { return slog.String(string(TemporalWorkflowIDKey), v) }
 
 func SecurityPlacement(v string) attribute.KeyValue { return SecurityPlacementKey.String(v) }
 func SlogSecurityPlacement(v string) slog.Attr      { return slog.String(string(SecurityPlacementKey), v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -167,7 +167,7 @@ const (
 	OAuthConnectedKey              = attribute.Key("gram.oauth.connected")
 	OAuthExpiredKey                = attribute.Key("gram.oauth.expired")
 	OAuthProxyServerIDKey          = attribute.Key("gram.oauth.proxy_server_id")
-	ObserverCountKey               = attribute.Key("gram.observer.count")
+	MessageObserverCountKey        = attribute.Key("gram.message_observer.count")
 	OAuthProviderCountKey          = attribute.Key("gram.oauth.provider_count")
 	OpenAPIMethodKey               = attribute.Key("gram.openapi.method")
 	OpenAPIOperationIDKey          = attribute.Key("gram.openapi.operation_id")
@@ -778,8 +778,10 @@ func SlogOAuthProxyServerID(v string) slog.Attr {
 	return slog.String(string(OAuthProxyServerIDKey), v)
 }
 
-func ObserverCount(v int) attribute.KeyValue { return ObserverCountKey.Int(v) }
-func SlogObserverCount(v int) slog.Attr      { return slog.Int(string(ObserverCountKey), v) }
+func MessageObserverCount(v int) attribute.KeyValue { return MessageObserverCountKey.Int(v) }
+func SlogMessageObserverCount(v int) slog.Attr {
+	return slog.Int(string(MessageObserverCountKey), v)
+}
 
 func OAuthProviderCount(v int) attribute.KeyValue { return OAuthProviderCountKey.Int(v) }
 func SlogOAuthProviderCount(v int) slog.Attr      { return slog.Int(string(OAuthProviderCountKey), v) }

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -150,10 +150,16 @@ type RiskAnalysisSignaler interface {
 // TemporalRiskAnalysisSignaler implements RiskAnalysisSignaler using Temporal.
 type TemporalRiskAnalysisSignaler struct {
 	TemporalEnv *tenv.Environment
+	Logger      *slog.Logger
 }
 
 func (s *TemporalRiskAnalysisSignaler) SignalNewMessages(ctx context.Context, params DrainRiskAnalysisParams) error {
 	if s.TemporalEnv == nil {
+		if s.Logger != nil {
+			s.Logger.WarnContext(ctx, "temporal env is nil, skipping risk signal",
+				attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+			)
+		}
 		return nil
 	}
 
@@ -178,6 +184,13 @@ func (s *TemporalRiskAnalysisSignaler) SignalNewMessages(ctx context.Context, pa
 	if err != nil {
 		return fmt.Errorf("signal-with-start drain workflow: %w", err)
 	}
+
+	if s.Logger != nil {
+		s.Logger.DebugContext(ctx, "temporal signal-with-start sent",
+			attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+			attr.SlogTemporalWorkflowID(wfID),
+		)
+	}
 	return nil
 }
 
@@ -192,23 +205,34 @@ func drainWorkflowID(policyID uuid.UUID) string {
 // are coalesced into a single trailing signal when the window expires.
 type ThrottledSignaler struct {
 	inner    RiskAnalysisSignaler
+	logger   *slog.Logger
 	throttle *throttle.Throttle[uuid.UUID, DrainRiskAnalysisParams]
 }
 
 // NewThrottledSignaler wraps inner with a per-policy cooldown. A zero or
 // negative cooldown disables throttling.
 func NewThrottledSignaler(inner RiskAnalysisSignaler, cooldown time.Duration, logger *slog.Logger) *ThrottledSignaler {
-	return &ThrottledSignaler{
-		inner: inner,
-		throttle: throttle.New(cooldown, func(params DrainRiskAnalysisParams) uuid.UUID {
-			return params.RiskPolicyID
-		}, func(params DrainRiskAnalysisParams) error {
-			if err := inner.SignalNewMessages(context.Background(), params); err != nil {
-				logger.ErrorContext(context.Background(), "throttled trailing signal failed", attr.SlogError(err))
-			}
-			return nil
-		}),
+	ts := &ThrottledSignaler{
+		inner:    inner,
+		logger:   logger,
+		throttle: nil,
 	}
+	ts.throttle = throttle.New(cooldown, func(params DrainRiskAnalysisParams) uuid.UUID {
+		return params.RiskPolicyID
+	}, func(params DrainRiskAnalysisParams) error {
+		if err := inner.SignalNewMessages(context.Background(), params); err != nil {
+			logger.ErrorContext(context.Background(), "throttled trailing signal failed",
+				attr.SlogError(err),
+				attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+			)
+			return fmt.Errorf("throttled trailing signal: %w", err)
+		}
+		logger.DebugContext(context.Background(), "risk signal fired (trailing edge)",
+			attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+		)
+		return nil
+	})
+	return ts
 }
 
 func (t *ThrottledSignaler) SignalNewMessages(ctx context.Context, params DrainRiskAnalysisParams) error {
@@ -219,9 +243,23 @@ func (t *ThrottledSignaler) SignalNewMessages(ctx context.Context, params DrainR
 		return nil
 	}
 	if t.throttle.Do(params) {
+		t.logger.DebugContext(ctx, "risk signal fired (leading edge)",
+			attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+		)
 		if err := t.inner.SignalNewMessages(ctx, params); err != nil {
 			return fmt.Errorf("signal new messages: %w", err)
 		}
+	} else {
+		t.logger.DebugContext(ctx, "risk signal throttled (pending trailing)",
+			attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+		)
 	}
 	return nil
+}
+
+// Shutdown flushes any pending throttled signals. Call during graceful shutdown
+// to prevent losing trailing signals when a pod restarts.
+func (t *ThrottledSignaler) Shutdown() {
+	t.logger.InfoContext(context.Background(), "flushing pending risk analysis signals")
+	t.throttle.Flush()
 }

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -259,7 +259,8 @@ func (t *ThrottledSignaler) SignalNewMessages(ctx context.Context, params DrainR
 
 // Shutdown flushes any pending throttled signals. Call during graceful shutdown
 // to prevent losing trailing signals when a pod restarts.
-func (t *ThrottledSignaler) Shutdown() {
+func (t *ThrottledSignaler) Shutdown(_ context.Context) error {
 	t.logger.InfoContext(context.Background(), "flushing pending risk analysis signals")
 	t.throttle.Flush()
+	return nil
 }

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -154,15 +154,6 @@ type TemporalRiskAnalysisSignaler struct {
 }
 
 func (s *TemporalRiskAnalysisSignaler) SignalNewMessages(ctx context.Context, params DrainRiskAnalysisParams) error {
-	if s.TemporalEnv == nil {
-		if s.Logger != nil {
-			s.Logger.WarnContext(ctx, "temporal env is nil, skipping risk signal",
-				attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
-			)
-		}
-		return nil
-	}
-
 	wfID := drainWorkflowID(params.RiskPolicyID)
 
 	// SignalWithStartWorkflow atomically signals an existing workflow or
@@ -185,12 +176,10 @@ func (s *TemporalRiskAnalysisSignaler) SignalNewMessages(ctx context.Context, pa
 		return fmt.Errorf("signal-with-start drain workflow: %w", err)
 	}
 
-	if s.Logger != nil {
-		s.Logger.DebugContext(ctx, "temporal signal-with-start sent",
-			attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
-			attr.SlogTemporalWorkflowID(wfID),
-		)
-	}
+	s.Logger.DebugContext(ctx, "temporal signal-with-start sent",
+		attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+		attr.SlogTemporalWorkflowID(wfID),
+	)
 	return nil
 }
 

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -84,7 +84,7 @@ func (s *ChatMessageCaptureStrategy) notifyObservers(ctx context.Context, projec
 
 		s.logger.DebugContext(ctx, "notifying message observers",
 			attr.SlogProjectID(projectID.String()),
-			attr.SlogObserverCount(len(s.observers)),
+			attr.SlogMessageObserverCount(len(s.observers)),
 		)
 
 		for _, obs := range s.observers {

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -82,6 +82,11 @@ func (s *ChatMessageCaptureStrategy) notifyObservers(ctx context.Context, projec
 		stop := context.AfterFunc(s.shutdownCtx, cancel)
 		defer stop()
 
+		s.logger.DebugContext(ctx, "notifying message observers",
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogObserverCount(len(s.observers)),
+		)
+
 		for _, obs := range s.observers {
 			obs.OnMessagesStored(ctx, projectID)
 		}

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -113,6 +113,11 @@ func (s *Service) OnMessagesStored(ctx context.Context, projectID uuid.UUID) {
 		return
 	}
 
+	s.logger.DebugContext(ctx, "risk observer signaling policies",
+		attr.SlogProjectID(projectID.String()),
+		attr.SlogRiskPolicyCount(len(policies)),
+	)
+
 	for _, p := range policies {
 		if err := s.signaler.SignalNewMessages(ctx, background.DrainRiskAnalysisParams{
 			ProjectID:    p.ProjectID,

--- a/server/internal/throttle/throttle.go
+++ b/server/internal/throttle/throttle.go
@@ -68,6 +68,31 @@ func (t *Throttle[K, V]) Do(v V) bool {
 	return false
 }
 
+// Flush fires all pending trailing callbacks immediately and cleans up timers.
+// Call this during shutdown to prevent losing pending signals.
+func (t *Throttle[K, V]) Flush() {
+	t.mu.Lock()
+	type pending struct {
+		key   K
+		value V
+	}
+	var toFire []pending
+	for key, e := range t.entries {
+		if e.timer != nil {
+			e.timer.Stop()
+		}
+		if e.pending {
+			toFire = append(toFire, pending{key: key, value: e.latest})
+		}
+		delete(t.entries, key)
+	}
+	t.mu.Unlock()
+
+	for _, p := range toFire {
+		_ = t.onTrailing(p.value)
+	}
+}
+
 func (t *Throttle[K, V]) onExpired(key K) {
 	t.mu.Lock()
 	e, ok := t.entries[key]

--- a/server/internal/throttle/throttle_test.go
+++ b/server/internal/throttle/throttle_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestThrottle_LeadingEdge(t *testing.T) {
@@ -54,6 +55,71 @@ func TestThrottle_NoTrailingWithoutPending(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, int64(0), trailingCount.Load(), "no trailing when nothing was pending")
+}
+
+func TestThrottle_FlushFiresPending(t *testing.T) {
+	t.Parallel()
+
+	var fired atomic.Int64
+	var lastValue atomic.Value
+	th := New[string, string](
+		time.Hour, // long cooldown so timer never fires naturally
+		func(v string) string { return v },
+		func(v string) error { fired.Add(1); lastValue.Store(v); return nil },
+	)
+
+	th.Do("a")                   // leading edge
+	th.Do("a")                   // suppressed, pending=true, latest="a"
+	require.False(t, th.Do("a")) // still suppressed
+
+	th.Flush()
+
+	require.Equal(t, int64(1), fired.Load(), "flush should fire the pending trailing callback")
+	require.Equal(t, "a", lastValue.Load().(string))
+
+	// After flush, the throttle should be clean and accept new leading calls.
+	require.True(t, th.Do("a"), "should fire again after flush")
+}
+
+func TestThrottle_FlushNoopWhenNoPending(t *testing.T) {
+	t.Parallel()
+
+	var fired atomic.Int64
+	th := New[string, string](
+		time.Hour,
+		func(v string) string { return v },
+		func(v string) error { fired.Add(1); return nil },
+	)
+
+	// Leading fire only, no suppressed calls.
+	th.Do("a")
+	th.Flush()
+
+	require.Equal(t, int64(0), fired.Load(), "flush should not fire when nothing is pending")
+
+	// Throttle should be clean.
+	require.True(t, th.Do("a"), "should fire again after flush")
+}
+
+func TestThrottle_FlushMultipleKeys(t *testing.T) {
+	t.Parallel()
+
+	var fired atomic.Int64
+	th := New[string, string](
+		time.Hour,
+		func(v string) string { return v },
+		func(v string) error { fired.Add(1); return nil },
+	)
+
+	th.Do("a")
+	th.Do("a") // pending
+	th.Do("b")
+	th.Do("b") // pending
+	th.Do("c") // leading only, no pending
+
+	th.Flush()
+
+	require.Equal(t, int64(2), fired.Load(), "flush should fire trailing for both pending keys")
 }
 
 func TestThrottle_ResetsAfterCooldown(t *testing.T) {

--- a/server/internal/throttle/throttle_test.go
+++ b/server/internal/throttle/throttle_test.go
@@ -75,7 +75,9 @@ func TestThrottle_FlushFiresPending(t *testing.T) {
 	th.Flush()
 
 	require.Equal(t, int64(1), fired.Load(), "flush should fire the pending trailing callback")
-	require.Equal(t, "a", lastValue.Load().(string))
+	val, ok := lastValue.Load().(string)
+	require.True(t, ok, "expected string value")
+	require.Equal(t, "a", val)
 
 	// After flush, the throttle should be clean and accept new leading calls.
 	require.True(t, th.Do("a"), "should fire again after flush")


### PR DESCRIPTION
## Summary

- Structured debug logging at each step of the risk analysis signal chain (observer, throttler, Temporal signaler)
- Flush pending throttled signals on graceful shutdown to prevent signal loss during pod restarts
- New attr helpers: `MessageObserverCount`, `RiskPolicyCount`, `RiskPolicyID`, `TemporalWorkflowID`

## Why

Risk analysis workflow stopped receiving signals, leaving messages unanalyzed. Zero logging across the chain made it impossible to diagnose where the signal was lost. Most likely cause: pod restart during 30s throttle cooldown loses the in-memory pending trailing signal.

## Test plan

- [x] `server-test` passing
- [x] `server-build-lint` passing
- [ ] Deploy and confirm debug logs appear for each signal chain step