### PR TITLE
feat: add glint lint rules for audit log event struct types

### DIFF
--- a/glint/audit_event_typed_snapshot.go
+++ b/glint/audit_event_typed_snapshot.go
@@ -1,0 +1,110 @@
+package glint
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	auditEventTypedSnapshotAnalyzer = "auditeventtypedsnapshot"
+	auditEventTypedSnapshotDoc      = "audit Log*Event SnapshotBefore/SnapshotAfter fields must use a typed Go type instead of any or interface{}"
+	auditEventTypedSnapshotMessage  = "use typed struct field type, such as *types.Example, instead of arbitrary typed data"
+)
+
+// auditPkgPathSuffix gates the audit-event lint rules to the audit package.
+// Suffix matching covers both the production import path and any analysistest
+// testdata layout that ends in server/internal/audit.
+const auditPkgPathSuffix = "server/internal/audit"
+
+type auditEventTypedSnapshotSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newAuditEventTypedSnapshotAnalyzer(rule auditEventTypedSnapshotSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: auditEventTypedSnapshotAnalyzer,
+		Doc:  auditEventTypedSnapshotDoc,
+		Run: func(pass *analysis.Pass) (any, error) {
+			if !strings.HasSuffix(pass.Pkg.Path(), auditPkgPathSuffix) {
+				return nil, nil
+			}
+
+			for _, file := range pass.Files {
+				for _, decl := range file.Decls {
+					genDecl, ok := decl.(*ast.GenDecl)
+					if !ok || genDecl.Tok != token.TYPE {
+						continue
+					}
+
+					for _, spec := range genDecl.Specs {
+						typeSpec, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+
+						if !isLogEventTypeName(typeSpec.Name.Name) {
+							continue
+						}
+
+						structType, ok := typeSpec.Type.(*ast.StructType)
+						if !ok {
+							continue
+						}
+
+						for _, field := range structType.Fields.List {
+							if !fieldHasSnapshotName(field) {
+								continue
+							}
+
+							fieldType := pass.TypesInfo.TypeOf(field.Type)
+							if !isEmptyInterface(fieldType) {
+								continue
+							}
+
+							pass.ReportRangef(field, "%s", auditEventTypedSnapshotMessage)
+						}
+					}
+				}
+			}
+
+			return nil, nil
+		},
+	}
+}
+
+// isLogEventTypeName reports whether a type name follows the audit Log*Event
+// convention (Log prefix, Event suffix, with at least one character between).
+func isLogEventTypeName(name string) bool {
+	return len(name) > len("LogEvent") && strings.HasPrefix(name, "Log") && strings.HasSuffix(name, "Event")
+}
+
+// fieldHasSnapshotName reports whether any of the field's declared names
+// contain SnapshotBefore or SnapshotAfter.
+func fieldHasSnapshotName(field *ast.Field) bool {
+	for _, name := range field.Names {
+		if strings.Contains(name.Name, "SnapshotBefore") || strings.Contains(name.Name, "SnapshotAfter") {
+			return true
+		}
+	}
+	return false
+}
+
+// isEmptyInterface reports whether the type is the bare empty interface
+// (`any` or `interface{}`). Named or anonymous interfaces with methods or
+// embedded type sets are not flagged.
+func isEmptyInterface(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+
+	iface, ok := t.Underlying().(*types.Interface)
+	if !ok {
+		return false
+	}
+
+	return iface.Empty()
+}

--- a/glint/audit_event_typed_snapshot_test.go
+++ b/glint/audit_event_typed_snapshot_test.go
@@ -1,0 +1,34 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAuditEventTypedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditEventTypedSnapshotAnalyzer(auditEventTypedSnapshotSettings{}), "auditeventtypedsnapshot/server/internal/audit")
+}
+
+func TestAuditEventTypedSnapshotSkipsNonAuditPackage(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditEventTypedSnapshotAnalyzer(auditEventTypedSnapshotSettings{}), "notaudit")
+}
+
+func TestBuildAnalyzersSkipsDisabledAuditEventTypedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+	p.settings.Rules.AuditEventTypedSnapshot.Disabled = false
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, auditEventTypedSnapshotAnalyzer, analyzers[0].Name)
+}

