### PR TITLE
fix: use $CURSOR_PLUGIN_ROOT in cursor plugin hooks

### DIFF
--- a/hooks/plugin-cursor/hooks/hooks.json
+++ b/hooks/plugin-cursor/hooks/hooks.json
@@ -3,52 +3,52 @@
   "hooks": {
     "beforeSubmitPrompt": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "timeout": 10
       }
     ],
     "afterAgentResponse": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "timeout": 10
       }
     ],
     "afterAgentThought": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "timeout": 10
       }
     ],
     "preToolUse": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "matcher": "^(?!MCP:)",
         "timeout": 10
       }
     ],
     "postToolUse": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "matcher": "^(?!MCP:)",
         "timeout": 10
       }
     ],
     "postToolUseFailure": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "matcher": "^(?!MCP:)",
         "timeout": 10
       }
     ],
     "beforeMCPExecution": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "timeout": 10
       }
     ],
     "afterMCPExecution": [
       {
-        "command": "./hooks/send_hook.sh",
+        "command": "bash \"$CURSOR_PLUGIN_ROOT/hooks/send_hook.sh\"",
         "timeout": 10
       }
     ]


### PR DESCRIPTION
Plugin hook commands run with cwd set to the user's open project, not the plugin install dir, so the previous relative paths only worked by accident. Anchor all hook commands to $CURSOR_PLUGIN_ROOT to match the Claude plugin pattern.

https://forum.cursor.com/t/stop-hook-uses-wrong-or-different-working-directory-when-executing/157195/8