### PR TITLE
chore: parallelize test container launches in testenv.Launch

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -657,8 +657,11 @@ jobs:
             ${{ env.GOCACHE }}
             ${{ env.GOMODCACHE }}
 
-      - name: Install Go deps
-        run: mise run install:go
+      - name: Install Go deps & pre-pull test images
+        run: |
+          docker pull mcr.microsoft.com/presidio-analyzer:2.2.362 &
+          mise run install:go
+          wait
 
       - name: Test
         run: mise run test:server

--- a/server/internal/testenv/launch.go
+++ b/server/internal/testenv/launch.go
@@ -110,7 +110,7 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 	}
 
 	if err := launchEg.Wait(); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("start containers: %w", err)
 	}
 
 	if opts.Temporal {

--- a/server/internal/testenv/launch.go
+++ b/server/internal/testenv/launch.go
@@ -110,6 +110,13 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 	}
 
 	if err := launchEg.Wait(); err != nil {
+		for _, c := range []terminateable{pgcontainer, rediscontainer, clickhousecontainer, presidiocontainer} {
+			if c != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				_ = c.Terminate(ctx)
+				cancel()
+			}
+		}
 		return nil, nil, fmt.Errorf("start containers: %w", err)
 	}
 

--- a/server/internal/testenv/launch.go
+++ b/server/internal/testenv/launch.go
@@ -59,40 +59,58 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 		NewPresidioClient:   unsupportedPresidioClientFunc(),
 	}
 
+	var launchEg errgroup.Group
+
 	if opts.Postgres {
-		container, cloner, err := NewTestPostgres(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start postgres container: %w", err)
-		}
-		pgcontainer = container
-		res.CloneTestDatabase = cloner
+		launchEg.Go(func() error {
+			container, cloner, err := NewTestPostgres(ctx)
+			if err != nil {
+				return fmt.Errorf("start postgres container: %w", err)
+			}
+			pgcontainer = container
+			res.CloneTestDatabase = cloner
+			return nil
+		})
 	}
 
 	if opts.Redis {
-		container, rcFactory, err := NewTestRedis(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start redis container: %w", err)
-		}
-		rediscontainer = container
-		res.NewRedisClient = rcFactory
+		launchEg.Go(func() error {
+			container, rcFactory, err := NewTestRedis(ctx)
+			if err != nil {
+				return fmt.Errorf("start redis container: %w", err)
+			}
+			rediscontainer = container
+			res.NewRedisClient = rcFactory
+			return nil
+		})
 	}
 
 	if opts.ClickHouse {
-		container, chFactory, err := NewTestClickhouse(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start clickhouse container: %w", err)
-		}
-		clickhousecontainer = container
-		res.NewClickhouseClient = chFactory
+		launchEg.Go(func() error {
+			container, chFactory, err := NewTestClickhouse(ctx)
+			if err != nil {
+				return fmt.Errorf("start clickhouse container: %w", err)
+			}
+			clickhousecontainer = container
+			res.NewClickhouseClient = chFactory
+			return nil
+		})
 	}
 
 	if opts.Presidio {
-		container, pcFactory, err := NewTestPresidio(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("start presidio container: %w", err)
-		}
-		presidiocontainer = container
-		res.NewPresidioClient = pcFactory
+		launchEg.Go(func() error {
+			container, pcFactory, err := NewTestPresidio(ctx)
+			if err != nil {
+				return fmt.Errorf("start presidio container: %w", err)
+			}
+			presidiocontainer = container
+			res.NewPresidioClient = pcFactory
+			return nil
+		})
+	}
+
+	if err := launchEg.Wait(); err != nil {
+		return nil, nil, err
 	}
 
 	if opts.Temporal {


### PR DESCRIPTION
## Why

The `risk_analysis` test package was timing out in CI at 319s ([failing run](https://github.com/speakeasy-api/gram/actions/runs/25065055270/job/73429823948)). The root cause: `testenv.Launch` starts containers sequentially, so the Presidio image pull had to wait for Postgres to fully start before beginning. In CI where Docker images aren't cached, this sequential startup exceeds the test timeout.

## What changed

**Before:** Containers (Postgres, Redis, ClickHouse, Presidio) started one after another in `Launch()`. A test requesting Postgres + Presidio would wait for Postgres to finish before even starting the Presidio pull.

**After:** All container startups run concurrently via `errgroup`. `Launch()` waits for all containers to be ready before returning. This benefits all 36 test packages that use `testenv.Launch`, especially those requesting 2+ containers (Postgres + Redis, Postgres + Redis + Temporal, etc.).