### PR TITLE
mig: add presidio_entities, action, and auto_name columns to risk_policies

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2191,6 +2191,8 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   name TEXT NOT NULL,
   sources TEXT[] NOT NULL,
   presidio_entities TEXT[],
+  action TEXT NOT NULL DEFAULT 'flag',
+  auto_name BOOLEAN NOT NULL DEFAULT TRUE,
   version BIGINT NOT NULL,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -987,6 +987,8 @@ type RiskPolicy struct {
 	Name             string
 	Sources          []string
 	PresidioEntities []string
+	Action           string
+	AutoName         bool
 	Version          int64
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -17,6 +17,8 @@ type RiskPolicy struct {
 	Name             string
 	Sources          []string
 	PresidioEntities []string
+	Action           string
+	AutoName         bool
 	Version          int64
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -19,7 +19,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -38,6 +38,8 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.Action,
+		&i.AutoName,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -139,7 +141,7 @@ VALUES (
   , $7
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -171,6 +173,8 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.Action,
+		&i.AutoName,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -301,7 +305,7 @@ func (q *Queries) GetMessageContentBatch(ctx context.Context, arg GetMessageCont
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -324,6 +328,8 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.Action,
+		&i.AutoName,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -352,7 +358,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -376,6 +382,8 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.Name,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.Action,
+			&i.AutoName,
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -393,7 +401,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -417,6 +425,8 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.Name,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.Action,
+			&i.AutoName,
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -766,7 +776,7 @@ SET name = $1
 WHERE id = $5
   AND project_id = $6
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -796,6 +806,8 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.Action,
+		&i.AutoName,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/migrations/20260430201533_risk-policies-action-and-auto-name.sql
+++ b/server/migrations/20260430201533_risk-policies-action-and-auto-name.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "action" text NOT NULL DEFAULT 'flag', ADD COLUMN "auto_name" boolean NOT NULL DEFAULT true;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:30GVS3vdj0VS7nGZp2BSq2566xT4iAKHq4ZGF9ZnheE=
+h1:B6DVNKzEJOgtvdi6DJGSIYJhGcmnjQbWcCRkg1OzqRQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -149,3 +149,4 @@ h1:30GVS3vdj0VS7nGZp2BSq2566xT4iAKHq4ZGF9ZnheE=
 20260429103554_drop_mcp_frontends_and_slugs.sql h1:gzlbVdjsiTS5Rcfe9ZarON+sjhOrKGFVdELohFxjoVI=
 20260429131558_mcp_servers_and_endpoints.sql h1:sNg8L6mZfYPnbP4xBreK4S9la7SwGzTBCw0Qe68h3DY=
 20260430111449_add-workos-roles-and-sync-tables.sql h1:tIK7+g0gEt27jixmoso4bHI7GYAtxUzfL8l24k2Os8g=
+20260430201533_risk-policies-action-and-auto-name.sql h1:3tvGuQlzBnUX2gvFtad56YpeX1wpE9asgXh74ywEIhE=


### PR DESCRIPTION
## Why

Migration for the risk policy actions feature (#2444). Separated per migration PR policy.

## What changed

### PostgreSQL
- `risk_policies` table: add nullable `action TEXT` column
- Nullable per postgresql skill conventions; defaults handled in Go code (NULL/empty treated as "flag")
- Uses `IF NOT EXISTS` for idempotent application

ClickHouse changes (has_blocked, trace_summaries) removed per Chase's feedback -- he'll handle those in #2449/#2450.