### PR TITLE
fix: bypass guardian SSRF policy for Presidio internal client

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -827,7 +827,7 @@ func newStartCommand() *cli.Command {
 				group.Go(func() {
 					var piiScanner risk_analysis.PIIScanner = &risk_analysis.StubPIIScanner{}
 					if presidioURL := c.String("presidio-analyzer-url"); presidioURL != "" {
-						piiScanner = risk_analysis.NewPresidioClient(presidioURL, guardianPolicy.PooledClient(), tracerProvider, meterProvider, logger)
+						piiScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger)
 					}
 
 					temporalWorker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, &background.WorkerOptions{

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -556,7 +556,7 @@ func newWorkerCommand() *cli.Command {
 
 			var piiScanner risk_analysis.PIIScanner = &risk_analysis.StubPIIScanner{}
 			if presidioURL := c.String("presidio-analyzer-url"); presidioURL != "" {
-				piiScanner = risk_analysis.NewPresidioClient(presidioURL, guardianPolicy.PooledClient(), tracerProvider, meterProvider, logger)
+				piiScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger)
 				logger.InfoContext(ctx, "presidio PII scanner enabled", attr.SlogURL(presidioURL))
 			}
 

--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -1,9 +1,7 @@
 package risk_analysis_test
 
 import (
-	"net/http"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +44,6 @@ func TestAnalyzeBatch_GracefulDegradationWhenPresidioDown(t *testing.T) {
 	// PresidioClient pointed at a dead URL simulates Presidio being down
 	deadClient := risk_analysis.NewPresidioClient(
 		"http://127.0.0.1:1",
-		&http.Client{Timeout: 1 * time.Second},
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testenv.NewLogger(t),

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-cleanhttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -50,9 +52,12 @@ type presidioResult struct {
 const presidioMaxWorkers = 100
 
 // PresidioClient calls the Presidio Analyzer HTTP API.
+// Presidio is a trusted cluster-internal service, so the client bypasses
+// guardian's SSRF blocklist (which rejects private IP ranges like 10.0.0.0/8
+// that Kubernetes ClusterIPs fall into).
 type PresidioClient struct {
 	baseURL         string
-	httpClient      *http.Client //nolint:forbidigo // Injected via guardian.Policy in the wiring layer.
+	httpClient      *http.Client //nolint:forbidigo // Internal pooled client, not guardian-managed.
 	tracer          trace.Tracer
 	logger          *slog.Logger
 	maxWorkers      int
@@ -61,8 +66,7 @@ type PresidioClient struct {
 }
 
 // NewPresidioClient creates a client pointing at the given base URL.
-// The httpClient should be obtained from guardian.Policy.PooledClient().
-func NewPresidioClient(baseURL string, httpClient *http.Client, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger) *PresidioClient { //nolint:forbidigo // Accepts guardian-provided client.
+func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger) *PresidioClient {
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio")
 
 	requestDuration, _ := meter.Float64Histogram(
@@ -78,6 +82,11 @@ func NewPresidioClient(baseURL string, httpClient *http.Client, tracerProvider t
 		metric.WithUnit("{request}"),
 	)
 
+	httpClient := &http.Client{Transport: otelhttp.NewTransport( //nolint:forbidigo // Internal pooled client, not guardian-managed.
+		cleanhttp.DefaultPooledTransport(),
+		otelhttp.WithTracerProvider(tracerProvider),
+	)}
+
 	return &PresidioClient{
 		baseURL:         strings.TrimRight(baseURL, "/"),
 		httpClient:      httpClient,
@@ -91,8 +100,8 @@ func NewPresidioClient(baseURL string, httpClient *http.Client, tracerProvider t
 
 // NewPresidioClientWithWorkers is like NewPresidioClient but allows overriding
 // the concurrency limit. Used for benchmarking.
-func NewPresidioClientWithWorkers(baseURL string, httpClient *http.Client, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, maxWorkers int) *PresidioClient { //nolint:forbidigo // Accepts guardian-provided client.
-	c := NewPresidioClient(baseURL, httpClient, tracerProvider, meterProvider, logger)
+func NewPresidioClientWithWorkers(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, maxWorkers int) *PresidioClient {
+	c := NewPresidioClient(baseURL, tracerProvider, meterProvider, logger)
 	c.maxWorkers = maxWorkers
 	return c
 }

--- a/server/internal/testenv/presidio.go
+++ b/server/internal/testenv/presidio.go
@@ -3,7 +3,6 @@ package testenv
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -49,7 +48,6 @@ func newPresidioClientFunc(container testcontainers.Container) PresidioClientFun
 
 		return risk_analysis.NewPresidioClient(
 			baseURL,
-			&http.Client{Timeout: 30 * time.Second},
 			NewTracerProvider(t),
 			NewMeterProvider(t),
 			NewLogger(t),


### PR DESCRIPTION
## Why

Presidio runs as a cluster-internal K8s service (`gram-presidio-analyzer:3000`) whose ClusterIP resolves to a `10.x.x.x` address. The guardian SSRF policy blocks all RFC 1918 private ranges (`10.0.0.0/8`), causing every Presidio HTTP call from the worker to fail with `dial tcp 10.1.23.104:3000: blocked ip`. This produced ~96k warnings in the last 24h, meaning all PII scanning has been silently skipped since Presidio was enabled in prod.

## What changed

**Before:** Presidio HTTP client was created via `guardianPolicy.PooledClient()`, which enforces the CIDR blocklist and blocks private IPs.

**After:** Added `InternalPooledClient()` to `guardian.Policy` that provides OTel instrumentation without the CIDR blocklist. Used it for the Presidio HTTP client in both `start.go` (single-process mode) and `worker.go` (dedicated worker mode).