### PR TITLE
feat: audit logs AI insights sidebar

### DIFF
--- a/.changeset/audit-logs-insights.md
+++ b/.changeset/audit-logs-insights.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": minor
+---
+
+Add `Plugin.id` field and `recommended.except()` helper for selectively excluding plugins by identifier.

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -1379,7 +1379,7 @@ async function upsertToolset(init: {
   return toolset;
 }
 
-// The Gram API + platform tools that compose the built-in MCP Logs server.
+// The Gram API tools that compose the built-in MCP Logs server.
 // These match the production `speakeasy-team-mcp-logs` toolset.
 const MCP_LOGS_TOOL_URNS = new Set([
   "tools:http:gram:gram_list_tools",

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -1379,7 +1379,7 @@ async function upsertToolset(init: {
   return toolset;
 }
 
-// The 11 Gram API tools that compose the built-in MCP Logs server.
+// The Gram API + platform tools that compose the built-in MCP Logs server.
 // These match the production `speakeasy-team-mcp-logs` toolset.
 const MCP_LOGS_TOOL_URNS = new Set([
   "tools:http:gram:gram_list_tools",
@@ -1393,6 +1393,9 @@ const MCP_LOGS_TOOL_URNS = new Set([
   "tools:http:gram:gram_list_chats_with_resolutions",
   "tools:http:gram:gram_get_deployment_logs",
   "tools:http:gram:gram_list_chats",
+  // Audit log tools
+  "tools:http:gram:gram_list_audit_logs",
+  "tools:http:gram:gram_list_audit_log_facets",
 ]);
 
 async function upsertMcpLogsToolset(init: {

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -611,11 +611,12 @@ function AuditLogsInsightsWrapper({ children }: { children: React.ReactNode }) {
 }
 
 export default function OrgAuditLogs() {
-  const { hasScope } = useRBAC();
+  const { hasAnyScope } = useRBAC();
   const organization = useOrganization();
-  // Only wrap with InsightsProvider when user has org:read and at least
-  // one project exists (needed for Elements session auth).
-  const showInsights = hasScope("org:read") && organization.projects.length > 0;
+  // Only wrap with InsightsProvider when user has org:read or org:admin
+  // and at least one project exists (needed for Elements session auth).
+  const showInsights =
+    hasAnyScope(["org:read", "org:admin"]) && organization.projects.length > 0;
 
   const page = (
     <Page>

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -19,7 +19,7 @@ import { Type } from "@/components/ui/type";
 import { Switch } from "@/components/ui/switch";
 import { useOrganization, useSession } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
-import { useRBAC, Scope } from "@/hooks/useRBAC";
+import { useRBAC } from "@/hooks/useRBAC";
 import type { AuditLog } from "@gram/client/models/components";
 import { chatSessionsCreate } from "@gram/client/funcs/chatSessionsCreate";
 import {
@@ -615,8 +615,7 @@ export default function OrgAuditLogs() {
   const organization = useOrganization();
   // Only wrap with InsightsProvider when user has org:read and at least
   // one project exists (needed for Elements session auth).
-  const showInsights =
-    hasScope("org:read" as Scope) && organization.projects.length > 0;
+  const showInsights = hasScope("org:read") && organization.projects.length > 0;
 
   const page = (
     <Page>

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -1,5 +1,10 @@
 import { useQueryState } from "nuqs";
+import { recommended } from "@gram-ai/elements/plugins";
 import { RequireScope } from "@/components/require-scope";
+import {
+  InsightsConfig,
+  InsightsProvider,
+} from "@/components/insights-sidebar";
 import { Page } from "@/components/page-layout";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,12 +17,15 @@ import {
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { Switch } from "@/components/ui/switch";
-import { useOrganization } from "@/contexts/Auth";
+import { useOrganization, useSession } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
+import { useRBAC, Scope } from "@/hooks/useRBAC";
 import type { AuditLog } from "@gram/client/models/components";
+import { chatSessionsCreate } from "@gram/client/funcs/chatSessionsCreate";
 import {
   useAuditLogsInfinite,
   useAuditLogFacets,
+  useGramContext,
 } from "@gram/client/react-query";
 import { Icon, Input } from "@speakeasy-api/moonshine";
 import React, {
@@ -35,7 +43,7 @@ import {
   getActionColorConfig,
 } from "@/lib/audit-log-colors";
 import { StructuredDiff } from "@/components/auditlogs/structured-diff";
-import { cn } from "@/lib/utils";
+import { cn, getServerURL } from "@/lib/utils";
 
 type FacetOption = {
   count?: number;
@@ -499,8 +507,118 @@ function FacetSelect({
   );
 }
 
-export default function OrgAuditLogs() {
+/**
+ * Wraps the audit logs page in an InsightsProvider so the AI Insights
+ * trigger appears in the breadcrumb bar. Uses the org's first project
+ * for Elements session auth (required by the chat API).
+ */
+function AuditLogsInsightsWrapper({ children }: { children: React.ReactNode }) {
+  const organization = useOrganization();
+  const { session } = useSession();
+  const client = useGramContext();
+
+  const projectSlug = organization.projects[0]?.slug ?? "";
+
+  const getSession = useCallback(async () => {
+    const res = await chatSessionsCreate(
+      client,
+      {
+        createRequestBody: {
+          embedOrigin: window.location.origin,
+        },
+      },
+      undefined,
+      {
+        headers: {
+          "Gram-Project": projectSlug,
+        },
+      },
+    );
+    return res.value?.clientToken ?? "";
+  }, [client, projectSlug]);
+
+  const serverURL = getServerURL();
+
+  // Derive observability MCP URL the same way useObservabilityMcpConfig does.
+  const mcpUrl = serverURL.includes("app.getgram.ai")
+    ? "https://app.getgram.ai/mcp/speakeasy-team-gram"
+    : serverURL.includes("dev.getgram.ai")
+      ? "https://dev.getgram.ai/mcp/speakeasy-team-gram"
+      : import.meta.env.VITE_GRAM_OBSERVABILITY_MCP_URL || undefined;
+
+  const auditToolsFilter = useCallback(
+    ({ toolName }: { toolName: string }) =>
+      toolName.includes("audit") ||
+      toolName.includes("logs") ||
+      toolName.includes("tool_calls"),
+    [],
+  );
+
+  const mcpConfig = useMemo(
+    () => ({
+      projectSlug,
+      plugins: recommended.except("generative-ui"),
+      tools: {
+        toolsToInclude: auditToolsFilter,
+      },
+      api: {
+        url: serverURL,
+        session: getSession,
+        headers: {
+          "X-Gram-Source": "dashboard-ai-insights-audit-logs",
+        },
+      },
+      environment: {
+        GRAM_SERVER_URL: serverURL,
+        GRAM_SESSION_HEADER_GRAM_SESSION: session,
+        GRAM_APIKEY_HEADER_GRAM_KEY: "",
+        GRAM_PROJECT_SLUG_HEADER_GRAM_PROJECT: projectSlug,
+      },
+      ...(mcpUrl && { mcp: mcpUrl }),
+    }),
+    [projectSlug, auditToolsFilter, serverURL, getSession, session, mcpUrl],
+  );
+
   return (
+    <InsightsProvider
+      mcpConfig={mcpConfig}
+      title="Audit Log Insights"
+      subtitle="Ask about organization activity, changes, and audit events."
+      suggestions={[
+        {
+          title: "Recent changes",
+          label: "What changed recently?",
+          prompt:
+            "Summarize the most significant recent changes across the organization based on the audit logs.",
+        },
+        {
+          title: "Security review",
+          label: "Security-relevant events",
+          prompt:
+            "What security-relevant events have occurred recently? Look for API key changes, permission modifications, or unusual patterns.",
+        },
+        {
+          title: "Active users",
+          label: "Most active team members",
+          prompt:
+            "Who have been the most active users recently and what kinds of changes have they been making?",
+        },
+      ]}
+    >
+      {children}
+    </InsightsProvider>
+  );
+}
+
+export default function OrgAuditLogs() {
+  const { hasScope } = useRBAC();
+  const organization = useOrganization();
+  // Only wrap with InsightsProvider when user has org:read and at least
+  // one project exists (needed for Elements session auth).
+  const showInsights =
+    hasScope("org:read" as Scope) && organization.projects.length > 0;
+
+  const page = (
     <Page>
       <Page.Header>
         <Page.Header.Breadcrumbs />
@@ -512,6 +630,10 @@ export default function OrgAuditLogs() {
       </Page.Body>
     </Page>
   );
+
+  if (!showInsights) return page;
+
+  return <AuditLogsInsightsWrapper>{page}</AuditLogsInsightsWrapper>;
 }
 
 export function OrgAuditLogsInner() {
@@ -581,6 +703,41 @@ export function OrgAuditLogsInner() {
     () => groupLogsByDate(logs, tsMode),
     [logs, tsMode],
   );
+
+  // Feed current page state to the AI Insights sidebar as context.
+  const insightsContext = useMemo(() => {
+    const parts: string[] = [
+      "The user is viewing the organization Audit Logs page.",
+      `Organization: ${organization.name || orgSlug}`,
+    ];
+    if (selectedProjectSlug !== "all") {
+      parts.push(`Filtered to project: ${selectedProjectSlug}`);
+    }
+    if (selectedAction !== "all") {
+      parts.push(`Filtered to action: ${selectedAction}`);
+    }
+    if (selectedActor !== "all") {
+      parts.push(`Filtered to actor: ${selectedActor}`);
+    }
+    parts.push(`Currently showing ${logs.length} audit log entries.`);
+    if (dateGroups.length > 0) {
+      const firstDate = dateGroups[0].date;
+      const lastDate = dateGroups[dateGroups.length - 1].date;
+      parts.push(
+        `Date range: ${formatDateHeader(lastDate, tsMode)} to ${formatDateHeader(firstDate, tsMode)}`,
+      );
+    }
+    return parts.join("\n");
+  }, [
+    organization.name,
+    orgSlug,
+    selectedProjectSlug,
+    selectedAction,
+    selectedActor,
+    logs.length,
+    dateGroups,
+    tsMode,
+  ]);
 
   const logFlatIndices = useMemo(() => {
     const map = new Map<string, number>();
@@ -826,6 +983,7 @@ export function OrgAuditLogsInner() {
 
   return (
     <div className="flex w-full flex-col gap-4">
+      <InsightsConfig contextInfo={insightsContext} />
       <div>
         <Type className="font-medium">Recent activity across Gram</Type>
         <Type muted small className="mt-1">

--- a/elements/src/plugins/chart/index.ts
+++ b/elements/src/plugins/chart/index.ts
@@ -5,6 +5,7 @@ import { ChartRenderer } from "./component";
  * This plugin renders charts using json-render format.
  */
 export const chart: Plugin = {
+  id: "chart",
   language: "chart",
   prompt: `WHEN TO USE CHARTS:
 Create charts to visualize numerical data when it helps users understand patterns, trends, or comparisons. Use the 'chart' code block format.

--- a/elements/src/plugins/generative-ui/index.ts
+++ b/elements/src/plugins/generative-ui/index.ts
@@ -6,6 +6,7 @@ import { GenerativeUIRenderer } from "./component";
  * Use the language identifier 'ui' or 'json-render' in code blocks.
  */
 export const generativeUI: Plugin = {
+  id: "generative-ui",
   language: "ui",
   prompt: `Render structured data as visual UI using \`\`\`ui code blocks with valid JSON.
 

--- a/elements/src/plugins/index.test.ts
+++ b/elements/src/plugins/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { recommended } from "./index";
+import { recommended, type Plugin } from "./index";
 import { chart } from "./chart";
 import { generativeUI } from "./generative-ui";
 
@@ -36,6 +36,21 @@ describe("recommended.except", () => {
   it("returns all plugins when called with no arguments", () => {
     const result = recommended.except();
     expect(result).toHaveLength(2);
+  });
+
+  it("is assignable to Plugin[] for backwards compatibility", () => {
+    // Consumers may have typed variables as Plugin[]
+    const plugins: Plugin[] = recommended.except("chart");
+    expect(plugins).toHaveLength(1);
+
+    // Spread into a plain array
+    const spread: Plugin[] = [...recommended];
+    expect(spread).toHaveLength(2);
+
+    // Nullish coalescing fallback (common pattern in ElementsProvider)
+    const config: { plugins?: Plugin[] } = {};
+    const resolved = config.plugins ?? recommended;
+    expect(resolved).toHaveLength(2);
   });
 
   it("does not match on language when id is set", () => {

--- a/elements/src/plugins/index.test.ts
+++ b/elements/src/plugins/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { recommended } from "./index";
+import { chart } from "./chart";
+import { generativeUI } from "./generative-ui";
+
+describe("recommended", () => {
+  it("contains chart and generative-ui plugins", () => {
+    expect(recommended).toHaveLength(2);
+    expect(recommended).toContain(chart);
+    expect(recommended).toContain(generativeUI);
+  });
+
+  it("is usable as a plain array", () => {
+    const ids = recommended.map((p) => p.id);
+    expect(ids).toEqual(["chart", "generative-ui"]);
+  });
+});
+
+describe("recommended.except", () => {
+  it("excludes a plugin by id", () => {
+    const result = recommended.except("generative-ui");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(chart);
+  });
+
+  it("excludes multiple plugins", () => {
+    const result = recommended.except("chart", "generative-ui");
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns all plugins when no ids match", () => {
+    const result = recommended.except("nonexistent");
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns all plugins when called with no arguments", () => {
+    const result = recommended.except();
+    expect(result).toHaveLength(2);
+  });
+
+  it("does not match on language when id is set", () => {
+    // generative-ui has id="generative-ui" and language="ui"
+    // Excluding by language value "ui" should not match because id takes precedence
+    const result = recommended.except("ui");
+    expect(result).toHaveLength(2);
+  });
+});

--- a/elements/src/plugins/index.ts
+++ b/elements/src/plugins/index.ts
@@ -2,7 +2,20 @@ import type { Plugin } from "@/types/plugins";
 import { chart } from "./chart";
 import { generativeUI } from "./generative-ui";
 
-export const recommended: Plugin[] = [chart, generativeUI];
+export type PluginList = Plugin[] & {
+  except(...ids: string[]): Plugin[];
+};
+
+function createPluginList(plugins: Plugin[]): PluginList {
+  const arr = [...plugins] as PluginList;
+  arr.except = (...ids: string[]) => {
+    const excluded = new Set(ids);
+    return arr.filter((p) => !excluded.has(p.id ?? p.language));
+  };
+  return arr;
+}
+
+export const recommended: PluginList = createPluginList([chart, generativeUI]);
 export { chart } from "./chart";
 export { generativeUI } from "./generative-ui";
 

--- a/elements/src/types/plugins.ts
+++ b/elements/src/types/plugins.ts
@@ -16,6 +16,12 @@ import { ComponentType } from "react";
  */
 export interface Plugin {
   /**
+   * Unique identifier for the plugin. Used by `recommended.except()` to
+   * selectively exclude plugins. Defaults to `language` if not set.
+   */
+  id?: string;
+
+  /**
    * Any prompt that the plugin may need to add to the system prompt.
    * Will be appended to the built-in system prompt.
    *


### PR DESCRIPTION
## Summary
- Add AI Insights sidebar to the org Audit Logs page, gated behind `org:read` RBAC scope
- Include audit log HTTP tool URNs (`gram_list_audit_logs`, `gram_list_audit_log_facets`) in the MCP Logs seed toolset so the AI can query real audit data
- Filter tools to only audit, logs, and tool_calls — no unrelated tools exposed
- Feed current dashboard state (filters, date range, log count) as context to the AI
- Add `Plugin.id` field and `recommended.except()` helper to Elements plugin system for selective plugin exclusion (disables generative-ui for audit insights, keeps charts)

## Test plan
- [ ] Open audit logs page → InsightsTrigger button appears in breadcrumb bar
- [ ] Click trigger → sidebar opens with audit-specific welcome message and suggestions
- [ ] Ask AI about recent changes → uses `gram_list_audit_logs` tool (not hallucinated)
- [ ] Verify `recommended.except("generative-ui")` excludes generative-ui but keeps chart plugin
- [ ] User without `org:read` scope → no insights trigger shown
- [ ] Org with no projects → no insights trigger shown (needs project for session auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)