### PR TITLE
chore(skills): add new gram-* skills to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,9 @@ Activate a skill when your task falls within its scope.
 | `frontend`                    | Working on the React frontends in `client/` or `elements/`                 |
 | `vercel-react-best-practices` | Optimizing React performance, reviewing components for best practices      |
 | `gram-functions`              | Understanding or modifying the Gram Functions serverless execution feature |
+| `gram-management-api`         | Designing or modifying management API endpoints (Goa design, impl)         |
+| `gram-audit-logging`          | Recording or exposing audit events via the auditlogs management API        |
+| `gram-rbac`                   | Adding or enforcing authorization scopes, grants, or roles                 |
 | `mise-tasks`                  | Creating or editing mise task scripts in `.mise-tasks/`                    |
 | `datadog`                     | Investigating errors, performance, incidents, or telemetry via Datadog     |
 | `datadog-insights`            | Running the full Gram production health digest and posting it to Slack     |


### PR DESCRIPTION
Something missed when introducing them. In one session, Claude didn't automatically load the new skills and when prompted why it mentioned it was because they were not in this skills table. In another session asking about best practices after this feedback, Claude said that was not strictly necessary due to auto discovery, but suggested making this change anyways so adding here to cover bases.