--- a/glint/audit_event_urn_naming.go
+++ b/glint/audit_event_urn_naming.go
@@ -1,0 +1,89 @@
+package glint
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	auditEventURNNamingAnalyzer = "auditeventurnnaming"
+	auditEventURNNamingDoc      = "audit Log*Event subject identifier fields must use URN naming and a URN type instead of an Id/ID suffix"
+	auditEventURNNamingMessage  = "use URN field naming and URN type instead of ID"
+)
+
+// auditEventURNNamingExemptFields are subject-identifier-shaped names that
+// are exempt from URN naming because they are not subject identifiers.
+// ProjectID and OrganizationID identify the audit row's scope, not its
+// subject. Matching is exact: subject ids that happen to share a suffix
+// (e.g. SourceProjectID) are not exempt.
+var auditEventURNNamingExemptFields = map[string]struct{}{
+	"ProjectID":      {},
+	"OrganizationID": {},
+}
+
+type auditEventURNNamingSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newAuditEventURNNamingAnalyzer(rule auditEventURNNamingSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: auditEventURNNamingAnalyzer,
+		Doc:  auditEventURNNamingDoc,
+		Run: func(pass *analysis.Pass) (any, error) {
+			if !strings.HasSuffix(pass.Pkg.Path(), auditPkgPathSuffix) {
+				return nil, nil
+			}
+
+			for _, file := range pass.Files {
+				for _, decl := range file.Decls {
+					genDecl, ok := decl.(*ast.GenDecl)
+					if !ok || genDecl.Tok != token.TYPE {
+						continue
+					}
+
+					for _, spec := range genDecl.Specs {
+						typeSpec, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+
+						if !isLogEventTypeName(typeSpec.Name.Name) {
+							continue
+						}
+
+						structType, ok := typeSpec.Type.(*ast.StructType)
+						if !ok {
+							continue
+						}
+
+						for _, field := range structType.Fields.List {
+							for _, name := range field.Names {
+								if _, exempt := auditEventURNNamingExemptFields[name.Name]; exempt {
+									continue
+								}
+
+								if !hasIDSuffix(name.Name) {
+									continue
+								}
+
+								pass.ReportRangef(name, "%s", auditEventURNNamingMessage)
+							}
+						}
+					}
+				}
+			}
+
+			return nil, nil
+		},
+	}
+}
+
+// hasIDSuffix reports whether a field name ends in either Id or ID. Suffix
+// matching avoids false positives on names that contain "Id" elsewhere
+// (e.g. Identifier).
+func hasIDSuffix(name string) bool {
+	return strings.HasSuffix(name, "ID") || strings.HasSuffix(name, "Id")
+}

--- a/glint/audit_event_urn_naming_test.go
+++ b/glint/audit_event_urn_naming_test.go
@@ -1,0 +1,34 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAuditEventURNNaming(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditEventURNNamingAnalyzer(auditEventURNNamingSettings{}), "auditeventurnnaming/server/internal/audit")
+}
+
+func TestAuditEventURNNamingSkipsNonAuditPackage(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditEventURNNamingAnalyzer(auditEventURNNamingSettings{}), "notaudit")
+}
+
+func TestBuildAnalyzersSkipsDisabledAuditEventURNNaming(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+	p.settings.Rules.AuditEventURNNaming.Disabled = false
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, auditEventURNNamingAnalyzer, analyzers[0].Name)
+}

