### PR TITLE
feat: reject private/reserved IPs in remote MCP server URL validation

### DIFF
--- a/.changeset/social-tables-wait.md
+++ b/.changeset/social-tables-wait.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+reject private/reserved IPs in Remote MCP Server URL validation

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -778,7 +778,7 @@ func newStartCommand() *cli.Command {
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine))
 			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
-			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine))
+			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy))
 			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, billingRepo, billingTracker), mcpService, mcpMetadataService)
 			triggers.Attach(mux, triggers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, triggerApp))
 			tools.Attach(mux, tools.NewService(logger, tracerProvider, db, sessionManager, authzEngine))

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -151,6 +151,7 @@ func WithResolver(resolver *net.Resolver) func(*htttpClientOptions) {
 type Policy struct {
 	tracerProvider    trace.TracerProvider
 	blockedCIDRBlocks []*net.IPNet
+	resolver          dns.Resolver
 }
 
 // NewDefaultPolicy creates a new Policy that blocks common private and reserved
@@ -159,6 +160,7 @@ func NewDefaultPolicy(tracerProvider trace.TracerProvider) *Policy {
 	return &Policy{
 		tracerProvider:    tracerProvider,
 		blockedCIDRBlocks: defaultBlockedCIDRBlocks,
+		resolver:          dns.NewNetResolver(),
 	}
 }
 
@@ -179,7 +181,17 @@ func NewUnsafePolicy(tracerProvider trace.TracerProvider, disallowedCIDRBlocks [
 	return &Policy{
 		tracerProvider:    tracerProvider,
 		blockedCIDRBlocks: disallowedBlocks,
+		resolver:          dns.NewNetResolver(),
 	}, nil
+}
+
+// WithResolver mutates the Policy in place to replace its resolver and
+// returns the receiver for chaining. Intended for tests that need to inject a
+// [dns.MockResolver]; production code should use the resolver supplied by the
+// constructor.
+func (p *Policy) WithResolver(resolver dns.Resolver) *Policy {
+	p.resolver = resolver
+	return p
 }
 
 // PooledClient returns an [http.Client] backed by a pooled transport that
@@ -262,7 +274,7 @@ func (p *Policy) Dialer(options ...func(*dialerOptions)) *net.Dialer {
 
 	resolver := opts.resolver
 	if resolver == nil {
-		resolver = dns.NewNetResolver().Resolver()
+		resolver = p.resolver.Resolver()
 	}
 
 	return &net.Dialer{
@@ -281,15 +293,66 @@ func (p *Policy) Dialer(options ...func(*dialerOptions)) *net.Dialer {
 				return fmt.Errorf("%s: %w: bad ip", address, ErrBadHost)
 			}
 
-			for _, block := range p.blockedCIDRBlocks {
-				if block.Contains(ip) {
-					return fmt.Errorf("%s: %w", ip, ErrBlockedIP)
-				}
-			}
-
-			return nil
+			return p.checkIP(ip)
 		},
 	}
+}
+
+// ValidateHost checks whether the given host is permitted by the policy's
+// CIDR blocklist. If host is an IP literal, it is checked directly; otherwise
+// host is resolved via the policy's resolver and every returned address is
+// checked. Returns [ErrBlockedIP] when any address falls within a blocked
+// CIDR, and [ErrBadHost] when host is empty, fails to resolve, or resolves to
+// no addresses.
+//
+// ValidateHost is intended for management-time URL validation so that callers
+// reject blocked hosts before persisting them. Runtime enforcement still
+// happens via [Policy.Dialer] regardless.
+//
+// For hostnames with multiple resolved addresses, ValidateHost fails closed:
+// any single blocked address rejects the host. This is stricter than the
+// runtime [net.Dialer], which only fails when it actually attempts a blocked
+// address. The asymmetry is intentional — validation should not persist a row
+// whose host points anywhere blocked, even if a public address happens to be
+// tried first at dial time.
+func (p *Policy) ValidateHost(ctx context.Context, host string) error {
+	if host == "" {
+		return fmt.Errorf("%w: empty host", ErrBadHost)
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		return p.checkIP(ip)
+	}
+
+	ips, err := p.resolver.LookupIP(ctx, "ip", host)
+	if err != nil {
+		return fmt.Errorf("%s: lookup ip: %w: %w", host, ErrBadHost, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("%s: %w: no addresses", host, ErrBadHost)
+	}
+
+	for _, ip := range ips {
+		if err := p.checkIP(ip); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkIP returns [ErrBlockedIP] if ip falls within any of the policy's
+// blocked CIDR ranges, and nil otherwise. It is the shared CIDR-membership
+// test used by both [Policy.Dialer]'s ControlContext callback and
+// [Policy.ValidateHost], so that runtime and management-time enforcement stay
+// in sync.
+func (p *Policy) checkIP(ip net.IP) error {
+	for _, block := range p.blockedCIDRBlocks {
+		if block.Contains(ip) {
+			return fmt.Errorf("%s: %w", ip, ErrBlockedIP)
+		}
+	}
+	return nil
 }
 
 func parseCIDR(cidr string) (*net.IPNet, error) {

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -142,33 +142,42 @@ func WithRetryConfig(config *RetryConfig) func(*htttpClientOptions) {
 	}
 }
 
-func WithResolver(resolver *net.Resolver) func(*htttpClientOptions) {
-	return func(o *htttpClientOptions) {
-		o.resolver = resolver
-	}
-}
-
 type Policy struct {
 	tracerProvider    trace.TracerProvider
 	blockedCIDRBlocks []*net.IPNet
 	resolver          dns.Resolver
 }
 
+// WithResolver is a functional option that sets the Policy's resolver.
+// This is intended for tests that need to inject a [dns.MockResolver]; production
+// code should use the default resolver supplied by the constructor.
+func WithResolver(resolver dns.Resolver) func(*Policy) {
+	return func(p *Policy) {
+		p.resolver = resolver
+	}
+}
+
 // NewDefaultPolicy creates a new Policy that blocks common private and reserved
 // IP ranges.
-func NewDefaultPolicy(tracerProvider trace.TracerProvider) *Policy {
-	return &Policy{
+func NewDefaultPolicy(tracerProvider trace.TracerProvider, options ...func(*Policy)) *Policy {
+	policy := &Policy{
 		tracerProvider:    tracerProvider,
 		blockedCIDRBlocks: defaultBlockedCIDRBlocks,
 		resolver:          dns.NewNetResolver(),
 	}
+
+	for _, option := range options {
+		option(policy)
+	}
+
+	return policy
 }
 
 // NewUnsafePolicy creates a new Policy with the provided disallowed CIDR blocks.
 // It returns an error if any of the CIDR blocks cannot be parsed.
 // Use NewDefaultPolicy for a safe default that blocks common private and
 // reserved IP ranges.
-func NewUnsafePolicy(tracerProvider trace.TracerProvider, disallowedCIDRBlocks []string) (*Policy, error) {
+func NewUnsafePolicy(tracerProvider trace.TracerProvider, disallowedCIDRBlocks []string, options ...func(*Policy)) (*Policy, error) {
 	var disallowedBlocks []*net.IPNet
 	for _, cidr := range disallowedCIDRBlocks {
 		block, err := parseCIDR(cidr)
@@ -178,20 +187,17 @@ func NewUnsafePolicy(tracerProvider trace.TracerProvider, disallowedCIDRBlocks [
 		disallowedBlocks = append(disallowedBlocks, block)
 	}
 
-	return &Policy{
+	policy := &Policy{
 		tracerProvider:    tracerProvider,
 		blockedCIDRBlocks: disallowedBlocks,
 		resolver:          dns.NewNetResolver(),
-	}, nil
-}
+	}
 
-// WithResolver mutates the Policy in place to replace its resolver and
-// returns the receiver for chaining. Intended for tests that need to inject a
-// [dns.MockResolver]; production code should use the resolver supplied by the
-// constructor.
-func (p *Policy) WithResolver(resolver dns.Resolver) *Policy {
-	p.resolver = resolver
-	return p
+	for _, option := range options {
+		option(policy)
+	}
+
+	return policy, nil
 }
 
 // PooledClient returns an [http.Client] backed by a pooled transport that

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -2,6 +2,7 @@ package guardian_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/speakeasy-api/gram/server/internal/dns"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/require"
@@ -490,4 +492,120 @@ func TestPolicy_IPv6VariationsBlocking(t *testing.T) {
 			require.ErrorIs(t, err, guardian.ErrBlockedIP, "Expected ErrBlockedIP for %s", tt.address)
 		})
 	}
+}
+
+func TestPolicy_ValidateHost_EmptyHost(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	err := policy.ValidateHost(t.Context(), "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, guardian.ErrBadHost)
+}
+
+func TestPolicy_ValidateHost_BlockedIPv4Literal(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	for _, host := range []string{"127.0.0.1", "10.0.0.1", "172.16.0.1", "192.168.1.1", "169.254.169.254"} {
+		err := policy.ValidateHost(t.Context(), host)
+		require.Error(t, err, "expected %s to be blocked", host)
+		require.ErrorIs(t, err, guardian.ErrBlockedIP, "expected ErrBlockedIP for %s", host)
+	}
+}
+
+func TestPolicy_ValidateHost_BlockedIPv6Literal(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	for _, host := range []string{"::1", "fe80::1", "fc00::1"} {
+		err := policy.ValidateHost(t.Context(), host)
+		require.Error(t, err, "expected %s to be blocked", host)
+		require.ErrorIs(t, err, guardian.ErrBlockedIP, "expected ErrBlockedIP for %s", host)
+	}
+}
+
+func TestPolicy_ValidateHost_AllowedPublicIPv4Literal(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	err := policy.ValidateHost(t.Context(), "8.8.8.8")
+	require.NoError(t, err)
+}
+
+func TestPolicy_ValidateHost_AllowedPublicIPv6Literal(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	err := policy.ValidateHost(t.Context(), "2606:4700:4700::1111")
+	require.NoError(t, err)
+}
+
+func TestPolicy_ValidateHost_HostnameResolvesToBlockedIP(t *testing.T) {
+	t.Parallel()
+	mock := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(ctx context.Context, network, host string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("10.0.0.1")}, nil
+		},
+	})
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	err := policy.ValidateHost(t.Context(), "internal.example.com")
+	require.Error(t, err)
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestPolicy_ValidateHost_HostnameResolvesToAllowedIP(t *testing.T) {
+	t.Parallel()
+	mock := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(ctx context.Context, network, host string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("1.2.3.4")}, nil
+		},
+	})
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	err := policy.ValidateHost(t.Context(), "example.com")
+	require.NoError(t, err)
+}
+
+func TestPolicy_ValidateHost_HostnameResolvesToMixedAddressesWithOneBlocked(t *testing.T) {
+	t.Parallel()
+	mock := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(ctx context.Context, network, host string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("127.0.0.1")}, nil
+		},
+	})
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	err := policy.ValidateHost(t.Context(), "split.example.com")
+	require.Error(t, err)
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestPolicy_ValidateHost_HostnameResolutionError(t *testing.T) {
+	t.Parallel()
+	resolveErr := errors.New("nxdomain")
+	mock := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(ctx context.Context, network, host string) ([]net.IP, error) {
+			return nil, resolveErr
+		},
+	})
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	err := policy.ValidateHost(t.Context(), "broken.example.com")
+	require.Error(t, err)
+	require.ErrorIs(t, err, guardian.ErrBadHost)
+	require.ErrorIs(t, err, resolveErr)
+}
+
+func TestPolicy_ValidateHost_HostnameResolvesToNoAddresses(t *testing.T) {
+	t.Parallel()
+	mock := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(ctx context.Context, network, host string) ([]net.IP, error) {
+			return nil, nil
+		},
+	})
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	err := policy.ValidateHost(t.Context(), "empty.example.com")
+	require.Error(t, err)
+	require.ErrorIs(t, err, guardian.ErrBadHost)
+}
+
+func TestPolicy_ValidateHost_UnsafePolicyPermitsBlockedLiteral(t *testing.T) {
+	t.Parallel()
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	require.NoError(t, policy.ValidateHost(t.Context(), "127.0.0.1"))
+	require.NoError(t, policy.ValidateHost(t.Context(), "10.0.0.1"))
 }

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -543,7 +543,10 @@ func TestPolicy_ValidateHost_HostnameResolvesToBlockedIP(t *testing.T) {
 			return []net.IP{net.ParseIP("10.0.0.1")}, nil
 		},
 	})
