### PR TITLE
mig: drop unique constraint on principal_grants resource column

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1775,8 +1775,7 @@ CREATE TABLE IF NOT EXISTS principal_grants (
 
   CONSTRAINT principal_grants_pkey PRIMARY KEY (id),
   CONSTRAINT principal_grants_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT principal_grants_selectors_check CHECK (selectors IS NULL OR jsonb_typeof(selectors) = 'object'),
-  CONSTRAINT principal_grants_org_principal_scope_resource_key UNIQUE (organization_id, principal_urn, scope, resource)
+  CONSTRAINT principal_grants_selectors_check CHECK (selectors IS NULL OR jsonb_typeof(selectors) = 'object')
 );
 
 COMMENT ON TABLE principal_grants IS 'RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource=''*'' means unrestricted. Selectors can further constrain applicability.';

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -17,13 +17,11 @@ FROM principal_grants
 WHERE organization_id = @organization_id
   AND principal_urn = ANY(@principal_urns::text[]);
 
--- name: UpsertPrincipalGrant :one
--- Creates or updates a single grant row. On conflict (same org/principal/scope/resource),
--- the updated_at timestamp is refreshed. Returns the full row.
+-- name: InsertPrincipalGrant :one
+-- Inserts a single grant row. Callers (SyncGrants) delete-then-insert
+-- within a transaction, so duplicates should not occur.
 INSERT INTO principal_grants (organization_id, principal_urn, scope, resource)
 VALUES (@organization_id, @principal_urn, @scope, @resource)
-ON CONFLICT (organization_id, principal_urn, scope, resource)
-DO UPDATE SET updated_at = clock_timestamp()
 RETURNING id, organization_id, principal_urn, principal_type, scope, resource, created_at, updated_at;
 
 -- name: DeletePrincipalGrant :execrows

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -122,6 +122,53 @@ func (q *Queries) GetPrincipalGrants(ctx context.Context, arg GetPrincipalGrants
 	return items, nil
 }
 
