### PR TITLE
chore: hardcode internal SDK versioning

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -720,7 +720,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Regenerate SDK
-        run: mise run gen:sdk --skip-versioning --skip-upload-spec
+        run: mise run gen:sdk --skip-upload-spec
 
       # Prevent perpetual failure for code samples digest.
       - name: Restore .speakeasy/workflow.lock

--- a/client/sdk/.speakeasy/gen.lock
+++ b/client/sdk/.speakeasy/gen.lock
@@ -6,7 +6,7 @@ management:
   speakeasyVersion: 1.761.5
   generationVersion: 2.879.13
   releaseVersion: 0.33.7
-  configChecksum: 9ba14fcf143cf0b894eeccc68c820028
+  configChecksum: beb35cd99e450093f6a64fc566e10c76
 persistentEdits:
   generation_id: bb7e101e-7ad4-46ab-85f8-4945a377ddd8
   pristine_commit_hash: 8f637eb1797d8010346278d429048da266e99c54

--- a/client/sdk/.speakeasy/gen.yaml
+++ b/client/sdk/.speakeasy/gen.yaml
@@ -26,7 +26,7 @@ generation:
   schemas:
     allOfMergeStrategy: shallowMerge
   requestBodyFieldName: ""
-  versioningStrategy: automatic
+  versioningStrategy: manual
   persistentEdits:
     enabled: never
   tests:


### PR DESCRIPTION
## Summary

Switches the `client/sdk` Speakeasy generator from `automatic` to `manual` versioning so the generated `@gram/client` package no longer auto-bumps on each regen, eliminating extraneous diffs and merge conflicts in `client/sdk/package.json` and `client/sdk/.speakeasy/gen.lock`. Also drops `--skip-versioning` from the PR regeneration workflow since it is now redundant.

## Why no additional handling is needed

`changeset version` cannot bump `@gram/client` because:

- The hygiene check at `.github/workflows/hygiene.yaml` blocks any changeset that targets `@gram/client` directly.
- `@gram/client` has no `workspace:*` deps, so cascade bumps via `updateInternalDependencies` cannot reach it (cascade flows from depended-on → dependents, and `@gram/client` is a leaf).
- `@gram/client` is not in any `fixed` or `linked` group in `.changeset/config.json`.

Resolves [AGE-1945](https://linear.app/speakeasy/issue/AGE-1945/tech-debt-hardcode-internal-sdk-versioning).