--- a/glint/audit_event_urn_typing.go
+++ b/glint/audit_event_urn_typing.go
@@ -1,0 +1,112 @@
+package glint
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	auditEventURNTypingAnalyzer = "auditeventurntyping"
+	auditEventURNTypingDoc      = "audit Log*Event URN-named fields must use a type from server/internal/urn"
+	auditEventURNTypingMessage  = "use server/internal/urn type"
+)
+
+// urnPkgPathSuffix matches both the production import path of the URN package
+// and any analysistest layout that ends in server/internal/urn.
+const urnPkgPathSuffix = "server/internal/urn"
+
+type auditEventURNTypingSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newAuditEventURNTypingAnalyzer(rule auditEventURNTypingSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: auditEventURNTypingAnalyzer,
+		Doc:  auditEventURNTypingDoc,
+		Run: func(pass *analysis.Pass) (any, error) {
+			if !strings.HasSuffix(pass.Pkg.Path(), auditPkgPathSuffix) {
+				return nil, nil
+			}
+
+			for _, file := range pass.Files {
+				for _, decl := range file.Decls {
+					genDecl, ok := decl.(*ast.GenDecl)
+					if !ok || genDecl.Tok != token.TYPE {
+						continue
+					}
+
+					for _, spec := range genDecl.Specs {
+						typeSpec, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+
+						if !isLogEventTypeName(typeSpec.Name.Name) {
+							continue
+						}
+
+						structType, ok := typeSpec.Type.(*ast.StructType)
+						if !ok {
+							continue
+						}
+
+						for _, field := range structType.Fields.List {
+							if !fieldHasURNName(field) {
+								continue
+							}
+
+							if isURNTyped(pass.TypesInfo.TypeOf(field.Type)) {
+								continue
+							}
+
+							pass.ReportRangef(field, "%s", auditEventURNTypingMessage)
+						}
+					}
+				}
+			}
+
+			return nil, nil
+		},
+	}
+}
+
+// fieldHasURNName reports whether any of the field's declared names ends in
+// either Urn or URN.
+func fieldHasURNName(field *ast.Field) bool {
+	for _, name := range field.Names {
+		if strings.HasSuffix(name.Name, "URN") || strings.HasSuffix(name.Name, "Urn") {
+			return true
+		}
+	}
+	return false
+}
+
+// isURNTyped reports whether t is a named type defined in the URN package,
+// drilling through a single level of pointer indirection. Slices, maps, and
+// other composite carriers of URN types are intentionally not treated as
+// URN-typed: audit Log*Event fields are expected to be plain values.
+func isURNTyped(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+
+	return strings.HasSuffix(obj.Pkg().Path(), urnPkgPathSuffix)
+}

--- a/glint/audit_event_urn_typing_test.go
+++ b/glint/audit_event_urn_typing_test.go
@@ -1,0 +1,34 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAuditEventURNTyping(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditEventURNTypingAnalyzer(auditEventURNTypingSettings{}), "auditeventurntyping/server/internal/audit")
+}
+
+func TestAuditEventURNTypingSkipsNonAuditPackage(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditEventURNTypingAnalyzer(auditEventURNTypingSettings{}), "notaudit")
+}
+
+func TestBuildAnalyzersSkipsDisabledAuditEventURNTyping(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+	p.settings.Rules.AuditEventURNTyping.Disabled = false
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, auditEventURNTypingAnalyzer, analyzers[0].Name)
+}

