### PR TITLE
fix: centralize chat message writes with enforced risk notification

### DIFF
--- a/glint/no_direct_chat_message_insert.go
+++ b/glint/no_direct_chat_message_insert.go
@@ -1,0 +1,66 @@
+package glint
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	noDirectChatMessageInsertAnalyzer = "nodirectchatmessageinsert"
+	noDirectChatMessageInsertMessage  = "do not call CreateChatMessage directly; use chat.ChatMessageWriter.Write() or .RunInTx() to ensure risk analysis observers are notified"
+
+	chatRepoPkgPath = "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	chatPkgPath     = "github.com/speakeasy-api/gram/server/internal/chat"
+)
+
+type noDirectChatMessageInsertSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newNoDirectChatMessageInsertAnalyzer(rule noDirectChatMessageInsertSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: noDirectChatMessageInsertAnalyzer,
+		Doc:  noDirectChatMessageInsertMessage,
+		Run: func(pass *analysis.Pass) (any, error) {
+			// Allow calls from within the chat package itself.
+			if pass.Pkg.Path() == chatPkgPath {
+				return nil, nil
+			}
+
+			for _, file := range pass.Files {
+				ast.Inspect(file, func(node ast.Node) bool {
+					callExpr, ok := node.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+
+					selectorExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+
+					if selectorExpr.Sel.Name != "CreateChatMessage" {
+						return true
+					}
+
+					called, ok := pass.TypesInfo.Uses[selectorExpr.Sel].(*types.Func)
+					if !ok || called.Pkg() == nil {
+						return true
+					}
+
+					if called.Pkg().Path() != chatRepoPkgPath {
+						return true
+					}
+
+					pass.ReportRangef(callExpr, "%s", noDirectChatMessageInsertMessage)
+
+					return true
+				})
+			}
+
+			return nil, nil
+		},
+	}
+}

--- a/glint/no_direct_chat_message_insert.go
+++ b/glint/no_direct_chat_message_insert.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	noDirectChatMessageInsertAnalyzer = "nodirectchatmessageinsert"
-	noDirectChatMessageInsertMessage  = "do not call CreateChatMessage directly; use chat.ChatMessageWriter.Write() or .RunInTx() to ensure risk analysis observers are notified"
+	noDirectChatMessageInsertMessage  = "do not call CreateChatMessage directly; use chat.ChatMessageWriter.Write() or .WriteTurn() to ensure risk analysis observers are notified"
 
 	chatRepoPkgPath = "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	chatPkgPath     = "github.com/speakeasy-api/gram/server/internal/chat"

--- a/glint/no_direct_chat_message_insert_test.go
+++ b/glint/no_direct_chat_message_insert_test.go
@@ -1,0 +1,14 @@
+package glint
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestNoDirectChatMessageInsert(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newNoDirectChatMessageInsertAnalyzer(noDirectChatMessageInsertSettings{}), "github.com/speakeasy-api/gram/server/internal/hooks")
+}

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -29,6 +29,7 @@ type ruleSettings struct {
 	AuditEventTypedSnapshot    auditEventTypedSnapshotSettings    `json:"audit-event-typed-snapshot"`
 	AuditEventURNNaming        auditEventURNNamingSettings        `json:"audit-event-urn-naming"`
 	AuditEventURNTyping        auditEventURNTypingSettings        `json:"audit-event-urn-typing"`
+	NoDirectChatMessageInsert  noDirectChatMessageInsertSettings  `json:"no-direct-chat-message-insert"`
 }
 
 type plugin struct {
@@ -72,6 +73,9 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	}
 	if !p.settings.Rules.AuditEventURNTyping.Disabled {
 		analyzers = append(analyzers, newAuditEventURNTypingAnalyzer(p.settings.Rules.AuditEventURNTyping))
+	}
+	if !p.settings.Rules.NoDirectChatMessageInsert.Disabled {
+		analyzers = append(analyzers, newNoDirectChatMessageInsertAnalyzer(p.settings.Rules.NoDirectChatMessageInsert))
 	}
 
 	return analyzers, nil

--- a/glint/plugin_test.go
+++ b/glint/plugin_test.go
@@ -21,6 +21,7 @@ func disabledAllRulesPlugin() *plugin {
 				AuditEventTypedSnapshot:    auditEventTypedSnapshotSettings{Disabled: true},
 				AuditEventURNNaming:        auditEventURNNamingSettings{Disabled: true},
 				AuditEventURNTyping:        auditEventURNTypingSettings{Disabled: true},
+				NoDirectChatMessageInsert:  noDirectChatMessageInsertSettings{Disabled: true},
 			},
 		},
 	}
@@ -41,5 +42,5 @@ func TestBuildAnalyzersAllEnabled(t *testing.T) {
 	p := &plugin{}
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
-	require.Len(t, analyzers, 9)
+	require.Len(t, analyzers, 10)
 }

--- a/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/chat/repo/stub.go
+++ b/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/chat/repo/stub.go
@@ -1,0 +1,13 @@
+package repo
+
+import "context"
+
+type CreateChatMessageParams struct{}
+
+type Queries struct{}
+
+func New(db any) *Queries { return &Queries{} }
+
+func (q *Queries) CreateChatMessage(_ context.Context, _ []CreateChatMessageParams) (int64, error) {
+	return 0, nil
+}

