### PR TITLE
chore: batch DB queries in listToolsetsForOrg

### DIFF
--- a/server/internal/externalmcp/queries.sql
+++ b/server/internal/externalmcp/queries.sql
@@ -179,6 +179,31 @@ WHERE t.tool_urn = ANY(@tool_urns::text[])
   AND t.deleted IS FALSE
   AND e.deleted IS FALSE;
 
+-- name: FindExternalMCPToolEntriesForProjects :many
+-- Batch-resolves external MCP tool entries across multiple projects.
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id) d.project_id, d.id as deployment_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY(@project_ids::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+)
+SELECT
+  pd.project_id,
+  t.id,
+  t.tool_urn,
+  e.slug,
+  t.read_only_hint,
+  t.destructive_hint,
+  t.idempotent_hint,
+  t.open_world_hint
+FROM external_mcp_tool_definitions t
+JOIN external_mcp_attachments e ON t.external_mcp_attachment_id = e.id
+JOIN project_deployments pd ON e.deployment_id = pd.deployment_id
+WHERE t.deleted IS FALSE
+  AND e.deleted IS FALSE;
+
 -- name: GetExternalMCPToolsRequiringOAuth :many
 SELECT
   t.id,
@@ -214,30 +239,3 @@ WHERE e.deployment_id = @deployment_id
   AND t.requires_oauth = TRUE
   AND t.deleted IS FALSE
   AND e.deleted IS FALSE;
-
--- name: GetExternalMCPToolDefinitionsByURNsBatch :many
--- Batch variant of GetExternalMCPToolDefinitionsByURNs across multiple projects.
-WITH project_deployments AS (
-    SELECT DISTINCT ON (d.project_id)
-        d.id,
-        d.project_id
-    FROM deployments d
-    JOIN deployment_statuses ds ON d.id = ds.deployment_id
-    WHERE d.project_id = ANY(@project_ids::uuid[])
-      AND ds.status = 'completed'
-    ORDER BY d.project_id, d.seq DESC
-)
-SELECT
-    pd.project_id,
-    t.id,
-    t.tool_urn,
-    e.slug,
-    t.read_only_hint,
-    t.destructive_hint,
-    t.idempotent_hint,
-    t.open_world_hint
-FROM project_deployments pd
-JOIN external_mcp_attachments e ON e.deployment_id = pd.id AND e.deleted IS FALSE
-JOIN external_mcp_tool_definitions t ON t.external_mcp_attachment_id = e.id
-WHERE t.tool_urn = ANY(@tool_urns::text[])
-  AND t.deleted IS FALSE;

--- a/server/internal/externalmcp/queries.sql
+++ b/server/internal/externalmcp/queries.sql
@@ -214,3 +214,30 @@ WHERE e.deployment_id = @deployment_id
   AND t.requires_oauth = TRUE
   AND t.deleted IS FALSE
   AND e.deleted IS FALSE;
+
+-- name: GetExternalMCPToolDefinitionsByURNsBatch :many
+-- Batch variant of GetExternalMCPToolDefinitionsByURNs across multiple projects.
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id)
+        d.id,
+        d.project_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY(@project_ids::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+)
+SELECT
+    pd.project_id,
+    t.id,
+    t.tool_urn,
+    e.slug,
+    t.read_only_hint,
+    t.destructive_hint,
+    t.idempotent_hint,
+    t.open_world_hint
+FROM project_deployments pd
+JOIN external_mcp_attachments e ON e.deployment_id = pd.id AND e.deleted IS FALSE
+JOIN external_mcp_tool_definitions t ON t.external_mcp_attachment_id = e.id
+WHERE t.tool_urn = ANY(@tool_urns::text[])
+  AND t.deleted IS FALSE;

--- a/server/internal/externalmcp/repo/queries.sql.go
+++ b/server/internal/externalmcp/repo/queries.sql.go
@@ -211,6 +211,72 @@ func (q *Queries) CreateExternalMCPToolDefinition(ctx context.Context, arg Creat
 	return i, err
 }
 
+const findExternalMCPToolEntriesForProjects = `-- name: FindExternalMCPToolEntriesForProjects :many
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id) d.project_id, d.id as deployment_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY($1::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+)
+SELECT
+  pd.project_id,
+  t.id,
+  t.tool_urn,
+  e.slug,
+  t.read_only_hint,
+  t.destructive_hint,
+  t.idempotent_hint,
+  t.open_world_hint
+FROM external_mcp_tool_definitions t
+JOIN external_mcp_attachments e ON t.external_mcp_attachment_id = e.id
+JOIN project_deployments pd ON e.deployment_id = pd.deployment_id
+WHERE t.deleted IS FALSE
+  AND e.deleted IS FALSE
+`
+
+type FindExternalMCPToolEntriesForProjectsRow struct {
+	ProjectID       uuid.UUID
+	ID              uuid.UUID
+	ToolUrn         string
+	Slug            string
+	ReadOnlyHint    pgtype.Bool
+	DestructiveHint pgtype.Bool
+	IdempotentHint  pgtype.Bool
+	OpenWorldHint   pgtype.Bool
+}
+
+// Batch-resolves external MCP tool entries across multiple projects.
+func (q *Queries) FindExternalMCPToolEntriesForProjects(ctx context.Context, projectIds []uuid.UUID) ([]FindExternalMCPToolEntriesForProjectsRow, error) {
+	rows, err := q.db.Query(ctx, findExternalMCPToolEntriesForProjects, projectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FindExternalMCPToolEntriesForProjectsRow
+	for rows.Next() {
+		var i FindExternalMCPToolEntriesForProjectsRow
+		if err := rows.Scan(
+			&i.ProjectID,
+			&i.ID,
+			&i.ToolUrn,
+			&i.Slug,
+			&i.ReadOnlyHint,
+			&i.DestructiveHint,
+			&i.IdempotentHint,
+			&i.OpenWorldHint,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getExternalMCPToolDefinitionByURN = `-- name: GetExternalMCPToolDefinitionByURN :one
 WITH deployment AS (
     SELECT d.id
@@ -381,79 +447,6 @@ func (q *Queries) GetExternalMCPToolDefinitionsByURNs(ctx context.Context, arg G
 	for rows.Next() {
 		var i GetExternalMCPToolDefinitionsByURNsRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.ToolUrn,
-			&i.Slug,
-			&i.ReadOnlyHint,
-			&i.DestructiveHint,
-			&i.IdempotentHint,
-			&i.OpenWorldHint,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getExternalMCPToolDefinitionsByURNsBatch = `-- name: GetExternalMCPToolDefinitionsByURNsBatch :many
-WITH project_deployments AS (
-    SELECT DISTINCT ON (d.project_id)
-        d.id,
-        d.project_id
-    FROM deployments d
-    JOIN deployment_statuses ds ON d.id = ds.deployment_id
-    WHERE d.project_id = ANY($2::uuid[])
-      AND ds.status = 'completed'
-    ORDER BY d.project_id, d.seq DESC
-)
-SELECT
-    pd.project_id,
-    t.id,
-    t.tool_urn,
-    e.slug,
-    t.read_only_hint,
-    t.destructive_hint,
-    t.idempotent_hint,
-    t.open_world_hint
-FROM project_deployments pd
-JOIN external_mcp_attachments e ON e.deployment_id = pd.id AND e.deleted IS FALSE
-JOIN external_mcp_tool_definitions t ON t.external_mcp_attachment_id = e.id
-WHERE t.tool_urn = ANY($1::text[])
-  AND t.deleted IS FALSE
-`
-
-type GetExternalMCPToolDefinitionsByURNsBatchParams struct {
-	ToolUrns   []string
-	ProjectIds []uuid.UUID
-}
-
-type GetExternalMCPToolDefinitionsByURNsBatchRow struct {
-	ProjectID       uuid.UUID
-	ID              uuid.UUID
-	ToolUrn         string
-	Slug            string
-	ReadOnlyHint    pgtype.Bool
-	DestructiveHint pgtype.Bool
-	IdempotentHint  pgtype.Bool
-	OpenWorldHint   pgtype.Bool
-}
-
-// Batch variant of GetExternalMCPToolDefinitionsByURNs across multiple projects.
-func (q *Queries) GetExternalMCPToolDefinitionsByURNsBatch(ctx context.Context, arg GetExternalMCPToolDefinitionsByURNsBatchParams) ([]GetExternalMCPToolDefinitionsByURNsBatchRow, error) {
-	rows, err := q.db.Query(ctx, getExternalMCPToolDefinitionsByURNsBatch, arg.ToolUrns, arg.ProjectIds)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetExternalMCPToolDefinitionsByURNsBatchRow
-	for rows.Next() {
-		var i GetExternalMCPToolDefinitionsByURNsBatchRow
-		if err := rows.Scan(
-			&i.ProjectID,
 			&i.ID,
 			&i.ToolUrn,
 			&i.Slug,

--- a/server/internal/externalmcp/repo/queries.sql.go
+++ b/server/internal/externalmcp/repo/queries.sql.go
@@ -399,6 +399,79 @@ func (q *Queries) GetExternalMCPToolDefinitionsByURNs(ctx context.Context, arg G
 	return items, nil
 }
 
+const getExternalMCPToolDefinitionsByURNsBatch = `-- name: GetExternalMCPToolDefinitionsByURNsBatch :many
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id)
+        d.id,
+        d.project_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY($2::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+)
+SELECT
+    pd.project_id,
+    t.id,
+    t.tool_urn,
+    e.slug,
+    t.read_only_hint,
+    t.destructive_hint,
+    t.idempotent_hint,
+    t.open_world_hint
+FROM project_deployments pd
+JOIN external_mcp_attachments e ON e.deployment_id = pd.id AND e.deleted IS FALSE
+JOIN external_mcp_tool_definitions t ON t.external_mcp_attachment_id = e.id
+WHERE t.tool_urn = ANY($1::text[])
+  AND t.deleted IS FALSE
+`
+
+type GetExternalMCPToolDefinitionsByURNsBatchParams struct {
+	ToolUrns   []string
+	ProjectIds []uuid.UUID
+}
+
+type GetExternalMCPToolDefinitionsByURNsBatchRow struct {
+	ProjectID       uuid.UUID
+	ID              uuid.UUID
+	ToolUrn         string
+	Slug            string
+	ReadOnlyHint    pgtype.Bool
+	DestructiveHint pgtype.Bool
+	IdempotentHint  pgtype.Bool
+	OpenWorldHint   pgtype.Bool
+}
+
+// Batch variant of GetExternalMCPToolDefinitionsByURNs across multiple projects.
+func (q *Queries) GetExternalMCPToolDefinitionsByURNsBatch(ctx context.Context, arg GetExternalMCPToolDefinitionsByURNsBatchParams) ([]GetExternalMCPToolDefinitionsByURNsBatchRow, error) {
+	rows, err := q.db.Query(ctx, getExternalMCPToolDefinitionsByURNsBatch, arg.ToolUrns, arg.ProjectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetExternalMCPToolDefinitionsByURNsBatchRow
+	for rows.Next() {
+		var i GetExternalMCPToolDefinitionsByURNsBatchRow
+		if err := rows.Scan(
+			&i.ProjectID,
+			&i.ID,
+			&i.ToolUrn,
+			&i.Slug,
+			&i.ReadOnlyHint,
+			&i.DestructiveHint,
+			&i.IdempotentHint,
+			&i.OpenWorldHint,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getExternalMCPToolsRequiringOAuth = `-- name: GetExternalMCPToolsRequiringOAuth :many
 SELECT
   t.id,

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -635,56 +635,67 @@ func GetToolsetsSummary(
 	variationsRepo := vr.New(tx)
 	extMCPRepo := externalmcpR.New(tx)
 
-	var httpTools []tr.FindHttpToolEntriesForProjectsRow
-	var funcTools []tr.FindFunctionToolEntriesForProjectsRow
-	var promptTools []templatesR.PeekTemplatesForProjectsRow
-	var variations []vr.FindGlobalVariationsForProjectsRow
-	var externalMCPTools []externalmcpR.FindExternalMCPToolEntriesForProjectsRow
+	httpToolsCh := make(chan []tr.FindHttpToolEntriesForProjectsRow, 1)
+	funcToolsCh := make(chan []tr.FindFunctionToolEntriesForProjectsRow, 1)
+	promptToolsCh := make(chan []templatesR.PeekTemplatesForProjectsRow, 1)
+	variationsCh := make(chan []vr.FindGlobalVariationsForProjectsRow, 1)
+	externalMCPToolsCh := make(chan []externalmcpR.FindExternalMCPToolEntriesForProjectsRow, 1)
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		var err error
-		httpTools, err = toolsRepo.FindHttpToolEntriesForProjects(egCtx, projectIDs)
+		rows, err := toolsRepo.FindHttpToolEntriesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch http tools: %w", err)
 		}
+		httpToolsCh <- rows
+		close(httpToolsCh)
 		return nil
 	})
 	eg.Go(func() error {
-		var err error
-		funcTools, err = toolsRepo.FindFunctionToolEntriesForProjects(egCtx, projectIDs)
+		rows, err := toolsRepo.FindFunctionToolEntriesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch function tools: %w", err)
 		}
+		funcToolsCh <- rows
+		close(funcToolsCh)
 		return nil
 	})
 	eg.Go(func() error {
-		var err error
-		promptTools, err = tplRepo.PeekTemplatesForProjects(egCtx, projectIDs)
+		rows, err := tplRepo.PeekTemplatesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch prompt tools: %w", err)
 		}
+		promptToolsCh <- rows
+		close(promptToolsCh)
 		return nil
 	})
 	eg.Go(func() error {
-		var err error
-		variations, err = variationsRepo.FindGlobalVariationsForProjects(egCtx, projectIDs)
+		rows, err := variationsRepo.FindGlobalVariationsForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch variations: %w", err)
 		}
+		variationsCh <- rows
+		close(variationsCh)
 		return nil
 	})
 	eg.Go(func() error {
-		var err error
-		externalMCPTools, err = extMCPRepo.FindExternalMCPToolEntriesForProjects(egCtx, projectIDs)
+		rows, err := extMCPRepo.FindExternalMCPToolEntriesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch external mcp tools: %w", err)
 		}
+		externalMCPToolsCh <- rows
+		close(externalMCPToolsCh)
 		return nil
 	})
 	if err := eg.Wait(); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "batch fetch tool entries").Log(ctx, logger)
 	}
