### PR TITLE
mig: add presidio_entities column to risk_policies

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2053,6 +2053,7 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   enabled BOOLEAN NOT NULL DEFAULT TRUE,
   name TEXT NOT NULL,
   sources TEXT[] NOT NULL,
+  presidio_entities TEXT[],
   version BIGINT NOT NULL,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/migrations/20260424180558_risk-policies-presidio-entities.sql
+++ b/server/migrations/20260424180558_risk-policies-presidio-entities.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "presidio_entities" text[] NULL;

--- a/server/migrations/20260424180559_risk-policies-default-pii.sql
+++ b/server/migrations/20260424180559_risk-policies-default-pii.sql
@@ -1,0 +1,7 @@
+-- Enable PII scanning on all existing risk policies that only have gitleaks.
+UPDATE risk_policies
+SET sources = sources || '{presidio}'
+  , presidio_entities = '{PERSON,EMAIL_ADDRESS,PHONE_NUMBER,LOCATION,IP_ADDRESS,URL,MAC_ADDRESS,DATE_TIME,NRP}'
+  , version = version + 1
+WHERE NOT sources @> '{presidio}'
+  AND deleted IS FALSE;

--- a/server/migrations/20260424180559_risk-policies-default-pii.sql
+++ b/server/migrations/20260424180559_risk-policies-default-pii.sql
@@ -1,7 +1,7 @@
 -- Enable PII scanning on all existing risk policies that only have gitleaks.
 UPDATE risk_policies
 SET sources = sources || '{presidio}'
-  , presidio_entities = '{PERSON,EMAIL_ADDRESS,PHONE_NUMBER,LOCATION,IP_ADDRESS,URL,MAC_ADDRESS,DATE_TIME,NRP}'
+  , presidio_entities = '{PERSON,EMAIL_ADDRESS,PHONE_NUMBER,LOCATION,IP_ADDRESS,URL,MAC_ADDRESS,DATE_TIME,NRP,CREDIT_CARD,CRYPTO,IBAN_CODE,US_BANK_NUMBER,US_SSN,US_ITIN,US_PASSPORT,US_DRIVER_LICENSE,MEDICAL_LICENSE,UK_NHS}'
   , version = version + 1
 WHERE NOT sources @> '{presidio}'
   AND deleted IS FALSE;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:E4wru1NBRkyguBVwOuNNZB29mOZ725US+Xih3I+qM0I=
+h1:zhjPpLQP0rCWjTgqTDLBrQgfitT791MJ1R0wIv8uhQI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -138,3 +138,4 @@ h1:E4wru1NBRkyguBVwOuNNZB29mOZ725US+Xih3I+qM0I=
 20260423100002_external-mcp-tool-definitions-tool-urn-idx.sql h1:4gyE/U5pj1jyYV3i8b0jLsYaUK8/8Cv1pzllNVOpBNA=
 20260423131344_functions-machine-specs.sql h1:s3h0Cn9yFq8bAUsknM3Mdt+y5PmGDW9LjxDncy9u6fM=
 20260424180558_risk-policies-presidio-entities.sql h1:J2K6r/ugugOHgE4MtV0aJzi59x2WcQDdUcUgUyNEfUQ=
+20260424180559_risk-policies-default-pii.sql h1:Y65C/Ex0m8nIrW7C2IXpung3tJFTSox5HTY/gVPHvTM=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zhjPpLQP0rCWjTgqTDLBrQgfitT791MJ1R0wIv8uhQI=
+h1:lwl5YnT5hPTM1XdxBRmt1QrxjuGHP+d7UVNDxTmYm4s=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -138,4 +138,4 @@ h1:zhjPpLQP0rCWjTgqTDLBrQgfitT791MJ1R0wIv8uhQI=
 20260423100002_external-mcp-tool-definitions-tool-urn-idx.sql h1:4gyE/U5pj1jyYV3i8b0jLsYaUK8/8Cv1pzllNVOpBNA=
 20260423131344_functions-machine-specs.sql h1:s3h0Cn9yFq8bAUsknM3Mdt+y5PmGDW9LjxDncy9u6fM=
 20260424180558_risk-policies-presidio-entities.sql h1:J2K6r/ugugOHgE4MtV0aJzi59x2WcQDdUcUgUyNEfUQ=
-20260424180559_risk-policies-default-pii.sql h1:Y65C/Ex0m8nIrW7C2IXpung3tJFTSox5HTY/gVPHvTM=
+20260424180559_risk-policies-default-pii.sql h1:gnfxcIteTHTpr1bHJK3uguPLOW5fGSIHYV+Pt8R8Jn4=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0+6KapUbFYb/rxoRWr3V0kk5wWFiJHBn6EUkHyEdvbw=
+h1:E4wru1NBRkyguBVwOuNNZB29mOZ725US+Xih3I+qM0I=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -137,3 +137,4 @@ h1:0+6KapUbFYb/rxoRWr3V0kk5wWFiJHBn6EUkHyEdvbw=
 20260423100001_prompt-templates-project-tool-urn-idx.sql h1:5QTsAtHrIvT12QS2/OeICut3HlurbgiZfIJwouG/SQk=
 20260423100002_external-mcp-tool-definitions-tool-urn-idx.sql h1:4gyE/U5pj1jyYV3i8b0jLsYaUK8/8Cv1pzllNVOpBNA=
 20260423131344_functions-machine-specs.sql h1:s3h0Cn9yFq8bAUsknM3Mdt+y5PmGDW9LjxDncy9u6fM=
+20260424180558_risk-policies-presidio-entities.sql h1:J2K6r/ugugOHgE4MtV0aJzi59x2WcQDdUcUgUyNEfUQ=


### PR DESCRIPTION
## Why

Prerequisite for Presidio PII scanning in the risk analysis pipeline (#2396). Risk policies need a way to configure which PII entity types to scan for, and existing policies need to be backfilled with defaults.

## What changed

**Before:** `risk_policies` table has no concept of PII entity configuration.

**After:**
- New nullable `presidio_entities TEXT[]` column on `risk_policies`
- All existing non-deleted policies backfilled with `presidio` in sources and default entity types (`PERSON`, `EMAIL_ADDRESS`, `PHONE_NUMBER`, `LOCATION`, `IP_ADDRESS`, `URL`, `MAC_ADDRESS`, `DATE_TIME`, `NRP`)

## Test plan

- [ ] `Lint migrations with Atlas` passes
- [ ] `Push migrations to Atlas Registry` passes