### PR TITLE
fix: filter ListMembers by organization_user_relationships

### DIFF
--- a/server/internal/access/createrole_test.go
+++ b/server/internal/access/createrole_test.go
@@ -69,7 +69,7 @@ func TestService_CreateRole(t *testing.T) {
 			{Scope: string(ScopeProjectRead), Resources: []string{"project-1", "project-2"}},
 			{Scope: string(ScopeMCPConnect), Resources: nil},
 		},
-		MemberIds: []string{"user_1", "user_2"},
+		MemberIds: []string{"local_user_1", "local_user_2"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, "Custom Builder", role.Name)
@@ -230,7 +230,7 @@ func TestService_CreateRole_GrantSyncFailureDoesNotAssignMembers(t *testing.T) {
 		Grants: []*gen.RoleGrant{
 			{Scope: string(ScopeProjectRead), Resources: []string{"project-1"}},
 		},
-		MemberIds: []string{"user_1", "user_2"},
+		MemberIds: []string{"local_user_1", "local_user_2"},
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "sync grants for created role")

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -259,6 +259,13 @@ func (s *Service) CreateRole(ctx context.Context, payload *gen.CreateRolePayload
 
 	assignedWorkosIDs := make([]string, 0, len(payload.MemberIds))
 	if len(payload.MemberIds) > 0 {
+		// payload.MemberIds are Gram user IDs (returned by ListMembers).
+		// Resolve them to WorkOS user IDs so we can look up WorkOS memberships.
+		gramToWorkos, err := gramToWorkosIDMap(ctx, s.db, payload.MemberIds)
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "resolve gram user ids to workos ids").Log(ctx, logger)
+		}
+
 		members, err := s.roles.ListMembers(ctx, workosOrgID)
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, logger)
@@ -266,8 +273,12 @@ func (s *Service) CreateRole(ctx context.Context, payload *gen.CreateRolePayload
 
 		membershipByUser := membershipsByUserID(members)
 
-		for _, userID := range payload.MemberIds {
-			membershipID, ok := membershipByUser[userID]
+		for _, gramID := range payload.MemberIds {
+			workosID, ok := gramToWorkos[gramID]
+			if !ok {
+				continue
+			}
+			membershipID, ok := membershipByUser[workosID]
 			if !ok {
 				continue
 			}
@@ -276,7 +287,7 @@ func (s *Service) CreateRole(ctx context.Context, payload *gen.CreateRolePayload
 				return nil, oops.E(oops.CodeUnexpected, err, "assign members to created role").Log(ctx, logger)
 			}
 
-			assignedWorkosIDs = append(assignedWorkosIDs, userID)
+			assignedWorkosIDs = append(assignedWorkosIDs, workosID)
 		}
 		s.access.InvalidateAllRoleCaches(ctx, ac.ActiveOrganizationID)
 	}
@@ -390,10 +401,19 @@ func (s *Service) UpdateRole(ctx context.Context, payload *gen.UpdateRolePayload
 	}
 
 	if payload.MemberIds != nil {
+		gramToWorkos, err := gramToWorkosIDMap(ctx, s.db, payload.MemberIds)
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "resolve gram user ids to workos ids").Log(ctx, logger)
+		}
+
 		membershipByUser := membershipsByUserID(membersBefore)
 
