### PR TITLE
fix(dashboard): wrap deployment log lines to prevent modal overflow

### DIFF
--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -947,7 +947,7 @@ function DeployingPhaseContent({
           {releaseState.deploymentLogs.map((log) => (
             <div
               key={log.id}
-              className={log.event.includes("error") ? "text-destructive" : ""}
+              className={`break-all ${log.event.includes("error") ? "text-destructive" : ""}`}
             >
               {log.message}
             </div>
@@ -1213,7 +1213,7 @@ function ErrorPhaseContent({
           {releaseState.deploymentLogs.map((log) => (
             <div
               key={log.id}
-              className={log.event.includes("error") ? "text-destructive" : ""}
+              className={`break-all ${log.event.includes("error") ? "text-destructive" : ""}`}
             >
               {log.message}
             </div>


### PR DESCRIPTION
## Summary
- Long unbreakable strings in deployment logs (regex patterns with pipe-delimited tokens, JSON Schema URLs) were escaping the **Add to Project** modal because the log container only had `overflow-y-auto` and individual log lines had no word-break rules.
- Added `break-all` to each log line in both the in-progress (`DeployingPhaseContent`) and failure-state log panels so monospace content wraps inside its container instead of pushing the modal width.

## Test plan
- [x] Trigger a deployment with a tool that produces long unbreakable log strings (e.g. a regex error like the catalog repro) and confirm the log panel stays inside the modal in both the deploying and failure states.
- [x] Verify short log lines render unchanged (no awkward mid-word breaks for normal messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)