### PR TITLE
fix(mcp): build well-known OAuth body before writing 200 status

### DIFF
--- a/.changeset/wellknown-oauth-status-ordering.md
+++ b/.changeset/wellknown-oauth-status-ordering.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Build well-known OAuth metadata response body before writing 200 status so error paths surface as the real status code instead of 200 with an error body

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -313,9 +313,15 @@ func (s *Service) HandleWellKnownOAuthServerMetadata(w http.ResponseWriter, r *h
 		return nil
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	return writeOAuthServerMetadataResponse(ctx, s.logger, w, result)
+}
 
+// writeOAuthServerMetadataResponse builds the OAuth server metadata body and
+// only commits the 200 OK status once the body is ready. This ordering matters:
+// if marshaling fails or the result kind is unrecognized, the caller's error
+// handler middleware needs an unwritten ResponseWriter so it can emit the real
+// error status — Go's net/http silently drops a second WriteHeader call.
+func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, result *wellknown.OAuthServerMetadataResult) error {
 	var body []byte
 	switch result.Kind {
 	case wellknown.OAuthServerMetadataResultKindRaw:
@@ -324,15 +330,16 @@ func (s *Service) HandleWellKnownOAuthServerMetadata(w http.ResponseWriter, r *h
 		var marshalErr error
 		body, marshalErr = json.Marshal(result.Static)
 		if marshalErr != nil {
-			return oops.E(oops.CodeUnexpected, marshalErr, "failed to marshal OAuth server metadata").Log(ctx, s.logger)
+			return oops.E(oops.CodeUnexpected, marshalErr, "failed to marshal OAuth server metadata").Log(ctx, logger)
 		}
 	default:
-		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").Log(ctx, logger)
 	}
 
-	_, writeErr := w.Write(body)
-	if writeErr != nil {
-		return oops.E(oops.CodeUnexpected, writeErr, "failed to write response body").Log(ctx, s.logger)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
 	}
 
 	return nil
@@ -375,17 +382,23 @@ func (s *Service) HandleWellKnownOAuthProtectedResourceMetadata(w http.ResponseW
 		return oops.E(oops.CodeNotFound, nil, "not found")
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	return writeOAuthProtectedResourceMetadataResponse(ctx, s.logger, w, metadata)
+}
 
+// writeOAuthProtectedResourceMetadataResponse builds the OAuth protected
+// resource metadata body and only commits the 200 OK status once the body is
+// ready. See writeOAuthServerMetadataResponse for the rationale behind the
+// ordering.
+func writeOAuthProtectedResourceMetadataResponse(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, metadata *wellknown.OAuthProtectedResourceMetadata) error {
 	body, err := json.Marshal(metadata)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").Log(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").Log(ctx, logger)
 	}
 
-	_, writeErr := w.Write(body)
-	if writeErr != nil {
-		return oops.E(oops.CodeUnexpected, writeErr, "failed to write response body").Log(ctx, s.logger)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/mcp/wellknown_oauth_test.go
+++ b/server/internal/mcp/wellknown_oauth_test.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
+)
+
+func Test_writeOAuthServerMetadataResponse_Static(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	w := httptest.NewRecorder()
+
+	result := &wellknown.OAuthServerMetadataResult{
+		Kind: wellknown.OAuthServerMetadataResultKindStatic,
+		Static: &wellknown.OAuthServerMetadata{
+			Issuer:                        "https://example.test/oauth/foo",
+			AuthorizationEndpoint:         "https://example.test/oauth/foo/authorize",
+			TokenEndpoint:                 "https://example.test/oauth/foo/token",
+			RegistrationEndpoint:          "https://example.test/oauth/foo/register",
+			ScopesSupported:               []string{"offline_access"},
+			ResponseTypesSupported:        []string{"code"},
+			GrantTypesSupported:           []string{"authorization_code", "refresh_token"},
+			CodeChallengeMethodsSupported: []string{"S256"},
+		},
+		Raw:      nil,
+		ProxyURL: "",
+	}
+
+	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, result)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var got wellknown.OAuthServerMetadata
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, *result.Static, got)
+}
+
+func Test_writeOAuthServerMetadataResponse_Raw(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	w := httptest.NewRecorder()
+
+	raw := json.RawMessage(`{"issuer":"https://example.test/raw"}`)
+	result := &wellknown.OAuthServerMetadataResult{
+		Kind:     wellknown.OAuthServerMetadataResultKindRaw,
+		Static:   nil,
+		Raw:      raw,
+		ProxyURL: "",
+	}
+
+	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, result)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.JSONEq(t, string(raw), w.Body.String())
+}
+
+// Test_writeOAuthServerMetadataResponse_UnknownKind_DoesNotWriteResponse is a
+// regression test for AGE-1970. The handler used to call WriteHeader(200)
+// before constructing the body, so error paths in body construction left the
+// caller's middleware unable to emit the real error status (Go silently
+// drops a second WriteHeader). Asserting that no headers or body were
+// written on the error path catches reintroductions of that pattern.
+func Test_writeOAuthServerMetadataResponse_UnknownKind_DoesNotWriteResponse(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	w := httptest.NewRecorder()
+
+	result := &wellknown.OAuthServerMetadataResult{
+		Kind:     wellknown.OAuthServerMetadataResultKind("bogus"),
+		Static:   nil,
+		Raw:      nil,
+		ProxyURL: "",
+	}
+
+	err := writeOAuthServerMetadataResponse(t.Context(), logger, w, result)
+	require.Error(t, err)
+	require.Empty(t, w.Header().Get("Content-Type"))
+	require.Empty(t, w.Body.Bytes())
+}
+
+func Test_writeOAuthProtectedResourceMetadataResponse_Success(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	w := httptest.NewRecorder()
+
+	metadata := &wellknown.OAuthProtectedResourceMetadata{
+		Resource:             "https://example.test/mcp/foo",
+		AuthorizationServers: []string{"https://example.test/oauth/foo"},
+		ScopesSupported:      []string{"offline_access"},
+	}
+
+	err := writeOAuthProtectedResourceMetadataResponse(t.Context(), logger, w, metadata)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var got wellknown.OAuthProtectedResourceMetadata
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, *metadata, got)
+}


### PR DESCRIPTION
## Summary

- Linear: [AGE-1970](https://linear.app/speakeasy/issue/AGE-1970/bug-well-known-oauth-handlers-send-200-ok-before-error-paths-masking)
- The two `.well-known` OAuth metadata handlers in `server/internal/mcp/impl.go` called `w.WriteHeader(http.StatusOK)` *before* building the JSON body. If body construction failed (`json.Marshal` error or an unrecognized `OAuthServerMetadataResultKind`), the handler returned an error to `oops.ErrHandle`, whose subsequent `WriteHeader(code)` was silently dropped by `net/http` — clients saw `200 OK` with an error JSON body shaped like `{"name":"unexpected","message":"..."}`.
- Extracted body-build-then-write into two package-level helpers (`writeOAuthServerMetadataResponse`, `writeOAuthProtectedResourceMetadataResponse`) so the body is fully built before any header is committed. Each helper documents the ordering invariant.
- Added `server/internal/mcp/wellknown_oauth_test.go` with happy-path coverage plus a regression test that passes a bogus result kind and asserts the helper returns an error and leaves the `ResponseWriter` untouched (no `Content-Type`, empty body) — catches reintroductions of the original ordering.

## Notes

- Surfaced by Devin AI review on #2463.
- No behavior change on the happy path; existing `TestService_HandleWellKnownOAuth*` tests still pass.