--- a/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/hooks/stub.go
+++ b/glint/testdata/src/github.com/speakeasy-api/gram/server/internal/hooks/stub.go
@@ -1,0 +1,12 @@
+package hooks
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+)
+
+func bad() {
+	q := repo.New(nil)
+	q.CreateChatMessage(context.Background(), nil) // want "do not call CreateChatMessage directly"
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -617,8 +617,10 @@ func newStartCommand() *cli.Command {
 				hooksCache = hooks.NewLocalSessionCache(hooksCache, db)
 			}
 
-			captureStrategy, shutdown := chat.NewChatMessageCaptureStrategy(logger, db, assetStorage)
-			shutdownFuncs = append(shutdownFuncs, shutdown)
+			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db)
+			shutdownFuncs = append(shutdownFuncs, chatWriterShutdown)
+
+			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, assetStorage, chatWriter)
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,
@@ -726,7 +728,7 @@ func newStartCommand() *cli.Command {
 			about.Attach(mux, about.NewService(logger, tracerProvider))
 			access.Attach(mux, access.NewService(logger, tracerProvider, db, sessionManager, roleClient, authzEngine, productFeatures))
 			assistants.Attach(mux, assistantsSvc)
-			hooks.Attach(mux, hooks.NewService(logger, db, tracerProvider, telemLogger, sessionManager, hooksCache, chatClient, temporalEnv, authzEngine, productFeatures, &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}))
+			hooks.Attach(mux, hooks.NewService(logger, db, tracerProvider, telemLogger, sessionManager, hooksCache, chatClient, temporalEnv, authzEngine, productFeatures, &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}, chatWriter))
 			audit.Attach(mux, audit.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			auth.Attach(mux, auth.NewService(
 				logger,
@@ -795,7 +797,7 @@ func newStartCommand() *cli.Command {
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
 			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, authzEngine, riskSignaler)
-			captureStrategy.AddObserver(riskService)
+			chatWriter.AddObserver(riskService)
 			risk.Attach(mux, riskService)
 
 			slack.Attach(mux, slack.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, redisClient, slackClient, temporalEnv, slack.Configurations{

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -617,10 +617,10 @@ func newStartCommand() *cli.Command {
 				hooksCache = hooks.NewLocalSessionCache(hooksCache, db)
 			}
 
-			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db)
+			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db, assetStorage)
 			shutdownFuncs = append(shutdownFuncs, chatWriterShutdown)
 
-			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, assetStorage, chatWriter)
+			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, chatWriter)
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -463,10 +463,10 @@ func newWorkerCommand() *cli.Command {
 			 * BEGIN -- MCP service setup for agent client
 			 */
 
-			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db)
+			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db, assetStorage)
 			shutdownFuncs = append(shutdownFuncs, chatWriterShutdown)
 
-			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, assetStorage, chatWriter)
+			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, chatWriter)
 
 			riskSignaler := background.NewThrottledSignaler(
 				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -463,8 +463,10 @@ func newWorkerCommand() *cli.Command {
 			 * BEGIN -- MCP service setup for agent client
 			 */
 
-			captureStrategy, shutdown := chat.NewChatMessageCaptureStrategy(logger, db, assetStorage)
-			shutdownFuncs = append(shutdownFuncs, shutdown)
+			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db)
+			shutdownFuncs = append(shutdownFuncs, chatWriterShutdown)
+
+			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, db, assetStorage, chatWriter)
 
 			riskSignaler := background.NewThrottledSignaler(
 				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},
