### PR TITLE
mig: remove noisy non-PII entities from risk detection rules

### DIFF
--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -1218,6 +1218,16 @@ export const DETECTION_RULES: Record<RuleCategory, DetectionRule[]> = {
       title: "Geographically defined location",
       source: "presidio",
     },
+    {
+      id: "IP_ADDRESS",
+      title: "IPv4 or IPv6 address",
+      source: "presidio",
+    },
+    {
+      id: "MAC_ADDRESS",
+      title: "Network interface identifier",
+      source: "presidio",
+    },
   ],
   government_ids: [
     {

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -1218,27 +1218,6 @@ export const DETECTION_RULES: Record<RuleCategory, DetectionRule[]> = {
       title: "Geographically defined location",
       source: "presidio",
     },
-    {
-      id: "IP_ADDRESS",
-      title: "IPv4 or IPv6 address",
-      source: "presidio",
-    },
-    { id: "URL", title: "Uniform Resource Locator", source: "presidio" },
-    {
-      id: "MAC_ADDRESS",
-      title: "Network interface identifier",
-      source: "presidio",
-    },
-    {
-      id: "DATE_TIME",
-      title: "Absolute or relative dates/times",
-      source: "presidio",
-    },
-    {
-      id: "NRP",
-      title: "Nationality / religious / political group",
-      source: "presidio",
-    },
   ],
   government_ids: [
     {

--- a/server/migrations/20260427000002_remove-noisy-pii-entities.sql
+++ b/server/migrations/20260427000002_remove-noisy-pii-entities.sql
@@ -1,21 +1,15 @@
 -- Remove non-PII entities that were incorrectly backfilled into the PII
--- category by 20260424180559_risk-policies-default-pii.sql. These cause
--- excessive false positives in a coding context:
---   URL         - every URL in code/docs/configs
---   IP_ADDRESS  - common in configs, logs, networking code
---   MAC_ADDRESS - common in networking code
---   DATE_TIME   - ubiquitous in any codebase
---   NRP         - nationality/religious/political group, not PII
+-- category by 20260424180559_risk-policies-default-pii.sql. These are not
+-- personally identifiable information:
+--   URL       - not PII, every URL in code/docs/configs would trigger
+--   DATE_TIME - not PII, ubiquitous in any codebase
+--   NRP       - nationality/religious/political group, not PII
 UPDATE risk_policies
 SET presidio_entities = array_remove(
       array_remove(
-        array_remove(
-          array_remove(
-            array_remove(presidio_entities, 'URL'),
-          'IP_ADDRESS'),
-        'MAC_ADDRESS'),
+        array_remove(presidio_entities, 'URL'),
       'DATE_TIME'),
     'NRP')
   , version = version + 1
-WHERE presidio_entities && '{URL,IP_ADDRESS,MAC_ADDRESS,DATE_TIME,NRP}'
+WHERE presidio_entities && '{URL,DATE_TIME,NRP}'
   AND deleted IS FALSE;

--- a/server/migrations/20260427000002_remove-noisy-pii-entities.sql
+++ b/server/migrations/20260427000002_remove-noisy-pii-entities.sql
@@ -1,0 +1,21 @@
+-- Remove non-PII entities that were incorrectly backfilled into the PII
+-- category by 20260424180559_risk-policies-default-pii.sql. These cause
+-- excessive false positives in a coding context:
+--   URL         - every URL in code/docs/configs
+--   IP_ADDRESS  - common in configs, logs, networking code
+--   MAC_ADDRESS - common in networking code
+--   DATE_TIME   - ubiquitous in any codebase
+--   NRP         - nationality/religious/political group, not PII
+UPDATE risk_policies
+SET presidio_entities = array_remove(
+      array_remove(
+        array_remove(
+          array_remove(
+            array_remove(presidio_entities, 'URL'),
+          'IP_ADDRESS'),
+        'MAC_ADDRESS'),
+      'DATE_TIME'),
+    'NRP')
+  , version = version + 1
+WHERE presidio_entities && '{URL,IP_ADDRESS,MAC_ADDRESS,DATE_TIME,NRP}'
+  AND deleted IS FALSE;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:RkVkTO3ZjyDvyFbuVym+JxA0okQ4Dj5/oQkqsYhOjYo=
+h1:4QPq7px9D+njHWwEXxGU1p7qk9ouJRGjzbhX9ElttGk=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -143,3 +143,4 @@ h1:RkVkTO3ZjyDvyFbuVym+JxA0okQ4Dj5/oQkqsYhOjYo=
 20260424180455_assistants-add-created-by-user-id.sql h1:rxhY6U/NefDBWyw7DGTbYyadyEVO0phfYsiVLQJDti4=
 20260424180558_risk-policies-presidio-entities.sql h1:T603WV4fB4zZ34l49+reMuJTFHlf2Ca5UIkJe0zhHI8=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
+20260427000002_remove-noisy-pii-entities.sql h1:RrPWfnUuhhIaOrfhtUNSuZTVJMLz62nh2n5Cc3W4X/8=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4QPq7px9D+njHWwEXxGU1p7qk9ouJRGjzbhX9ElttGk=
+h1:f2dW4NrBww0BVhiIfJMx5Qvpv3CrUEoibLmiL989DDA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -143,4 +143,4 @@ h1:4QPq7px9D+njHWwEXxGU1p7qk9ouJRGjzbhX9ElttGk=
 20260424180455_assistants-add-created-by-user-id.sql h1:rxhY6U/NefDBWyw7DGTbYyadyEVO0phfYsiVLQJDti4=
 20260424180558_risk-policies-presidio-entities.sql h1:T603WV4fB4zZ34l49+reMuJTFHlf2Ca5UIkJe0zhHI8=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
-20260427000002_remove-noisy-pii-entities.sql h1:RrPWfnUuhhIaOrfhtUNSuZTVJMLz62nh2n5Cc3W4X/8=
+20260427000002_remove-noisy-pii-entities.sql h1:t4PebqHsToQv2WWEAiHCSnY3zaB5hGUSYHd1k2pfayk=


### PR DESCRIPTION
## Why

The PII category in risk policy detection rules included entities that aren't personally identifiable information and cause false positives in coding contexts. URL, DATE_TIME, and NRP were incorrectly categorized under PII and backfilled into all existing policies by `20260424180559_risk-policies-default-pii.sql`.

## What changed

### Before
PII category included 9 entities: PERSON, EMAIL_ADDRESS, PHONE_NUMBER, LOCATION, IP_ADDRESS, URL, MAC_ADDRESS, DATE_TIME, NRP

### After
PII category includes 6 entities: PERSON, EMAIL_ADDRESS, PHONE_NUMBER, LOCATION, IP_ADDRESS, MAC_ADDRESS

Removed:
- **URL** - not PII, triggers on every URL in code/docs/configs
- **DATE_TIME** - not PII, ubiquitous in any codebase
- **NRP** - nationality/religious/political group, not PII (would flag "Japanese locale", "German translation", etc.)

Kept IP_ADDRESS and MAC_ADDRESS as they are legitimate device/user identifiers (PII under GDPR).

- Frontend: removed 3 non-PII entities from `policy-data.ts`
- Migration: strips URL, DATE_TIME, NRP from existing policies and bumps version to trigger re-analysis