### PR TITLE
feat: registry => gram linkage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ junit-report.xml
 !.vscode/extensions.json
 *.code-workspace
 .idea
+.run
 /posting
 /gram.posting.yaml
 /posting.env

--- a/.mise-tasks/kill-ports.sh
+++ b/.mise-tasks/kill-ports.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+#MISE description="Kill processes listening on development ports (app services only)"
+
+# Application service ports (non-Docker)
+PORTS=(
+  "8080:gram-server"
+  "8081:gram-control"
+  "8082:gram-worker-control"
+  "35291:mock-idp"
+  "5173:dashboard"
+  "6007:elements-storybook"
+)
+
+killed=0
+for entry in "${PORTS[@]}"; do
+  port="${entry%%:*}"
+  name="${entry##*:}"
+  pids=$(lsof -ti "tcp:$port" 2>/dev/null || true)
+  if [[ -n "$pids" ]]; then
+    echo "Killing $name (port $port): PIDs $pids"
+    echo "$pids" | xargs kill -9 2>/dev/null || true
+    killed=$((killed + 1))
+  fi
+done
+
+if [[ "$killed" -eq 0 ]]; then
+  echo "No processes found on any development ports."
+else
+  echo "Killed processes on $killed port(s)."
+fi

--- a/.mise-tasks/start/mock-idp.sh
+++ b/.mise-tasks/start/mock-idp.sh
@@ -6,8 +6,10 @@ set -e
 
 if [[ -n "$USE_LOCAL_SPEAKEASY_REGISTRY_AUTH" ]]; then
   echo "USE_LOCAL_SPEAKEASY_REGISTRY_AUTH is set, skipping mock-idp."
-  # Sleep forever so madprocs doesn't restart the process.
-  exec sleep infinity
+  # Keep the task alive so madprocs doesn't restart it.
+  while true; do
+    sleep 86400
+  done
 fi
 
 exec go run ./mock-speakeasy-idp/main

--- a/.mise-tasks/start/mock-idp.sh
+++ b/.mise-tasks/start/mock-idp.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
+
 #MISE description="Start the mock Speakeasy IDP server for local development auth"
 
 set -e
+
+if [[ -n "$USE_LOCAL_SPEAKEASY_REGISTRY_AUTH" ]]; then
+  echo "USE_LOCAL_SPEAKEASY_REGISTRY_AUTH is set, skipping mock-idp."
+  # Sleep forever so madprocs doesn't restart the process.
+  exec sleep infinity
+fi
 
 exec go run ./mock-speakeasy-idp/main

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -89,6 +89,32 @@ func TestService_Callback(t *testing.T) {
 		require.Equal(t, "other-org-123", authCtx.ActiveOrganizationID, "final destination org should select active org")
 	})
 
