### PR TITLE
mig: drop resource column from principal_grants

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1759,46 +1759,35 @@ CREATE TABLE IF NOT EXISTS hooks_server_name_overrides (
 
 CREATE INDEX IF NOT EXISTS hooks_server_name_overrides_project_id_display_name_idx ON hooks_server_name_overrides(project_id, display_name);
 
--- The sentinel value '*' for resource means "all resources" (wildcard).
--- This avoids NULL semantics and enables pure index-only scans on the
--- unique B-tree index for permission checks:
 CREATE TABLE IF NOT EXISTS principal_grants (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,
   principal_urn TEXT NOT NULL,
   principal_type TEXT NOT NULL GENERATED ALWAYS AS (split_part(principal_urn, ':', 1)) STORED,
   scope TEXT NOT NULL,
-  resource TEXT NOT NULL DEFAULT '*',
-  selectors JSONB,
+  selectors JSONB NOT NULL,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT principal_grants_pkey PRIMARY KEY (id),
   CONSTRAINT principal_grants_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT principal_grants_selectors_check CHECK (selectors IS NULL OR jsonb_typeof(selectors) = 'object')
+  CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}')
 );
 
-COMMENT ON TABLE principal_grants IS 'RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource=''*'' means unrestricted. Selectors can further constrain applicability.';
+COMMENT ON TABLE principal_grants IS 'RBAC grants. One row per (org, principal, scope, selectors). Selectors define resource constraints.';
 COMMENT ON COLUMN principal_grants.organization_id IS 'The organization this grant belongs to. Grants are always org-scoped.';
 COMMENT ON COLUMN principal_grants.principal_urn IS 'URN identifying the principal, e.g. "user:user_abc", "role:admin". Format is type:id.';
 COMMENT ON COLUMN principal_grants.principal_type IS 'Derived from principal_urn. The type prefix, e.g. "user", "role".';
 COMMENT ON COLUMN principal_grants.scope IS 'The scope being granted, e.g. "build:read". Validated in application code, not via FK.';
