### PR TITLE
feat(dashboard): show member reassignment in delete role dialog

### DIFF
--- a/.changeset/delete-role-member-reassignment.md
+++ b/.changeset/delete-role-member-reassignment.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+feat(access): reassign members to the default role on role deletion and surface the affected members in the dashboard delete dialog

--- a/client/dashboard/src/pages/access/DeleteRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/DeleteRoleDialog.tsx
@@ -1,6 +1,12 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Dialog } from "@/components/ui/dialog";
-import { Button } from "@speakeasy-api/moonshine";
 import { Type } from "@/components/ui/type";
+import { cn } from "@/lib/utils";
+import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import type { Role } from "@gram/client/models/components/role.js";
+import { Button } from "@speakeasy-api/moonshine";
+import { ArrowRight } from "lucide-react";
 import { PropsWithChildren } from "react";
 
 export interface DeleteRoleDialogProps extends PropsWithChildren {
@@ -8,7 +14,9 @@ export interface DeleteRoleDialogProps extends PropsWithChildren {
   onOpenChange?: (open: boolean) => void;
   handleDeleteRole: () => void;
   handleCancel: () => void;
-  role: { name: string } | null;
+  role: Role | null;
+  members: AccessMember[];
+  defaultRole: Role | null;
 }
 
 export const DeleteRoleDialog = ({
@@ -17,8 +25,12 @@ export const DeleteRoleDialog = ({
   handleDeleteRole,
   handleCancel,
   role,
+  members,
+  defaultRole,
   children,
 }: DeleteRoleDialogProps) => {
+  const hasMembers = members.length > 0;
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <Dialog.Trigger asChild>{children}</Dialog.Trigger>
@@ -27,12 +39,97 @@ export const DeleteRoleDialog = ({
           <Dialog.Title>Delete Role</Dialog.Title>
         </Dialog.Header>
         <div className="space-y-4 py-4">
-          <Type variant="body">
-            <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
-              {role?.name}
-            </code>{" "}
-            will be permanently deleted. This action cannot be undone.
-          </Type>
+          {hasMembers ? (
+            <Type variant="body">
+              Are you sure? The members in this role will be assigned to the
+              default role
+              {defaultRole && (
+                <>
+                  {" "}
+                  <Badge
+                    variant="outline"
+                    size="sm"
+                    className="font-mono text-[10px] uppercase"
+                  >
+                    {defaultRole.name}
+                  </Badge>
+                </>
+              )}
+              .
+            </Type>
+          ) : (
+            <Type variant="body">
+              <code className="bg-muted rounded px-1 py-0.5 font-mono font-bold">
+                {role?.name}
+              </code>{" "}
+              will be permanently deleted. This action cannot be undone.
+            </Type>
+          )}
+
+          {hasMembers && (
+            <div className="border-border divide-border max-h-72 divide-y overflow-y-auto rounded-md border">
+              {members.map((member) => (
+                <div
+                  key={member.id}
+                  className="flex items-center gap-3 px-3 py-2.5"
+                >
+                  <Avatar className="h-7 w-7">
+                    {member.photoUrl && (
+                      <AvatarImage src={member.photoUrl} alt={member.name} />
+                    )}
+                    <AvatarFallback className="text-xs">
+                      {member.name
+                        .split(" ")
+                        .map((n) => n[0])
+                        .join("")
+                        .toUpperCase()
+                        .slice(0, 2)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1 space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      <Type variant="body" className="text-sm font-medium">
+                        {member.name}
+                      </Type>
+                      {role && (
+                        <div className="flex items-center gap-1">
+                          <Badge
+                            variant="outline"
+                            size="sm"
+                            className={cn(
+                              "font-mono text-[10px] uppercase",
+                              "line-through opacity-60",
+                            )}
+                          >
+                            {role.name}
+                          </Badge>
+                          {defaultRole && (
+                            <>
+                              <ArrowRight className="text-muted-foreground h-3 w-3 shrink-0" />
+                              <Badge
+                                variant="outline"
+                                size="sm"
+                                className="border-primary text-primary font-mono text-[10px] uppercase"
+                              >
+                                {defaultRole.name}
+                              </Badge>
+                            </>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <Type
+                      variant="body"
+                      className="text-muted-foreground text-xs"
+                    >
+                      {member.email}
+                    </Type>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
           <div className="flex justify-end space-x-2">
             <Button variant="secondary" onClick={handleCancel}>
               Cancel

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -6,7 +6,10 @@ import {
   invalidateAllRoles,
   useRoles,
 } from "@gram/client/react-query/roles.js";
-import { invalidateAllMembers } from "@gram/client/react-query/members.js";
+import {
+  invalidateAllMembers,
+  useMembers,
+} from "@gram/client/react-query/members.js";
 import { useDeleteRoleMutation } from "@gram/client/react-query/deleteRole.js";
 import { SkeletonTable } from "@/components/ui/skeleton";
 import {
@@ -33,6 +36,14 @@ export function RolesTab() {
   const queryClient = useQueryClient();
   const { data: rolesData, isLoading } = useRoles();
   const roles = rolesData?.roles ?? [];
+  const { data: membersData } = useMembers();
+  const members = membersData?.members ?? [];
+
+  const defaultRole =
+    roles.find((r) => r.isSystem && r.name === "Member") ?? null;
+  const membersOfDeletingRole = deletingRole
+    ? members.filter((m) => m.roleId === deletingRole.id)
+    : [];
 
   const deleteRole = useDeleteRoleMutation({
     onSuccess: async () => {
@@ -214,6 +225,8 @@ export function RolesTab() {
         }}
         handleCancel={() => setDeletingRole(null)}
         role={deletingRole}
+        members={membersOfDeletingRole}
+        defaultRole={defaultRole}
       />
     </div>
   );

--- a/server/internal/access/deleterole_test.go
+++ b/server/internal/access/deleterole_test.go
@@ -102,6 +102,43 @@ func TestService_DeleteRole_ReassignFailureHaltsDelete(t *testing.T) {
 	require.Len(t, grants, 1)
 }
 
+func TestService_DeleteRole_PartialReassignFailureStopsLoop(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
+		mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"),
+	}, nil).Once()
+	// Iteration order over the slice is deterministic, so seed an explicit
+	// success-then-failure pair to exercise the partial-failure cache flush.
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{
+		mockMember(mockidp.MockOrgID, "membership_1", "user_1", "custom-builder"),
+		mockMember(mockidp.MockOrgID, "membership_2", "user_2", "custom-builder"),
+	}, nil).Once()
+	ti.roles.On("UpdateMemberRole", mock.Anything, "membership_1", authz.SystemRoleMember).Return(&thirdpartyworkos.Member{
+		ID:             "membership_1",
+		UserID:         "user_1",
+		OrganizationID: mockidp.MockOrgID,
+		RoleSlug:       authz.SystemRoleMember,
+		CreatedAt:      mockMembershipTimestamp,
+	}, nil).Once()
+	ti.roles.On("UpdateMemberRole", mock.Anything, "membership_2", authz.SystemRoleMember).Return((*thirdpartyworkos.Member)(nil), errors.New("workos unavailable")).Once()
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+
+	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: "role_custom"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reassign member to default role")
+
+	// The mock's AssertExpectations (registered in newMockRoleProvider) verifies
+	// that DeleteRole was never called and the loop stopped at the first failure.
+	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"))
+	require.Len(t, grants, 1)
+}
+
 func TestService_DeleteRole_NotFound(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/access/deleterole_test.go
+++ b/server/internal/access/deleterole_test.go
@@ -28,6 +28,7 @@ func TestService_DeleteRole(t *testing.T) {
 	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
 		mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"),
 	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{}, nil).Once()
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeMCPConnect, authz.WildcardResource)
@@ -37,6 +38,68 @@ func TestService_DeleteRole(t *testing.T) {
 
 	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"))
 	require.Empty(t, grants)
+}
+
+func TestService_DeleteRole_ReassignsMembersToDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
+		mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"),
+	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{
+		mockMember(mockidp.MockOrgID, "membership_1", "user_1", "custom-builder"),
+		mockMember(mockidp.MockOrgID, "membership_2", "user_2", "custom-builder"),
+		mockMember(mockidp.MockOrgID, "membership_other", "user_3", "admin"),
+	}, nil).Once()
+	ti.roles.On("UpdateMemberRole", mock.Anything, "membership_1", authz.SystemRoleMember).Return(&thirdpartyworkos.Member{
+		ID:             "membership_1",
+		UserID:         "user_1",
+		OrganizationID: mockidp.MockOrgID,
+		RoleSlug:       authz.SystemRoleMember,
+		CreatedAt:      mockMembershipTimestamp,
+	}, nil).Once()
+	ti.roles.On("UpdateMemberRole", mock.Anything, "membership_2", authz.SystemRoleMember).Return(&thirdpartyworkos.Member{
+		ID:             "membership_2",
+		UserID:         "user_2",
+		OrganizationID: mockidp.MockOrgID,
+		RoleSlug:       authz.SystemRoleMember,
+		CreatedAt:      mockMembershipTimestamp,
+	}, nil).Once()
+	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
+
+	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: "role_custom"})
+	require.NoError(t, err)
+}
+
+func TestService_DeleteRole_ReassignFailureHaltsDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
+		mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"),
+	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{
+		mockMember(mockidp.MockOrgID, "membership_1", "user_1", "custom-builder"),
+	}, nil).Once()
+	ti.roles.On("UpdateMemberRole", mock.Anything, "membership_1", authz.SystemRoleMember).Return((*thirdpartyworkos.Member)(nil), errors.New("workos unavailable")).Once()
+	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
+
+	err := ti.service.DeleteRole(ctx, &gen.DeleteRolePayload{ID: "role_custom"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reassign member to default role")
+
+	// Grants must remain since reassignment failed before grant cleanup ran.
+	grants := listPrincipalGrants(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"))
+	require.Len(t, grants, 1)
 }
 
 func TestService_DeleteRole_NotFound(t *testing.T) {
@@ -73,6 +136,7 @@ func TestService_DeleteRole_WorkOSDeleteFailure(t *testing.T) {
 	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
 		mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"),
 	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{}, nil).Once()
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(errors.New("workos unavailable")).Once()
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
 
@@ -98,6 +162,7 @@ func TestService_DeleteRole_AuditLog(t *testing.T) {
 	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
 		mockRole("role_custom", "Audit Builder", "custom-builder", "Old description"),
 	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{}, nil).Once()
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
 

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -519,6 +519,9 @@ func (s *Service) DeleteRole(ctx context.Context, payload *gen.DeleteRolePayload
 			continue
 		}
 		if _, err := s.roles.UpdateMemberRole(ctx, m.ID, authz.SystemRoleMember); err != nil {
+			if reassigned {
+				s.authz.InvalidateAllRoleCaches(ctx, ac.ActiveOrganizationID)
+			}
 			return oops.E(oops.CodeUnexpected, err, "reassign member to default role").Log(ctx, logger)
 		}
 		reassigned = true

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -507,6 +507,26 @@ func (s *Service) DeleteRole(ctx context.Context, payload *gen.DeleteRolePayload
 		return oops.E(oops.CodeBadRequest, nil, "system roles cannot be deleted").Log(ctx, logger)
 	}
 
+	// WorkOS rejects deleting a role that still has members assigned, so move
+	// any assigned members to the default member role first.
+	members, err := s.roles.ListMembers(ctx, workosOrgID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list members from workos").Log(ctx, logger)
+	}
+	reassigned := false
+	for _, m := range members {
+		if m.RoleSlug != currentRole.Slug {
+			continue
+		}
+		if _, err := s.roles.UpdateMemberRole(ctx, m.ID, authz.SystemRoleMember); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "reassign member to default role").Log(ctx, logger)
+		}
+		reassigned = true
+	}
+	if reassigned {
+		s.authz.InvalidateAllRoleCaches(ctx, ac.ActiveOrganizationID)
+	}
+
 	if _, err := repo.New(s.db).DeletePrincipalGrantsByPrincipal(ctx, repo.DeletePrincipalGrantsByPrincipalParams{
 		OrganizationID: ac.ActiveOrganizationID,
 		PrincipalUrn:   urn.NewPrincipal(urn.PrincipalTypeRole, currentRole.Slug),

--- a/server/internal/access/rbac_test.go
+++ b/server/internal/access/rbac_test.go
@@ -235,6 +235,7 @@ func TestService_DeleteRole_AllowsOrgAdminGrant(t *testing.T) {
 	ti.roles.On("ListRoles", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Role{
 		mockRole("role_custom", "Custom Builder", "custom-builder", "Old description"),
 	}, nil).Once()
+	ti.roles.On("ListMembers", mock.Anything, mockidp.MockOrgID).Return([]thirdpartyworkos.Member{}, nil).Once()
 	ti.roles.On("DeleteRole", mock.Anything, mockidp.MockOrgID, "custom-builder").Return(nil).Once()
 	seedGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, urn.NewPrincipal(urn.PrincipalTypeRole, "custom-builder"), authz.ScopeProjectRead, "project-1")
 


### PR DESCRIPTION
When deleting a role with assigned members, list the affected members
with avatars and a struck-through current → default role badge so admins
understand the WorkOS-side reassignment that will happen on delete.