### PR TITLE
chore: declare admin env vars in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -77,9 +77,9 @@ TEMPORAL_ADDRESS = "{{env.TEMPORAL_HOST}}:{{env.TEMPORAL_PORT}}"
 PRESIDIO_PORT = "5050"
 PRESIDIO_ANALYZER_URL = "http://127.0.0.1:{{env.PRESIDIO_PORT}}"
 
-###################################
-## Gram server and worker config ##
-###################################
+##########################################
+## Gram server, admin and worker config ##
+##########################################
 ## Setting this to 1 will run the server and worker in a single process.
 ## This is useful when debugging during local development. It can also be used
 ## for simple production deployments although you are encouraged to run the gram
@@ -89,6 +89,10 @@ GRAM_SERVER_PORT = "8080"
 GRAM_SERVER_ADDRESS = ":{{env.GRAM_SERVER_PORT}}"
 GRAM_CONTROL_PORT = "8081"
 GRAM_CONTROL_ADDRESS = ":{{env.GRAM_CONTROL_PORT}}"
+GRAM_ADMIN_SERVER_PORT = "9090"
+GRAM_ADMIN_SERVER_ADDRESS = ":{{env.GRAM_ADMIN_SERVER_PORT}}"
+GRAM_ADMIN_CONTROL_PORT = "9091"
+GRAM_ADMIN_CONTROL_ADDRESS = ":{{env.GRAM_ADMIN_CONTROL_PORT}}"
 GRAM_WORKER_CONTROL_PORT = "8082"
 GRAM_WORKER_CONTROL_ADDRESS = ":{{env.GRAM_WORKER_CONTROL_PORT}}"
 ## The following variable can be one of: local, test, prod


### PR DESCRIPTION
This change adds missing entries for admin server environment variables.