--- a/glint/enforce_o11y_conventions_test.go
+++ b/glint/enforce_o11y_conventions_test.go
@@ -29,18 +29,7 @@ func TestEnforceO11yConventionsCustomMessage(t *testing.T) {
 func TestBuildAnalyzersSkipsDisabledEnforceO11yConventions(t *testing.T) {
 	t.Parallel()
 
-	p := &plugin{
-		settings: settings{
-			Rules: ruleSettings{
-				NoAnonymousDefer:           noAnonymousDeferSettings{Disabled: true},
-				EnforceO11yConventions:     enforceO11yConventionsSettings{Disabled: true},
-				ServiceHasServiceAssertion: serviceHasServiceAssertionSettings{Disabled: true},
-				ServiceHasAutherAssertion:  serviceHasAutherAssertionSettings{Disabled: true},
-				ServiceHasAttachFunc:       serviceHasAttachFuncSettings{Disabled: true},
-				NoRepoFieldsInService:      noRepoFieldsInServiceSettings{Disabled: true},
-			},
-		},
-	}
+	p := disabledAllRulesPlugin()
 
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)

--- a/glint/no_anonymous_defer_test.go
+++ b/glint/no_anonymous_defer_test.go
@@ -29,18 +29,7 @@ func TestNoAnonymousDeferCustomMessage(t *testing.T) {
 func TestBuildAnalyzersSkipsDisabledNoAnonymousDefer(t *testing.T) {
 	t.Parallel()
 
-	p := &plugin{
-		settings: settings{
-			Rules: ruleSettings{
-				NoAnonymousDefer:           noAnonymousDeferSettings{Disabled: true},
-				EnforceO11yConventions:     enforceO11yConventionsSettings{Disabled: true},
-				ServiceHasServiceAssertion: serviceHasServiceAssertionSettings{Disabled: true},
-				ServiceHasAutherAssertion:  serviceHasAutherAssertionSettings{Disabled: true},
-				ServiceHasAttachFunc:       serviceHasAttachFuncSettings{Disabled: true},
-				NoRepoFieldsInService:      noRepoFieldsInServiceSettings{Disabled: true},
-			},
-		},
-	}
+	p := disabledAllRulesPlugin()
 
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -26,6 +26,9 @@ type ruleSettings struct {
 	ServiceHasAutherAssertion  serviceHasAutherAssertionSettings  `json:"service-has-auther-assertion"`
 	ServiceHasAttachFunc       serviceHasAttachFuncSettings       `json:"service-has-attach-func"`
 	NoRepoFieldsInService      noRepoFieldsInServiceSettings      `json:"no-repo-fields-in-service"`
+	AuditEventTypedSnapshot    auditEventTypedSnapshotSettings    `json:"audit-event-typed-snapshot"`
+	AuditEventURNNaming        auditEventURNNamingSettings        `json:"audit-event-urn-naming"`
+	AuditEventURNTyping        auditEventURNTypingSettings        `json:"audit-event-urn-typing"`
 }
 
 type plugin struct {
@@ -60,6 +63,15 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	}
 	if !p.settings.Rules.NoRepoFieldsInService.Disabled {
 		analyzers = append(analyzers, newNoRepoFieldsInServiceAnalyzer(p.settings.Rules.NoRepoFieldsInService))
+	}
+	if !p.settings.Rules.AuditEventTypedSnapshot.Disabled {
+		analyzers = append(analyzers, newAuditEventTypedSnapshotAnalyzer(p.settings.Rules.AuditEventTypedSnapshot))
+	}
+	if !p.settings.Rules.AuditEventURNNaming.Disabled {
+		analyzers = append(analyzers, newAuditEventURNNamingAnalyzer(p.settings.Rules.AuditEventURNNaming))
+	}
+	if !p.settings.Rules.AuditEventURNTyping.Disabled {
+		analyzers = append(analyzers, newAuditEventURNTypingAnalyzer(p.settings.Rules.AuditEventURNTyping))
 	}
 
 	return analyzers, nil

--- a/glint/plugin_test.go
+++ b/glint/plugin_test.go
@@ -18,6 +18,9 @@ func disabledAllRulesPlugin() *plugin {
 				ServiceHasAutherAssertion:  serviceHasAutherAssertionSettings{Disabled: true},
 				ServiceHasAttachFunc:       serviceHasAttachFuncSettings{Disabled: true},
 				NoRepoFieldsInService:      noRepoFieldsInServiceSettings{Disabled: true},
+				AuditEventTypedSnapshot:    auditEventTypedSnapshotSettings{Disabled: true},
+				AuditEventURNNaming:        auditEventURNNamingSettings{Disabled: true},
+				AuditEventURNTyping:        auditEventURNTypingSettings{Disabled: true},
 			},
 		},
 	}
@@ -38,5 +41,5 @@ func TestBuildAnalyzersAllEnabled(t *testing.T) {
 	p := &plugin{}
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
-	require.Len(t, analyzers, 6)
+	require.Len(t, analyzers, 9)
 }

--- a/glint/testdata/src/auditeventtypedsnapshot/server/internal/audit/typed_snapshot.go
+++ b/glint/testdata/src/auditeventtypedsnapshot/server/internal/audit/typed_snapshot.go
@@ -1,0 +1,51 @@
+package audit
+
+type SnapshotPayload struct {
+	Field string
+}
+
+// LogTypedSnapshotBadEvent uses bare any/interface{} snapshot fields and
+// should be flagged on each.
+type LogTypedSnapshotBadEvent struct {
+	ID             string
+	SnapshotBefore any         // want "use typed struct field type, such as \\*types.Example, instead of arbitrary typed data"
+	SnapshotAfter  interface{} // want "use typed struct field type, such as \\*types.Example, instead of arbitrary typed data"
+}
+
+// LogTypedSnapshotGroupedBadEvent declares both snapshot fields on one line
+// and exercises the multi-name field case.
+type LogTypedSnapshotGroupedBadEvent struct {
+	ID                            string
+	SnapshotBefore, SnapshotAfter any // want "use typed struct field type, such as \\*types.Example, instead of arbitrary typed data"
+}
+
+// LogTypedSnapshotGoodEvent uses a typed snapshot and must not be flagged.
+type LogTypedSnapshotGoodEvent struct {
+	ID             string
+	SnapshotBefore *SnapshotPayload
+	SnapshotAfter  *SnapshotPayload
+}
+
+// LogTypedSnapshotNamedInterfaceEvent uses an interface that carries methods,
+// which is permitted because the rule only flags the bare empty interface.
+type marshaler interface {
+	Marshal() ([]byte, error)
+}
+
+type LogTypedSnapshotNamedInterfaceEvent struct {
+	ID             string
+	SnapshotBefore marshaler
+	SnapshotAfter  marshaler
+}
+
+// NotALogEventStruct holds an `any` snapshot field but does not match the
+// Log*Event naming convention, so the rule must not flag it.
+type NotALogEventStruct struct {
+	SnapshotBefore any
+	SnapshotAfter  any
+}
+
+// LogNoSnapshotEvent has no snapshot fields and must not be flagged.
+type LogNoSnapshotEvent struct {
+	ID string
+}

--- a/glint/testdata/src/auditeventurnnaming/server/internal/audit/urn_naming.go
+++ b/glint/testdata/src/auditeventurnnaming/server/internal/audit/urn_naming.go
@@ -1,0 +1,45 @@
+package audit
+
+// LogURNNamingBadEvent has both an exempt scope id and a flagged subject id.
+type LogURNNamingBadEvent struct {
+	OrganizationID string
+	ProjectID      string
+	SubjectID      string // want "use URN field naming and URN type instead of ID"
+	OtherId        string // want "use URN field naming and URN type instead of ID"
+	OtherName      string
+}
+
+// LogURNNamingGoodEvent uses URN-suffixed names exclusively (modulo the
+// exempt scope ids), so the rule must not fire.
+type LogURNNamingGoodEvent struct {
+	OrganizationID string
+	ProjectID      string
+	SubjectURN     string
+	OtherUrn       string
+}
+
+// LogURNNamingNamesContainingIdEvent exercises the suffix match: Identifier
+// contains the substring "Id" but does not end in Id/ID and must not be
+// flagged.
+type LogURNNamingNamesContainingIdEvent struct {
+	OrganizationID string
+	ProjectID      string
+	Identifier     string
+	Hidden         string
+}
+
+// LogURNNamingNonExemptScopeEvent confirms that fields like SourceProjectID
+// are not covered by the ProjectID exemption.
+type LogURNNamingNonExemptScopeEvent struct {
+	OrganizationID  string
+	ProjectID       string
+	SourceProjectID string // want "use URN field naming and URN type instead of ID"
+}
+
+// LogURNNamingTypedSubjectEvent confirms the rule fires regardless of the
+// subject id field's Go type — naming alone is enough.
+type LogURNNamingTypedSubjectEvent struct {
+	OrganizationID string
+	ProjectID      string
+	SubjectID      [16]byte // want "use URN field naming and URN type instead of ID"
+}

--- a/glint/testdata/src/auditeventurntyping/server/internal/audit/urn_typing.go
+++ b/glint/testdata/src/auditeventurntyping/server/internal/audit/urn_typing.go
@@ -1,0 +1,29 @@
+package audit
+
+import "auditeventurntyping/server/internal/urn"
+
+// LogURNTypingBadEvent declares URN-named fields with non-urn types and
+// must be flagged on each.
+type LogURNTypingBadEvent struct {
+	OrganizationID string
+	ProjectID      string
+	SubjectURN     string // want "use server/internal/urn type"
+	OtherUrn       int    // want "use server/internal/urn type"
+}
+
+// LogURNTypingGoodEvent declares URN-named fields with urn-package types
+// (direct and pointer) and must not be flagged.
+type LogURNTypingGoodEvent struct {
+	OrganizationID string
+	ProjectID      string
+	ActorURN       urn.Principal
+	SubjectURN     *urn.RemoteMcpServer
+}
+
+// LogURNTypingNoURNFieldsEvent has no URN-named fields and must not be
+// flagged regardless of its other field types.
+type LogURNTypingNoURNFieldsEvent struct {
+	OrganizationID string
+	ProjectID      string
+	SubjectID      string
+}

--- a/glint/testdata/src/auditeventurntyping/server/internal/urn/urn.go
+++ b/glint/testdata/src/auditeventurntyping/server/internal/urn/urn.go
@@ -1,0 +1,10 @@
+package urn
+
+type Principal struct {
+	Type string
+	ID   string
+}
+
+type RemoteMcpServer struct {
+	ID string
+}

--- a/glint/testdata/src/notaudit/notaudit.go
+++ b/glint/testdata/src/notaudit/notaudit.go
@@ -1,0 +1,11 @@
+package notaudit
+
+// LogTypedSnapshotBadEvent matches the Log*Event name pattern but lives in a
+// non-audit package, so all three audit-event rules must skip it.
+type LogTypedSnapshotBadEvent struct {
+	OrganizationID string
+	ResourceID     string
+	ResourceURN    string
+	SnapshotBefore any
+	SnapshotAfter  any
+}

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -123,6 +123,12 @@ linters:
               disabled: true
             no-repo-fields-in-service:
               disabled: true
+            audit-event-typed-snapshot:
+              disabled: false
+            audit-event-urn-naming:
+              disabled: false
+            audit-event-urn-typing:
+              disabled: false
     gosec:
       excludes:
         # Temporarily ignore this lint rule because it needs to be a separate

--- a/server/internal/audit/access.go
+++ b/server/internal/audit/access.go
@@ -26,7 +26,7 @@ type LogAccessRoleCreateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RoleID   string
+	RoleID   string //nolint:glint // TODO(AGE-1954): discuss URN treatment for RBAC role identifiers; pending team discussion
 	RoleName string
 	RoleSlug string
 }
