### PR TITLE
chore: reap all old fly apps

### DIFF
--- a/.changeset/crazy-brooms-change.md
+++ b/.changeset/crazy-brooms-change.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Updated fly app reaping to target all apps used by old deployments, leaving only the most recent deployment's app(s) untouched. This is a more aggressive strategy that is coming ahead of support for scaling up fly apps to multiple machines per deployment.

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -105,7 +105,7 @@ func NewActivities(
 		processDeployment:             activities.NewProcessDeployment(logger, tracerProvider, meterProvider, guardianPolicy, db, features, assetStorage, billingRepo, mcpRegistryClient),
 		provisionFunctionsAccess:      activities.NewProvisionFunctionsAccess(logger, db, encryption),
 		deployFunctionRunners:         activities.NewDeployFunctionRunners(logger, db, functionsDeployer, functionsVersion, encryption),
-		reapFlyApps:                   activities.NewReapFlyApps(logger, meterProvider, db, functionsDeployer, 3),
+		reapFlyApps:                   activities.NewReapFlyApps(logger, meterProvider, db, functionsDeployer, 1),
 		refreshBillingUsage:           activities.NewRefreshBillingUsage(logger, db, billingRepo),
 		refreshOpenRouterKey:          activities.NewRefreshOpenRouterKey(logger, db, openrouterProvisioner),
 		slackChatCompletion:           activities.NewSlackChatCompletionActivity(logger, slackClient, chatClient),


### PR DESCRIPTION
This change updates fly app reaping to target all apps used by old deployments, leaving only the most recent deployment's app(s) untouched.

This is a more aggressive strategy that is coming ahead of support for scaling up fly apps to multiple machines per deployment.