+	t.Run("non-admin admin override is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		userInfo.Organizations = append(userInfo.Organizations, MockOrganizationEntry{
+			ID:                 "override-org-123",
+			Name:               "Override Organization",
+			Slug:               "override-org",
+			UserWorkspaceSlugs: []string{"override-workspace"},
+		})
+
+		ctx, instance := newTestAuthService(t, userInfo)
+		ctx = contextvalues.SetAdminOverrideInContext(ctx, "override-org")
+
+		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{Code: "mock_code"})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotEmpty(t, result.SessionToken)
+
+		ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+		require.NoError(t, err, "load session after callback")
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok, "auth context should be set after callback")
+		require.Equal(t, "org-123", authCtx.ActiveOrganizationID, "non-admin users should ignore admin override")
+	})
+
 	t.Run("successful callback for admin with override", func(t *testing.T) {
 		t.Parallel()
 
@@ -114,31 +140,6 @@ func TestService_Callback(t *testing.T) {
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
 		require.True(t, ok, "auth context should be set after callback")
 		require.Equal(t, "admin-org-123", authCtx.ActiveOrganizationID, "incorrect active organization id for admin override")
-	})
-
-	t.Run("admin without override does not default to speakeasy-team", func(t *testing.T) {
-		t.Parallel()
-
-		userInfo := adminMockUserInfo()
-		userInfo.Organizations = append(userInfo.Organizations, MockOrganizationEntry{
-			ID:                 "speakeasy-team-456",
-			Name:               "Speakeasy Team",
-			Slug:               "speakeasy-team",
-			WorkosID:           nil,
-			UserWorkspaceSlugs: []string{"speakeasy-workspace"},
-		})
-
-		ctx, instance := newTestAuthService(t, userInfo)
-		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{Code: "mock_code"})
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		require.NotEmpty(t, result.SessionToken)
-
-		ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
-		require.NoError(t, err, "load session after callback")
-		authCtx, ok := contextvalues.GetAuthContext(ctx)
-		require.True(t, ok, "auth context should be set after callback")
-		require.Equal(t, "admin-org-123", authCtx.ActiveOrganizationID, "admin without explicit override should use first returned org")
 	})
 
 	t.Run("user with no organizations returns successful redirect", func(t *testing.T) {

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -119,6 +119,8 @@ func TestService_Callback(t *testing.T) {
 		t.Parallel()
 
 		userInfo := adminMockUserInfo()
+		userInfo.UserID = "admin-override-user-123"
+		userInfo.Email = "admin-override@speakeasyapi.dev"
 		userInfo.Organizations = append(userInfo.Organizations, MockOrganizationEntry{
 			ID:                 "customer-org-123",
 			Name:               "Customer Organization",

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -34,10 +34,11 @@ func TestService_Callback(t *testing.T) {
 		require.Equal(t, result.SessionToken, result.SessionCookie)
 	})
 
-	t.Run("successful callback for speakeasy user defaults to speakeasy-team", func(t *testing.T) {
+	t.Run("speakeasy user without state uses first returned organization", func(t *testing.T) {
 		t.Parallel()
 
 		userInfo := speakeasyMockUserInfo()
+		userInfo.Organizations[0], userInfo.Organizations[1] = userInfo.Organizations[1], userInfo.Organizations[0]
 		ctx, instance := newTestAuthService(t, userInfo)
 		code := "mock_code"
 		payload := &gen.CallbackPayload{
@@ -55,22 +56,43 @@ func TestService_Callback(t *testing.T) {
 		require.NoError(t, err, "load session after callback")
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
 		require.True(t, ok, "auth context should be set after callback")
-		require.Equal(t, "speakeasy-team-123", authCtx.ActiveOrganizationID, "incorrect active organization id for speakeasy user")
+		require.Equal(t, "other-org-123", authCtx.ActiveOrganizationID, "speakeasy user without state should use first returned org")
+	})
+
+	t.Run("callback final destination selects active organization", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := speakeasyMockUserInfo()
+		ctx, instance := newTestAuthService(t, userInfo)
+		redirectURL := "https://dev.getgram.ai/other-org/projects/default"
+
+		stateJSON, err := json.Marshal(map[string]string{
+			"final_destination_url": redirectURL,
+		})
+		require.NoError(t, err)
+		stateParam := base64.RawURLEncoding.EncodeToString(stateJSON)
+
+		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
+			Code:  "mock_code",
+			State: &stateParam,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Equal(t, "/other-org/projects/default", result.Location)
+		require.NotEmpty(t, result.SessionToken)
+
+		ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+		require.NoError(t, err, "load session after callback")
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok, "auth context should be set after callback")
+		require.Equal(t, "other-org-123", authCtx.ActiveOrganizationID, "final destination org should select active org")
 	})
 
 	t.Run("successful callback for admin with override", func(t *testing.T) {
 		t.Parallel()
 
 		userInfo := adminMockUserInfo()
-		// Add multiple orgs including speakeasy-team
-		userInfo.Organizations = append(userInfo.Organizations, MockOrganizationEntry{
-			ID:                 "speakeasy-team-456",
-			Name:               "Speakeasy Team",
-			Slug:               "speakeasy-team",
-			WorkosID:           nil,
-			UserWorkspaceSlugs: []string{"speakeasy-workspace"},
-		})
-
 		ctx, instance := newTestAuthService(t, userInfo)
 
 		// Set admin override in context
@@ -92,6 +114,31 @@ func TestService_Callback(t *testing.T) {
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
 		require.True(t, ok, "auth context should be set after callback")
 		require.Equal(t, "admin-org-123", authCtx.ActiveOrganizationID, "incorrect active organization id for admin override")
+	})
+
+	t.Run("admin without override does not default to speakeasy-team", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := adminMockUserInfo()
+		userInfo.Organizations = append(userInfo.Organizations, MockOrganizationEntry{
+			ID:                 "speakeasy-team-456",
+			Name:               "Speakeasy Team",
+			Slug:               "speakeasy-team",
+			WorkosID:           nil,
+			UserWorkspaceSlugs: []string{"speakeasy-workspace"},
+		})
+
+		ctx, instance := newTestAuthService(t, userInfo)
+		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{Code: "mock_code"})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotEmpty(t, result.SessionToken)
+
+		ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+		require.NoError(t, err, "load session after callback")
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok, "auth context should be set after callback")
+		require.Equal(t, "admin-org-123", authCtx.ActiveOrganizationID, "admin without explicit override should use first returned org")
 	})
 
 	t.Run("user with no organizations returns successful redirect", func(t *testing.T) {

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -119,10 +119,16 @@ func TestService_Callback(t *testing.T) {
 		t.Parallel()
 
 		userInfo := adminMockUserInfo()
+		userInfo.Organizations = append(userInfo.Organizations, MockOrganizationEntry{
+			ID:                 "customer-org-123",
+			Name:               "Customer Organization",
+			Slug:               "customer-org",
+			UserWorkspaceSlugs: []string{"customer-workspace"},
+		})
 		ctx, instance := newTestAuthService(t, userInfo)
 
 		// Set admin override in context
-		ctx = contextvalues.SetAdminOverrideInContext(ctx, "admin-org")
+		ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
 		code := "mock_code"
 		payload := &gen.CallbackPayload{
 			Code: code,
@@ -139,7 +145,7 @@ func TestService_Callback(t *testing.T) {
 		require.NoError(t, err, "load session after callback")
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
 		require.True(t, ok, "auth context should be set after callback")
-		require.Equal(t, "admin-org-123", authCtx.ActiveOrganizationID, "incorrect active organization id for admin override")
+		require.Equal(t, "customer-org-123", authCtx.ActiveOrganizationID, "incorrect active organization id for admin override")
 	})
 
 	t.Run("user with no organizations returns successful redirect", func(t *testing.T) {

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -239,14 +239,16 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 }
 
 func activeOrganizationFromState(payload *gen.CallbackPayload, organizations []sessions.Organization) (sessions.Organization, bool) {
+	var empty sessions.Organization
+
 	state := decodeStateParam(payload)
 	if state == nil {
-		return sessions.Organization{}, false
+		return empty, false
 	}
 
 	orgSlug := organizationSlugFromDestinationURL(state.FinalDestinationURL)
 	if orgSlug == "" {
-		return sessions.Organization{}, false
+		return empty, false
 	}
 
 	for _, org := range organizations {
@@ -255,7 +257,7 @@ func activeOrganizationFromState(payload *gen.CallbackPayload, organizations []s
 		}
 	}
 
-	return sessions.Organization{}, false
+	return empty, false
 }
 
 func organizationSlugFromDestinationURL(destinationURL string) string {

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -166,20 +166,20 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 	}
 
 	activeOrg := userInfo.Organizations[0]
+	selectedActiveOrgFromState := false
+	if org, ok := activeOrganizationFromState(payload, userInfo.Organizations); ok {
+		activeOrg = org
+		selectedActiveOrgFromState = true
+	}
 
-	// For speakeasy users and admins we default speakeasy-team being the active organization if present
-	// For admins we allow you to override the active organization returned by header if present
-	if strings.HasSuffix(userInfo.Email, "@speakeasy.com") || strings.HasSuffix(userInfo.Email, "@speakeasyapi.dev") || userInfo.Admin {
-		override := "speakeasy-team"
-		if userInfo.Admin {
-			if adminOverride, _ := contextvalues.GetAdminOverrideFromContext(ctx); adminOverride != "" {
-				override = adminOverride
-			}
-		}
-		for _, org := range userInfo.Organizations {
-			if org.Slug == override {
-				activeOrg = org
-				break
+	// For admins we allow you to override the active organization returned by header if present.
+	if !selectedActiveOrgFromState && userInfo.Admin {
+		if adminOverride, _ := contextvalues.GetAdminOverrideFromContext(ctx); adminOverride != "" {
+			for _, org := range userInfo.Organizations {
+				if org.Slug == adminOverride {
+					activeOrg = org
+					break
+				}
 			}
 		}
 	}
@@ -236,6 +236,46 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 	return &gen.LoginResult{
 		Location: location,
 	}, nil
+}
+
+func activeOrganizationFromState(payload *gen.CallbackPayload, organizations []sessions.Organization) (sessions.Organization, bool) {
+	state := decodeStateParam(payload)
+	if state == nil {
+		return sessions.Organization{}, false
+	}
+
+	orgSlug := organizationSlugFromDestinationURL(state.FinalDestinationURL)
+	if orgSlug == "" {
+		return sessions.Organization{}, false
+	}
+
+	for _, org := range organizations {
+		if org.Slug == orgSlug {
+			return org, true
+		}
+	}
+
+	return sessions.Organization{}, false
+}
+
+func organizationSlugFromDestinationURL(destinationURL string) string {
+	location := relativeURL(destinationURL)
+	if location == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return ""
+	}
+
+	path := strings.Trim(parsed.Path, "/")
+	if path == "" {
+		return ""
+	}
+
+	orgSlug, _, _ := strings.Cut(path, "/")
+	return orgSlug
 }
 
 func (s *Service) SwitchScopes(ctx context.Context, payload *gen.SwitchScopesPayload) (res *gen.SwitchScopesResult, err error) {

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -81,6 +81,7 @@ type MockOrganizationEntry struct {
 // createMockAuthServer creates an httptest.Server that serves mock auth responses
 func createMockAuthServer(userInfo *MockUserInfo) *httptest.Server {
 	mux := http.NewServeMux()
+	idToken := fmt.Sprintf("mock_id_token_%p", userInfo)
 
 	// Mock the validate endpoint that sessions.GetUserInfoFromSpeakeasy calls
 	mux.HandleFunc("/v1/speakeasy_provider/validate", func(w http.ResponseWriter, r *http.Request) {
@@ -252,7 +253,7 @@ func createMockAuthServer(userInfo *MockUserInfo) *httptest.Server {
 		tokenResp := struct {
 			IDToken string `json:"id_token"`
 		}{
-			IDToken: "mock_id_token",
+			IDToken: idToken,
 		}
 
 		if err := json.NewEncoder(w).Encode(tokenResp); err != nil {


### PR DESCRIPTION
 * Enables a "MCP Platform" button from the registry. This allows someone who has access to multiple organizations in speakeasy-registry to access the associated gram one. This is done through extracting the slug from the destination url, validating the user has access, then setting it. Falls back to the first organization (existing behaviour)
 * A minor mise task that is useful if running a bunch of services on a workstation
 * Magic `USE_LOCAL_SPEAKEASY_REGISTRY_AUTH` to do auth via the registry locally, which enables better testing of these flows