-COMMENT ON COLUMN principal_grants.resource IS '''*'' = unrestricted (scope applies to all resources in the org). Any other value = a specific resource ID this scope is granted on.';
-COMMENT ON COLUMN principal_grants.selectors IS 'Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.';
+COMMENT ON COLUMN principal_grants.selectors IS 'JSON selector constraints defining what the grant applies to, e.g. {"resource_kind":"project","resource_id":"proj_123"}.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_selector_key
-ON principal_grants (organization_id, principal_urn, scope, selectors)
-WHERE selectors IS NOT NULL;
-
-CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_unrestricted_key
-ON principal_grants (organization_id, principal_urn, scope, resource)
-WHERE selectors IS NULL;
+ON principal_grants (organization_id, principal_urn, scope, selectors);
 
 CREATE INDEX IF NOT EXISTS principal_grants_selectors_idx
 ON principal_grants
-USING GIN (selectors)
-WHERE selectors IS NOT NULL;
+USING GIN (selectors);
 
 CREATE TABLE IF NOT EXISTS audit_logs (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -3,28 +3,28 @@
 
 -- name: ListPrincipalGrantsByOrg :many
 -- Returns all grant rows for an organization, optionally filtered by principal URN.
-SELECT id, organization_id, principal_urn, principal_type, scope, resource, selectors, created_at, updated_at
+SELECT id, organization_id, principal_urn, principal_type, scope, selectors, created_at, updated_at
 FROM principal_grants
 WHERE organization_id = @organization_id
   AND (@principal_urn::text = '' OR principal_urn = @principal_urn)
-ORDER BY principal_urn, scope, resource;
+ORDER BY principal_urn, scope;
 
 -- name: GetPrincipalGrants :many
 -- Returns all grant rows matching a set of principal URNs within an org.
 -- Used by the access resolver to load grants for a user+role in a single query.
-SELECT scope, resource, selectors
+SELECT scope, selectors
 FROM principal_grants
 WHERE organization_id = @organization_id
   AND principal_urn = ANY(@principal_urns::text[]);
 
 -- name: UpsertPrincipalGrant :one
 -- Creates or updates a single grant row. On conflict (same org/principal/scope/selectors),
--- the updated_at is refreshed. Uses the selector partial index for non-NULL selectors.
-INSERT INTO principal_grants (organization_id, principal_urn, scope, resource, selectors)
-VALUES (@organization_id, @principal_urn, @scope, @resource, @selectors)
-ON CONFLICT (organization_id, principal_urn, scope, selectors) WHERE selectors IS NOT NULL
+-- the updated_at is refreshed.
+INSERT INTO principal_grants (organization_id, principal_urn, scope, selectors)
+VALUES (@organization_id, @principal_urn, @scope, @selectors)
+ON CONFLICT (organization_id, principal_urn, scope, selectors)
 DO UPDATE SET updated_at = clock_timestamp()
-RETURNING id, organization_id, principal_urn, principal_type, scope, resource, selectors, created_at, updated_at;
+RETURNING id, organization_id, principal_urn, principal_type, scope, selectors, created_at, updated_at;
 
 -- name: DeletePrincipalGrant :execrows
 -- Removes a specific grant row by ID, scoped to the organization for safety.
@@ -32,24 +32,9 @@ DELETE FROM principal_grants
 WHERE id = @id
   AND organization_id = @organization_id;
 
--- name: DeletePrincipalGrantByTuple :execrows
--- Removes a single grant row matching the exact (org, principal, scope, resource) tuple.
-DELETE FROM principal_grants
-WHERE organization_id = @organization_id
-  AND principal_urn = @principal_urn
-  AND scope = @scope
-  AND resource = @resource;
-
 -- name: DeletePrincipalGrantsByPrincipal :execrows
 -- Removes all grants for a specific principal within an org.
 -- Useful when removing a user from an organization.
 DELETE FROM principal_grants
 WHERE organization_id = @organization_id
   AND principal_urn = @principal_urn;
-
--- name: RemoveResourceFromGrants :execrows
--- Deletes all grant rows referencing a specific resource within an org.
--- Called when a resource (project, MCP server) is deleted.
-DELETE FROM principal_grants
-WHERE organization_id = @organization_id
-  AND resource = @resource;

--- a/server/internal/access/repo/models.go
+++ b/server/internal/access/repo/models.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-// RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource='*' means unrestricted. Selectors can further constrain applicability.
+// RBAC grants. One row per (org, principal, scope, selectors). Selectors define resource constraints.
 type PrincipalGrant struct {
 	ID uuid.UUID
 	// The organization this grant belongs to. Grants are always org-scoped.
@@ -21,9 +21,7 @@ type PrincipalGrant struct {
 	PrincipalType string
 	// The scope being granted, e.g. "build:read". Validated in application code, not via FK.
 	Scope string
-	// '*' = unrestricted (scope applies to all resources in the org). Any other value = a specific resource ID this scope is granted on.
-	Resource string
-	// Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.
+	// JSON selector constraints defining what the grant applies to, e.g. {"resource_kind":"project","resource_id":"proj_123"}.
 	Selectors []byte
 	CreatedAt pgtype.Timestamptz
 	UpdatedAt pgtype.Timestamptz

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -32,35 +32,6 @@ func (q *Queries) DeletePrincipalGrant(ctx context.Context, arg DeletePrincipalG
 	return result.RowsAffected(), nil
 }
 
-const deletePrincipalGrantByTuple = `-- name: DeletePrincipalGrantByTuple :execrows
-DELETE FROM principal_grants
-WHERE organization_id = $1
-  AND principal_urn = $2
-  AND scope = $3
-  AND resource = $4
-`
-
-type DeletePrincipalGrantByTupleParams struct {
-	OrganizationID string
-	PrincipalUrn   urn.Principal
-	Scope          string
-	Resource       string
-}
-
-// Removes a single grant row matching the exact (org, principal, scope, resource) tuple.
-func (q *Queries) DeletePrincipalGrantByTuple(ctx context.Context, arg DeletePrincipalGrantByTupleParams) (int64, error) {
-	result, err := q.db.Exec(ctx, deletePrincipalGrantByTuple,
-		arg.OrganizationID,
-		arg.PrincipalUrn,
-		arg.Scope,
-		arg.Resource,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const deletePrincipalGrantsByPrincipal = `-- name: DeletePrincipalGrantsByPrincipal :execrows
 DELETE FROM principal_grants
 WHERE organization_id = $1
@@ -83,7 +54,7 @@ func (q *Queries) DeletePrincipalGrantsByPrincipal(ctx context.Context, arg Dele
 }
 
 const getPrincipalGrants = `-- name: GetPrincipalGrants :many
-SELECT scope, resource, selectors
+SELECT scope, selectors
 FROM principal_grants
 WHERE organization_id = $1
   AND principal_urn = ANY($2::text[])
@@ -96,7 +67,6 @@ type GetPrincipalGrantsParams struct {
 
 type GetPrincipalGrantsRow struct {
 	Scope     string
-	Resource  string
 	Selectors []byte
 }
 
@@ -111,7 +81,7 @@ func (q *Queries) GetPrincipalGrants(ctx context.Context, arg GetPrincipalGrants
 	var items []GetPrincipalGrantsRow
 	for rows.Next() {
 		var i GetPrincipalGrantsRow
-		if err := rows.Scan(&i.Scope, &i.Resource, &i.Selectors); err != nil {
+		if err := rows.Scan(&i.Scope, &i.Selectors); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -124,11 +94,11 @@ func (q *Queries) GetPrincipalGrants(ctx context.Context, arg GetPrincipalGrants
 
 const listPrincipalGrantsByOrg = `-- name: ListPrincipalGrantsByOrg :many
 
-SELECT id, organization_id, principal_urn, principal_type, scope, resource, selectors, created_at, updated_at
+SELECT id, organization_id, principal_urn, principal_type, scope, selectors, created_at, updated_at
 FROM principal_grants
 WHERE organization_id = $1
   AND ($2::text = '' OR principal_urn = $2)
-ORDER BY principal_urn, scope, resource
+ORDER BY principal_urn, scope
 `
 
 type ListPrincipalGrantsByOrgParams struct {
@@ -154,7 +124,6 @@ func (q *Queries) ListPrincipalGrantsByOrg(ctx context.Context, arg ListPrincipa
 			&i.PrincipalUrn,
 			&i.PrincipalType,
 			&i.Scope,
-			&i.Resource,
 			&i.Selectors,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -169,51 +138,28 @@ func (q *Queries) ListPrincipalGrantsByOrg(ctx context.Context, arg ListPrincipa
 	return items, nil
 }
 
-const removeResourceFromGrants = `-- name: RemoveResourceFromGrants :execrows
-DELETE FROM principal_grants
-WHERE organization_id = $1
-  AND resource = $2
-`
-
-type RemoveResourceFromGrantsParams struct {
-	OrganizationID string
-	Resource       string
-}
-
-// Deletes all grant rows referencing a specific resource within an org.
-// Called when a resource (project, MCP server) is deleted.
-func (q *Queries) RemoveResourceFromGrants(ctx context.Context, arg RemoveResourceFromGrantsParams) (int64, error) {
-	result, err := q.db.Exec(ctx, removeResourceFromGrants, arg.OrganizationID, arg.Resource)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const upsertPrincipalGrant = `-- name: UpsertPrincipalGrant :one
-INSERT INTO principal_grants (organization_id, principal_urn, scope, resource, selectors)
-VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (organization_id, principal_urn, scope, selectors) WHERE selectors IS NOT NULL
+INSERT INTO principal_grants (organization_id, principal_urn, scope, selectors)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (organization_id, principal_urn, scope, selectors)
 DO UPDATE SET updated_at = clock_timestamp()
-RETURNING id, organization_id, principal_urn, principal_type, scope, resource, selectors, created_at, updated_at
+RETURNING id, organization_id, principal_urn, principal_type, scope, selectors, created_at, updated_at
 `
 
 type UpsertPrincipalGrantParams struct {
 	OrganizationID string
 	PrincipalUrn   urn.Principal
 	Scope          string
-	Resource       string
 	Selectors      []byte
 }
 
 // Creates or updates a single grant row. On conflict (same org/principal/scope/selectors),
-// the updated_at is refreshed. Uses the selector partial index for non-NULL selectors.
+// the updated_at is refreshed.
 func (q *Queries) UpsertPrincipalGrant(ctx context.Context, arg UpsertPrincipalGrantParams) (PrincipalGrant, error) {
 	row := q.db.QueryRow(ctx, upsertPrincipalGrant,
 		arg.OrganizationID,
 		arg.PrincipalUrn,
 		arg.Scope,
-		arg.Resource,
 		arg.Selectors,
 	)
 	var i PrincipalGrant
@@ -223,7 +169,6 @@ func (q *Queries) UpsertPrincipalGrant(ctx context.Context, arg UpsertPrincipalG
 		&i.PrincipalUrn,
 		&i.PrincipalType,
 		&i.Scope,
-		&i.Resource,
 		&i.Selectors,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/internal/access/setup_internal_test.go
+++ b/server/internal/access/setup_internal_test.go
@@ -55,7 +55,6 @@ func seedInternalGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, or
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          scope,
-		Resource:       resource,
 		Selectors:      selectors,
 	})
 	require.NoError(t, err)

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -117,7 +117,6 @@ func seedGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizati
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(scope),
-		Resource:       resource,
 		Selectors:      selectors,
 	})
 	require.NoError(t, err)

--- a/server/internal/access/syncgrants_test.go
+++ b/server/internal/access/syncgrants_test.go
@@ -51,7 +51,7 @@ func TestService_syncGrants_replacesRoleGrants(t *testing.T) {
 
 	got := make([]string, 0, len(rows))
 	for _, row := range rows {
-		selectors, err := authz.SelectorFromRow(row.Selectors, authz.Scope(row.Scope), row.Resource)
+		selectors, err := authz.SelectorFromRow(row.Selectors)
 		require.NoError(t, err)
 		got = append(got, row.Scope+"|"+selectors.ResourceID())
 	}
@@ -68,7 +68,7 @@ func TestService_syncGrants_replacesRoleGrants(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, otherRows, 1)
-	otherSel, err := authz.SelectorFromRow(otherRows[0].Selectors, authz.Scope(otherRows[0].Scope), otherRows[0].Resource)
+	otherSel, err := authz.SelectorFromRow(otherRows[0].Selectors)
 	require.NoError(t, err)
 	require.Equal(t, "project-other", otherSel.ResourceID())
 }

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -120,7 +120,6 @@ func SyncGrants(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, orgI
 				OrganizationID: orgID,
 				PrincipalUrn:   principalURN,
 				Scope:          grant.Scope,
-				Resource:       WildcardResource,
 				Selectors:      selBytes,
 			}); err != nil {
 				return fmt.Errorf("upsert unrestricted grant %q for role %q: %w", grant.Scope, roleSlug, err)
@@ -141,7 +140,6 @@ func SyncGrants(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, orgI
 				OrganizationID: orgID,
 				PrincipalUrn:   principalURN,
 				Scope:          grant.Scope,
-				Resource:       sel.ResourceID(),
 				Selectors:      selBytes,
 			}); err != nil {
 				return fmt.Errorf("upsert grant %q for role %q: %w", grant.Scope, roleSlug, err)
@@ -167,7 +165,7 @@ func GrantsForRole(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, o
 
 	grantRows := make([]Grant, 0, len(rows))
 	for _, row := range rows {
-		selectors, err := SelectorFromRow(row.Selectors, Scope(row.Scope), row.Resource)
+		selectors, err := SelectorFromRow(row.Selectors)
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "unmarshal grant selector").Log(ctx, logger)
 		}

--- a/server/internal/authz/load.go
+++ b/server/internal/authz/load.go
@@ -29,7 +29,7 @@ func LoadGrants(ctx context.Context, db accessrepo.DBTX, organizationID string, 
 
 	grantRows := make([]Grant, 0, len(rows))
 	for _, row := range rows {
-		selectors, err := SelectorFromRow(row.Selectors, Scope(row.Scope), row.Resource)
+		selectors, err := SelectorFromRow(row.Selectors)
 		if err != nil {
 			return nil, fmt.Errorf("unmarshal grant selector: %w", err)
 		}

--- a/server/internal/authz/selector.go
+++ b/server/internal/authz/selector.go
@@ -155,17 +155,13 @@ func (s Selector) ResourceID() string {
 	return WildcardResource
 }
 
-// SelectorFromRow parses the selectors JSONB column, falling back to
-// constructing a selector from the scope and resource if selectors is NULL.
-func SelectorFromRow(selectors []byte, scope Scope, resource string) (Selector, error) {
-	if len(selectors) > 0 {
-		var sel Selector
-		if err := json.Unmarshal(selectors, &sel); err != nil {
-			return nil, fmt.Errorf("unmarshal selector: %w", err)
-		}
-		return sel, nil
+// SelectorFromRow parses the selectors JSONB column into a Selector.
+func SelectorFromRow(selectors []byte) (Selector, error) {
+	var sel Selector
+	if err := json.Unmarshal(selectors, &sel); err != nil {
+		return nil, fmt.Errorf("unmarshal selector: %w", err)
 	}
-	return NewSelector(scope, resource), nil
+	return sel, nil
 }
 
 // MarshalJSON implements json.Marshaler. A nil selector marshals as the

--- a/server/internal/authz/setup_test.go
+++ b/server/internal/authz/setup_test.go
@@ -86,7 +86,6 @@ func seedGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizati
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(scope),
-		Resource:       resource,
 		Selectors:      selectors,
 	})
 	require.NoError(t, err)

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -838,7 +838,7 @@ type PluginServer struct {
 	Deleted     bool
 }
 
-// RBAC grants. Normalized: one row per (org, principal, scope, resource). Resource='*' means unrestricted. Selectors can further constrain applicability.
+// RBAC grants. One row per (org, principal, scope, selectors). Selectors define resource constraints.
 type PrincipalGrant struct {
 	ID uuid.UUID
 	// The organization this grant belongs to. Grants are always org-scoped.
@@ -849,9 +849,7 @@ type PrincipalGrant struct {
 	PrincipalType string
 	// The scope being granted, e.g. "build:read". Validated in application code, not via FK.
 	Scope string
-	// '*' = unrestricted (scope applies to all resources in the org). Any other value = a specific resource ID this scope is granted on.
-	Resource string
-	// Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.
+	// JSON selector constraints defining what the grant applies to, e.g. {"resource_kind":"project","resource_id":"proj_123"}.
 	Selectors []byte
 	CreatedAt pgtype.Timestamptz
 	UpdatedAt pgtype.Timestamptz

--- a/server/internal/keys/setup_test.go
+++ b/server/internal/keys/setup_test.go
@@ -105,7 +105,6 @@ func withDefaultOrgAdminGrant(t *testing.T, ctx context.Context, conn *pgxpool.P
 		OrganizationID: authCtx.ActiveOrganizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(authz.ScopeOrgAdmin),
-		Resource:       authCtx.ActiveOrganizationID,
 		Selectors:      selectors,
 	})
 	require.NoError(t, err)

--- a/server/internal/plugins/setup_test.go
+++ b/server/internal/plugins/setup_test.go
@@ -182,7 +182,6 @@ func withauthzGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool, gran
 			OrganizationID: authCtx.ActiveOrganizationID,
 			PrincipalUrn:   userPrincipal,
 			Scope:          string(grant.Scope),
-			Resource:       grant.Selector.ResourceID(),
 			Selectors:      selectors,
 		})
 		require.NoError(t, err)

--- a/server/internal/projects/setup_test.go
+++ b/server/internal/projects/setup_test.go
@@ -145,7 +145,6 @@ func seedGrant(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizati
 		OrganizationID: organizationID,
 		PrincipalUrn:   principal,
 		Scope:          string(scope),
-		Resource:       resource,
 		Selectors:      selectors,
 	})
 	require.NoError(t, err)

--- a/server/internal/remotemcp/setup_test.go
+++ b/server/internal/remotemcp/setup_test.go
@@ -100,7 +100,6 @@ func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 			OrganizationID: authCtx.ActiveOrganizationID,
 			PrincipalUrn:   principal,
 			Scope:          string(grant.Scope),
-			Resource:       grant.Selector.ResourceID(),
 			Selectors:      selectors,
 		})
 		require.NoError(t, err)

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -117,7 +117,6 @@ func withExactAccessGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 			OrganizationID: authCtx.ActiveOrganizationID,
 			PrincipalUrn:   principal,
 			Scope:          string(grant.Scope),
-			Resource:       grant.Selector.ResourceID(),
 			Selectors:      selectors,
 		})
 		require.NoError(t, err)

--- a/server/migrations/20260427000001_drop-grant-resource-column.sql
+++ b/server/migrations/20260427000001_drop-grant-resource-column.sql
@@ -47,3 +47,7 @@ ON principal_grants USING GIN (selectors);
 -- PR #2357 was the expand (added selectors, stopped reading/writing resource).
 -- atlas:nolint DS103
 ALTER TABLE principal_grants DROP COLUMN resource;
+
+-- Update comments to reflect the new schema (selectors is now the sole mechanism).
+COMMENT ON TABLE principal_grants IS 'RBAC grants. One row per (org, principal, scope, selectors). Selectors define resource constraints.';
+COMMENT ON COLUMN principal_grants.selectors IS 'JSON selector constraints defining what the grant applies to, e.g. {"resource_kind":"project","resource_id":"proj_123"}.';

--- a/server/migrations/20260427000001_drop-grant-resource-column.sql
+++ b/server/migrations/20260427000001_drop-grant-resource-column.sql
@@ -1,0 +1,27 @@
+-- atlas:txmode none
+
+-- Drop the legacy `resource` column from principal_grants.
+-- All grants now use the `selectors` JSONB column exclusively.
+
+-- Make selectors NOT NULL.
+ALTER TABLE principal_grants ALTER COLUMN selectors SET NOT NULL;
+
+-- Tighten CHECK constraint (old one allowed NULL).
+ALTER TABLE principal_grants DROP CONSTRAINT IF EXISTS principal_grants_selectors_check;
+ALTER TABLE principal_grants ADD CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}');
+
+-- Drop the resource-based unique index.
+DROP INDEX IF EXISTS principal_grants_org_principal_scope_unrestricted_key;
+
+-- Drop partial selector unique index, recreate as non-partial.
+DROP INDEX IF EXISTS principal_grants_org_principal_scope_selector_key;
+CREATE UNIQUE INDEX CONCURRENTLY principal_grants_org_principal_scope_selector_key
+ON principal_grants (organization_id, principal_urn, scope, selectors);
+
+-- Drop and recreate GIN index without partial WHERE clause.
+DROP INDEX IF EXISTS principal_grants_selectors_idx;
+CREATE INDEX CONCURRENTLY principal_grants_selectors_idx
+ON principal_grants USING GIN (selectors);
+
+-- Drop the resource column.
+ALTER TABLE principal_grants DROP COLUMN resource;

--- a/server/migrations/20260427000001_drop-grant-resource-column.sql
+++ b/server/migrations/20260427000001_drop-grant-resource-column.sql
@@ -3,6 +3,23 @@
 -- Drop the legacy `resource` column from principal_grants.
 -- All grants now use the `selectors` JSONB column exclusively.
 
+-- Backfill any rows that still have NULL selectors (created before the selectors
+-- column was populated by application code). Derive resource_kind from the scope
+-- prefix and use the existing resource column as resource_id.
+UPDATE principal_grants
+SET selectors = jsonb_build_object(
+  'resource_kind', CASE
+    WHEN scope LIKE 'project:%' THEN 'project'
+    WHEN scope LIKE 'build:%' THEN 'project'
+    WHEN scope LIKE 'mcp:%' THEN 'mcp'
+    WHEN scope LIKE 'remote-mcp:%' THEN 'mcp'
+    WHEN scope LIKE 'org:%' THEN 'org'
+    ELSE '*'
+  END,
+  'resource_id', COALESCE(resource, '*')
+)
+WHERE selectors IS NULL;
+
 -- Make selectors NOT NULL.
 ALTER TABLE principal_grants ALTER COLUMN selectors SET NOT NULL;
 

--- a/server/migrations/20260427000001_drop-grant-resource-column.sql
+++ b/server/migrations/20260427000001_drop-grant-resource-column.sql
@@ -20,25 +20,30 @@ SET selectors = jsonb_build_object(
 )
 WHERE selectors IS NULL;
 
--- Make selectors NOT NULL.
+-- Make selectors NOT NULL (table is small — full scan acceptable).
+-- atlas:nolint PG303
 ALTER TABLE principal_grants ALTER COLUMN selectors SET NOT NULL;
 
--- Tighten CHECK constraint (old one allowed NULL).
+-- Tighten CHECK constraint (old one allowed NULL). Use NOT VALID + VALIDATE
+-- to avoid holding ACCESS EXCLUSIVE lock during the scan.
 ALTER TABLE principal_grants DROP CONSTRAINT IF EXISTS principal_grants_selectors_check;
-ALTER TABLE principal_grants ADD CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}');
+ALTER TABLE principal_grants ADD CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}') NOT VALID;
+ALTER TABLE principal_grants VALIDATE CONSTRAINT principal_grants_selectors_check;
 
--- Drop the resource-based unique index.
-DROP INDEX IF EXISTS principal_grants_org_principal_scope_unrestricted_key;
+-- Drop the resource-based unique index concurrently.
+DROP INDEX CONCURRENTLY IF EXISTS principal_grants_org_principal_scope_unrestricted_key;
 
--- Drop partial selector unique index, recreate as non-partial.
-DROP INDEX IF EXISTS principal_grants_org_principal_scope_selector_key;
+-- Drop partial selector unique index concurrently, recreate as non-partial.
+DROP INDEX CONCURRENTLY IF EXISTS principal_grants_org_principal_scope_selector_key;
 CREATE UNIQUE INDEX CONCURRENTLY principal_grants_org_principal_scope_selector_key
 ON principal_grants (organization_id, principal_urn, scope, selectors);
 
--- Drop and recreate GIN index without partial WHERE clause.
-DROP INDEX IF EXISTS principal_grants_selectors_idx;
+-- Drop and recreate GIN index concurrently without partial WHERE clause.
+DROP INDEX CONCURRENTLY IF EXISTS principal_grants_selectors_idx;
 CREATE INDEX CONCURRENTLY principal_grants_selectors_idx
 ON principal_grants USING GIN (selectors);
 
--- Drop the resource column.
+-- Drop the resource column. This is the "contract" step of expand-contract:
+-- PR #2357 was the expand (added selectors, stopped reading/writing resource).
+-- atlas:nolint DS103
 ALTER TABLE principal_grants DROP COLUMN resource;

--- a/server/migrations/20260427000001_drop-grant-resource-column.sql
+++ b/server/migrations/20260427000001_drop-grant-resource-column.sql
@@ -3,24 +3,8 @@
 -- Drop the legacy `resource` column from principal_grants.
 -- All grants now use the `selectors` JSONB column exclusively.
 
--- Backfill any rows that still have NULL selectors (created before the selectors
--- column was populated by application code). Derive resource_kind from the scope
--- prefix and use the existing resource column as resource_id.
-UPDATE principal_grants
-SET selectors = jsonb_build_object(
-  'resource_kind', CASE
-    WHEN scope LIKE 'project:%' THEN 'project'
-    WHEN scope LIKE 'build:%' THEN 'project'
-    WHEN scope LIKE 'mcp:%' THEN 'mcp'
-    WHEN scope LIKE 'remote-mcp:%' THEN 'mcp'
-    WHEN scope LIKE 'org:%' THEN 'org'
-    ELSE '*'
-  END,
-  'resource_id', COALESCE(resource, '*')
-)
-WHERE selectors IS NULL;
-
 -- Make selectors NOT NULL (table is small — full scan acceptable).
+-- All rows already have selectors populated by PR #2357's migration.
 -- atlas:nolint PG303
 ALTER TABLE principal_grants ALTER COLUMN selectors SET NOT NULL;
 

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:f2dW4NrBww0BVhiIfJMx5Qvpv3CrUEoibLmiL989DDA=
+h1:E3xYK+0eEBcyIgYC4T60iPpPVizN3/8sP0DcGWCKLhw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -143,4 +143,5 @@ h1:f2dW4NrBww0BVhiIfJMx5Qvpv3CrUEoibLmiL989DDA=
 20260424180455_assistants-add-created-by-user-id.sql h1:rxhY6U/NefDBWyw7DGTbYyadyEVO0phfYsiVLQJDti4=
 20260424180558_risk-policies-presidio-entities.sql h1:T603WV4fB4zZ34l49+reMuJTFHlf2Ca5UIkJe0zhHI8=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
-20260427000002_remove-noisy-pii-entities.sql h1:t4PebqHsToQv2WWEAiHCSnY3zaB5hGUSYHd1k2pfayk=
+20260427000001_drop-grant-resource-column.sql h1:sSbjqXQFRt3ilAZbh6h3JdHRcpaKg3g3FiLPhTwXQsY=
+20260427000002_remove-noisy-pii-entities.sql h1:exgASSfFW9EY3RahmSMbq9NBpt0qTzHVPBALskuq2w4=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:E3xYK+0eEBcyIgYC4T60iPpPVizN3/8sP0DcGWCKLhw=
+h1:y4BtoEKWtg/PcOlIIPIsBxDWuXTtQoY39fQHh3Ic/mk=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -143,5 +143,5 @@ h1:E3xYK+0eEBcyIgYC4T60iPpPVizN3/8sP0DcGWCKLhw=
 20260424180455_assistants-add-created-by-user-id.sql h1:rxhY6U/NefDBWyw7DGTbYyadyEVO0phfYsiVLQJDti4=
 20260424180558_risk-policies-presidio-entities.sql h1:T603WV4fB4zZ34l49+reMuJTFHlf2Ca5UIkJe0zhHI8=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
-20260427000001_drop-grant-resource-column.sql h1:sSbjqXQFRt3ilAZbh6h3JdHRcpaKg3g3FiLPhTwXQsY=
-20260427000002_remove-noisy-pii-entities.sql h1:exgASSfFW9EY3RahmSMbq9NBpt0qTzHVPBALskuq2w4=
+20260427000001_drop-grant-resource-column.sql h1:RPk2GkMDbvWQ3s2r2pzgLcX9/XlKvX6PGCwfMqm+tjM=
+20260427000002_remove-noisy-pii-entities.sql h1:xG5cTRFC0OOy/y01d6QtJ5DfX3+FPWuCMsKTTkftjpc=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZGjcNo6Yj9Kd/hTrB44B691cd0X/EtWEDlNYYLrm2pE=
+h1:dVpxonle5E1LeXSE+5WxqyetP+KJVskEHylJOL9NxuE=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -143,5 +143,5 @@ h1:ZGjcNo6Yj9Kd/hTrB44B691cd0X/EtWEDlNYYLrm2pE=
 20260424180455_assistants-add-created-by-user-id.sql h1:rxhY6U/NefDBWyw7DGTbYyadyEVO0phfYsiVLQJDti4=
 20260424180558_risk-policies-presidio-entities.sql h1:T603WV4fB4zZ34l49+reMuJTFHlf2Ca5UIkJe0zhHI8=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
-20260427000001_drop-grant-resource-column.sql h1:/jZGo7akOfr67tD6BsHd6zS0Upp1/dteGXoonaf2EXU=
-20260427000002_remove-noisy-pii-entities.sql h1:0u9T/aH25JTGcuSlEz/dHjBFboX0HVoYR3z7AS8OWRE=
+20260427000001_drop-grant-resource-column.sql h1:aq4TSwig+FjqIPDEHB10wCdg4BQ7AVTP0jGs5h7p7kI=
+20260427000002_remove-noisy-pii-entities.sql h1:oJvCq4MwdU6X3vt4+h8LcEjvmPKGMO4Gd+0ksEsR5Cs=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:dVpxonle5E1LeXSE+5WxqyetP+KJVskEHylJOL9NxuE=
+h1:5PTkUIoAloVHytNyn5XmMyOMm9k3/OfQd2yfpuu4Zoc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -143,5 +143,5 @@ h1:dVpxonle5E1LeXSE+5WxqyetP+KJVskEHylJOL9NxuE=
 20260424180455_assistants-add-created-by-user-id.sql h1:rxhY6U/NefDBWyw7DGTbYyadyEVO0phfYsiVLQJDti4=
 20260424180558_risk-policies-presidio-entities.sql h1:T603WV4fB4zZ34l49+reMuJTFHlf2Ca5UIkJe0zhHI8=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
-20260427000001_drop-grant-resource-column.sql h1:aq4TSwig+FjqIPDEHB10wCdg4BQ7AVTP0jGs5h7p7kI=
-20260427000002_remove-noisy-pii-entities.sql h1:oJvCq4MwdU6X3vt4+h8LcEjvmPKGMO4Gd+0ksEsR5Cs=
+20260427000001_drop-grant-resource-column.sql h1:Jitic/8a1v2PYnK6/UGxEqiAw2/w+WLDYoxlcpiR4Io=
+20260427000002_remove-noisy-pii-entities.sql h1:FqvDsDMiIG8deyZZpAj4+ipt3bUqL204W8qi4GmEAzU=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:y4BtoEKWtg/PcOlIIPIsBxDWuXTtQoY39fQHh3Ic/mk=
+h1:ZGjcNo6Yj9Kd/hTrB44B691cd0X/EtWEDlNYYLrm2pE=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -143,5 +143,5 @@ h1:y4BtoEKWtg/PcOlIIPIsBxDWuXTtQoY39fQHh3Ic/mk=
 20260424180455_assistants-add-created-by-user-id.sql h1:rxhY6U/NefDBWyw7DGTbYyadyEVO0phfYsiVLQJDti4=
 20260424180558_risk-policies-presidio-entities.sql h1:T603WV4fB4zZ34l49+reMuJTFHlf2Ca5UIkJe0zhHI8=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
-20260427000001_drop-grant-resource-column.sql h1:RPk2GkMDbvWQ3s2r2pzgLcX9/XlKvX6PGCwfMqm+tjM=
-20260427000002_remove-noisy-pii-entities.sql h1:xG5cTRFC0OOy/y01d6QtJ5DfX3+FPWuCMsKTTkftjpc=
+20260427000001_drop-grant-resource-column.sql h1:/jZGo7akOfr67tD6BsHd6zS0Upp1/dteGXoonaf2EXU=
+20260427000002_remove-noisy-pii-entities.sql h1:0u9T/aH25JTGcuSlEz/dHjBFboX0HVoYR3z7AS8OWRE=


### PR DESCRIPTION
## Summary

- Drop the legacy `resource` column from `principal_grants` — selectors are now the sole source of truth
- Migration makes `selectors` NOT NULL, rejects empty objects (`{}`), rebuilds indexes as non-partial
- Remove two unused queries: `DeletePrincipalGrantByTuple`, `RemoveResourceFromGrants`
- Simplify `SelectorFromRow` signature from `([]byte, Scope, string)` → `([]byte)`

Follows up on #2357 which moved authz to selector-based system.

## Test plan

- [x] `go build ./server/...` passes
- [x] `go vet` passes on all touched packages
- [x] `go test ./server/internal/access/...` passes
- [x] `go test ./server/internal/authz/...` passes
- [ ] CI green