-		for _, userID := range payload.MemberIds {
-			membershipID, ok := membershipByUser[userID]
+		for _, gramID := range payload.MemberIds {
+			workosID, ok := gramToWorkos[gramID]
+			if !ok {
+				continue
+			}
+			membershipID, ok := membershipByUser[workosID]
 			if !ok {
 				continue
 			}
@@ -896,6 +916,23 @@ func (s *Service) localMemberCounts(ctx context.Context, organizationID string, 
 		}
 	}
 	return counts, nil
+}
+
+// gramToWorkosIDMap resolves Gram user IDs to WorkOS user IDs.
+// Dashboard sends Gram IDs (from ListMembers), but WorkOS membership lookups
+// require WorkOS user IDs.
+func gramToWorkosIDMap(ctx context.Context, db *pgxpool.Pool, gramIDs []string) (map[string]string, error) {
+	users, err := usersrepo.New(db).GetUsersByIDs(ctx, gramIDs)
+	if err != nil {
+		return nil, fmt.Errorf("get users by ids: %w", err)
+	}
+	m := make(map[string]string, len(users))
+	for _, u := range users {
+		if u.WorkosID.Valid && u.WorkosID.String != "" {
+			m[u.ID] = u.WorkosID.String
+		}
+	}
+	return m, nil
 }
 
 func membershipsByUserID(members []workos.Member) map[string]string {

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -560,16 +560,21 @@ func (s *Service) ListMembers(ctx context.Context, _ *gen.ListMembersPayload) (*
 		return nil, oops.E(oops.CodeUnexpected, err, "list org users from workos").Log(ctx, s.logger)
 	}
 
-	// Batch-resolve WorkOS user IDs to local Gram users so the member list
-	// returns Gram user IDs (the stable identity used by UpdateMemberRole
-	// and the organization_user_relationships table).
+	// Batch-resolve WorkOS user IDs to local Gram users, filtering to only
+	// those connected to this organization via organization_user_relationships.
+	// This single joined query prevents the list from surfacing users who
+	// exist in Gram but aren't connected to the current org (which would
+	// cause UpdateMemberRole to fail).
 	workosIDs := make([]string, 0, len(users))
 	for workosUID := range users {
 		workosIDs = append(workosIDs, workosUID)
 	}
-	localUserRows, err := usersrepo.New(s.db).GetUsersByWorkosIDs(ctx, workosIDs)
+	localUserRows, err := usersrepo.New(s.db).GetConnectedUsersByWorkosIDs(ctx, usersrepo.GetConnectedUsersByWorkosIDsParams{
+		WorkosIds:      workosIDs,
+		OrganizationID: ac.ActiveOrganizationID,
+	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "resolve local users by workos ids").Log(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve connected users by workos ids").Log(ctx, s.logger)
 	}
 	localUsers := make(map[string]usersrepo.User, len(localUserRows))
 	for _, u := range localUserRows {
@@ -587,7 +592,7 @@ func (s *Service) ListMembers(ctx context.Context, _ *gen.ListMembersPayload) (*
 
 		local, ok := localUsers[member.UserID]
 		if !ok {
-			continue // user exists in WorkOS but hasn't logged into Gram yet
+			continue
 		}
 
 		result = append(result, &gen.AccessMember{

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -127,7 +127,7 @@ func (s *Service) ListRoles(ctx context.Context, _ *gen.ListRolesPayload) (*gen.
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, s.logger)
 	}
-	memberCounts, err := s.localMemberCounts(ctx, members)
+	memberCounts, err := s.localMemberCounts(ctx, ac.ActiveOrganizationID, members)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, s.logger)
 	}
@@ -175,7 +175,7 @@ func (s *Service) GetRole(ctx context.Context, payload *gen.GetRolePayload) (*ge
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, s.logger)
 	}
 
-	memberCounts, err := s.localMemberCounts(ctx, members)
+	memberCounts, err := s.localMemberCounts(ctx, ac.ActiveOrganizationID, members)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, s.logger)
 	}
@@ -281,13 +281,16 @@ func (s *Service) CreateRole(ctx context.Context, payload *gen.CreateRolePayload
 		s.access.InvalidateAllRoleCaches(ctx, ac.ActiveOrganizationID)
 	}
 
