### PR TITLE
feat: show published GitHub repo URL on plugins page

### DIFF
--- a/.changeset/plugins-show-repo-url.md
+++ b/.changeset/plugins-show-repo-url.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Show the published GitHub repo URL on the plugins page, and include it in the publish success toast.

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -42,10 +42,17 @@ export default function Plugins() {
   const { data: publishStatus } = usePublishStatusSuspense();
 
   const publishMutation = usePublishPluginsMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
       setIsPublishDialogOpen(false);
       invalidateAllPublishStatus(queryClient);
-      toast.success("Plugins published to GitHub");
+      toast.success("Plugins published to GitHub", {
+        description: data.repoUrl,
+        action: {
+          label: "Open",
+          onClick: () =>
+            window.open(data.repoUrl, "_blank", "noopener,noreferrer"),
+        },
+      });
     },
     onError: () => {
       toast.error("Failed to publish plugins to GitHub");
@@ -187,34 +194,50 @@ export default function Plugins() {
           </Page.Section.Description>
           <Page.Section.CTA>
             {hasPlugins && (
-              <Stack direction="horizontal" gap={2}>
-                {publishStatus?.configured && (
-                  <Button
-                    variant="secondary"
-                    onClick={() => setIsPublishDialogOpen(true)}
-                    disabled={publishMutation.isPending}
-                  >
+              <Stack direction="vertical" gap={1} align="end">
+                <Stack direction="horizontal" gap={2}>
+                  {publishStatus?.configured && (
+                    <Button
+                      variant="secondary"
+                      onClick={() => setIsPublishDialogOpen(true)}
+                      disabled={publishMutation.isPending}
+                    >
+                      <Button.LeftIcon>
+                        <Icon
+                          name={
+                            publishStatus.connected ? "refresh-cw" : "upload"
+                          }
+                          className="h-4 w-4"
+                        />
+                      </Button.LeftIcon>
+                      <Button.Text>
+                        {publishMutation.isPending
+                          ? "Publishing..."
+                          : publishStatus.connected
+                            ? "Re-publish"
+                            : "Publish to GitHub"}
+                      </Button.Text>
+                    </Button>
+                  )}
+                  <Button onClick={() => setIsCreateDialogOpen(true)}>
                     <Button.LeftIcon>
-                      <Icon
-                        name={publishStatus.connected ? "refresh-cw" : "upload"}
-                        className="h-4 w-4"
-                      />
+                      <Plus className="h-4 w-4" />
                     </Button.LeftIcon>
-                    <Button.Text>
-                      {publishMutation.isPending
-                        ? "Publishing..."
-                        : publishStatus.connected
-                          ? "Re-publish"
-                          : "Publish to GitHub"}
-                    </Button.Text>
+                    <Button.Text>New Plugin</Button.Text>
                   </Button>
+                </Stack>
+                {publishStatus?.connected && publishStatus.repoUrl && (
+                  <a
+                    href={publishStatus.repoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-sky-500 hover:text-sky-600 hover:underline"
+                  >
+                    {publishStatus.repoOwner && publishStatus.repoName
+                      ? `${publishStatus.repoOwner}/${publishStatus.repoName}`
+                      : publishStatus.repoUrl}
+                  </a>
                 )}
-                <Button onClick={() => setIsCreateDialogOpen(true)}>
-                  <Button.LeftIcon>
-                    <Plus className="h-4 w-4" />
-                  </Button.LeftIcon>
-                  <Button.Text>New Plugin</Button.Text>
-                </Button>
               </Stack>
             )}
           </Page.Section.CTA>

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -226,18 +226,6 @@ export default function Plugins() {
                     <Button.Text>New Plugin</Button.Text>
                   </Button>
                 </Stack>
-                {publishStatus?.connected && publishStatus.repoUrl && (
-                  <a
-                    href={publishStatus.repoUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-sky-500 hover:text-sky-600 hover:underline"
-                  >
-                    {publishStatus.repoOwner && publishStatus.repoName
-                      ? `${publishStatus.repoOwner}/${publishStatus.repoName}`
-                      : publishStatus.repoUrl}
-                  </a>
-                )}
               </Stack>
             )}
           </Page.Section.CTA>
@@ -263,6 +251,21 @@ export default function Plugins() {
               </div>
             ) : (
               <>
+                {publishStatus?.connected && publishStatus.repoUrl && (
+                  <span>
+                    Plugin marketplace:{" "}
+                    <a
+                      href={publishStatus.repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-sky-500 hover:text-sky-600 hover:underline"
+                    >
+                      {publishStatus.repoOwner && publishStatus.repoName
+                        ? `${publishStatus.repoOwner}/${publishStatus.repoName}`
+                        : publishStatus.repoUrl}
+                    </a>
+                  </span>
+                )}
                 <Stack
                   direction="horizontal"
                   justify="space-between"


### PR DESCRIPTION
Surface repoUrl from the publish status query as a link under the publish button, and include it in the success toast with an "Open" action so users can jump straight to the published repo.
<img width="2576" height="709" alt="Screenshot 2026-04-24 at 1 59 31 PM" src="https://github.com/user-attachments/assets/fbcabb5c-56d8-43ed-87bc-4875bcb2d0e6" />
