### PR TITLE
chore: add support for wide event tracking

### DIFF
--- a/plog/testdata/handler_dedup_attr_keys.golden
+++ b/plog/testdata/handler_dedup_attr_keys.golden
@@ -1,0 +1,4 @@
+00:00:00.000 INFO  response
+    gram.component: final
+    status: 200
+

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -89,7 +89,7 @@ linters:
           - forbidigo
         text: GG002
       # This is the only sanctioned place to use slog attribute builders to establish conventions.
-      - path: internal/attr/conventions\.go
+      - path: internal/attr/
         linters:
           - glint
         text: enforceo11yconventions

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -86,18 +86,6 @@ const (
 	TemporalWorkflowIDKey    = attribute.Key("temporal.workflow.id")
 	TemporalRunIDKey         = attribute.Key("temporal.run.id")
 
-	AuthAccountTypeKey      = attribute.Key("gram.auth.account_type")
-	AuthAPIKeyIDKey         = attribute.Key("gram.auth.api_key.id")
-	AuthOrganizationIDKey   = attribute.Key("gram.auth.organization_id")
-	AuthOrganizationSlugKey = attribute.Key("gram.auth.organization_slug")
-	AuthProjectIDKey        = attribute.Key("gram.auth.project_id")
-	AuthProjectSlugKey      = attribute.Key("gram.auth.project_slug")
-	AuthSchemeKey           = attribute.Key("gram.auth.scheme")
-	AuthSessionIDKey        = attribute.Key("gram.auth.session_id")
-	AuthUserEmailKey        = attribute.Key("gram.auth.user_email")
-	AuthUserIDKey           = attribute.Key("gram.auth.user_id")
-	AuthUserExternalIDKey   = attribute.Key("gram.auth.external_user_id")
-
 	AssetIDKey                     = attribute.Key("gram.asset.id")
 	AssetURLKey                    = attribute.Key("gram.asset.url")
 	ChatIDKey                      = attribute.Key("gram.chat.id")
@@ -488,41 +476,6 @@ func SlogGoaService(v string) slog.Attr      { return slog.String(string(GoaServ
 
 func GoaMethod(v string) attribute.KeyValue { return GoaMethodKey.String(v) }
 func SlogGoaMethod(v string) slog.Attr      { return slog.String(string(GoaMethodKey), v) }
-
-func AuthAccountType(v string) attribute.KeyValue { return AuthAccountTypeKey.String(v) }
-func SlogAuthAccountType(v string) slog.Attr      { return slog.String(string(AuthAccountTypeKey), v) }
-
-func AuthAPIKeyID(v string) attribute.KeyValue { return AuthAPIKeyIDKey.String(v) }
-func SlogAuthAPIKeyID(v string) slog.Attr      { return slog.String(string(AuthAPIKeyIDKey), v) }
-
-func AuthOrganizationID(v string) attribute.KeyValue { return AuthOrganizationIDKey.String(v) }
-func SlogAuthOrganizationID(v string) slog.Attr      { return slog.String(string(AuthOrganizationIDKey), v) }
-
-func AuthOrganizationSlug(v string) attribute.KeyValue { return AuthOrganizationSlugKey.String(v) }
-func SlogAuthOrganizationSlug(v string) slog.Attr {
-	return slog.String(string(AuthOrganizationSlugKey), v)
-}
-
-func AuthProjectID(v string) attribute.KeyValue { return AuthProjectIDKey.String(v) }
-func SlogAuthProjectID(v string) slog.Attr      { return slog.String(string(AuthProjectIDKey), v) }
-
-func AuthProjectSlug(v string) attribute.KeyValue { return AuthProjectSlugKey.String(v) }
-func SlogAuthProjectSlug(v string) slog.Attr      { return slog.String(string(AuthProjectSlugKey), v) }
-
-func AuthScheme(v string) attribute.KeyValue { return AuthSchemeKey.String(v) }
-func SlogAuthScheme(v string) slog.Attr      { return slog.String(string(AuthSchemeKey), v) }
-
-func AuthSessionID(v string) attribute.KeyValue { return AuthSessionIDKey.String(v) }
-func SlogAuthSessionID(v string) slog.Attr      { return slog.String(string(AuthSessionIDKey), v) }
-
-func AuthUserEmail(v string) attribute.KeyValue { return AuthUserEmailKey.String(v) }
-func SlogAuthUserEmail(v string) slog.Attr      { return slog.String(string(AuthUserEmailKey), v) }
-
-func AuthUserID(v string) attribute.KeyValue { return AuthUserIDKey.String(v) }
-func SlogAuthUserID(v string) slog.Attr      { return slog.String(string(AuthUserIDKey), v) }
-
-func AuthUserExternalID(v string) attribute.KeyValue { return AuthUserExternalIDKey.String(v) }
-func SlogAuthUserExternalID(v string) slog.Attr      { return slog.String(string(AuthUserExternalIDKey), v) }
 
 func AssetID(v string) attribute.KeyValue { return AssetIDKey.String(v) }
 func SlogAssetID(v string) slog.Attr      { return slog.String(string(AssetIDKey), v) }

--- a/server/internal/attr/wide.go
+++ b/server/internal/attr/wide.go
@@ -1,0 +1,171 @@
+package attr
+
+import (
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	WideEventKey = attribute.Key("gram.wide_event")
+
+	RequestPanicKey      = attribute.Key("gram.request.panic")
+	RequestPanicStackKey = attribute.Key("gram.request.panic_stack")
+
+	RequestAuthAccountTypeKey            = attribute.Key("gram.request.auth_account_type")
+	RequestAuthAPIKeyIDKey               = attribute.Key("gram.request.auth_api_key_id")
+	RequestAuthOrganizationIDKey         = attribute.Key("gram.request.auth_organization_id")
+	RequestAuthOrganizationSlugKey       = attribute.Key("gram.request.auth_organization_slug")
+	RequestAuthProjectIDKey              = attribute.Key("gram.request.auth_project_id")
+	RequestAuthProjectSlugKey            = attribute.Key("gram.request.auth_project_slug")
+	RequestAuthSchemeSessionKey          = attribute.Key("gram.request.auth_scheme_session")
+	RequestAuthSchemeProjectKey          = attribute.Key("gram.request.auth_scheme_project")
+	RequestAuthSchemeAPIKeyKey           = attribute.Key("gram.request.auth_scheme_api_key")
+	RequestAuthSessionIDKey              = attribute.Key("gram.request.auth_session_id")
+	RequestAuthUserEmailKey              = attribute.Key("gram.request.auth_user_email")
+	RequestAuthUserIDKey                 = attribute.Key("gram.request.auth_user_id")
+	RequestAuthUserExternalIDKey         = attribute.Key("gram.request.auth_external_user_id")
+	RequestAuthSchemeAPIKeyErrorKey      = attribute.Key("gram.request.auth_api_key_error")
+	RequestAuthSchemeSessionErrorKey     = attribute.Key("gram.request.auth_session_error")
+	RequestAuthSchemeProjectSlugErrorKey = attribute.Key("gram.request.auth_project_slug_error")
+	RequestCustomDomainIDKey             = attribute.Key("gram.request.custom_domain_id")
+	RequestCustomDomainNameKey           = attribute.Key("gram.request.custom_domain_name")
+	RequestMCPSlugKey                    = attribute.Key("gram.request.mcp_slug")
+	RequestMCPAuthorizationHeaderSetKey  = attribute.Key("gram.request.mcp_authorization_header_set")
+	RequestMCPChatSessionHeaderSetKey    = attribute.Key("gram.request.mcp_chat_session_header_set")
+)
+
+func WideEvent() attribute.KeyValue { return WideEventKey.Bool(true) }
+func SlogWideEvent() slog.Attr      { return slog.Bool(string(WideEventKey), true) }
+
+func RequestPanic(v any) attribute.KeyValue { return RequestPanicKey.String(fmt.Sprintf("%v", v)) }
+func SlogRequestPanic(v any) slog.Attr      { return slog.Any(string(RequestPanicKey), v) }
+
+func RequestPanicStack(v string) attribute.KeyValue { return RequestPanicStackKey.String(v) }
+func SlogRequestPanicStack(v string) slog.Attr      { return slog.String(string(RequestPanicStackKey), v) }
+
+func RequestAuthAccountType(v string) attribute.KeyValue { return RequestAuthAccountTypeKey.String(v) }
+func SlogRequestAuthAccountType(v string) slog.Attr {
+	return slog.String(string(RequestAuthAccountTypeKey), v)
+}
+
+func RequestAuthAPIKeyID(v string) attribute.KeyValue { return RequestAuthAPIKeyIDKey.String(v) }
+func SlogRequestAuthAPIKeyID(v string) slog.Attr {
+	return slog.String(string(RequestAuthAPIKeyIDKey), v)
+}
+
+func RequestAuthOrganizationID(v string) attribute.KeyValue {
+	return RequestAuthOrganizationIDKey.String(v)
+}
+func SlogRequestAuthOrganizationID(v string) slog.Attr {
+	return slog.String(string(RequestAuthOrganizationIDKey), v)
+}
+
+func RequestAuthOrganizationSlug(v string) attribute.KeyValue {
+	return RequestAuthOrganizationSlugKey.String(v)
+}
+func SlogRequestAuthOrganizationSlug(v string) slog.Attr {
+	return slog.String(string(RequestAuthOrganizationSlugKey), v)
+}
+
+func RequestAuthProjectID(v string) attribute.KeyValue { return RequestAuthProjectIDKey.String(v) }
+func SlogRequestAuthProjectID(v string) slog.Attr {
+	return slog.String(string(RequestAuthProjectIDKey), v)
+}
+
+func RequestAuthProjectSlug(v string) attribute.KeyValue { return RequestAuthProjectSlugKey.String(v) }
+func SlogRequestAuthProjectSlug(v string) slog.Attr {
+	return slog.String(string(RequestAuthProjectSlugKey), v)
+}
+
+func RequestAuthSessionScheme(matched bool) attribute.KeyValue {
+	return RequestAuthSchemeSessionKey.Bool(matched)
+}
+func SlogRequestAuthSessionScheme(matched bool) slog.Attr {
+	return slog.Bool(string(RequestAuthSchemeSessionKey), matched)
+}
+func RequestAuthProjectScheme(matched bool) attribute.KeyValue {
+	return RequestAuthSchemeProjectKey.Bool(matched)
+}
+func SlogRequestAuthProjectScheme(matched bool) slog.Attr {
+	return slog.Bool(string(RequestAuthSchemeProjectKey), matched)
+}
+func RequestAuthAPIKeyScheme(matched bool) attribute.KeyValue {
+	return RequestAuthSchemeAPIKeyKey.Bool(matched)
+}
+func SlogRequestAuthAPIKeyScheme(matched bool) slog.Attr {
+	return slog.Bool(string(RequestAuthSchemeAPIKeyKey), matched)
+}
+
+func RequestAuthSessionID(v string) attribute.KeyValue { return RequestAuthSessionIDKey.String(v) }
+func SlogRequestAuthSessionID(v string) slog.Attr {
+	return slog.String(string(RequestAuthSessionIDKey), v)
+}
+
+func RequestAuthUserEmail(v string) attribute.KeyValue { return RequestAuthUserEmailKey.String(v) }
+func SlogRequestAuthUserEmail(v string) slog.Attr {
+	return slog.String(string(RequestAuthUserEmailKey), v)
+}
+
+func RequestAuthUserID(v string) attribute.KeyValue { return RequestAuthUserIDKey.String(v) }
+func SlogRequestAuthUserID(v string) slog.Attr      { return slog.String(string(RequestAuthUserIDKey), v) }
+
+func RequestAuthUserExternalID(v string) attribute.KeyValue {
+	return RequestAuthUserExternalIDKey.String(v)
+}
+func SlogRequestAuthUserExternalID(v string) slog.Attr {
+	return slog.String(string(RequestAuthUserExternalIDKey), v)
+}
+
+func RequestAuthSchemeAPIKeyError(v string) attribute.KeyValue {
+	return RequestAuthSchemeAPIKeyErrorKey.String(v)
+}
+func SlogRequestAuthSchemeAPIKeyError(v string) slog.Attr {
+	return slog.String(string(RequestAuthSchemeAPIKeyErrorKey), v)
+}
+
+func RequestAuthSchemeSessionError(v string) attribute.KeyValue {
+	return RequestAuthSchemeSessionErrorKey.String(v)
+}
+func SlogRequestAuthSchemeSessionError(v string) slog.Attr {
+	return slog.String(string(RequestAuthSchemeSessionErrorKey), v)
+}
+
+func RequestAuthSchemeProjectSlugError(v string) attribute.KeyValue {
+	return RequestAuthSchemeProjectSlugErrorKey.String(v)
+}
+func SlogRequestAuthSchemeProjectSlugError(v string) slog.Attr {
+	return slog.String(string(RequestAuthSchemeProjectSlugErrorKey), v)
+}
+
+func RequestCustomDomainID(v string) attribute.KeyValue { return RequestCustomDomainIDKey.String(v) }
+func SlogRequestCustomDomainID(v string) slog.Attr {
+	return slog.String(string(RequestCustomDomainIDKey), v)
+}
+
+func RequestCustomDomainName(v string) attribute.KeyValue {
+	return RequestCustomDomainNameKey.String(v)
+}
+func SlogRequestCustomDomainName(v string) slog.Attr {
+	return slog.String(string(RequestCustomDomainNameKey), v)
+}
+
+func RequestMCPSlug(v string) attribute.KeyValue { return RequestMCPSlugKey.String(v) }
+func SlogRequestMCPSlug(v string) slog.Attr {
+	return slog.String(string(RequestMCPSlugKey), v)
+}
+
+func RequestMCPAuthorizationHeaderSet(v bool) attribute.KeyValue {
+	return RequestMCPAuthorizationHeaderSetKey.Bool(v)
+}
+func SlogRequestMCPAuthorizationHeaderSet(v bool) slog.Attr {
+	return slog.Bool(string(RequestMCPAuthorizationHeaderSetKey), v)
+}
+
+func RequestMCPChatSessionHeaderSet(v bool) attribute.KeyValue {
+	return RequestMCPChatSessionHeaderSetKey.Bool(v)
+}
+func SlogRequestMCPChatSessionHeaderSet(v bool) slog.Attr {
+	return slog.Bool(string(RequestMCPChatSessionHeaderSetKey), v)
+}

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 )
 
 type Auth struct {
@@ -54,17 +55,17 @@ func (s *Auth) Authorize(ctx context.Context, key string, scheme *security.APIKe
 	}
 
 	var err error
-	defer func() {
-		s.logAuthContext(ctx, err, scheme.Name)
-	}()
 
 	switch scheme.Name {
 	case constants.KeySecurityScheme:
 		ctx, err = s.keys.KeyBasedAuth(ctx, key, scheme.RequiredScopes)
+		s.logAuthContext(ctx, err, scheme.Name, attr.SlogRequestAuthAPIKeyScheme, attr.SlogRequestAuthSchemeAPIKeyError)
 	case constants.SessionSecurityScheme:
 		ctx, err = s.sessions.Authenticate(ctx, key)
+		s.logAuthContext(ctx, err, scheme.Name, attr.SlogRequestAuthSessionScheme, attr.SlogRequestAuthSchemeSessionError)
 	case constants.ProjectSlugSecuritySchema:
 		ctx, err = s.checkProjectAccess(ctx, s.logger, key)
+		s.logAuthContext(ctx, err, scheme.Name, attr.SlogRequestAuthProjectScheme, attr.SlogRequestAuthSchemeProjectSlugError)
 	default:
 		err = oops.E(oops.CodeUnauthorized, nil, "unsupported security scheme")
 	}
@@ -146,46 +147,54 @@ func (s *Auth) CheckProjectAccess(ctx context.Context, logger *slog.Logger, proj
 	return nil
 }
 
-func (s *Auth) logAuthContext(ctx context.Context, err error, scheme string) {
+func (s *Auth) logAuthContext(
+	ctx context.Context,
+	err error,
+	scheme string,
+	schemeAttr func(matched bool) slog.Attr,
+	errAttr func(v string) slog.Attr,
+) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok {
 		return
 	}
 
-	attrs := []any{
-		attr.SlogAuthScheme(scheme),
-		attr.SlogAuthOrganizationID(authCtx.ActiveOrganizationID),
-		attr.SlogAuthOrganizationSlug(authCtx.OrganizationSlug),
-		attr.SlogAuthAccountType(authCtx.AccountType),
+	attrs := []slog.Attr{
+		schemeAttr(err == nil),
+		attr.SlogRequestAuthOrganizationID(authCtx.ActiveOrganizationID),
+		attr.SlogRequestAuthOrganizationSlug(authCtx.OrganizationSlug),
+		attr.SlogRequestAuthAccountType(authCtx.AccountType),
 	}
 	if err != nil {
-		attrs = append(attrs, attr.SlogError(err))
+		attrs = append(attrs, errAttr(err.Error()))
 	}
 	if authCtx.UserID != "" {
-		attrs = append(attrs, attr.SlogAuthUserID(authCtx.UserID))
+		attrs = append(attrs, attr.SlogRequestAuthUserID(authCtx.UserID))
 	}
 	if authCtx.ExternalUserID != "" {
-		attrs = append(attrs, attr.SlogAuthUserExternalID(authCtx.ExternalUserID))
+		attrs = append(attrs, attr.SlogRequestAuthUserExternalID(authCtx.ExternalUserID))
 	}
 	if authCtx.Email != nil {
-		attrs = append(attrs, attr.SlogAuthUserEmail(*authCtx.Email))
+		attrs = append(attrs, attr.SlogRequestAuthUserEmail(*authCtx.Email))
 	}
 	if authCtx.APIKeyID != "" {
-		attrs = append(attrs, attr.SlogAuthAPIKeyID(authCtx.APIKeyID))
+		attrs = append(attrs, attr.SlogRequestAuthAPIKeyID(authCtx.APIKeyID))
 	}
 	if authCtx.SessionID != nil {
-		attrs = append(attrs, attr.SlogAuthSessionID(*authCtx.SessionID))
+		attrs = append(attrs, attr.SlogRequestAuthSessionID(*authCtx.SessionID))
 	}
 	if authCtx.ProjectID != nil {
-		attrs = append(attrs, attr.SlogAuthProjectID(authCtx.ProjectID.String()))
+		attrs = append(attrs, attr.SlogRequestAuthProjectID(authCtx.ProjectID.String()))
 	}
 	if authCtx.ProjectSlug != nil {
-		attrs = append(attrs, attr.SlogAuthProjectSlug(*authCtx.ProjectSlug))
+		attrs = append(attrs, attr.SlogRequestAuthProjectSlug(*authCtx.ProjectSlug))
 	}
 
+	wide.Push(ctx, attrs...)
+
 	if err != nil {
-		s.logger.ErrorContext(ctx, fmt.Sprintf("auth scheme check failed (%s)", scheme), attrs...)
+		s.logger.LogAttrs(ctx, slog.LevelError, fmt.Sprintf("auth scheme check failed (%s)", scheme), attrs...)
 	} else {
-		s.logger.InfoContext(ctx, fmt.Sprintf("auth scheme check passed (%s)", scheme), attrs...)
+		s.logger.LogAttrs(ctx, slog.LevelInfo, fmt.Sprintf("auth scheme check passed (%s)", scheme), attrs...)
 	}
 }

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -9,10 +9,12 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	domainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 )
 
 func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *url.URL) func(next http.Handler) http.Handler {
@@ -64,6 +66,13 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 				}
 
 				return
+			}
+
+			if domain.ID != uuid.Nil {
+				wide.Push(ctx, attr.SlogRequestCustomDomainID(domain.ID.String()))
+			}
+			if domain.Domain != "" {
+				wide.Push(ctx, attr.SlogRequestCustomDomainName(domain.Domain))
 			}
 
 			if !domain.Activated || !domain.Verified {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -418,6 +419,13 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	authToken = strings.TrimPrefix(authToken, "Bearer ")
 	authToken = strings.TrimPrefix(authToken, "bearer ")
 	chatSessionJwt := r.Header.Get(constants.ChatSessionsTokenHeader)
+
+	wide.Push(
+		ctx,
+		attr.SlogRequestMCPSlug(mcpSlug),
+		attr.SlogRequestMCPAuthorizationHeaderSet(authToken != ""),
+		attr.SlogRequestMCPChatSessionHeaderSet(chatSessionJwt != ""),
+	)
 
 	var tokenInputs []oauthTokenInputs
 

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -49,6 +50,8 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+			ctx = wide.Start(ctx, attr.SlogWideEvent())
+
 			requestID := conv.TruncateString(r.Header.Get("X-Request-ID"), 64)
 
 			spanCtx := trace.SpanContextFromContext(ctx)
@@ -82,10 +85,13 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 
 			rw := newResponseWriter(w)
 			r = r.WithContext(ctx)
-			attrs := []any{
+			attrs := []slog.Attr{
 				attr.SlogHTTPRequestMethod(r.Method),
 				attr.SlogURLOriginal(r.URL.String()),
 				attr.SlogHostName(r.Host),
+			}
+			if r.Pattern != "" {
+				attrs = append(attrs, attr.SlogHTTPRoute(r.Pattern))
 			}
 			if requestContext.ReqID != "" {
 				attrs = append(attrs, attr.SlogHTTPRequestID(requestContext.ReqID))
@@ -100,7 +106,7 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 				attrs = append(attrs, attr.SlogHTTPReferrerHost(requestContext.RefererHost))
 			}
 
-			logger.InfoContext(ctx, "request", attrs...)
+			logger.LogAttrs(ctx, slog.LevelInfo, "request", attrs...)
 
 			next.ServeHTTP(rw, r)
 
@@ -125,7 +131,8 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 				attrs = append(attrs, attr.SlogHTTPResponseFiltered(true))
 			}
 
-			logger.InfoContext(ctx, "response", attrs...)
+			wide.Push(ctx, attrs...)
+			logger.LogAttrs(ctx, slog.LevelInfo, "response", wide.Emit(ctx)...)
 		})
 	}
 }

