### PR TITLE
fix(toolsets): defer close channels in errgroup goroutines

### DIFF
--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -643,48 +643,48 @@ func GetToolsetsSummary(
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
+		defer close(httpToolsCh)
 		rows, err := toolsRepo.FindHttpToolEntriesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch http tools: %w", err)
 		}
 		httpToolsCh <- rows
-		close(httpToolsCh)
 		return nil
 	})
 	eg.Go(func() error {
+		defer close(funcToolsCh)
 		rows, err := toolsRepo.FindFunctionToolEntriesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch function tools: %w", err)
 		}
 		funcToolsCh <- rows
-		close(funcToolsCh)
 		return nil
 	})
 	eg.Go(func() error {
+		defer close(promptToolsCh)
 		rows, err := tplRepo.PeekTemplatesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch prompt tools: %w", err)
 		}
 		promptToolsCh <- rows
-		close(promptToolsCh)
 		return nil
 	})
 	eg.Go(func() error {
+		defer close(variationsCh)
 		rows, err := variationsRepo.FindGlobalVariationsForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch variations: %w", err)
 		}
 		variationsCh <- rows
-		close(variationsCh)
 		return nil
 	})
 	eg.Go(func() error {
+		defer close(externalMCPToolsCh)
 		rows, err := extMCPRepo.FindExternalMCPToolEntriesForProjects(egCtx, projectIDs)
 		if err != nil {
 			return fmt.Errorf("batch external mcp tools: %w", err)
 		}
 		externalMCPToolsCh <- rows
-		close(externalMCPToolsCh)
 		return nil
 	})
 	if err := eg.Wait(); err != nil {


### PR DESCRIPTION
## Summary

- Moves `close(ch)` to `defer close(ch)` at the top of each errgroup goroutine in `GetToolsetsSummary`
- Ensures channels are closed on all return paths (success, error, panic), not just the happy path
- Defensive fix — current code is safe since channel reads only happen after `eg.Wait()`, but this prevents future code from accidentally blocking if reads are ever moved earlier

## Related

Follows on from #2394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)