### PR TITLE
chore: bump presidio test container startup timeout to 300s

### DIFF
--- a/server/internal/testenv/presidio.go
+++ b/server/internal/testenv/presidio.go
@@ -3,6 +3,7 @@ package testenv
 import (
 	"context"
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -14,11 +15,14 @@ import (
 type PresidioClientFunc func(t *testing.T) *risk_analysis.PresidioClient
 
 func NewTestPresidio(ctx context.Context) (testcontainers.Container, PresidioClientFunc, error) {
+	startedAt := time.Now()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        "mcr.microsoft.com/presidio-analyzer:2.2.362",
 			ExposedPorts: []string{"3000/tcp"},
-			WaitingFor:   wait.ForHTTP("/health").WithPort("3000/tcp").WithStartupTimeout(120 * time.Second),
+			WaitingFor: wait.ForHTTP("/health").
+				WithPort("3000/tcp").
+				WithStartupTimeout(300 * time.Second),
 		},
 		Started: true,
 		Logger:  NewTestcontainersLogger(),
@@ -26,6 +30,7 @@ func NewTestPresidio(ctx context.Context) (testcontainers.Container, PresidioCli
 	if err != nil {
 		return nil, nil, fmt.Errorf("start presidio container: %w", err)
 	}
+	log.Printf("presidio container ready in %s", time.Since(startedAt).Round(time.Millisecond))
 
 	return container, newPresidioClientFunc(container), nil
 }


### PR DESCRIPTION
## Summary

- Linear: [AGE-1974](https://linear.app/speakeasy/issue/AGE-1974/investigation-non-deterministic-failure-starting-presidio-test)
- Cold-start of `mcr.microsoft.com/presidio-analyzer:2.2.362` (image pull + uvicorn + spaCy model load) measures **~139s** on a clean machine, which exceeded the previous 120s `WithStartupTimeout` and produced a 10%+ flake rate locally and in CI.
- Raise `WithStartupTimeout` to 300s, giving ~160s of headroom over observed cold-start time.
- Add a `log.Printf` recording the actual container-ready duration so future regressions in cold-start time are visible in test output rather than silently re-introducing the flake.

## Notes

- Warm-start measured at ~2s, so the timeout bump has no impact on the common path.
- Considered combining HTTP probe with a `wait.ForLog` strategy and adding a client-side ping retry loop (mirroring `redis.go`); rejected because `wait.ForAll` widens the failure surface (a missing log line would still hit the new ceiling) and the testcontainers HTTP probe already validates the mapped port from outside the container, so a post-ready ping would be redundant.
- Considered parallelizing container startup in `testenv.Launch` and pre-pulling the image in CI; deferred. The single-file timeout bump is reversible and the new ready-duration log will tell us whether a more invasive fix is needed.