### PR TITLE
fix(mcp): skip logging expected .well-known OAuth probe misses

### DIFF
--- a/.changeset/oauth-probe-log-noise.md
+++ b/.changeset/oauth-probe-log-noise.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Stop logging expected .well-known OAuth probe misses

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -287,7 +287,7 @@ func (s *Service) HandleWellKnownOAuthServerMetadata(w http.ResponseWriter, r *h
 	}
 
 	if result == nil {
-		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
 	}
 
 	// Handle proxy case - reverse proxy to external MCP OAuth server
@@ -372,7 +372,7 @@ func (s *Service) HandleWellKnownOAuthProtectedResourceMetadata(w http.ResponseW
 	}
 
 	if metadata == nil {
-		return oops.E(oops.CodeNotFound, nil, "not found").Log(ctx, s.logger)
+		return oops.E(oops.CodeNotFound, nil, "not found")
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/oops/pp_test.go
+++ b/server/internal/oops/pp_test.go
@@ -1,0 +1,41 @@
+package oops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func startRecordedSpan(t *testing.T) (context.Context, *tracetest.SpanRecorder) {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	ctx, span := tp.Tracer("oops-test").Start(t.Context(), "test-span")
+	t.Cleanup(func() { span.End() })
+	return ctx, recorder
+}
+
+func TestShareableError_Log_LogsAtError(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+	ctx, recorder := startRecordedSpan(t)
+
+	_ = E(CodeNotFound, nil, "resource not found").Log(ctx, logger)
+
+	entries := parseLogEntries(t, logBuf)
+	require.Len(t, entries, 1)
+	require.Equal(t, "ERROR", entries[0].Level)
+	require.Equal(t, "resource not found", entries[0].Msg)
+	require.NotEmpty(t, entries[0].ErrorID)
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Len(t, spans[0].Events(), 1, "Log should record the error as a span event")
+}


### PR DESCRIPTION
## Summary

The two `.well-known` OAuth metadata probe handlers ([`HandleWellKnownOAuthServerMetadata`](server/internal/mcp/impl.go) and `HandleWellKnownOAuthProtectedResourceMetadata`) were logging expected probe misses at `ERROR` level. These are 404 responses returned when an MCP server has no OAuth configured — protocol-correct "no" answers to client probes, not actual errors. They accounted for ~72% of `gram-server` `status:error` log volume in production over the last 24h (~2,159 of ~3,000 daily error logs).

## Change

Drops the `.Log(ctx, s.logger)` call on the two probe-miss branches in `server/internal/mcp/impl.go`. The HTTP middleware still serializes a `404` response to the client; no log entry is emitted, and the OTel span is no longer marked as error.

Unexpected branches in the same handlers (DB lookup failures, marshal/write failures, multi-provider misconfig in `wellknown.go`) keep the existing `.Log()` behavior at `ERROR`.

HTTP responses to clients are unchanged — same `404` status, same `not_found` error code, same response body, same `error.id` for log/client correlation.

## Metrics retained

Existing `otelhttp` HTTP server instrumentation continues to emit `trace.http.server.request.hits` (and related metrics) tagged with `http.status_code:404`, `resource_name:GET /.well-known/oauth-...`, `@http.route`, and `@url.path`. Per-MCP-slug, per-status, per-user-agent breakdowns remain available in Datadog APM with no additional instrumentation.

## Test coverage

Adds `server/internal/oops/pp_test.go` with a regression test for `ShareableError.Log` covering both log emission (`ERROR` level, `error.id` attached) and OTel span behavior (status `Error`, one recorded exception event), using `tracetest.SpanRecorder`.

## Linear

https://linear.app/speakeasy/issue/AGE-1958/investigation-downgrade-existing-not-found-errors-to-warnings