### PR TITLE
feat(dashboard): refactor scope picker, polish access page

### DIFF
--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -94,12 +94,6 @@ export function CreateRoleDialog({
   const [showMembers, setShowMembers] = useState(false);
   const [showPermissions, setShowPermissions] = useState(true);
   const [initialized, setInitialized] = useState(false);
-  // Track which MCP scopes have "Custom" mode selected (UI-only state)
-  const [customScopes, setCustomScopes] = useState<Set<string>>(new Set());
-  // Track which MCP scopes have "Specific collections" mode selected (UI-only state)
-  const [collectionScopes, setCollectionScopes] = useState<Set<string>>(
-    new Set(),
-  );
 
   const queryClient = useQueryClient();
   const { data: membersData } = useMembers();
@@ -136,14 +130,12 @@ export function CreateRoleDialog({
         .map((g) => g.label),
     );
     setExpandedGroups(autoExpanded);
-    // Restore custom mode and active tab for MCP scopes with tool/disposition selectors
-    const restoredCustom = new Set<string>();
+    // Restore custom tab hints for MCP scopes with tool/disposition selectors
     for (const [scope, grant] of Object.entries(roleGrants)) {
       if (!scope.startsWith("mcp:")) continue;
       const hasCustomSelectors =
         grant.selectors?.some((s) => s.tool || s.disposition) ?? false;
       if (!hasCustomSelectors) continue;
-      restoredCustom.add(scope);
       const detected = inferCustomTab(grant.selectors ?? []);
       roleGrants[scope] = {
         ...grant,
@@ -152,7 +144,6 @@ export function CreateRoleDialog({
       };
     }
     setGrants(roleGrants);
-    setCustomScopes(restoredCustom);
     const assignedIds = new Set(
       members.filter((m) => m.roleId === editingRole.id).map((m) => m.id),
     );
@@ -194,16 +185,6 @@ export function CreateRoleDialog({
       const next = { ...prev };
       if (next[scope]) {
         delete next[scope];
-        setCustomScopes((s) => {
-          const n = new Set(s);
-          n.delete(scope);
-          return n;
-        });
-        setCollectionScopes((s) => {
-          const n = new Set(s);
-          n.delete(scope);
-          return n;
-        });
       } else {
         next[scope] = { scope, selectors: null };
       }
@@ -318,8 +299,6 @@ export function CreateRoleDialog({
     setSelectedMembers(new Set());
     setShowMembers(false);
     setShowPermissions(true);
-    setCustomScopes(new Set());
-    setCollectionScopes(new Set());
     setInitialized(false);
     onOpenChange(false);
   };
@@ -494,34 +473,6 @@ export function CreateRoleDialog({
                                           scopeDef.slug,
                                           selectors,
                                         )
-                                      }
-                                      customMode={customScopes.has(
-                                        scopeDef.slug,
-                                      )}
-                                      onCustomModeChange={(custom) =>
-                                        setCustomScopes((prev) => {
-                                          const next = new Set(prev);
-                                          if (custom) {
-                                            next.add(scopeDef.slug);
-                                          } else {
-                                            next.delete(scopeDef.slug);
-                                          }
-                                          return next;
-                                        })
-                                      }
-                                      collectionMode={collectionScopes.has(
-                                        scopeDef.slug,
-                                      )}
-                                      onCollectionModeChange={(mode) =>
-                                        setCollectionScopes((prev) => {
-                                          const next = new Set(prev);
-                                          if (mode) {
-                                            next.add(scopeDef.slug);
-                                          } else {
-                                            next.delete(scopeDef.slug);
-                                          }
-                                          return next;
-                                        })
                                       }
                                       annotations={grant.annotations}
                                       onChangeAnnotations={(annotations) =>

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -96,6 +96,10 @@ export function CreateRoleDialog({
   const [initialized, setInitialized] = useState(false);
   // Track which MCP scopes have "Custom" mode selected (UI-only state)
   const [customScopes, setCustomScopes] = useState<Set<string>>(new Set());
+  // Track which MCP scopes have "Specific collections" mode selected (UI-only state)
+  const [collectionScopes, setCollectionScopes] = useState<Set<string>>(
+    new Set(),
+  );
 
   const queryClient = useQueryClient();
   const { data: membersData } = useMembers();
@@ -305,6 +309,7 @@ export function CreateRoleDialog({
     setShowMembers(false);
     setShowPermissions(true);
     setCustomScopes(new Set());
+    setCollectionScopes(new Set());
     setInitialized(false);
     onOpenChange(false);
   };
@@ -487,6 +492,20 @@ export function CreateRoleDialog({
                                         setCustomScopes((prev) => {
                                           const next = new Set(prev);
                                           if (custom) {
+                                            next.add(scopeDef.slug);
+                                          } else {
+                                            next.delete(scopeDef.slug);
+                                          }
+                                          return next;
+                                        })
+                                      }
+                                      collectionMode={collectionScopes.has(
+                                        scopeDef.slug,
+                                      )}
+                                      onCollectionModeChange={(mode) =>
+                                        setCollectionScopes((prev) => {
+                                          const next = new Set(prev);
+                                          if (mode) {
                                             next.add(scopeDef.slug);
                                           } else {
                                             next.delete(scopeDef.slug);

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -194,6 +194,16 @@ export function CreateRoleDialog({
       const next = { ...prev };
       if (next[scope]) {
         delete next[scope];
+        setCustomScopes((s) => {
+          const n = new Set(s);
+          n.delete(scope);
+          return n;
+        });
+        setCollectionScopes((s) => {
+          const n = new Set(s);
+          n.delete(scope);
+          return n;
+        });
       } else {
         next[scope] = { scope, selectors: null };
       }

--- a/client/dashboard/src/pages/access/MembersTab.tsx
+++ b/client/dashboard/src/pages/access/MembersTab.tsx
@@ -10,6 +10,9 @@ import { Button, Column, Icon, Table } from "@speakeasy-api/moonshine";
 import { useState } from "react";
 import { ChangeRoleDialog } from "./ChangeRoleDialog";
 import { RequireScope } from "@/components/require-scope";
+import { useOrganization } from "@/contexts/Auth";
+import { useTelemetry } from "@/contexts/Telemetry";
+import { useOrgRoutes } from "@/routes";
 
 function getInitials(name: string) {
   return name
@@ -24,10 +27,19 @@ export function MembersTab() {
   const [changingMember, setChangingMember] = useState<AccessMember | null>(
     null,
   );
+  const organization = useOrganization();
+  const telemetry = useTelemetry();
+  const orgRoutes = useOrgRoutes();
+  const isTeamPageEnabled =
+    telemetry.isFeatureEnabled("gram-team-page") ?? false;
   const { data: membersData, isLoading: membersLoading } = useMembers();
   const { data: rolesData } = useRoles();
-  const members = membersData?.members ?? [];
   const roles = rolesData?.roles ?? [];
+  const members = [...(membersData?.members ?? [])].sort((a, b) => {
+    const aSystem = roles.find((r) => r.id === a.roleId)?.isSystem ?? false;
+    const bSystem = roles.find((r) => r.id === b.roleId)?.isSystem ?? false;
+    return Number(bSystem) - Number(aSystem);
+  });
 
   const getRoleName = (roleId: string) =>
     roles.find((r) => r.id === roleId)?.name ?? "Unknown";
@@ -120,12 +132,35 @@ export function MembersTab() {
       )}
       <div className="border-border flex justify-center rounded-b-lg border border-t-0 py-3">
         <RequireScope scope="org:admin" level="component">
-          <Button variant="tertiary" size="sm">
-            <Button.Text>Manage Team</Button.Text>
-            <Button.RightIcon>
-              <Icon name="arrow-right" className="h-4 w-4" />
-            </Button.RightIcon>
-          </Button>
+          {isTeamPageEnabled ? (
+            <Button
+              variant="tertiary"
+              size="sm"
+              onClick={() => orgRoutes.team.goTo()}
+            >
+              <Button.Text>Manage Team</Button.Text>
+              <Button.RightIcon>
+                <Icon name="arrow-right" className="h-4 w-4" />
+              </Button.RightIcon>
+            </Button>
+          ) : (
+            <Button variant="tertiary" size="sm" asChild>
+              <a
+                href={
+                  organization?.userWorkspaceSlugs?.length
+                    ? `https://app.speakeasy.com/org/${organization.slug}/${organization.userWorkspaceSlugs[0]}/settings/team`
+                    : "https://app.speakeasy.com"
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button.Text>Manage Team</Button.Text>
+                <Button.RightIcon>
+                  <Icon name="external-link" className="h-4 w-4" />
+                </Button.RightIcon>
+              </a>
+            </Button>
+          )}
         </RequireScope>
       </div>
 

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -28,6 +28,43 @@ import { CreateRoleDialog } from "./CreateRoleDialog";
 import { DeleteRoleDialog } from "./DeleteRoleDialog";
 import { Ellipsis } from "lucide-react";
 import { RequireScope } from "@/components/require-scope";
+import { cn } from "@/lib/utils";
+
+function RoleActionsMenu({
+  role,
+  onEdit,
+  onDelete,
+}: {
+  role: Role;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <RequireScope scope="org:admin" level="component">
+      <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "text-muted-foreground hover:bg-accent hover:text-foreground flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition-colors",
+              open && "bg-accent text-foreground",
+            )}
+          >
+            <Ellipsis className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>
+          {!role.isSystem && (
+            <DropdownMenuItem onSelect={onDelete}>Delete</DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </RequireScope>
+  );
+}
 
 export function RolesTab() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -35,7 +72,9 @@ export function RolesTab() {
   const [deletingRole, setDeletingRole] = useState<Role | null>(null);
   const queryClient = useQueryClient();
   const { data: rolesData, isLoading } = useRoles();
-  const roles = rolesData?.roles ?? [];
+  const roles = [...(rolesData?.roles ?? [])].sort(
+    (a, b) => Number(b.isSystem) - Number(a.isSystem),
+  );
   const { data: membersData } = useMembers();
   const members = membersData?.members ?? [];
 
@@ -99,40 +138,11 @@ export function RolesTab() {
       header: "",
       width: "80px",
       render: (role) => (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="tertiary"
-              size="sm"
-              className="opacity-50 hover:opacity-100"
-            >
-              <Button.LeftIcon>
-                <Ellipsis className="h-4 w-4" />
-              </Button.LeftIcon>
-              <span className="hidden">Actions</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <RequireScope scope="org:admin" level="component">
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onSelect={() => setTimeout(() => setEditingRole(role), 0)}
-              >
-                Edit
-              </DropdownMenuItem>
-            </RequireScope>
-            {!role.isSystem && (
-              <RequireScope scope="org:admin" level="component">
-                <DropdownMenuItem
-                  className="text-destructive focus:text-destructive cursor-pointer"
-                  onSelect={() => setTimeout(() => setDeletingRole(role), 0)}
-                >
-                  Delete
-                </DropdownMenuItem>
-              </RequireScope>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <RoleActionsMenu
+          role={role}
+          onEdit={() => setEditingRole(role)}
+          onDelete={() => setDeletingRole(role)}
+        />
       ),
     },
   ];

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -56,9 +56,13 @@ function RoleActionsMenu({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setTimeout(onEdit, 0)}>
+            Edit
+          </DropdownMenuItem>
           {!role.isSystem && (
-            <DropdownMenuItem onSelect={onDelete}>Delete</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setTimeout(onDelete, 0)}>
+              Delete
+            </DropdownMenuItem>
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -31,7 +31,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type {
@@ -149,6 +149,7 @@ export function ScopePickerPopover({
   const mcpServers = useMCPServers(resourceType === "mcp");
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const [collectionCount, setCollectionCount] = useState(0);
   const customToolCount = useMemo(() => {
     if (!customMode && !collectionMode) return 0;
     return (selectors ?? []).length;
@@ -176,6 +177,7 @@ export function ScopePickerPopover({
     customMode,
     collectionMode,
     customToolCount,
+    collectionCount,
   );
 
   const resourceKind = resourceType === "project" ? "project" : "mcp";
@@ -390,6 +392,7 @@ export function ScopePickerPopover({
           selectors={selectors ?? []}
           onChangeSelectors={onChangeSelectors}
           onNavigate={() => setPopoverOpen(false)}
+          onSelectedCountChange={setCollectionCount}
         />
       </div>
     </div>
@@ -795,11 +798,13 @@ function CollectionGroupPanel({
   selectors,
   onChangeSelectors,
   onNavigate,
+  onSelectedCountChange,
 }: {
   mcpServers: ServerGroup[];
   selectors: Selector[];
   onChangeSelectors: (selectors: Selector[] | null) => void;
   onNavigate?: () => void;
+  onSelectedCountChange?: (count: number) => void;
 }) {
   const client = useSdkClient();
   const orgRoutes = useOrgRoutes();
@@ -862,6 +867,26 @@ function CollectionGroupPanel({
       })
       .filter((g) => g.servers.some((s) => s.tools.length > 0));
   }, [collections, serverQueries, mcpSlugToServer]);
+
+  const selectedCollectionCount = useMemo(() => {
+    return collectionGroups.filter((group) => {
+      const allToolSelectors = group.servers.flatMap((s) =>
+        s.tools.map((t) => ({ resourceId: s.id, tool: t.name })),
+      );
+      return (
+        allToolSelectors.length > 0 &&
+        allToolSelectors.every((ts) =>
+          selectors.some(
+            (s) => s.resourceId === ts.resourceId && s.tool === ts.tool,
+          ),
+        )
+      );
+    }).length;
+  }, [collectionGroups, selectors]);
+
+  useEffect(() => {
+    onSelectedCountChange?.(selectedCollectionCount);
+  }, [selectedCollectionCount, onSelectedCountChange]);
 
   const goToCreateCollection = () => {
     onNavigate?.();
@@ -1060,6 +1085,7 @@ function getLabel(
   customMode?: boolean,
   collectionMode?: boolean,
   customToolCount?: number,
+  collectionCount?: number,
 ): string {
   if (customMode) {
     const count = customToolCount ?? 0;
@@ -1069,9 +1095,9 @@ function getLabel(
     return `${count} ${noun}${count === 1 ? "" : "s"} selected`;
   }
   if (collectionMode) {
-    const count = (selectors ?? []).length;
+    const count = collectionCount ?? 0;
     if (count === 0) return "Select...";
-    return `${count} tool${count === 1 ? "" : "s"} selected`;
+    return `${count} collection${count === 1 ? "" : "s"} selected`;
   }
   if (selectors === null) {
     return resourceType === "project" ? "All projects" : "All servers";

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -198,7 +198,11 @@ export function ScopePickerPopover({
   const isResourceSelected = (id: string) =>
     selectors?.some((s) => s.resourceId === id) ?? false;
 
-  const scopeOptions = (
+  const renderScopeOptions = ({
+    includeCollection,
+  }: {
+    includeCollection: boolean;
+  }) => (
     <div className="shrink-0 pb-1.5">
       <ScopeOption
         label={resourceType === "project" ? "All projects" : "All servers"}
@@ -246,7 +250,7 @@ export function ScopePickerPopover({
           }}
         />
       )}
-      {isMcpConnect && (
+      {isMcpConnect && includeCollection && (
         <ScopeOption
           label="Specific collections"
           selected={!!collectionMode}
@@ -417,7 +421,7 @@ export function ScopePickerPopover({
             transitionTimingFunction: "cubic-bezier(0.32, 0.72, 0, 1)",
           }}
         >
-          {scopeOptions}
+          {renderScopeOptions({ includeCollection: true })}
           {resourceList}
           {customMode && (
             <div className="-mx-1.5 -mb-1.5 flex max-h-[min(420px,60vh)] flex-col">
@@ -466,7 +470,7 @@ export function ScopePickerPopover({
             </button>
           </div>
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-1.5">
-            {scopeOptions}
+            {renderScopeOptions({ includeCollection: false })}
             {customTabs()}
           </div>
         </Dialog.Content>

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -5,11 +5,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { RequireScope } from "@/components/require-scope";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useOrganization } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { getServerURL } from "@/lib/utils";
 import { cn } from "@/lib/utils";
+import { useOrgRoutes } from "@/routes";
 import { useListCollections } from "@gram/client/react-query/listCollections.js";
 import { useListToolsetsForOrg } from "@gram/client/react-query/listToolsetsForOrg.js";
 import {
@@ -20,10 +22,10 @@ import {
   Maximize2,
   Minimize2,
   Globe,
+  Plus,
   Repeat,
   Shield,
   Loader2,
-  SquareLibrary,
   Tag,
   Wrench,
   X,
@@ -50,6 +52,9 @@ interface ScopePickerPopoverProps {
   /** Whether "Custom" mode is active (MCP scopes only) */
   customMode?: boolean;
   onCustomModeChange?: (custom: boolean) => void;
+  /** Whether "Specific collections" mode is active (MCP scopes only) */
+  collectionMode?: boolean;
+  onCollectionModeChange?: (mode: boolean) => void;
   /** Selected annotation hints for auto-group matching */
   annotations?: AnnotationHint[];
   onChangeAnnotations?: (annotations: AnnotationHint[]) => void;
@@ -132,6 +137,8 @@ export function ScopePickerPopover({
   onChangeSelectors,
   customMode,
   onCustomModeChange,
+  collectionMode,
+  onCollectionModeChange,
   annotations,
   onChangeAnnotations,
   customTab,
@@ -142,9 +149,9 @@ export function ScopePickerPopover({
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const customToolCount = useMemo(() => {
-    if (!customMode) return 0;
+    if (!customMode && !collectionMode) return 0;
     return (selectors ?? []).length;
-  }, [customMode, selectors]);
+  }, [customMode, collectionMode, selectors]);
 
   // Org-scoped permissions have no resource picker — they're always org-wide
   if (resourceType === "org") {
@@ -162,7 +169,13 @@ export function ScopePickerPopover({
     name: p.name,
   }));
 
-  const label = getLabel(resourceType, selectors, customMode, customToolCount);
+  const label = getLabel(
+    resourceType,
+    selectors,
+    customMode,
+    collectionMode,
+    customToolCount,
+  );
 
   const resourceKind = resourceType === "project" ? "project" : "mcp";
 
@@ -189,11 +202,14 @@ export function ScopePickerPopover({
     <div className="shrink-0 pb-1.5">
       <ScopeOption
         label={resourceType === "project" ? "All projects" : "All servers"}
-        selected={isUnrestricted && !customMode}
+        selected={isUnrestricted && !customMode && !collectionMode}
         onClick={() => {
           if (customMode) {
             onCustomModeChange?.(false);
             onChangeAnnotations?.([]);
+          }
+          if (collectionMode) {
+            onCollectionModeChange?.(false);
           }
           onChangeSelectors(null);
         }}
@@ -202,12 +218,15 @@ export function ScopePickerPopover({
         label={
           resourceType === "project" ? "Specific projects" : "Specific servers"
         }
-        selected={!isUnrestricted && !customMode}
+        selected={!isUnrestricted && !customMode && !collectionMode}
         onClick={() => {
           if (customMode) {
             onCustomModeChange?.(false);
             onChangeSelectors([]);
             onChangeAnnotations?.([]);
+          } else if (collectionMode) {
+            onCollectionModeChange?.(false);
+            onChangeSelectors([]);
           } else if (isUnrestricted) {
             onChangeSelectors([]);
           }
@@ -219,6 +238,7 @@ export function ScopePickerPopover({
           selected={!!customMode}
           onClick={() => {
             if (!customMode) {
+              if (collectionMode) onCollectionModeChange?.(false);
               onCustomModeChange?.(true);
               onChangeSelectors([]);
               onChangeAnnotations?.([]);
@@ -226,10 +246,26 @@ export function ScopePickerPopover({
           }}
         />
       )}
+      {isMcpConnect && (
+        <ScopeOption
+          label="Specific collections"
+          selected={!!collectionMode}
+          onClick={() => {
+            if (!collectionMode) {
+              if (customMode) {
+                onCustomModeChange?.(false);
+                onChangeAnnotations?.([]);
+              }
+              onCollectionModeChange?.(true);
+              onChangeSelectors([]);
+            }
+          }}
+        />
+      )}
     </div>
   );
 
-  const resourceList = !isUnrestricted && !customMode && (
+  const resourceList = !isUnrestricted && !customMode && !collectionMode && (
     <>
       <div className="bg-border my-1 h-px" />
       {resourceType === "project"
@@ -287,14 +323,6 @@ export function ScopePickerPopover({
           <Tag className="h-3.5 w-3.5" />
           By annotation
         </TabsTrigger>
-        <div className="bg-border/40 my-1 w-px self-stretch" />
-        <TabsTrigger
-          value="collection"
-          className="text-muted-foreground hover:bg-muted/50 data-[state=active]:bg-muted data-[state=active]:text-foreground h-auto rounded-sm border-none px-3 py-2 text-sm shadow-none data-[state=active]:shadow-none"
-        >
-          <SquareLibrary className="h-3.5 w-3.5" />
-          By collection
-        </TabsTrigger>
       </TabsList>
       <TabsContent
         value="select"
@@ -346,17 +374,20 @@ export function ScopePickerPopover({
           mcpServers={mcpServers}
         />
       </TabsContent>
-      <TabsContent
-        value="collection"
-        className="min-h-[200px] flex-1 overflow-y-auto px-2 py-1"
-      >
+    </Tabs>
+  );
+
+  const collectionPanel = (
+    <div className="-mx-1.5 -mb-1.5 flex max-h-[min(420px,60vh)] flex-col overflow-hidden">
+      <div className="border-border flex min-h-0 flex-1 flex-col overflow-y-auto border-y px-2 py-1">
         <CollectionGroupPanel
           mcpServers={mcpServers}
           selectors={selectors ?? []}
           onChangeSelectors={onChangeSelectors}
+          onNavigate={() => setPopoverOpen(false)}
         />
-      </TabsContent>
-    </Tabs>
+      </div>
+    </div>
   );
 
   return (
@@ -376,7 +407,11 @@ export function ScopePickerPopover({
           sideOffset={8}
           className={cn(
             "p-1.5 transition-[width] duration-500",
-            customMode ? "w-[620px]" : "max-h-[300px] w-44 overflow-y-auto",
+            customMode
+              ? "w-[620px]"
+              : collectionMode
+                ? "w-[360px]"
+                : "max-h-[300px] w-44 overflow-y-auto",
           )}
           style={{
             transitionTimingFunction: "cubic-bezier(0.32, 0.72, 0, 1)",
@@ -404,6 +439,7 @@ export function ScopePickerPopover({
               )}
             </div>
           )}
+          {collectionMode && collectionPanel}
         </PopoverContent>
       </Popover>
 
@@ -753,12 +789,15 @@ function CollectionGroupPanel({
   mcpServers,
   selectors,
   onChangeSelectors,
+  onNavigate,
 }: {
   mcpServers: ServerGroup[];
   selectors: Selector[];
   onChangeSelectors: (selectors: Selector[] | null) => void;
+  onNavigate?: () => void;
 }) {
   const client = useSdkClient();
+  const orgRoutes = useOrgRoutes();
 
   // Fetch org-level collections
   const { data: collectionsData, isLoading: collectionsLoading } =
@@ -819,6 +858,39 @@ function CollectionGroupPanel({
       .filter((g) => g.servers.some((s) => s.tools.length > 0));
   }, [collections, serverQueries, mcpSlugToServer]);
 
+  const goToCreateCollection = () => {
+    onNavigate?.();
+    orgRoutes.collections.create.goTo();
+  };
+
+  const intro = (
+    <div className="text-muted-foreground px-2 pt-2 pb-1 text-xs leading-relaxed">
+      Collections are reusable groups of MCP servers that can be installed into
+      multiple projects at once. Selecting a collection grants access to all of
+      its tools.
+    </div>
+  );
+
+  const createButton = (
+    <RequireScope
+      scope="org:admin"
+      level="component"
+      reason="You need org admin to create a collection."
+      className="w-full"
+    >
+      {({ disabled }) => (
+        <button
+          type="button"
+          onClick={disabled ? undefined : goToCreateCollection}
+          className="border-border bg-background hover:bg-muted/50 text-foreground mx-2 my-2 flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-dashed px-3 py-2 text-xs transition-colors"
+        >
+          <Plus className="h-3 w-3" />
+          Create new collection
+        </button>
+      )}
+    </RequireScope>
+  );
+
   if (collectionsLoading) {
     return (
       <div className="flex items-center justify-center py-6">
@@ -829,14 +901,19 @@ function CollectionGroupPanel({
 
   if (collections.length === 0 || collectionGroups.length === 0) {
     return (
-      <div className="text-muted-foreground py-6 text-center text-sm">
-        No collections with tools found
+      <div className="py-1">
+        {intro}
+        <div className="text-muted-foreground px-2 py-4 text-center text-sm">
+          No collections with tools found
+        </div>
+        {createButton}
       </div>
     );
   }
 
   return (
     <div className="py-1">
+      {intro}
       <div className="text-muted-foreground px-2 py-2 text-sm">
         Select all tools by collection:
       </div>
@@ -900,6 +977,7 @@ function CollectionGroupPanel({
           </button>
         );
       })}
+      {createButton}
     </div>
   );
 }
@@ -967,6 +1045,7 @@ function getLabel(
   resourceType: ResourceType,
   selectors: Selector[] | null,
   customMode?: boolean,
+  collectionMode?: boolean,
   customToolCount?: number,
 ): string {
   if (customMode) {
@@ -975,6 +1054,11 @@ function getLabel(
     const hasTools = (selectors ?? []).some((s) => s.tool);
     const noun = hasTools ? "tool" : "rule";
     return `${count} ${noun}${count === 1 ? "" : "s"} selected`;
+  }
+  if (collectionMode) {
+    const count = (selectors ?? []).length;
+    if (count === 0) return "Select...";
+    return `${count} tool${count === 1 ? "" : "s"} selected`;
   }
   if (selectors === null) {
     return resourceType === "project" ? "All projects" : "All servers";

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -19,6 +19,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  Info,
   Maximize2,
   Minimize2,
   Globe,
@@ -867,34 +868,6 @@ function CollectionGroupPanel({
     orgRoutes.collections.create.goTo();
   };
 
-  const intro = (
-    <div className="text-muted-foreground px-2 pt-2 pb-1 text-xs leading-relaxed">
-      Collections are reusable groups of MCP servers that can be installed into
-      multiple projects at once. Selecting a collection grants access to all of
-      its tools.
-    </div>
-  );
-
-  const createButton = (
-    <RequireScope
-      scope="org:admin"
-      level="component"
-      reason="You need org admin to create a collection."
-      className="w-full"
-    >
-      {({ disabled }) => (
-        <button
-          type="button"
-          onClick={disabled ? undefined : goToCreateCollection}
-          className="border-border bg-background hover:bg-muted/50 text-foreground mx-2 my-2 flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-dashed px-3 py-2 text-xs transition-colors"
-        >
-          <Plus className="h-3 w-3" />
-          Create new collection
-        </button>
-      )}
-    </RequireScope>
-  );
-
   if (collectionsLoading) {
     return (
       <div className="flex items-center justify-center py-6">
@@ -905,20 +878,38 @@ function CollectionGroupPanel({
 
   if (collections.length === 0 || collectionGroups.length === 0) {
     return (
-      <div className="py-1">
-        {intro}
-        <div className="text-muted-foreground px-2 py-4 text-center text-sm">
-          No collections with tools found
+      <div className="flex flex-col items-center px-4 py-5 text-center">
+        <div className="bg-muted mb-3 flex h-8 w-8 items-center justify-center rounded-full">
+          <Info className="text-muted-foreground h-4 w-4" />
         </div>
-        {createButton}
+        <p className="text-muted-foreground mb-4 text-xs leading-relaxed">
+          Collections group MCP servers for reuse across projects.
+          <br />
+          Selecting one grants access to all its tools.
+        </p>
+        <RequireScope
+          scope="org:admin"
+          level="component"
+          reason="You need org admin to create a collection."
+        >
+          {({ disabled }) => (
+            <button
+              type="button"
+              onClick={disabled ? undefined : goToCreateCollection}
+              className="border-input text-foreground hover:bg-accent inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs shadow-xs transition-colors"
+            >
+              <Plus className="h-3 w-3" />
+              Create new collection
+            </button>
+          )}
+        </RequireScope>
       </div>
     );
   }
 
   return (
     <div className="py-1">
-      {intro}
-      <div className="text-muted-foreground px-2 py-2 text-sm">
+      <div className="text-muted-foreground px-2 py-2 text-xs">
         Select all tools by collection:
       </div>
       {collectionGroups.map((group) => {
@@ -981,7 +972,25 @@ function CollectionGroupPanel({
           </button>
         );
       })}
-      {createButton}
+      <div className="border-border mx-2 mt-2 border-t pt-2">
+        <RequireScope
+          scope="org:admin"
+          level="component"
+          reason="You need org admin to create a collection."
+          className="w-full"
+        >
+          {({ disabled }) => (
+            <button
+              type="button"
+              onClick={disabled ? undefined : goToCreateCollection}
+              className="text-muted-foreground hover:text-foreground flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-sm px-3 py-1.5 text-xs transition-colors"
+            >
+              <Plus className="h-3 w-3" />
+              Create new collection
+            </button>
+          )}
+        </RequireScope>
+      </div>
     </div>
   );
 }

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -30,7 +30,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type {
@@ -159,12 +159,10 @@ export function ScopePickerPopover({
       : panelState.activePanel;
   const label = panelState.label;
 
-  // Clear override once selectors have content (user made a selection)
-  useEffect(() => {
-    if (selectors !== null && selectors.length > 0) {
-      setPanelOverride(null);
-    }
-  }, [selectors]);
+  // panelOverride persists until the user explicitly switches panels via
+  // switchPanel(). The derivation above already ignores the override when
+  // selectors have content, so clearing it eagerly only causes the UI to
+  // jump back to "servers" when the user deselects all items.
 
   // Org-scoped permissions have no resource picker — they're always org-wide
   if (resourceType === "org") {
@@ -394,7 +392,7 @@ export function ScopePickerPopover({
               ? "w-[620px]"
               : activePanel === "collection"
                 ? "w-[360px]"
-                : "max-h-[300px] w-44 overflow-y-auto",
+                : "max-h-[300px] w-52 overflow-y-auto",
           )}
           style={{
             transitionTimingFunction: "cubic-bezier(0.32, 0.72, 0, 1)",

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -26,7 +26,6 @@ import {
   Plus,
   Repeat,
   Shield,
-  Loader2,
   Tag,
   Wrench,
   X,
@@ -35,12 +34,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type {
+  ActivePanel,
   AnnotationHint,
   CustomTab,
   ResourceType,
   Selector,
 } from "./types";
 import { ANNOTATION_TO_DISPOSITION } from "./types";
+import { computePanelState, type CollectionGroup } from "./computePanelState";
 
 interface ScopePickerPopoverProps {
   /** The resource type determines which resource list to show */
@@ -50,12 +51,6 @@ interface ScopePickerPopoverProps {
   /** null = unrestricted; Selector[] = constrained */
   selectors: Selector[] | null;
   onChangeSelectors: (selectors: Selector[] | null) => void;
-  /** Whether "Custom" mode is active (MCP scopes only) */
-  customMode?: boolean;
-  onCustomModeChange?: (custom: boolean) => void;
-  /** Whether "Specific collections" mode is active (MCP scopes only) */
-  collectionMode?: boolean;
-  onCollectionModeChange?: (mode: boolean) => void;
   /** Selected annotation hints for auto-group matching */
   annotations?: AnnotationHint[];
   onChangeAnnotations?: (annotations: AnnotationHint[]) => void;
@@ -136,10 +131,6 @@ export function ScopePickerPopover({
   scope,
   selectors,
   onChangeSelectors,
-  customMode,
-  onCustomModeChange,
-  collectionMode,
-  onCollectionModeChange,
   annotations,
   onChangeAnnotations,
   customTab,
@@ -149,11 +140,31 @@ export function ScopePickerPopover({
   const mcpServers = useMCPServers(resourceType === "mcp");
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
-  const [collectionCount, setCollectionCount] = useState(0);
-  const customToolCount = useMemo(() => {
-    if (!customMode && !collectionMode) return 0;
-    return (selectors ?? []).length;
-  }, [customMode, collectionMode, selectors]);
+  // Override for when user clicks a mode but selectors are still empty
+  const [panelOverride, setPanelOverride] = useState<ActivePanel | null>(null);
+
+  const isMcpConnect = scope === "mcp:connect";
+  const collectionGroups = useCollectionGroups(mcpServers, isMcpConnect);
+
+  const panelState = computePanelState(
+    selectors,
+    collectionGroups,
+    resourceType,
+    customTab,
+  );
+  // Use override only when selectors are empty (user just switched mode)
+  const activePanel =
+    selectors !== null && selectors.length === 0 && panelOverride
+      ? panelOverride
+      : panelState.activePanel;
+  const label = panelState.label;
+
+  // Clear override once selectors have content (user made a selection)
+  useEffect(() => {
+    if (selectors !== null && selectors.length > 0) {
+      setPanelOverride(null);
+    }
+  }, [selectors]);
 
   // Org-scoped permissions have no resource picker — they're always org-wide
   if (resourceType === "org") {
@@ -164,21 +175,10 @@ export function ScopePickerPopover({
     );
   }
 
-  const isUnrestricted = selectors === null;
-  const isMcpConnect = scope === "mcp:connect";
   const projectList = organization.projects.map((p) => ({
     id: p.id,
     name: p.name,
   }));
-
-  const label = getLabel(
-    resourceType,
-    selectors,
-    customMode,
-    collectionMode,
-    customToolCount,
-    collectionCount,
-  );
 
   const resourceKind = resourceType === "project" ? "project" : "mcp";
 
@@ -201,6 +201,18 @@ export function ScopePickerPopover({
   const isResourceSelected = (id: string) =>
     selectors?.some((s) => s.resourceId === id) ?? false;
 
+  const switchPanel = (panel: ActivePanel) => {
+    setPanelOverride(panel);
+    if (panel === "all") {
+      onChangeSelectors(null);
+    } else {
+      onChangeSelectors([]);
+    }
+    if (panel !== "tools") {
+      onChangeAnnotations?.([]);
+    }
+  };
+
   const renderScopeOptions = ({
     includeCollection,
   }: {
@@ -209,70 +221,34 @@ export function ScopePickerPopover({
     <div className="shrink-0 pb-1.5">
       <ScopeOption
         label={resourceType === "project" ? "All projects" : "All servers"}
-        selected={isUnrestricted && !customMode && !collectionMode}
-        onClick={() => {
-          if (customMode) {
-            onCustomModeChange?.(false);
-            onChangeAnnotations?.([]);
-          }
-          if (collectionMode) {
-            onCollectionModeChange?.(false);
-          }
-          onChangeSelectors(null);
-        }}
+        selected={activePanel === "all"}
+        onClick={() => switchPanel("all")}
       />
       <ScopeOption
         label={
           resourceType === "project" ? "Specific projects" : "Specific servers"
         }
-        selected={!isUnrestricted && !customMode && !collectionMode}
-        onClick={() => {
-          if (customMode) {
-            onCustomModeChange?.(false);
-            onChangeSelectors([]);
-            onChangeAnnotations?.([]);
-          } else if (collectionMode) {
-            onCollectionModeChange?.(false);
-            onChangeSelectors([]);
-          } else if (isUnrestricted) {
-            onChangeSelectors([]);
-          }
-        }}
+        selected={activePanel === "servers"}
+        onClick={() => switchPanel("servers")}
       />
       {isMcpConnect && (
         <ScopeOption
           label="Specific tools"
-          selected={!!customMode}
-          onClick={() => {
-            if (!customMode) {
-              if (collectionMode) onCollectionModeChange?.(false);
-              onCustomModeChange?.(true);
-              onChangeSelectors([]);
-              onChangeAnnotations?.([]);
-            }
-          }}
+          selected={activePanel === "tools"}
+          onClick={() => switchPanel("tools")}
         />
       )}
       {isMcpConnect && includeCollection && (
         <ScopeOption
           label="Specific collections"
-          selected={!!collectionMode}
-          onClick={() => {
-            if (!collectionMode) {
-              if (customMode) {
-                onCustomModeChange?.(false);
-                onChangeAnnotations?.([]);
-              }
-              onCollectionModeChange?.(true);
-              onChangeSelectors([]);
-            }
-          }}
+          selected={activePanel === "collection"}
+          onClick={() => switchPanel("collection")}
         />
       )}
     </div>
   );
 
-  const resourceList = !isUnrestricted && !customMode && !collectionMode && (
+  const resourceList = activePanel === "servers" && (
     <>
       <div className="bg-border my-1 h-px" />
       {resourceType === "project"
@@ -388,11 +364,10 @@ export function ScopePickerPopover({
     <div className="-mx-1.5 -mb-1.5 flex max-h-[min(420px,60vh)] flex-col overflow-hidden">
       <div className="border-border flex min-h-0 flex-1 flex-col overflow-y-auto border-y px-2 py-1">
         <CollectionGroupPanel
-          mcpServers={mcpServers}
+          collectionGroups={collectionGroups}
           selectors={selectors ?? []}
           onChangeSelectors={onChangeSelectors}
           onNavigate={() => setPopoverOpen(false)}
-          onSelectedCountChange={setCollectionCount}
         />
       </div>
     </div>
@@ -415,9 +390,9 @@ export function ScopePickerPopover({
           sideOffset={8}
           className={cn(
             "p-1.5 transition-[width] duration-500",
-            customMode
+            activePanel === "tools"
               ? "w-[620px]"
-              : collectionMode
+              : activePanel === "collection"
                 ? "w-[360px]"
                 : "max-h-[300px] w-44 overflow-y-auto",
           )}
@@ -427,7 +402,7 @@ export function ScopePickerPopover({
         >
           {renderScopeOptions({ includeCollection: true })}
           {resourceList}
-          {customMode && (
+          {activePanel === "tools" && (
             <div className="-mx-1.5 -mb-1.5 flex max-h-[min(420px,60vh)] flex-col">
               {customTabs("max-h-[min(340px,50vh)]")}
               {(customTab ?? "select") === "select" && (
@@ -447,7 +422,7 @@ export function ScopePickerPopover({
               )}
             </div>
           )}
-          {collectionMode && collectionPanel}
+          {activePanel === "collection" && collectionPanel}
         </PopoverContent>
       </Popover>
 
@@ -793,63 +768,43 @@ function AnnotationGroupPanel({
   );
 }
 
-function CollectionGroupPanel({
-  mcpServers,
-  selectors,
-  onChangeSelectors,
-  onNavigate,
-  onSelectedCountChange,
-}: {
-  mcpServers: ServerGroup[];
-  selectors: Selector[];
-  onChangeSelectors: (selectors: Selector[] | null) => void;
-  onNavigate?: () => void;
-  onSelectedCountChange?: (count: number) => void;
-}) {
+/** Fetches collection groups with resolved server/tool data. */
+function useCollectionGroups(
+  mcpServers: ServerGroup[],
+  enabled: boolean,
+): CollectionGroup[] {
   const client = useSdkClient();
-  const orgRoutes = useOrgRoutes();
-
-  // Fetch org-level collections
-  const { data: collectionsData, isLoading: collectionsLoading } =
-    useListCollections({}, undefined);
+  const { data: collectionsData } = useListCollections({}, undefined, {
+    enabled,
+  });
   const collections = useMemo(
     () => collectionsData?.collections ?? [],
     [collectionsData?.collections],
   );
 
-  // Fetch servers for each collection in parallel
   const serverQueries = useQueries({
     queries: collections.map((c) => ({
       queryKey: ["collections", "listServers", c.slug],
       queryFn: () =>
-        client.collections.listServers({
-          collectionSlug: c.slug!,
-        }),
-      enabled: !!c.slug,
+        client.collections.listServers({ collectionSlug: c.slug! }),
+      enabled: enabled && !!c.slug,
     })),
   });
 
-  // Build mcpSlug → Server lookup from the already-loaded toolset data
   const mcpSlugToServer = useMemo(() => {
     const map = new Map<string, Server>();
     for (const group of mcpServers) {
       for (const server of group.servers) {
-        if (server.mcpSlug) {
-          map.set(server.mcpSlug, server);
-        }
+        if (server.mcpSlug) map.set(server.mcpSlug, server);
       }
     }
     return map;
   }, [mcpServers]);
 
-  // Resolve each collection's servers to internal toolset servers with tools.
-  // Filter out collections that have no tools (no matched servers or all empty).
-  const collectionGroups = useMemo(() => {
+  return useMemo(() => {
     return collections
       .map((c, i) => {
-        const serversResponse = serverQueries[i]?.data;
-        const externalServers = serversResponse?.servers ?? [];
-
+        const externalServers = serverQueries[i]?.data?.servers ?? [];
         const matchedServers: Server[] = [];
         for (const es of externalServers) {
           const parts = es.registrySpecifier.split("/");
@@ -857,51 +812,36 @@ function CollectionGroupPanel({
           const server = mcpSlugToServer.get(mcpSlug);
           if (server) matchedServers.push(server);
         }
-
         return {
-          id: c.id,
-          name: c.name,
+          id: c.id!,
+          name: c.name!,
           slug: c.slug,
           servers: matchedServers,
         };
       })
       .filter((g) => g.servers.some((s) => s.tools.length > 0));
   }, [collections, serverQueries, mcpSlugToServer]);
+}
 
-  const selectedCollectionCount = useMemo(() => {
-    return collectionGroups.filter((group) => {
-      const allToolSelectors = group.servers.flatMap((s) =>
-        s.tools.map((t) => ({ resourceId: s.id, tool: t.name })),
-      );
-      return (
-        allToolSelectors.length > 0 &&
-        allToolSelectors.every((ts) =>
-          selectors.some(
-            (s) => s.resourceId === ts.resourceId && s.tool === ts.tool,
-          ),
-        )
-      );
-    }).length;
-  }, [collectionGroups, selectors]);
-
-  useEffect(() => {
-    onSelectedCountChange?.(selectedCollectionCount);
-  }, [selectedCollectionCount, onSelectedCountChange]);
+function CollectionGroupPanel({
+  collectionGroups,
+  selectors,
+  onChangeSelectors,
+  onNavigate,
+}: {
+  collectionGroups: CollectionGroup[];
+  selectors: Selector[];
+  onChangeSelectors: (selectors: Selector[] | null) => void;
+  onNavigate?: () => void;
+}) {
+  const orgRoutes = useOrgRoutes();
 
   const goToCreateCollection = () => {
     onNavigate?.();
     orgRoutes.collections.create.goTo();
   };
 
-  if (collectionsLoading) {
-    return (
-      <div className="flex items-center justify-center py-6">
-        <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
-      </div>
-    );
-  }
-
-  if (collections.length === 0 || collectionGroups.length === 0) {
+  if (collectionGroups.length === 0) {
     return (
       <div className="flex flex-col items-center px-4 py-5 text-center">
         <div className="bg-muted mb-3 flex h-8 w-8 items-center justify-center rounded-full">
@@ -1077,32 +1017,4 @@ function ScopeOption({
       <span>{label}</span>
     </button>
   );
-}
-
-function getLabel(
-  resourceType: ResourceType,
-  selectors: Selector[] | null,
-  customMode?: boolean,
-  collectionMode?: boolean,
-  customToolCount?: number,
-  collectionCount?: number,
-): string {
-  if (customMode) {
-    const count = customToolCount ?? 0;
-    if (count === 0) return "Select...";
-    const hasTools = (selectors ?? []).some((s) => s.tool);
-    const noun = hasTools ? "tool" : "rule";
-    return `${count} ${noun}${count === 1 ? "" : "s"} selected`;
-  }
-  if (collectionMode) {
-    const count = collectionCount ?? 0;
-    if (count === 0) return "Select...";
-    return `${count} collection${count === 1 ? "" : "s"} selected`;
-  }
-  if (selectors === null) {
-    return resourceType === "project" ? "All projects" : "All servers";
-  }
-  if (selectors.length === 0) return "Select...";
-  const noun = resourceType === "project" ? "project" : "server";
-  return `${selectors.length} ${noun}${selectors.length === 1 ? "" : "s"} selected`;
 }

--- a/client/dashboard/src/pages/access/computePanelState.test.ts
+++ b/client/dashboard/src/pages/access/computePanelState.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "vitest";
+import {
+  computePanelState,
+  getSelectedCollectionCount,
+  type CollectionGroup,
+} from "./computePanelState";
+import type { Selector } from "./types";
+
+// --- Helpers ---
+
+const tool = (resourceId: string, toolName: string): Selector => ({
+  resourceKind: "mcp",
+  resourceId,
+  tool: toolName,
+});
+
+const server = (resourceId: string): Selector => ({
+  resourceKind: "mcp",
+  resourceId,
+});
+
+const disposition = (d: string): Selector => ({
+  resourceKind: "mcp",
+  resourceId: "*",
+  disposition: d as Selector["disposition"],
+});
+
+// --- Fixtures ---
+
+const collections: CollectionGroup[] = [
+  {
+    id: "col-1",
+    name: "Backend Tools",
+    servers: [
+      {
+        id: "srv-a",
+        tools: [{ name: "create-user" }, { name: "delete-user" }],
+      },
+      { id: "srv-b", tools: [{ name: "send-email" }] },
+    ],
+  },
+  {
+    id: "col-2",
+    name: "Frontend Tools",
+    servers: [
+      { id: "srv-c", tools: [{ name: "deploy" }, { name: "preview" }] },
+    ],
+  },
+];
+
+// --- Tests ---
+
+describe("computePanelState", () => {
+  describe("all panel", () => {
+    it("null selectors → all panel with correct label", () => {
+      const result = computePanelState(null, [], "mcp");
+      expect(result).toEqual({ activePanel: "all", label: "All servers" });
+    });
+
+    it("null selectors with project resourceType", () => {
+      const result = computePanelState(null, [], "project");
+      expect(result).toEqual({ activePanel: "all", label: "All projects" });
+    });
+
+    it("ignores collection data when null", () => {
+      const result = computePanelState(null, collections, "mcp");
+      expect(result.activePanel).toBe("all");
+    });
+  });
+
+  describe("servers panel", () => {
+    it("empty selectors → servers with Select... label", () => {
+      const result = computePanelState([], [], "mcp");
+      expect(result).toEqual({
+        activePanel: "servers",
+        selectedServerIds: [],
+        label: "Select...",
+      });
+    });
+
+    it("server-level selectors → servers panel with IDs", () => {
+      const result = computePanelState(
+        [server("srv-a"), server("srv-b")],
+        collections,
+        "mcp",
+      );
+      expect(result).toEqual({
+        activePanel: "servers",
+        selectedServerIds: ["srv-a", "srv-b"],
+        label: "2 servers selected",
+      });
+    });
+
+    it("single server → singular label", () => {
+      const result = computePanelState([server("srv-a")], [], "mcp");
+      expect(result).toEqual({
+        activePanel: "servers",
+        selectedServerIds: ["srv-a"],
+        label: "1 server selected",
+      });
+    });
+
+    it("project resource type uses 'project' noun", () => {
+      const result = computePanelState(
+        [server("proj-1"), server("proj-2")],
+        [],
+        "project",
+      );
+      expect(result).toEqual({
+        activePanel: "servers",
+        selectedServerIds: ["proj-1", "proj-2"],
+        label: "2 projects selected",
+      });
+    });
+  });
+
+  describe("tools panel — select tab", () => {
+    it("tool selectors with no collection match → tools/select", () => {
+      const result = computePanelState(
+        [tool("srv-a", "create-user")], // partial — doesn't complete a collection
+        collections,
+        "mcp",
+      );
+      expect(result).toEqual({
+        activePanel: "tools",
+        tab: "select",
+        annotations: [],
+        selectedTools: [{ serverId: "srv-a", tool: "create-user" }],
+        label: "1 tool selected",
+      });
+    });
+
+    it("multiple tool selectors without collection match", () => {
+      const result = computePanelState(
+        [tool("srv-x", "foo"), tool("srv-x", "bar"), tool("srv-y", "baz")],
+        collections,
+        "mcp",
+      );
+      expect(result.activePanel).toBe("tools");
+      if (result.activePanel === "tools" && result.tab === "select") {
+        expect(result.selectedTools).toHaveLength(3);
+        expect(result.label).toBe("3 tools selected");
+      }
+    });
+
+    it("tool selectors with no collection data → tools", () => {
+      const result = computePanelState(
+        [
+          tool("srv-a", "create-user"),
+          tool("srv-a", "delete-user"),
+          tool("srv-b", "send-email"),
+        ],
+        [], // no collection data available
+        "mcp",
+      );
+      expect(result.activePanel).toBe("tools");
+    });
+  });
+
+  describe("tools panel — auto-groups tab", () => {
+    it("disposition selectors → tools/auto-groups", () => {
+      const result = computePanelState(
+        [disposition("read_only"), disposition("idempotent")],
+        collections,
+        "mcp",
+      );
+      expect(result).toEqual({
+        activePanel: "tools",
+        tab: "auto-groups",
+        annotations: ["readOnlyHint", "idempotentHint"],
+        label: "2 rules selected",
+      });
+    });
+
+    it("single disposition → singular label", () => {
+      const result = computePanelState([disposition("destructive")], [], "mcp");
+      expect(result).toEqual({
+        activePanel: "tools",
+        tab: "auto-groups",
+        annotations: ["destructiveHint"],
+        label: "1 rule selected",
+      });
+    });
+  });
+
+  describe("collection panel", () => {
+    it("selectors matching one full collection → collection panel", () => {
+      const result = computePanelState(
+        [
+          tool("srv-a", "create-user"),
+          tool("srv-a", "delete-user"),
+          tool("srv-b", "send-email"),
+        ],
+        collections,
+        "mcp",
+      );
+      expect(result).toEqual({
+        activePanel: "collection",
+        selectedCollectionCount: 1,
+        label: "1 collection selected",
+      });
+    });
+
+    it("selectors matching both collections → correct count", () => {
+      const result = computePanelState(
+        [
+          tool("srv-a", "create-user"),
+          tool("srv-a", "delete-user"),
+          tool("srv-b", "send-email"),
+          tool("srv-c", "deploy"),
+          tool("srv-c", "preview"),
+        ],
+        collections,
+        "mcp",
+      );
+      expect(result).toEqual({
+        activePanel: "collection",
+        selectedCollectionCount: 2,
+        label: "2 collections selected",
+      });
+    });
+
+    it("selectors matching one collection plus extra tools → still collection", () => {
+      const result = computePanelState(
+        [
+          tool("srv-a", "create-user"),
+          tool("srv-a", "delete-user"),
+          tool("srv-b", "send-email"),
+          tool("srv-z", "unrelated"),
+        ],
+        collections,
+        "mcp",
+      );
+      // At least one collection fully matched
+      expect(result.activePanel).toBe("collection");
+      if (result.activePanel === "collection") {
+        expect(result.selectedCollectionCount).toBe(1);
+      }
+    });
+  });
+});
+
+describe("getSelectedCollectionCount", () => {
+  it("returns 0 for empty selectors", () => {
+    expect(getSelectedCollectionCount([], collections)).toBe(0);
+  });
+
+  it("returns 0 for partial collection match", () => {
+    expect(
+      getSelectedCollectionCount([tool("srv-a", "create-user")], collections),
+    ).toBe(0);
+  });
+
+  it("returns 1 for one full collection", () => {
+    expect(
+      getSelectedCollectionCount(
+        [
+          tool("srv-a", "create-user"),
+          tool("srv-a", "delete-user"),
+          tool("srv-b", "send-email"),
+        ],
+        collections,
+      ),
+    ).toBe(1);
+  });
+
+  it("returns 2 for both collections", () => {
+    expect(
+      getSelectedCollectionCount(
+        [
+          tool("srv-a", "create-user"),
+          tool("srv-a", "delete-user"),
+          tool("srv-b", "send-email"),
+          tool("srv-c", "deploy"),
+          tool("srv-c", "preview"),
+        ],
+        collections,
+      ),
+    ).toBe(2);
+  });
+
+  it("skips collections with empty tool sets", () => {
+    const emptyCollection: CollectionGroup[] = [
+      { id: "empty", name: "Empty", servers: [{ id: "x", tools: [] }] },
+    ];
+    expect(
+      getSelectedCollectionCount([tool("x", "anything")], emptyCollection),
+    ).toBe(0);
+  });
+});

--- a/client/dashboard/src/pages/access/computePanelState.ts
+++ b/client/dashboard/src/pages/access/computePanelState.ts
@@ -1,0 +1,171 @@
+import type {
+  AnnotationHint,
+  CustomTab,
+  ResourceType,
+  Selector,
+} from "./types";
+import { DISPOSITION_TO_ANNOTATION } from "./types";
+
+// --- Collection group shape (minimal interface for computation) ---
+
+export interface CollectionGroup {
+  id: string;
+  name: string;
+  servers: { id: string; tools: { name: string }[] }[];
+}
+
+// --- Discriminated union for panel state ---
+
+export type PanelState =
+  | AllPanel
+  | ServersPanel
+  | ToolsSelectPanel
+  | ToolsAnnotationPanel
+  | CollectionPanel;
+
+interface AllPanel {
+  activePanel: "all";
+  label: string;
+}
+
+interface ServersPanel {
+  activePanel: "servers";
+  selectedServerIds: string[];
+  label: string;
+}
+
+interface ToolsSelectPanel {
+  activePanel: "tools";
+  tab: "select";
+  selectedTools: { serverId: string; tool: string }[];
+  label: string;
+}
+
+interface ToolsAnnotationPanel {
+  activePanel: "tools";
+  tab: "auto-groups";
+  annotations: AnnotationHint[];
+  label: string;
+}
+
+interface CollectionPanel {
+  activePanel: "collection";
+  selectedCollectionCount: number;
+  label: string;
+}
+
+// --- Pure computation ---
+
+export function computePanelState(
+  selectors: Selector[] | null,
+  collectionGroups: CollectionGroup[],
+  resourceType: ResourceType,
+  customTab?: CustomTab,
+): PanelState {
+  const noun = resourceType === "project" ? "project" : "server";
+
+  // Unrestricted
+  if (selectors === null) {
+    return {
+      activePanel: "all",
+      label: resourceType === "project" ? "All projects" : "All servers",
+    };
+  }
+
+  // Empty — user switched mode but hasn't selected anything yet
+  if (selectors.length === 0) {
+    return {
+      activePanel: "servers",
+      selectedServerIds: [],
+      label: "Select...",
+    };
+  }
+
+  // Disposition-based (annotation auto-groups)
+  const hasDisposition = selectors.some((s) => s.disposition);
+  if (hasDisposition) {
+    const annotations = selectors
+      .map((s) =>
+        s.disposition ? DISPOSITION_TO_ANNOTATION[s.disposition] : undefined,
+      )
+      .filter((a): a is AnnotationHint => !!a);
+    const count = annotations.length;
+    return {
+      activePanel: "tools",
+      tab: "auto-groups",
+      annotations,
+      label:
+        count === 0
+          ? "Select..."
+          : `${count} rule${count === 1 ? "" : "s"} selected`,
+    };
+  }
+
+  // Tool-level selectors
+  const hasTools = selectors.some((s) => s.tool);
+  if (hasTools) {
+    // Check if selectors match collection groups
+    const collectionCount = getSelectedCollectionCount(
+      selectors,
+      collectionGroups,
+    );
+    if (collectionCount > 0) {
+      return {
+        activePanel: "collection",
+        selectedCollectionCount: collectionCount,
+        label: `${collectionCount} collection${collectionCount === 1 ? "" : "s"} selected`,
+      };
+    }
+
+    // Individual tool selection
+    const selectedTools = selectors
+      .filter((s) => s.tool && s.resourceId)
+      .map((s) => ({ serverId: s.resourceId!, tool: s.tool! }));
+    const count = selectedTools.length;
+    return {
+      activePanel: "tools",
+      tab: customTab === "auto-groups" ? "auto-groups" : "select",
+      annotations: [],
+      selectedTools,
+      label:
+        count === 0
+          ? "Select..."
+          : `${count} tool${count === 1 ? "" : "s"} selected`,
+    } as ToolsSelectPanel;
+  }
+
+  // Server-level selectors only
+  const selectedServerIds = selectors
+    .filter((s) => s.resourceId)
+    .map((s) => s.resourceId!);
+  const count = selectedServerIds.length;
+  return {
+    activePanel: "servers",
+    selectedServerIds,
+    label:
+      count === 0
+        ? "Select..."
+        : `${count} ${noun}${count === 1 ? "" : "s"} selected`,
+  };
+}
+
+/**
+ * Counts how many collection groups are fully selected (all their tools
+ * present in selectors).
+ */
+export function getSelectedCollectionCount(
+  selectors: Selector[],
+  collectionGroups: CollectionGroup[],
+): number {
+  return collectionGroups.filter((group) => {
+    const allToolSelectors = group.servers.flatMap((s) =>
+      s.tools.map((t) => ({ resourceId: s.id, tool: t.name })),
+    );
+    if (allToolSelectors.length === 0) return false;
+    return allToolSelectors.every((ts) =>
+      selectors.some(
+        (s) => s.resourceId === ts.resourceId && s.tool === ts.tool,
+      ),
+    );
+  }).length;
+}

--- a/client/dashboard/src/pages/access/types.ts
+++ b/client/dashboard/src/pages/access/types.ts
@@ -21,6 +21,9 @@ export type AnnotationHint =
 /** The tool-selection tabs in custom mode. */
 export type CustomTab = "select" | "auto-groups";
 
+/** Which panel the scope picker is displaying. Derived from selectors. */
+export type ActivePanel = "all" | "servers" | "tools" | "collection";
+
 /** A single grant within a role: a scope + optional selector constraints. */
 export interface RoleGrant {
   scope: Scope;

--- a/client/dashboard/src/pages/access/types.ts
+++ b/client/dashboard/src/pages/access/types.ts
@@ -18,8 +18,8 @@ export type AnnotationHint =
   | "idempotentHint"
   | "openWorldHint";
 
-/** The three tool-selection tabs in custom mode. */
-export type CustomTab = "select" | "auto-groups" | "collection";
+/** The tool-selection tabs in custom mode. */
+export type CustomTab = "select" | "auto-groups";
 
 /** A single grant within a role: a scope + optional selector constraints. */
 export interface RoleGrant {

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -93,6 +93,9 @@ func TestService_Callback(t *testing.T) {
 		t.Parallel()
 
 		userInfo := defaultMockUserInfo()
+		userInfo.UserID = "nonadmin-override-user"
+		userInfo.Email = "nonadmin-override@example.com"
+		userInfo.Organizations[0].ID = "nonadmin-primary-org"
 		userInfo.Organizations = append(userInfo.Organizations, MockOrganizationEntry{
 			ID:                 "override-org-123",
 			Name:               "Override Organization",
@@ -112,7 +115,7 @@ func TestService_Callback(t *testing.T) {
 		require.NoError(t, err, "load session after callback")
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
 		require.True(t, ok, "auth context should be set after callback")
-		require.Equal(t, "org-123", authCtx.ActiveOrganizationID, "non-admin users should ignore admin override")
+		require.Equal(t, "nonadmin-primary-org", authCtx.ActiveOrganizationID, "non-admin users should ignore admin override")
 	})
 
 	t.Run("successful callback for admin with override", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Scope picker refactor**: derive panel state (`all` / `servers` / `tools` / `collection`) purely from selectors via `computePanelState()` — eliminates stored `customMode` / `collectionMode` state that broke on refresh
- **"Specific collections" promoted** to top-level scope option alongside All, Servers, Tools
- **Access page polish**: 3-dot actions menu with active state, system-first sort for roles & members tables, feature-flag-aware "Manage Team" link
- **Flaky test fix**: unique userID/email/orgID in `callback_test.go` to prevent Redis cache contamination

## Changes

| File | What |
|------|------|
| `computePanelState.ts` | New pure function + discriminated union types for panel state derivation |
| `computePanelState.test.ts` | 20 unit tests covering all panel states |
| `ScopePickerPopover.tsx` | Refactored to use `computePanelState()`, extracted `useCollectionGroups` hook |
| `CreateRoleDialog.tsx` | Simplified — removed `customScopes`/`collectionScopes` state |
| `RolesTab.tsx` | `RoleActionsMenu` component, system-first sort |
| `MembersTab.tsx` | System-first sort, feature-flagged manage team link |
| `types.ts` | Added `ActivePanel` type |
| `callback_test.go` | Unique IDs for non-admin override test |

## Test plan

- [x] Unit tests for `computePanelState` (20 cases)
- [ ] Manual: create/edit role → scope picker shows correct panel based on existing grants
- [ ] Manual: refresh page with collection grant → still shows "1 collection selected"
- [ ] Manual: 3-dot menu opens/closes cleanly, button stays highlighted when open
- [ ] Manual: roles & members tables sort system roles first
- [ ] Manual: "Manage Team" link respects `gram-team-page` feature flag