### PR TITLE
chore(observability): log org slug in billing refresh failure errors

### DIFF
--- a/server/internal/background/activities/refresh_billing_usage.go
+++ b/server/internal/background/activities/refresh_billing_usage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sourcegraph/conc/pool"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -41,14 +42,21 @@ func (r *RefreshBillingUsage) Do(ctx context.Context, orgIDs []string) error {
 
 	for _, orgID := range orgIDs {
 		workers.Go(func() error {
+			orgLogger := r.logger.With(attr.SlogOrganizationID(orgID))
+
 			// significant to refresh polar related caching
-			if _, err := mv.DescribeOrganization(ctx, r.logger, r.orgRepo, r.billingRepo, orgID); err != nil {
+			org, err := mv.DescribeOrganization(ctx, r.logger, r.orgRepo, r.billingRepo, orgID)
+			if err != nil {
+				orgLogger.ErrorContext(ctx, "failed to describe organization", attr.SlogError(err))
 				return fmt.Errorf("failed to describe organization %s: %w", orgID, err)
 			}
 
+			orgLogger = orgLogger.With(attr.SlogOrganizationSlug(org.Slug))
+
 			// we refresh the period usage data store up to date at least hourly
 			if _, err := r.billingRepo.GetPeriodUsage(ctx, orgID); err != nil {
-				return fmt.Errorf("failed to get period usage for org %s: %w", orgID, err)
+				orgLogger.ErrorContext(ctx, "failed to get period usage", attr.SlogError(err))
+				return fmt.Errorf("failed to get period usage for org %s (%s): %w", org.Slug, orgID, err)
 			}
 
 			return nil


### PR DESCRIPTION
## Summary

- Adds `@gram.org.id` and `@gram.org.slug` structured slog attributes to per-org failures inside `RefreshBillingUsage.Do`
- Includes the slug in the wrapper error string (`failed to get period usage for org <slug> (<id>): ...`)
- Lets on-call pivot from a Datadog `Elevated temporal workflow failures` alert directly to `https://app.getgram.ai/<slug>`

## Motivation

The `Elevated temporal workflow failures in Gram` monitor recently fired on the nightly `RefreshBillingUsageWorkflow` because Polar returned a transient HTTP 502 for a single org's `tool call usage` endpoint. The retry storm tripped the `> 5/5min` threshold. Investigating it required pivoting from an org UUID → org name, but neither Datadog logs/spans nor PostHog events/groups carried that mapping, forcing a Postgres lookup.

This change adds the slug as a first-class structured field on every per-org failure log so future alerts surface the offending tenant without a DB round-trip.

## What changed

`server/internal/background/activities/refresh_billing_usage.go`:

- Per-org `slog.Logger` derived once per goroutine, scoped with `attr.SlogOrganizationID` and (after `DescribeOrganization` succeeds) `attr.SlogOrganizationSlug`.
- Distinct error logs at each failure point inside the goroutine — outer `oops.E(...).Log()` summary stays unchanged, so retry semantics are identical.
- Wrapper error string for `GetPeriodUsage` failure now includes both slug and UUID.

## What is unchanged

- Concurrency model (`pool.New().WithErrors().WithMaxGoroutines(25)`)
- Temporal retry behavior — a single per-org failure still fails the whole activity attempt and triggers SDK retries. A separate follow-up could isolate per-org Polar 5xx as logged-but-non-error to silence the monitor.

## Test plan

- [x] `mise build:server` — passes locally
- [ ] After deploy, confirm the next billing-refresh failure produces a Datadog log row with `@gram.org.slug:*` populated
- [ ] Confirm the existing outer `failed to refresh billing usage` log line still appears
- [ ] Verify the on-call query `service:gram-worker @gram.org.slug:* status:error "failed to get period usage"` returns rows when Polar 5xx happens