@@ -69,7 +69,7 @@ type LogAccessRoleUpdateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RoleID   string
+	RoleID   string //nolint:glint // TODO(AGE-1954): discuss URN treatment for RBAC role identifiers; pending team discussion
 	RoleName string
 	RoleSlug string
 
@@ -125,7 +125,7 @@ type LogAccessRoleDeleteEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RoleID   string
+	RoleID   string //nolint:glint // TODO(AGE-1954): discuss URN treatment for RBAC role identifiers; pending team discussion
 	RoleName string
 	RoleSlug string
 }
@@ -167,7 +167,7 @@ type LogAccessMemberRoleUpdateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	MemberID    string
+	MemberID    string //nolint:glint // TODO(AGE-1954): discuss URN treatment for RBAC member identifiers; pending team discussion
 	MemberName  string
 	MemberEmail string
 

--- a/server/internal/audit/deployments.go
+++ b/server/internal/audit/deployments.go
@@ -129,14 +129,14 @@ type LogDeploymentRedeployEvent struct {
 
 	DeploymentURN urn.Deployment
 
-	SourceDeploymentID urn.Deployment
+	SourceDeploymentURN urn.Deployment
 }
 
 func LogDeploymentRedeploy(ctx context.Context, dbtx repo.DBTX, event LogDeploymentRedeployEvent) error {
 	action := ActionDeploymentsRedeploy
 
 	metadata, err := marshalAuditPayload(map[string]any{
-		"source_deployment_id": event.SourceDeploymentID,
+		"source_deployment_id": event.SourceDeploymentURN,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)

--- a/server/internal/audit/environments.go
+++ b/server/internal/audit/environments.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/audit/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -71,8 +72,8 @@ type LogEnvironmentUpdateEvent struct {
 	EnvironmentURN            urn.Environment
 	EnvironmentName           string
 	EnvironmentSlug           string
-	EnvironmentSnapshotBefore any
-	EnvironmentSnapshotAfter  any
+	EnvironmentSnapshotBefore *types.Environment
+	EnvironmentSnapshotAfter  *types.Environment
 }
 
 func LogEnvironmentUpdate(ctx context.Context, dbtx repo.DBTX, event LogEnvironmentUpdateEvent) error {

--- a/server/internal/audit/remotemcpservers.go
+++ b/server/internal/audit/remotemcpservers.go
@@ -26,7 +26,7 @@ type LogRemoteMcpServerCreateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RemoteMcpServerID  uuid.UUID
+	RemoteMcpServerID  uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.RemoteMcpServer and migrate to RemoteMcpServerURN; pending team discussion
 	RemoteMcpServerURL string
 }
 
@@ -68,7 +68,7 @@ type LogRemoteMcpServerUpdateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RemoteMcpServerID  uuid.UUID
+	RemoteMcpServerID  uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.RemoteMcpServer and migrate to RemoteMcpServerURN; pending team discussion
 	RemoteMcpServerURL string
 	SnapshotBefore     *types.RemoteMcpServer
 	SnapshotAfter      *types.RemoteMcpServer
@@ -123,7 +123,7 @@ type LogRemoteMcpServerDeleteEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RemoteMcpServerID  uuid.UUID
+	RemoteMcpServerID  uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.RemoteMcpServer and migrate to RemoteMcpServerURN; pending team discussion
 	RemoteMcpServerURL string
 }
 

--- a/server/internal/audit/remotemcpservers.go
+++ b/server/internal/audit/remotemcpservers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/audit/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -69,8 +70,8 @@ type LogRemoteMcpServerUpdateEvent struct {
 
 	RemoteMcpServerID  uuid.UUID
 	RemoteMcpServerURL string
-	SnapshotBefore     any
-	SnapshotAfter      any
+	SnapshotBefore     *types.RemoteMcpServer
+	SnapshotAfter      *types.RemoteMcpServer
 }
 
 func LogRemoteMcpServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogRemoteMcpServerUpdateEvent) error {

--- a/server/internal/audit/risk.go
+++ b/server/internal/audit/risk.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/audit/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -71,8 +72,8 @@ type LogRiskPolicyUpdateEvent struct {
 	RiskPolicyID   uuid.UUID
 	RiskPolicyName string
 
-	SnapshotBefore any
-	SnapshotAfter  any
+	SnapshotBefore *types.RiskPolicy
+	SnapshotAfter  *types.RiskPolicy
 }
 
 func LogRiskPolicyUpdate(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyUpdateEvent) error {

--- a/server/internal/audit/risk.go
+++ b/server/internal/audit/risk.go
@@ -27,7 +27,7 @@ type LogRiskPolicyCreateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RiskPolicyID   uuid.UUID
+	RiskPolicyID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.RiskPolicy and migrate to RiskPolicyURN; pending team discussion
 	RiskPolicyName string
 }
 
@@ -69,7 +69,7 @@ type LogRiskPolicyUpdateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RiskPolicyID   uuid.UUID
+	RiskPolicyID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.RiskPolicy and migrate to RiskPolicyURN; pending team discussion
 	RiskPolicyName string
 
 	SnapshotBefore *types.RiskPolicy
@@ -125,7 +125,7 @@ type LogRiskPolicyDeleteEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RiskPolicyID   uuid.UUID
+	RiskPolicyID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.RiskPolicy and migrate to RiskPolicyURN; pending team discussion
 	RiskPolicyName string
 }
 
