### PR TITLE
feat: automatically register client when registration endpoint available

### DIFF
--- a/.changeset/floppy-brooms-bet.md
+++ b/.changeset/floppy-brooms-bet.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Improve automatic setup of OAuth Settings for Remote MCP servers

--- a/client/dashboard/src/pages/mcp/oauth-wizard/AutoRegisterChoice.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/AutoRegisterChoice.tsx
@@ -1,0 +1,60 @@
+import { Dialog } from "@/components/ui/dialog";
+import { Type } from "@/components/ui/type";
+import { Button } from "@speakeasy-api/moonshine";
+import { Loader2 } from "lucide-react";
+
+import { WizardContext } from "./machine";
+
+export function AutoRegisterChoice() {
+  const send = WizardContext.useActorRef().send;
+  const isLoading = WizardContext.useSelector(
+    (s) =>
+      s.matches({ proxy: "registering" }) ||
+      (s.matches({ proxy: "submitting" }) && s.context.autoRegistering),
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-12">
+        <Loader2 className="text-muted-foreground h-12 w-12 animate-spin" />
+        <Type className="text-center text-lg font-medium">
+          Fetching credentials...
+        </Type>
+        <Type muted small className="max-w-md text-center">
+          Registering Gram with the upstream OAuth provider and storing the
+          returned credentials.
+        </Type>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 pt-2 pb-4">
+        <Type>Automatic Client Registration</Type>
+        <Type muted small>
+          Speakeasy can automatically fetch the required credentials (Client ID
+          and Client Secret) from the OAuth server.
+        </Type>
+        <Type muted small>
+          How would you like to proceed?
+        </Type>
+      </div>
+
+      <Dialog.Footer className="flex justify-between">
+        <Button variant="secondary" onClick={() => send({ type: "BACK" })}>
+          Back
+        </Button>
+        <div className="ml-auto flex gap-2">
+          <Button
+            variant="secondary"
+            onClick={() => send({ type: "MANUAL_CREDENTIALS" })}
+          >
+            Supply my Own
+          </Button>
+          <Button onClick={() => send({ type: "AUTO_REGISTER" })}>Fetch</Button>
+        </div>
+      </Dialog.Footer>
+    </>
+  );
+}

--- a/client/dashboard/src/pages/mcp/oauth-wizard/AutoRegisterFailedStep.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/AutoRegisterFailedStep.tsx
@@ -1,0 +1,39 @@
+import { Dialog } from "@/components/ui/dialog";
+import { Link } from "@/components/ui/link";
+import { Type } from "@/components/ui/type";
+import { Button } from "@speakeasy-api/moonshine";
+import { AlertTriangle } from "lucide-react";
+
+export function AutoRegisterFailedStep({
+  error,
+  onClose,
+}: {
+  error: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <div className="flex flex-col items-center justify-center gap-4 py-8">
+        <AlertTriangle className="text-destructive h-12 w-12" />
+        <Type className="text-center text-lg font-medium">
+          Couldn't fetch credentials
+        </Type>
+        <Type muted small className="max-w-md text-center">
+          {error ??
+            "We weren't able to fetch OAuth credentials from the upstream provider."}
+        </Type>
+        <Type muted small className="max-w-md text-center">
+          Please reach out to{" "}
+          <Link external to="mailto:support@speakeasy.com">
+            customer support
+          </Link>{" "}
+          and we'll help you get this MCP server connected.
+        </Type>
+      </div>
+
+      <Dialog.Footer className="flex justify-end">
+        <Button onClick={onClose}>Close</Button>
+      </Dialog.Footer>
+    </>
+  );
+}

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
@@ -65,6 +65,12 @@ vi.mock("@/contexts/Auth", () => ({
   useSession: () => ({ activeOrganizationId: "org-1" }),
 }));
 
+vi.mock("@/contexts/Fetcher", () => ({
+  useFetcher: () => ({
+    fetch: vi.fn().mockResolvedValue(new Response("{}", { status: 200 })),
+  }),
+}));
+
 vi.mock("@/contexts/Telemetry", () => ({
   useTelemetry: () => ({ capture: mocks.capture }),
 }));

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -15,8 +15,9 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { Globe } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
 
+import { AutoRegisterChoice } from "./AutoRegisterChoice";
+import { AutoRegisterFailedStep } from "./AutoRegisterFailedStep";
 import { ExternalOAuthForm } from "./ExternalOAuthForm";
 import { FatalErrorStep } from "./FatalErrorStep";
 import {
@@ -114,15 +115,6 @@ function WizardBody({
               action: "oauth_proxy_configured",
               slug: toolsetSlug,
             }),
-          notifyAutoRegisterFailed: ({ event }) => {
-            const err = (event as { error?: unknown }).error;
-            const reason = err instanceof Error ? err.message : null;
-            toast.error(
-              reason
-                ? `Auto-registration failed: ${reason}. Enter credentials manually.`
-                : "Auto-registration failed. Enter credentials manually.",
-            );
-          },
         },
       }),
     [client, queryClient, telemetry, toolsetSlug, authedFetch],
