### PR TITLE
mig: add machine config for deployment functions

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -338,6 +338,9 @@ CREATE TABLE IF NOT EXISTS deployments_functions (
   runtime TEXT NOT NULL, -- nodejs:22, python:3.12, ...
   runner_version TEXT,
 
+  memory_mib INT,
+  scale INT,
+
   CONSTRAINT deployments_functions_pkey PRIMARY KEY (id),
   CONSTRAINT deployments_functions_deployment_id_fkey FOREIGN KEY (deployment_id) REFERENCES deployments (id) ON DELETE CASCADE,
   CONSTRAINT deployments_functions_asset_id_fkey FOREIGN KEY (asset_id) REFERENCES assets (id) ON DELETE CASCADE

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -307,6 +307,8 @@ type DeploymentsFunction struct {
 	Slug          string
 	Runtime       string
 	RunnerVersion pgtype.Text
+	MemoryMib     pgtype.Int4
+	Scale         pgtype.Int4
 }
 
 type DeploymentsOpenapiv3Asset struct {

--- a/server/internal/deployments/repo/models.go
+++ b/server/internal/deployments/repo/models.go
@@ -36,6 +36,8 @@ type DeploymentsFunction struct {
 	Slug          string
 	Runtime       string
 	RunnerVersion pgtype.Text
+	MemoryMib     pgtype.Int4
+	Scale         pgtype.Int4
 }
 
 type DeploymentsOpenapiv3Asset struct {

--- a/server/internal/deployments/repo/queries.sql.go
+++ b/server/internal/deployments/repo/queries.sql.go
@@ -1084,7 +1084,7 @@ func (q *Queries) GetDeploymentByIdempotencyKey(ctx context.Context, arg GetDepl
 }
 
 const getDeploymentFunctions = `-- name: GetDeploymentFunctions :many
-SELECT df.id, df.deployment_id, df.asset_id, df.name, df.slug, df.runtime, df.runner_version
+SELECT df.id, df.deployment_id, df.asset_id, df.name, df.slug, df.runtime, df.runner_version, df.memory_mib, df.scale
 FROM deployments_functions df
 INNER JOIN deployments d ON df.deployment_id = d.id
 WHERE 
@@ -1114,6 +1114,8 @@ func (q *Queries) GetDeploymentFunctions(ctx context.Context, arg GetDeploymentF
 			&i.Slug,
 			&i.Runtime,
 			&i.RunnerVersion,
+			&i.MemoryMib,
+			&i.Scale,
 		); err != nil {
 			return nil, err
 		}

--- a/server/migrations/20260423131344_functions-machine-specs.sql
+++ b/server/migrations/20260423131344_functions-machine-specs.sql
@@ -1,0 +1,2 @@
+-- Modify "deployments_functions" table
+ALTER TABLE "deployments_functions" ADD COLUMN "memory_mib" integer NULL, ADD COLUMN "scale" integer NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:z+U7rIe8lkCuJ25vXX8yWXxZGS7tFi4HRoZvpVqzphE=
+h1:0+6KapUbFYb/rxoRWr3V0kk5wWFiJHBn6EUkHyEdvbw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -136,3 +136,4 @@ h1:z+U7rIe8lkCuJ25vXX8yWXxZGS7tFi4HRoZvpVqzphE=
 20260423100000_http-tool-definitions-deployment-tool-urn-idx.sql h1:/QswsN5QFVzo/XpvzLX9JWe8VrOthViQemIZTl4oFGI=
 20260423100001_prompt-templates-project-tool-urn-idx.sql h1:5QTsAtHrIvT12QS2/OeICut3HlurbgiZfIJwouG/SQk=
 20260423100002_external-mcp-tool-definitions-tool-urn-idx.sql h1:4gyE/U5pj1jyYV3i8b0jLsYaUK8/8Cv1pzllNVOpBNA=
+20260423131344_functions-machine-specs.sql h1:s3h0Cn9yFq8bAUsknM3Mdt+y5PmGDW9LjxDncy9u6fM=


### PR DESCRIPTION
This change adds fields configuring scale (machine count) and memory for deployment functions. It is part of upcoming work to allow users to scale up/down their Gram Functions.