### PR TITLE
fix: use testcontainers for Presidio tests

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -204,6 +204,8 @@ linters:
         - '^github.com/urfave/cli/v2\..*Flag$'
         - '^gopkg.in/yaml.v3\.Node$'
         - '^github.com/redis/go-redis/v9\.Options$'
+        - '^github.com/testcontainers/testcontainers-go\.GenericContainerRequest$'
+        - '^github.com/testcontainers/testcontainers-go\.ContainerRequest$'
         - '^github.com/go-redis/cache/v9\.Options$'
         - '^github.com/go-redis/cache/v9\.Item$'
         - '^github.com/gomarkdown/markdown/html\.RendererOptions$'

--- a/server/internal/background/activities/risk_analysis/presidio_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_test.go
@@ -2,8 +2,6 @@ package risk_analysis_test
 
 import (
 	"fmt"
-	"net/http"
-	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -13,28 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
-	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
-
-func presidioClient(t *testing.T) *risk_analysis.PresidioClient {
-	t.Helper()
-	url := os.Getenv("PRESIDIO_ANALYZER_URL")
-	if url == "" {
-		url = "http://127.0.0.1:5050"
-	}
-	resp, err := http.Get(url + "/health") //nolint:noctx // Test-only health check.
-	if err != nil || resp.StatusCode != http.StatusOK {
-		t.Skipf("presidio not running at %s", url) //nolint:forbidigo // Integration test requires external service.
-	}
-	resp.Body.Close() //nolint:errcheck // Test only.
-	return risk_analysis.NewPresidioClient(url, &http.Client{Timeout: 30 * time.Second}, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), testenv.NewLogger(t))
-}
 
 // --- Real positives: PII that should be detected ---
 
 func TestPresidio_DetectsPersonName(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"My name is John Smith and I live in New York",
 	}, nil, nil)
@@ -48,7 +31,7 @@ func TestPresidio_DetectsPersonName(t *testing.T) {
 
 func TestPresidio_DetectsEmail(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"Please contact me at john.smith@acmecorp.com for details",
 	}, nil, nil)
