### PR TITLE
fix: chart legend clipping, keyboard shortcuts in shadow DOM, asset ID wrapping

### DIFF
--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -438,7 +438,11 @@ export const LogsTabContent = ({
     const handleKeyDown = (e: KeyboardEvent) => {
       // Check if the logs container or its children are focused
       const logsContainer = logsContainerRef.current;
-      const activeElement = document.activeElement;
+      // Walk through shadow roots to find the real focused element
+      let activeElement: Element | null = document.activeElement;
+      while (activeElement?.shadowRoot?.activeElement) {
+        activeElement = activeElement.shadowRoot.activeElement;
+      }
       const isWithinLogsSection = logsContainer?.contains(
         activeElement as Node,
       );
@@ -472,7 +476,11 @@ export const LogsTabContent = ({
         return;
       }
 
-      const isInInput = document.activeElement?.tagName === "INPUT";
+      const isInInput =
+        activeElement?.tagName === "INPUT" ||
+        activeElement?.tagName === "TEXTAREA" ||
+        activeElement?.tagName === "SELECT" ||
+        activeElement?.closest("[contenteditable]") !== null;
       if (!isInInput) {
         switch (e.key) {
           case "/": {

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -186,7 +186,10 @@ function renderSubject(log: AuditLog, orgSlug: string) {
     return (
       <SimpleTooltip tooltip={subjectLabel}>
         <span
-          className={cn(monoClass, "inline-block max-w-[34ch] align-bottom")}
+          className={cn(
+            monoClass,
+            "inline-block max-w-[34ch] truncate align-bottom",
+          )}
         >
           {truncateMiddle(subjectLabel)}
         </span>
@@ -882,7 +885,11 @@ export function OrgAuditLogsInner() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const logsContainer = logsContainerRef.current;
-      const activeElement = document.activeElement;
+      // Walk through shadow roots to find the real focused element
+      let activeElement = document.activeElement;
+      while (activeElement?.shadowRoot?.activeElement) {
+        activeElement = activeElement.shadowRoot.activeElement;
+      }
       const isWithinLogsSection = logsContainer?.contains(
         activeElement as Node,
       );
@@ -918,7 +925,8 @@ export function OrgAuditLogsInner() {
       const isInInput =
         activeElement?.tagName === "INPUT" ||
         activeElement?.tagName === "TEXTAREA" ||
-        activeElement?.tagName === "SELECT";
+        activeElement?.tagName === "SELECT" ||
+        activeElement?.closest("[contenteditable]") !== null;
       if (!isInInput) {
         switch (e.key) {
           case "/": {

--- a/elements/src/plugins/chart/ui/bar-chart.tsx
+++ b/elements/src/plugins/chart/ui/bar-chart.tsx
@@ -58,6 +58,14 @@ export const BarChart: FC<BarChartProps> = ({
 }) => {
   const isHorizontal = layout === "horizontal";
 
+  // Estimate YAxis width from longest label to prevent clipping
+  const yAxisWidth = isHorizontal
+    ? Math.max(
+        80,
+        Math.min(200, Math.max(...data.map((d) => d.label.length)) * 7 + 16),
+      )
+    : undefined;
+
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       {title && (
@@ -87,7 +95,7 @@ export const BarChart: FC<BarChartProps> = ({
                 <YAxis
                   dataKey="label"
                   type="category"
-                  width={80}
+                  width={yAxisWidth}
                   tick={{ fill: "var(--foreground)", fontSize: 12 }}
                   axisLine={{ stroke: "var(--border)" }}
                   tickLine={{ stroke: "var(--border)" }}


### PR DESCRIPTION
## Summary
- **Chart legend clipping**: Dynamic YAxis width in horizontal bar charts based on longest label length (was hardcoded 80px, causing email addresses to be cut off)
- **Keyboard shortcuts in shadow DOM**: `j`/`k`/`g` navigation keybinds were intercepting keystrokes in the Elements AI Insights chat composer because `document.activeElement` doesn't pierce Shadow DOM boundaries — now recursively walks shadow roots to find the real focused element
- **Asset ID wrapping**: Added `truncate` to asset ID spans in audit logs to prevent line-break at hyphens in filenames like `functions-asset...zip`

## Test plan
- [ ] Open audit logs page with AI Insights sidebar open — type `j`, `k`, `g` in chat composer and verify they appear as text (not triggering log navigation)
- [ ] View a horizontal bar chart with long labels (e.g. email addresses) — verify labels are fully visible
- [ ] View audit log entries with asset subjects — verify asset IDs don't wrap mid-word