### PR TITLE
fix: revert "point gf bin to source .ts to avoid pnpm install warning"

### DIFF
--- a/.changeset/mighty-islands-join.md
+++ b/.changeset/mighty-islands-join.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/functions": patch
+---
+
+Restore corrrect bin path in package.json

--- a/ts-framework/functions/package.json
+++ b/ts-framework/functions/package.json
@@ -17,7 +17,7 @@
     "directory": "ts-framework/functions"
   },
   "bin": {
-    "gf": "./src/bin/cli.ts"
+    "gf": "./dist/bin/cli.js"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
Reverts speakeasy-api/gram#2260

This change is breaking the CLI when running under node.js with:

```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently unsupported for files under node_modules, for "file:///home/disintegrator/code/scratch/wows/node_modules/.pnpm/@gram-ai+functions@0.15.0_@modelcontextprotocol+sdk@1.29.0_zod@4.3.6_/node_modules/@gram-ai/functions/src/bin/cli.ts"
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:183:11)
    at ModuleLoader.<anonymous> (node:internal/modules/esm/translators:663:29)
    at #translate (node:internal/modules/esm/loader:473:20)
    at afterLoad (node:internal/modules/esm/loader:529:29)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:534:12)
    at #getOrCreateModuleJobAfterResolve (node:internal/modules/esm/loader:577:36)
    at afterResolve (node:internal/modules/esm/loader:625:52)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:631:12)
    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:650:32)
    at TracingChannel.tracePromise (node:diagnostics_channel:350:14) {
  code: 'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING'
}

Node.js v24.13.1
```