--- a/server/internal/wide/context.go
+++ b/server/internal/wide/context.go
@@ -1,0 +1,72 @@
+package wide
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"sync/atomic"
+)
+
+type ctxKey struct{}
+
+var eventCtxKey ctxKey
+
+type node struct {
+	attrs []slog.Attr
+	next  atomic.Pointer[node]
+}
+
+type ctxState struct {
+	head atomic.Pointer[node]
+}
+
+func Start(ctx context.Context, attrs ...slog.Attr) context.Context {
+	ev := &ctxState{head: atomic.Pointer[node]{}}
+	if len(attrs) > 0 {
+		n := &node{attrs: attrs, next: atomic.Pointer[node]{}}
+		ev.head.Store(n)
+	}
+
+	return context.WithValue(ctx, eventCtxKey, ev)
+}
+
+func Push(ctx context.Context, attrs ...slog.Attr) {
+	ev, ok := ctx.Value(eventCtxKey).(*ctxState)
+	if !ok {
+		return
+	}
+
+	n := &node{attrs: attrs, next: atomic.Pointer[node]{}}
+	for {
+		old := ev.head.Load()
+		n.next.Store(old)
+		if ev.head.CompareAndSwap(old, n) {
+			return
+		}
+	}
+}
+
+func Emit(ctx context.Context) []slog.Attr {
+	ev, ok := ctx.Value(eventCtxKey).(*ctxState)
+	if !ok {
+		return nil
+	}
+
+	var nodes []*node
+	total := 0
+	for n := ev.head.Load(); n != nil; n = n.next.Load() {
+		nodes = append(nodes, n)
+		total += len(n.attrs)
+	}
+
+	// List is in prepend-order (newest first). Reverse node pointers so the
+	// forward walk yields attrs in oldest-first order while preserving the
+	// attr order within each Push call.
+	slices.Reverse(nodes)
+	out := make([]slog.Attr, 0, total)
+	for _, n := range nodes {
+		out = append(out, n.attrs...)
+	}
+
+	return out
+}