@@ -167,7 +167,7 @@ type LogRiskPolicyTriggerEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	RiskPolicyID   uuid.UUID
+	RiskPolicyID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.RiskPolicy and migrate to RiskPolicyURN; pending team discussion
 	RiskPolicyName string
 }
 

--- a/server/internal/audit/templates.go
+++ b/server/internal/audit/templates.go
@@ -24,7 +24,7 @@ type LogTemplateCreateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	TemplateID   uuid.UUID
+	TemplateID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Template and migrate to TemplateURN; pending team discussion
 	TemplateURN  urn.Tool
 	TemplateName string
 }
@@ -74,7 +74,7 @@ type LogTemplateUpdateEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	TemplateID   uuid.UUID
+	TemplateID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Template and migrate to TemplateURN; pending team discussion
 	TemplateURN  urn.Tool
 	TemplateName string
 }
@@ -124,7 +124,7 @@ type LogTemplateDeleteEvent struct {
 	ActorDisplayName *string
 	ActorSlug        *string
 
-	TemplateID   uuid.UUID
+	TemplateID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Template and migrate to TemplateURN; pending team discussion
 	TemplateURN  urn.Tool
 	TemplateName string
 }

--- a/server/internal/audit/toolsets.go
+++ b/server/internal/audit/toolsets.go
@@ -199,7 +199,7 @@ type LogToolsetAttachExternalOAuthEvent struct {
 	ToolsetSlug         string
 	ToolsetVersionAfter int64
 
-	ExternalOAuthServerID   string
+	ExternalOAuthServerID   string //nolint:glint // TODO(AGE-1954): discuss URN treatment for external OAuth server identifiers; pending team discussion
 	ExternalOAuthServerSlug string
 }
 
