### PR TITLE
chore(insights-sidebar): clarify hook.source vs tool_call.source

### DIFF
--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -187,7 +187,9 @@ Custom attributes: SDK users can attach arbitrary key-value attributes to their 
 When a user asks about logs for a specific user, tenant, customer, or entity:
 1. Always call listAttributeKeys first for the relevant time window to discover which @-prefixed attributes exist.
 2. Identify the most relevant attribute and filter on it (e.g. { path: "@user", operator: "eq", values: ["someone@example.com"] }).
-3. If no relevant @-prefixed attributes exist, tell the user and fall back to text search instead.`;
+3. If no relevant @-prefixed attributes exist, tell the user and fall back to text search instead.
+
+MCP server vs. client breakdowns: \`gram.hook.source\` and \`gram.tool_call.source\` are complementary dimensions, not aliases. \`gram.hook.source\` identifies the agent/client that invoked Gram (e.g. "claude-code", "cursor") — use this for adoption / "who's using us" questions. \`gram.tool_call.source\` identifies the downstream MCP server that handled the call (e.g. "datadog-mcp", "linear") — use this for "top servers" / per-MCP usage questions. When asked about MCP server-level breakdowns, query BOTH dimensions: a server can appear in one and not the other depending on whether you're slicing by caller or callee.`;
 
   const systemPrompt = contextInfo
     ? `${baseInstructions}


### PR DESCRIPTION
## Summary

- Adds a paragraph to the Insights sidebar agent's system prompt distinguishing `gram.hook.source` (the calling agent/client, e.g. `claude-code`) from `gram.tool_call.source` (the downstream MCP server that handled the call, e.g. `datadog-mcp`).
- Instructs the agent to query **both** dimensions when asked for MCP server-level breakdowns, since a server can show up in one and not the other depending on whether you slice by caller or callee.

## Why

When asked about top MCP servers, the agent was filtering on a single source attribute and missing rows. The two attributes are complementary, not aliases. Priming this in the system prompt avoids the agent having to rediscover the distinction via `listAttributeKeys` every session.

## Test plan

- [ ] Open the Insights sidebar and ask "what are the top MCP servers used in the last 7 days?" — agent should query both `gram.hook.source` and `gram.tool_call.source`.
- [ ] Ask "which agents/clients are calling Gram?" — agent should filter on `gram.hook.source` only.
- [ ] Ask "how often is `datadog-mcp` getting called?" — agent should filter on `gram.tool_call.source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)