-	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	policy := guardian.NewDefaultPolicy(
+		testenv.NewTracerProvider(t),
+		guardian.WithResolver(mock),
+	)
 	err := policy.ValidateHost(t.Context(), "internal.example.com")
 	require.Error(t, err)
 	require.ErrorIs(t, err, guardian.ErrBlockedIP)
@@ -556,7 +559,10 @@ func TestPolicy_ValidateHost_HostnameResolvesToAllowedIP(t *testing.T) {
 			return []net.IP{net.ParseIP("1.2.3.4")}, nil
 		},
 	})
-	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	policy := guardian.NewDefaultPolicy(
+		testenv.NewTracerProvider(t),
+		guardian.WithResolver(mock),
+	)
 	err := policy.ValidateHost(t.Context(), "example.com")
 	require.NoError(t, err)
 }
@@ -568,7 +574,11 @@ func TestPolicy_ValidateHost_HostnameResolvesToMixedAddressesWithOneBlocked(t *t
 			return []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("127.0.0.1")}, nil
 		},
 	})
-	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	policy := guardian.NewDefaultPolicy(
+		testenv.NewTracerProvider(t),
+		guardian.WithResolver(mock),
+	)
+
 	err := policy.ValidateHost(t.Context(), "split.example.com")
 	require.Error(t, err)
 	require.ErrorIs(t, err, guardian.ErrBlockedIP)