-	// Only count assigned members who have local Gram accounts, consistent with
-	// how ListRoles/GetRole/UpdateRole count members via localMemberCounts.
+	// Only count assigned members who have local Gram accounts and are
+	// connected to this org, consistent with how ListMembers filters users.
 	assignedCount := 0
 	if len(assignedWorkosIDs) > 0 {
-		localRows, err := usersrepo.New(s.db).GetUsersByWorkosIDs(ctx, assignedWorkosIDs)
+		localRows, err := usersrepo.New(s.db).GetConnectedUsersByWorkosIDs(ctx, usersrepo.GetConnectedUsersByWorkosIDsParams{
+			WorkosIds:      assignedWorkosIDs,
+			OrganizationID: ac.ActiveOrganizationID,
+		})
 		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get users by workos ids: %w", err), "resolve local assigned members").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get connected users by workos ids: %w", err), "resolve local assigned members").Log(ctx, logger)
 		}
 		assignedCount = len(localRows)
 	}
@@ -361,7 +364,7 @@ func (s *Service) UpdateRole(ctx context.Context, payload *gen.UpdateRolePayload
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, logger)
 	}
-	memberCountsBefore, err := s.localMemberCounts(ctx, membersBefore)
+	memberCountsBefore, err := s.localMemberCounts(ctx, ac.ActiveOrganizationID, membersBefore)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, logger)
 	}
@@ -407,7 +410,7 @@ func (s *Service) UpdateRole(ctx context.Context, payload *gen.UpdateRolePayload
 		return nil, oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, logger)
 	}
 
-	memberCounts, err := s.localMemberCounts(ctx, members)
+	memberCounts, err := s.localMemberCounts(ctx, ac.ActiveOrganizationID, members)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "count local members by role").Log(ctx, logger)
 	}
@@ -865,16 +868,20 @@ func formatUserName(user workos.User) string {
 }
 
 // localMemberCounts counts WorkOS members per role slug, but only for members
-// who have a local Gram account. This ensures counts match what ListMembers
-// returns — users in WorkOS who have never logged into Gram are excluded.
-func (s *Service) localMemberCounts(ctx context.Context, members []workos.Member) (map[string]int, error) {
+// who have a local Gram account and are connected to the given organization
+// via organization_user_relationships. This ensures counts match what
+// ListMembers returns.
+func (s *Service) localMemberCounts(ctx context.Context, organizationID string, members []workos.Member) (map[string]int, error) {
 	workosIDs := make([]string, 0, len(members))
 	for _, m := range members {
 		workosIDs = append(workosIDs, m.UserID)
 	}
-	localRows, err := usersrepo.New(s.db).GetUsersByWorkosIDs(ctx, workosIDs)
+	localRows, err := usersrepo.New(s.db).GetConnectedUsersByWorkosIDs(ctx, usersrepo.GetConnectedUsersByWorkosIDsParams{
+		WorkosIds:      workosIDs,
+		OrganizationID: organizationID,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("get users by workos ids: %w", err)
+		return nil, fmt.Errorf("get connected users by workos ids: %w", err)
 	}
 	localSet := make(map[string]struct{}, len(localRows))
 	for _, u := range localRows {

--- a/server/internal/access/listmembers_test.go
+++ b/server/internal/access/listmembers_test.go
@@ -55,6 +55,37 @@ func TestService_ListMembers(t *testing.T) {
 	require.Equal(t, "role_builder", byID["local_user_2"].RoleID)
 }
 
+func TestService_ListMembers_ExcludesDisconnectedUsers(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+
+	// user_1 is connected to the org (has organization_user_relationships row).
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "ada@example.com", "Ada Lovelace", "user_1", "membership_1")
+	// user_2 exists in the users table with a workos_id but is NOT connected
+	// to this org — no row in organization_user_relationships.
+	seedDisconnectedUser(t, ctx, ti.conn, "local_user_2", "grace@example.com", "Grace", "user_2")
+
+	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
+		mockSystemRole("role_admin", "Admin", "admin"),
+	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{
+		mockMember(mockidp.MockOrgID, "membership_1", "user_1", "admin"),
+		mockMember(mockidp.MockOrgID, "membership_2", "user_2", "admin"),
+	}, nil).Once()
+	ti.roles.On("ListOrgUsers", mock.Anything, mockidp.MockOrgID).Return(map[string]thirdpartyworkos.User{
+		"user_1": mockUser("user_1", "Ada", "Lovelace", "ada@example.com"),
+		"user_2": mockUser("user_2", "Grace", "", "grace@example.com"),
+	}, nil).Once()
+
+	result, err := ti.service.ListMembers(ctx, &gen.ListMembersPayload{})
+	require.NoError(t, err)
+	require.Len(t, result.Members, 1, "disconnected user should be excluded")
+	require.Equal(t, "local_user_1", result.Members[0].ID)
+	require.Equal(t, "Ada Lovelace", result.Members[0].Name)
+}
+
 func TestService_ListMembers_WorkOSUsersFailure(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/access/listroles_test.go
+++ b/server/internal/access/listroles_test.go
@@ -76,3 +76,32 @@ func TestService_ListRoles(t *testing.T) {
 	require.ElementsMatch(t, []string{"project-1", "project-2"}, grantsByScope[string(ScopeProjectRead)].Resources)
 	require.Nil(t, grantsByScope[string(ScopeMCPConnect)].Resources)
 }
+
+func TestService_ListRoles_ExcludesDisconnectedUsersFromMemberCounts(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	// user_1 is connected to the org.
+	seedConnectedUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "local_user_1", "user1@test.com", "User 1", "user_1", "membership_1")
+	// user_2 exists locally with a workos_id but is NOT connected to this org
+	// (no organization_user_relationships row). Should not inflate member count.
+	seedDisconnectedUser(t, ctx, ti.conn, "local_user_2", "user2@test.com", "User 2", "user_2")
+
+	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
+		mockSystemRole("role_admin", "Admin", "admin"),
+	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{
+		mockMember(mockidp.MockOrgID, "membership_1", "user_1", "admin"),
+		// user_2 appears in WorkOS members but is disconnected locally.
+		mockMember(mockidp.MockOrgID, "membership_2", "user_2", "admin"),
+	}, nil).Once()
+
+	result, err := ti.service.ListRoles(ctx, &gen.ListRolesPayload{})
+	require.NoError(t, err)
+	require.Len(t, result.Roles, 1)
+	// Only user_1 should be counted — user_2 has a local account but no org connection.
+	require.Equal(t, 1, result.Roles[0].MemberCount)
+}

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -152,6 +152,28 @@ func listPrincipalGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, 
 	return grants
 }
 