+const insertPrincipalGrant = `-- name: InsertPrincipalGrant :one
+INSERT INTO principal_grants (organization_id, principal_urn, scope, resource)
+VALUES ($1, $2, $3, $4)
+RETURNING id, organization_id, principal_urn, principal_type, scope, resource, created_at, updated_at
+`
+
+type InsertPrincipalGrantParams struct {
+	OrganizationID string
+	PrincipalUrn   urn.Principal
+	Scope          string
+	Resource       string
+}
+
+type InsertPrincipalGrantRow struct {
+	ID             uuid.UUID
+	OrganizationID string
+	PrincipalUrn   urn.Principal
+	PrincipalType  string
+	Scope          string
+	Resource       string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
+// Inserts a single grant row. Callers (SyncGrants) delete-then-insert
+// within a transaction, so duplicates should not occur.
+func (q *Queries) InsertPrincipalGrant(ctx context.Context, arg InsertPrincipalGrantParams) (InsertPrincipalGrantRow, error) {
+	row := q.db.QueryRow(ctx, insertPrincipalGrant,
+		arg.OrganizationID,
+		arg.PrincipalUrn,
+		arg.Scope,
+		arg.Resource,
+	)
+	var i InsertPrincipalGrantRow
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.PrincipalUrn,
+		&i.PrincipalType,
+		&i.Scope,
+		&i.Resource,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listPrincipalGrantsByOrg = `-- name: ListPrincipalGrantsByOrg :many
 
 SELECT id, organization_id, principal_urn, principal_type, scope, resource, created_at, updated_at
@@ -198,53 +245,4 @@ func (q *Queries) RemoveResourceFromGrants(ctx context.Context, arg RemoveResour
 		return 0, err
 	}
 	return result.RowsAffected(), nil
-}
-
-const upsertPrincipalGrant = `-- name: UpsertPrincipalGrant :one
-INSERT INTO principal_grants (organization_id, principal_urn, scope, resource)
-VALUES ($1, $2, $3, $4)
-ON CONFLICT (organization_id, principal_urn, scope, resource)
-DO UPDATE SET updated_at = clock_timestamp()
-RETURNING id, organization_id, principal_urn, principal_type, scope, resource, created_at, updated_at
-`
-
-type UpsertPrincipalGrantParams struct {
-	OrganizationID string
-	PrincipalUrn   urn.Principal
-	Scope          string
-	Resource       string
-}
-
-type UpsertPrincipalGrantRow struct {
-	ID             uuid.UUID
-	OrganizationID string
-	PrincipalUrn   urn.Principal
-	PrincipalType  string
-	Scope          string
-	Resource       string
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
-}
-
-// Creates or updates a single grant row. On conflict (same org/principal/scope/resource),
-// the updated_at timestamp is refreshed. Returns the full row.
-func (q *Queries) UpsertPrincipalGrant(ctx context.Context, arg UpsertPrincipalGrantParams) (UpsertPrincipalGrantRow, error) {
-	row := q.db.QueryRow(ctx, upsertPrincipalGrant,
-		arg.OrganizationID,
-		arg.PrincipalUrn,
-		arg.Scope,
-		arg.Resource,
-	)
-	var i UpsertPrincipalGrantRow
-	err := row.Scan(
-		&i.ID,
-		&i.OrganizationID,
-		&i.PrincipalUrn,
-		&i.PrincipalType,
-		&i.Scope,
-		&i.Resource,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
 }

--- a/server/internal/access/setup_internal_test.go
+++ b/server/internal/access/setup_internal_test.go
@@ -47,7 +47,7 @@ func seedInternalOrganization(t *testing.T, ctx context.Context, conn *pgxpool.P
 func seedInternalGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, principal urn.Principal, scope string, resource string) {
 	t.Helper()
 
-	_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+	_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          scope,

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -110,7 +110,7 @@ func seedOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, org
 func seedGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, principal urn.Principal, scope authz.Scope, resource string) {
 	t.Helper()
 
-	_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+	_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(scope),

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -107,7 +107,7 @@ func SyncGrants(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, orgI
 		}
 
 		if grant.Resources == nil {
-			if _, err := q.UpsertPrincipalGrant(ctx, repo.UpsertPrincipalGrantParams{
+			if _, err := q.InsertPrincipalGrant(ctx, repo.InsertPrincipalGrantParams{
 				OrganizationID: orgID,
 				PrincipalUrn:   principalURN,
 				Scope:          grant.Scope,
@@ -120,7 +120,7 @@ func SyncGrants(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, orgI
 		}
 
 		for _, resource := range grant.Resources {
-			if _, err := q.UpsertPrincipalGrant(ctx, repo.UpsertPrincipalGrantParams{
+			if _, err := q.InsertPrincipalGrant(ctx, repo.InsertPrincipalGrantParams{
 				OrganizationID: orgID,
 				PrincipalUrn:   principalURN,
 				Scope:          grant.Scope,

--- a/server/internal/authz/setup_test.go
+++ b/server/internal/authz/setup_test.go
@@ -79,7 +79,7 @@ func seedOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, org
 func seedGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, principal urn.Principal, scope Scope, resource string) {
 	t.Helper()
 
-	_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+	_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(scope),

--- a/server/internal/keys/setup_test.go
+++ b/server/internal/keys/setup_test.go
@@ -100,7 +100,7 @@ func withDefaultOrgAdminGrant(t *testing.T, ctx context.Context, conn *pgxpool.P
 	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "keys-default-grants-"+uuid.NewString())
-	_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+	_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(authz.ScopeOrgAdmin),

--- a/server/internal/plugins/setup_test.go
+++ b/server/internal/plugins/setup_test.go
@@ -126,7 +126,7 @@ func withauthzGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, gran
 
 	userPrincipal := urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)
 	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 			OrganizationID: authCtx.ActiveOrganizationID,
 			PrincipalUrn:   userPrincipal,
 			Scope:          string(grant.Scope),

--- a/server/internal/projects/setup_test.go
+++ b/server/internal/projects/setup_test.go
@@ -138,7 +138,7 @@ func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 func seedGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, principal urn.Principal, scope authz.Scope, resource string) {
 	t.Helper()
 
-	_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+	_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(scope),

--- a/server/internal/remotemcp/setup_test.go
+++ b/server/internal/remotemcp/setup_test.go
@@ -95,7 +95,7 @@ func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 
 	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "remotemcp-rbac-grants-"+uuid.NewString())
 	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 			OrganizationID: authCtx.ActiveOrganizationID,
 			PrincipalUrn:   principal,
 			Scope:          string(grant.Scope),

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -112,7 +112,7 @@ func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 
 	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "risk-rbac-grants-"+uuid.NewString())
 	for _, grant := range grants {
-		_, err := accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		_, err := accessrepo.New(conn).InsertPrincipalGrant(ctx, accessrepo.InsertPrincipalGrantParams{
 			OrganizationID: authCtx.ActiveOrganizationID,
 			PrincipalUrn:   principal,
 			Scope:          string(grant.Scope),

--- a/server/migrations/20260424100001_drop-grant-resource-unique.sql
+++ b/server/migrations/20260424100001_drop-grant-resource-unique.sql
@@ -1,0 +1,5 @@
+-- Drop the old composite unique constraint that prevents multiple selectors
+-- with the same resource_id (e.g. two tools on the same MCP server).
+-- The selectors JSONB column is now the source of truth for grant identity.
+ALTER TABLE principal_grants
+  DROP CONSTRAINT IF EXISTS principal_grants_org_principal_scope_resource_key;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:z8Najw4t8dwFjzDM2Vg/iGhVG5y/dU+nLTWZAlWya+M=
+h1:007DgYsFrNHrWl1o2W39de+p4C8mp1zbmAGlv+M05OA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -138,3 +138,4 @@ h1:z8Najw4t8dwFjzDM2Vg/iGhVG5y/dU+nLTWZAlWya+M=
 20260423100002_external-mcp-tool-definitions-tool-urn-idx.sql h1:4gyE/U5pj1jyYV3i8b0jLsYaUK8/8Cv1pzllNVOpBNA=
 20260423131344_functions-machine-specs.sql h1:s3h0Cn9yFq8bAUsknM3Mdt+y5PmGDW9LjxDncy9u6fM=
 20260424000001_plugin-github-connections.sql h1:ZQ3SVGPTDCTQQ4yekOw0ulg6CIi5PDeCoUP6W8ID/B0=
+20260424100001_drop-grant-resource-unique.sql h1:pBZbAEJ77hCRvWPpZ34hNYFVksgIifpjPcRaSW0QzZM=


### PR DESCRIPTION
## Summary
- Drop `principal_grants_org_principal_scope_resource_key` unique constraint
- Multiple selectors can now share the same `resource_id` (e.g. two tools on same MCP server)
- Prerequisite for `feat/selector-grants` which uses JSONB selectors as source of truth