--- a/server/internal/wide/context_bench_test.go
+++ b/server/internal/wide/context_bench_test.go
@@ -1,0 +1,247 @@
+package wide_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/wide"
+)
+
+// ---------------------------------------------------------------------------
+// Baseline: no synchronisation (unsafe under concurrency)
+// ---------------------------------------------------------------------------
+
+type baselineCtxKey string
+
+const baselineKey baselineCtxKey = "baseline"
+
+type baselineState struct {
+	attrs []slog.Attr
+}
+
+func baselineStart(ctx context.Context, attrs ...slog.Attr) context.Context {
+	ev := &baselineState{attrs: make([]slog.Attr, 0, len(attrs))}
+	ev.attrs = append(ev.attrs, attrs...)
+	return context.WithValue(ctx, baselineKey, ev)
+}
+
+func baselinePush(ctx context.Context, attrs ...slog.Attr) {
+	ev, ok := ctx.Value(baselineKey).(*baselineState)
+	if !ok {
+		return
+	}
+	ev.attrs = append(ev.attrs, attrs...)
+}
+
+func baselineEmit(ctx context.Context) []slog.Attr {
+	ev, ok := ctx.Value(baselineKey).(*baselineState)
+	if !ok {
+		return nil
+	}
+	return ev.attrs
+}
+
+// ---------------------------------------------------------------------------
+// Mutex variant
+// ---------------------------------------------------------------------------
+
+type mutexCtxKey string
+
+const mutexKey mutexCtxKey = "mutex"
+
+type mutexState struct {
+	mu    sync.Mutex
+	attrs []slog.Attr
+}
+
+func mutexStart(ctx context.Context, attrs ...slog.Attr) context.Context {
+	ev := &mutexState{attrs: make([]slog.Attr, 0, len(attrs))}
+	ev.attrs = append(ev.attrs, attrs...)
+	return context.WithValue(ctx, mutexKey, ev)
+}
+
+func mutexPush(ctx context.Context, attrs ...slog.Attr) {
+	ev, ok := ctx.Value(mutexKey).(*mutexState)
+	if !ok {
+		return
+	}
+	ev.mu.Lock()
+	ev.attrs = append(ev.attrs, attrs...)
+	ev.mu.Unlock()
+}
+
+func mutexEmit(ctx context.Context) []slog.Attr {
+	ev, ok := ctx.Value(mutexKey).(*mutexState)
+	if !ok {
+		return nil
+	}
+	ev.mu.Lock()
+	out := make([]slog.Attr, len(ev.attrs))
+	copy(out, ev.attrs)
+	ev.mu.Unlock()
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Lock-free linked list: the real wide package implementation
+// ---------------------------------------------------------------------------
+
+// Defined as a variant so it sits alongside the others in benchmark output.
+func lockfreeStart(ctx context.Context, attrs ...slog.Attr) context.Context {
+	return wide.Start(ctx, attrs...)
+}
+
+func lockfreePush(ctx context.Context, attrs ...slog.Attr) {
+	wide.Push(ctx, attrs...)
+}
+
+func lockfreeEmit(ctx context.Context) []slog.Attr {
+	return wide.Emit(ctx)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark helpers
+// ---------------------------------------------------------------------------
+
+var sinkAttrs []slog.Attr
+
+type variant struct {
+	name  string
+	start func(context.Context, ...slog.Attr) context.Context
+	push  func(context.Context, ...slog.Attr)
+	emit  func(context.Context) []slog.Attr
+}
+
+var variants = []variant{
+	{"Baseline", baselineStart, baselinePush, baselineEmit},
+	{"Mutex", mutexStart, mutexPush, mutexEmit},
+	{"LockFree", lockfreeStart, lockfreePush, lockfreeEmit},
+}
+
+func testAttrs(i int) []slog.Attr {
+	return []slog.Attr{
+		slog.String("key", "value"),
+		slog.Int("i", i),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Serial: Push N attrs then Emit (single goroutine, the common case)
+// ---------------------------------------------------------------------------
+
+func BenchmarkSerialPushEmit(b *testing.B) {
+	const pushes = 10
+
+	for _, v := range variants {
+		b.Run(v.name, func(b *testing.B) {
+			for b.Loop() {
+				ctx := v.start(context.Background())
+				for i := range pushes {
+					v.push(ctx, testAttrs(i)...)
+				}
+				sinkAttrs = v.emit(ctx)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Serial: Push only (measures raw insert cost)
+// ---------------------------------------------------------------------------
+
+func BenchmarkSerialPush(b *testing.B) {
+	for _, v := range variants {
+		b.Run(v.name, func(b *testing.B) {
+			ctx := v.start(context.Background())
+			for b.Loop() {
+				v.push(ctx, slog.String("k", "v"))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent: N goroutines each push attrs, then one Emit
+// ---------------------------------------------------------------------------
+
+func BenchmarkConcurrentPush(b *testing.B) {
+	goroutines := []int{2, 4, 8}
+
+	for _, v := range variants {
+		// Skip baseline under concurrency — it's unsafe and only here for
+		// serial comparison.
+		if v.name == "Baseline" {
+			continue
+		}
+		for _, g := range goroutines {
+			b.Run(v.name+"/goroutines="+itoa(g), func(b *testing.B) {
+				ctx := v.start(context.Background())
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						v.push(ctx, testAttrs(i)...)
+						i++
+					}
+				})
+				sinkAttrs = v.emit(ctx)
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent: interleaved Push + Emit
+// ---------------------------------------------------------------------------
+
+func BenchmarkConcurrentPushWithEmit(b *testing.B) {
+	goroutines := []int{2, 4, 8}
+	const pushesPerIter = 10 // typical attrs per request cycle
+
+	for _, v := range variants {
+		if v.name == "Baseline" {
+			continue
+		}
+		for _, g := range goroutines {
+			b.Run(v.name+"/goroutines="+itoa(g), func(b *testing.B) {
+				for b.Loop() {
+					// One fresh ctx per iteration models a request lifecycle and
+					// keeps Emit cost bounded — otherwise the accumulator grows
+					// across iterations and Emit becomes O(b.N).
+					ctx := v.start(context.Background())
+
+					var wg sync.WaitGroup
+					wg.Add(g)
+					for range g {
+						go func() {
+							defer wg.Done()
+							for i := range pushesPerIter {
+								v.push(ctx, testAttrs(i)...)
+								if i%5 == 0 {
+									sinkAttrs = v.emit(ctx)
+								}
+							}
+						}()
+					}
+					wg.Wait()
+					sinkAttrs = v.emit(ctx)
+				}
+			})
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := [20]byte{}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/server/internal/wide/context_concurrent_test.go
+++ b/server/internal/wide/context_concurrent_test.go
@@ -1,0 +1,166 @@
+package wide_test
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/wide"
+)
+
+func TestConcurrentPushAllAttrsDelivered(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			goroutines = 16
+			pushesEach = 64
+		)
+
+		ctx := wide.Start(t.Context())
+
+		for g := range goroutines {
+			go func() {
+				for i := range pushesEach {
+					wide.Push(ctx, slog.String("v", fmt.Sprintf("g%d-i%d", g, i)))
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, goroutines*pushesEach)
+
+		seen := make(map[string]bool, goroutines*pushesEach)
+		for _, a := range got {
+			v := a.Value.String()
+			require.False(t, seen[v], "duplicate value: %s", v)
+			seen[v] = true
+		}
+		require.Len(t, seen, goroutines*pushesEach)
+	})
+}
+
+func TestConcurrentPushWithinBatchOrderPreserved(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			goroutines = 16
+			batches    = 10
+		)
+
+		ctx := wide.Start(t.Context())
+
+		for g := range goroutines {
+			go func() {
+				for b := range batches {
+					prefix := fmt.Sprintf("g%d-b%d", g, b)
+					wide.Push(ctx,
+						slog.String("v", prefix+"-A"),
+						slog.String("v", prefix+"-B"),
+						slog.String("v", prefix+"-C"),
+					)
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, goroutines*batches*3)
+
+		// Walk the output in triples. Cross-batch ordering is unspecified, but
+		// each 3-tuple must be a contiguous (A, B, C) of the same batch prefix —
+		// this is the regression surface for the intra-node reversal bug.
+		for k := 0; k < len(got); k += 3 {
+			a := got[k].Value.String()
+			b := got[k+1].Value.String()
+			c := got[k+2].Value.String()
+
+			require.True(t, strings.HasSuffix(a, "-A"), "pos %d: got %q, want suffix -A", k, a)
+			require.True(t, strings.HasSuffix(b, "-B"), "pos %d: got %q, want suffix -B", k+1, b)
+			require.True(t, strings.HasSuffix(c, "-C"), "pos %d: got %q, want suffix -C", k+2, c)
+
+			aPfx := strings.TrimSuffix(a, "-A")
+			bPfx := strings.TrimSuffix(b, "-B")
+			cPfx := strings.TrimSuffix(c, "-C")
+			require.Equal(t, aPfx, bPfx, "batch prefix drift at pos %d", k)
+			require.Equal(t, bPfx, cPfx, "batch prefix drift at pos %d", k)
+		}
+	})
+}
+
+func TestConcurrentPushAndEmit(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			writers   = 4
+			perWriter = 32
+		)
+
+		ctx := wide.Start(t.Context())
+
+		for g := range writers {
+			go func() {
+				for i := range perWriter {
+					wide.Push(ctx, slog.String("v", fmt.Sprintf("w%d-i%d", g, i)))
+					_ = wide.Emit(ctx) // interleave reads with writes
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, writers*perWriter)
+
+		seen := make(map[string]bool, writers*perWriter)
+		for _, a := range got {
+			v := a.Value.String()
+			require.False(t, seen[v], "duplicate: %s", v)
+			seen[v] = true
+		}
+	})
+}
+
+func TestConcurrentEmitNoTornReads(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			pushes    = 128
+			emitters  = 4
+			emitsEach = 16
+		)
+
+		ctx := wide.Start(t.Context())
+
+		go func() {
+			for i := range pushes {
+				wide.Push(ctx, slog.String("v", fmt.Sprintf("p%d", i)))
+			}
+		}()
+
+		for range emitters {
+			go func() {
+				for range emitsEach {
+					snap := wide.Emit(ctx)
+					for _, a := range snap {
+						if a.Key == "" {
+							t.Errorf("torn read: empty attr key in snapshot of len %d", len(snap))
+							return
+						}
+					}
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, pushes)
+	})
+}

--- a/server/internal/wide/context_test.go
+++ b/server/internal/wide/context_test.go
@@ -1,0 +1,178 @@
+package wide_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/wide"
+)
+
+func TestEmitOrdering(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String("event", "WideEvent"))
+	wide.Push(ctx,
+		slog.String("scheme", "https"),
+		slog.String("org.id", "org_123"),
+		slog.String("org.slug", "acme"),
+	)
+	wide.Push(ctx,
+		slog.String("method", "GET"),
+		slog.String("url", "/v1/widgets"),
+		slog.Int("status_code", 200),
+	)
+
+	want := []string{
+		"event",
+		"scheme", "org.id", "org.slug",
+		"method", "url", "status_code",
+	}
+	require.Equal(t, want, keysOf(wide.Emit(ctx)))
+}
+
+func TestEmitNoStart(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, wide.Emit(t.Context()))
+}
+
+func TestEmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := wide.Emit(wide.Start(t.Context()))
+	require.NotNil(t, got)
+	require.Empty(t, got)
+}
+
+func TestPushNoStart(t *testing.T) {
+	t.Parallel()
+	// No panic, no observable error. Push on a ctx without Start is a no-op.
+	wide.Push(t.Context(), slog.String("k", "v"))
+}
+
+func TestEmitIsRepeatable(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String("a", "1"))
+	wide.Push(ctx, slog.String("b", "2"))
+	first := wide.Emit(ctx)
+	wide.Push(ctx, slog.String("c", "3"))
+	second := wide.Emit(ctx)
+
+	require.Equal(t, []string{"a", "b"}, keysOf(first), "first snapshot must not see later pushes")
+	require.Equal(t, []string{"a", "b", "c"}, keysOf(second))
+}
+
+func TestStartWithAttrsNoPush(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String("a", "1"), slog.String("b", "2"))
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(ctx)))
+}
+
+func TestPushEmptyVariadic(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String("a", "1"))
+	wide.Push(ctx)
+	require.Equal(t, []string{"a"}, keysOf(wide.Emit(ctx)))
+}
+
+func TestPushedAttrsAliasing(t *testing.T) {
+	t.Parallel()
+
+	// Characterization: Push stores the caller's slice header by reference, so
+	// post-Push mutation of the caller-owned slice is visible through Emit.
+	// design.md describes attrs as "fixed at allocation" but that is an internal
+	// invariant, not a caller-facing contract. Update this test if Push ever
+	// copies.
+	ctx := wide.Start(t.Context())
+	attrs := []slog.Attr{slog.String("k", "original")}
+	wide.Push(ctx, attrs...)
+	attrs[0] = slog.String("k", "mutated")
+
+	got := wide.Emit(ctx)
+	require.Len(t, got, 1)
+	require.Equal(t, "mutated", got[0].Value.String())
+}
+
+func TestCancelledContextEmitStillWorks(t *testing.T) {
+	t.Parallel()
+
+	parent := wide.Start(t.Context(), slog.String("a", "1"))
+	ctx, cancel := context.WithCancel(parent)
+	wide.Push(ctx, slog.String("b", "2"))
+	cancel()
+
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(ctx)))
+}
+
+func TestDerivedContextSharesState(t *testing.T) {
+	t.Parallel()
+
+	type otherKey struct{}
+	parent := wide.Start(t.Context(), slog.String("a", "1"))
+	child := context.WithValue(parent, otherKey{}, "v")
+	wide.Push(child, slog.String("b", "2"))
+
+	// The *ctxState pointer is shared across context.WithValue layers, so a
+	// Push on the child is visible from the parent.
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(parent)))
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(child)))
+}
+
+func TestIndependentStartsAreIsolated(t *testing.T) {
+	t.Parallel()
+
+	ctx1 := wide.Start(t.Context(), slog.String("one", "1"))
+	ctx2 := wide.Start(t.Context(), slog.String("two", "2"))
+	wide.Push(ctx1, slog.String("extra", "e"))
+
+	require.Equal(t, []string{"one", "extra"}, keysOf(wide.Emit(ctx1)))
+	require.Equal(t, []string{"two"}, keysOf(wide.Emit(ctx2)))
+}
+
+func TestLargeNumberOfPushes(t *testing.T) {
+	t.Parallel()
+
+	const n = 10_000
+	ctx := wide.Start(t.Context())
+	for i := range n {
+		wide.Push(ctx, slog.Int("i", i))
+	}
+
+	got := wide.Emit(ctx)
+	require.Len(t, got, n)
+	for i := range n {
+		require.Equal(t, int64(i), got[i].Value.Int64(), "position %d", i)
+	}
+}
+
+func TestLargeBatchPerPush(t *testing.T) {
+	t.Parallel()
+
+	const n = 1_000
+	attrs := make([]slog.Attr, n)
+	for i := range n {
+		attrs[i] = slog.Int("i", i)
+	}
+
+	ctx := wide.Start(t.Context())
+	wide.Push(ctx, attrs...)
+
+	got := wide.Emit(ctx)
+	require.Len(t, got, n)
+	for i := range n {
+		require.Equal(t, int64(i), got[i].Value.Int64(), "position %d", i)
+	}
+}
+
+func keysOf(attrs []slog.Attr) []string {
+	out := make([]string, len(attrs))
+	for i, a := range attrs {
+		out[i] = a.Key
+	}
+	return out
+}

