### PR TITLE
fix(billing): reduce per-batch concurrency against Polar /quantities

### DIFF
--- a/.changeset/brave-paws-sparkle.md
+++ b/.changeset/brave-paws-sparkle.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Reduced per-batch concurrency against Polar /quantities

--- a/.changeset/yellow-kids-feel.md
+++ b/.changeset/yellow-kids-feel.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+reduce concurrency on polar meter requests

--- a/server/internal/background/activities/refresh_billing_usage.go
+++ b/server/internal/background/activities/refresh_billing_usage.go
@@ -37,7 +37,9 @@ func NewRefreshBillingUsage(logger *slog.Logger, db *pgxpool.Pool, billingRepo b
 // Send usage data to posthog for tracking purposes
 
 func (r *RefreshBillingUsage) Do(ctx context.Context, orgIDs []string) error {
-	workers := pool.New().WithErrors().WithMaxGoroutines(25)
+	// Polar's /quantities endpoint serializes work per-meter, so high client-side
+	// concurrency just queues requests and runs them into the activity timeout.
+	workers := pool.New().WithErrors().WithMaxGoroutines(5)
 
 	for _, orgID := range orgIDs {
 		workers.Go(func() error {

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -14,7 +14,7 @@ import (
 
 // safely wait for polar rate limits
 const (
-	refreshBillingUsageBatchSize     = 25
+	refreshBillingUsageBatchSize     = 5
 	refreshBillingUsagesWaitInterval = 10 * time.Second
 )
 


### PR DESCRIPTION
## Summary
- Drop `RefreshBillingUsage` activity per-batch worker count from 25 → 5 to stop saturating Polar's `/v1/meters/{id}/quantities` endpoint with concurrent requests against the same meter.

## Why
The hourly `RefreshBillingUsageWorkflow` has been failing on the first batch for at least 24h (Datadog monitor [274771871](https://app.datadoghq.com/monitors/274771871) — *Elevated temporal workflow failures in Gram*, sustained ~7/5m on `temporal_activity_execution_failed`). The Temporal failure event for a recent run shows **22 orgs in the same batch** failing with:

> `Get "https://api.polar.sh/v1/meters/7ec16f6d.../quantities?...": context deadline exceeded` / `net/http: request canceled (Client.Timeout exceeded while awaiting headers)`

The activity has a 60s `StartToCloseTimeout`, fires 25 concurrent requests against the *same* Polar meter, and Polar appears to serialize work per-meter. The requests queue up, run past the timeout, the whole batch errors, retries (max 3) all fail the same way, and the workflow ends with `RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED`.

Reducing concurrency to 5 should let each request actually finish inside the timeout. This is the minimal fix; longer-term improvements still worth doing separately:
- shorten the meter query window or use coarser `interval`,
- isolate per-org failures so one slow org doesn't fail the batch,
- log per-org errors inside `pool.Go` so they appear in `service:gram-worker` logs (currently Temporal is the only place the per-org errors show up).

The monitor threshold should also be bumped from `> 5` to `> 10` in the Datadog UI to give headroom while this rolls out (no IaC for it in the repo).

## Test plan
- [ ] CI passes (build/lint/tests).
- [ ] After deploy, watch `temporal_activity_execution_failed{namespace:gram-prod.dmx2k,activity_type:refreshbillingusage}` over the next 1–2 hourly runs and confirm the rate drops to 0.
- [ ] Confirm the workflow `v1:refresh-billing-usage-schedule/scheduled` completes successfully end-to-end in Temporal UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)