@@ -472,7 +474,7 @@ func newWorkerCommand() *cli.Command {
 				logger,
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
-			captureStrategy.AddObserver(risk.NewObserver(logger, db, riskSignaler))
+			chatWriter.AddObserver(risk.NewObserver(logger, db, riskSignaler))
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -24,11 +23,10 @@ import (
 // ChatMessageCaptureStrategy captures completion messages to the database.
 // It implements the MessageCaptureStrategy interface.
 type ChatMessageCaptureStrategy struct {
-	logger       *slog.Logger
-	db           *pgxpool.Pool
-	repo         *repo.Queries
-	assetStorage assets.BlobStore
-	writer       *ChatMessageWriter
+	logger *slog.Logger
+	db     *pgxpool.Pool
+	repo   *repo.Queries
+	writer *ChatMessageWriter
 }
 
 var _ openrouter.MessageCaptureStrategy = (*ChatMessageCaptureStrategy)(nil)
@@ -49,15 +47,13 @@ type chatCaptureSession struct {
 func NewChatMessageCaptureStrategy(
 	logger *slog.Logger,
 	db *pgxpool.Pool,
-	assetStorage assets.BlobStore,
 	writer *ChatMessageWriter,
 ) *ChatMessageCaptureStrategy {
 	return &ChatMessageCaptureStrategy{
-		logger:       logger,
-		db:           db,
-		repo:         repo.New(db),
-		assetStorage: assetStorage,
-		writer:       writer,
+		logger: logger,
+		db:     db,
+		repo:   repo.New(db),
+		writer: writer,
 	}
 }
 
@@ -118,7 +114,7 @@ func (s *ChatMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, requ
 	// parentHash after the last new message becomes the chain tip for the assistant.
 	tipHash := rows[len(rows)-1].contentHash
 
-	if err := storeMessages(ctx, s.logger, s.db, s.assetStorage, rows); err != nil {
+	if err := s.writer.WriteWithAssets(ctx, projectID, rows); err != nil {
 		s.logger.ErrorContext(ctx, "failed to store chat messages", attr.SlogError(err))
 		// Keep the rows on the session so CaptureMessage can flush them atomically
 		// with the assistant response. We deliberately do not fail the request —
@@ -129,8 +125,6 @@ func (s *ChatMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, requ
 			pendingRows: rows,
 		}, nil
 	}
-
-	s.writer.notifyMessagesStored(ctx, projectID)
 
 	return &chatCaptureSession{
 		generation:  generation,
@@ -444,7 +438,7 @@ func (s *ChatMessageCaptureStrategy) resolveSession(ctx context.Context, raw ope
 // Postgres transaction. Observer notification is handled by RunInTx after commit.
 func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, projectID uuid.UUID, pending []chatMessageRow, assistants []repo.CreateChatMessageParams) error {
 	return s.writer.RunInTx(ctx, projectID, func(tx pgx.Tx) error {
-		if err := storeMessages(ctx, s.logger, tx, s.assetStorage, pending); err != nil {
+		if err := s.writer.storeMessages(ctx, tx, pending); err != nil {
 			return fmt.Errorf("store pending chat messages: %w", err)
 		}
 

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/google/uuid"
@@ -18,7 +17,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
@@ -30,8 +28,7 @@ type ChatMessageCaptureStrategy struct {
 	db           *pgxpool.Pool
 	repo         *repo.Queries
 	assetStorage assets.BlobStore
-	observers    []MessageObserver
-	shutdownCtx  context.Context //nolint:containedctx // shutdown context must outlive any single request
+	writer       *ChatMessageWriter
 }
 
 var _ openrouter.MessageCaptureStrategy = (*ChatMessageCaptureStrategy)(nil)
@@ -53,44 +50,15 @@ func NewChatMessageCaptureStrategy(
 	logger *slog.Logger,
 	db *pgxpool.Pool,
 	assetStorage assets.BlobStore,
-) (strategy *ChatMessageCaptureStrategy, shutdown func(context.Context) error) {
-	ctx, cancel := context.WithCancel(context.Background()) //nolint:contextcheck,gosec // this context must be tied to the lifetime of the application; cancel is called via the returned shutdown function
-	shutdown = func(_ context.Context) error {
-		cancel()
-		return nil
-	}
-
+	writer *ChatMessageWriter,
+) *ChatMessageCaptureStrategy {
 	return &ChatMessageCaptureStrategy{
 		logger:       logger,
 		db:           db,
 		repo:         repo.New(db),
 		assetStorage: assetStorage,
-		observers:    nil,
-		shutdownCtx:  ctx,
-	}, shutdown
-}
-
-// AddObserver registers a MessageObserver to be notified when messages are stored.
-func (s *ChatMessageCaptureStrategy) AddObserver(obs MessageObserver) {
-	s.observers = append(s.observers, obs)
-}
-
-func (s *ChatMessageCaptureStrategy) notifyObservers(ctx context.Context, projectID uuid.UUID) {
-	go func() {
-		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		stop := context.AfterFunc(s.shutdownCtx, cancel)
-		defer stop()
-
-		s.logger.DebugContext(ctx, "notifying message observers",
-			attr.SlogProjectID(projectID.String()),
-			attr.SlogMessageObserverCount(len(s.observers)),
-		)
-
-		for _, obs := range s.observers {
-			obs.OnMessagesStored(ctx, projectID)
-		}
-	}()
+		writer:       writer,
+	}
 }
 
 func (s *ChatMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, request openrouter.CompletionRequest) (openrouter.CaptureSession, error) {
@@ -162,7 +130,7 @@ func (s *ChatMessageCaptureStrategy) StartOrResumeChat(ctx context.Context, requ
 		}, nil
 	}
 
-	s.notifyObservers(ctx, projectID)
+	s.writer.notifyMessagesStored(ctx, projectID)
 
 	return &chatCaptureSession{
 		generation:  generation,
@@ -336,11 +304,10 @@ func (s *ChatMessageCaptureStrategy) CaptureMessage(
 	assistantRows := buildAssistantRows(request, response, projectID, toolCallsJSON, origin, userAgent, ipAddress, session.parentHash, session.generation)
 
 	if len(session.pendingRows) == 0 {
-		if _, err := s.repo.CreateChatMessage(ctx, assistantRows); err != nil {
+		if _, err := s.writer.Write(ctx, projectID, assistantRows); err != nil {
 			s.logger.ErrorContext(ctx, "failed to store chat message", attr.SlogError(err))
 			return fmt.Errorf("store chat message: %w", err)
 		}
-		s.notifyObservers(ctx, projectID)
 		return nil
 	}
 
@@ -348,10 +315,9 @@ func (s *ChatMessageCaptureStrategy) CaptureMessage(
 	// assistant row atomically so either the whole turn lands or none of it
 	// does. A partial write would orphan the assistant and force divergence
 	// detection to open a new generation on the next turn.
-	if err := s.flushTurnAtomically(ctx, session.pendingRows, assistantRows); err != nil {
+	if err := s.flushTurnAtomically(ctx, projectID, session.pendingRows, assistantRows); err != nil {
 		return err
 	}
-	s.notifyObservers(ctx, projectID)
 	return nil
 }
 
@@ -475,29 +441,21 @@ func (s *ChatMessageCaptureStrategy) resolveSession(ctx context.Context, raw ope
 
 // flushTurnAtomically writes the pending user rows (via storeMessages, which
 // also handles asset-storage upload) and the assistant rows inside a single
-// Postgres transaction.
-func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, pending []chatMessageRow, assistants []repo.CreateChatMessageParams) error {
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		s.logger.ErrorContext(ctx, "failed to begin transaction for catch-up flush", attr.SlogError(err))
-		return fmt.Errorf("begin transaction: %w", err)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+// Postgres transaction. Observer notification is handled by RunInTx after commit.
+func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, projectID uuid.UUID, pending []chatMessageRow, assistants []repo.CreateChatMessageParams) error {
+	return s.writer.RunInTx(ctx, projectID, func(tx pgx.Tx) error {
+		if err := storeMessages(ctx, s.logger, tx, s.assetStorage, pending); err != nil {
+			return fmt.Errorf("store pending chat messages: %w", err)
+		}
 
-	if err := storeMessages(ctx, s.logger, dbtx, s.assetStorage, pending); err != nil {
-		return fmt.Errorf("store pending chat messages: %w", err)
-	}
+		txRepo := repo.New(tx)
+		if _, err := txRepo.CreateChatMessage(ctx, assistants); err != nil {
+			s.logger.ErrorContext(ctx, "failed to store assistant chat message", attr.SlogError(err))
+			return fmt.Errorf("store assistant chat message: %w", err)
+		}
 
-	txRepo := repo.New(dbtx)
-	if _, err := txRepo.CreateChatMessage(ctx, assistants); err != nil {
-		s.logger.ErrorContext(ctx, "failed to store assistant chat message", attr.SlogError(err))
-		return fmt.Errorf("store assistant chat message: %w", err)
-	}
-
-	if err := dbtx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit catch-up transaction: %w", err)
-	}
-	return nil
+		return nil
+	})
 }
 
 // NoOpCaptureStrategy is a message capture strategy that does nothing.

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -437,18 +437,19 @@ func (s *ChatMessageCaptureStrategy) resolveSession(ctx context.Context, raw ope
 // also handles asset-storage upload) and the assistant rows inside a single
 // Postgres transaction. Observer notification is handled by RunInTx after commit.
 func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, projectID uuid.UUID, pending []chatMessageRow, assistants []repo.CreateChatMessageParams) error {
-	return s.writer.RunInTx(ctx, projectID, func(tx pgx.Tx) error {
+	return s.writer.RunInTx(ctx, projectID, func(tx pgx.Tx) (int64, error) {
 		if err := s.writer.storeMessages(ctx, tx, pending); err != nil {
-			return fmt.Errorf("store pending chat messages: %w", err)
+			return 0, fmt.Errorf("store pending chat messages: %w", err)
 		}
 
 		txRepo := repo.New(tx)
-		if _, err := txRepo.CreateChatMessage(ctx, assistants); err != nil {
+		n, err := txRepo.CreateChatMessage(ctx, assistants)
+		if err != nil {
 			s.logger.ErrorContext(ctx, "failed to store assistant chat message", attr.SlogError(err))
-			return fmt.Errorf("store assistant chat message: %w", err)
+			return 0, fmt.Errorf("store assistant chat message: %w", err)
 		}
 
-		return nil
+		return int64(len(pending)) + n, nil
 	})
 }
 

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -433,24 +433,14 @@ func (s *ChatMessageCaptureStrategy) resolveSession(ctx context.Context, raw ope
 	}
 }
 
-// flushTurnAtomically writes the pending user rows (via storeMessages, which
-// also handles asset-storage upload) and the assistant rows inside a single
-// Postgres transaction. Observer notification is handled by RunInTx after commit.
+// flushTurnAtomically writes the pending user rows and the assistant rows in
+// a single transaction so the turn lands as a unit.
 func (s *ChatMessageCaptureStrategy) flushTurnAtomically(ctx context.Context, projectID uuid.UUID, pending []chatMessageRow, assistants []repo.CreateChatMessageParams) error {
-	return s.writer.RunInTx(ctx, projectID, func(tx pgx.Tx) (int64, error) {
-		if err := s.writer.storeMessages(ctx, tx, pending); err != nil {
-			return 0, fmt.Errorf("store pending chat messages: %w", err)
-		}
-
-		txRepo := repo.New(tx)
-		n, err := txRepo.CreateChatMessage(ctx, assistants)
-		if err != nil {
-			s.logger.ErrorContext(ctx, "failed to store assistant chat message", attr.SlogError(err))
-			return 0, fmt.Errorf("store assistant chat message: %w", err)
-		}
-
-		return int64(len(pending)) + n, nil
-	})
+	if err := s.writer.WriteTurn(ctx, projectID, pending, assistants); err != nil {
+		s.logger.ErrorContext(ctx, "failed to flush chat turn", attr.SlogError(err))
+		return fmt.Errorf("flush chat turn: %w", err)
+	}
+	return nil
 }
 
 // NoOpCaptureStrategy is a message capture strategy that does nothing.

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -19,12 +19,11 @@ import (
 
 func newCaptureStrategy(t *testing.T, conn *pgxpool.Pool) *chat.ChatMessageCaptureStrategy {
 	t.Helper()
-	writer, writerShutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn)
+	writer, writerShutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, assetstest.NewTestBlobStore(t))
 	t.Cleanup(func() { _ = writerShutdown(t.Context()) })
 	return chat.NewChatMessageCaptureStrategy(
 		testenv.NewLogger(t),
 		conn,
-		assetstest.NewTestBlobStore(t),
 		writer,
 	)
 }

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -19,13 +19,14 @@ import (
 
 func newCaptureStrategy(t *testing.T, conn *pgxpool.Pool) *chat.ChatMessageCaptureStrategy {
 	t.Helper()
-	strategy, shutdown := chat.NewChatMessageCaptureStrategy(
+	writer, writerShutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn)
+	t.Cleanup(func() { _ = writerShutdown(t.Context()) })
+	return chat.NewChatMessageCaptureStrategy(
 		testenv.NewLogger(t),
 		conn,
 		assetstest.NewTestBlobStore(t),
+		writer,
 	)
-	t.Cleanup(func() { _ = shutdown(t.Context()) })
-	return strategy
 }
 
 func makeRequest(chatID, projectID uuid.UUID, orgID string, msgs ...or.ChatMessages) openrouter.CompletionRequest {

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -1,0 +1,107 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+)
+
+// ChatMessageWriter is the only sanctioned way to persist chat messages.
+// It wraps repo.CreateChatMessage and ensures observers are always notified
+// after a successful write.
+//
+// External packages must use Write or RunInTx. The unexported
+// notifyMessagesStored method is available to the chat package's own
+// internal helpers (e.g. storeMessages) where the insert and notification
+// are managed separately.
+type ChatMessageWriter struct {
+	db          *pgxpool.Pool
+	logger      *slog.Logger
+	observers   []MessageObserver
+	shutdownCtx context.Context //nolint:containedctx // must outlive any single request
+	cancel      context.CancelFunc
+}
+
+func NewChatMessageWriter(logger *slog.Logger, db *pgxpool.Pool) (w *ChatMessageWriter, shutdown func(context.Context) error) {
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:contextcheck,gosec
+	w = &ChatMessageWriter{
+		db:          db,
+		logger:      logger,
+		shutdownCtx: ctx,
+		cancel:      cancel,
+	}
+	shutdown = func(_ context.Context) error {
+		cancel()
+		return nil
+	}
+	return w, shutdown
+}
+
+func (w *ChatMessageWriter) AddObserver(obs MessageObserver) {
+	w.observers = append(w.observers, obs)
+}
+
+// Write inserts messages via the pool and notifies observers on success.
+func (w *ChatMessageWriter) Write(ctx context.Context, projectID uuid.UUID, params []repo.CreateChatMessageParams) (int64, error) {
+	n, err := repo.New(w.db).CreateChatMessage(ctx, params)
+	if err != nil {
+		return 0, err
+	}
+	w.notifyMessagesStored(ctx, projectID)
+	return n, nil
+}
+
+// RunInTx runs fn inside a transaction. If fn succeeds and the transaction
+// commits, observers are notified. The caller cannot forget notification
+// because it is handled by RunInTx itself.
+func (w *ChatMessageWriter) RunInTx(ctx context.Context, projectID uuid.UUID, fn func(tx pgx.Tx) error) error {
+	tx, err := w.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	w.notifyMessagesStored(ctx, projectID)
+	return nil
+}
+
+// notifyMessagesStored fires all registered observers asynchronously.
+// Unexported so that external packages are forced through Write or RunInTx.
+// The chat package uses this directly only when the insert is performed by
+// a private helper (e.g. storeMessages) where Write/RunInTx cannot be used.
+func (w *ChatMessageWriter) notifyMessagesStored(ctx context.Context, projectID uuid.UUID) {
+	if w == nil || len(w.observers) == 0 {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		stop := context.AfterFunc(w.shutdownCtx, cancel)
+		defer stop()
+
+		w.logger.DebugContext(ctx, "notifying message observers",
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogMessageObserverCount(len(w.observers)),
+		)
+
+		for _, obs := range w.observers {
+			obs.OnMessagesStored(ctx, projectID)
+		}
+	}()
+}

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
 // ChatMessageWriter is the only sanctioned way to persist chat messages.
@@ -74,7 +75,7 @@ func (w *ChatMessageWriter) WriteTurn(ctx context.Context, projectID uuid.UUID, 
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	if err := w.storeMessages(ctx, tx, pending); err != nil {
 		return fmt.Errorf("store pending chat messages: %w", err)
@@ -112,7 +113,7 @@ func (w *ChatMessageWriter) WriteWithAssets(ctx context.Context, projectID uuid.
 
 // storeMessages uploads message content to asset storage in parallel, then
 // batch-inserts the messages via the given DBTX. Used by WriteWithAssets
-// (with the pool) and inside RunInTx callbacks (with a transaction).
+// (with the pool) and WriteTurn (with a transaction).
 func (w *ChatMessageWriter) storeMessages(ctx context.Context, tx repo.DBTX, rows []chatMessageRow) error {
 	return storeMessages(ctx, w.logger, tx, w.assetStorage, rows)
 }

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -10,33 +10,31 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 )
 
 // ChatMessageWriter is the only sanctioned way to persist chat messages.
 // It wraps repo.CreateChatMessage and ensures observers are always notified
-// after a successful write.
-//
-// External packages must use Write or RunInTx. The unexported
-// notifyMessagesStored method is available to the chat package's own
-// internal helpers (e.g. storeMessages) where the insert and notification
-// are managed separately.
+// after a successful write. External packages must use Write or RunInTx.
 type ChatMessageWriter struct {
-	db          *pgxpool.Pool
-	logger      *slog.Logger
-	observers   []MessageObserver
-	shutdownCtx context.Context //nolint:containedctx // must outlive any single request
-	cancel      context.CancelFunc
+	db           *pgxpool.Pool
+	logger       *slog.Logger
+	assetStorage assets.BlobStore
+	observers    []MessageObserver
+	shutdownCtx  context.Context //nolint:containedctx // must outlive any single request
+	cancel       context.CancelFunc
 }
 
-func NewChatMessageWriter(logger *slog.Logger, db *pgxpool.Pool) (w *ChatMessageWriter, shutdown func(context.Context) error) {
+func NewChatMessageWriter(logger *slog.Logger, db *pgxpool.Pool, assetStorage assets.BlobStore) (w *ChatMessageWriter, shutdown func(context.Context) error) {
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:contextcheck,gosec
 	w = &ChatMessageWriter{
-		db:          db,
-		logger:      logger,
-		shutdownCtx: ctx,
-		cancel:      cancel,
+		db:           db,
+		logger:       logger,
+		assetStorage: assetStorage,
+		shutdownCtx:  ctx,
+		cancel:       cancel,
 	}
 	shutdown = func(_ context.Context) error {
 		cancel()
@@ -81,10 +79,26 @@ func (w *ChatMessageWriter) RunInTx(ctx context.Context, projectID uuid.UUID, fn
 	return nil
 }
 
+// WriteWithAssets uploads message content to asset storage, inserts the
+// messages via the pool, and notifies observers on success. This is the
+// full pipeline for the OpenRouter proxy path where messages carry rich
+// content that needs asset storage.
+func (w *ChatMessageWriter) WriteWithAssets(ctx context.Context, projectID uuid.UUID, rows []chatMessageRow) error {
+	if err := w.storeMessages(ctx, w.db, rows); err != nil {
+		return err
+	}
+	w.notifyMessagesStored(ctx, projectID)
+	return nil
+}
+
+// storeMessages uploads message content to asset storage in parallel, then
+// batch-inserts the messages via the given DBTX. Used by WriteWithAssets
+// (with the pool) and inside RunInTx callbacks (with a transaction).
+func (w *ChatMessageWriter) storeMessages(ctx context.Context, tx repo.DBTX, rows []chatMessageRow) error {
+	return storeMessages(ctx, w.logger, tx, w.assetStorage, rows)
+}
+
 // notifyMessagesStored fires all registered observers asynchronously.
-// Unexported so that external packages are forced through Write or RunInTx.
-// The chat package uses this directly only when the insert is performed by
-// a private helper (e.g. storeMessages) where Write/RunInTx cannot be used.
 func (w *ChatMessageWriter) notifyMessagesStored(ctx context.Context, projectID uuid.UUID) {
 	if w == nil || len(w.observers) == 0 {
 		return

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -16,8 +16,9 @@ import (
 )
 
 // ChatMessageWriter is the only sanctioned way to persist chat messages.
-// It wraps repo.CreateChatMessage and ensures observers are always notified
-// after a successful write. External packages must use Write or RunInTx.
+// It wraps repo.CreateChatMessage and notifies observers after a successful
+// write that stored at least one message. External packages must use Write
+// or RunInTx.
 type ChatMessageWriter struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
@@ -28,11 +29,12 @@ type ChatMessageWriter struct {
 }
 
 func NewChatMessageWriter(logger *slog.Logger, db *pgxpool.Pool, assetStorage assets.BlobStore) (w *ChatMessageWriter, shutdown func(context.Context) error) {
-	ctx, cancel := context.WithCancel(context.Background()) //nolint:contextcheck,gosec
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:contextcheck,gosec // shutdown context must outlive any single request
 	w = &ChatMessageWriter{
 		db:           db,
 		logger:       logger,
 		assetStorage: assetStorage,
+		observers:    nil,
 		shutdownCtx:  ctx,
 		cancel:       cancel,
 	}
@@ -51,23 +53,27 @@ func (w *ChatMessageWriter) AddObserver(obs MessageObserver) {
 func (w *ChatMessageWriter) Write(ctx context.Context, projectID uuid.UUID, params []repo.CreateChatMessageParams) (int64, error) {
 	n, err := repo.New(w.db).CreateChatMessage(ctx, params)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("create chat messages: %w", err)
 	}
-	w.notifyMessagesStored(ctx, projectID)
+	if n > 0 {
+		w.notifyMessagesStored(ctx, projectID)
+	}
 	return n, nil
 }
 
-// RunInTx runs fn inside a transaction. If fn succeeds and the transaction
-// commits, observers are notified. The caller cannot forget notification
-// because it is handled by RunInTx itself.
-func (w *ChatMessageWriter) RunInTx(ctx context.Context, projectID uuid.UUID, fn func(tx pgx.Tx) error) error {
+// RunInTx runs fn inside a transaction. fn returns the number of messages it
+// stored; if that count is positive and the transaction commits, observers are
+// notified. The caller cannot forget notification because it is handled by
+// RunInTx itself.
+func (w *ChatMessageWriter) RunInTx(ctx context.Context, projectID uuid.UUID, fn func(tx pgx.Tx) (int64, error)) error {
 	tx, err := w.db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if err := fn(tx); err != nil {
+	stored, err := fn(tx)
+	if err != nil {
 		return err
 	}
 
@@ -75,7 +81,9 @@ func (w *ChatMessageWriter) RunInTx(ctx context.Context, projectID uuid.UUID, fn
 		return fmt.Errorf("commit transaction: %w", err)
 	}
 
-	w.notifyMessagesStored(ctx, projectID)
+	if stored > 0 {
+		w.notifyMessagesStored(ctx, projectID)
+	}
 	return nil
 }
 
@@ -84,6 +92,9 @@ func (w *ChatMessageWriter) RunInTx(ctx context.Context, projectID uuid.UUID, fn
 // full pipeline for the OpenRouter proxy path where messages carry rich
 // content that needs asset storage.
 func (w *ChatMessageWriter) WriteWithAssets(ctx context.Context, projectID uuid.UUID, rows []chatMessageRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
 	if err := w.storeMessages(ctx, w.db, rows); err != nil {
 		return err
 	}

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
@@ -17,8 +16,8 @@ import (
 
 // ChatMessageWriter is the only sanctioned way to persist chat messages.
 // It wraps repo.CreateChatMessage and notifies observers after a successful
-// write that stored at least one message. External packages must use Write
-// or RunInTx.
+// write that stored at least one message. External packages must use Write,
+// WriteTurn, or WriteWithAssets.
 type ChatMessageWriter struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
@@ -61,27 +60,36 @@ func (w *ChatMessageWriter) Write(ctx context.Context, projectID uuid.UUID, para
 	return n, nil
 }
 
-// RunInTx runs fn inside a transaction. fn returns the number of messages it
-// stored; if that count is positive and the transaction commits, observers are
-// notified. The caller cannot forget notification because it is handled by
-// RunInTx itself.
-func (w *ChatMessageWriter) RunInTx(ctx context.Context, projectID uuid.UUID, fn func(tx pgx.Tx) (int64, error)) error {
+// WriteTurn persists a complete chat turn atomically: pending user/tool rows
+// (with asset upload) and pre-built assistant rows in a single transaction.
+// Observers are notified after commit if anything was stored. A partial write
+// would orphan the assistant row and force divergence detection to open a new
+// generation on the next turn, so atomicity is required.
+func (w *ChatMessageWriter) WriteTurn(ctx context.Context, projectID uuid.UUID, pending []chatMessageRow, assistants []repo.CreateChatMessageParams) error {
+	if len(pending) == 0 && len(assistants) == 0 {
+		return nil
+	}
+
 	tx, err := w.db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	stored, err := fn(tx)
+	if err := w.storeMessages(ctx, tx, pending); err != nil {
+		return fmt.Errorf("store pending chat messages: %w", err)
+	}
+
+	n, err := repo.New(tx).CreateChatMessage(ctx, assistants)
 	if err != nil {
-		return err
+		return fmt.Errorf("store assistant chat messages: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit transaction: %w", err)
 	}
 
-	if stored > 0 {
+	if int64(len(pending))+n > 0 {
 		w.notifyMessagesStored(ctx, projectID)
 	}
 	return nil

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
@@ -46,6 +47,7 @@ type Service struct {
 	repo               *repo.Queries
 	productFeatures    ProductFeaturesClient
 	chatTitleGenerator ChatTitleGenerator
+	writer             *chat.ChatMessageWriter
 }
 
 // SessionMetadata contains validated session information from the Logs endpoint
@@ -91,6 +93,7 @@ func NewService(
 	authz *authz.Engine,
 	pfClient ProductFeaturesClient,
 	chatTitleGenerator ChatTitleGenerator,
+	writer *chat.ChatMessageWriter,
 ) *Service {
 	return &Service{
 		tracer:             tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/hooks"),
@@ -105,6 +108,7 @@ func NewService(
 		repo:               repo.New(db),
 		productFeatures:    pfClient,
 		chatTitleGenerator: chatTitleGenerator,
+		writer:             writer,
 	}
 }
 

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -124,36 +124,33 @@ func (s *Service) insertMessageWithFallbackUpsert(
 		return nil
 	}
 
-	chatRepoQueries := chatRepo.New(s.db)
-
-	// Try to insert the message
-	_, err = chatRepoQueries.CreateChatMessage(ctx, []chatRepo.CreateChatMessageParams{msgParams})
-	if err != nil {
-		// Check if this is a foreign key violation (chat doesn't exist)
-		if isForeignKeyViolation(err) {
-			// Create the chat and retry
-			_, upsertErr := s.repo.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
-				ID:             chatID,
-				ProjectID:      projectID,
-				OrganizationID: metadata.GramOrgID,
-				UserID:         conv.ToPGTextEmpty(""),
-				ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
-				Title:          conv.ToPGText(defaultTitle),
-			})
-			if upsertErr != nil {
-				return fmt.Errorf("upsert claude code session after FK violation: %w", upsertErr)
-			}
-
-			// Retry message creation
-			_, err = chatRepoQueries.CreateChatMessage(ctx, []chatRepo.CreateChatMessageParams{msgParams})
-			if err != nil {
-				return fmt.Errorf("insert chat message after creating chat: %w", err)
-			}
-		} else {
-			return fmt.Errorf("insert chat message: %w", err)
-		}
+	// Try to insert the message (Write handles notification on success).
+	_, err = s.writer.Write(ctx, projectID, []chatRepo.CreateChatMessageParams{msgParams})
+	if err == nil {
+		return nil
 	}
 
+	// If this is not a foreign key violation (chat doesn't exist), fail.
+	if !isForeignKeyViolation(err) {
+		return fmt.Errorf("insert chat message: %w", err)
+	}
+
+	// Create the chat and retry.
+	_, upsertErr := s.repo.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID:             chatID,
+		ProjectID:      projectID,
+		OrganizationID: metadata.GramOrgID,
+		UserID:         conv.ToPGTextEmpty(""),
+		ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
+		Title:          conv.ToPGText(defaultTitle),
+	})
+	if upsertErr != nil {
+		return fmt.Errorf("upsert claude code session after FK violation: %w", upsertErr)
+	}
+
+	if _, err = s.writer.Write(ctx, projectID, []chatRepo.CreateChatMessageParams{msgParams}); err != nil {
+		return fmt.Errorf("insert chat message after creating chat: %w", err)
+	}
 	return nil
 }
 

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -78,7 +78,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 
 	// Pass nil for telemetry logger, temporalEnv, productFeatures, and chatTitleGenerator in tests
 	authzEngine := authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn)
+	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, nil)
 	t.Cleanup(func() { _ = chatWriterShutdown(t.Context()) })
 	svc := NewService(logger, conn, tracerProvider, nil, sessionManager, cacheAdapter, nil, nil, authzEngine, nil, nil, chatWriter)
 

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
@@ -77,7 +78,9 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 
 	// Pass nil for telemetry logger, temporalEnv, productFeatures, and chatTitleGenerator in tests
 	authzEngine := authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := NewService(logger, conn, tracerProvider, nil, sessionManager, cacheAdapter, nil, nil, authzEngine, nil, nil)
+	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn)
+	t.Cleanup(func() { _ = chatWriterShutdown(t.Context()) })
+	svc := NewService(logger, conn, tracerProvider, nil, sessionManager, cacheAdapter, nil, nil, authzEngine, nil, nil, chatWriter)
 
 	return ctx, &testInstance{
 		service:        svc,


### PR DESCRIPTION
## Why

Messages stored through Claude Code and Cursor hook paths were never scanned by risk policies. Only messages going through the OpenRouter proxy path notified observers, so IDE-originated sessions were invisible to risk policy enforcement. The root cause: observer notification was opt-in and scattered across multiple subsystems, making it easy to add a new message path and forget to notify.

## What changed

### Before

- `ChatMessageCaptureStrategy` and `hooks.Service` each maintained their own observer list and `notifyObservers` implementation
- Hooks inserted messages via `chatRepo.New(s.db).CreateChatMessage()` directly, with no observer notification
- Any new message-insertion path would silently skip risk analysis unless the author remembered to wire observers

### After

- Introduced `ChatMessageWriter` as the single gateway for persisting chat messages
- Three methods, all with automatic observer notification:
  - `Write(ctx, projectID, params)` for plain inserts (hooks path)
  - `WriteWithAssets(ctx, projectID, rows)` for asset upload + insert (proxy path)
  - `RunInTx(ctx, projectID, fn)` for transactional writes with post-commit notification
- `notifyMessagesStored` is unexported, so external packages cannot bypass notification
- Added `no-direct-chat-message-insert` glint lint rule that flags any `CreateChatMessage` call outside the `chat` package, directing the developer to use `ChatMessageWriter` instead
- `assetStorage` moved from `ChatMessageCaptureStrategy` to `ChatMessageWriter` since the writer now owns the full write pipeline
- Observer registration happens once per process (`chatWriter.AddObserver(riskService)`) instead of on each subsystem independently