@@ -70,7 +53,7 @@ func TestPresidio_DetectsEmail(t *testing.T) {
 
 func TestPresidio_DetectsCreditCard(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"My credit card number is 4111111111111111",
 		"Card: 5500-0000-0000-0004",
@@ -87,7 +70,7 @@ func TestPresidio_DetectsCreditCard(t *testing.T) {
 
 func TestPresidio_DetectsPhoneNumber(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"Please call my phone number 425-882-8080 to confirm the appointment",
 		"My phone is +44 20 7946 0958",
@@ -110,7 +93,7 @@ func TestPresidio_DetectsPhoneNumber(t *testing.T) {
 
 func TestPresidio_DetectsMultiplePIIInSingleMessage(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"Patient Jane Doe (jane.doe@hospital.org) has credit card 4111111111111111. Call 555-123-4567.",
 	}, nil, nil)
@@ -128,7 +111,7 @@ func TestPresidio_DetectsMultiplePIIInSingleMessage(t *testing.T) {
 
 func TestPresidio_NoFalsePositiveOnVersionNumbers(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"Version 1.234.567.890 was released",
 		"API v2.0.0-beta.1 is now available",
@@ -143,7 +126,7 @@ func TestPresidio_NoFalsePositiveOnVersionNumbers(t *testing.T) {
 
 func TestPresidio_NoFalsePositiveOnUUIDs(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"Transaction ID: 550e8400-e29b-41d4-a716-446655440000",
 		"Session: a1b2c3d4-e5f6-7890-abcd-ef1234567890",
@@ -157,7 +140,7 @@ func TestPresidio_NoFalsePositiveOnUUIDs(t *testing.T) {
 
 func TestPresidio_NoFalsePositiveOnCodeSnippets(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		`func main() { fmt.Println("hello world") }`,
 		`SELECT * FROM users WHERE id = 12345`,
@@ -178,7 +161,7 @@ func TestPresidio_NoFalsePositiveOnCodeSnippets(t *testing.T) {
 
 func TestPresidio_CleanMessagesProduceNoFindings(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"The deployment completed successfully.",
 		"Please review the pull request when you get a chance.",
@@ -196,7 +179,7 @@ func TestPresidio_CleanMessagesProduceNoFindings(t *testing.T) {
 
 func TestCombinedScanners_BothSourcesAppear(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 	scanner := risk_analysis.NewScanner()
 
 	// Message with both a secret (AWS key) and PII (email)
@@ -222,7 +205,7 @@ func TestCombinedScanners_BothSourcesAppear(t *testing.T) {
 
 func TestPresidio_StressBatch(t *testing.T) {
 	t.Parallel()
-	client := presidioClient(t)
+	client := infra.NewPresidioClient(t)
 
 	messages := make([]string, 200)
 	for i := range messages {

--- a/server/internal/background/activities/risk_analysis/setup_test.go
+++ b/server/internal/background/activities/risk_analysis/setup_test.go
@@ -22,7 +22,7 @@ import (
 var infra *testenv.Environment
 
 func TestMain(m *testing.M) {
-	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Presidio: true})
 	if err != nil {
 		log.Fatalf("launch test infrastructure: %v", err)
 	}

--- a/server/internal/testenv/launch.go
+++ b/server/internal/testenv/launch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
+	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -26,6 +27,7 @@ type LaunchOptions struct {
 	Redis      bool
 	ClickHouse bool
 	Temporal   bool
+	Presidio   bool
 }
 
 type Environment struct {
@@ -33,16 +35,18 @@ type Environment struct {
 	NewRedisClient      RedisClientFunc
 	NewClickhouseClient ClickhouseClientFunc
 	NewTemporalEnv      func(t *testing.T) (env *temporal.Environment, server *testsuite.DevServer)
+	NewPresidioClient   PresidioClientFunc
 }
 
 func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error, error) {
-	if !opts.Postgres && !opts.Redis && !opts.ClickHouse && !opts.Temporal {
+	if !opts.Postgres && !opts.Redis && !opts.ClickHouse && !opts.Temporal && !opts.Presidio {
 		return nil, nil, fmt.Errorf("launch options: %w", errCapabilityNotEnabled)
 	}
 
 	var pgcontainer terminateable
 	var rediscontainer terminateable
 	var clickhousecontainer terminateable
+	var presidiocontainer terminateable
 	var temporalserver *testsuite.DevServer
 	var temporalserverErr error
 	var temporalserverOnce sync.Once
@@ -52,6 +56,7 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 		NewRedisClient:      unsupportedRedisClientFunc(),
 		NewClickhouseClient: unsupportedClickhouseClientFunc(),
 		NewTemporalEnv:      unsupportedTemporalEnvFunc(),
+		NewPresidioClient:   unsupportedPresidioClientFunc(),
 	}
 
 	if opts.Postgres {
@@ -79,6 +84,15 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 		}
 		clickhousecontainer = container
 		res.NewClickhouseClient = chFactory
+	}
+
+	if opts.Presidio {
+		container, pcFactory, err := NewTestPresidio(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("start presidio container: %w", err)
+		}
+		presidiocontainer = container
+		res.NewPresidioClient = pcFactory
 	}
 
 	if opts.Temporal {
@@ -129,6 +143,16 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 				return nil
 			})
 		}
+		if presidiocontainer != nil {
+			eg.Go(func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if err := presidiocontainer.Terminate(ctx); err != nil {
+					log.Printf("terminate presidio container: %v", err)
+				}
+				return nil
+			})
+		}
 		if temporalserver != nil {
 			eg.Go(func() error {
 				temporalserver.Client().Close()
@@ -162,6 +186,14 @@ func unsupportedRedisClientFunc() RedisClientFunc {
 func unsupportedClickhouseClientFunc() ClickhouseClientFunc {
 	return func(_ *testing.T) (clickhouse.Conn, error) {
 		return nil, fmt.Errorf("new clickhouse client: %w", errCapabilityNotEnabled)
+	}
+}
+
+func unsupportedPresidioClientFunc() PresidioClientFunc {
+	return func(t *testing.T) *risk_analysis.PresidioClient {
+		t.Helper()
+		t.Fatal(fmt.Errorf("new presidio client: %w", errCapabilityNotEnabled))
+		return nil
 	}
 }
 

--- a/server/internal/testenv/presidio.go
+++ b/server/internal/testenv/presidio.go
@@ -1,0 +1,58 @@
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type PresidioClientFunc func(t *testing.T) *risk_analysis.PresidioClient
+
+func NewTestPresidio(ctx context.Context) (testcontainers.Container, PresidioClientFunc, error) {
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mcr.microsoft.com/presidio-analyzer:2.2.362",
+			ExposedPorts: []string{"3000/tcp"},
+			WaitingFor:   wait.ForHTTP("/health").WithPort("3000/tcp").WithStartupTimeout(120 * time.Second),
+		},
+		Started: true,
+		Logger:  NewTestcontainersLogger(),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("start presidio container: %w", err)
+	}
+
+	return container, newPresidioClientFunc(container), nil
+}
+
+func newPresidioClientFunc(container testcontainers.Container) PresidioClientFunc {
+	return func(t *testing.T) *risk_analysis.PresidioClient {
+		t.Helper()
+
+		host, err := container.Host(t.Context())
+		if err != nil {
+			t.Fatalf("get presidio container host: %v", err)
+		}
+
+		port, err := container.MappedPort(t.Context(), "3000/tcp")
+		if err != nil {
+			t.Fatalf("get presidio container port: %v", err)
+		}
+
+		baseURL := fmt.Sprintf("http://%s:%s", host, port.Port())
+
+		return risk_analysis.NewPresidioClient(
+			baseURL,
+			&http.Client{Timeout: 30 * time.Second},
+			NewTracerProvider(t),
+			NewMeterProvider(t),
+			NewLogger(t),
+		)
+	}
+}


### PR DESCRIPTION
## Why
Presidio tests were all silently skipped in CI and on dev machines because they relied on a locally running Presidio instance. The `presidioClient()` helper checked a hardcoded URL and called `t.Skip()` if unreachable, so these tests never actually ran.

## What changed

**Before:**
- `presidioClient()` helper in `presidio_test.go` checked `PRESIDIO_ANALYZER_URL` env var (default `http://127.0.0.1:5050`), skipped if Presidio was not reachable
- All 11 Presidio tests silently skipped

**After:**
- New `testenv.NewTestPresidio()` spins up a `mcr.microsoft.com/presidio-analyzer:2.2.362` container via testcontainers (matching `compose.yml`)
- `Presidio bool` added to `testenv.LaunchOptions`, wired into `Launch()` and cleanup
- `presidio_test.go` replaces old `presidioClient(t)` with `infra.NewPresidioClient(t)`
- `setup_test.go` passes `Presidio: true` to `testenv.Launch()`
- All 11 tests now run and pass