@@ -155,6 +147,7 @@ function WizardSteps({
   const hasMultipleOAuth2AuthCode = oauth2SecurityCount > 1;
 
   const isProxyCreating = state.matches({ proxy: "submitting" });
+  const isAutoRegistering = state.context.autoRegistering;
 
   return (
     <>
@@ -171,12 +164,18 @@ function WizardSteps({
         />
       )}
 
-      {(state.matches({ proxy: "metadata" }) ||
-        state.matches({ proxy: "registering" })) && <ProxyMetadataForm />}
+      {state.matches({ proxy: "metadata" }) && <ProxyMetadataForm />}
 
-      {(state.matches({ proxy: "credentials" }) || isProxyCreating) && (
-        <ProxyCredentialsForm />
+      {(state.matches({ proxy: "autoRegisterChoice" }) ||
+        state.matches({ proxy: "registering" }) ||
+        (isProxyCreating && isAutoRegistering)) && <AutoRegisterChoice />}
+
+      {state.matches({ proxy: "autoRegisterFailed" }) && (
+        <AutoRegisterFailedStep error={state.context.error} onClose={onClose} />
       )}
+
+      {(state.matches({ proxy: "credentials" }) ||
+        (isProxyCreating && !isAutoRegistering)) && <ProxyCredentialsForm />}
 
       {state.matches({ proxy: "fatalError" }) && (
         <FatalErrorStep error={state.context.error} onClose={onClose} />

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -1,6 +1,7 @@
 import { FeatureRequestModal } from "@/components/FeatureRequestModal";
 import { Dialog } from "@/components/ui/dialog";
 import { useSession } from "@/contexts/Auth";
+import { useFetcher } from "@/contexts/Fetcher";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Toolset } from "@/lib/toolTypes";
 import { getServerURL } from "@/lib/utils";
@@ -14,6 +15,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { Globe } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import { ExternalOAuthForm } from "./ExternalOAuthForm";
 import { FatalErrorStep } from "./FatalErrorStep";
@@ -87,13 +89,14 @@ function WizardBody({
   const queryClient = useQueryClient();
   const telemetry = useTelemetry();
   const session = useSession();
+  const { fetch: authedFetch } = useFetcher();
 
   const discovered = useDiscoveredOAuth(toolset);
 
   const provided = useMemo(
     () =>
       oauthWizardMachine.provide({
-        actors: createWizardServices(client, queryClient),
+        actors: createWizardServices(client, queryClient, authedFetch),
         actions: {
           invalidateOnExternalSuccess: () => invalidateAllToolset(queryClient),
           invalidateOnProxyCreate: () => {
@@ -111,9 +114,18 @@ function WizardBody({
               action: "oauth_proxy_configured",
               slug: toolsetSlug,
             }),
+          notifyAutoRegisterFailed: ({ event }) => {
+            const err = (event as { error?: unknown }).error;
+            const reason = err instanceof Error ? err.message : null;
+            toast.error(
+              reason
+                ? `Auto-registration failed: ${reason}. Enter credentials manually.`
+                : "Auto-registration failed. Enter credentials manually.",
+            );
+          },
         },
       }),
-    [client, queryClient, telemetry, toolsetSlug],
+    [client, queryClient, telemetry, toolsetSlug, authedFetch],
   );
 
   const input: Input = {
@@ -159,7 +171,8 @@ function WizardSteps({
         />
       )}
 
-      {state.matches({ proxy: "metadata" }) && <ProxyMetadataForm />}
+      {(state.matches({ proxy: "metadata" }) ||
+        state.matches({ proxy: "registering" })) && <ProxyMetadataForm />}
 
       {(state.matches({ proxy: "credentials" }) || isProxyCreating) && (
         <ProxyCredentialsForm />

--- a/client/dashboard/src/pages/mcp/oauth-wizard/ProxyMetadataForm.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/ProxyMetadataForm.tsx
@@ -12,9 +12,6 @@ export function ProxyMetadataForm() {
   const proxy = WizardContext.useSelector((s) => s.context.proxy);
   const error = WizardContext.useSelector((s) => s.context.error);
   const discovered = WizardContext.useSelector((s) => s.context.discovered);
-  const isRegistering = WizardContext.useSelector((s) =>
-    s.matches({ proxy: "registering" }),
-  );
 
   const setField = (key: ProxyFormKey, value: string) =>
     send({ type: "FIELD_PROXY", key, value });
@@ -145,24 +142,19 @@ export function ProxyMetadataForm() {
       </div>
 
       <Dialog.Footer className="flex justify-between">
-        <Button
-          variant="secondary"
-          disabled={isRegistering}
-          onClick={() => send({ type: "BACK" })}
-        >
+        <Button variant="secondary" onClick={() => send({ type: "BACK" })}>
           Back
         </Button>
         <div className="ml-auto">
           <Button
             onClick={() => send({ type: "NEXT" })}
             disabled={
-              isRegistering ||
               !proxy.slug.trim() ||
               !proxy.authorizationEndpoint.trim() ||
               !proxy.tokenEndpoint.trim()
             }
           >
-            {isRegistering ? "Registering client..." : "Next"}
+            Next
           </Button>
         </div>
       </Dialog.Footer>

--- a/client/dashboard/src/pages/mcp/oauth-wizard/ProxyMetadataForm.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/ProxyMetadataForm.tsx
@@ -12,6 +12,9 @@ export function ProxyMetadataForm() {
   const proxy = WizardContext.useSelector((s) => s.context.proxy);
   const error = WizardContext.useSelector((s) => s.context.error);
   const discovered = WizardContext.useSelector((s) => s.context.discovered);
+  const isRegistering = WizardContext.useSelector((s) =>
+    s.matches({ proxy: "registering" }),
+  );
 
   const setField = (key: ProxyFormKey, value: string) =>
     send({ type: "FIELD_PROXY", key, value });
@@ -132,8 +135,8 @@ export function ProxyMetadataForm() {
                 value={proxy.tokenAuthMethod}
                 onChange={(e) => setField("tokenAuthMethod", e.target.value)}
               >
-                <option value="client_secret_post">client_secret_post</option>
                 <option value="client_secret_basic">client_secret_basic</option>
+                <option value="client_secret_post">client_secret_post</option>
                 <option value="none">none</option>
               </select>
             </div>
@@ -142,19 +145,24 @@ export function ProxyMetadataForm() {
       </div>
 
       <Dialog.Footer className="flex justify-between">
-        <Button variant="secondary" onClick={() => send({ type: "BACK" })}>
+        <Button
+          variant="secondary"
+          disabled={isRegistering}
+          onClick={() => send({ type: "BACK" })}
+        >
           Back
         </Button>
         <div className="ml-auto">
           <Button
             onClick={() => send({ type: "NEXT" })}
             disabled={
+              isRegistering ||
               !proxy.slug.trim() ||
               !proxy.authorizationEndpoint.trim() ||
               !proxy.tokenEndpoint.trim()
             }
           >
-            Next
+            {isRegistering ? "Registering client..." : "Next"}
           </Button>
         </div>
       </Dialog.Footer>

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
@@ -40,6 +40,11 @@ export type Context = {
   };
   envSlug: string | null;
   error: string | null;
+  // True when the user picked "Fetch Credentials" so submission is driven by
+  // auto-registration. Lets the rendering layer keep the chooser/loading UI
+  // visible during creatingEnvironment + creatingProxy instead of flashing
+  // the manual credentials form.
+  autoRegistering: boolean;
   result: { success: boolean; message: string } | null;
   toolsetSlug: string;
   toolsetName: string;
@@ -62,6 +67,8 @@ export type WizardEvent =
   | { type: "BACK" }
   | { type: "NEXT" }
   | { type: "SUBMIT" }
+  | { type: "AUTO_REGISTER" }
+  | { type: "MANUAL_CREDENTIALS" }
   | { type: "RESET" };
 
 export function parseScopes(raw: string): string[] {

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
@@ -23,6 +23,8 @@ import {
   type CreateEnvironmentInput,
   type CreateEnvironmentOutput,
   type DeleteEnvironmentInput,
+  type RegisterClientInput,
+  type RegisterClientOutput,
 } from "./services";
 
 // ---------------------------------------------------------------------------
@@ -66,6 +68,24 @@ function happyServices() {
     addOAuthProxy: fromPromise<void, AddOAuthProxyInput>(async () => {}),
     deleteEnvironment: fromPromise<void, DeleteEnvironmentInput>(
       async () => {},
+    ),
+    registerClient: fromPromise<RegisterClientOutput, RegisterClientInput>(
+      async () => ({
+        clientId: "auto-cid",
+        clientSecret: "auto-secret",
+        tokenAuthMethod: "client_secret_basic",
+      }),
+    ),
+  };
+}
+
+function servicesWithRegisterFailure() {
+  return {
+    ...happyServices(),
+    registerClient: fromPromise<RegisterClientOutput, RegisterClientInput>(
+      async () => {
+        throw new Error("DCR boom");
+      },
     ),
   };
 }
@@ -592,6 +612,90 @@ describe("oauthWizardMachine — external happy path", () => {
     actor.send({ type: "FIELD_EXTERNAL", key: "slug", value: "" });
     actor.send({ type: "APPLY_DISCOVERED" });
     expect(actor.getSnapshot().context.external.slug).toBe("discovered-slug");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Machine — auto-register chooser flow (discovered registration_endpoint)
+// ---------------------------------------------------------------------------
+
+describe("oauthWizardMachine — auto-register chooser", () => {
+  const inputWithDiscovered: Input = {
+    ...baseInput,
+    discovered: DISCOVERED_2_1,
+  };
+
+  it("NEXT from metadata routes to autoRegisterChoice when registration_endpoint discovered", () => {
+    const actor = makeActor(inputWithDiscovered);
+    actor.start();
+    actor.send({ type: "SELECT_PROXY" });
+    fillProxyForm(actor);
+    actor.send({ type: "NEXT" });
+    expect(actor.getSnapshot().matches({ proxy: "autoRegisterChoice" })).toBe(
+      true,
+    );
+  });
+
+  it("AUTO_REGISTER walks autoRegisterChoice → registering → submitting → result.success and skips manual creds form", async () => {
+    const actor = makeActor(inputWithDiscovered);
+    actor.start();
+    actor.send({ type: "SELECT_PROXY" });
+    fillProxyForm(actor);
+    actor.send({ type: "NEXT" });
+    actor.send({ type: "AUTO_REGISTER" });
+
+    await waitFor(actor, (s) => s.matches({ result: "success" }), {
+      timeout: 1000,
+    });
+
+    const snap = actor.getSnapshot();
+    expect(snap.context.proxy.clientId).toBe("auto-cid");
+    expect(snap.context.proxy.clientSecret).toBe("auto-secret");
+    expect(snap.context.proxy.tokenAuthMethod).toBe("client_secret_basic");
+    expect(snap.context.envSlug).toBe("env-new");
+  });
+
+  it("MANUAL_CREDENTIALS routes to credentials and clears autoRegistering flag", () => {
+    const actor = makeActor(inputWithDiscovered);
+    actor.start();
+    actor.send({ type: "SELECT_PROXY" });
+    fillProxyForm(actor);
+    actor.send({ type: "NEXT" });
+    actor.send({ type: "MANUAL_CREDENTIALS" });
+    const snap = actor.getSnapshot();
+    expect(snap.matches({ proxy: "credentials" })).toBe(true);
+    expect(snap.context.autoRegistering).toBe(false);
+  });
+
+  it("BACK from autoRegisterChoice returns to metadata", () => {
+    const actor = makeActor(inputWithDiscovered);
+    actor.start();
+    actor.send({ type: "SELECT_PROXY" });
+    fillProxyForm(actor);
+    actor.send({ type: "NEXT" });
+    actor.send({ type: "BACK" });
+    expect(actor.getSnapshot().matches({ proxy: "metadata" })).toBe(true);
+  });
+
+  it("registerClient failure routes to terminal autoRegisterFailed with error", async () => {
+    const actor = makeActor(inputWithDiscovered, servicesWithRegisterFailure());
+    actor.start();
+    actor.send({ type: "SELECT_PROXY" });
+    fillProxyForm(actor);
+    actor.send({ type: "NEXT" });
+    actor.send({ type: "AUTO_REGISTER" });
+
+    await waitFor(actor, (s) => s.matches({ proxy: "autoRegisterFailed" }), {
+      timeout: 1000,
+    });
+
+    const snap = actor.getSnapshot();
+    expect(snap.context.error).toContain("DCR boom");
+    // terminal — no further transitions
+    actor.send({ type: "BACK" });
+    expect(actor.getSnapshot().matches({ proxy: "autoRegisterFailed" })).toBe(
+      true,
+    );
   });
 });
 

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
@@ -212,6 +212,7 @@ function withExternal(over: Partial<Context["external"]> = {}): Context {
     },
     envSlug: null,
     error: null,
+    autoRegistering: false,
     result: null,
     toolsetSlug: "",
     toolsetName: "",

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
@@ -40,6 +40,7 @@ function initialContext(input: Input): Context {
     proxy: initialProxy(),
     envSlug: null,
     error: null,
+    autoRegistering: false,
     result: null,
     toolsetSlug: input.toolsetSlug,
     toolsetName: input.toolsetName,
@@ -131,7 +132,6 @@ export const oauthWizardMachine = setup({
     invalidateOnProxyCreate: () => {},
     captureExternalSuccess: () => {},
     captureProxyCreateSuccess: () => {},
-    notifyAutoRegisterFailed: () => {},
   },
 }).createMachine({
   id: "oauthWizard",
@@ -293,7 +293,7 @@ export const oauthWizardMachine = setup({
             NEXT: [
               {
                 guard: "canAutoRegister",
-                target: "registering",
+                target: "autoRegisterChoice",
                 actions: assign({ error: () => null }),
               },
               {
@@ -311,6 +311,17 @@ export const oauthWizardMachine = setup({
               },
             ],
             BACK: "#oauthWizard.pathSelection",
+          },
+        },
+        autoRegisterChoice: {
+          meta: { title: "Configure OAuth Proxy" },
+          on: {
+            AUTO_REGISTER: {
+              target: "registering",
+              actions: assign({ autoRegistering: () => true }),
+            },
+            MANUAL_CREDENTIALS: "credentials",
+            BACK: "metadata",
           },
         },
         registering: {
@@ -343,13 +354,21 @@ export const oauthWizardMachine = setup({
               }),
             },
             onError: {
-              target: "credentials",
-              actions: ["notifyAutoRegisterFailed"],
+              target: "autoRegisterFailed",
+              actions: assign({
+                error: ({ event }) =>
+                  errorMessage(event.error, "Failed to fetch credentials"),
+              }),
             },
           },
         },
+        autoRegisterFailed: {
+          meta: { title: "Couldn't Fetch Credentials" },
+          type: "final",
+        },
         credentials: {
           meta: { title: "OAuth Client Credentials" },
+          entry: assign({ autoRegistering: () => false }),
           on: {
             FIELD_PROXY: {
               actions: assign({

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
@@ -14,6 +14,8 @@ import {
   type CreateEnvironmentInput,
   type CreateEnvironmentOutput,
   type DeleteEnvironmentInput,
+  type RegisterClientInput,
+  type RegisterClientOutput,
 } from "./services";
 
 function initialProxy(): Context["proxy"] {
@@ -23,7 +25,7 @@ function initialProxy(): Context["proxy"] {
     tokenEndpoint: "",
     scopes: "",
     audience: "",
-    tokenAuthMethod: "client_secret_post",
+    tokenAuthMethod: "client_secret_basic",
     environmentSlug: "",
     clientId: "",
     clientSecret: "",
@@ -77,6 +79,18 @@ function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
 }
 
+function discoveredRegistrationEndpoint(
+  d: DiscoveredOAuth | null,
+): string | null {
+  const v = d?.metadata.registration_endpoint;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function discoveredAuthMethods(d: DiscoveredOAuth | null): string[] {
+  const v = d?.metadata.token_endpoint_auth_methods_supported;
+  return Array.isArray(v) ? (v as string[]) : [];
+}
+
 function placeholder<TInput, TOutput = void>(name: string) {
   return fromPromise<TOutput, TInput>(async () => {
     throw new Error(
@@ -100,17 +114,24 @@ export const oauthWizardMachine = setup({
     >("createEnvironment"),
     addOAuthProxy: placeholder<AddOAuthProxyInput>("addOAuthProxy"),
     deleteEnvironment: placeholder<DeleteEnvironmentInput>("deleteEnvironment"),
+    registerClient: placeholder<RegisterClientInput, RegisterClientOutput>(
+      "registerClient",
+    ),
   },
   guards: {
     validExternal: ({ context }) => checkExternal(context).ok,
     validProxyMeta: ({ context }) => checkProxyMeta(context).ok,
     validCreds: ({ context }) => checkCreds(context).ok,
+    canAutoRegister: ({ context }) =>
+      checkProxyMeta(context).ok &&
+      discoveredRegistrationEndpoint(context.discovered) !== null,
   },
   actions: {
     invalidateOnExternalSuccess: () => {},
     invalidateOnProxyCreate: () => {},
     captureExternalSuccess: () => {},
     captureProxyCreateSuccess: () => {},
+    notifyAutoRegisterFailed: () => {},
   },
 }).createMachine({
   id: "oauthWizard",
@@ -271,6 +292,11 @@ export const oauthWizardMachine = setup({
             },
             NEXT: [
               {
+                guard: "canAutoRegister",
+                target: "registering",
+                actions: assign({ error: () => null }),
+              },
+              {
                 guard: "validProxyMeta",
                 target: "credentials",
                 actions: assign({ error: () => null }),
@@ -285,6 +311,41 @@ export const oauthWizardMachine = setup({
               },
             ],
             BACK: "#oauthWizard.pathSelection",
+          },
+        },
+        registering: {
+          meta: { title: "Configure OAuth Proxy" },
+          invoke: {
+            src: "registerClient",
+            input: ({ context }): RegisterClientInput => ({
+              registrationEndpoint:
+                discoveredRegistrationEndpoint(context.discovered) ?? "",
+              scopesSupported: context.proxy.scopes
+                .split(",")
+                .map((s) => s.trim())
+                .filter((s) => s.length > 0),
+              tokenEndpointAuthMethodsSupported: discoveredAuthMethods(
+                context.discovered,
+              ),
+            }),
+            onDone: {
+              target: "submitting",
+              actions: assign({
+                proxy: ({ context, event }) => ({
+                  ...context.proxy,
+                  clientId: event.output.clientId,
+                  clientSecret: event.output.clientSecret,
+                  tokenAuthMethod:
+                    event.output.tokenAuthMethod ??
+                    context.proxy.tokenAuthMethod,
+                }),
+                error: () => null,
+              }),
+            },
+            onError: {
+              target: "credentials",
+              actions: ["notifyAutoRegisterFailed"],
+            },
           },
         },
         credentials: {

--- a/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
@@ -45,6 +45,23 @@ export type AddOAuthProxyInput = {
 
 export type DeleteEnvironmentInput = { envSlug: string };
 
+export type RegisterClientInput = {
+  registrationEndpoint: string;
+  scopesSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+};
+
+export type RegisterClientOutput = {
+  clientId: string;
+  clientSecret: string;
+  tokenAuthMethod: string | null;
+};
+
+export type AuthedFetch = (
+  endpoint: string,
+  opts: RequestInit,
+) => Promise<Response>;
+
 export type WizardServices = {
   addExternalOAuth: ReturnType<typeof fromPromise<void, AddExternalOAuthInput>>;
   createEnvironment: ReturnType<
@@ -54,6 +71,9 @@ export type WizardServices = {
   deleteEnvironment: ReturnType<
     typeof fromPromise<void, DeleteEnvironmentInput>
   >;
+  registerClient: ReturnType<
+    typeof fromPromise<RegisterClientOutput, RegisterClientInput>
+  >;
 };
 
 export type GramClient = ReturnType<typeof useGramContext>;
@@ -61,6 +81,7 @@ export type GramClient = ReturnType<typeof useGramContext>;
 export function createWizardServices(
   client: GramClient,
   queryClient: QueryClient,
+  authedFetch: AuthedFetch,
 ): WizardServices {
   const addExternalOAuth = fromPromise<void, AddExternalOAuthInput>(
     async ({ input, signal }) => {
@@ -145,11 +166,48 @@ export function createWizardServices(
     },
   );
 
+  const registerClient = fromPromise<RegisterClientOutput, RegisterClientInput>(
+    async ({ input, signal }) => {
+      const response = await authedFetch("/oauth/proxy-register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          registration_endpoint: input.registrationEndpoint,
+          scopes_supported: input.scopesSupported,
+          token_endpoint_auth_methods_supported:
+            input.tokenEndpointAuthMethodsSupported,
+        }),
+        signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Registration failed (HTTP ${response.status})`);
+      }
+
+      const result = (await response.json()) as {
+        client_id?: string;
+        client_secret?: string;
+        token_endpoint_auth_method?: string;
+      };
+
+      if (!result.client_id) {
+        throw new Error("Upstream did not return a client_id");
+      }
+
+      return {
+        clientId: result.client_id,
+        clientSecret: result.client_secret ?? "",
+        tokenAuthMethod: result.token_endpoint_auth_method ?? null,
+      };
+    },
+  );
+
   return {
     addExternalOAuth,
     createEnvironment,
     addOAuthProxy,
     deleteEnvironment,
+    registerClient,
   };
 }
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -647,7 +647,7 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager)
+			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager, guardianPolicy)
 			externalOAuthService := oauth.NewExternalOAuthService(logger, guardianPolicy, db, cache.NewRedisCacheAdapter(redisClient), authorizer, encryptionClient, externalMcpOAuthConfig)
 			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemLogger, serverURL)
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -509,7 +509,7 @@ func newWorkerCommand() *cli.Command {
 
 			chatSessionsManager := chatsessions.NewManager(logger, redisClient, c.String("jwt-signing-key"))
 
-			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager)
+			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager, guardianPolicy)
 			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemetryLogger, serverURL)
 
 			assistantTokenManager := assistanttokens.New(c.String("jwt-signing-key"), db, authzEngine)

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -111,7 +111,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	env := environments.NewEnvironmentEntries(logger, conn, enc, mcpMetadataRepo)
 	posthog := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
-	oauthService := oauth.NewService(logger, tracerProvider, meterProvider, conn, serverURL, cacheAdapter, enc, env, sessionManager)
+	oauthService := oauth.NewService(logger, tracerProvider, meterProvider, conn, serverURL, cacheAdapter, enc, env, sessionManager, guardianPolicy)
 	billingStub := billing.NewStubClient(logger, tracerProvider)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
 	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, nil, nil, nil, nil, nil)

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -949,7 +949,7 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		s.logger.ErrorContext(ctx, "DCR failed",
 			attr.SlogHTTPResponseStatusCode(resp.StatusCode),
-			attr.SlogHTTPRequestBody(string(respBody)))
+			attr.SlogHTTPResponseBody(string(respBody)))
 		return oops.E(oops.CodeGatewayError, nil, "registration endpoint returned %d", resp.StatusCode).Log(ctx, s.logger)
 	}
 

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -35,6 +35,7 @@ import (
 	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oauth/providers"
 	"github.com/speakeasy-api/gram/server/internal/oauth/repo"
@@ -90,13 +91,14 @@ type Service struct {
 	gramProvider              *providers.GramProvider
 	customProvider            *providers.CustomProvider
 	upstreamPKCEStorage       cache.TypedCacheObject[UpstreamPKCEVerifier]
+	httpClient                *guardian.HTTPClient
 	successPageTmpl           *template.Template
 	failurePageTmpl           *template.Template
 	oauthStatusPageScriptHash string
 	oauthStatusPageScriptData []byte
 }
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, db *pgxpool.Pool, serverURL *url.URL, cacheImpl cache.Cache, enc *encryption.Client, env *environments.EnvironmentEntries, sessions *sessions.Manager) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, db *pgxpool.Pool, serverURL *url.URL, cacheImpl cache.Cache, enc *encryption.Client, env *environments.EnvironmentEntries, sessions *sessions.Manager, guardianPolicy *guardian.Policy) *Service {
 	logger = logger.With(attr.SlogComponent("oauth"))
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/oauth")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/oauth")
@@ -117,6 +119,11 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 	// Calculate content hash for success script (for cache busting)
 	hash := sha256.Sum256(oauthSuccessScriptData)
 	scriptHash := hex.EncodeToString(hash[:])[:8] // Use first 8 chars like hosted page
+
+	var httpClient *guardian.HTTPClient
+	if guardianPolicy != nil {
+		httpClient = guardianPolicy.Client()
+	}
 
 	return &Service{
 		logger:            logger,
@@ -141,6 +148,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 		gramProvider:        gramProvider,
 		customProvider:      customProvider,
 		upstreamPKCEStorage: cache.NewTypedObjectCache[UpstreamPKCEVerifier](logger.With(attr.SlogCacheNamespace("upstream_pkce")), cacheImpl, cache.SuffixNone),
+		httpClient:          httpClient,
 
 		// HTML templates
 		successPageTmpl: successPageTmpl,
@@ -171,6 +179,13 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	// OAuth 2.1 Token Endpoint
 	o11y.AttachHandler(mux, "POST", "/oauth/{mcpSlug}/token", func(w http.ResponseWriter, r *http.Request) {
 		oops.ErrHandle(service.logger, service.handleToken).ServeHTTP(w, r)
+	})
+
+	// OAuth Proxy DCR helper — performs Dynamic Client Registration against an
+	// upstream provider on behalf of the dashboard user, used by the OAuth Proxy
+	// wizard to pre-fill client credentials.
+	o11y.AttachHandler(mux, "POST", "/oauth/proxy-register", func(w http.ResponseWriter, r *http.Request) {
+		oops.ErrHandle(service.logger, service.handleProxyRegister).ServeHTTP(w, r)
 	})
 
 	// OAuth success page script (with cache busting hash)
@@ -845,4 +860,141 @@ func (s *Service) RefreshProxyToken(ctx context.Context, toolsetID uuid.UUID, to
 	}
 
 	return token, nil
+}
+
+type ProxyRegisterRequest struct {
+	RegistrationEndpoint              string   `json:"registration_endpoint"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+}
+
+type ProxyRegisterResponse struct {
+	ClientID                string `json:"client_id"`
+	ClientSecret            string `json:"client_secret,omitempty"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+}
+
+// handleProxyRegister performs Dynamic Client Registration against an upstream
+// OAuth provider on behalf of the dashboard user so the OAuth Proxy wizard can
+// pre-fill client credentials. We perform this registration server side to avoid
+// CORS frustrations on the Client. We constrain the proxying behavior to be
+// limited to registration requests to avoid SSRF vulnerability to risk. Because
+// of this requirement we implement the business logic of determining client
+// properties in the server as well.
+// The goal behavior is that this registration will be performed entirely server
+// side without client orchestration as part of the remote MCP import flow and
+// this handler will be removed, but for the time being we leave it to the
+// client to orchestrate.
+func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	if _, err := s.sessions.AuthenticateWithCookie(ctx); err != nil {
+		return oops.E(oops.CodeUnauthorized, err, "authentication required").Log(ctx, s.logger)
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, requestMaxBodyBytes)
+	var req ProxyRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return oops.E(oops.CodeBadRequest, err, "invalid JSON in request body").Log(ctx, s.logger)
+	}
+
+	endpoint, err := url.Parse(req.RegistrationEndpoint)
+	if err != nil || (endpoint.Scheme != "http" && endpoint.Scheme != "https") || endpoint.Host == "" {
+		return oops.E(oops.CodeBadRequest, err, "invalid registration_endpoint").Log(ctx, s.logger)
+	}
+
+	authMethod := pickProxyAuthMethod(req.TokenEndpointAuthMethodsSupported)
+	callbackURL := fmt.Sprintf("%s/oauth/callback", s.serverURL.String())
+
+	dcrReq := DCRRequest{
+		RedirectURIs:            []string{callbackURL},
+		TokenEndpointAuthMethod: authMethod,
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		ClientName:              "Gram",
+		ClientURI:               s.serverURL.String(),
+		Scope:                   strings.Join(req.ScopesSupported, " "),
+	}
+
+	body, err := json.Marshal(dcrReq)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal DCR request").Log(ctx, s.logger)
+	}
+
+	upstreamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(upstreamCtx, http.MethodPost, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to create DCR request").Log(ctx, s.logger)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return oops.E(oops.CodeGatewayError, err, "failed to reach registration endpoint").Log(ctx, s.logger)
+	}
+	defer o11y.LogDefer(ctx, s.logger, func() error {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			return fmt.Errorf("close DCR response body: %w", closeErr)
+		}
+		return nil
+	})
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, requestMaxBodyBytes))
+	if err != nil {
+		return oops.E(oops.CodeGatewayError, err, "failed to read DCR response").Log(ctx, s.logger)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		s.logger.ErrorContext(ctx, "DCR failed",
+			attr.SlogHTTPResponseStatusCode(resp.StatusCode),
+			attr.SlogHTTPRequestBody(string(respBody)))
+		return oops.E(oops.CodeGatewayError, nil, "registration endpoint returned %d", resp.StatusCode).Log(ctx, s.logger)
+	}
+
+	var dcrResp DCRResponse
+	if err := json.Unmarshal(respBody, &dcrResp); err != nil {
+		return oops.E(oops.CodeGatewayError, err, "invalid DCR response").Log(ctx, s.logger)
+	}
+	if dcrResp.ClientID == "" {
+		return oops.E(oops.CodeGatewayError, nil, "DCR response missing client_id").Log(ctx, s.logger)
+	}
+
+	respondedAuthMethod := dcrResp.TokenEndpointAuthMethod
+	if respondedAuthMethod == "" {
+		respondedAuthMethod = authMethod
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(ProxyRegisterResponse{
+		ClientID:                dcrResp.ClientID,
+		ClientSecret:            dcrResp.ClientSecret,
+		TokenEndpointAuthMethod: respondedAuthMethod,
+	}); err != nil {
+		s.logger.ErrorContext(ctx, "failed to encode proxyRegister response", attr.SlogError(err))
+	}
+	return nil
+}
+
+// pickProxyAuthMethod selects a token endpoint auth method from those advertised
+// by the upstream provider, preferring client_secret_basic > client_secret_post >
+// none. Falls back to the upstream's first advertised method, or
+// client_secret_basic when nothing is advertised.
+func pickProxyAuthMethod(supported []string) string {
+	advertised := make(map[string]struct{}, len(supported))
+	for _, m := range supported {
+		advertised[m] = struct{}{}
+	}
+	for _, m := range []string{"client_secret_basic", "client_secret_post", "none"} {
+		if _, ok := advertised[m]; ok {
+			return m
+		}
+	}
+	if len(supported) > 0 {
+		return supported[0]
+	}
+	return "client_secret_basic"
 }

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -91,7 +91,7 @@ type Service struct {
 	gramProvider              *providers.GramProvider
 	customProvider            *providers.CustomProvider
 	upstreamPKCEStorage       cache.TypedCacheObject[UpstreamPKCEVerifier]
-	httpClient                *guardian.HTTPClient
+	guardianPolicy            *guardian.Policy
 	successPageTmpl           *template.Template
 	failurePageTmpl           *template.Template
 	oauthStatusPageScriptHash string
@@ -120,11 +120,6 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 	hash := sha256.Sum256(oauthSuccessScriptData)
 	scriptHash := hex.EncodeToString(hash[:])[:8] // Use first 8 chars like hosted page
 
-	var httpClient *guardian.HTTPClient
-	if guardianPolicy != nil {
-		httpClient = guardianPolicy.Client()
-	}
-
 	return &Service{
 		logger:            logger,
 		tracer:            tracer,
@@ -148,7 +143,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 		gramProvider:        gramProvider,
 		customProvider:      customProvider,
 		upstreamPKCEStorage: cache.NewTypedObjectCache[UpstreamPKCEVerifier](logger.With(attr.SlogCacheNamespace("upstream_pkce")), cacheImpl, cache.SuffixNone),
-		httpClient:          httpClient,
+		guardianPolicy:      guardianPolicy,
 
 		// HTML templates
 		successPageTmpl: successPageTmpl,
@@ -892,6 +887,10 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 		return oops.E(oops.CodeUnauthorized, err, "authentication required").Log(ctx, s.logger)
 	}
 
+	if s.guardianPolicy == nil {
+		return oops.E(oops.CodeUnexpected, nil, "proxy register handler is not configured").Log(ctx, s.logger)
+	}
+
 	r.Body = http.MaxBytesReader(w, r.Body, requestMaxBodyBytes)
 	var req ProxyRegisterRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -931,7 +930,7 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
 
-	resp, err := s.httpClient.Do(httpReq)
+	resp, err := s.guardianPolicy.Client().Do(httpReq)
 	if err != nil {
 		return oops.E(oops.CodeGatewayError, err, "failed to reach registration endpoint").Log(ctx, s.logger)
 	}

--- a/server/internal/oauth/setup_test.go
+++ b/server/internal/oauth/setup_test.go
@@ -170,7 +170,7 @@ func newOAuthServiceTestEnv(t *testing.T) *oauthServiceTestEnv {
 	// The oauth.Service is created with nil DB / sessions / environments because
 	// RefreshProxyToken only needs the cache and the CustomProvider (which
 	// resolves credentials from provider.Secrets directly).
-	svc := oauth.NewService(logger, tracerProvider, meterProvider, nil, serverURL, cacheAdapter, enc, nil, nil)
+	svc := oauth.NewService(logger, tracerProvider, meterProvider, nil, serverURL, cacheAdapter, enc, nil, nil, nil)
 
 	// Build a token test env on the SAME cache so tokens issued here are
 	// visible to the service's internal TokenService.


### PR DESCRIPTION
This pull request makes a change to make setting up the oauth proxy for remote MCPs more user friendly in the dashboard. In particular, it automatically sets up an OAuth Client when OAuth 2.1 is available. This converges to the simplest possible flow and will move many possible issues with tool calling from tool call time to MCP setup time.

Furthermore, it is a much closer match to expected behavior from mcp servers and should make the general catalog experience much more reliable.

It has been confirmed to work with key servers
like Linear and Notion. Making this zero-click flow is ongoing work with Hubspot.