### PR TITLE
chore: replace GetToolsetByID with scoped variants

### DIFF
--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -432,15 +432,15 @@ func (s *Service) ListServers(ctx context.Context, payload *gen.ListServersPaylo
 }
 
 func (s *Service) attachServerToCollection(ctx context.Context, queries *repo.Queries, collectionID, toolsetID uuid.UUID, organizationID, userID string) error {
-	toolset, err := s.toolsets.GetToolsetByID(ctx, toolsetID)
+	toolset, err := s.toolsets.GetToolsetByIDAndOrganization(ctx, toolsetsRepo.GetToolsetByIDAndOrganizationParams{
+		ID:             toolsetID,
+		OrganizationID: organizationID,
+	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
 		return oops.E(oops.CodeUnexpected, err, "error accessing toolset").Log(ctx, s.logger)
-	}
-	if toolset.OrganizationID != organizationID {
-		return oops.C(oops.CodeNotFound)
 	}
 	if !toolset.McpEnabled || !toolset.McpSlug.Valid {
 		return oops.E(oops.CodeInvalid, nil, "cannot attach a toolset that is not enabled as an MCP server").Log(ctx, s.logger)

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -661,6 +661,14 @@ func (s *ExternalOAuthService) handleExternalDisconnect(w http.ResponseWriter, r
 		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
 	}
 
+	// Verify toolset belongs to caller's project before deleting the token
+	if _, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        toolsetID,
+		ProjectID: *authCtx.ProjectID,
+	}); err != nil {
+		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+	}
+
 	// Delete token
 	if err := s.oauthRepo.DeleteUserOAuthTokenByToolset(ctx, repo.DeleteUserOAuthTokenByToolsetParams{
 		UserID:         authCtx.UserID,

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -292,14 +292,12 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 	}
 
 	// Load toolset and verify user has access
-	toolset, err := s.toolsetsRepo.GetToolsetByID(ctx, toolsetID)
+	toolset, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        toolsetID,
+		ProjectID: *authCtx.ProjectID,
+	})
 	if err != nil {
 		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
-	}
-
-	// Verify user has access to this toolset's organization
-	if toolset.OrganizationID != authCtx.ActiveOrganizationID {
-		return oops.E(oops.CodeForbidden, nil, "access denied").Log(ctx, s.logger)
 	}
 
 	// Get external MCP OAuth configuration from toolset
@@ -425,7 +423,10 @@ func (s *ExternalOAuthService) handleExternalCallback(w http.ResponseWriter, r *
 	}
 
 	// Get OAuth config to get client credentials
-	toolset, err := s.toolsetsRepo.GetToolsetByID(ctx, state.ToolsetID)
+	toolset, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        state.ToolsetID,
+		ProjectID: state.ProjectID,
+	})
 	if err != nil {
 		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
 	}
@@ -578,14 +579,11 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 	}
 
 	// Load toolset to verify user has access
-	toolset, err := s.toolsetsRepo.GetToolsetByID(ctx, toolsetID)
-	if err != nil {
+	if _, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        toolsetID,
+		ProjectID: *authCtx.ProjectID,
+	}); err != nil {
 		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
-	}
-
-	// Verify user has access
-	if toolset.OrganizationID != authCtx.ActiveOrganizationID {
-		return oops.E(oops.CodeForbidden, nil, "access denied").Log(ctx, s.logger)
 	}
 
 	// Check if user has a token for this toolset

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -438,15 +438,15 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 	}
 
 	// Verify the toolset exists and belongs to the same project.