+// seedDisconnectedUser creates a user in the users table with a workos_id but
+// does NOT insert into organization_user_relationships, simulating a WorkOS
+// user who hasn't been connected to the Gram org.
+func seedDisconnectedUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, userID string, email string, displayName string, workosUserID string) {
+	t.Helper()
+
+	_, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: displayName,
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	err = usersrepo.New(conn).SetUserWorkosID(ctx, usersrepo.SetUserWorkosIDParams{
+		WorkosID: conv.PtrToPGText(conv.PtrEmpty(workosUserID)),
+		ID:       userID,
+	})
+	require.NoError(t, err)
+}
+
 func seedConnectedUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, userID string, email string, displayName string, workosUserID string, workosMembershipID string) {
 	t.Helper()
 

--- a/server/internal/access/updaterole_test.go
+++ b/server/internal/access/updaterole_test.go
@@ -79,7 +79,7 @@ func TestService_UpdateRole(t *testing.T) {
 			{Scope: string(ScopeProjectWrite), Resources: []string{"project-1", "project-2"}},
 			{Scope: string(ScopeMCPConnect), Resources: nil},
 		},
-		MemberIds: []string{"user_1", "user_2"},
+		MemberIds: []string{"local_user_1", "local_user_2"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, "role_custom", role.ID)

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -34,6 +34,10 @@ WHERE u.workos_id = ANY(@workos_ids::text[])
   AND our.organization_id = @organization_id
   AND our.deleted_at IS NULL;
 
+-- name: GetUsersByIDs :many
+SELECT * FROM users
+WHERE id = ANY(@ids::text[]);
+
 -- name: SetUserWorkosID :exec
 UPDATE users 
 SET workos_id = @workos_id, 

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -27,6 +27,13 @@ LIMIT 1;
 SELECT * FROM users
 WHERE workos_id = ANY(@workos_ids::text[]);
 
+-- name: GetConnectedUsersByWorkosIDs :many
+SELECT u.* FROM users u
+JOIN organization_user_relationships our ON our.user_id = u.id
+WHERE u.workos_id = ANY(@workos_ids::text[])
+  AND our.organization_id = @organization_id
+  AND our.deleted_at IS NULL;
+
 -- name: SetUserWorkosID :exec
 UPDATE users 
 SET workos_id = @workos_id, 

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -111,6 +111,41 @@ func (q *Queries) GetUserIDByWorkosID(ctx context.Context, workosID pgtype.Text)
 	return id, err
 }
 
