### PR TITLE
fix(dashboard): factor impersonation banner into page height calc

### DIFF
--- a/.changeset/impersonation-banner-page-height.md
+++ b/.changeset/impersonation-banner-page-height.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+fix(dashboard): factor impersonation banner into page height calc so the bottom of the page stays reachable when impersonating an organization

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -40,7 +40,12 @@ export const AppLayout = () => {
       style={
         {
           "--sidebar-width": "14rem",
-          ...(isImpersonating ? { "--header-offset": "5.75rem" } : undefined),
+          ...(isImpersonating
+            ? {
+                "--header-offset": "5.75rem",
+                "--banner-offset": "2.25rem",
+              }
+            : undefined),
         } as React.CSSProperties
       }
     >
@@ -201,7 +206,12 @@ export const OrgLayout = () => {
       style={
         {
           "--sidebar-width": "14rem",
-          ...(isImpersonating ? { "--header-offset": "5.75rem" } : undefined),
+          ...(isImpersonating
+            ? {
+                "--header-offset": "5.75rem",
+                "--banner-offset": "2.25rem",
+              }
+            : undefined),
         } as React.CSSProperties
       }
     >

--- a/client/dashboard/src/components/page-layout.tsx
+++ b/client/dashboard/src/components/page-layout.tsx
@@ -14,8 +14,9 @@ import { XYFade } from "./ui/xy-fade.tsx";
 
 function PageLayout({ children }: { children: React.ReactNode }) {
   return (
-    // The height calculation accounts for the page body "visual" gutter
-    <div className="flex h-[calc(100vh-16px)] flex-col overflow-hidden">
+    // The height calculation accounts for the page body "visual" gutter and
+    // the impersonation banner (when present, via --banner-offset).
+    <div className="flex h-[calc(100vh-16px-var(--banner-offset,0px))] flex-col overflow-hidden">
       <ContentErrorBoundary>{children}</ContentErrorBoundary>
     </div>
   );


### PR DESCRIPTION
The PageLayout container used `h-[calc(100vh-16px)]` which did not account for the impersonation banner. With a window shorter than the page content, the bottom 36px were unreachable, cutting off buttons.

Plumb a `--banner-offset` CSS variable from the layout shell (set to `2.25rem` only when impersonating) into PageLayout's height calc.