@@ -256,7 +256,7 @@ type LogToolsetDetachExternalOAuthEvent struct {
 	ToolsetSlug         string
 	ToolsetVersionAfter int64
 
-	ExternalOAuthServerID   *string
+	ExternalOAuthServerID   *string //nolint:glint // TODO(AGE-1954): discuss URN treatment for external OAuth server identifiers; pending team discussion
 	ExternalOAuthServerSlug *string
 }
 
@@ -313,7 +313,7 @@ type LogToolsetAttachOAuthProxyEvent struct {
 	ToolsetSlug         string
 	ToolsetVersionAfter int64
 
-	OAuthProxyServerID   string
+	OAuthProxyServerID   string //nolint:glint // TODO(AGE-1954): discuss URN treatment for OAuth proxy server identifiers; pending team discussion
 	OAuthProxyServerSlug string
 }
 
@@ -370,7 +370,7 @@ type LogToolsetDetachOAuthProxyEvent struct {
 	ToolsetSlug         string
 	ToolsetVersionAfter int64
 
-	OAuthProxyServerID   *string
+	OAuthProxyServerID   *string //nolint:glint // TODO(AGE-1954): discuss URN treatment for OAuth proxy server identifiers; pending team discussion
 	OAuthProxyServerSlug *string
 }
 