+const getUsersByIDs = `-- name: GetUsersByIDs :many
+SELECT id, email, display_name, photo_url, admin, last_login, workos_id, created_at, updated_at FROM users
+WHERE id = ANY($1::text[])
+`
+
+func (q *Queries) GetUsersByIDs(ctx context.Context, ids []string) ([]User, error) {
+	rows, err := q.db.Query(ctx, getUsersByIDs, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []User
+	for rows.Next() {
+		var i User
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.DisplayName,
+			&i.PhotoUrl,
+			&i.Admin,
+			&i.LastLogin,
+			&i.WorkosID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getUsersByWorkosIDs = `-- name: GetUsersByWorkosIDs :many
 SELECT id, email, display_name, photo_url, admin, last_login, workos_id, created_at, updated_at FROM users
 WHERE workos_id = ANY($1::text[])

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -11,6 +11,49 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const getConnectedUsersByWorkosIDs = `-- name: GetConnectedUsersByWorkosIDs :many
+SELECT u.id, u.email, u.display_name, u.photo_url, u.admin, u.last_login, u.workos_id, u.created_at, u.updated_at FROM users u
+JOIN organization_user_relationships our ON our.user_id = u.id
+WHERE u.workos_id = ANY($1::text[])
+  AND our.organization_id = $2
+  AND our.deleted_at IS NULL
+`
+
+type GetConnectedUsersByWorkosIDsParams struct {
+	WorkosIds      []string
+	OrganizationID string
+}
+
+func (q *Queries) GetConnectedUsersByWorkosIDs(ctx context.Context, arg GetConnectedUsersByWorkosIDsParams) ([]User, error) {
+	rows, err := q.db.Query(ctx, getConnectedUsersByWorkosIDs, arg.WorkosIds, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []User
+	for rows.Next() {
+		var i User
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.DisplayName,
+			&i.PhotoUrl,
+			&i.Admin,
+			&i.LastLogin,
+			&i.WorkosID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getUser = `-- name: GetUser :one
 SELECT id, email, display_name, photo_url, admin, last_login, workos_id, created_at, updated_at FROM users
 WHERE id = $1


### PR DESCRIPTION
## Summary
- `ListMembers` was using `GetUsersByWorkosIDs` which only checked the `users` table — it didn't verify membership in `organization_user_relationships`. This caused disconnected users (exist in Gram but not connected to the org) to appear in the member list, and then `UpdateMemberRole` would fail because it enforces the join table check via `connectedUser()`.
- Added a new `GetConnectedUsersByWorkosIDs` SQL query that joins `users` with `organization_user_relationships` in a single query, replacing both the old user lookup and the missing org membership check.
- Added `TestService_ListMembers_ExcludesDisconnectedUsers` test that seeds a disconnected user and verifies they're excluded from the list.

## Test plan
- [x] Existing `TestService_ListMembers` still passes (connected users still returned correctly)
- [x] New `TestService_ListMembers_ExcludesDisconnectedUsers` passes — user in `users` table with `workos_id` but no `organization_user_relationships` row is excluded
- [x] `TestService_ListMembers_WorkOSUsersFailure` still passes
- [x] `TestService_ListMembers_ForbiddenWithoutOrgReadGrant` and `AllowsOrgReadGrant` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)