--- a/server/internal/wide/design.md
+++ b/server/internal/wide/design.md
@@ -1,0 +1,58 @@
+# wide: collection design
+
+## Goal
+
+Provide a concurrency-safe attribute collector where the dominant workload is
+serial pushes followed by a single emit — the pattern seen in HTTP request
+handling.
+
+## Approach: lock-free prepend list
+
+Each `Push` allocates a small node and atomically prepends it to a singly
+linked list via `CompareAndSwap` on the head pointer. `Emit` walks the list,
+collects all attributes into a slice, and reverses it to restore insertion
+order.
+
+```
+head ──▶ [node C] ──▶ [node B] ──▶ [node A] ──▶ nil
+          (newest)                   (oldest)
+```
+
+## Why not a mutex-guarded slice?
+
+A mutex adds overhead to every `Push` and `Emit` call even when there is no
+contention, which is the common case (single-goroutine request handlers).
+Benchmarks show the mutex variant is ~35% slower than the lock-free list in the
+serial push+emit path.
+
+## Why not a growing context chain?
+
+An alternative is to have `Push` return a new `context.Context` via
+`context.WithValue` on every call. This avoids shared mutable state entirely
+but builds a long context chain — one extra layer per push — which increases
+the cost of every subsequent `context.Value` lookup for all context keys, not
+just ours.
+
+## Trade-offs
+
+| Property                   | Lock-free list                         | Mutex slice              | Context chain                                       |
+| -------------------------- | -------------------------------------- | ------------------------ | --------------------------------------------------- |
+| Serial push+emit speed     | Fastest                                | ~35% slower              | Comparable, but degrades `context.Value` lookups    |
+| Concurrent push            | Safe (CAS retry)                       | Safe (lock)              | Safe (immutable)                                    |
+| Concurrent push throughput | Lower than mutex under high contention | Higher under contention  | N/A (no shared state)                               |
+| Memory per push            | 80 B node alloc                        | Amortised (slice growth) | `context.WithValue` wrapper + state copy            |
+| Emit cost                  | List walk + reverse                    | Slice copy under lock    | Chain walk + collect                                |
+| API                        | `Push(ctx, attrs...)`                  | Same                     | `ctx = Push(ctx, attrs...)` — caller must propagate |
+
+## Benchmark summary (10 pushes + 1 emit, arm64)
+
+| Variant            | ns/op      | B/op      | allocs/op |
+| ------------------ | ---------- | --------- | --------- |
+| Baseline (unsafe)  | ~1,580     | 3,544     | 17        |
+| Mutex              | ~2,115     | 4,448     | 18        |
+| **Lock-free list** | **~1,010** | **2,072** | **23**    |
+
+The lock-free list trades a higher allocation count (one node per push) for
+lower total bytes and faster throughput. The benchmark suite in
+`context_bench_test.go` covers serial and concurrent scenarios across all three
+variants.

