### PR TITLE
fix: migrate hooks validateGramToolsetCall to GetToolsetByIDAndOrganization

### DIFF
--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -191,11 +191,11 @@ func (s *Service) validateGramToolsetCall(
 		return deny(fmt.Sprintf("invalid %q value: not a UUID", xGramToolsetIDField))
 	}
 
-	toolsetRow, err := tsr.New(s.db).GetToolsetByID(ctx, toolsetID)
+	toolsetRow, err := tsr.New(s.db).GetToolsetByIDAndOrganization(ctx, tsr.GetToolsetByIDAndOrganizationParams{
+		ID:             toolsetID,
+		OrganizationID: orgID,
+	})
 	if err != nil {
-		return deny(fmt.Sprintf("toolset %s not found in this organization", toolsetID))
-	}
-	if toolsetRow.OrganizationID != orgID {
 		return deny(fmt.Sprintf("toolset %s not found in this organization", toolsetID))
 	}
 


### PR DESCRIPTION
## Summary

[#2421](https://github.com/speakeasy-api/gram/pull/2421) replaced `GetToolsetByID` with scoped variants but missed the call site introduced concurrently by [#2449](https://github.com/speakeasy-api/gram/pull/2449) (shadow mcp blocking) in `server/internal/hooks/impl.go`. `main` currently fails to build:

```
internal/hooks/impl.go:194: tsr.New(s.db).GetToolsetByID undefined
```

This migrates the `validateGramToolsetCall` site to `GetToolsetByIDAndOrganization` and drops the redundant `OrganizationID` Go post-check, matching the pattern applied to `collections` in #2421.