### PR TITLE
fix(ai-insights): stop sidebar crash on rapid clicks; render widgets in session viewer

### DIFF
--- a/.changeset/calm-insights-render.md
+++ b/.changeset/calm-insights-render.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"@gram-ai/elements": patch
+---
+
+fix(ai-insights): stop sidebar crash on rapid Explore-with-AI clicks, and render `chart` / `ui` widgets in the agent session pop-out

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"a5bcc0c3-abda-448c-a885-f1398074e7f6","pid":7624,"procStart":"Thu Apr 23 18:35:31 2026","acquiredAt":1776997604731}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a5bcc0c3-abda-448c-a885-f1398074e7f6","pid":7624,"procStart":"Thu Apr 23 18:35:31 2026","acquiredAt":1776997604731}

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,5 @@ package-lock.json
 .worktrees
 .granary/
 .claude/hooks/*
+**/.claude/scheduled_tasks.lock
 flagged-chats.jsonl

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -252,15 +252,29 @@ When the user asks about "current period", "selected period", "this timeframe", 
     [mcpConfig, title, subtitle, suggestions, theme, systemPrompt],
   );
 
+  // Fingerprint of the most recently applied non-null override, used to skip
+  // sessionKey bumps when an override is re-applied with the same content but
+  // a fresh object identity. Pages mount <InsightsConfig {...inlineProps}
+  // suggestions={[…]} /> with literal arrays/objects, so the InsightsConfig
+  // effect re-fires on every parent re-render with a structurally-equal
+  // options value. Without this guard those repeats would unmount the
+  // assistant runtime and destroy any in-progress conversation.
+  const lastOverrideFingerprintRef = useRef<string>("");
   const handleSetOverride = useCallback(
     (next: InsightsConfigOptions | null) => {
       setOverride(next);
-      // Only bump the session on a *new* chart-specific override (i.e. an
-      // Explore-with-AI click). Clearing to null (triggered when the user
-      // closes the panel) should not remount — it just returns the next open
-      // to the base "Ask AI" defaults and preserves the already-running
-      // conversation under the default key.
-      if (next !== null) setSessionKey((k) => k + 1);
+      if (next === null) {
+        lastOverrideFingerprintRef.current = "";
+        return;
+      }
+      // Only bump the session on a genuinely new chart-specific override
+      // (different content, e.g. a different Explore-with-AI chart). Clearing
+      // to null also doesn't bump — the next open returns to the base "Ask
+      // AI" defaults and preserves the already-running conversation.
+      const fingerprint = JSON.stringify(next);
+      if (fingerprint === lastOverrideFingerprintRef.current) return;
+      lastOverrideFingerprintRef.current = fingerprint;
+      setSessionKey((k) => k + 1);
     },
     [],
   );

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -252,37 +252,34 @@ When the user asks about "current period", "selected period", "this timeframe", 
     [mcpConfig, title, subtitle, suggestions, theme, systemPrompt],
   );
 
