### PR TITLE
fix: extract external MCP tool names from URN

### DIFF
--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -232,10 +232,15 @@ func DescribeToolsetEntry(
 			if err != nil {
 				continue // Skip if not found
 			}
+			// Extract the actual tool name from the URN (tools:external-mcp:<source>:<name>).
+			externalToolName := externalMCPTool.Slug
+			if parsed, parseErr := urn.ParseTool(toolUrn); parseErr == nil {
+				externalToolName = parsed.Name
+			}
 			tools = append(tools, &types.ToolEntry{
 				Type:        string(urn.ToolKindExternalMCP),
 				ID:          externalMCPTool.ID.String(),
-				Name:        externalMCPTool.Slug + ":proxy",
+				Name:        externalToolName,
 				ToolUrn:     externalMCPTool.ToolUrn,
 				Annotations: conv.AnnotationsFromColumns(externalMCPTool.ReadOnlyHint, externalMCPTool.DestructiveHint, externalMCPTool.IdempotentHint, externalMCPTool.OpenWorldHint),
 				HTTPMethod:  nil,
@@ -771,10 +776,14 @@ func GetToolsetsSummary(
 					continue
 				}
 				seen[def.ToolUrn] = true
+				externalToolName := def.Slug
+				if parsed, parseErr := urn.ParseTool(def.ToolUrn); parseErr == nil {
+					externalToolName = parsed.Name
+				}
 				projectTools[def.ToolUrn] = &types.ToolEntry{
 					Type:        string(urn.ToolKindExternalMCP),
 					ID:          def.ID.String(),
-					Name:        def.Slug + ":proxy",
+					Name:        externalToolName,
 					ToolUrn:     def.ToolUrn,
 					Annotations: conv.AnnotationsFromColumns(def.ReadOnlyHint, def.DestructiveHint, def.IdempotentHint, def.OpenWorldHint),
 					HTTPMethod:  nil,

--- a/server/internal/toolsets/externalmcp_toolnames_test.go
+++ b/server/internal/toolsets/externalmcp_toolnames_test.go
@@ -1,0 +1,139 @@
+package toolsets_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/toolsets"
+	externalmcpRepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	externalmcpTypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestToolsetsService_ListToolsetsForOrg_ExternalMCPToolNames(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+
+	// Create a deployment so external MCP attachments have something to reference.
+	dep := createPetstoreDeployment(t, ctx, ti)
+	deploymentID := uuid.MustParse(dep.Deployment.ID)
+
+	// Create an MCP registry entry (no SQLc query exists for mcp_registries).
+	var registryID uuid.UUID
+	err := ti.conn.QueryRow(ctx, `
+		INSERT INTO mcp_registries (name, url)
+		VALUES ($1, $2)
+		RETURNING id
+	`, "test-registry-toolnames", "https://example.com/mcp").Scan(&registryID)
+	require.NoError(t, err)
+
+	// Create an external MCP attachment with slug "my-github-mcp".
+	attachmentSlug := "my-github-mcp"
+	emcpRepo := externalmcpRepo.New(ti.conn)
+	attachment, err := emcpRepo.CreateExternalMCPAttachment(ctx, externalmcpRepo.CreateExternalMCPAttachmentParams{
+		DeploymentID:            deploymentID,
+		RegistryID:              uuid.NullUUID{UUID: registryID, Valid: true},
+		Name:                    "My GitHub MCP",
+		Slug:                    attachmentSlug,
+		RegistryServerSpecifier: "test-server",
+	})
+	require.NoError(t, err)
+
+	// Create two external MCP tool definitions with distinct tool names in the URN.
+	toolURN1 := urn.NewTool(urn.ToolKindExternalMCP, attachmentSlug, "create-issue").String()
+	toolURN2 := urn.NewTool(urn.ToolKindExternalMCP, attachmentSlug, "list-repos").String()
+
+	_, err = emcpRepo.CreateExternalMCPToolDefinition(ctx, externalmcpRepo.CreateExternalMCPToolDefinitionParams{
+		ExternalMcpAttachmentID:    attachment.ID,
+		ToolUrn:                    toolURN1,
+		Type:                       "proxy",
+		Name:                       pgtype.Text{},
+		Description:                pgtype.Text{},
+		Schema:                     nil,
+		RemoteUrl:                  "https://example.com/mcp",
+		TransportType:              externalmcpTypes.TransportTypeStreamableHTTP,
+		RequiresOauth:              false,
+		OauthVersion:               "none",
+		OauthAuthorizationEndpoint: pgtype.Text{},
+		OauthTokenEndpoint:         pgtype.Text{},
+		OauthRegistrationEndpoint:  pgtype.Text{},
+		OauthScopesSupported:       []string{},
+		HeaderDefinitions:          nil,
+		Title:                      pgtype.Text{},
+		ReadOnlyHint:               pgtype.Bool{},
+		DestructiveHint:            pgtype.Bool{},
+		IdempotentHint:             pgtype.Bool{},
+		OpenWorldHint:              pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	_, err = emcpRepo.CreateExternalMCPToolDefinition(ctx, externalmcpRepo.CreateExternalMCPToolDefinitionParams{
+		ExternalMcpAttachmentID:    attachment.ID,
+		ToolUrn:                    toolURN2,
+		Type:                       "proxy",
+		Name:                       pgtype.Text{},
+		Description:                pgtype.Text{},
+		Schema:                     nil,
+		RemoteUrl:                  "https://example.com/mcp",
+		TransportType:              externalmcpTypes.TransportTypeStreamableHTTP,
+		RequiresOauth:              false,
+		OauthVersion:               "none",
+		OauthAuthorizationEndpoint: pgtype.Text{},
+		OauthTokenEndpoint:         pgtype.Text{},
+		OauthRegistrationEndpoint:  pgtype.Text{},
+		OauthScopesSupported:       []string{},
+		HeaderDefinitions:          nil,
+		Title:                      pgtype.Text{},
+		ReadOnlyHint:               pgtype.Bool{},
+		DestructiveHint:            pgtype.Bool{},
+		IdempotentHint:             pgtype.Bool{},
+		OpenWorldHint:              pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	// Create a toolset that references these external MCP tool URNs.
+	toolset, err := ti.service.CreateToolset(ctx, &gen.CreateToolsetPayload{
+		SessionToken:           nil,
+		Name:                   "External MCP Toolset",
+		Description:            nil,
+		ToolUrns:               []string{toolURN1, toolURN2},
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		ProjectSlugInput:       nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, toolset)
+
+	// ListToolsetsForOrg and verify tool names come from URN, not attachment slug.
+	result, err := ti.service.ListToolsetsForOrg(ctx, &gen.ListToolsetsForOrgPayload{
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Find our toolset in the results.
+	var found bool
+	for _, ts := range result.Toolsets {
+		if ts.ID != toolset.ID {
+			continue
+		}
+		found = true
+		require.Len(t, ts.Tools, 2)
+
+		namesByURN := make(map[string]string)
+		for _, tool := range ts.Tools {
+			namesByURN[tool.ToolUrn] = tool.Name
+		}
+
+		// Names must be the URN tool name, NOT the attachment slug.
+		require.Equal(t, "create-issue", namesByURN[toolURN1],
+			"tool name should be 'create-issue' from URN, not the attachment slug")
+		require.Equal(t, "list-repos", namesByURN[toolURN2],
+			"tool name should be 'list-repos' from URN, not the attachment slug")
+	}
+	require.True(t, found, "toolset should appear in ListToolsetsForOrg results")
+}


### PR DESCRIPTION
## Summary

- External MCP tool names in `listForOrg` and `listToolsets` were showing the attachment slug (e.g. `my-github-mcp:proxy`) for every tool instead of the actual tool name from the URN (e.g. `create-issue`)
- Fixed both `DescribeToolsetEntry` and `GetToolsetsSummary` paths in `server/internal/mv/toolset.go`
- Added test covering `ListToolsetsForOrg` with multiple external MCP tools asserting correct name extraction

Closes AGE-1929

## Test plan

- [x] New test `TestToolsetsService_ListToolsetsForOrg_ExternalMCPToolNames` passes
- [x] All existing `ListToolsetsForOrg` tests pass (8/8)
- [ ] Verify in Roles & Permissions UI that external MCP tools show distinct names

🤖 Generated with [Claude Code](https://claude.com/claude-code)