### PR TITLE
feat: assistants v0 Fly.io runtime provider

### DIFF
--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -1,0 +1,809 @@
+package assistants
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	backoff "github.com/cenkalti/backoff/v5"
+	"github.com/google/uuid"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/fly-go/tokens"
+	"go.opentelemetry.io/otel"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+)
+
+const (
+	defaultFlyRuntimeAPIURL         = "https://api.fly.io"
+	defaultFlyRuntimeMachinesURL    = "https://api.machines.dev"
+	defaultFlyRuntimeHealthTimeout  = 45 * time.Second
+	defaultFlyRuntimeRequestTimeout = 2 * time.Minute
+)
+
+type flyRuntimeMetadata struct {
+	AppName    string `json:"app_name"`
+	AppURL     string `json:"app_url"`
+	AppIP      string `json:"app_ip,omitempty"`
+	MachineID  string `json:"machine_id"`
+	Region     string `json:"region"`
+	LastBootID string `json:"last_boot_id,omitempty"`
+}
+
+type flyRuntimeStateResponse struct {
+	Configured bool `json:"configured"`
+}
+
+type flyRuntimeAPIClient interface {
+	AllocateIPAddress(ctx context.Context, appName string, addrType string, region string, orgID string, network string) (*fly.IPAddress, error)
+	AllocateSharedIPAddress(ctx context.Context, appName string) (net.IP, error)
+	CreateApp(ctx context.Context, input fly.CreateAppInput) (*fly.App, error)
+	DeleteApp(ctx context.Context, appName string) error
+	GetApp(ctx context.Context, appName string) (*fly.App, error)
+	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
+}
+
+type flyRuntimeFlapsClient interface {
+	Get(ctx context.Context, appName, machineID string) (*fly.Machine, error)
+	Launch(ctx context.Context, appName string, input fly.LaunchMachineInput) (*fly.Machine, error)
+	List(ctx context.Context, appName, state string) ([]*fly.Machine, error)
+	Start(ctx context.Context, appName, machineID string, nonce string) (*fly.MachineStartResponse, error)
+	Wait(ctx context.Context, appName string, machine *fly.Machine, state string, timeout time.Duration) error
+}
+
+type flyRuntimeFlapsFactory interface {
+	New(ctx context.Context) (flyRuntimeFlapsClient, error)
+}
+
+type flyRuntimeHTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type defaultFlyRuntimeFlapsFactory struct {
+	serviceName    string
+	serviceVersion string
+	tokens         *tokens.Tokens
+	logger         *slog.Logger
+}
+
+func (f *defaultFlyRuntimeFlapsFactory) New(ctx context.Context) (flyRuntimeFlapsClient, error) {
+	client, err := flaps.NewWithOptions(ctx, flaps.NewClientOpts{
+		UserAgent: fmt.Sprintf("%s/%s", f.serviceName, f.serviceVersion),
+		Tokens:    f.tokens,
+		Logger: &assistantFlyLogger{
+			logger: f.logger.With(attr.SlogComponent("assistants_flyio_flaps")),
+			contextFunc: func() context.Context {
+				return ctx
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create fly flaps client: %w", err)
+	}
+	return client, nil
+}
+
+type FlyRuntimeBackend struct {
+	logger       *slog.Logger
+	config       FlyRuntimeConfig
+	client       flyRuntimeAPIClient
+	flapsFactory flyRuntimeFlapsFactory
+	httpClient   flyRuntimeHTTPDoer
+}
+
+func NewFlyRuntimeBackend(logger *slog.Logger, config FlyRuntimeConfig) (*FlyRuntimeBackend, error) {
+	config.DefaultFlyRegion = firstNonEmpty(config.DefaultFlyRegion, defaultFlyRuntimeRegion)
+	config.AppNamePrefix = sanitizeFlyAppNamePrefix(firstNonEmpty(config.AppNamePrefix, defaultFlyRuntimePrefix))
+	if config.AppNamePrefix == "" {
+		config.AppNamePrefix = defaultFlyRuntimePrefix
+	}
+	if config.ServiceName == "" {
+		config.ServiceName = "gram"
+	}
+	if config.FlyAPIURL == "" {
+		config.FlyAPIURL = defaultFlyRuntimeAPIURL
+	}
+	if config.FlyMachinesBaseURL == "" {
+		config.FlyMachinesBaseURL = defaultFlyRuntimeMachinesURL
+	}
+	if err := validateFlyRuntimeConfig(config); err != nil {
+		return nil, err
+	}
+
+	httpPolicy, err := guardian.NewUnsafePolicy(otel.GetTracerProvider(), []string{})
+	if err != nil {
+		return nil, fmt.Errorf("create assistant fly runtime guardian policy: %w", err)
+	}
+
+	client := fly.NewClientFromOptions(fly.ClientOptions{
+		BaseURL: config.FlyAPIURL,
+		Tokens:  config.FlyTokens,
+		Name:    config.ServiceName,
+		Version: config.ServiceVersion,
+		Transport: &fly.Transport{
+			UnderlyingTransport: httpPolicy.PooledClient(guardian.WithDefaultRetryConfig()).Transport,
+			UserAgent:           fmt.Sprintf("%s/%s", config.ServiceName, config.ServiceVersion),
+			Tokens:              config.FlyTokens,
+		},
+		Logger: &assistantFlyLogger{
+			logger:      logger.With(attr.SlogComponent("assistants_flyio_client")),
+			contextFunc: context.Background,
+		},
+	})
+
+	return &FlyRuntimeBackend{
+		logger: logger.With(attr.SlogComponent("assistants_flyio_runtime")),
+		config: config,
+		client: client,
+		flapsFactory: &defaultFlyRuntimeFlapsFactory{
+			serviceName:    config.ServiceName,
+			serviceVersion: config.ServiceVersion,
+			tokens:         config.FlyTokens,
+			logger:         logger,
+		},
+		// No retry wrapper — /turn is non-idempotent (each retry duplicates an
+		// LLM turn + tool calls on the runner, even if the original is still in
+		// flight). Callers that want retries wrap specific calls themselves
+		// (waitForRuntimeHealth already polls /healthz in its own loop).
+		httpClient: httpPolicy.PooledClient(),
+	}, nil
+}
+
+func validateFlyRuntimeConfig(config FlyRuntimeConfig) error {
+	switch {
+	case config.FlyTokens == nil:
+		return fmt.Errorf("assistant fly runtime token is not configured")
+	case config.DefaultFlyOrg == "":
+		return fmt.Errorf("assistant fly runtime organization is not configured")
+	case config.OCIImage == "":
+		return fmt.Errorf("assistant fly runtime OCI image is not configured")
+	case config.ImageVersion == "":
+		return fmt.Errorf("assistant fly runtime image version is not configured")
+	default:
+		return nil
+	}
+}
+
+func (f *FlyRuntimeBackend) Backend() string {
+	return runtimeBackendFlyIO
+}
+
+func (f *FlyRuntimeBackend) SupportsBackend(backend string) bool {
+	return backend == runtimeBackendFlyIO
+}
+
+// Ensure does not auto-recreate the app on ensureExisting errors. Health and
+// configure timeouts must bubble so Temporal retries drive convergence.
+// Destructive app recreation churns Fly's allocated IPs and creates DNS-stale
+// feedback loops.
+func (f *FlyRuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+
+	flapsClient, err := f.flapsFactory.New(ctx)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, fmt.Errorf("create fly runtime flaps client: %w", err)
+	}
+
+	metadata, err := decodeFlyRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+
+	return f.ensureExisting(ctx, runtime, flapsClient, metadata)
+}
+
+func (f *FlyRuntimeBackend) ensureExisting(
+	ctx context.Context,
+	runtime assistantRuntimeRecord,
+	flapsClient flyRuntimeFlapsClient,
+	metadata flyRuntimeMetadata,
+) (RuntimeBackendEnsureResult, error) {
+	appName := metadata.AppName
+	if appName == "" {
+		appName = f.appName(runtime.AssistantThreadID)
+	}
+
+	appURL := metadata.AppURL
+	if appURL == "" {
+		appURL = flyRuntimeAppURL(appName)
+	}
+
+	appIP, err := f.ensureApp(ctx, appName)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+	if appIP == "" {
+		appIP = metadata.AppIP
+	}
+
+	machine, err := f.resolveMachine(ctx, flapsClient, appName, metadata.MachineID)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, err
+	}
+
+	coldStart := false
+	if machine == nil {
+		machine, err = f.launchMachine(ctx, flapsClient, runtime, appName)
+		if err != nil {
+			return RuntimeBackendEnsureResult{}, err
+		}
+		coldStart = true
+	}
+
+	if !machine.IsActive() {
+		if _, err := flapsClient.Start(ctx, appName, machine.ID, ""); err != nil {
+			return RuntimeBackendEnsureResult{}, fmt.Errorf("start assistant fly runtime machine: %w", err)
+		}
+		if err := flapsClient.Wait(ctx, appName, machine, "started", defaultFlyRuntimeHealthTimeout); err != nil {
+			return RuntimeBackendEnsureResult{}, fmt.Errorf("wait for assistant fly runtime machine start: %w", err)
+		}
+		coldStart = true
+		refreshed, getErr := flapsClient.Get(ctx, appName, machine.ID)
+		if getErr == nil && refreshed != nil {
+			machine = refreshed
+		}
+	}
+
+	target := flyRuntimeTarget{URL: appURL, IP: appIP}
+	if err := f.waitForRuntimeHealth(ctx, target); err != nil {
+		return RuntimeBackendEnsureResult{}, fmt.Errorf("wait for assistant fly runtime health: %w", err)
+	}
+
+	state, err := f.runtimeState(ctx, target)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, fmt.Errorf("load assistant fly runtime state: %w", err)
+	}
+
+	if machine.InstanceID != "" && machine.InstanceID != metadata.LastBootID {
+		coldStart = true
+	}
+
+	needsConfigure := !state.Configured
+	if needsConfigure {
+		coldStart = true
+	}
+
+	nextMetadata := flyRuntimeMetadata{
+		AppName:    appName,
+		AppURL:     appURL,
+		AppIP:      appIP,
+		MachineID:  machine.ID,
+		Region:     firstNonEmpty(machine.Region, metadata.Region, f.config.DefaultFlyRegion),
+		LastBootID: machine.InstanceID,
+	}
+
+	rawMetadata, err := json.Marshal(nextMetadata)
+	if err != nil {
+		return RuntimeBackendEnsureResult{}, fmt.Errorf("marshal assistant fly runtime metadata: %w", err)
+	}
+
+	return RuntimeBackendEnsureResult{
+		ColdStart:           coldStart,
+		NeedsConfigure:      needsConfigure,
+		BackendMetadataJSON: rawMetadata,
+	}, nil
+}
+
+// ensureApp returns the app's shared v4 IP so callers can dial it directly
+// instead of waiting on public DNS propagation (see flyRuntimeTarget).
+func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (string, error) {
+	app, err := f.client.GetApp(ctx, appName)
+	switch {
+	case err == nil:
+		return app.SharedIPAddress, nil
+	case isFlyNotFound(err):
+		org, err := f.client.GetOrganizationBySlug(ctx, f.config.DefaultFlyOrg)
+		if err != nil {
+			return "", fmt.Errorf("resolve assistant fly runtime organization: %w", err)
+		}
+		_, err = f.client.CreateApp(ctx, fly.CreateAppInput{
+			OrganizationID:  org.ID,
+			Name:            appName,
+			PreferredRegion: new(f.config.DefaultFlyRegion),
+		})
+		if err != nil && !isFlyAppNameTaken(err) {
+			return "", fmt.Errorf("create assistant fly runtime app: %w", err)
+		}
+		if _, getErr := f.client.GetApp(ctx, appName); getErr != nil {
+			return "", fmt.Errorf("verify assistant fly runtime app: %w", getErr)
+		}
+		ip, err := f.client.AllocateSharedIPAddress(ctx, appName)
+		if err != nil && !isFlyIPAlreadyAssigned(err) {
+			return "", fmt.Errorf("allocate assistant fly runtime shared ip: %w", err)
+		}
+		ipStr := ""
+		if ip != nil {
+			ipStr = ip.String()
+		}
+		// Dedicated v6 in addition to the shared v4. Fresh apps with only a
+		// shared v4 can take minutes for `<app>.fly.dev` A records to
+		// propagate, blowing past waitForRuntimeHealth's budget. Allocating
+		// a v6 forces an immediate DNS publish for both records.
+		if _, err := f.client.AllocateIPAddress(ctx, appName, "v6", "", org.ID, ""); err != nil && !isFlyIPAlreadyAssigned(err) {
+			return "", fmt.Errorf("allocate assistant fly runtime v6 ip: %w", err)
+		}
+		if ipStr == "" {
+			// IP was already allocated previously (isFlyIPAlreadyAssigned path
+			// or nil return); fetch it from the app record.
+			if refreshed, getErr := f.client.GetApp(ctx, appName); getErr == nil {
+				ipStr = refreshed.SharedIPAddress
+			}
+		}
+		return ipStr, nil
+	default:
+		return "", fmt.Errorf("load assistant fly runtime app: %w", err)
+	}
+}
+
+func (f *FlyRuntimeBackend) resolveMachine(
+	ctx context.Context,
+	flapsClient flyRuntimeFlapsClient,
+	appName string,
+	machineID string,
+) (*fly.Machine, error) {
+	if machineID != "" {
+		machine, err := flapsClient.Get(ctx, appName, machineID)
+		switch {
+		case err == nil:
+			return machine, nil
+		case !isFlyNotFound(err):
+			return nil, fmt.Errorf("load assistant fly runtime machine: %w", err)
+		}
+	}
+
+	machines, err := flapsClient.List(ctx, appName, "")
+	if err != nil {
+		return nil, fmt.Errorf("list assistant fly runtime machines: %w", err)
+	}
+	if len(machines) == 0 {
+		return nil, nil
+	}
+	return machines[0], nil
+}
+
+func (f *FlyRuntimeBackend) launchMachine(
+	ctx context.Context,
+	flapsClient flyRuntimeFlapsClient,
+	runtime assistantRuntimeRecord,
+	appName string,
+) (*fly.Machine, error) {
+	input := fly.LaunchMachineInput{
+		Config:              f.machineConfig(runtime),
+		Region:              f.config.DefaultFlyRegion,
+		Name:                "assistant-" + shortRuntimeName(runtime.AssistantThreadID),
+		SkipLaunch:          false,
+		RequiresReplacement: true,
+	}
+
+	machine, err := f.launchMachineWithRetry(ctx, flapsClient, appName, input)
+	if err != nil {
+		return nil, fmt.Errorf("launch assistant fly runtime machine: %w", err)
+	}
+	if err := flapsClient.Wait(ctx, appName, machine, "started", defaultFlyRuntimeHealthTimeout); err != nil {
+		return nil, fmt.Errorf("wait for assistant fly runtime machine launch: %w", err)
+	}
+	return machine, nil
+}
+
+func (f *FlyRuntimeBackend) launchMachineWithRetry(
+	ctx context.Context,
+	flapsClient flyRuntimeFlapsClient,
+	appName string,
+	input fly.LaunchMachineInput,
+) (*fly.Machine, error) {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = time.Second
+	bo.MaxInterval = 8 * time.Second
+	bo.Multiplier = 2
+
+	machine, err := backoff.Retry(ctx, func() (*fly.Machine, error) {
+		machine, err := flapsClient.Launch(ctx, appName, input)
+		if err == nil {
+			return machine, nil
+		}
+		if isFlyAppReady(err) {
+			return nil, backoff.Permanent(fmt.Errorf("launch assistant fly runtime machine: %w", err))
+		}
+		return nil, fmt.Errorf("launch assistant fly runtime machine: %w", err)
+	}, backoff.WithBackOff(bo), backoff.WithMaxTries(5))
+	if err != nil {
+		return nil, fmt.Errorf("retry launch assistant fly runtime machine: %w", err)
+	}
+	return machine, nil
+}
+
+func (f *FlyRuntimeBackend) Configure(ctx context.Context, runtime assistantRuntimeRecord, config runtimeStartupConfig) error {
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return err
+	}
+	metadata, err := decodeFlyRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return err
+	}
+	if metadata.AppURL == "" {
+		return fmt.Errorf("assistant fly runtime app url is not available")
+	}
+
+	body, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal assistant fly runtime config: %w", err)
+	}
+	_, err = f.runtimeRequest(ctx, targetFromMetadata(metadata), runtimeHTTPRequest{
+		Method:         http.MethodPost,
+		Path:           "/configure",
+		ContentType:    "application/json",
+		Body:           body,
+		MaxTimeSeconds: 0,
+		IdempotencyKey: "",
+	})
+	if err != nil {
+		return fmt.Errorf("configure assistant fly runtime: %w", err)
+	}
+	return nil
+}
+
+func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntimeRecord, idempotencyKey string, authToken string, history []runtimeMessage, prompt string) error {
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return err
+	}
+	metadata, err := decodeFlyRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return err
+	}
+	if metadata.AppURL == "" {
+		return fmt.Errorf("assistant fly runtime app url is not available")
+	}
+
+	reqBody, err := json.Marshal(runtimeTurnRequest{
+		History:   history,
+		Input:     prompt,
+		AuthToken: authToken,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal assistant fly runtime turn request: %w", err)
+	}
+
+	body, err := f.runtimeRequest(ctx, targetFromMetadata(metadata), runtimeHTTPRequest{
+		Method:         http.MethodPost,
+		Path:           "/turn",
+		ContentType:    "application/json",
+		Body:           reqBody,
+		IdempotencyKey: idempotencyKey,
+		MaxTimeSeconds: 30 * 60,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: execute fly turn request: %w", ErrRuntimeUnhealthy, err)
+	}
+
+	var turnResp runtimeTurnResponse
+	if err := json.Unmarshal(body, &turnResp); err != nil {
+		return fmt.Errorf("decode assistant fly runtime turn response: %w; body=%s", err, truncateForMetadata(string(body), 16*1024))
+	}
+	if turnResp.Error != "" {
+		return fmt.Errorf("assistant fly runtime turn error: %s", turnResp.Error)
+	}
+	return nil
+}
+
+func (f *FlyRuntimeBackend) ServerURL(_ context.Context, runtime assistantRuntimeRecord, raw *url.URL) (*url.URL, error) {
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return nil, err
+	}
+
+	candidate := raw
+	if f.config.ServerURLOverride != nil {
+		candidate = f.config.ServerURLOverride
+	}
+	if candidate == nil {
+		return nil, fmt.Errorf("assistant runtime server URL is not configured")
+	}
+	if host := candidate.Hostname(); host == "" || isLoopbackHost(host) {
+		return nil, fmt.Errorf("assistant fly runtime requires a public --assistant-runtime-server-url or --server-url; got %q", candidate.String())
+	}
+
+	cloned := *candidate
+	return &cloned, nil
+}
+
+func (f *FlyRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return err
+	}
+	metadata, err := decodeFlyRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return err
+	}
+	if metadata.AppName == "" {
+		return nil
+	}
+	return f.deleteApp(ctx, metadata.AppName)
+}
+
+func (f *FlyRuntimeBackend) deleteApp(ctx context.Context, appName string) error {
+	if err := f.client.DeleteApp(ctx, appName); err != nil && !isFlyNotFound(err) {
+		return fmt.Errorf("delete assistant fly runtime app: %w", err)
+	}
+	return nil
+}
+
+func (f *FlyRuntimeBackend) machineConfig(runtime assistantRuntimeRecord) *fly.MachineConfig {
+	stop := fly.MachineAutostopOff
+	autostart := true
+	return &fly.MachineConfig{
+		Image: fmt.Sprintf("%s:%s", f.config.OCIImage, f.config.ImageVersion),
+		Env: map[string]string{
+			"GRAM_ASSISTANT_ID":         runtime.AssistantID.String(),
+			"GRAM_ASSISTANT_PROJECT_ID": runtime.ProjectID.String(),
+			"GRAM_ASSISTANT_THREAD_ID":  runtime.AssistantThreadID.String(),
+		},
+		Guest: &fly.MachineGuest{
+			CPUKind:       "shared",
+			CPUs:          2,
+			MemoryMB:      1024,
+			PersistRootfs: fly.MachinePersistRootfsNever,
+		},
+		Metadata: map[string]string{
+			fly.MachineConfigMetadataKeyFlyPlatformVersion: "v2",
+			fly.MachineConfigMetadataKeyFlyProcessGroup:    "assistant_runtime",
+			"gram_assistant_id":                            runtime.AssistantID.String(),
+			"gram_assistant_project_id":                    runtime.ProjectID.String(),
+			"gram_assistant_thread_id":                     runtime.AssistantThreadID.String(),
+			"gram_role":                                    "assistant_runtime",
+		},
+		Services: []fly.MachineService{
+			{
+				Protocol:           "tcp",
+				InternalPort:       defaultRuntimeGuestPort,
+				Autostop:           &stop,
+				Autostart:          &autostart,
+				MinMachinesRunning: new(0),
+				Ports: []fly.MachinePort{
+					{
+						Handlers: []string{"tls"},
+						Port:     new(443),
+					},
+				},
+				Checks: []fly.MachineServiceCheck{
+					{
+						Type:         new("http"),
+						HTTPProtocol: new("http"),
+						HTTPMethod:   ptr(http.MethodGet),
+						HTTPPath:     new("/healthz"),
+						Interval:     &fly.Duration{Duration: 15 * time.Second},
+						Timeout:      &fly.Duration{Duration: 5 * time.Second},
+						GracePeriod:  &fly.Duration{Duration: 5 * time.Second},
+					},
+				},
+			},
+		},
+		Restart: &fly.MachineRestart{
+			Policy:     "on-failure",
+			MaxRetries: 3,
+		},
+	}
+}
+
+// flyRuntimeTarget bundles the app URL with its allocated public IP so HTTP
+// calls can bypass public DNS — a freshly created app's A record can take
+// 30-60s to propagate, but the shared IP is routable the moment Fly's proxy
+// sees the allocation. Dial the IP directly, keep the hostname on the URL so
+// SNI + wildcard cert verification still pass.
+type flyRuntimeTarget struct {
+	URL string
+	IP  string
+}
+
+func targetFromMetadata(md flyRuntimeMetadata) flyRuntimeTarget {
+	return flyRuntimeTarget{URL: md.AppURL, IP: md.AppIP}
+}
+
+func (f *FlyRuntimeBackend) waitForRuntimeHealth(ctx context.Context, target flyRuntimeTarget) error {
+	deadline := time.Now().Add(defaultFlyRuntimeHealthTimeout)
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("runtime health check timed out")
+		}
+		if ctx.Err() != nil {
+			return fmt.Errorf("wait for runtime health: %w", ctx.Err())
+		}
+		if _, err := f.runtimeRequest(ctx, target, runtimeHTTPRequest{
+			Method:         http.MethodGet,
+			Path:           "/healthz",
+			ContentType:    "",
+			Body:           nil,
+			MaxTimeSeconds: 0,
+			IdempotencyKey: "",
+		}); err == nil {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func (f *FlyRuntimeBackend) runtimeState(ctx context.Context, target flyRuntimeTarget) (flyRuntimeStateResponse, error) {
+	body, err := f.runtimeRequest(ctx, target, runtimeHTTPRequest{
+		Method:         http.MethodGet,
+		Path:           "/state",
+		ContentType:    "",
+		Body:           nil,
+		MaxTimeSeconds: 0,
+		IdempotencyKey: "",
+	})
+	if err != nil {
+		return flyRuntimeStateResponse{}, err
+	}
+	var state flyRuntimeStateResponse
+	if err := json.Unmarshal(body, &state); err != nil {
+		return flyRuntimeStateResponse{}, fmt.Errorf("decode assistant fly runtime state: %w", err)
+	}
+	return state, nil
+}
+
+// clientForTarget used to dial target.IP directly to bypass public DNS
+// propagation on fresh apps. Doesn't work on shared Fly IPs: the edge
+// accepts TLS but drops the backend with EOF until the SNI→app mapping
+// finishes registering — same propagation window as DNS. Kept as a hook
+// point; a future dedicated-IP or single-app-many-machines design (see
+// plan B) can flip the pinning back on.
+func (f *FlyRuntimeBackend) clientForTarget(_ flyRuntimeTarget) flyRuntimeHTTPDoer {
+	return f.httpClient
+}
+
+func (f *FlyRuntimeBackend) runtimeRequest(ctx context.Context, target flyRuntimeTarget, request runtimeHTTPRequest) ([]byte, error) {
+	reqCtx, cancel := runtimeRequestContext(ctx, request.MaxTimeSeconds, defaultFlyRuntimeRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, request.Method, strings.TrimRight(target.URL, "/")+request.Path, bytes.NewReader(request.Body))
+	if err != nil {
+		return nil, fmt.Errorf("build assistant fly runtime request: %w", err)
+	}
+	if request.ContentType != "" {
+		req.Header.Set("Content-Type", request.ContentType)
+	}
+	if request.IdempotencyKey != "" {
+		req.Header.Set("X-Idempotency-Key", request.IdempotencyKey)
+	}
+
+	client := f.clientForTarget(target)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send assistant fly runtime request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read assistant fly runtime response: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func (f *FlyRuntimeBackend) appName(threadID uuid.UUID) string {
+	return fmt.Sprintf("%s-%s", f.config.AppNamePrefix, strings.ToLower(threadID.String()))
+}
+
+func decodeFlyRuntimeMetadata(raw []byte) (flyRuntimeMetadata, error) {
+	if len(raw) == 0 {
+		return flyRuntimeMetadata{
+			AppName:    "",
+			AppURL:     "",
+			AppIP:      "",
+			MachineID:  "",
+			Region:     "",
+			LastBootID: "",
+		}, nil
+	}
+	var metadata flyRuntimeMetadata
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return flyRuntimeMetadata{}, fmt.Errorf("decode assistant fly runtime metadata: %w", err)
+	}
+	return metadata, nil
+}
+
+func shortRuntimeName(id uuid.UUID) string {
+	raw := strings.ReplaceAll(strings.ToLower(id.String()), "-", "")
+	if len(raw) > 12 {
+		return raw[:12]
+	}
+	return raw
+}
+
+func flyRuntimeAppURL(appName string) string {
+	return fmt.Sprintf("https://%s.fly.dev", appName)
+}
+
+func sanitizeFlyAppNamePrefix(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return ""
+	}
+	var out strings.Builder
+	lastDash := false
+	for _, ch := range raw {
+		switch {
+		case ch >= 'a' && ch <= 'z':
+			out.WriteRune(ch)
+			lastDash = false
+		case ch >= '0' && ch <= '9':
+			out.WriteRune(ch)
+			lastDash = false
+		case ch == '-':
+			if !lastDash {
+				out.WriteRune(ch)
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(out.String(), "-")
+}
+
+func isFlyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "could not find") ||
+		strings.Contains(msg, "no rows in result set")
+}
+
+func isFlyAppNameTaken(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "name has already been taken")
+}
+
+func isFlyIPAlreadyAssigned(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already allocated") || strings.Contains(msg, "already has")
+}
+
+// isFlyAppReady reports whether the error does NOT indicate a transient Fly.io
+// propagation failure where the Machines API hasn't seen the app yet.
+func isFlyAppReady(err error) bool {
+	if err == nil {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return !strings.Contains(msg, "no rows in result set") && !strings.Contains(msg, "failed to get app")
+}
+
+type assistantFlyLogger struct {
+	logger      *slog.Logger
+	contextFunc func() context.Context
+}
+
+func (f *assistantFlyLogger) Debug(v ...any) {
+	f.logger.DebugContext(f.contextFunc(), fmt.Sprint(v...))
+}
+
+func (f *assistantFlyLogger) Debugf(format string, v ...any) {
+	f.logger.DebugContext(f.contextFunc(), fmt.Sprintf(format, v...))
+}
+
+//go:fix inline
+func ptr[T any](v T) *T {
+	return new(v)
+}

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -1,0 +1,342 @@
+package assistants
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestFlyRuntimeBackendEnsureColdCreate(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, false)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	apiClient.getAppErr = errors.New("not found")
+	apiClient.organization = &fly.Organization{ID: "org-123"}
+	flapsClient.listMachines = []*fly.Machine{}
+	flapsClient.launchMachine = &fly.Machine{
+		ID:         "machine-1",
+		State:      "started",
+		Region:     "ord",
+		InstanceID: "boot-1",
+	}
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID: uuid.New(),
+		AssistantID:       uuid.New(),
+		ProjectID:         uuid.New(),
+		Backend:           runtimeBackendFlyIO,
+	})
+	require.NoError(t, err)
+	require.True(t, result.ColdStart)
+	require.True(t, result.NeedsConfigure)
+
+	var metadata flyRuntimeMetadata
+	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &metadata))
+	require.Equal(t, "machine-1", metadata.MachineID)
+	require.Equal(t, "ord", metadata.Region)
+	require.NotEmpty(t, metadata.AppName)
+	require.Equal(t, "boot-1", metadata.LastBootID)
+}
+
+func TestFlyRuntimeBackendEnsureWarmReuse(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      "started",
+		Region:     "iad",
+		InstanceID: "boot-1",
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.False(t, result.ColdStart)
+	require.False(t, result.NeedsConfigure)
+}
+
+func TestFlyRuntimeBackendEnsureMachineUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, false)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      "started",
+		Region:     "iad",
+		InstanceID: "boot-1",
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.True(t, result.ColdStart)
+	require.True(t, result.NeedsConfigure)
+}
+
+func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, _ := newTestFlyRuntimeBackend(t, server)
+
+	apiClient.deleteErr = errors.New("not found")
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{AppName: "gram-asst-test"})
+	require.NoError(t, err)
+
+	err = backend.Stop(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+}
+
+func TestFlyRuntimeBackendServerURLRejectsLoopback(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, _, _ := newTestFlyRuntimeBackend(t, server)
+	backend.config.ServerURLOverride = nil
+
+	_, err := backend.ServerURL(context.Background(), assistantRuntimeRecord{
+		Backend: runtimeBackendFlyIO,
+	}, &url.URL{Scheme: "https", Host: "127.0.0.1:8080"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "public")
+}
+
+type testFlyRuntimeAPIClient struct {
+	app          *fly.App
+	getAppErr    error
+	deleteErr    error
+	createAppErr error
+	organization *fly.Organization
+}
+
+func (c *testFlyRuntimeAPIClient) AllocateSharedIPAddress(_ context.Context, _ string) (net.IP, error) {
+	// Returning nil leaves AppIP empty so clientForTarget falls back to the
+	// default httpClient — tests point AppURL at a local httptest server that
+	// isn't reachable by the real shared-IP dialer.
+	return nil, nil
+}
+
+func (c *testFlyRuntimeAPIClient) AllocateIPAddress(_ context.Context, _ string, _ string, _ string, _ string, _ string) (*fly.IPAddress, error) {
+	return &fly.IPAddress{Address: "2001:db8::1"}, nil
+}
+
+func (c *testFlyRuntimeAPIClient) CreateApp(_ context.Context, input fly.CreateAppInput) (*fly.App, error) {
+	if c.createAppErr != nil {
+		return nil, c.createAppErr
+	}
+	c.app = &fly.App{Name: input.Name}
+	c.getAppErr = nil
+	return c.app, nil
+}
+
+func (c *testFlyRuntimeAPIClient) DeleteApp(_ context.Context, _ string) error {
+	return c.deleteErr
+}
+
+func (c *testFlyRuntimeAPIClient) GetApp(_ context.Context, _ string) (*fly.App, error) {
+	if c.getAppErr != nil {
+		return nil, c.getAppErr
+	}
+	if c.app == nil {
+		return nil, errors.New("not found")
+	}
+	return c.app, nil
+}
+
+func (c *testFlyRuntimeAPIClient) GetOrganizationBySlug(_ context.Context, _ string) (*fly.Organization, error) {
+	if c.organization == nil {
+		return nil, errors.New("organization not configured")
+	}
+	return c.organization, nil
+}
+
+type testFlyRuntimeFlapsClient struct {
+	machine       *fly.Machine
+	getErr        error
+	listMachines  []*fly.Machine
+	launchMachine *fly.Machine
+	launchErr     error
+	startErr      error
+	waitErr       error
+}
+
+func (c *testFlyRuntimeFlapsClient) Get(_ context.Context, _ string, _ string) (*fly.Machine, error) {
+	if c.getErr != nil {
+		return nil, c.getErr
+	}
+	if c.machine == nil {
+		return nil, errors.New("not found")
+	}
+	return c.machine, nil
+}
+
+func (c *testFlyRuntimeFlapsClient) Launch(_ context.Context, _ string, _ fly.LaunchMachineInput) (*fly.Machine, error) {
+	if c.launchErr != nil {
+		return nil, c.launchErr
+	}
+	if c.launchMachine != nil {
+		c.machine = c.launchMachine
+		return c.launchMachine, nil
+	}
+	return nil, errors.New("launch machine not configured")
+}
+
+func (c *testFlyRuntimeFlapsClient) List(_ context.Context, _ string, _ string) ([]*fly.Machine, error) {
+	return c.listMachines, nil
+}
+
+func (c *testFlyRuntimeFlapsClient) Start(_ context.Context, _ string, _ string, _ string) (*fly.MachineStartResponse, error) {
+	if c.startErr != nil {
+		return nil, c.startErr
+	}
+	if c.machine != nil {
+		c.machine.State = "started"
+	}
+	return &fly.MachineStartResponse{}, nil
+}
+
+func (c *testFlyRuntimeFlapsClient) Wait(_ context.Context, _ string, _ *fly.Machine, _ string, _ time.Duration) error {
+	return c.waitErr
+}
+
+type testFlyRuntimeFlapsFactory struct {
+	client flyRuntimeFlapsClient
+}
+
+func (f *testFlyRuntimeFlapsFactory) New(context.Context) (flyRuntimeFlapsClient, error) {
+	return f.client, nil
+}
+
+func newTestAssistantRuntimeServer(t *testing.T, configured bool) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/state", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(flyRuntimeStateResponse{Configured: configured})
+	})
+	mux.HandleFunc("/configure", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/turn", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(runtimeTurnResponse{FinalText: "ok"})
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newTestFlyRuntimeBackend(t *testing.T, server *httptest.Server) (*FlyRuntimeBackend, *testFlyRuntimeAPIClient, *testFlyRuntimeFlapsClient) {
+	t.Helper()
+
+	apiClient := &testFlyRuntimeAPIClient{}
+	flapsClient := &testFlyRuntimeFlapsClient{}
+
+	backend := &FlyRuntimeBackend{
+		logger: testenv.NewLogger(t),
+		config: FlyRuntimeConfig{
+			DefaultFlyOrg:     "speakeasy-lab",
+			DefaultFlyRegion:  "iad",
+			OCIImage:          "registry.fly.io/assistant-runtime",
+			ImageVersion:      "dev",
+			AppNamePrefix:     "gram-asst",
+			ServerURLOverride: mustParseURL(t, "https://gram.example.com"),
+		},
+		client:       apiClient,
+		flapsFactory: &testFlyRuntimeFlapsFactory{client: flapsClient},
+		httpClient: &testRuntimeHTTPDoer{
+			baseURL: server.URL,
+			client:  server.Client(),
+		},
+	}
+
+	return backend, apiClient, flapsClient
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	return parsed
+}
+
+var _ RuntimeBackend = (*FlyRuntimeBackend)(nil)
+
+type testRuntimeHTTPDoer struct {
+	baseURL string
+	client  *http.Client
+}
+
+func (d *testRuntimeHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	target, err := url.Parse(d.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse runtime base url: %w", err)
+	}
+	cloned.URL.Scheme = target.Scheme
+	cloned.URL.Host = target.Host
+	cloned.Host = target.Host
+	resp, err := d.client.Do(cloned)
+	if err != nil {
+		return nil, fmt.Errorf("send test runtime request: %w", err)
+	}
+	return resp, nil
+}

--- a/server/internal/assistants/runtime_http_test.go
+++ b/server/internal/assistants/runtime_http_test.go
@@ -43,6 +43,26 @@ func TestRuntimeManagerRuntimeRequestDirectHonorsMaxTimeSeconds(t *testing.T) {
 	require.Less(t, time.Since(start), 1400*time.Millisecond)
 }
 
+func TestFlyRuntimeRequestHonorsMaxTimeSeconds(t *testing.T) {
+	t.Parallel()
+
+	server := newSlowAssistantRuntimeServer(t, 1500*time.Millisecond)
+
+	backend := &FlyRuntimeBackend{
+		httpClient: server.Client(),
+	}
+
+	start := time.Now()
+	_, err := backend.runtimeRequest(context.Background(), flyRuntimeTarget{URL: server.URL}, runtimeHTTPRequest{
+		Method:         http.MethodGet,
+		Path:           "/slow",
+		MaxTimeSeconds: 1,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "context deadline exceeded")
+	require.Less(t, time.Since(start), 1400*time.Millisecond)
+}
+
 func newSlowAssistantRuntimeServer(t *testing.T, delay time.Duration) *httptest.Server {
 	t.Helper()
 

--- a/server/internal/assistants/runtime_provider.go
+++ b/server/internal/assistants/runtime_provider.go
@@ -15,6 +15,9 @@ import (
 const (
 	RuntimeProviderLocal = runtimeBackendLocal
 	RuntimeProviderFlyIO = runtimeBackendFlyIO
+
+	defaultFlyRuntimeRegion = "us"
+	defaultFlyRuntimePrefix = "gram-asst"
 )
 
 type RuntimeBackendConfig struct {
@@ -50,6 +53,8 @@ func NewRuntimeBackend(logger *slog.Logger, config RuntimeBackendConfig) (Runtim
 	switch normalizeRuntimeProvider(config.Provider) {
 	case RuntimeProviderLocal:
 		return NewRuntimeManager(logger, config.Local), nil
+	case RuntimeProviderFlyIO:
+		return NewFlyRuntimeBackend(logger, config.Fly)
 	default:
 		return nil, fmt.Errorf("unsupported assistant runtime provider %q", config.Provider)
 	}


### PR DESCRIPTION
## Why

Stacked on #2371. Activates the FlyIO branch of the runtime provider factory so threads actually boot machines on Fly instead of staying on the local runtime scaffold.

## What changed

- `server/internal/assistants/runtime_fly.go` — Fly machines backend. Provisions apps/machines, manages warm pool, tears down on expire. ~800 LOC, fully isolated to its own file.
- `server/internal/assistants/runtime_fly_test.go` — unit tests.
- `server/internal/assistants/runtime_provider.go` — re-enable the `FlyIO` case in `NewRuntimeBackend`; restore `defaultFlyRuntimeRegion` and `defaultFlyRuntimePrefix` constants used by `runtime_fly`.
- `server/internal/assistants/runtime_http_test.go` — restore `TestFlyRuntimeRequestHonorsMaxTimeSeconds` coverage. Removed in PR 1 because it referenced `FlyRuntimeBackend` from this file.

### Before

`NewRuntimeBackend` returned `unsupported assistant runtime provider` for `flyio`. Only the local runtime worked.

### After

Fly config (via `flags_assistants.go`, already present in PR 1) routes to the real `FlyRuntimeBackend` and boots machines against the image tag published by PR 3.

## Depends on

- #2371 — workflows (base branch).
- Transitively: #2370 — API + runtime scaffold.

## Blocked by

- #2368 — assistant runtime image. Must be tag-available before Fly config points at it.

Closes AGE-1938

✻ Clauded...