@@ -427,7 +427,7 @@ type LogToolsetUpdateOAuthProxyEvent struct {
 	ToolsetSlug         string
 	ToolsetVersionAfter int64
 
-	OAuthProxyServerID   string
+	OAuthProxyServerID   string //nolint:glint // TODO(AGE-1954): discuss URN treatment for OAuth proxy server identifiers; pending team discussion
 	OAuthProxyServerSlug string
 
 	ToolsetSnapshotBefore *types.Toolset

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -899,7 +899,7 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 
 		DeploymentURN: urn.NewDeployment(newID),
 
-		SourceDeploymentID: urn.NewDeployment(deploymentID),
+		SourceDeploymentURN: urn.NewDeployment(deploymentID),
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error adding deployment redeploy audit log").Log(ctx, s.logger)
 	}


### PR DESCRIPTION
## Summary

Adds three glint lint rules that enforce `Log*Event` struct conventions in `server/internal/audit/`: typed snapshots instead of `any`, URN-suffixed subject identifier names, and URN types from `server/internal/urn`. Fixes the 6 typed-snapshot violators inline and grandfathers 19 remaining URN-naming violators with `//nolint:glint` and `TODO(AGE-1954)` comments for team discussion. The URN-typing rule surfaces no violators today.

## Rules introduced

- `audit-event-typed-snapshot` — `SnapshotBefore`/`SnapshotAfter` fields must be a typed Go type, not `any`/`interface{}`.
- `audit-event-urn-naming` — subject identifier fields must end in `*URN` instead of `*ID`/`*Id` (`ProjectID` and `OrganizationID` exempt).
- `audit-event-urn-typing` — fields named `*URN`/`*Urn` must use a type from `server/internal/urn`.

All three are independently togglable via `disabled:` in `server/.golangci.yaml`. Rule scoping is in-rule via `pass.Pkg.Path()` suffix matching.

## Commits

- `feat: add glint lint rules for audit log event struct types` — the linter implementation, three analyzers, tests, testdata, and golangci config. In isolation, this surfaces all 26 violations (6 `audit-event-typed-snapshot` + 20 `audit-event-urn-naming` + 0 `audit-event-urn-typing`).
- `fix: type audit log event snapshots instead of any` — replaces `any` with concrete `*types.RiskPolicy`, `*types.RemoteMcpServer`, `*types.Environment` on the three update events. Every callsite already constructs the corresponding `*types.*` value, so no callers change.
- `fix: rename SourceDeploymentID and grandfather remaining audit ID fields` — the only trivial `audit-event-urn-naming` fix is `LogDeploymentRedeployEvent.SourceDeploymentID → SourceDeploymentURN` (the type was already `urn.Deployment`). Everything else gets a `//nolint:glint` with a `TODO(AGE-1954)` reason.

## Discussion needed: grandfathered fields

The `audit-event-urn-naming` rule surfaces 19 remaining `*ID` fields on `Log*Event` structs that I haven't migrated. They split into three groups:

| Fields | Why grandfathered |
| --- | --- |
| `RiskPolicyID`, `RemoteMcpServerID`, `TemplateID` | Would require introducing `urn.RiskPolicy`, `urn.RemoteMcpServer`, `urn.Template` URN types in `server/internal/urn/`. Per-subject decision; may want to land alongside RBAC integration. |
| `RoleID`, `MemberID` (access events) | RBAC role/member identifiers are already string-keyed and routed through the access subsystem; whether they should also be expressed as URN types is a design question. |
| `ExternalOAuthServerID`, `OAuthProxyServerID` (toolset events) | These reference OAuth servers; URN typing may not be appropriate. |

The team can use the rule's reports as a checklist to either: (a) introduce URN types and migrate, (b) decide some fields legitimately stay as `*ID`, or (c) decide the rule is too coarse and refine its matching to ignore RBAC and external resource identifiers. Until the decision is made, every grandfathered site is discoverable via `grep -rn 'AGE-1954' server/internal/audit/`.

## Linear

https://linear.app/speakeasy/issue/AGE-1954/add-glint-lint-rules-for-audit-log-event-struct-types