--- a/server/internal/wide/doc.go
+++ b/server/internal/wide/doc.go
@@ -1,0 +1,25 @@
+// Package wide implements wide-event logging.
+//
+// A wide event collects structured attributes ([log/slog.Attr]) from
+// multiple layers of a call stack into a single log line emitted once at
+// the end. This replaces scattered per-layer log calls with one
+// information-dense record that is easier to query and correlate.
+//
+// Usage follows a three-phase lifecycle:
+//
+//  1. An outer caller invokes [Start] to initialise the event on a
+//     [context.Context].
+//  2. Inner callees call [Push] to attach attributes as they become
+//     available.
+//  3. Once the work is complete, the outer caller invokes [Emit] to
+//     collect every accumulated attribute and log them together.
+//
+// A prime use case is HTTP middleware: the logging middleware starts the
+// event, handlers and auth layers push attributes throughout the request,
+// and the middleware emits a single wide log line after the response is
+// written.
+//
+// The underlying collection is a lock-free linked list, so [Push] may be
+// called from multiple goroutines without synchronisation. In the common
+// single-goroutine case the overhead is a single atomic store per push.
+package wide


### PR DESCRIPTION
This change adds a wide event tracking facility that is intended to emit a singular log event with dense information about a backend transaction such as processing a HTTP request.

<img width="4384" height="2644" alt="CleanShot 2026-04-22 at 22 49 30@2x" src="https://github.com/user-attachments/assets/9a9aeeac-0c88-4eeb-8ca6-5a3c717568aa" />
