### PR TITLE
fix(dashboard): clear stale selectors when switching to specific tools mode

### DIFF
--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -218,8 +218,11 @@ export function ScopePickerPopover({
           label="Specific tools"
           selected={!!customMode}
           onClick={() => {
-            onCustomModeChange?.(true);
-            if (isUnrestricted) onChangeSelectors([]);
+            if (!customMode) {
+              onCustomModeChange?.(true);
+              onChangeSelectors([]);
+              onChangeAnnotations?.([]);
+            }
           }}
         />
       )}


### PR DESCRIPTION
## Summary

- When switching from "Specific servers" → "Specific tools" in the RBAC scope picker, old server-level selectors were not cleared
- The `isUnrestricted` guard only cleared selectors when coming from "All servers" mode (where selectors is `null`), so switching from "Specific servers" mode left the server-level selectors in state
- Tool selectors got appended on top, causing both to be sent to the backend — granting broader MCP access than intended

## Fix

Guard on `!customMode` instead of `isUnrestricted`, so selectors are always cleared when entering custom (tool-specific) mode from any non-custom state.

## Test plan

- [ ] Create a role with `mcp:connect` → "Specific servers" → select a server
- [ ] Edit the role, switch to "Specific tools" → select a specific tool
- [ ] Save and verify only the tool-specific selector exists in `principal_grants` (no leftover server-level row)
- [ ] Verify switching from "All servers" → "Specific tools" still works correctly