+
+	httpTools := <-httpToolsCh
+	funcTools := <-funcToolsCh
+	promptTools := <-promptToolsCh
+	variations := <-variationsCh
+	externalMCPTools := <-externalMCPToolsCh
 
 	// Build variation name overrides: projectID → toolURN → name.
 	variationNames := make(map[uuid.UUID]map[string]string)

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -33,6 +33,7 @@ import (
 	tsr "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	vr "github.com/speakeasy-api/gram/server/internal/variations/repo"
+	"golang.org/x/sync/errgroup"
 )
 
 // functionManifestVariable represents a variable definition from a function manifest.
@@ -594,12 +595,11 @@ func DescribeToolset(
 }
 
 // GetToolsetsSummary builds ToolsetSummary results for a set of toolsets
-// using bulk queries grouped by project. This avoids the N+1 query pattern of
-// calling DescribeToolsetEntry per toolset.
-//
-// Returns a lightweight summary per toolset: identity fields (ID, ProjectID,
-// OrganizationID, Name, Slug), MCP config, and tool entries (Type, ID, Name,
-// ToolUrn, Annotations, HTTPMethod). Variation name overrides are applied.
+// using batch queries across all projects. Instead of running per-project
+// queries (which incur ~18ms query planning overhead each × N projects),
+// it fires 5 batch queries in parallel — one per tool type — resolving all
+// projects' deployments in a single CTE. Results are filtered in Go against
+// each toolset's URN set.
 func GetToolsetsSummary(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -610,221 +610,206 @@ func GetToolsetsSummary(
 		return []*types.ToolsetSummary{}, nil
 	}
 
-	// Group tool URNs by project for batch fetching.
-	// Version data (tool_urns) is already inlined via LEFT JOIN LATERAL.
-	type projectToolsets struct {
-		toolUrns []string
-	}
-	projectMap := make(map[uuid.UUID]*projectToolsets)
-
+	// Collect unique project IDs and per-project URN sets for Go-side filtering.
+	projectIDSet := make(map[uuid.UUID]struct{})
+	urnsByProject := make(map[uuid.UUID]map[string]struct{})
 	for _, ts := range toolsets {
-		urns := make([]string, len(ts.LatestToolUrns))
-		for i, u := range ts.LatestToolUrns {
-			urns[i] = u.String()
+		projectIDSet[ts.ProjectID] = struct{}{}
+		urnSet, ok := urnsByProject[ts.ProjectID]
+		if !ok {
+			urnSet = make(map[string]struct{})
+			urnsByProject[ts.ProjectID] = urnSet
 		}
-
-		pt, exists := projectMap[ts.ProjectID]
-		if !exists {
-			pt = &projectToolsets{toolUrns: nil}
-			projectMap[ts.ProjectID] = pt
+		for _, u := range ts.LatestToolUrns {
+			urnSet[u.String()] = struct{}{}
 		}
-		pt.toolUrns = append(pt.toolUrns, urns...)
+	}
+	projectIDs := make([]uuid.UUID, 0, len(projectIDSet))
+	for pid := range projectIDSet {
+		projectIDs = append(projectIDs, pid)
 	}
 
-	// Collect all project IDs and all URNs for cross-project batch queries.
-	// This reduces O(projects × 5) DB round trips to O(5) total.
-	allProjectIDs := make([]uuid.UUID, 0, len(projectMap))
-	allURNs := make([]string, 0)
-	for projectID, pt := range projectMap {
-		if len(pt.toolUrns) == 0 {
+	// 5 batch queries in parallel — one round-trip each, no per-project overhead.
+	toolsRepo := tr.New(tx)
+	tplRepo := templatesR.New(tx)
+	variationsRepo := vr.New(tx)
+	extMCPRepo := externalmcpR.New(tx)
+
+	var httpTools []tr.FindHttpToolEntriesForProjectsRow
+	var funcTools []tr.FindFunctionToolEntriesForProjectsRow
+	var promptTools []templatesR.PeekTemplatesForProjectsRow
+	var variations []vr.FindGlobalVariationsForProjectsRow
+	var externalMCPTools []externalmcpR.FindExternalMCPToolEntriesForProjectsRow
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		var err error
+		httpTools, err = toolsRepo.FindHttpToolEntriesForProjects(egCtx, projectIDs)
+		if err != nil {
+			return fmt.Errorf("batch http tools: %w", err)
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		var err error
+		funcTools, err = toolsRepo.FindFunctionToolEntriesForProjects(egCtx, projectIDs)
+		if err != nil {
+			return fmt.Errorf("batch function tools: %w", err)
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		var err error
+		promptTools, err = tplRepo.PeekTemplatesForProjects(egCtx, projectIDs)
+		if err != nil {
+			return fmt.Errorf("batch prompt tools: %w", err)
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		var err error
+		variations, err = variationsRepo.FindGlobalVariationsForProjects(egCtx, projectIDs)
+		if err != nil {
+			return fmt.Errorf("batch variations: %w", err)
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		var err error
+		externalMCPTools, err = extMCPRepo.FindExternalMCPToolEntriesForProjects(egCtx, projectIDs)
+		if err != nil {
+			return fmt.Errorf("batch external mcp tools: %w", err)
+		}
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "batch fetch tool entries").Log(ctx, logger)
+	}
+
+	// Build variation name overrides: projectID → toolURN → name.
+	variationNames := make(map[uuid.UUID]map[string]string)
+	for _, v := range variations {
+		n := conv.FromPGText[string](v.Name)
+		if n == nil || *n == "" {
 			continue
 		}
-		allProjectIDs = append(allProjectIDs, projectID)
-		allURNs = append(allURNs, pt.toolUrns...)
+		m, ok := variationNames[v.ProjectID]
+		if !ok {
+			m = make(map[string]string)
+			variationNames[v.ProjectID] = m
+		}
+		m[v.SrcToolUrn.String()] = *n
 	}
 
-	// Keyed by projectID to avoid cross-project URN collisions (two projects
-	// deploying the same API produce identical tool URNs).
-	toolsByProject := make(map[uuid.UUID]map[string]*types.ToolEntry)
-
-	if len(allProjectIDs) == 0 {
-		goto assemble
+	// Build tool index: projectID → toolURN → ToolEntry.
+	toolsByProject := make(map[uuid.UUID]map[string]*types.ToolEntry, len(projectIDSet))
+	for pid := range projectIDSet {
+		toolsByProject[pid] = make(map[string]*types.ToolEntry)
+	}
+	for _, def := range httpTools {
+		toolURN := def.ToolUrn.String()
+		projTools := toolsByProject[def.ProjectID]
+		if projTools == nil {
+			continue
+		}
+		if _, exists := projTools[toolURN]; exists {
+			continue
+		}
+		name := def.Name
+		if variedName, ok := variationNames[def.ProjectID][toolURN]; ok {
+			name = variedName
+		}
+		projTools[toolURN] = &types.ToolEntry{
+			Type:        string(urn.ToolKindHTTP),
+			ID:          def.ID.String(),
+			Name:        name,
+			ToolUrn:     toolURN,
+			Annotations: conv.AnnotationsFromColumns(def.ReadOnlyHint, def.DestructiveHint, def.IdempotentHint, def.OpenWorldHint),
+			HTTPMethod:  &def.HttpMethod,
+		}
 	}
 
-	{
-		toolsRepo := tr.New(tx)
-		tplRepo := templatesR.New(tx)
-		variationsRepo := vr.New(tx)
+	for _, def := range funcTools {
+		toolURN := def.ToolUrn.String()
+		projTools := toolsByProject[def.ProjectID]
+		if projTools == nil {
+			continue
+		}
+		if _, exists := projTools[toolURN]; exists {
+			continue
+		}
+		projTools[toolURN] = &types.ToolEntry{
+			Type:        string(urn.ToolKindFunction),
+			ID:          def.ID.String(),
+			Name:        def.Name,
+			ToolUrn:     toolURN,
+			Annotations: conv.AnnotationsFromColumns(def.ReadOnlyHint, def.DestructiveHint, def.IdempotentHint, def.OpenWorldHint),
+			HTTPMethod:  nil,
+		}
+	}
 
-		// 1. Batch-fetch variations (needed to override tool names).
-		variationNamesByProject := make(map[uuid.UUID]map[string]string)
-		allVariations, err := variationsRepo.FindGlobalVariationNamesByToolURNsBatch(ctx, vr.FindGlobalVariationNamesByToolURNsBatchParams{
-			ProjectIds: allProjectIDs,
-			ToolUrns:   allURNs,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch variations").Log(ctx, logger)
+	for _, pt := range promptTools {
+		toolURN := pt.ToolUrn.String()
+		projTools := toolsByProject[pt.ProjectID]
+		if projTools == nil {
+			continue
 		}
-		for _, v := range allVariations {
-			n := conv.FromPGText[string](v.Name)
-			if n == nil || *n == "" {
-				continue
-			}
-			m, ok := variationNamesByProject[v.ProjectID]
-			if !ok {
-				m = make(map[string]string)
-				variationNamesByProject[v.ProjectID] = m
-			}
-			m[v.SrcToolUrn.String()] = *n
+		if _, exists := projTools[toolURN]; exists {
+			continue
 		}
+		projTools[toolURN] = &types.ToolEntry{
+			Type:        string(urn.ToolKindPrompt),
+			ID:          pt.ID.String(),
+			Name:        pt.Name,
+			ToolUrn:     toolURN,
+			Annotations: nil,
+			HTTPMethod:  nil,
+		}
+	}
 
-		// Helper to get or create the per-project tool map.
-		getProjectTools := func(pid uuid.UUID) map[string]*types.ToolEntry {
-			m, ok := toolsByProject[pid]
-			if !ok {
-				m = make(map[string]*types.ToolEntry)
-				toolsByProject[pid] = m
-			}
-			return m
-		}
-
-		// 2. Batch-fetch HTTP tools.
-		httpTools, err := toolsRepo.FindHttpToolEntriesByUrnBatch(ctx, tr.FindHttpToolEntriesByUrnBatchParams{
-			ProjectIds: allProjectIDs,
-			Urns:       allURNs,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch http tools").Log(ctx, logger)
-		}
-		for _, def := range httpTools {
-			pt := getProjectTools(def.ProjectID)
-			toolURN := def.ToolUrn.String()
-			if _, exists := pt[toolURN]; exists {
-				continue
-			}
-			varNames := variationNamesByProject[def.ProjectID]
-			name := conv.Default(varNames[toolURN], def.Name)
-			pt[toolURN] = &types.ToolEntry{
-				Type:        string(urn.ToolKindHTTP),
-				ID:          def.ID.String(),
-				Name:        name,
-				ToolUrn:     toolURN,
-				Annotations: conv.AnnotationsFromColumns(def.ReadOnlyHint, def.DestructiveHint, def.IdempotentHint, def.OpenWorldHint),
-				HTTPMethod:  &def.HttpMethod,
-			}
-		}
-
-		// 3. Batch-fetch function tools.
-		funcTools, err := toolsRepo.FindFunctionToolEntriesByUrnBatch(ctx, tr.FindFunctionToolEntriesByUrnBatchParams{
-			ProjectIds: allProjectIDs,
-			Urns:       allURNs,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch function tools").Log(ctx, logger)
-		}
-		for _, def := range funcTools {
-			pt := getProjectTools(def.ProjectID)
-			toolURN := def.ToolUrn.String()
-			if _, exists := pt[toolURN]; exists {
-				continue
-			}
-			pt[toolURN] = &types.ToolEntry{
-				Type:        string(urn.ToolKindFunction),
-				ID:          def.ID.String(),
-				Name:        def.Name,
-				ToolUrn:     toolURN,
-				Annotations: conv.AnnotationsFromColumns(def.ReadOnlyHint, def.DestructiveHint, def.IdempotentHint, def.OpenWorldHint),
-				HTTPMethod:  nil,
-			}
-		}
-
-		// 4. Batch-fetch prompt templates.
-		promptTools, err := tplRepo.PeekTemplatesByUrnsBatch(ctx, templatesR.PeekTemplatesByUrnsBatchParams{
-			ProjectIds: allProjectIDs,
-			Urns:       allURNs,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch prompt tools").Log(ctx, logger)
-		}
-		for _, def := range promptTools {
-			pt := getProjectTools(def.ProjectID)
-			toolURN := def.ToolUrn.String()
-			if _, exists := pt[toolURN]; exists {
-				continue
-			}
-			pt[toolURN] = &types.ToolEntry{
-				Type:        string(urn.ToolKindPrompt),
-				ID:          def.ID.String(),
-				Name:        def.Name,
-				ToolUrn:     toolURN,
-				Annotations: nil,
-				HTTPMethod:  nil,
-			}
-		}
-
-		// 5. Platform tools (local lookup, no DB).
-		for projectID, projToolsets := range projectMap {
-			pt := getProjectTools(projectID)
-			for _, entry := range platformtools.FindToolEntries(projToolsets.toolUrns) {
-				if _, exists := pt[entry.ToolUrn]; !exists {
-					pt[entry.ToolUrn] = entry
-				}
-			}
-		}
-
-		// 6. Batch-fetch external MCP tool entries.
-		allExternalMCPUrns := make([]string, 0)
-		for projectID, projToolsets := range projectMap {
-			pt := getProjectTools(projectID)
-			for _, toolUrn := range projToolsets.toolUrns {
-				var parsedUrn urn.Tool
-				if err := parsedUrn.UnmarshalText([]byte(toolUrn)); err == nil {
-					if parsedUrn.Kind == urn.ToolKindExternalMCP {
-						if _, exists := pt[toolUrn]; !exists {
-							allExternalMCPUrns = append(allExternalMCPUrns, toolUrn)
-						}
-					}
-				}
-			}
-		}
-		if len(allExternalMCPUrns) > 0 {
-			externalmcpRepo := externalmcpR.New(tx)
-			externalTools, err := externalmcpRepo.GetExternalMCPToolDefinitionsByURNsBatch(ctx, externalmcpR.GetExternalMCPToolDefinitionsByURNsBatchParams{
-				ProjectIds: allProjectIDs,
-				ToolUrns:   allExternalMCPUrns,
-			})
-			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch external mcp tools").Log(ctx, logger)
-			}
-			for _, def := range externalTools {
-				pt := getProjectTools(def.ProjectID)
-				if _, exists := pt[def.ToolUrn]; exists {
-					continue
-				}
-				pt[def.ToolUrn] = &types.ToolEntry{
-					Type:        string(urn.ToolKindExternalMCP),
-					ID:          def.ID.String(),
-					Name:        def.Slug + ":proxy",
-					ToolUrn:     def.ToolUrn,
-					Annotations: conv.AnnotationsFromColumns(def.ReadOnlyHint, def.DestructiveHint, def.IdempotentHint, def.OpenWorldHint),
-					HTTPMethod:  nil,
+	// Build platform tool index from the static registry (11 tools), not from 17k URNs.
+	platformIndex := make(map[string]*types.ToolEntry)
+	for _, desc := range platformtools.ListPlatformTools() {
+		entry := desc.ToToolEntry()
+		platformIndex[entry.ToolUrn] = entry
+	}
+	for pid, urnSet := range urnsByProject {
+		projTools := toolsByProject[pid]
+		for u := range urnSet {
+			if _, exists := projTools[u]; !exists {
+				if entry, ok := platformIndex[u]; ok {
+					projTools[u] = entry
 				}
 			}
 		}
 	}
 
-assemble:
+	for _, def := range externalMCPTools {
+		projTools := toolsByProject[def.ProjectID]
+		if projTools == nil {
+			continue
+		}
+		if _, exists := projTools[def.ToolUrn]; exists {
+			continue
+		}
+		projTools[def.ToolUrn] = &types.ToolEntry{
+			Type:        string(urn.ToolKindExternalMCP),
+			ID:          def.ID.String(),
+			Name:        def.Slug + ":proxy",
+			ToolUrn:     def.ToolUrn,
+			Annotations: conv.AnnotationsFromColumns(def.ReadOnlyHint, def.DestructiveHint, def.IdempotentHint, def.OpenWorldHint),
+			HTTPMethod:  nil,
+		}
+	}
 
-	// Assemble results.
+	// Assemble results — look up each toolset's tools from the index.
 	result := make([]*types.ToolsetSummary, 0, len(toolsets))
 	for _, ts := range toolsets {
 		tools := []*types.ToolEntry{}
-		if len(ts.LatestToolUrns) > 0 {
-			projectTools := toolsByProject[ts.ProjectID]
-			for _, u := range ts.LatestToolUrns {
-				if entry, ok := projectTools[u.String()]; ok {
-					tools = append(tools, entry)
-				}
+		projTools := toolsByProject[ts.ProjectID]
+		for _, u := range ts.LatestToolUrns {
+			if entry, ok := projTools[u.String()]; ok {
+				tools = append(tools, entry)
 			}
 		}
 

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -631,74 +631,80 @@ func GetToolsetsSummary(
 		pt.toolUrns = append(pt.toolUrns, urns...)
 	}
 
-	// Per unique project: batch-fetch tool entries and variations.
-	// This is O(projects) not O(toolsets).
-	// Keyed by projectID to avoid cross-project URN collisions (two projects
-	// deploying the same API produce identical tool URNs).
-	toolsByProject := make(map[uuid.UUID]map[string]*types.ToolEntry)
-
+	// Collect all project IDs and all URNs for cross-project batch queries.
+	// This reduces O(projects × 5) DB round trips to O(5) total.
+	allProjectIDs := make([]uuid.UUID, 0, len(projectMap))
+	allURNs := make([]string, 0)
 	for projectID, pt := range projectMap {
 		if len(pt.toolUrns) == 0 {
 			continue
 		}
+		allProjectIDs = append(allProjectIDs, projectID)
+		allURNs = append(allURNs, pt.toolUrns...)
+	}
 
-		projectTools := make(map[string]*types.ToolEntry)
-		toolsByProject[projectID] = projectTools
+	// Keyed by projectID to avoid cross-project URN collisions (two projects
+	// deploying the same API produce identical tool URNs).
+	toolsByProject := make(map[uuid.UUID]map[string]*types.ToolEntry)
 
+	if len(allProjectIDs) == 0 {
+		goto assemble
+	}
+
+	{
 		toolsRepo := tr.New(tx)
-		variationsRepo := vr.New(tx)
 		tplRepo := templatesR.New(tx)
+		variationsRepo := vr.New(tx)
 
-		httpTools, err := toolsRepo.FindHttpToolEntriesByUrn(ctx, tr.FindHttpToolEntriesByUrnParams{
-			ProjectID: projectID,
-			Urns:      pt.toolUrns,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch http tools").Log(ctx, logger)
-		}
-
-		funcTools, err := toolsRepo.FindFunctionToolEntriesByUrn(ctx, tr.FindFunctionToolEntriesByUrnParams{
-			ProjectID: projectID,
-			Urns:      pt.toolUrns,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch function tools").Log(ctx, logger)
-		}
-
-		promptTools, err := tplRepo.PeekTemplatesByUrns(ctx, templatesR.PeekTemplatesByUrnsParams{
-			ProjectID: projectID,
-			Urns:      pt.toolUrns,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch prompt tools").Log(ctx, logger)
-		}
-
-		allVariations, err := variationsRepo.FindGlobalVariationsByToolURNs(ctx, vr.FindGlobalVariationsByToolURNsParams{
-			ProjectID: projectID,
-			ToolUrns:  pt.toolUrns,
+		// 1. Batch-fetch variations (needed to override tool names).
+		variationNamesByProject := make(map[uuid.UUID]map[string]string)
+		allVariations, err := variationsRepo.FindGlobalVariationNamesByToolURNsBatch(ctx, vr.FindGlobalVariationNamesByToolURNsBatchParams{
+			ProjectIds: allProjectIDs,
+			ToolUrns:   allURNs,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch variations").Log(ctx, logger)
 		}
-
-		urnToVariedName := make(map[string]string, len(allVariations))
-		for _, variation := range allVariations {
-			n := conv.FromPGText[string](variation.Name)
+		for _, v := range allVariations {
+			n := conv.FromPGText[string](v.Name)
 			if n == nil || *n == "" {
 				continue
 			}
-			urnToVariedName[variation.SrcToolUrn.String()] = *n
+			m, ok := variationNamesByProject[v.ProjectID]
+			if !ok {
+				m = make(map[string]string)
+				variationNamesByProject[v.ProjectID] = m
+			}
+			m[v.SrcToolUrn.String()] = *n
 		}
 
-		seen := make(map[string]bool)
+		// Helper to get or create the per-project tool map.
+		getProjectTools := func(pid uuid.UUID) map[string]*types.ToolEntry {
+			m, ok := toolsByProject[pid]
+			if !ok {
+				m = make(map[string]*types.ToolEntry)
+				toolsByProject[pid] = m
+			}
+			return m
+		}
+
+		// 2. Batch-fetch HTTP tools.
+		httpTools, err := toolsRepo.FindHttpToolEntriesByUrnBatch(ctx, tr.FindHttpToolEntriesByUrnBatchParams{
+			ProjectIds: allProjectIDs,
+			Urns:       allURNs,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch http tools").Log(ctx, logger)
+		}
 		for _, def := range httpTools {
+			pt := getProjectTools(def.ProjectID)
 			toolURN := def.ToolUrn.String()
-			if seen[toolURN] {
+			if _, exists := pt[toolURN]; exists {
 				continue
 			}
-			seen[toolURN] = true
-			name := conv.Default(urnToVariedName[toolURN], def.Name)
-			projectTools[toolURN] = &types.ToolEntry{
+			varNames := variationNamesByProject[def.ProjectID]
+			name := conv.Default(varNames[toolURN], def.Name)
+			pt[toolURN] = &types.ToolEntry{
 				Type:        string(urn.ToolKindHTTP),
 				ID:          def.ID.String(),
 				Name:        name,
@@ -708,13 +714,21 @@ func GetToolsetsSummary(
 			}
 		}
 
+		// 3. Batch-fetch function tools.
+		funcTools, err := toolsRepo.FindFunctionToolEntriesByUrnBatch(ctx, tr.FindFunctionToolEntriesByUrnBatchParams{
+			ProjectIds: allProjectIDs,
+			Urns:       allURNs,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch function tools").Log(ctx, logger)
+		}
 		for _, def := range funcTools {
+			pt := getProjectTools(def.ProjectID)
 			toolURN := def.ToolUrn.String()
-			if seen[toolURN] {
+			if _, exists := pt[toolURN]; exists {
 				continue
 			}
-			seen[toolURN] = true
-			projectTools[toolURN] = &types.ToolEntry{
+			pt[toolURN] = &types.ToolEntry{
 				Type:        string(urn.ToolKindFunction),
 				ID:          def.ID.String(),
 				Name:        def.Name,
@@ -724,54 +738,70 @@ func GetToolsetsSummary(
 			}
 		}
 
-		for _, pt := range promptTools {
-			toolURN := pt.ToolUrn.String()
-			if seen[toolURN] {
+		// 4. Batch-fetch prompt templates.
+		promptTools, err := tplRepo.PeekTemplatesByUrnsBatch(ctx, templatesR.PeekTemplatesByUrnsBatchParams{
+			ProjectIds: allProjectIDs,
+			Urns:       allURNs,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch prompt tools").Log(ctx, logger)
+		}
+		for _, def := range promptTools {
+			pt := getProjectTools(def.ProjectID)
+			toolURN := def.ToolUrn.String()
+			if _, exists := pt[toolURN]; exists {
 				continue
 			}
-			seen[toolURN] = true
-			projectTools[toolURN] = &types.ToolEntry{
+			pt[toolURN] = &types.ToolEntry{
 				Type:        string(urn.ToolKindPrompt),
-				ID:          pt.ID.String(),
-				Name:        pt.Name,
+				ID:          def.ID.String(),
+				Name:        def.Name,
 				ToolUrn:     toolURN,
 				Annotations: nil,
 				HTTPMethod:  nil,
 			}
 		}
 
-		for _, entry := range platformtools.FindToolEntries(pt.toolUrns) {
-			if !seen[entry.ToolUrn] {
-				seen[entry.ToolUrn] = true
-				projectTools[entry.ToolUrn] = entry
-			}
-		}
-
-		// Batch-fetch external MCP tool entries.
-		externalMCPUrns := make([]string, 0)
-		for _, toolUrn := range pt.toolUrns {
-			var parsedUrn urn.Tool
-			if err := parsedUrn.UnmarshalText([]byte(toolUrn)); err == nil {
-				if parsedUrn.Kind == urn.ToolKindExternalMCP && !seen[toolUrn] {
-					externalMCPUrns = append(externalMCPUrns, toolUrn)
+		// 5. Platform tools (local lookup, no DB).
+		for projectID, projToolsets := range projectMap {
+			pt := getProjectTools(projectID)
+			for _, entry := range platformtools.FindToolEntries(projToolsets.toolUrns) {
+				if _, exists := pt[entry.ToolUrn]; !exists {
+					pt[entry.ToolUrn] = entry
 				}
 			}
 		}
-		if len(externalMCPUrns) > 0 {
+
+		// 6. Batch-fetch external MCP tool entries.
+		allExternalMCPUrns := make([]string, 0)
+		for projectID, projToolsets := range projectMap {
+			pt := getProjectTools(projectID)
+			for _, toolUrn := range projToolsets.toolUrns {
+				var parsedUrn urn.Tool
+				if err := parsedUrn.UnmarshalText([]byte(toolUrn)); err == nil {
+					if parsedUrn.Kind == urn.ToolKindExternalMCP {
+						if _, exists := pt[toolUrn]; !exists {
+							allExternalMCPUrns = append(allExternalMCPUrns, toolUrn)
+						}
+					}
+				}
+			}
+		}
+		if len(allExternalMCPUrns) > 0 {
 			externalmcpRepo := externalmcpR.New(tx)
-			externalTools, err := externalmcpRepo.GetExternalMCPToolDefinitionsByURNs(ctx, externalmcpR.GetExternalMCPToolDefinitionsByURNsParams{
-				ProjectID: projectID,
-				ToolUrns:  externalMCPUrns,
+			externalTools, err := externalmcpRepo.GetExternalMCPToolDefinitionsByURNsBatch(ctx, externalmcpR.GetExternalMCPToolDefinitionsByURNsBatchParams{
+				ProjectIds: allProjectIDs,
+				ToolUrns:   allExternalMCPUrns,
 			})
 			if err != nil {
 				return nil, oops.E(oops.CodeUnexpected, err, "failed to batch-fetch external mcp tools").Log(ctx, logger)
 			}
 			for _, def := range externalTools {
-				if seen[def.ToolUrn] {
+				pt := getProjectTools(def.ProjectID)
+				if _, exists := pt[def.ToolUrn]; exists {
 					continue
 				}
-				seen[def.ToolUrn] = true
-				projectTools[def.ToolUrn] = &types.ToolEntry{
+				pt[def.ToolUrn] = &types.ToolEntry{
 					Type:        string(urn.ToolKindExternalMCP),
 					ID:          def.ID.String(),
 					Name:        def.Slug + ":proxy",
@@ -782,6 +812,8 @@ func GetToolsetsSummary(
 			}
 		}
 	}
+
+assemble:
 
 	// Assemble results.
 	result := make([]*types.ToolsetSummary, 0, len(toolsets))

--- a/server/internal/templates/queries.sql
+++ b/server/internal/templates/queries.sql
@@ -151,3 +151,13 @@ WHERE project_id = @project_id
   AND id = @id
   AND deleted IS FALSE
 RETURNING id, name, tool_urn;
+
+-- name: PeekTemplatesByUrnsBatch :many
+-- Batch variant of PeekTemplatesByUrns across multiple projects.
+SELECT DISTINCT ON (pt.project_id, pt.tool_urn)
+    pt.project_id, pt.id, pt.tool_urn, pt.history_id, pt.name
+FROM prompt_templates pt
+WHERE pt.project_id = ANY(@project_ids::uuid[])
+  AND pt.tool_urn = ANY(@urns::TEXT[])
+  AND pt.deleted IS FALSE
+ORDER BY pt.project_id, pt.tool_urn, pt.id DESC;

--- a/server/internal/templates/queries.sql
+++ b/server/internal/templates/queries.sql
@@ -23,6 +23,14 @@ WHERE pt.project_id = @project_id
   AND pt.deleted IS FALSE
 ORDER BY pt.project_id, pt.tool_urn, pt.id DESC;
 
+-- name: PeekTemplatesForProjects :many
+-- Batch-resolves prompt template entries across multiple projects.
+SELECT DISTINCT ON (pt.project_id, pt.tool_urn) pt.project_id, pt.id, pt.tool_urn, pt.name
+FROM prompt_templates pt
+WHERE pt.project_id = ANY(@project_ids::uuid[])
+  AND pt.deleted IS FALSE
+ORDER BY pt.project_id, pt.tool_urn, pt.id DESC;
+
 -- name: GetTemplateByURN :one
 SELECT DISTINCT ON (pt.project_id, pt.tool_urn) *
 FROM prompt_templates pt
@@ -151,13 +159,3 @@ WHERE project_id = @project_id
   AND id = @id
   AND deleted IS FALSE
 RETURNING id, name, tool_urn;
-
--- name: PeekTemplatesByUrnsBatch :many
--- Batch variant of PeekTemplatesByUrns across multiple projects.
-SELECT DISTINCT ON (pt.project_id, pt.tool_urn)
-    pt.project_id, pt.id, pt.tool_urn, pt.history_id, pt.name
-FROM prompt_templates pt
-WHERE pt.project_id = ANY(@project_ids::uuid[])
-  AND pt.tool_urn = ANY(@urns::TEXT[])
-  AND pt.deleted IS FALSE
-ORDER BY pt.project_id, pt.tool_urn, pt.id DESC;

--- a/server/internal/templates/repo/queries.sql.go
+++ b/server/internal/templates/repo/queries.sql.go
@@ -460,44 +460,35 @@ func (q *Queries) PeekTemplatesByUrns(ctx context.Context, arg PeekTemplatesByUr
 	return items, nil
 }
 
-const peekTemplatesByUrnsBatch = `-- name: PeekTemplatesByUrnsBatch :many
-SELECT DISTINCT ON (pt.project_id, pt.tool_urn)
-    pt.project_id, pt.id, pt.tool_urn, pt.history_id, pt.name
+const peekTemplatesForProjects = `-- name: PeekTemplatesForProjects :many
+SELECT DISTINCT ON (pt.project_id, pt.tool_urn) pt.project_id, pt.id, pt.tool_urn, pt.name
 FROM prompt_templates pt
 WHERE pt.project_id = ANY($1::uuid[])
-  AND pt.tool_urn = ANY($2::TEXT[])
   AND pt.deleted IS FALSE
 ORDER BY pt.project_id, pt.tool_urn, pt.id DESC
 `
 
-type PeekTemplatesByUrnsBatchParams struct {
-	ProjectIds []uuid.UUID
-	Urns       []string
-}
-
-type PeekTemplatesByUrnsBatchRow struct {
+type PeekTemplatesForProjectsRow struct {
 	ProjectID uuid.UUID
 	ID        uuid.UUID
 	ToolUrn   urn.Tool
-	HistoryID uuid.UUID
 	Name      string
 }
 
-// Batch variant of PeekTemplatesByUrns across multiple projects.
-func (q *Queries) PeekTemplatesByUrnsBatch(ctx context.Context, arg PeekTemplatesByUrnsBatchParams) ([]PeekTemplatesByUrnsBatchRow, error) {
-	rows, err := q.db.Query(ctx, peekTemplatesByUrnsBatch, arg.ProjectIds, arg.Urns)
+// Batch-resolves prompt template entries across multiple projects.
+func (q *Queries) PeekTemplatesForProjects(ctx context.Context, projectIds []uuid.UUID) ([]PeekTemplatesForProjectsRow, error) {
+	rows, err := q.db.Query(ctx, peekTemplatesForProjects, projectIds)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []PeekTemplatesByUrnsBatchRow
+	var items []PeekTemplatesForProjectsRow
 	for rows.Next() {
-		var i PeekTemplatesByUrnsBatchRow
+		var i PeekTemplatesForProjectsRow
 		if err := rows.Scan(
 			&i.ProjectID,
 			&i.ID,
 			&i.ToolUrn,
-			&i.HistoryID,
 			&i.Name,
 		); err != nil {
 			return nil, err

--- a/server/internal/templates/repo/queries.sql.go
+++ b/server/internal/templates/repo/queries.sql.go
@@ -460,6 +460,56 @@ func (q *Queries) PeekTemplatesByUrns(ctx context.Context, arg PeekTemplatesByUr
 	return items, nil
 }
 
+const peekTemplatesByUrnsBatch = `-- name: PeekTemplatesByUrnsBatch :many
+SELECT DISTINCT ON (pt.project_id, pt.tool_urn)
+    pt.project_id, pt.id, pt.tool_urn, pt.history_id, pt.name
+FROM prompt_templates pt
+WHERE pt.project_id = ANY($1::uuid[])
+  AND pt.tool_urn = ANY($2::TEXT[])
+  AND pt.deleted IS FALSE
+ORDER BY pt.project_id, pt.tool_urn, pt.id DESC
+`
+
+type PeekTemplatesByUrnsBatchParams struct {
+	ProjectIds []uuid.UUID
+	Urns       []string
+}
+
+type PeekTemplatesByUrnsBatchRow struct {
+	ProjectID uuid.UUID
+	ID        uuid.UUID
+	ToolUrn   urn.Tool
+	HistoryID uuid.UUID
+	Name      string
+}
+
+// Batch variant of PeekTemplatesByUrns across multiple projects.
+func (q *Queries) PeekTemplatesByUrnsBatch(ctx context.Context, arg PeekTemplatesByUrnsBatchParams) ([]PeekTemplatesByUrnsBatchRow, error) {
+	rows, err := q.db.Query(ctx, peekTemplatesByUrnsBatch, arg.ProjectIds, arg.Urns)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []PeekTemplatesByUrnsBatchRow
+	for rows.Next() {
+		var i PeekTemplatesByUrnsBatchRow
+		if err := rows.Scan(
+			&i.ProjectID,
+			&i.ID,
+			&i.ToolUrn,
+			&i.HistoryID,
+			&i.Name,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateTemplate = `-- name: UpdateTemplate :one
 INSERT INTO prompt_templates (
   project_id,

--- a/server/internal/tools/queries.sql
+++ b/server/internal/tools/queries.sql
@@ -306,3 +306,56 @@ SELECT
     (SELECT id FROM third_party),
     (SELECT id FROM function_tools)
   ) AS id;
+
+-- name: FindHttpToolEntriesByUrnBatch :many
+-- Batch variant of FindHttpToolEntriesByUrn across multiple projects.
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id)
+        d.id,
+        d.project_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY(@project_ids::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+),
+all_deployment_ids AS (
+    SELECT pd.project_id, pd.id AS deployment_id FROM project_deployments pd
+    UNION ALL
+    SELECT pd.project_id, pv.deployment_id
+    FROM project_deployments pd
+    JOIN deployments_packages dp ON dp.deployment_id = pd.id
+    JOIN package_versions pv ON dp.version_id = pv.id
+)
+SELECT
+    adi.project_id,
+    htd.id, htd.tool_urn, htd.deployment_id, htd.name, htd.security, htd.server_env_var,
+    htd.read_only_hint, htd.destructive_hint, htd.idempotent_hint, htd.open_world_hint,
+    htd.http_method
+FROM all_deployment_ids adi
+JOIN http_tool_definitions htd ON htd.deployment_id = adi.deployment_id
+WHERE htd.deleted IS FALSE
+  AND htd.tool_urn = ANY(@urns::text[])
+ORDER BY htd.id DESC;
+
+-- name: FindFunctionToolEntriesByUrnBatch :many
+-- Batch variant of FindFunctionToolEntriesByUrn across multiple projects.
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id)
+        d.id,
+        d.project_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY(@project_ids::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+)
+SELECT
+    pd.project_id,
+    ftd.id, ftd.tool_urn, ftd.deployment_id, ftd.name, ftd.variables, ftd.auth_input,
+    ftd.read_only_hint, ftd.destructive_hint, ftd.idempotent_hint, ftd.open_world_hint
+FROM project_deployments pd
+JOIN function_tool_definitions ftd ON ftd.deployment_id = pd.id
+WHERE ftd.deleted IS FALSE
+  AND ftd.tool_urn = ANY(@urns::text[])
+ORDER BY ftd.id DESC;

--- a/server/internal/tools/queries.sql
+++ b/server/internal/tools/queries.sql
@@ -269,6 +269,63 @@ LEFT JOIN functions_access access
 ORDER BY access.seq DESC NULLS LAST
 LIMIT 1;
 
+-- name: FindHttpToolEntriesForProjects :many
+-- Batch-resolves HTTP tool entries across multiple projects in a single query.
+-- Resolves each project's latest completed deployment once, including package deployments.
+-- No URN filter — caller filters in Go against toolset version URN sets.
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id) d.project_id, d.id as deployment_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY(@project_ids::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+),
+all_deployment_ids AS (
+    SELECT project_id, deployment_id as id FROM project_deployments
+    UNION
+    SELECT pd.project_id, pv.deployment_id as id
+    FROM project_deployments pd
+    JOIN deployments_packages dp ON dp.deployment_id = pd.deployment_id
+    JOIN package_versions pv ON dp.version_id = pv.id
+)
+SELECT
+  adi.project_id,
+  htd.id,
+  htd.tool_urn,
+  htd.name,
+  htd.read_only_hint,
+  htd.destructive_hint,
+  htd.idempotent_hint,
+  htd.open_world_hint,
+  htd.http_method
+FROM http_tool_definitions htd
+INNER JOIN all_deployment_ids adi ON htd.deployment_id = adi.id
+WHERE htd.deleted IS FALSE;
+
+-- name: FindFunctionToolEntriesForProjects :many
+-- Batch-resolves function tool entries across multiple projects in a single query.
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id) d.project_id, d.id as deployment_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY(@project_ids::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+)
+SELECT
+  pd.project_id,
+  ftd.id,
+  ftd.tool_urn,
+  ftd.name,
+  ftd.read_only_hint,
+  ftd.destructive_hint,
+  ftd.idempotent_hint,
+  ftd.open_world_hint
+FROM function_tool_definitions ftd
+INNER JOIN project_deployments pd ON ftd.deployment_id = pd.deployment_id
+WHERE ftd.deleted IS FALSE;
+
 -- name: PokeToolDefinitionByUrn :one
 WITH first_party AS (
   SELECT id
@@ -306,56 +363,3 @@ SELECT
     (SELECT id FROM third_party),
     (SELECT id FROM function_tools)
   ) AS id;
-
--- name: FindHttpToolEntriesByUrnBatch :many
--- Batch variant of FindHttpToolEntriesByUrn across multiple projects.
-WITH project_deployments AS (
-    SELECT DISTINCT ON (d.project_id)
-        d.id,
-        d.project_id
-    FROM deployments d
-    JOIN deployment_statuses ds ON d.id = ds.deployment_id
-    WHERE d.project_id = ANY(@project_ids::uuid[])
-      AND ds.status = 'completed'
-    ORDER BY d.project_id, d.seq DESC
-),
-all_deployment_ids AS (
-    SELECT pd.project_id, pd.id AS deployment_id FROM project_deployments pd
-    UNION ALL
-    SELECT pd.project_id, pv.deployment_id
-    FROM project_deployments pd
-    JOIN deployments_packages dp ON dp.deployment_id = pd.id
-    JOIN package_versions pv ON dp.version_id = pv.id
-)
-SELECT
-    adi.project_id,
-    htd.id, htd.tool_urn, htd.deployment_id, htd.name, htd.security, htd.server_env_var,
-    htd.read_only_hint, htd.destructive_hint, htd.idempotent_hint, htd.open_world_hint,
-    htd.http_method
-FROM all_deployment_ids adi
-JOIN http_tool_definitions htd ON htd.deployment_id = adi.deployment_id
-WHERE htd.deleted IS FALSE
-  AND htd.tool_urn = ANY(@urns::text[])
-ORDER BY htd.id DESC;
-
--- name: FindFunctionToolEntriesByUrnBatch :many
--- Batch variant of FindFunctionToolEntriesByUrn across multiple projects.
-WITH project_deployments AS (
-    SELECT DISTINCT ON (d.project_id)
-        d.id,
-        d.project_id
-    FROM deployments d
-    JOIN deployment_statuses ds ON d.id = ds.deployment_id
-    WHERE d.project_id = ANY(@project_ids::uuid[])
-      AND ds.status = 'completed'
-    ORDER BY d.project_id, d.seq DESC
-)
-SELECT
-    pd.project_id,
-    ftd.id, ftd.tool_urn, ftd.deployment_id, ftd.name, ftd.variables, ftd.auth_input,
-    ftd.read_only_hint, ftd.destructive_hint, ftd.idempotent_hint, ftd.open_world_hint
-FROM project_deployments pd
-JOIN function_tool_definitions ftd ON ftd.deployment_id = pd.id
-WHERE ftd.deleted IS FALSE
-  AND ftd.tool_urn = ANY(@urns::text[])
-ORDER BY ftd.id DESC;

--- a/server/internal/tools/repo/queries.sql.go
+++ b/server/internal/tools/repo/queries.sql.go
@@ -84,6 +84,80 @@ func (q *Queries) FindFunctionToolEntriesByUrn(ctx context.Context, arg FindFunc
 	return items, nil
 }
 
+const findFunctionToolEntriesByUrnBatch = `-- name: FindFunctionToolEntriesByUrnBatch :many
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id)
+        d.id,
+        d.project_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY($2::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+)
+SELECT
+    pd.project_id,
+    ftd.id, ftd.tool_urn, ftd.deployment_id, ftd.name, ftd.variables, ftd.auth_input,
+    ftd.read_only_hint, ftd.destructive_hint, ftd.idempotent_hint, ftd.open_world_hint
+FROM project_deployments pd
+JOIN function_tool_definitions ftd ON ftd.deployment_id = pd.id
+WHERE ftd.deleted IS FALSE
+  AND ftd.tool_urn = ANY($1::text[])
+ORDER BY ftd.id DESC
+`
+
+type FindFunctionToolEntriesByUrnBatchParams struct {
+	Urns       []string
+	ProjectIds []uuid.UUID
+}
+
+type FindFunctionToolEntriesByUrnBatchRow struct {
+	ProjectID       uuid.UUID
+	ID              uuid.UUID
+	ToolUrn         urn.Tool
+	DeploymentID    uuid.UUID
+	Name            string
+	Variables       []byte
+	AuthInput       []byte
+	ReadOnlyHint    pgtype.Bool
+	DestructiveHint pgtype.Bool
+	IdempotentHint  pgtype.Bool
+	OpenWorldHint   pgtype.Bool
+}
+
+// Batch variant of FindFunctionToolEntriesByUrn across multiple projects.
+func (q *Queries) FindFunctionToolEntriesByUrnBatch(ctx context.Context, arg FindFunctionToolEntriesByUrnBatchParams) ([]FindFunctionToolEntriesByUrnBatchRow, error) {
+	rows, err := q.db.Query(ctx, findFunctionToolEntriesByUrnBatch, arg.Urns, arg.ProjectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FindFunctionToolEntriesByUrnBatchRow
+	for rows.Next() {
+		var i FindFunctionToolEntriesByUrnBatchRow
+		if err := rows.Scan(
+			&i.ProjectID,
+			&i.ID,
+			&i.ToolUrn,
+			&i.DeploymentID,
+			&i.Name,
+			&i.Variables,
+			&i.AuthInput,
+			&i.ReadOnlyHint,
+			&i.DestructiveHint,
+			&i.IdempotentHint,
+			&i.OpenWorldHint,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findFunctionToolsByUrn = `-- name: FindFunctionToolsByUrn :many
 WITH deployment AS (
     SELECT d.id
@@ -218,6 +292,91 @@ func (q *Queries) FindHttpToolEntriesByUrn(ctx context.Context, arg FindHttpTool
 	for rows.Next() {
 		var i FindHttpToolEntriesByUrnRow
 		if err := rows.Scan(
+			&i.ID,
+			&i.ToolUrn,
+			&i.DeploymentID,
+			&i.Name,
+			&i.Security,
+			&i.ServerEnvVar,
+			&i.ReadOnlyHint,
+			&i.DestructiveHint,
+			&i.IdempotentHint,
+			&i.OpenWorldHint,
+			&i.HttpMethod,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findHttpToolEntriesByUrnBatch = `-- name: FindHttpToolEntriesByUrnBatch :many
+WITH project_deployments AS (
+    SELECT DISTINCT ON (d.project_id)
+        d.id,
+        d.project_id
+    FROM deployments d
+    JOIN deployment_statuses ds ON d.id = ds.deployment_id
+    WHERE d.project_id = ANY($2::uuid[])
+      AND ds.status = 'completed'
+    ORDER BY d.project_id, d.seq DESC
+),
+all_deployment_ids AS (
+    SELECT pd.project_id, pd.id AS deployment_id FROM project_deployments pd
+    UNION ALL
+    SELECT pd.project_id, pv.deployment_id
+    FROM project_deployments pd
+    JOIN deployments_packages dp ON dp.deployment_id = pd.id
+    JOIN package_versions pv ON dp.version_id = pv.id
+)
+SELECT
+    adi.project_id,
+    htd.id, htd.tool_urn, htd.deployment_id, htd.name, htd.security, htd.server_env_var,
+    htd.read_only_hint, htd.destructive_hint, htd.idempotent_hint, htd.open_world_hint,
+    htd.http_method
+FROM all_deployment_ids adi
+JOIN http_tool_definitions htd ON htd.deployment_id = adi.deployment_id
+WHERE htd.deleted IS FALSE
+  AND htd.tool_urn = ANY($1::text[])
+ORDER BY htd.id DESC
+`
+
+type FindHttpToolEntriesByUrnBatchParams struct {
+	Urns       []string
+	ProjectIds []uuid.UUID
+}
+
+type FindHttpToolEntriesByUrnBatchRow struct {
+	ProjectID       uuid.UUID
+	ID              uuid.UUID
+	ToolUrn         urn.Tool
+	DeploymentID    uuid.UUID
+	Name            string
+	Security        []byte
+	ServerEnvVar    string
+	ReadOnlyHint    pgtype.Bool
+	DestructiveHint pgtype.Bool
+	IdempotentHint  pgtype.Bool
+	OpenWorldHint   pgtype.Bool
+	HttpMethod      string
+}
+
+// Batch variant of FindHttpToolEntriesByUrn across multiple projects.
+func (q *Queries) FindHttpToolEntriesByUrnBatch(ctx context.Context, arg FindHttpToolEntriesByUrnBatchParams) ([]FindHttpToolEntriesByUrnBatchRow, error) {
+	rows, err := q.db.Query(ctx, findHttpToolEntriesByUrnBatch, arg.Urns, arg.ProjectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FindHttpToolEntriesByUrnBatchRow
+	for rows.Next() {
+		var i FindHttpToolEntriesByUrnBatchRow
+		if err := rows.Scan(
+			&i.ProjectID,
 			&i.ID,
 			&i.ToolUrn,
 			&i.DeploymentID,

--- a/server/internal/tools/repo/queries.sql.go
+++ b/server/internal/tools/repo/queries.sql.go
@@ -84,65 +84,55 @@ func (q *Queries) FindFunctionToolEntriesByUrn(ctx context.Context, arg FindFunc
 	return items, nil
 }
 
-const findFunctionToolEntriesByUrnBatch = `-- name: FindFunctionToolEntriesByUrnBatch :many
+const findFunctionToolEntriesForProjects = `-- name: FindFunctionToolEntriesForProjects :many
 WITH project_deployments AS (
-    SELECT DISTINCT ON (d.project_id)
-        d.id,
-        d.project_id
+    SELECT DISTINCT ON (d.project_id) d.project_id, d.id as deployment_id
     FROM deployments d
     JOIN deployment_statuses ds ON d.id = ds.deployment_id
-    WHERE d.project_id = ANY($2::uuid[])
+    WHERE d.project_id = ANY($1::uuid[])
       AND ds.status = 'completed'
     ORDER BY d.project_id, d.seq DESC
 )
 SELECT
-    pd.project_id,
-    ftd.id, ftd.tool_urn, ftd.deployment_id, ftd.name, ftd.variables, ftd.auth_input,
-    ftd.read_only_hint, ftd.destructive_hint, ftd.idempotent_hint, ftd.open_world_hint
-FROM project_deployments pd
-JOIN function_tool_definitions ftd ON ftd.deployment_id = pd.id
+  pd.project_id,
+  ftd.id,
+  ftd.tool_urn,
+  ftd.name,
+  ftd.read_only_hint,
+  ftd.destructive_hint,
+  ftd.idempotent_hint,
+  ftd.open_world_hint
+FROM function_tool_definitions ftd
+INNER JOIN project_deployments pd ON ftd.deployment_id = pd.deployment_id
 WHERE ftd.deleted IS FALSE
-  AND ftd.tool_urn = ANY($1::text[])
-ORDER BY ftd.id DESC
 `
 
-type FindFunctionToolEntriesByUrnBatchParams struct {
-	Urns       []string
-	ProjectIds []uuid.UUID
-}
-
-type FindFunctionToolEntriesByUrnBatchRow struct {
+type FindFunctionToolEntriesForProjectsRow struct {
 	ProjectID       uuid.UUID
 	ID              uuid.UUID
 	ToolUrn         urn.Tool
-	DeploymentID    uuid.UUID
 	Name            string
-	Variables       []byte
-	AuthInput       []byte
 	ReadOnlyHint    pgtype.Bool
 	DestructiveHint pgtype.Bool
 	IdempotentHint  pgtype.Bool
 	OpenWorldHint   pgtype.Bool
 }
 
-// Batch variant of FindFunctionToolEntriesByUrn across multiple projects.
-func (q *Queries) FindFunctionToolEntriesByUrnBatch(ctx context.Context, arg FindFunctionToolEntriesByUrnBatchParams) ([]FindFunctionToolEntriesByUrnBatchRow, error) {
-	rows, err := q.db.Query(ctx, findFunctionToolEntriesByUrnBatch, arg.Urns, arg.ProjectIds)
+// Batch-resolves function tool entries across multiple projects in a single query.
+func (q *Queries) FindFunctionToolEntriesForProjects(ctx context.Context, projectIds []uuid.UUID) ([]FindFunctionToolEntriesForProjectsRow, error) {
+	rows, err := q.db.Query(ctx, findFunctionToolEntriesForProjects, projectIds)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []FindFunctionToolEntriesByUrnBatchRow
+	var items []FindFunctionToolEntriesForProjectsRow
 	for rows.Next() {
-		var i FindFunctionToolEntriesByUrnBatchRow
+		var i FindFunctionToolEntriesForProjectsRow
 		if err := rows.Scan(
 			&i.ProjectID,
 			&i.ID,
 			&i.ToolUrn,
-			&i.DeploymentID,
 			&i.Name,
-			&i.Variables,
-			&i.AuthInput,
 			&i.ReadOnlyHint,
 			&i.DestructiveHint,
 			&i.IdempotentHint,
@@ -314,50 +304,43 @@ func (q *Queries) FindHttpToolEntriesByUrn(ctx context.Context, arg FindHttpTool
 	return items, nil
 }
 
-const findHttpToolEntriesByUrnBatch = `-- name: FindHttpToolEntriesByUrnBatch :many
+const findHttpToolEntriesForProjects = `-- name: FindHttpToolEntriesForProjects :many
 WITH project_deployments AS (
-    SELECT DISTINCT ON (d.project_id)
-        d.id,
-        d.project_id
+    SELECT DISTINCT ON (d.project_id) d.project_id, d.id as deployment_id
     FROM deployments d
     JOIN deployment_statuses ds ON d.id = ds.deployment_id
-    WHERE d.project_id = ANY($2::uuid[])
+    WHERE d.project_id = ANY($1::uuid[])
       AND ds.status = 'completed'
     ORDER BY d.project_id, d.seq DESC
 ),
 all_deployment_ids AS (
-    SELECT pd.project_id, pd.id AS deployment_id FROM project_deployments pd
-    UNION ALL
-    SELECT pd.project_id, pv.deployment_id
+    SELECT project_id, deployment_id as id FROM project_deployments
+    UNION
+    SELECT pd.project_id, pv.deployment_id as id
     FROM project_deployments pd
-    JOIN deployments_packages dp ON dp.deployment_id = pd.id
+    JOIN deployments_packages dp ON dp.deployment_id = pd.deployment_id
     JOIN package_versions pv ON dp.version_id = pv.id
 )
 SELECT
-    adi.project_id,
-    htd.id, htd.tool_urn, htd.deployment_id, htd.name, htd.security, htd.server_env_var,
-    htd.read_only_hint, htd.destructive_hint, htd.idempotent_hint, htd.open_world_hint,
-    htd.http_method
-FROM all_deployment_ids adi
-JOIN http_tool_definitions htd ON htd.deployment_id = adi.deployment_id
+  adi.project_id,
+  htd.id,
+  htd.tool_urn,
+  htd.name,
+  htd.read_only_hint,
+  htd.destructive_hint,
+  htd.idempotent_hint,
+  htd.open_world_hint,
+  htd.http_method
+FROM http_tool_definitions htd
+INNER JOIN all_deployment_ids adi ON htd.deployment_id = adi.id
 WHERE htd.deleted IS FALSE
-  AND htd.tool_urn = ANY($1::text[])
-ORDER BY htd.id DESC
 `
 
-type FindHttpToolEntriesByUrnBatchParams struct {
-	Urns       []string
-	ProjectIds []uuid.UUID
-}
-
-type FindHttpToolEntriesByUrnBatchRow struct {
+type FindHttpToolEntriesForProjectsRow struct {
 	ProjectID       uuid.UUID
 	ID              uuid.UUID
 	ToolUrn         urn.Tool
-	DeploymentID    uuid.UUID
 	Name            string
-	Security        []byte
-	ServerEnvVar    string
 	ReadOnlyHint    pgtype.Bool
 	DestructiveHint pgtype.Bool
 	IdempotentHint  pgtype.Bool
@@ -365,24 +348,23 @@ type FindHttpToolEntriesByUrnBatchRow struct {
 	HttpMethod      string
 }
 
-// Batch variant of FindHttpToolEntriesByUrn across multiple projects.
-func (q *Queries) FindHttpToolEntriesByUrnBatch(ctx context.Context, arg FindHttpToolEntriesByUrnBatchParams) ([]FindHttpToolEntriesByUrnBatchRow, error) {
-	rows, err := q.db.Query(ctx, findHttpToolEntriesByUrnBatch, arg.Urns, arg.ProjectIds)
+// Batch-resolves HTTP tool entries across multiple projects in a single query.
+// Resolves each project's latest completed deployment once, including package deployments.
+// No URN filter — caller filters in Go against toolset version URN sets.
+func (q *Queries) FindHttpToolEntriesForProjects(ctx context.Context, projectIds []uuid.UUID) ([]FindHttpToolEntriesForProjectsRow, error) {
+	rows, err := q.db.Query(ctx, findHttpToolEntriesForProjects, projectIds)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []FindHttpToolEntriesByUrnBatchRow
+	var items []FindHttpToolEntriesForProjectsRow
 	for rows.Next() {
-		var i FindHttpToolEntriesByUrnBatchRow
+		var i FindHttpToolEntriesForProjectsRow
 		if err := rows.Scan(
 			&i.ProjectID,
 			&i.ID,
 			&i.ToolUrn,
-			&i.DeploymentID,
 			&i.Name,
-			&i.Security,
-			&i.ServerEnvVar,
 			&i.ReadOnlyHint,
 			&i.DestructiveHint,
 			&i.IdempotentHint,

--- a/server/internal/variations/queries.sql
+++ b/server/internal/variations/queries.sql
@@ -100,6 +100,20 @@ WHERE
   AND src_tool_urn = ANY(@tool_urns::text[])
   AND deleted IS FALSE;
 
+-- name: FindGlobalVariationsForProjects :many
+-- Batch-resolves variation name overrides across multiple projects.
+WITH global_groups AS (
+  SELECT DISTINCT ON (ptv.project_id) ptv.project_id, tvg.id as group_id
+  FROM tool_variations_groups tvg
+  INNER JOIN project_tool_variations ptv ON tvg.id = ptv.group_id
+  WHERE ptv.project_id = ANY(@project_ids::uuid[])
+  ORDER BY ptv.project_id, ptv.id DESC
+)
+SELECT gg.project_id, tv.src_tool_urn, tv.name
+FROM tool_variations tv
+INNER JOIN global_groups gg ON tv.group_id = gg.group_id
+WHERE tv.deleted IS FALSE;
+
 -- name: DeleteGlobalToolVariation :one
 UPDATE tool_variations SET deleted_at = clock_timestamp()
 WHERE tool_variations.id = @id
@@ -111,24 +125,3 @@ WHERE tool_variations.id = @id
   )
   AND tool_variations.deleted IS FALSE
 RETURNING tool_variations.id, tool_variations.src_tool_urn;
-
--- name: FindGlobalVariationNamesByToolURNsBatch :many
--- Batch variant of FindGlobalVariationsByToolURNs: returns only the fields
--- needed for the variation-name mapping across multiple projects.
-WITH project_groups AS (
-    SELECT DISTINCT ON (ptv.project_id)
-        ptv.project_id,
-        tvg.id AS group_id
-    FROM tool_variations_groups tvg
-    INNER JOIN project_tool_variations ptv ON tvg.id = ptv.group_id
-    WHERE ptv.project_id = ANY(@project_ids::uuid[])
-    ORDER BY ptv.project_id, ptv.id DESC
-)
-SELECT
-    pg.project_id,
-    tv.src_tool_urn,
-    tv.name
-FROM project_groups pg
-JOIN tool_variations tv ON tv.group_id = pg.group_id
-WHERE tv.src_tool_urn = ANY(@tool_urns::text[])
-  AND tv.deleted IS FALSE;

--- a/server/internal/variations/queries.sql
+++ b/server/internal/variations/queries.sql
@@ -111,3 +111,24 @@ WHERE tool_variations.id = @id
   )
   AND tool_variations.deleted IS FALSE
 RETURNING tool_variations.id, tool_variations.src_tool_urn;
+
+-- name: FindGlobalVariationNamesByToolURNsBatch :many
+-- Batch variant of FindGlobalVariationsByToolURNs: returns only the fields
+-- needed for the variation-name mapping across multiple projects.
+WITH project_groups AS (
+    SELECT DISTINCT ON (ptv.project_id)
+        ptv.project_id,
+        tvg.id AS group_id
+    FROM tool_variations_groups tvg
+    INNER JOIN project_tool_variations ptv ON tvg.id = ptv.group_id
+    WHERE ptv.project_id = ANY(@project_ids::uuid[])
+    ORDER BY ptv.project_id, ptv.id DESC
+)
+SELECT
+    pg.project_id,
+    tv.src_tool_urn,
+    tv.name
+FROM project_groups pg
+JOIN tool_variations tv ON tv.group_id = pg.group_id
+WHERE tv.src_tool_urn = ANY(@tool_urns::text[])
+  AND tv.deleted IS FALSE;

--- a/server/internal/variations/repo/queries.sql.go
+++ b/server/internal/variations/repo/queries.sql.go
@@ -43,6 +43,59 @@ func (q *Queries) DeleteGlobalToolVariation(ctx context.Context, arg DeleteGloba
 	return i, err
 }
 
+const findGlobalVariationNamesByToolURNsBatch = `-- name: FindGlobalVariationNamesByToolURNsBatch :many
+WITH project_groups AS (
+    SELECT DISTINCT ON (ptv.project_id)
+        ptv.project_id,
+        tvg.id AS group_id
+    FROM tool_variations_groups tvg
+    INNER JOIN project_tool_variations ptv ON tvg.id = ptv.group_id
+    WHERE ptv.project_id = ANY($2::uuid[])
+    ORDER BY ptv.project_id, ptv.id DESC
+)
+SELECT
+    pg.project_id,
+    tv.src_tool_urn,
+    tv.name
+FROM project_groups pg
+JOIN tool_variations tv ON tv.group_id = pg.group_id
+WHERE tv.src_tool_urn = ANY($1::text[])
+  AND tv.deleted IS FALSE
+`
+
+type FindGlobalVariationNamesByToolURNsBatchParams struct {
+	ToolUrns   []string
+	ProjectIds []uuid.UUID
+}
+
+type FindGlobalVariationNamesByToolURNsBatchRow struct {
+	ProjectID  uuid.UUID
+	SrcToolUrn urn.Tool
+	Name       pgtype.Text
+}
+
+// Batch variant of FindGlobalVariationsByToolURNs: returns only the fields
+// needed for the variation-name mapping across multiple projects.
+func (q *Queries) FindGlobalVariationNamesByToolURNsBatch(ctx context.Context, arg FindGlobalVariationNamesByToolURNsBatchParams) ([]FindGlobalVariationNamesByToolURNsBatchRow, error) {
+	rows, err := q.db.Query(ctx, findGlobalVariationNamesByToolURNsBatch, arg.ToolUrns, arg.ProjectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FindGlobalVariationNamesByToolURNsBatchRow
+	for rows.Next() {
+		var i FindGlobalVariationNamesByToolURNsBatchRow
+		if err := rows.Scan(&i.ProjectID, &i.SrcToolUrn, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const findGlobalVariationsByToolURNs = `-- name: FindGlobalVariationsByToolURNs :many
 WITH global_group AS (
   SELECT tool_variations_groups.id

--- a/server/internal/variations/repo/queries.sql.go
+++ b/server/internal/variations/repo/queries.sql.go
@@ -43,59 +43,6 @@ func (q *Queries) DeleteGlobalToolVariation(ctx context.Context, arg DeleteGloba
 	return i, err
 }
 
-const findGlobalVariationNamesByToolURNsBatch = `-- name: FindGlobalVariationNamesByToolURNsBatch :many
-WITH project_groups AS (
-    SELECT DISTINCT ON (ptv.project_id)
-        ptv.project_id,
-        tvg.id AS group_id
-    FROM tool_variations_groups tvg
-    INNER JOIN project_tool_variations ptv ON tvg.id = ptv.group_id
-    WHERE ptv.project_id = ANY($2::uuid[])
-    ORDER BY ptv.project_id, ptv.id DESC
-)
-SELECT
-    pg.project_id,
-    tv.src_tool_urn,
-    tv.name
-FROM project_groups pg
-JOIN tool_variations tv ON tv.group_id = pg.group_id
-WHERE tv.src_tool_urn = ANY($1::text[])
-  AND tv.deleted IS FALSE
-`
-
-type FindGlobalVariationNamesByToolURNsBatchParams struct {
-	ToolUrns   []string
-	ProjectIds []uuid.UUID
-}
-
-type FindGlobalVariationNamesByToolURNsBatchRow struct {
-	ProjectID  uuid.UUID
-	SrcToolUrn urn.Tool
-	Name       pgtype.Text
-}
-
-// Batch variant of FindGlobalVariationsByToolURNs: returns only the fields
-// needed for the variation-name mapping across multiple projects.
-func (q *Queries) FindGlobalVariationNamesByToolURNsBatch(ctx context.Context, arg FindGlobalVariationNamesByToolURNsBatchParams) ([]FindGlobalVariationNamesByToolURNsBatchRow, error) {
-	rows, err := q.db.Query(ctx, findGlobalVariationNamesByToolURNsBatch, arg.ToolUrns, arg.ProjectIds)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []FindGlobalVariationNamesByToolURNsBatchRow
-	for rows.Next() {
-		var i FindGlobalVariationNamesByToolURNsBatchRow
-		if err := rows.Scan(&i.ProjectID, &i.SrcToolUrn, &i.Name); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const findGlobalVariationsByToolURNs = `-- name: FindGlobalVariationsByToolURNs :many
 WITH global_group AS (
   SELECT tool_variations_groups.id
@@ -149,6 +96,47 @@ func (q *Queries) FindGlobalVariationsByToolURNs(ctx context.Context, arg FindGl
 			&i.DeletedAt,
 			&i.Deleted,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findGlobalVariationsForProjects = `-- name: FindGlobalVariationsForProjects :many
+WITH global_groups AS (
+  SELECT DISTINCT ON (ptv.project_id) ptv.project_id, tvg.id as group_id
+  FROM tool_variations_groups tvg
+  INNER JOIN project_tool_variations ptv ON tvg.id = ptv.group_id
+  WHERE ptv.project_id = ANY($1::uuid[])
+  ORDER BY ptv.project_id, ptv.id DESC
+)
+SELECT gg.project_id, tv.src_tool_urn, tv.name
+FROM tool_variations tv
+INNER JOIN global_groups gg ON tv.group_id = gg.group_id
+WHERE tv.deleted IS FALSE
+`
+
+type FindGlobalVariationsForProjectsRow struct {
+	ProjectID  uuid.UUID
+	SrcToolUrn urn.Tool
+	Name       pgtype.Text
+}
+
+// Batch-resolves variation name overrides across multiple projects.
+func (q *Queries) FindGlobalVariationsForProjects(ctx context.Context, projectIds []uuid.UUID) ([]FindGlobalVariationsForProjectsRow, error) {
+	rows, err := q.db.Query(ctx, findGlobalVariationsForProjects, projectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FindGlobalVariationsForProjectsRow
+	for rows.Next() {
+		var i FindGlobalVariationsForProjectsRow
+		if err := rows.Scan(&i.ProjectID, &i.SrcToolUrn, &i.Name); err != nil {
 			return nil, err
 		}
 		items = append(items, i)


### PR DESCRIPTION
## Summary

- Replace per-project sequential DB queries in `GetToolsetsSummary` with 5 cross-project batch queries run in parallel via errgroup
- For an org with N projects, this reduces ~5N sequential DB round-trips to just 5 parallel batch queries
- Fix O(n×m) performance bug in `platformtools.FindToolEntries` — 17k URNs × 11 factory calls caused 5.6s of pure Go processing

### Batch queries added
- `FindHttpToolEntriesForProjects` — HTTP tools across all projects
- `FindFunctionToolEntriesForProjects` — function tools across all projects
- `PeekTemplatesForProjects` — prompt template entries across all projects
- `FindGlobalVariationsForProjects` — variation name overrides across all projects
- `FindExternalMCPToolEntriesForProjects` — external MCP tools across all projects

Each query uses a shared CTE pattern: `DISTINCT ON (d.project_id)` to resolve the latest completed deployment per project, then joins tool definitions without per-URN filtering (Go-side map lookup instead).

### Performance
| Metric | Before | After |
|--------|--------|-------|
| p95 latency | 7.3s | ~120ms (warm) / ~1.3s (cold) |
| DB round-trips | ~5N sequential | 5 parallel |
| Go processing | 5.6s (platform tools O(n×m)) | <1ms |

## Test plan
- [x] All `ListToolsetsForOrg` tests pass
- [x] Full toolsets package test suite passes (`go test ./server/internal/toolsets/...`)
- [x] Server builds cleanly
- [x] Linter passes
- [ ] Monitor p95 latency in Datadog after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)