@@ -582,7 +592,10 @@ func TestPolicy_ValidateHost_HostnameResolutionError(t *testing.T) {
 			return nil, resolveErr
 		},
 	})
-	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	policy := guardian.NewDefaultPolicy(
+		testenv.NewTracerProvider(t),
+		guardian.WithResolver(mock),
+	)
 	err := policy.ValidateHost(t.Context(), "broken.example.com")
 	require.Error(t, err)
 	require.ErrorIs(t, err, guardian.ErrBadHost)
@@ -596,7 +609,10 @@ func TestPolicy_ValidateHost_HostnameResolvesToNoAddresses(t *testing.T) {
 			return nil, nil
 		},
 	})
-	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)).WithResolver(mock)
+	policy := guardian.NewDefaultPolicy(
+		testenv.NewTracerProvider(t),
+		guardian.WithResolver(mock),
+	)
 	err := policy.ValidateHost(t.Context(), "empty.example.com")
 	require.Error(t, err)
 	require.ErrorIs(t, err, guardian.ErrBadHost)

--- a/server/internal/remotemcp/createserver_test.go
+++ b/server/internal/remotemcp/createserver_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
 func TestCreateServer(t *testing.T) {
@@ -117,6 +119,83 @@ func TestCreateServer_InvalidHeaderBothValues(t *testing.T) {
 
 	_, err := ti.service.CreateServer(ctx, payload)
 	require.Error(t, err)
+}
+
+// requireCreateServerInvalidURL asserts that creating a remote MCP server
+// with the given URL fails with [oops.CodeBadRequest], and returns the error
+// so the caller can make additional assertions on the error chain.
+func requireCreateServerInvalidURL(t *testing.T, url string) error {
+	t.Helper()
+
+	ctx, ti := newTestService(t)
+
+	_, err := ti.service.CreateServer(ctx, &gen.CreateServerPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		URL:              url,
+		TransportType:    "streamable-http",
+		Headers:          []*gen.HeaderInput{},
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeBadRequest)
+	return err //nolint:wrapcheck // returned for ErrorIs assertions on the chain
+}
+
+func TestCreateServer_InvalidURL_BlockedIPv4LiteralLoopback(t *testing.T) {
+	t.Parallel()
+	err := requireCreateServerInvalidURL(t, "http://127.0.0.1")
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestCreateServer_InvalidURL_BlockedIPv4LiteralPrivate(t *testing.T) {
+	t.Parallel()
+	err := requireCreateServerInvalidURL(t, "http://10.0.0.1")
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestCreateServer_InvalidURL_BlockedIPv6LiteralLoopback(t *testing.T) {
+	t.Parallel()
+	err := requireCreateServerInvalidURL(t, "http://[::1]")
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestCreateServer_InvalidURL_HostnameResolvesToBlockedIP(t *testing.T) {
+	t.Parallel()
+	err := requireCreateServerInvalidURL(t, "http://"+blockedTestHost)
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestCreateServer_InvalidURL_HostnameFailsToResolve(t *testing.T) {
+	t.Parallel()
+	err := requireCreateServerInvalidURL(t, "http://"+unresolvableTestHost)
+	require.ErrorIs(t, err, guardian.ErrBadHost)
+}
+
+func TestCreateServer_InvalidURL_UnsupportedScheme(t *testing.T) {
+	t.Parallel()
+	_ = requireCreateServerInvalidURL(t, "ftp://mcp.example.com")
+}
+
+func TestCreateServer_InvalidURL_MissingHost(t *testing.T) {
+	t.Parallel()
+	_ = requireCreateServerInvalidURL(t, "https://")
+}
+
+func TestCreateServer_AllowsPublicIPLiteral(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	result, err := ti.service.CreateServer(ctx, &gen.CreateServerPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		URL:              "http://8.8.8.8",
+		TransportType:    "streamable-http",
+		Headers:          []*gen.HeaderInput{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "http://8.8.8.8", result.URL)
 }
 
 func TestCreateServer_RBACForbidden(t *testing.T) {

--- a/server/internal/remotemcp/impl.go
+++ b/server/internal/remotemcp/impl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -40,12 +41,13 @@ type Service struct {
 	auth    *auth.Auth
 	authz   *authz.Engine
 	headers *Headers
+	policy  *guardian.Policy
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, enc *encryption.Client, authzEngine *authz.Engine) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, enc *encryption.Client, authzEngine *authz.Engine, policy *guardian.Policy) *Service {
 	logger = logger.With(attr.SlogComponent("remotemcp"))
 
 	return &Service{
@@ -55,6 +57,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		auth:    auth.New(logger, db, sessions, authzEngine),
 		authz:   authzEngine,
 		headers: NewHeaders(logger, db, enc),
+		policy:  policy,
 	}
 }
 
@@ -80,7 +83,7 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
-	if err := validateURL(payload.URL); err != nil {
+	if err := validateURL(ctx, s.policy, payload.URL); err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid url").Log(ctx, logger)
 	}
 
@@ -250,7 +253,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 	}
 
 	if payload.URL != nil {
-		if err := validateURL(*payload.URL); err != nil {
+		if err := validateURL(ctx, s.policy, *payload.URL); err != nil {
 			return nil, oops.E(oops.CodeBadRequest, err, "invalid url").Log(ctx, logger)
 		}
 	}
@@ -467,8 +470,9 @@ func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.A
 	return s.auth.Authorize(ctx, key, schema)
 }
 
-// validateURL checks that the given URL string is a valid absolute HTTP(S) URL.
-func validateURL(rawURL string) error {
+// validateURL checks that the given URL string is a valid absolute HTTP(S) URL
+// whose host is permitted by the supplied [guardian.Policy].
+func validateURL(ctx context.Context, policy *guardian.Policy, rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("parse url: %w", err)
@@ -480,6 +484,10 @@ func validateURL(rawURL string) error {
 
 	if u.Host == "" {
 		return fmt.Errorf("url must include a host")
+	}
+
+	if err := policy.ValidateHost(ctx, u.Hostname()); err != nil {
+		return fmt.Errorf("validate host: %w", err)
 	}
 
 	return nil

--- a/server/internal/remotemcp/setup_test.go
+++ b/server/internal/remotemcp/setup_test.go
@@ -83,7 +83,10 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	sessionsPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	servicePolicy := guardian.NewDefaultPolicy(tracerProvider).WithResolver(newRemoteMCPMockResolver())
+	servicePolicy := guardian.NewDefaultPolicy(
+		tracerProvider,
+		guardian.WithResolver(newRemoteMCPMockResolver()),
+	)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)

--- a/server/internal/remotemcp/setup_test.go
+++ b/server/internal/remotemcp/setup_test.go
@@ -2,7 +2,9 @@ package remotemcp_test
 
 import (
 	"context"
+	"errors"
 	"log"
+	"net"
 	"os"
 	"testing"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/dns"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp"
@@ -24,6 +27,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
+
+// blockedTestHost resolves to a private IP via the test mock resolver, so it
+// is rejected by the test guardian.Policy at validation time.
+const blockedTestHost = "internal.test"
+
+// unresolvableTestHost returns a resolver error via the test mock resolver, so
+// it is rejected by the test guardian.Policy at validation time.
+const unresolvableTestHost = "broken.test"
 
 var infra *testenv.Environment
 
@@ -59,8 +70,20 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
-	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+
+	// Two guardian policies are required because the test setup has two
+	// conflicting needs:
+	//
+	//   - sessionsPolicy permits loopback so the session manager can dial the
+	//     in-process mock IDP httptest.Server (which listens on 127.0.0.1).
+	//
+	//   - servicePolicy blocks loopback / private ranges so validateURL
+	//     exercises the real production CIDR set, and uses a mock resolver so
+	//     hostname-based test cases are deterministic.
+	sessionsPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
+
+	servicePolicy := guardian.NewDefaultPolicy(tracerProvider).WithResolver(newRemoteMCPMockResolver())
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
@@ -69,13 +92,13 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
-	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, sessionsPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
 	enc := testenv.NewEncryptionClient(t)
 
-	svc := remotemcp.NewService(logger, tracerProvider, conn, sessionManager, enc, authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache))
+	svc := remotemcp.NewService(logger, tracerProvider, conn, sessionManager, enc, authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), servicePolicy)
 
 	return ctx, &testInstance{
 		service:        svc,
@@ -117,4 +140,23 @@ func requireOopsCode(t *testing.T, err error, code oops.Code) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, code, oopsErr.Code)
+}
+
+// newRemoteMCPMockResolver returns a [dns.Resolver] used to make hostname
+// validation deterministic in tests. blockedTestHost resolves to a private IP
+// (which the test guardian.Policy blocks), unresolvableTestHost returns a
+// resolver error, and any other hostname resolves to a public IP.
+func newRemoteMCPMockResolver() dns.Resolver {
+	return dns.NewMockResolver(dns.MockResolverConfig{
+		LookupIPFunc: func(ctx context.Context, network, host string) ([]net.IP, error) {
+			switch host {
+			case blockedTestHost:
+				return []net.IP{net.ParseIP("10.0.0.1")}, nil
+			case unresolvableTestHost:
+				return nil, errors.New("mock resolver: nxdomain")
+			default:
+				return []net.IP{net.ParseIP("1.2.3.4")}, nil
+			}
+		},
+	})
 }

--- a/server/internal/remotemcp/updateserver_test.go
+++ b/server/internal/remotemcp/updateserver_test.go
@@ -8,6 +8,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/remote_mcp"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -295,4 +296,99 @@ func TestUpdateServer_PartialServerFields(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "https://mcp-new.example.com", updated.URL)
 	require.Equal(t, "streamable-http", updated.TransportType)
+}
+
+// requireUpdateServerInvalidURL creates a remote MCP server with a valid URL
+// and then asserts that updating it to the given URL fails with
+// [oops.CodeBadRequest], returning the error so the caller can make
+// additional assertions on the error chain.
+func requireUpdateServerInvalidURL(t *testing.T, url string) error {
+	t.Helper()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateServer(ctx, &gen.CreateServerPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		URL:              "https://mcp.example.com",
+		TransportType:    "streamable-http",
+		Headers:          []*gen.HeaderInput{},
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdateServer(ctx, &gen.UpdateServerPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		ID:               created.ID,
+		URL:              &url,
+		Headers:          nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeBadRequest)
+	return err //nolint:wrapcheck // returned for ErrorIs assertions on the chain
+}
+
+func TestUpdateServer_InvalidURL_BlockedIPv4LiteralLoopback(t *testing.T) {
+	t.Parallel()
+	err := requireUpdateServerInvalidURL(t, "http://127.0.0.1")
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestUpdateServer_InvalidURL_BlockedIPv4LiteralPrivate(t *testing.T) {
+	t.Parallel()
+	err := requireUpdateServerInvalidURL(t, "http://10.0.0.1")
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestUpdateServer_InvalidURL_BlockedIPv6LiteralLoopback(t *testing.T) {
+	t.Parallel()
+	err := requireUpdateServerInvalidURL(t, "http://[::1]")
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestUpdateServer_InvalidURL_HostnameResolvesToBlockedIP(t *testing.T) {
+	t.Parallel()
+	err := requireUpdateServerInvalidURL(t, "http://"+blockedTestHost)
+	require.ErrorIs(t, err, guardian.ErrBlockedIP)
+}
+
+func TestUpdateServer_InvalidURL_HostnameFailsToResolve(t *testing.T) {
+	t.Parallel()
+	err := requireUpdateServerInvalidURL(t, "http://"+unresolvableTestHost)
+	require.ErrorIs(t, err, guardian.ErrBadHost)
+}
+
+func TestUpdateServer_InvalidURL_UnsupportedScheme(t *testing.T) {
+	t.Parallel()
+	_ = requireUpdateServerInvalidURL(t, "ftp://mcp.example.com")
+}
+
+func TestUpdateServer_InvalidURL_MissingHost(t *testing.T) {
+	t.Parallel()
+	_ = requireUpdateServerInvalidURL(t, "https://")
+}
+
+func TestUpdateServer_AllowsPublicIPLiteral(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateServer(ctx, &gen.CreateServerPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		URL:              "https://mcp.example.com",
+		TransportType:    "streamable-http",
+		Headers:          []*gen.HeaderInput{},
+	})
+	require.NoError(t, err)
+
+	updated, err := ti.service.UpdateServer(ctx, &gen.UpdateServerPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		ID:               created.ID,
+		URL:              new("http://8.8.8.8"),
+		Headers:          nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "http://8.8.8.8", updated.URL)
 }


### PR DESCRIPTION
## Summary

- Adds `(*guardian.Policy).ValidateHost(ctx, host)` so callers can reject blocked hosts before persisting them. The method resolves the host via the policy's resolver and runs each result through the same CIDR check used by `Dialer().ControlContext`, sharing a new private `checkIP` helper.
- Plumbs `*guardian.Policy` into `remotemcp.NewService` and updates `validateURL` to call `ValidateHost`. Create and update endpoints now reject URLs whose host falls in a blocked CIDR with `400 Bad Request` before any database write, instead of failing later with an opaque dial-time error.
- Validation mirrors runtime semantics: public IP literals pass, all RFC-private/reserved ranges fail. For multi-A hostnames, `ValidateHost` fails closed on any blocked address. Dial-time enforcement is unchanged.
- Resolver becomes a field on `Policy` (defaulting to `dns.NewNetResolver()`) so `Dialer()` and `ValidateHost` share one source of truth. A new `WithResolver` builder lets tests inject a `dns.MockResolver`.

Resolves [AGE-1966](https://linear.app/speakeasy/issue/AGE-1966/reject-privatereserved-ips-in-remote-mcp-server-url-validation)