### PR TITLE
mig: add selector-based unique constraint on principal_grants

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1791,7 +1791,7 @@ ON principal_grants (organization_id, principal_urn, scope, selectors)
 WHERE selectors IS NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_unrestricted_key
-ON principal_grants (organization_id, principal_urn, scope)
+ON principal_grants (organization_id, principal_urn, scope, resource)
 WHERE selectors IS NULL;
 
 CREATE INDEX IF NOT EXISTS principal_grants_selectors_idx

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1786,6 +1786,14 @@ COMMENT ON COLUMN principal_grants.scope IS 'The scope being granted, e.g. "buil
 COMMENT ON COLUMN principal_grants.resource IS '''*'' = unrestricted (scope applies to all resources in the org). Any other value = a specific resource ID this scope is granted on.';
 COMMENT ON COLUMN principal_grants.selectors IS 'Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.';
 
+CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_selector_key
+ON principal_grants (organization_id, principal_urn, scope, selectors)
+WHERE selectors IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_unrestricted_key
+ON principal_grants (organization_id, principal_urn, scope)
+WHERE selectors IS NULL;
+
 CREATE INDEX IF NOT EXISTS principal_grants_selectors_idx
 ON principal_grants
 USING GIN (selectors)

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -18,10 +18,12 @@ WHERE organization_id = @organization_id
   AND principal_urn = ANY(@principal_urns::text[]);
 
 -- name: InsertPrincipalGrant :one
--- Inserts a single grant row. Callers (SyncGrants) delete-then-insert
--- within a transaction, so duplicates should not occur.
+-- Inserts a single grant row. On conflict (same org/principal/scope/resource
+-- with no selectors), returns the existing row unchanged.
 INSERT INTO principal_grants (organization_id, principal_urn, scope, resource)
 VALUES (@organization_id, @principal_urn, @scope, @resource)
+ON CONFLICT (organization_id, principal_urn, scope, resource) WHERE selectors IS NULL
+DO UPDATE SET updated_at = principal_grants.updated_at
 RETURNING id, organization_id, principal_urn, principal_type, scope, resource, created_at, updated_at;
 
 -- name: DeletePrincipalGrant :execrows

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -125,6 +125,8 @@ func (q *Queries) GetPrincipalGrants(ctx context.Context, arg GetPrincipalGrants
 const insertPrincipalGrant = `-- name: InsertPrincipalGrant :one
 INSERT INTO principal_grants (organization_id, principal_urn, scope, resource)
 VALUES ($1, $2, $3, $4)
+ON CONFLICT (organization_id, principal_urn, scope, resource) WHERE selectors IS NULL
+DO UPDATE SET updated_at = principal_grants.updated_at
 RETURNING id, organization_id, principal_urn, principal_type, scope, resource, created_at, updated_at
 `
 
@@ -146,8 +148,8 @@ type InsertPrincipalGrantRow struct {
 	UpdatedAt      pgtype.Timestamptz
 }
 
-// Inserts a single grant row. Callers (SyncGrants) delete-then-insert
-// within a transaction, so duplicates should not occur.
+// Inserts a single grant row. On conflict (same org/principal/scope/resource
+// with no selectors), returns the existing row unchanged.
 func (q *Queries) InsertPrincipalGrant(ctx context.Context, arg InsertPrincipalGrantParams) (InsertPrincipalGrantRow, error) {
 	row := q.db.QueryRow(ctx, insertPrincipalGrant,
 		arg.OrganizationID,

--- a/server/migrations/20260424100002_grant-selector-unique.sql
+++ b/server/migrations/20260424100002_grant-selector-unique.sql
@@ -1,0 +1,14 @@
+-- atlas:txmode none
+
+-- Add new unique constraints keyed on selectors instead of the old resource column.
+-- Two partial indexes: one for rows with selectors, one for unrestricted (NULL) rows.
+
+-- Rows WITH selectors: unique on full (org, principal, scope, selectors) tuple.
+CREATE UNIQUE INDEX CONCURRENTLY principal_grants_org_principal_scope_selector_key
+ON principal_grants (organization_id, principal_urn, scope, selectors)
+WHERE selectors IS NOT NULL;
+
+-- Rows WITHOUT selectors (unrestricted): unique on (org, principal, scope).
+CREATE UNIQUE INDEX CONCURRENTLY principal_grants_org_principal_scope_unrestricted_key
+ON principal_grants (organization_id, principal_urn, scope)
+WHERE selectors IS NULL;

--- a/server/migrations/20260424100002_grant-selector-unique.sql
+++ b/server/migrations/20260424100002_grant-selector-unique.sql
@@ -8,7 +8,10 @@ CREATE UNIQUE INDEX CONCURRENTLY principal_grants_org_principal_scope_selector_k
 ON principal_grants (organization_id, principal_urn, scope, selectors)
 WHERE selectors IS NOT NULL;
 
--- Rows WITHOUT selectors (unrestricted): unique on (org, principal, scope).
+-- Rows WITHOUT selectors (unrestricted): unique on (org, principal, scope, resource).
+-- Includes resource for backward compatibility — current code inserts multiple rows
+-- per scope with different resource values. A later migration will drop resource
+-- once all grants use selectors instead.
 CREATE UNIQUE INDEX CONCURRENTLY principal_grants_org_principal_scope_unrestricted_key
-ON principal_grants (organization_id, principal_urn, scope)
+ON principal_grants (organization_id, principal_urn, scope, resource)
 WHERE selectors IS NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:pnk2UppgqEwZo+jm/aa+slMHyg33+oUCpiN2z270mtE=
+h1:GT0DZFDAftSSXdPGkZhPO9cXcNFk5zzeb/311151rIc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -139,4 +139,4 @@ h1:pnk2UppgqEwZo+jm/aa+slMHyg33+oUCpiN2z270mtE=
 20260423131344_functions-machine-specs.sql h1:s3h0Cn9yFq8bAUsknM3Mdt+y5PmGDW9LjxDncy9u6fM=
 20260424000001_plugin-github-connections.sql h1:ZQ3SVGPTDCTQQ4yekOw0ulg6CIi5PDeCoUP6W8ID/B0=
 20260424100001_drop-grant-resource-unique.sql h1:pBZbAEJ77hCRvWPpZ34hNYFVksgIifpjPcRaSW0QzZM=
-20260424100002_grant-selector-unique.sql h1:haU98y14+S52VeMbm77aMSllmtV7a5swhayBilbj3uo=
+20260424100002_grant-selector-unique.sql h1:Aw0DO1C6Gxp1t8kcQrr21X9aK+YhgUpmQyqAx0NJTC4=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:007DgYsFrNHrWl1o2W39de+p4C8mp1zbmAGlv+M05OA=
+h1:pnk2UppgqEwZo+jm/aa+slMHyg33+oUCpiN2z270mtE=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -139,3 +139,4 @@ h1:007DgYsFrNHrWl1o2W39de+p4C8mp1zbmAGlv+M05OA=
 20260423131344_functions-machine-specs.sql h1:s3h0Cn9yFq8bAUsknM3Mdt+y5PmGDW9LjxDncy9u6fM=
 20260424000001_plugin-github-connections.sql h1:ZQ3SVGPTDCTQQ4yekOw0ulg6CIi5PDeCoUP6W8ID/B0=
 20260424100001_drop-grant-resource-unique.sql h1:pBZbAEJ77hCRvWPpZ34hNYFVksgIifpjPcRaSW0QzZM=
+20260424100002_grant-selector-unique.sql h1:haU98y14+S52VeMbm77aMSllmtV7a5swhayBilbj3uo=


### PR DESCRIPTION
## Summary

Adds two partial unique indexes on `principal_grants` to replace the old `(org, principal, scope, resource)` unique constraint (dropped in #2410):

- **`principal_grants_org_principal_scope_selector_key`** — `(organization_id, principal_urn, scope, selectors) WHERE selectors IS NOT NULL` — prevents duplicate selector-based grants.
- **`principal_grants_org_principal_scope_unrestricted_key`** — `(organization_id, principal_urn, scope, resource) WHERE selectors IS NULL` — prevents duplicate unrestricted grants. Includes `resource` for backward compatibility with current code that inserts multiple rows per scope with different resource values. A later migration will drop `resource` once all grants use JSONB selectors.

Both indexes are created `CONCURRENTLY` (with `atlas:txmode none`) to avoid locking the table in production.

## Why two partial indexes?

PostgreSQL `NULL` semantics mean a single B-tree index can't enforce uniqueness for both NULL and non-NULL `selectors` values. Two partial indexes cover both cases cleanly.

## Test plan

- [x] `server-build-lint` passes
- [x] `server-test` passes (all 2449 tests)
- [x] `Lint migrations with Atlas` passes
- [x] `Push migrations to Atlas Registry` passes