### PR TITLE
feat: add skill usage analytics charts

### DIFF
--- a/.changeset/famous-colts-pump.md
+++ b/.changeset/famous-colts-pump.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+add skill usage time series and users-per-skill charts

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2427,6 +2427,7 @@ async function seedObservabilityData(init: {
           skill: skillName,
         });
       if (isFailure) postToolAttrs["gram.hook.error"] = "Tool execution failed";
+      else postToolAttrs["gen_ai.tool.call.result"] = "ok";
 
       chInserts.push(
         `(${postTimeNano}, ${postTimeNano}, '${isFailure ? "ERROR" : "INFO"}', 'Tool: ${toolName}, Hook: ${postHookEvent}', '${traceId}', '${sqlAttrs(postToolAttrs)}', '{}', '${projectId}', '${toolName}', '${hookSource}', '${sessionId}')`,
@@ -2435,7 +2436,9 @@ async function seedObservabilityData(init: {
   }
 
   const chSQL = `
+    SET mutations_sync = 1;
     ALTER TABLE telemetry_logs DELETE WHERE gram_project_id = '${projectId}';
+    ALTER TABLE trace_summaries DELETE WHERE gram_project_id = '${projectId}';
     INSERT INTO telemetry_logs (time_unix_nano, observed_time_unix_nano, severity_text, body, trace_id, attributes, resource_attributes, gram_project_id, gram_urn, service_name, gram_chat_id) VALUES
     ${chInserts.join(",\n")};
   `;

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -42,7 +42,7 @@ import type {
 } from "@gram/client/models/components";
 import { useGramContext } from "@gram/client/react-query";
 import { unwrapAsync } from "@gram/client/types/fp";
-import { Icon } from "@speakeasy-api/moonshine";
+import { Badge, Icon } from "@speakeasy-api/moonshine";
 import { ChartCard } from "@/components/chart/ChartCard";
 import { MetricCard } from "@/components/chart/MetricCard";
 import { formatChartLabel } from "@/components/chart/chartUtils";
@@ -1621,14 +1621,18 @@ function UsersPerServerChart({
       onExpand={onExpand}
       hasData={labels.length > 0}
     >
-      <StackedBarChart
-        labels={labels}
-        datasets={datasets}
-        handleFilter={handleFilter}
-        expanded={expanded}
-        maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
-        onShowAll={() => onExpand(chartId)}
-      />
+      {labels.length === 0 ? (
+        <ChartNoData />
+      ) : (
+        <StackedBarChart
+          labels={labels}
+          datasets={datasets}
+          handleFilter={handleFilter}
+          expanded={expanded}
+          maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
+          onShowAll={() => onExpand(chartId)}
+        />
+      )}
     </ChartCard>
   );
 }
@@ -1682,14 +1686,18 @@ function UserEventCountsChart({
       onExpand={onExpand}
       hasData={labels.length > 0}
     >
-      <StackedBarChart
-        labels={labels}
-        datasets={datasets}
-        handleFilter={handleFilter}
-        expanded={expanded}
-        maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
-        onShowAll={() => onExpand(chartId)}
-      />
+      {labels.length === 0 ? (
+        <ChartNoData />
+      ) : (
+        <StackedBarChart
+          labels={labels}
+          datasets={datasets}
+          handleFilter={handleFilter}
+          expanded={expanded}
+          maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
+          onShowAll={() => onExpand(chartId)}
+        />
+      )}
     </ChartCard>
   );
 }
@@ -1810,9 +1818,7 @@ function ServerErrorRateChart({
       hasData={labels.length > 0}
     >
       {labels.length === 0 ? (
-        <div className="text-muted-foreground flex h-16 items-center justify-center text-sm">
-          No errors in this period
-        </div>
+        <ChartNoData />
       ) : (
         <>
           <div
@@ -1916,6 +1922,19 @@ function buildTimeSeriesFromSummary<
   return { labels, tooltipLabels, datasets };
 }
 
+function ChartNoData() {
+  return (
+    <div className="flex h-24 items-center justify-center">
+      <Badge variant="neutral">
+        <Badge.LeftIcon>
+          <Icon name="chart-no-axes-column" size="small" />
+        </Badge.LeftIcon>
+        <Badge.Text>No data</Badge.Text>
+      </Badge>
+    </div>
+  );
+}
+
 function MultiLineChart({
   labels,
   tooltipLabels,
@@ -1930,11 +1949,7 @@ function MultiLineChart({
   height?: number;
 }) {
   if (labels.length === 0) {
-    return (
-      <div className="text-muted-foreground flex h-24 items-center justify-center text-sm">
-        No data
-      </div>
-    );
+    return <ChartNoData />;
   }
 
   const options: ChartOptions<"line"> = {
@@ -2159,13 +2174,17 @@ function UsersPerSkillChart({
       onExpand={onExpand}
       hasData={labels.length > 0}
     >
-      <StackedBarChart
-        labels={labels}
-        datasets={datasets}
-        expanded={expanded}
-        maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
-        onShowAll={() => onExpand(chartId)}
-      />
+      {labels.length === 0 ? (
+        <ChartNoData />
+      ) : (
+        <StackedBarChart
+          labels={labels}
+          datasets={datasets}
+          expanded={expanded}
+          maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
+          onShowAll={() => onExpand(chartId)}
+        />
+      )}
     </ChartCard>
   );
 }
@@ -2265,9 +2284,7 @@ function ErrorsOverTimeChart({
       hasData={hasErrors}
     >
       {!hasErrors ? (
-        <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
-          No errors in this period
-        </div>
+        <ChartNoData />
       ) : (
         <MultiLineChart
           labels={labels}
@@ -2341,8 +2358,6 @@ function HooksAnalytics({
       uniqueTools,
     };
   }, [summaryData]);
-
-  const hasServers = (summaryData?.servers.length ?? 0) > 0;
 
   type FilterAxisConfig = Partial<Record<"user" | "server", "dataset" | "row">>;
 
@@ -2446,99 +2461,85 @@ function HooksAnalytics({
         )}
       </div>
 
-      {(timeSeries.length > 0 || hasServers) && (
-        <div
-          className={cn(
-            "grid gap-4",
-            expandedChart
+      <div
+        className={cn(
+          "grid gap-4",
+          expandedChart
+            ? "grid-cols-1"
+            : compact
               ? "grid-cols-1"
-              : compact
-                ? "grid-cols-1"
-                : "grid-cols-1 lg:grid-cols-2",
-          )}
-        >
-          {timeSeries.length > 0 && (
-            <ServerUsageTimeSeries
-              timeSeries={timeSeries}
-              from={from}
-              to={to}
-              serverNameMappings={serverNameMappings}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
-          {hasServers && (
-            <UsersPerServerChart
-              title="Users per Server"
-              breakdown={breakdown}
-              serverNameMappings={serverNameMappings}
-              handleFilter={makeFilterHandler({
-                server: "row",
-                user: "dataset",
-              })}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
+              : "grid-cols-1 lg:grid-cols-2",
+        )}
+      >
+        <ServerUsageTimeSeries
+          timeSeries={timeSeries}
+          from={from}
+          to={to}
+          serverNameMappings={serverNameMappings}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
 
-          {timeSeries.length > 0 && (
-            <UserUsageTimeSeries
-              timeSeries={timeSeries}
-              from={from}
-              to={to}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
-          {hasServers && (
-            <UserEventCountsChart
-              title="User Event Counts"
-              breakdown={breakdown}
-              handleFilter={makeFilterHandler({ user: "row" })}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
+        <UsersPerServerChart
+          title="Users per Server"
+          breakdown={breakdown}
+          serverNameMappings={serverNameMappings}
+          handleFilter={makeFilterHandler({
+            server: "row",
+            user: "dataset",
+          })}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
 
-          {skillTimeSeries.length > 0 && (
-            <SkillUsageTimeSeries
-              skillTimeSeries={skillTimeSeries}
-              from={from}
-              to={to}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
-          {skills.length > 0 && (
-            <UsersPerSkillChart
-              title="Users per Skill"
-              skills={skills}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
+        <UserUsageTimeSeries
+          timeSeries={timeSeries}
+          from={from}
+          to={to}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
 
-          {timeSeries.length > 0 && (
-            <ErrorsOverTimeChart
-              timeSeries={timeSeries}
-              from={from}
-              to={to}
-              serverNameMappings={serverNameMappings}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
-          {hasServers && (
-            <ServerErrorRateChart
-              title="Errors per Server and Tool"
-              breakdown={breakdown}
-              serverNameMappings={serverNameMappings}
-              expandedChart={expandedChart}
-              onExpand={setExpandedChart}
-            />
-          )}
-        </div>
-      )}
+        <UserEventCountsChart
+          title="User Event Counts"
+          breakdown={breakdown}
+          handleFilter={makeFilterHandler({ user: "row" })}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
+
+        <SkillUsageTimeSeries
+          skillTimeSeries={skillTimeSeries}
+          from={from}
+          to={to}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
+
+        <UsersPerSkillChart
+          title="Users per Skill"
+          skills={skills}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
+
+        <ErrorsOverTimeChart
+          timeSeries={timeSeries}
+          from={from}
+          to={to}
+          serverNameMappings={serverNameMappings}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
+
+        <ServerErrorRateChart
+          title="Errors per Server and Tool"
+          breakdown={breakdown}
+          serverNameMappings={serverNameMappings}
+          expandedChart={expandedChart}
+          onExpand={setExpandedChart}
+        />
+      </div>
     </div>
   );
 }

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -33,6 +33,7 @@ import type {
   GetHooksSummaryResult,
   HooksBreakdownRow,
   HooksTimeSeriesPoint,
+  SkillTimeSeriesPoint,
   HookTraceSummary as HookTrace,
   LogFilter,
   TelemetryLogRecord,
@@ -2058,6 +2059,51 @@ function UserUsageTimeSeries({
   return (
     <ChartCard
       title="User Usage"
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+      hasData={labels.length > 0}
+    >
+      <MultiLineChart
+        labels={labels}
+        tooltipLabels={tooltipLabels}
+        datasets={datasets}
+        height={
+          expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
+        }
+      />
+    </ChartCard>
+  );
+}
+
+function SkillUsageTimeSeries({
+  skillTimeSeries,
+  from,
+  to,
+  expandedChart,
+  onExpand,
+}: {
+  skillTimeSeries: SkillTimeSeriesPoint[];
+  from: Date;
+  to: Date;
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
+}) {
+  const chartId = "skill-usage";
+  const expanded = expandedChart === chartId;
+  const timeRangeMs = to.getTime() - from.getTime();
+  const { labels, tooltipLabels, datasets } = useMemo(
+    () =>
+      buildTimeSeriesFromSummary(
+        skillTimeSeries,
+        (pt) => pt.skillName,
+        timeRangeMs,
+      ),
+    [skillTimeSeries, timeRangeMs],
+  );
+  return (
+    <ChartCard
+      title="Skill Usage"
       chartId={chartId}
       expandedChart={expandedChart}
       onExpand={onExpand}

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1822,7 +1822,7 @@ function ServerErrorRateChart({
       hasData={labels.length > 0}
     >
       {labels.length === 0 ? (
-        <ChartNoData />
+        <ChartNoData message="No errors in this period" />
       ) : (
         <>
           <div
@@ -1926,14 +1926,18 @@ function buildTimeSeriesFromSummary<
   return { labels, tooltipLabels, datasets };
 }
 
-function ChartNoData() {
+function ChartNoData({
+  message = "No data in this period",
+}: {
+  message?: string;
+}) {
   return (
     <div className="flex h-24 items-center justify-center">
       <Badge variant="neutral">
         <Badge.LeftIcon>
           <Icon name="chart-no-axes-column" size="small" />
         </Badge.LeftIcon>
-        <Badge.Text>No data</Badge.Text>
+        <Badge.Text>{message}</Badge.Text>
       </Badge>
     </div>
   );
@@ -2298,7 +2302,7 @@ function ErrorsOverTimeChart({
       hasData={hasErrors}
     >
       {!hasErrors ? (
-        <ChartNoData />
+        <ChartNoData message="No errors in this period" />
       ) : (
         <MultiLineChart
           labels={labels}

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1852,9 +1852,9 @@ function ServerErrorRateChart({
 type TimeSeriesDataset = {
   label: string;
   data: number[];
-  borderColor: string | undefined;
+  borderColor: string;
   backgroundColor: string;
-  pointBackgroundColor: string | undefined;
+  pointBackgroundColor: string;
   fill: boolean;
   tension: number;
   borderWidth: number;

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -33,6 +33,7 @@ import type {
   GetHooksSummaryResult,
   HooksBreakdownRow,
   HooksTimeSeriesPoint,
+  SkillSummary,
   SkillTimeSeriesPoint,
   HookTraceSummary as HookTrace,
   LogFilter,
@@ -2116,6 +2117,54 @@ function SkillUsageTimeSeries({
         height={
           expanded ? LINE_CHART_HEIGHT.expanded : LINE_CHART_HEIGHT.collapsed
         }
+      />
+    </ChartCard>
+  );
+}
+
+function UsersPerSkillChart({
+  title,
+  skills,
+  expandedChart,
+  onExpand,
+}: {
+  title: string;
+  skills: SkillSummary[];
+  expandedChart: string | null;
+  onExpand: (id: string | null) => void;
+}) {
+  const chartId = "users-per-skill";
+  const expanded = expandedChart === chartId;
+  const { labels, datasets } = useMemo(() => {
+    const sorted = [...skills].sort((a, b) => b.useCount - a.useCount);
+    const color = USER_SOURCE_COLORS[0]!;
+    return {
+      labels: sorted.map((s) => s.skillName),
+      datasets: [
+        {
+          label: "Uses",
+          barThickness: BAR_THICKNESS.collapsed,
+          data: sorted.map((s) => s.useCount),
+          backgroundColor: color,
+          hoverBackgroundColor: color + "cc",
+        },
+      ] satisfies StackedBarDataset[],
+    };
+  }, [skills]);
+  return (
+    <ChartCard
+      title={title}
+      chartId={chartId}
+      expandedChart={expandedChart}
+      onExpand={onExpand}
+      hasData={labels.length > 0}
+    >
+      <StackedBarChart
+        labels={labels}
+        datasets={datasets}
+        expanded={expanded}
+        maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
+        onShowAll={() => onExpand(chartId)}
       />
     </ChartCard>
   );

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1837,11 +1837,26 @@ function ServerErrorRateChart({
   );
 }
 
-function buildTimeSeriesFromSummary(
-  timeSeries: HooksTimeSeriesPoint[],
-  keyFn: (p: HooksTimeSeriesPoint) => string,
+type TimeSeriesDataset = {
+  label: string;
+  data: number[];
+  borderColor: string | undefined;
+  backgroundColor: string;
+  pointBackgroundColor: string | undefined;
+  fill: boolean;
+  tension: number;
+  borderWidth: number;
+  pointRadius: number;
+  pointHoverRadius: number;
+};
+
+function buildTimeSeriesFromSummary<
+  T extends { bucketStartNs: string; eventCount: number },
+>(
+  timeSeries: T[],
+  keyFn: (p: T) => string,
   timeRangeMs: number,
-  valueFn: (p: HooksTimeSeriesPoint) => number = (p) => p.eventCount,
+  valueFn: (p: T) => number = (p) => p.eventCount,
 ) {
   if (timeSeries.length === 0)
     return { labels: [], tooltipLabels: [], datasets: [] };
@@ -1878,21 +1893,23 @@ function buildTimeSeriesFromSummary(
     }),
   );
 
-  const datasets = Array.from(seriesMap.entries()).map(([key, series], i) => {
-    const color = USER_SOURCE_COLORS[i % USER_SOURCE_COLORS.length];
-    return {
-      label: key,
-      data: sortedTs.map((ts) => series.get(ts) ?? 0),
-      borderColor: color,
-      backgroundColor: color + "1a",
-      pointBackgroundColor: color,
-      fill: false,
-      tension: 0.45,
-      borderWidth: 1.5,
-      pointRadius: 0,
-      pointHoverRadius: 4,
-    };
-  });
+  const datasets: TimeSeriesDataset[] = Array.from(seriesMap.entries()).map(
+    ([key, series], i) => {
+      const color = USER_SOURCE_COLORS[i % USER_SOURCE_COLORS.length];
+      return {
+        label: key,
+        data: sortedTs.map((ts) => series.get(ts) ?? 0),
+        borderColor: color,
+        backgroundColor: color + "1a",
+        pointBackgroundColor: color,
+        fill: false,
+        tension: 0.45,
+        borderWidth: 1.5,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+      };
+    },
+  );
 
   return { labels, tooltipLabels, datasets };
 }
@@ -1906,7 +1923,7 @@ function MultiLineChart({
 }: {
   labels: string[];
   tooltipLabels: string[];
-  datasets: ReturnType<typeof buildTimeSeriesFromSummary>["datasets"];
+  datasets: TimeSeriesDataset[];
   tooltipAfterBody?: (dataIndex: number) => string[];
   height?: number;
 }) {

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -2314,6 +2314,8 @@ function HooksAnalytics({
 }) {
   const breakdown = summaryData?.breakdown ?? [];
   const timeSeries = summaryData?.timeSeries ?? [];
+  const skillTimeSeries = summaryData?.skillTimeSeries ?? [];
+  const skills = summaryData?.skills ?? [];
 
   const kpis = useMemo(() => {
     if (!summaryData) return null;
@@ -2493,6 +2495,24 @@ function HooksAnalytics({
               title="User Event Counts"
               breakdown={breakdown}
               handleFilter={makeFilterHandler({ user: "row" })}
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            />
+          )}
+
+          {skillTimeSeries.length > 0 && (
+            <SkillUsageTimeSeries
+              skillTimeSeries={skillTimeSeries}
+              from={from}
+              to={to}
+              expandedChart={expandedChart}
+              onExpand={setExpandedChart}
+            />
+          )}
+          {skills.length > 0 && (
+            <UsersPerSkillChart
+              title="Users per Skill"
+              skills={skills}
               expandedChart={expandedChart}
               onExpand={setExpandedChart}
             />

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1971,7 +1971,7 @@ function MultiLineChart({
         callbacks: {
           title: (items) => tooltipLabels[items[0]?.dataIndex ?? 0] ?? "",
           label: (item) => {
-            if ((item.parsed.y ?? 0) === 0) return "";
+            if ((item.parsed.y ?? 0) === 0) return undefined;
             return item.formattedValue
               ? `${item.dataset.label}: ${item.formattedValue}`
               : "";

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -33,7 +33,7 @@ import type {
   GetHooksSummaryResult,
   HooksBreakdownRow,
   HooksTimeSeriesPoint,
-  SkillSummary,
+  SkillBreakdownRow,
   SkillTimeSeriesPoint,
   HookTraceSummary as HookTrace,
   LogFilter,
@@ -1462,7 +1462,7 @@ function StackedBarChart({
   labels: string[];
   datasets: StackedBarDataset[];
   handleFilter?: (datasetLabel: string, rowLabel: string) => void;
-  tooltipLabelFn?: (item: TooltipItem<"bar">) => string;
+  tooltipLabelFn?: (item: TooltipItem<"bar">) => string | string[] | undefined;
   expanded?: boolean;
   maxRows?: number;
   onShowAll?: () => void;
@@ -2147,42 +2147,60 @@ function SkillUsageTimeSeries({
 
 function UsersPerSkillChart({
   title,
-  skills,
+  skillBreakdown,
   expandedChart,
   onExpand,
 }: {
   title: string;
-  skills: SkillSummary[];
+  skillBreakdown: SkillBreakdownRow[];
   expandedChart: string | null;
   onExpand: (id: string | null) => void;
 }) {
   const chartId = "users-per-skill";
   const expanded = expandedChart === chartId;
-  const { labels, datasets, uniqueUsersMap } = useMemo(() => {
-    const sorted = [...skills].sort((a, b) => b.useCount - a.useCount);
-    const color = USER_SOURCE_COLORS[0]!;
-    return {
-      labels: sorted.map((s) => s.skillName),
-      datasets: [
-        {
-          label: "Uses",
-          barThickness: BAR_THICKNESS.collapsed,
-          data: sorted.map((s) => s.useCount),
-          backgroundColor: color,
-          hoverBackgroundColor: color + "cc",
-        },
-      ] satisfies StackedBarDataset[],
-      uniqueUsersMap: new Map(sorted.map((s) => [s.skillName, s.uniqueUsers])),
-    };
-  }, [skills]);
-  const tooltipLabelFn = useCallback(
-    (item: TooltipItem<"bar">) => {
-      const skillName = labels[item.dataIndex] ?? "";
-      const unique = uniqueUsersMap.get(skillName) ?? 0;
-      return ` Uses: ${item.parsed.x}  |  Unique users: ${unique}`;
-    },
-    [labels, uniqueUsersMap],
-  );
+  const { labels, datasets } = useMemo(() => {
+    const skillMap = new Map<string, Map<string, number>>();
+    const userSet = new Set<string>();
+    for (const row of skillBreakdown) {
+      const user = row.userEmail || "unknown";
+      userSet.add(user);
+      const inner = skillMap.get(row.skillName) ?? new Map<string, number>();
+      inner.set(user, (inner.get(user) ?? 0) + row.useCount);
+      skillMap.set(row.skillName, inner);
+    }
+
+    const sortedSkills = Array.from(skillMap.entries())
+      .map(([skill, userCounts]) => ({
+        skill,
+        total: Array.from(userCounts.values()).reduce((a, b) => a + b, 0),
+        userCounts,
+      }))
+      .sort((a, b) => b.total - a.total);
+
+    const userTotals = new Map<string, number>();
+    for (const user of userSet) {
+      userTotals.set(
+        user,
+        sortedSkills.reduce((s, sk) => s + (sk.userCounts.get(user) ?? 0), 0),
+      );
+    }
+    const sortedUsers = Array.from(userSet).sort(
+      (a, b) => (userTotals.get(b) ?? 0) - (userTotals.get(a) ?? 0),
+    );
+
+    const chartLabels = sortedSkills.map((s) => s.skill);
+    const chartDatasets = sortedUsers.map((user, i) => ({
+      label: user,
+      barThickness: BAR_THICKNESS.collapsed,
+      data: sortedSkills.map((s) => s.userCounts.get(user) ?? 0),
+      backgroundColor: USER_SOURCE_COLORS[i % USER_SOURCE_COLORS.length],
+      hoverBackgroundColor:
+        USER_SOURCE_COLORS[i % USER_SOURCE_COLORS.length] + "cc",
+    }));
+
+    return { labels: chartLabels, datasets: chartDatasets };
+  }, [skillBreakdown]);
+
   return (
     <ChartCard
       title={title}
@@ -2197,7 +2215,6 @@ function UsersPerSkillChart({
         <StackedBarChart
           labels={labels}
           datasets={datasets}
-          tooltipLabelFn={tooltipLabelFn}
           expanded={expanded}
           maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
           onShowAll={() => onExpand(chartId)}
@@ -2350,7 +2367,7 @@ function HooksAnalytics({
   const breakdown = summaryData?.breakdown ?? [];
   const timeSeries = summaryData?.timeSeries ?? [];
   const skillTimeSeries = summaryData?.skillTimeSeries ?? [];
-  const skills = summaryData?.skills ?? [];
+  const skillBreakdown = summaryData?.skillBreakdown ?? [];
 
   const kpis = useMemo(() => {
     if (!summaryData) return null;
@@ -2536,7 +2553,7 @@ function HooksAnalytics({
 
         <UsersPerSkillChart
           title="Users per Skill"
-          skills={skills}
+          skillBreakdown={skillBreakdown}
           expandedChart={expandedChart}
           onExpand={setExpandedChart}
         />

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -2168,7 +2168,7 @@ function UsersPerSkillChart({
           hoverBackgroundColor: color + "cc",
         },
       ] satisfies StackedBarDataset[],
-      uniqueUsersMap: new Map(skills.map((s) => [s.skillName, s.uniqueUsers])),
+      uniqueUsersMap: new Map(sorted.map((s) => [s.skillName, s.uniqueUsers])),
     };
   }, [skills]);
   const tooltipLabelFn = useCallback(

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1970,6 +1970,12 @@ function MultiLineChart({
         ...SHARED_TOOLTIP,
         callbacks: {
           title: (items) => tooltipLabels[items[0]?.dataIndex ?? 0] ?? "",
+          label: (item) => {
+            if ((item.parsed.y ?? 0) === 0) return "";
+            return item.formattedValue
+              ? `${item.dataset.label}: ${item.formattedValue}`
+              : "";
+          },
           ...(tooltipAfterBody
             ? {
                 afterBody: (items) =>

--- a/client/dashboard/src/pages/hooks/Hooks.tsx
+++ b/client/dashboard/src/pages/hooks/Hooks.tsx
@@ -1454,6 +1454,7 @@ function StackedBarChart({
   labels,
   datasets,
   handleFilter,
+  tooltipLabelFn,
   expanded = false,
   maxRows,
   onShowAll,
@@ -1461,6 +1462,7 @@ function StackedBarChart({
   labels: string[];
   datasets: StackedBarDataset[];
   handleFilter?: (datasetLabel: string, rowLabel: string) => void;
+  tooltipLabelFn?: (item: TooltipItem<"bar">) => string;
   expanded?: boolean;
   maxRows?: number;
   onShowAll?: () => void;
@@ -1507,13 +1509,15 @@ function StackedBarChart({
         tooltip: {
           ...SHARED_TOOLTIP,
           callbacks: {
-            label: (item: TooltipItem<"bar">) =>
-              ` ${item.dataset.label}: ${item.parsed.x}`,
+            label:
+              tooltipLabelFn ??
+              ((item: TooltipItem<"bar">) =>
+                ` ${item.dataset.label}: ${item.parsed.x}`),
           },
         },
       },
     }),
-    [datasets, visibleLabels, handleFilter],
+    [datasets, visibleLabels, handleFilter, tooltipLabelFn],
   );
 
   if (visibleLabels.length === 0) return null;
@@ -2150,7 +2154,7 @@ function UsersPerSkillChart({
 }) {
   const chartId = "users-per-skill";
   const expanded = expandedChart === chartId;
-  const { labels, datasets } = useMemo(() => {
+  const { labels, datasets, uniqueUsersMap } = useMemo(() => {
     const sorted = [...skills].sort((a, b) => b.useCount - a.useCount);
     const color = USER_SOURCE_COLORS[0]!;
     return {
@@ -2164,8 +2168,17 @@ function UsersPerSkillChart({
           hoverBackgroundColor: color + "cc",
         },
       ] satisfies StackedBarDataset[],
+      uniqueUsersMap: new Map(skills.map((s) => [s.skillName, s.uniqueUsers])),
     };
   }, [skills]);
+  const tooltipLabelFn = useCallback(
+    (item: TooltipItem<"bar">) => {
+      const skillName = labels[item.dataIndex] ?? "";
+      const unique = uniqueUsersMap.get(skillName) ?? 0;
+      return ` Uses: ${item.parsed.x}  |  Unique users: ${unique}`;
+    },
+    [labels, uniqueUsersMap],
+  );
   return (
     <ChartCard
       title={title}
@@ -2180,6 +2193,7 @@ function UsersPerSkillChart({
         <StackedBarChart
           labels={labels}
           datasets={datasets}
+          tooltipLabelFn={tooltipLabelFn}
           expanded={expanded}
           maxRows={COLLAPSED_BAR_CHART_MAX_ROWS}
           onShowAll={() => onExpand(chartId)}


### PR DESCRIPTION
## Summary
- Add `SkillUsageTimeSeries` line chart — per-skill event counts over time,
  sourced from new `skillTimeSeries` field
- Add `UsersPerSkillChart` bar chart — skills ranked by use count; tooltip
  shows both use count and unique user count
- Make `buildTimeSeriesFromSummary` generic to accept both
  `HooksTimeSeriesPoint[]` and `SkillTimeSeriesPoint[]`
- Add `tooltipLabelFn` prop to `StackedBarChart` for custom tooltip overrides
- Standardize empty states: replace ad-hoc "No data" divs with a shared
  `ChartNoData` Badge component (Moonshine Badge + chart icon)
- Remove per-chart render guards — charts always mount and show no-data
  state; loading state is the only suppression point

## Root cause
Hooks dashboard had no visibility into which skills users are invoking.
`skillTimeSeries` and `skills` are now available from the backend summary
endpoint; this PR wires them into the analytics UI.

## Test plan
- [x] Open Hooks dashboard with skill event data — "Skill Usage" line chart
      and "Users per Skill" bar chart appear
- [x] Expand/collapse both charts — expand button shows only when data present

## Related PR
- https://github.com/speakeasy-api/gram/pull/2381