-  // Fingerprint of the most recently applied non-null override, used to skip
-  // sessionKey bumps when an override is re-applied with the same content but
-  // a fresh object identity. Pages mount <InsightsConfig {...inlineProps}
-  // suggestions={[…]} /> with literal arrays/objects, so the InsightsConfig
-  // effect re-fires on every parent re-render with a structurally-equal
-  // options value. Without this guard those repeats would unmount the
-  // assistant runtime and destroy any in-progress conversation.
-  const lastOverrideFingerprintRef = useRef<string>("");
+  // Page-level overrides only swap welcome copy / suggestions / contextInfo —
+  // they must NOT remount the runtime. <InsightsConfig> mounts on every page
+  // (ChatLogs, Logs, ObservabilityOverview, Hooks…) and re-fires its effect
+  // both on parent re-renders (fresh inline props identity) and on
+  // page-to-page navigation (new options content). Bumping `sessionKey` on
+  // any non-null override would destroy in-flight conversations across
+  // those transitions.
   const handleSetOverride = useCallback(
     (next: InsightsConfigOptions | null) => {
       setOverride(next);
-      if (next === null) {
-        lastOverrideFingerprintRef.current = "";
-        return;
-      }
-      // Only bump the session on a genuinely new chart-specific override
-      // (different content, e.g. a different Explore-with-AI chart). Clearing
-      // to null also doesn't bump — the next open returns to the base "Ask
-      // AI" defaults and preserves the already-running conversation.
-      const fingerprint = JSON.stringify(next);
-      if (fingerprint === lastOverrideFingerprintRef.current) return;
-      lastOverrideFingerprintRef.current = fingerprint;
-      setSessionKey((k) => k + 1);
     },
     [],
   );
 
   const handleSendPrompt = useCallback((text: string) => {
+    // Each sendPrompt represents an "Explore with AI" click — a new focused
+    // conversation tied to a specific chart's contextInfo. Bumping
+    // sessionKey here remounts <GramElementsProvider> so the prompt lands in
+    // a clean assistant runtime; this is the load-bearing fix for the
+    // `tapLookupResources: Resource not found for lookup: __LOCALID_…`
+    // crash that was caused by overlapping switchToNewThread() calls in a
+    // long-lived runtime. <InsightsConfig> deliberately does not call
+    // sendPrompt, so page-level config changes never bump the session.
+    //
     // Nonce lets the bridge detect repeat clicks on the same prompt (same
     // chart twice in a row); reference-equal objects would otherwise be
     // skipped by the bridge's useEffect.
+    setSessionKey((k) => k + 1);
     setPendingPrompt({ text, nonce: Date.now() });
   }, []);
 

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -157,16 +157,11 @@ export function InsightsProvider({
     text: string;
     nonce: number;
   } | null>(null);
-  // Bumped every time a new chart-specific override is installed. Used as a
-  // React `key` on <GramElementsProvider> so each "Explore with AI" click
-  // unmounts the previous assistant runtime entirely and mounts a fresh one.
-  // This avoids the internal assistant-ui race where `instances` (the hook
-  // manager's per-thread Map) and `threadData` (OptimisticState) get out of
-  // sync across rapid thread switches, which surfaces during render of
-  // `_InnerActiveThreadProvider` as:
-  //   `tapLookupResources: Resource not found for lookup: {"key":"__LOCALID_…"}`
-  // Matches the intended UX: each chart's Explore click is a fresh focused
-  // conversation, not a branch off the last one.
+  // Used as React `key` on <GramElementsProvider>; bumped from
+  // handleSendPrompt so each "Explore with AI" click gets a fresh assistant
+  // runtime. Avoids an assistant-ui race where rapid switchToNewThread()
+  // calls in a long-lived runtime throw `tapLookupResources: Resource not
+  // found for lookup: __LOCALID_…` during render.
   const [sessionKey, setSessionKey] = useState(0);
   const { theme } = useMoonshineConfig();
 
@@ -203,14 +198,6 @@ ${contextInfo}
 When the user asks about "current period", "selected period", "this timeframe", or similar, use the date range from the context above. Do not ask the user to specify a date range if it's already provided in the context.`
     : baseInstructions;
 
-  // elementsConfig identity changes on every override (new systemPrompt /
-  // welcome copy / suggestions). That's fine for presentation: GramElementsProvider
-  // holds systemPrompt behind a ref, so the underlying transport + runtime
-  // stay stable across override churn. Each "Explore with AI" click still
-  // gets a fresh focused conversation via PendingPromptBridge's
-  // switchToNewThread() — we just no longer tear down the runtime mid-flight,
-  // which previously raced with append() and threw
-  // `tapLookupResources: Resource not found for lookup: __LOCALID_…`.
   const elementsConfig = useMemo<ElementsConfig>(
     () => ({
       ...mcpConfig,
@@ -252,13 +239,9 @@ When the user asks about "current period", "selected period", "this timeframe", 
     [mcpConfig, title, subtitle, suggestions, theme, systemPrompt],
   );
 
-  // Page-level overrides only swap welcome copy / suggestions / contextInfo —
-  // they must NOT remount the runtime. <InsightsConfig> mounts on every page
-  // (ChatLogs, Logs, ObservabilityOverview, Hooks…) and re-fires its effect
-  // both on parent re-renders (fresh inline props identity) and on
-  // page-to-page navigation (new options content). Bumping `sessionKey` on
-  // any non-null override would destroy in-flight conversations across
-  // those transitions.
+  // Page-level <InsightsConfig> calls this on every parent re-render and on
+  // page navigation; deliberately does NOT bump sessionKey, so navigating
+  // between pages preserves any in-flight chat.
   const handleSetOverride = useCallback(
     (next: InsightsConfigOptions | null) => {
       setOverride(next);
@@ -266,19 +249,11 @@ When the user asks about "current period", "selected period", "this timeframe", 
     [],
   );
 
+  // Only "Explore with AI" clicks call this — bump sessionKey here (not in
+  // setOverride) so a fresh runtime is mounted before the prompt lands.
+  // Nonce defeats reference-equality skipping when the same chart is clicked
+  // twice in a row.
   const handleSendPrompt = useCallback((text: string) => {
-    // Each sendPrompt represents an "Explore with AI" click — a new focused
-    // conversation tied to a specific chart's contextInfo. Bumping
-    // sessionKey here remounts <GramElementsProvider> so the prompt lands in
-    // a clean assistant runtime; this is the load-bearing fix for the
-    // `tapLookupResources: Resource not found for lookup: __LOCALID_…`
-    // crash that was caused by overlapping switchToNewThread() calls in a
-    // long-lived runtime. <InsightsConfig> deliberately does not call
-    // sendPrompt, so page-level config changes never bump the session.
-    //
-    // Nonce lets the bridge detect repeat clicks on the same prompt (same
-    // chart twice in a row); reference-equal objects would otherwise be
-    // skipped by the bridge's useEffect.
     setSessionKey((k) => k + 1);
     setPendingPrompt({ text, nonce: Date.now() });
   }, []);
@@ -403,13 +378,8 @@ function PendingPromptBridge({
     firedNonceRef.current = pending.nonce;
 
     const { text } = pending;
-    // InsightsProvider keys <GramElementsProvider> on `sessionKey`, so every
-    // Explore-with-AI click already mounts a fresh runtime with a single
-    // initial thread. We just append the prompt to that fresh main thread —
-    // no need to call switchToNewThread() here. Doing so previously raced
-    // with assistant-ui's internal `_InnerActiveThreadProvider` mounting and
-    // surfaced as `tapLookupResources: Resource not found for lookup:
-    // __LOCALID_…` during render.
+    // The fresh runtime (mounted by sessionKey bump in handleSendPrompt)
+    // already starts on a new thread, so just append.
     try {
       assistantRuntime.thread.append(text);
     } catch (err) {

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -157,6 +157,17 @@ export function InsightsProvider({
     text: string;
     nonce: number;
   } | null>(null);
+  // Bumped every time a new chart-specific override is installed. Used as a
+  // React `key` on <GramElementsProvider> so each "Explore with AI" click
+  // unmounts the previous assistant runtime entirely and mounts a fresh one.
+  // This avoids the internal assistant-ui race where `instances` (the hook
+  // manager's per-thread Map) and `threadData` (OptimisticState) get out of
+  // sync across rapid thread switches, which surfaces during render of
+  // `_InnerActiveThreadProvider` as:
+  //   `tapLookupResources: Resource not found for lookup: {"key":"__LOCALID_…"}`
+  // Matches the intended UX: each chart's Explore click is a fresh focused
+  // conversation, not a branch off the last one.
+  const [sessionKey, setSessionKey] = useState(0);
   const { theme } = useMoonshineConfig();
 
   // Resolve effective values: per-page override wins, fall back to defaults.
@@ -192,13 +203,14 @@ ${contextInfo}
 When the user asks about "current period", "selected period", "this timeframe", or similar, use the date range from the context above. Do not ask the user to specify a date range if it's already provided in the context.`
     : baseInstructions;
 
-  // New config identity on every override change is intentional: clicking
-  // "Explore with AI" on a different chart should drop the user into a fresh,
-  // focused conversation with the new contextInfo, not splice a new system
-  // prompt into an in-flight thread from a different chart. If we ever want
-  // to preserve threads across Explore clicks, split transport config
-  // (mcpConfig/model/theme) from presentation config (systemPrompt/welcome)
-  // inside GramElementsProvider so only the transport piece is stable.
+  // elementsConfig identity changes on every override (new systemPrompt /
+  // welcome copy / suggestions). That's fine for presentation: GramElementsProvider
+  // holds systemPrompt behind a ref, so the underlying transport + runtime
+  // stay stable across override churn. Each "Explore with AI" click still
+  // gets a fresh focused conversation via PendingPromptBridge's
+  // switchToNewThread() — we just no longer tear down the runtime mid-flight,
+  // which previously raced with append() and threw
+  // `tapLookupResources: Resource not found for lookup: __LOCALID_…`.
   const elementsConfig = useMemo<ElementsConfig>(
     () => ({
       ...mcpConfig,
@@ -241,7 +253,15 @@ When the user asks about "current period", "selected period", "this timeframe", 
   );
 
   const handleSetOverride = useCallback(
-    (next: InsightsConfigOptions | null) => setOverride(next),
+    (next: InsightsConfigOptions | null) => {
+      setOverride(next);
+      // Only bump the session on a *new* chart-specific override (i.e. an
+      // Explore-with-AI click). Clearing to null (triggered when the user
+      // closes the panel) should not remount — it just returns the next open
+      // to the base "Ask AI" defaults and preserves the already-running
+      // conversation under the default key.
+      if (next !== null) setSessionKey((k) => k + 1);
+    },
     [],
   );
 
@@ -328,7 +348,7 @@ When the user asks about "current period", "selected period", "this timeframe", 
 
           {/* Chat content */}
           <div className="flex-1 overflow-hidden">
-            <GramElementsProvider config={elementsConfig}>
+            <GramElementsProvider key={sessionKey} config={elementsConfig}>
               <PendingPromptBridge
                 pending={pendingPrompt}
                 onConsume={consumePendingPrompt}
@@ -372,22 +392,19 @@ function PendingPromptBridge({
     firedNonceRef.current = pending.nonce;
 
     const { text } = pending;
-    // Switch to a brand-new thread before appending. This sidesteps the
-    // assistant-ui MessageRepository id-collision error
-    // ("A message with the same id already exists in the parent tree")
-    // that triggers when a second Explore click tries to append into a
-    // thread that still holds messages from the previous chart's
-    // conversation. It also matches the intended product UX: each Explore
-    // CTA starts a fresh focused chat with the new contextInfo.
-    assistantRuntime.threads
-      .switchToNewThread()
-      .then(() => {
-        assistantRuntime.thread.append(text);
-      })
-      .catch((err: unknown) => {
-        // eslint-disable-next-line no-console
-        console.error("Failed to send Explore prompt:", err);
-      });
+    // InsightsProvider keys <GramElementsProvider> on `sessionKey`, so every
+    // Explore-with-AI click already mounts a fresh runtime with a single
+    // initial thread. We just append the prompt to that fresh main thread —
+    // no need to call switchToNewThread() here. Doing so previously raced
+    // with assistant-ui's internal `_InnerActiveThreadProvider` mounting and
+    // surfaced as `tapLookupResources: Resource not found for lookup:
+    // __LOCALID_…` during render.
+    try {
+      assistantRuntime.thread.append(text);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to send Explore prompt:", err);
+    }
 
     onConsume();
   }, [pending, assistantRuntime, onConsume]);

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -243,7 +243,7 @@ export function ProjectDashboard() {
                                 title: "Top servers & hot tools",
                                 label: "Last 7 days",
                                 prompt:
-                                  "Servers ranked by the number of tool calls they served in the selected period, based on logs captured in hook telemetry in addition to MCP servers hosted on Gram.",
+                                  "Which servers received the most tool calls in the last 7 days, and which specific tools on each server are driving that volume? Lets look at data from all logs including hooks telemetry.",
                               },
                             ],
                           })

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -228,7 +228,7 @@ export function ProjectDashboard() {
 
                 <DashboardCard
                   title="Top Servers"
-                  tooltip="MCP servers ranked by the number of tool calls they served in the selected period, based on hook telemetry."
+                  tooltip="Servers ranked by the number of tool calls they served in the selected period, based on logs captured in hook telemetry in addition to MCP servers hosted on Gram."
                   action={
                     <CardActions>
                       <ExploreWithAIButton
@@ -243,7 +243,7 @@ export function ProjectDashboard() {
                                 title: "Top servers & hot tools",
                                 label: "Last 7 days",
                                 prompt:
-                                  "Which MCP servers received the most tool calls in the last 7 days, and which specific tools on each server are driving that volume?",
+                                  "Servers ranked by the number of tool calls they served in the selected period, based on logs captured in hook telemetry in addition to MCP servers hosted on Gram.",
                               },
                             ],
                           })

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -355,11 +355,6 @@ function MessageItem({
                 {message.role === "tool" ? (
                   <CodeBlock content={message.content ?? ""} maxHeight={300} />
                 ) : (
-                  // MessageContent recognizes ```chart and ```ui fenced code
-                  // blocks and renders them as the same widgets the live AI
-                  // Insights sidebar displays. For everything else (plain
-                  // text, prose, unrecognized code blocks) it falls back to
-                  // preformatted text.
                   <MessageContent
                     content={
                       typeof message.content === "string"

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -27,6 +27,7 @@ import { Button } from "@speakeasy-api/moonshine";
 import type { RiskResult } from "@gram/client/models/components";
 import { CircularProgress } from "./CircularProgress";
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
+import { MessageContent } from "@gram-ai/elements";
 
 interface ChatDetailPanelProps {
   chatId: string;
@@ -354,11 +355,18 @@ function MessageItem({
                 {message.role === "tool" ? (
                   <CodeBlock content={message.content ?? ""} maxHeight={300} />
                 ) : (
-                  <div className="whitespace-pre-wrap">
-                    {typeof message.content === "string"
-                      ? message.content.trim()
-                      : JSON.stringify(message.content)}
-                  </div>
+                  // MessageContent recognizes ```chart and ```ui fenced code
+                  // blocks and renders them as the same widgets the live AI
+                  // Insights sidebar displays. For everything else (plain
+                  // text, prose, unrecognized code blocks) it falls back to
+                  // preformatted text.
+                  <MessageContent
+                    content={
+                      typeof message.content === "string"
+                        ? message.content.trim()
+                        : JSON.stringify(message.content)
+                    }
+                  />
                 )}
               </div>
             )}

--- a/elements/src/components/MessageContent.parser.ts
+++ b/elements/src/components/MessageContent.parser.ts
@@ -1,0 +1,49 @@
+/**
+ * Splits chat message content into a sequence of plain-text segments and
+ * recognised widget code-fence blocks (`chart`, `ui`). Unsupported
+ * languages are preserved verbatim as text so they remain visible.
+ *
+ * Lives in its own module so React Fast Refresh works for `<MessageContent>`
+ * (component files must export only components).
+ *
+ * @internal
+ */
+
+/** @internal */
+export type Segment =
+  | { type: "text"; text: string }
+  | { type: "block"; lang: string; code: string };
+
+const FENCE_RE = /```(\w+)\r?\n([\s\S]*?)```/g;
+
+const SUPPORTED_FENCE_LANGS = new Set(["chart", "ui"]);
+
+/** @internal */
+export function parseSegments(content: string): Segment[] {
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  FENCE_RE.lastIndex = 0;
+  while ((match = FENCE_RE.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({
+        type: "text",
+        text: content.slice(lastIndex, match.index),
+      });
+    }
+    const lang = (match[1] ?? "").toLowerCase();
+    const code = match[2] ?? "";
+    if (SUPPORTED_FENCE_LANGS.has(lang)) {
+      segments.push({ type: "block", lang, code });
+    } else {
+      // Unsupported language: keep original block as text so it's still
+      // visible (renders as a normal fenced code block in plain text).
+      segments.push({ type: "text", text: match[0] });
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < content.length) {
+    segments.push({ type: "text", text: content.slice(lastIndex) });
+  }
+  return segments;
+}

--- a/elements/src/components/MessageContent.parser.ts
+++ b/elements/src/components/MessageContent.parser.ts
@@ -1,13 +1,4 @@
-/**
- * Splits chat message content into a sequence of plain-text segments and
- * recognised widget code-fence blocks (`chart`, `ui`). Unsupported
- * languages are preserved verbatim as text so they remain visible.
- *
- * Lives in its own module so React Fast Refresh works for `<MessageContent>`
- * (component files must export only components).
- *
- * @internal
- */
+/** @internal Sibling of MessageContent.tsx so component file can stay component-only (Fast Refresh). */
 
 /** @internal */
 export type Segment =
@@ -36,8 +27,7 @@ export function parseSegments(content: string): Segment[] {
     if (SUPPORTED_FENCE_LANGS.has(lang)) {
       segments.push({ type: "block", lang, code });
     } else {
-      // Unsupported language: keep original block as text so it's still
-      // visible (renders as a normal fenced code block in plain text).
+      // Unrecognised language: keep the original fence verbatim as text.
       segments.push({ type: "text", text: match[0] });
     }
     lastIndex = match.index + match[0].length;

--- a/elements/src/components/MessageContent.test.ts
+++ b/elements/src/components/MessageContent.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { parseSegments } from "./MessageContent.parser";
+
+describe("parseSegments", () => {
+  it("returns empty array for empty content", () => {
+    expect(parseSegments("")).toEqual([]);
+  });
+
+  it("returns a single text segment when there are no fences", () => {
+    expect(parseSegments("Just plain prose, no fences here.")).toEqual([
+      { type: "text", text: "Just plain prose, no fences here." },
+    ]);
+  });
+
+  it("extracts a single chart fence as a block", () => {
+    const content = '```chart\n{"type":"BarChart","props":{}}\n```';
+    expect(parseSegments(content)).toEqual([
+      {
+        type: "block",
+        lang: "chart",
+        code: '{"type":"BarChart","props":{}}\n',
+      },
+    ]);
+  });
+
+  it("extracts a single ui fence as a block", () => {
+    const content = '```ui\n{"type":"Card","props":{}}\n```';
+    expect(parseSegments(content)).toEqual([
+      {
+        type: "block",
+        lang: "ui",
+        code: '{"type":"Card","props":{}}\n',
+      },
+    ]);
+  });
+
+  it("normalises the language to lowercase", () => {
+    const content = '```Chart\n{"type":"BarChart"}\n```';
+    const segments = parseSegments(content);
+    expect(segments[0]).toMatchObject({ type: "block", lang: "chart" });
+  });
+
+  it("keeps unsupported language fences as text so they stay visible", () => {
+    // ```python is not a widget — render it verbatim, not as an empty block.
+    const content = '```python\nprint("hi")\n```';
+    expect(parseSegments(content)).toEqual([
+      { type: "text", text: '```python\nprint("hi")\n```' },
+    ]);
+  });
+
+  it("handles text + chart + text + ui + text in order", () => {
+    const content = [
+      "Here is a chart:",
+      "```chart",
+      '{"type":"BarChart","props":{"title":"x"}}',
+      "```",
+      "And a card:",
+      "```ui",
+      '{"type":"Card","props":{}}',
+      "```",
+      "Done.",
+    ].join("\n");
+
+    const segments = parseSegments(content);
+    expect(segments.map((s) => s.type)).toEqual([
+      "text",
+      "block",
+      "text",
+      "block",
+      "text",
+    ]);
+    expect(segments[0]).toMatchObject({ type: "text" });
+    expect((segments[0] as { text: string }).text).toContain(
+      "Here is a chart:",
+    );
+    expect(segments[1]).toMatchObject({ type: "block", lang: "chart" });
+    expect(segments[3]).toMatchObject({ type: "block", lang: "ui" });
+    expect((segments[4] as { text: string }).text).toContain("Done.");
+  });
+
+  it("handles a chart fence at the very start of content", () => {
+    const content = '```chart\n{"type":"BarChart"}\n```\nfollow-up text';
+    const segments = parseSegments(content);
+    expect(segments[0]).toMatchObject({ type: "block", lang: "chart" });
+    expect(segments[1]).toMatchObject({ type: "text" });
+  });
+
+  it("handles a chart fence at the very end of content", () => {
+    const content = 'leading text\n```chart\n{"type":"BarChart"}\n```';
+    const segments = parseSegments(content);
+    expect(segments[0]).toMatchObject({ type: "text" });
+    expect(segments[1]).toMatchObject({ type: "block", lang: "chart" });
+  });
+
+  it("tolerates CRLF line endings between the fence and the body", () => {
+    const content = '```chart\r\n{"type":"BarChart"}\r\n```';
+    const segments = parseSegments(content);
+    expect(segments[0]).toMatchObject({ type: "block", lang: "chart" });
+    expect((segments[0] as { code: string }).code).toContain("BarChart");
+  });
+
+  it("is repeatable — each call resets the regex state", () => {
+    // Guards against the classic /g lastIndex bug where the second call
+    // misses content because the regex state leaked from the first run.
+    const content = '```chart\n{"type":"BarChart"}\n```';
+    const first = parseSegments(content);
+    const second = parseSegments(content);
+    expect(first).toEqual(second);
+  });
+});

--- a/elements/src/components/MessageContent.tsx
+++ b/elements/src/components/MessageContent.tsx
@@ -6,46 +6,12 @@ import type { ElementsContextType, Model } from "@/types";
 import { recommended } from "@/plugins";
 import { chart } from "@/plugins/chart";
 import { generativeUI } from "@/plugins/generative-ui";
+import { parseSegments } from "./MessageContent.parser";
 
 const SUPPORTED_LANGUAGES: Record<string, FC<{ code: string }>> = {
   chart: chart.Component as FC<{ code: string }>,
   ui: generativeUI.Component as FC<{ code: string }>,
 };
-
-type Segment =
-  | { type: "text"; text: string }
-  | { type: "block"; lang: string; code: string };
-
-const FENCE_RE = /```(\w+)\r?\n([\s\S]*?)```/g;
-
-function parseSegments(content: string): Segment[] {
-  const segments: Segment[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-  FENCE_RE.lastIndex = 0;
-  while ((match = FENCE_RE.exec(content)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({
-        type: "text",
-        text: content.slice(lastIndex, match.index),
-      });
-    }
-    const lang = (match[1] ?? "").toLowerCase();
-    const code = match[2] ?? "";
-    if (lang in SUPPORTED_LANGUAGES) {
-      segments.push({ type: "block", lang, code });
-    } else {
-      // Unsupported language: keep original block as text so it's still
-      // visible (renders as a normal fenced code block in plain text).
-      segments.push({ type: "text", text: match[0] });
-    }
-    lastIndex = match.index + match[0].length;
-  }
-  if (lastIndex < content.length) {
-    segments.push({ type: "text", text: content.slice(lastIndex) });
-  }
-  return segments;
-}
 
 // Minimal stub ElementsContext value. The chart/ui plugin renderers reach into
 // ElementsContext via useDensity()/useElements() to read density classes, so a

--- a/elements/src/components/MessageContent.tsx
+++ b/elements/src/components/MessageContent.tsx
@@ -14,14 +14,10 @@ const SUPPORTED_LANGUAGES: Record<string, FC<{ code: string }>> = {
   ui: generativeUI.Component as FC<{ code: string }>,
 };
 
-// Minimal stub ElementsContext value. The chart/ui plugin renderers reach into
-// ElementsContext via useDensity()/useElements() to read density classes, so a
-// static viewer must provide the context — but it doesn't need any of the
-// runtime/auth/MCP machinery that GramElementsProvider sets up.
+// Provides only what useDensity()/useElements() read inside the chart and ui
+// renderers — no auth, no MCP, no runtime.
 const STUB_CONTEXT: ElementsContextType = {
-  config: {
-    projectSlug: "",
-  },
+  config: { projectSlug: "" },
   setModel: () => {},
   model: "" as Model,
   isExpanded: false,
@@ -41,19 +37,15 @@ export interface MessageContentProps {
 }
 
 /**
- * Standalone renderer for stored chat message content. Recognizes the same
+ * Standalone renderer for stored chat message content. Recognises the same
  * `chart` and `ui` fenced code blocks that the live `<Chat />` component
- * renders as widgets — but works as a plain component without requiring an
- * `ElementsProvider`, MCP client, auth session, or assistant-ui runtime.
+ * renders as widgets, but works without an `ElementsProvider`, MCP client,
+ * auth session, or assistant-ui runtime.
  *
- * Use this in static viewers (agent session detail panels, replay, share
- * pages, etc.) so a `Tool Calls by Source — Last 7 Days` chart appears as
- * the actual bar chart it was rendered as live, instead of as raw JSON text.
- *
- * Plain markdown formatting is intentionally **not** applied — text segments
- * render as preformatted text. If the surrounding viewer needs full markdown,
- * mount this inside its own markdown component and let the markdown renderer
- * delegate `chart`/`ui` code blocks to this component instead.
+ * Use in static viewers (agent session detail panel, replay, share) so a
+ * stored bar chart appears as a chart instead of as raw JSON. Plain markdown
+ * formatting is intentionally not applied — text segments render as
+ * preformatted text.
  */
 export const MessageContent: FC<MessageContentProps> = ({
   content,
@@ -63,18 +55,11 @@ export const MessageContent: FC<MessageContentProps> = ({
 
   return (
     <ElementsContext.Provider value={STUB_CONTEXT}>
-      {/* Empty ToolExecutionProvider so generative-ui's <ActionButton> sees
-          isToolAvailable() === false and renders disabled instead of a
-          live-looking button that no-ops on click. Static viewers (session
-          detail panel, replay) intentionally don't run tool calls; the
-          ActionButton's defensive fallback would also catch this, but
-          mounting the provider explicitly makes the intent visible in code. */}
+      {/* Empty tools so generative-ui's <ActionButton> renders disabled. */}
       <ToolExecutionProvider tools={{}}>
         <div className={className}>
           {segments.map((seg, i) => {
             if (seg.type === "text") {
-              // Skip purely-whitespace text segments between adjacent widgets
-              // so the layout doesn't get blank line-height runs.
               if (seg.text.trim() === "") return null;
               return (
                 <div key={i} className="whitespace-pre-wrap">

--- a/elements/src/components/MessageContent.tsx
+++ b/elements/src/components/MessageContent.tsx
@@ -2,6 +2,7 @@
 
 import { FC, useMemo } from "react";
 import { ElementsContext } from "@/contexts/contexts";
+import { ToolExecutionProvider } from "@/contexts/ToolExecutionContext";
 import type { ElementsContextType, Model } from "@/types";
 import { recommended } from "@/plugins";
 import { chart } from "@/plugins/chart";
@@ -62,27 +63,35 @@ export const MessageContent: FC<MessageContentProps> = ({
 
   return (
     <ElementsContext.Provider value={STUB_CONTEXT}>
-      <div className={className}>
-        {segments.map((seg, i) => {
-          if (seg.type === "text") {
-            // Skip purely-whitespace text segments between adjacent widgets so
-            // the layout doesn't get blank line-height runs.
-            if (seg.text.trim() === "") return null;
+      {/* Empty ToolExecutionProvider so generative-ui's <ActionButton> sees
+          isToolAvailable() === false and renders disabled instead of a
+          live-looking button that no-ops on click. Static viewers (session
+          detail panel, replay) intentionally don't run tool calls; the
+          ActionButton's defensive fallback would also catch this, but
+          mounting the provider explicitly makes the intent visible in code. */}
+      <ToolExecutionProvider tools={{}}>
+        <div className={className}>
+          {segments.map((seg, i) => {
+            if (seg.type === "text") {
+              // Skip purely-whitespace text segments between adjacent widgets
+              // so the layout doesn't get blank line-height runs.
+              if (seg.text.trim() === "") return null;
+              return (
+                <div key={i} className="whitespace-pre-wrap">
+                  {seg.text}
+                </div>
+              );
+            }
+            const Component = SUPPORTED_LANGUAGES[seg.lang];
+            if (!Component) return null;
             return (
-              <div key={i} className="whitespace-pre-wrap">
-                {seg.text}
+              <div key={i} className="my-2">
+                <Component code={seg.code} />
               </div>
             );
-          }
-          const Component = SUPPORTED_LANGUAGES[seg.lang];
-          if (!Component) return null;
-          return (
-            <div key={i} className="my-2">
-              <Component code={seg.code} />
-            </div>
-          );
-        })}
-      </div>
+          })}
+        </div>
+      </ToolExecutionProvider>
     </ElementsContext.Provider>
   );
 };

--- a/elements/src/components/MessageContent.tsx
+++ b/elements/src/components/MessageContent.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { FC, useMemo } from "react";
+import { ElementsContext } from "@/contexts/contexts";
+import type { ElementsContextType, Model } from "@/types";
+import { recommended } from "@/plugins";
+import { chart } from "@/plugins/chart";
+import { generativeUI } from "@/plugins/generative-ui";
+
+const SUPPORTED_LANGUAGES: Record<string, FC<{ code: string }>> = {
+  chart: chart.Component as FC<{ code: string }>,
+  ui: generativeUI.Component as FC<{ code: string }>,
+};
+
+type Segment =
+  | { type: "text"; text: string }
+  | { type: "block"; lang: string; code: string };
+
+const FENCE_RE = /```(\w+)\r?\n([\s\S]*?)```/g;
+
+function parseSegments(content: string): Segment[] {
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  FENCE_RE.lastIndex = 0;
+  while ((match = FENCE_RE.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({
+        type: "text",
+        text: content.slice(lastIndex, match.index),
+      });
+    }
+    const lang = (match[1] ?? "").toLowerCase();
+    const code = match[2] ?? "";
+    if (lang in SUPPORTED_LANGUAGES) {
+      segments.push({ type: "block", lang, code });
+    } else {
+      // Unsupported language: keep original block as text so it's still
+      // visible (renders as a normal fenced code block in plain text).
+      segments.push({ type: "text", text: match[0] });
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < content.length) {
+    segments.push({ type: "text", text: content.slice(lastIndex) });
+  }
+  return segments;
+}
+
+// Minimal stub ElementsContext value. The chart/ui plugin renderers reach into
+// ElementsContext via useDensity()/useElements() to read density classes, so a
+// static viewer must provide the context — but it doesn't need any of the
+// runtime/auth/MCP machinery that GramElementsProvider sets up.
+const STUB_CONTEXT: ElementsContextType = {
+  config: {
+    projectSlug: "",
+  },
+  setModel: () => {},
+  model: "" as Model,
+  isExpanded: false,
+  setIsExpanded: () => {},
+  isOpen: false,
+  setIsOpen: () => {},
+  plugins: recommended,
+  mcpTools: undefined,
+};
+
+export interface MessageContentProps {
+  /** Raw assistant message content (markdown text optionally containing
+   * ```chart and ```ui fenced code blocks). */
+  content: string;
+  /** Optional className applied to the root container. */
+  className?: string;
+}
+
+/**
+ * Standalone renderer for stored chat message content. Recognizes the same
+ * `chart` and `ui` fenced code blocks that the live `<Chat />` component
+ * renders as widgets — but works as a plain component without requiring an
+ * `ElementsProvider`, MCP client, auth session, or assistant-ui runtime.
+ *
+ * Use this in static viewers (agent session detail panels, replay, share
+ * pages, etc.) so a `Tool Calls by Source — Last 7 Days` chart appears as
+ * the actual bar chart it was rendered as live, instead of as raw JSON text.
+ *
+ * Plain markdown formatting is intentionally **not** applied — text segments
+ * render as preformatted text. If the surrounding viewer needs full markdown,
+ * mount this inside its own markdown component and let the markdown renderer
+ * delegate `chart`/`ui` code blocks to this component instead.
+ */
+export const MessageContent: FC<MessageContentProps> = ({
+  content,
+  className,
+}) => {
+  const segments = useMemo(() => parseSegments(content), [content]);
+
+  return (
+    <ElementsContext.Provider value={STUB_CONTEXT}>
+      <div className={className}>
+        {segments.map((seg, i) => {
+          if (seg.type === "text") {
+            // Skip purely-whitespace text segments between adjacent widgets so
+            // the layout doesn't get blank line-height runs.
+            if (seg.text.trim() === "") return null;
+            return (
+              <div key={i} className="whitespace-pre-wrap">
+                {seg.text}
+              </div>
+            );
+          }
+          const Component = SUPPORTED_LANGUAGES[seg.lang];
+          if (!Component) return null;
+          return (
+            <div key={i} className="my-2">
+              <Component code={seg.code} />
+            </div>
+          );
+        })}
+      </div>
+    </ElementsContext.Provider>
+  );
+};

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -191,17 +191,20 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     toolsWithCustomComponents,
   );
 
-  // Hold systemPrompt in a ref so transport's useMemo identity is stable across
-  // prompt changes. Consumers like Gram's AI Insights sidebar rebuild
-  // elementsConfig whenever the page-level override changes (new welcome
-  // copy + new contextInfo for "Explore with AI"), which feeds a fresh
-  // systemPrompt through. If systemPrompt was a direct useMemo dep, the
-  // transport identity would change → useChatRuntime would rebuild the runtime
-  // → in-flight switchToNewThread().then(append) calls would resolve against
-  // a torn-down resources map and throw `tapLookupResources: Resource not
-  // found for lookup: {"key":"__LOCALID_…"}`. Reading via ref inside
-  // sendMessages keeps the transport identity stable while every new
-  // completion still picks up the latest system prompt.
+  // Optimization: hold systemPrompt in a ref so changing it doesn't churn the
+  // transport useMemo identity (which would otherwise force `useChatRuntime`'s
+  // dynamic-transport proxy to swap its underlying reference more than
+  // necessary). Aligns with the existing ensureValidHeadersRef and
+  // approvalHelpersRef patterns in this file.
+  //
+  // NOTE: The same `sendMessages` closure already captures other
+  // config-bound values (`config.api?.headers`, `config.gramEnvironment`,
+  // and the `mcpHeaders` mutable shared object) without re-deriving them
+  // when config changes. Today no consumer mutates those at runtime, but
+  // before extending the ref pattern to additional fields, verify the
+  // staleness implications for non-Insights consumers — the AI Insights
+  // sidebar happens to remount the whole provider via `sessionKey` so it
+  // never depends on this closure being current.
   const systemPromptRef = useRef(systemPrompt);
   systemPromptRef.current = systemPrompt;
 

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -191,6 +191,20 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     toolsWithCustomComponents,
   );
 
+  // Hold systemPrompt in a ref so transport's useMemo identity is stable across
+  // prompt changes. Consumers like Gram's AI Insights sidebar rebuild
+  // elementsConfig whenever the page-level override changes (new welcome
+  // copy + new contextInfo for "Explore with AI"), which feeds a fresh
+  // systemPrompt through. If systemPrompt was a direct useMemo dep, the
+  // transport identity would change → useChatRuntime would rebuild the runtime
+  // → in-flight switchToNewThread().then(append) calls would resolve against
+  // a torn-down resources map and throw `tapLookupResources: Resource not
+  // found for lookup: {"key":"__LOCALID_…"}`. Reading via ref inside
+  // sendMessages keeps the transport identity stable while every new
+  // completion still picks up the latest system prompt.
+  const systemPromptRef = useRef(systemPrompt);
+  systemPromptRef.current = systemPrompt;
+
   // Initialize error tracking on mount
   useEffect(() => {
     initErrorTracking({
@@ -422,7 +436,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
           const modelMessages = compaction.messages;
 
           const result = streamText({
-            system: systemPrompt,
+            system: systemPromptRef.current,
             model: modelToUse,
             messages: modelMessages,
             tools,
@@ -494,7 +508,6 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
       config.contextCompaction?.compactAtFraction,
       config.contextCompaction?.keepRecent,
       model,
-      systemPrompt,
       mcpTools,
       getApprovalHelpers,
       apiUrl,

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -191,20 +191,9 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     toolsWithCustomComponents,
   );
 
-  // Optimization: hold systemPrompt in a ref so changing it doesn't churn the
-  // transport useMemo identity (which would otherwise force `useChatRuntime`'s
-  // dynamic-transport proxy to swap its underlying reference more than
-  // necessary). Aligns with the existing ensureValidHeadersRef and
-  // approvalHelpersRef patterns in this file.
-  //
-  // NOTE: The same `sendMessages` closure already captures other
-  // config-bound values (`config.api?.headers`, `config.gramEnvironment`,
-  // and the `mcpHeaders` mutable shared object) without re-deriving them
-  // when config changes. Today no consumer mutates those at runtime, but
-  // before extending the ref pattern to additional fields, verify the
-  // staleness implications for non-Insights consumers — the AI Insights
-  // sidebar happens to remount the whole provider via `sessionKey` so it
-  // never depends on this closure being current.
+  // Read inside `sendMessages` via ref so prompt changes don't churn the
+  // transport useMemo identity. Same pattern as ensureValidHeadersRef /
+  // approvalHelpersRef below.
   const systemPromptRef = useRef(systemPrompt);
   systemPromptRef.current = systemPrompt;
 

--- a/elements/src/index.ts
+++ b/elements/src/index.ts
@@ -18,6 +18,8 @@ export { ChatHistory } from "@/components/ChatHistory";
 export { ShareButton } from "@/components/ShareButton";
 export type { ShareButtonProps } from "@/components/ShareButton";
 export { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+export { MessageContent } from "@/components/MessageContent";
+export type { MessageContentProps } from "@/components/MessageContent";
 
 // Replay
 export { Replay } from "@/components/Replay";


### PR DESCRIPTION
## Summary

Two AI Insights bugs that share the elements ↔ dashboard boundary.

**Bug 1 — sidebar crashed with `tapLookupResources: Resource not found for lookup: __LOCALID_…` on rapid *Explore with AI* clicks.** Each click churned `elementsConfig`, letting assistant-ui's per-thread `instances` Map and the `threadData` state drift out of sync inside `_InnerActiveThreadProvider`'s render. Fix: key `<GramElementsProvider>` on a `sessionKey` that bumps per Explore click, so each chart gets its own runtime lifetime (matches the intended UX). Header trigger toggles don't bump the key, so the default *Ask AI* conversation persists across open/close.

**Bug 2 — agent session pop-out rendered AI Insights ` ```chart` / ` ```ui` blocks as raw JSON instead of widgets.** Added `<MessageContent>` to `@gram-ai/elements` that recognises the fences and reuses the existing chart/UI plugin renderers. Wraps a stub `ElementsContext` so the renderers' `useDensity()` works without an MCP/auth/runtime — cheap to mount in any static viewer. Used in `ChatDetailPanel.MessageItem`.

<img width="1398" height="1118" alt="CleanShot 2026-04-23 at 21 46 22@2x" src="https://github.com/user-attachments/assets/ad730dd8-70ee-49be-afcd-1175082232d7" />

## Test plan

- [ ] Rapid Explore clicks across different charts → no `tapLookupResources` crash.
- [ ] Toggle the *AI Insights* header trigger → default conversation preserved.
- [ ] Open an AI Insights chat in the agent session pop-out → bar chart + UI cards render as widgets.
- [ ] Open a non-AI-Insights chat → rendering unchanged.

## Out of scope

Bug 2(b) (Tool Calls tab empty for AI Insights chats) — failed tool calls return early in `mcp/rpc_tools_call.go` before the telemetry defer is registered. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)