### PR TITLE
chore: rbac UI fixes for Specific Tools popover

### DIFF
--- a/client/dashboard/package.json
+++ b/client/dashboard/package.json
@@ -58,6 +58,7 @@
     "@tailwindcss/vite": "^4.1.17",
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.23",
     "@tremor/react": "^3.18.7",
     "@xyflow/react": "^12.8.6",
     "ai": "catalog:",

--- a/client/dashboard/src/pages/access/Access.tsx
+++ b/client/dashboard/src/pages/access/Access.tsx
@@ -44,7 +44,10 @@ export default function Access() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Breadcrumbs substitutions={tabDisplayNames} />
+        <Page.Header.Breadcrumbs
+          substitutions={tabDisplayNames}
+          skipSegments={["access"]}
+        />
       </Page.Header>
       <Page.Body>
         <RequireScope scope={["org:read", "org:admin"]} level="page">

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -99,7 +99,7 @@ function inferCustomTab(
   }
 
   // All tabs now use serverSlug:toolName, so we can't distinguish between
-  // "select", "http-method", and "collection" tabs from IDs alone.
+  // "select" and "collection" tabs from IDs alone.
   // Default to "select" — the user's tool selections are preserved correctly.
   return { tab: "select" };
 }

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -19,7 +19,6 @@ import {
   ChevronRight,
   Maximize2,
   Minimize2,
-  SquareAsterisk,
   Globe,
   Repeat,
   Shield,
@@ -31,6 +30,7 @@ import {
 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { AnnotationHint, CustomTab, ResourceType } from "./types";
 
 interface ScopePickerPopoverProps {
@@ -266,14 +266,6 @@ export function ScopePickerPopover({
         </TabsTrigger>
         <div className="bg-border/40 my-1 w-px self-stretch" />
         <TabsTrigger
-          value="http-method"
-          className="text-muted-foreground hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground h-auto rounded-sm border-none px-3 py-2 text-sm shadow-none data-[state=active]:shadow-none"
-        >
-          <SquareAsterisk className="h-3.5 w-3.5" />
-          By HTTP method
-        </TabsTrigger>
-        <div className="bg-border/40 my-1 w-px self-stretch" />
-        <TabsTrigger
           value="collection"
           className="text-muted-foreground hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground h-auto rounded-sm border-none px-3 py-2 text-sm shadow-none data-[state=active]:shadow-none"
         >
@@ -320,16 +312,6 @@ export function ScopePickerPopover({
         />
       </TabsContent>
       <TabsContent
-        value="http-method"
-        className="min-h-[200px] flex-1 overflow-y-auto px-2 py-1"
-      >
-        <HttpMethodGroupPanel
-          mcpServers={mcpServers}
-          resources={resources ?? []}
-          onChangeResources={onChangeResources}
-        />
-      </TabsContent>
-      <TabsContent
         value="collection"
         className="min-h-[200px] flex-1 overflow-y-auto px-2 py-1"
       >
@@ -370,19 +352,21 @@ export function ScopePickerPopover({
           {customMode && (
             <div className="-mx-1.5 -mb-1.5 flex max-h-[min(420px,60vh)] flex-col">
               {customTabs("max-h-[min(340px,50vh)]")}
-              <div className="bg-background border-border shrink-0 rounded-b-lg border-t">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setPopoverOpen(false);
-                    setExpanded(true);
-                  }}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted/50 flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-b-lg px-3 py-2.5 text-xs transition-colors"
-                >
-                  <Maximize2 className="h-3 w-3" />
-                  Open in full screen
-                </button>
-              </div>
+              {(customTab ?? "select") === "select" && (
+                <div className="bg-background border-border shrink-0 rounded-b-lg border-t">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setPopoverOpen(false);
+                      setExpanded(true);
+                    }}
+                    className="text-muted-foreground hover:text-foreground hover:bg-muted/50 flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-b-lg px-3 py-2.5 text-xs transition-colors"
+                  >
+                    <Maximize2 className="h-3 w-3" />
+                    Open in full screen
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </PopoverContent>
@@ -432,7 +416,10 @@ function ToolSelectionPanel({
   className?: string;
 }) {
   const allServers = useMemo(
-    () => mcpServers.flatMap((g) => g.servers),
+    () =>
+      mcpServers
+        .flatMap((g) => g.servers)
+        .sort((a, b) => a.name.localeCompare(b.name)),
     [mcpServers],
   );
   const [selectedServerId, setSelectedServerId] = useState<string | null>(
@@ -462,36 +449,79 @@ function ToolSelectionPanel({
     }
   }, []);
 
+  const serverScrollRef = useRef<HTMLDivElement>(null);
+  const handleServerWheel = useCallback((e: React.WheelEvent) => {
+    if (serverScrollRef.current) {
+      serverScrollRef.current.scrollTop += e.deltaY;
+    }
+  }, []);
+
+  const serverVirtualizer = useVirtualizer({
+    count: allServers.length,
+    getScrollElement: () => serverScrollRef.current,
+    estimateSize: () => 40,
+    overscan: 5,
+  });
+
+  const toolVirtualizer = useVirtualizer({
+    count: filteredTools.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 40,
+    overscan: 5,
+  });
+
   return (
     <div className={cn("flex min-h-0 flex-1", className)}>
       {/* Left column — server list */}
-      <div className="border-border w-[160px] shrink-0 overflow-y-auto border-r">
-        <div className="bg-muted/50 text-muted-foreground border-border flex h-10 items-center gap-1.5 border-b px-3 text-[10px] font-medium tracking-wider uppercase">
+      <div className="border-border flex min-h-0 w-[160px] shrink-0 flex-col border-r">
+        <div className="bg-muted/50 text-muted-foreground border-border flex h-10 shrink-0 items-center gap-1.5 border-b px-3 text-[10px] font-medium tracking-wider uppercase">
           <Globe className="h-3 w-3" />
           Server List
         </div>
-        {allServers.map((server) => {
-          const isActive = selectedServerId === server.id;
-          return (
-            <button
-              key={server.id}
-              type="button"
-              onClick={() => {
-                setSelectedServerId(server.id);
-                setSearch("");
-              }}
-              className={cn(
-                "hover:bg-muted/50 flex h-10 w-full cursor-pointer items-center justify-between truncate px-3 text-sm",
-                isActive && "bg-muted font-medium",
-              )}
-            >
-              <span className="truncate">{server.name}</span>
-              {isActive && (
-                <ChevronRight className="text-muted-foreground h-3 w-3 shrink-0" />
-              )}
-            </button>
-          );
-        })}
+        <div
+          ref={serverScrollRef}
+          onWheel={handleServerWheel}
+          className="min-h-0 flex-1 overflow-y-auto"
+        >
+          <div
+            style={{
+              height: `${serverVirtualizer.getTotalSize()}px`,
+              position: "relative",
+            }}
+          >
+            {serverVirtualizer.getVirtualItems().map((virtualItem) => {
+              const server = allServers[virtualItem.index];
+              const isActive = selectedServerId === server.id;
+              return (
+                <button
+                  key={server.id}
+                  type="button"
+                  onClick={() => {
+                    setSelectedServerId(server.id);
+                    setSearch("");
+                  }}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: `${virtualItem.size}px`,
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                  className={cn(
+                    "hover:bg-muted/50 flex cursor-pointer items-center justify-between truncate px-3 text-sm",
+                    isActive && "bg-muted font-medium",
+                  )}
+                >
+                  <span className="truncate">{server.name}</span>
+                  {isActive && (
+                    <ChevronRight className="text-muted-foreground h-3 w-3 shrink-0" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
 
       {/* Right column — tools for selected server */}
@@ -517,26 +547,45 @@ function ToolSelectionPanel({
         <div
           ref={scrollRef}
           onWheel={handleWheel}
-          className="tool-scroll min-h-0 flex-1 overflow-y-auto pb-2"
+          className="tool-scroll min-h-0 flex-1 overflow-y-auto"
         >
           {filteredTools.length === 0 ? (
             <div className="text-muted-foreground px-3 py-3 text-sm">
               {tools.length === 0 ? "No tools found" : "No matching tools"}
             </div>
           ) : (
-            filteredTools.map((tool) => {
-              const toolId = `${selectedServerId}:${tool.name}`;
-              return (
-                <ResourceCheckbox
-                  key={tool.id}
-                  id={toolId}
-                  name={tool.name}
-                  checked={resources.includes(toolId)}
-                  onToggle={onToggle}
-                  compact
-                />
-              );
-            })
+            <div
+              style={{
+                height: `${toolVirtualizer.getTotalSize()}px`,
+                position: "relative",
+              }}
+            >
+              {toolVirtualizer.getVirtualItems().map((virtualItem) => {
+                const tool = filteredTools[virtualItem.index];
+                const toolId = `${selectedServerId}:${tool.name}`;
+                return (
+                  <div
+                    key={tool.id}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      height: `${virtualItem.size}px`,
+                      transform: `translateY(${virtualItem.start}px)`,
+                    }}
+                  >
+                    <ResourceCheckbox
+                      id={toolId}
+                      name={tool.name}
+                      checked={resources.includes(toolId)}
+                      onToggle={onToggle}
+                      compact
+                    />
+                  </div>
+                );
+              })}
+            </div>
           )}
         </div>
       </div>
@@ -652,128 +701,6 @@ function AnnotationGroupPanel({
             </div>
             <span className="text-muted-foreground shrink-0 text-xs">
               {matchCount} tool{matchCount !== 1 ? "s" : ""}
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
-
-const METHOD_COLORS: Record<string, string> = {
-  GET: "text-blue-600 bg-blue-50",
-  POST: "text-green-600 bg-green-50",
-  PUT: "text-amber-600 bg-amber-50",
-  PATCH: "text-orange-600 bg-orange-50",
-  DELETE: "text-red-600 bg-red-50",
-};
-
-function HttpMethodGroupPanel({
-  mcpServers,
-  resources,
-  onChangeResources,
-}: {
-  mcpServers: ServerGroup[];
-  resources: string[];
-  onChangeResources: (resources: string[]) => void;
-}) {
-  const allTools = useMemo(
-    () =>
-      mcpServers.flatMap((g) =>
-        g.servers.flatMap((s) =>
-          s.tools.map((t) => ({ ...t, serverSlug: s.id, serverName: s.name })),
-        ),
-      ),
-    [mcpServers],
-  );
-
-  const httpTools = useMemo(
-    () => allTools.filter((t) => t.type === "http"),
-    [allTools],
-  );
-
-  const toolsByMethod = useMemo(() => {
-    const map = new Map<string, typeof httpTools>();
-    for (const tool of httpTools) {
-      const method = tool.httpMethod?.toUpperCase() ?? "OTHER";
-      const list = map.get(method) ?? [];
-      list.push(tool);
-      map.set(method, list);
-    }
-    // Sort tools within each method group
-    for (const [key, tools] of map) {
-      map.set(
-        key,
-        tools.sort((a, b) => a.name.localeCompare(b.name)),
-      );
-    }
-    // Sort method groups by HTTP_METHODS order, with OTHER last
-    const sorted = new Map<string, typeof httpTools>();
-    for (const method of HTTP_METHODS) {
-      const tools = map.get(method);
-      if (tools) sorted.set(method, tools);
-    }
-    const other = map.get("OTHER");
-    if (other) sorted.set("OTHER", other);
-    return sorted;
-  }, [httpTools]);
-
-  if (httpTools.length === 0) {
-    return (
-      <div className="text-muted-foreground py-6 text-center text-sm">
-        No HTTP tools found
-      </div>
-    );
-  }
-
-  return (
-    <div className="py-1">
-      <div className="text-muted-foreground px-2 py-2 text-sm">
-        Select all tools by HTTP method:
-      </div>
-      {[...toolsByMethod.entries()].map(([method, tools]) => {
-        const compoundIds = tools.map((t) => `${t.serverSlug}:${t.name}`);
-        const allSelected =
-          compoundIds.length > 0 &&
-          compoundIds.every((id) => resources.includes(id));
-        const colors =
-          METHOD_COLORS[method] ?? "text-muted-foreground bg-muted";
-
-        const toggleAll = () => {
-          if (allSelected) {
-            const removeSet = new Set(compoundIds);
-            onChangeResources(resources.filter((r) => !removeSet.has(r)));
-          } else {
-            const existing = new Set(resources);
-            const toAdd = compoundIds.filter((id) => !existing.has(id));
-            onChangeResources([...resources, ...toAdd]);
-          }
-        };
-
-        return (
-          <button
-            key={method}
-            type="button"
-            onClick={toggleAll}
-            className="hover:bg-accent flex w-full cursor-pointer items-center gap-3 rounded-sm px-3 py-2.5 text-sm"
-          >
-            <Checkbox
-              checked={allSelected}
-              className="focus-visible:border-input pointer-events-none focus-visible:ring-0"
-              tabIndex={-1}
-            />
-            <span
-              className={cn(
-                "inline-flex min-w-[52px] items-center justify-center rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide",
-                colors,
-              )}
-            >
-              {method}
-            </span>
-            <span className="flex-1 text-left">
-              {tools.length} tool{tools.length !== 1 ? "s" : ""}
             </span>
           </button>
         );

--- a/client/dashboard/src/pages/access/types.ts
+++ b/client/dashboard/src/pages/access/types.ts
@@ -13,7 +13,7 @@ export type AnnotationHint =
   | "openWorldHint";
 
 /** The four tool-selection tabs in custom mode. */
-export type CustomTab = "select" | "auto-groups" | "http-method" | "collection";
+export type CustomTab = "select" | "auto-groups" | "collection";
 
 /** A single grant within a role: a scope + optional resource allowlist. */
 export interface RoleGrant {

--- a/client/dashboard/src/pages/access/types.ts
+++ b/client/dashboard/src/pages/access/types.ts
@@ -12,7 +12,7 @@ export type AnnotationHint =
   | "idempotentHint"
   | "openWorldHint";
 
-/** The four tool-selection tabs in custom mode. */
+/** The three tool-selection tabs in custom mode. */
 export type CustomTab = "select" | "auto-groups" | "collection";
 
 /** A single grant within a role: a scope + optional resource allowlist. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.23
+        version: 3.13.23(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tremor/react':
         specifier: ^3.18.7
         version: 3.18.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4339,8 +4342,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.13.18':
-    resolution: {integrity: sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==}
+  '@tanstack/react-virtual@3.13.23':
+    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4458,8 +4461,8 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@tanstack/virtual-core@3.13.18':
-    resolution: {integrity: sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==}
+  '@tanstack/virtual-core@3.13.23':
+    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
   '@tanstack/virtual-file-routes@1.154.7':
     resolution: {integrity: sha512-cHHDnewHozgjpI+MIVp9tcib6lYEQK5MyUr0ChHpHFGBl8Xei55rohFK0I0ve/GKoHeioaK42Smd8OixPp6CTg==}
@@ -10638,7 +10641,7 @@ snapshots:
       '@floating-ui/react': 0.26.28(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@react-aria/focus': 3.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@react-aria/interactions': 3.26.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-virtual': 3.13.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-virtual': 3.13.23(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
@@ -12857,9 +12860,9 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/react-virtual@3.13.18(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-virtual@3.13.23(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/virtual-core': 3.13.18
+      '@tanstack/virtual-core': 3.13.23
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
@@ -13095,7 +13098,7 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@tanstack/virtual-core@3.13.18': {}
+  '@tanstack/virtual-core@3.13.23': {}
 
   '@tanstack/virtual-file-routes@1.154.7': {}
 


### PR DESCRIPTION
## Summary

- **Sort servers alphabetically** in the tool picker server list
- **Fix server list scrolling** — restructured to flex-col with virtualizer pattern (was missing `min-h-0` flex constraint)
- **Virtualise both columns** with `@tanstack/react-virtual` — server list and tool list now render only visible rows, handles large numbers of servers/tools efficiently
- **Remove "By HTTP method" tab** — external servers don't reliably provide tool lists, this tab was not useful
- **"Open in full screen" button** now only shown on the "All tools" tab (hidden on annotation/collection tabs)
- **Remove "Access" breadcrumb segment** from the RBAC page breadcrumbs

## Test plan
- [ ] Open Roles & Permissions → edit a role → set `mcp:connect` scope → click "Specific tools"
- [ ] Verify server list is sorted alphabetically
- [ ] Verify server list scrolls when there are many servers
- [ ] Verify tool list scrolls when there are many tools
- [ ] Switch between tabs — confirm "Open in full screen" only appears on "All tools" tab
- [ ] Confirm "By HTTP method" tab is gone
- [ ] Check breadcrumbs on the Access page show only tab name (no "Access" prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)