-	toolset, err := toolsetsrepo.New(s.db).GetToolsetByID(ctx, toolsetID)
+	toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
+		ID:        toolsetID,
+		ProjectID: *ac.ProjectID,
+	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeBadRequest, nil, "toolset not found")
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "verify toolset").Log(ctx, s.logger)
-	}
-	if toolset.ProjectID != *ac.ProjectID {
-		return nil, oops.E(oops.CodeBadRequest, nil, "toolset belongs to a different project")
 	}
 	if !toolset.McpEnabled || !toolset.McpSlug.Valid || toolset.McpSlug.String == "" {
 		return nil, oops.E(oops.CodeBadRequest, nil, "toolset does not have MCP enabled")

--- a/server/internal/thirdparty/slack/impl.go
+++ b/server/internal/thirdparty/slack/impl.go
@@ -542,12 +542,11 @@ func (s *Service) CreateSlackApp(ctx context.Context, payload *gen.CreateSlackAp
 		if err != nil {
 			return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset ID").Log(ctx, s.logger)
 		}
-		ts, err := s.toolsetRepo.GetToolsetByID(ctx, parsed)
-		if err != nil {
+		if _, err := s.toolsetRepo.GetToolsetByIDAndProject(ctx, toolset_repo.GetToolsetByIDAndProjectParams{
+			ID:        parsed,
+			ProjectID: *authCtx.ProjectID,
+		}); err != nil {
 			return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
-		}
-		if ts.ProjectID != *authCtx.ProjectID {
-			return nil, oops.E(oops.CodeNotFound, nil, "toolset not found").Log(ctx, s.logger)
 		}
 		toolsetIDs = append(toolsetIDs, tsID)
 	}

--- a/server/internal/toolsets/queries.sql
+++ b/server/internal/toolsets/queries.sql
@@ -3,10 +3,15 @@ SELECT *
 FROM toolsets
 WHERE slug = @slug AND project_id = @project_id AND deleted IS FALSE;
 
--- name: GetToolsetByID :one
+-- name: GetToolsetByIDAndProject :one
 SELECT *
 FROM toolsets
-WHERE id = @id AND deleted IS FALSE;
+WHERE id = @id AND project_id = @project_id AND deleted IS FALSE;
+
+-- name: GetToolsetByIDAndOrganization :one
+SELECT *
+FROM toolsets
+WHERE id = @id AND organization_id = @organization_id AND deleted IS FALSE;
 
 -- name: GetToolsetByMCPSlug :one
 -- project_id is required to ensure uniqueness since mcp_slug is only unique within a project

--- a/server/internal/toolsets/repo/queries.sql.go
+++ b/server/internal/toolsets/repo/queries.sql.go
@@ -558,14 +558,56 @@ func (q *Queries) GetToolset(ctx context.Context, arg GetToolsetParams) (Toolset
 	return i, err
 }
 
-const getToolsetByID = `-- name: GetToolsetByID :one
+const getToolsetByIDAndOrganization = `-- name: GetToolsetByIDAndOrganization :one
 SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
-WHERE id = $1 AND deleted IS FALSE
+WHERE id = $1 AND organization_id = $2 AND deleted IS FALSE
 `
 
-func (q *Queries) GetToolsetByID(ctx context.Context, id uuid.UUID) (Toolset, error) {
-	row := q.db.QueryRow(ctx, getToolsetByID, id)
+type GetToolsetByIDAndOrganizationParams struct {
+	ID             uuid.UUID
+	OrganizationID string
+}
+
+func (q *Queries) GetToolsetByIDAndOrganization(ctx context.Context, arg GetToolsetByIDAndOrganizationParams) (Toolset, error) {
+	row := q.db.QueryRow(ctx, getToolsetByIDAndOrganization, arg.ID, arg.OrganizationID)
+	var i Toolset
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.DefaultEnvironmentSlug,
+		&i.McpSlug,
+		&i.McpIsPublic,
+		&i.McpEnabled,
+		&i.ToolSelectionMode,
+		&i.CustomDomainID,
+		&i.ExternalOauthServerID,
+		&i.OauthProxyServerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
+const getToolsetByIDAndProject = `-- name: GetToolsetByIDAndProject :one
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, created_at, updated_at, deleted_at, deleted
+FROM toolsets
+WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
+`
+
+type GetToolsetByIDAndProjectParams struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+}
+
+func (q *Queries) GetToolsetByIDAndProject(ctx context.Context, arg GetToolsetByIDAndProjectParams) (Toolset, error) {
+	row := q.db.QueryRow(ctx, getToolsetByIDAndProject, arg.ID, arg.ProjectID)
 	var i Toolset
 	err := row.Scan(
 		&i.ID,


### PR DESCRIPTION
## Summary

Replace the unscoped `GetToolsetByID` query with two scoped variants and migrate all six call sites. Ownership enforcement moves from Go post-checks into SQL.

- `GetToolsetByIDAndProject` — used by the five sites where the caller has a project in scope (oauth external authorize/callback/status, plugins, slack apps).
- `GetToolsetByIDAndOrganization` — used by the collections site, which is organization-scoped by schema (`organization_mcp_collections` has no `project_id` column). Preserves existing behavior; forcing project scope here would have been a product change disallowing cross-project-within-org collection attachments.

Redundant `OrganizationID` / `ProjectID` post-checks are removed at each call site since SQL now enforces them.

Closes [AGE-1955](https://linear.app/speakeasy/issue/AGE-1955/replace-gettoolsetbyid-with-project-scoped-variant). #2412 will rebase on top of this and drop its temporary `GetToolsetByIDAndProject` definition.