### PR TITLE
feat: audit plugin actions

### DIFF
--- a/.changeset/plugins-audit-logging.md
+++ b/.changeset/plugins-audit-logging.md
@@ -1,0 +1,8 @@
+---
+"server": minor
+---
+
+Record plugin actions in the audit log. Plugin create, update, delete,
+server add/update/remove, role assignments, and publish each emit an
+audit entry inside the same transaction as the mutation, surfacing the
+events in `auditlogs.list` and the dashboard activity views.

--- a/client/dashboard/src/components/project/ActivityTimelineCard.tsx
+++ b/client/dashboard/src/components/project/ActivityTimelineCard.tsx
@@ -117,7 +117,11 @@ export function ActivityTimelineCard({ logs, isPending, viewAllHref }: Props) {
 type ActionMeta = { icon: LucideIcon; bg: string; fg: string };
 
 function getActionMeta(action: string): ActionMeta {
-  if (action.includes(":delete") || action.includes(":revoke")) {
+  if (
+    action.includes(":delete") ||
+    action.includes(":revoke") ||
+    action.includes(":remove")
+  ) {
     return {
       icon: Trash2,
       bg: "bg-red-100 dark:bg-red-950",

--- a/client/dashboard/src/components/project/ActivityTimelineCard.tsx
+++ b/client/dashboard/src/components/project/ActivityTimelineCard.tsx
@@ -8,6 +8,7 @@ import {
   KeyRound,
   Link2,
   Package,
+  Puzzle,
   Rocket,
   Shield,
   Sparkles,
@@ -199,6 +200,13 @@ function getActionMeta(action: string): ActionMeta {
       fg: "text-violet-600 dark:text-violet-400",
     };
   }
+  if (action.startsWith("plugin:")) {
+    return {
+      icon: Puzzle,
+      bg: "bg-pink-100 dark:bg-pink-950",
+      fg: "text-pink-600 dark:text-pink-400",
+    };
+  }
   return {
     icon: Clock,
     bg: "bg-muted",
@@ -238,6 +246,14 @@ const ACTION_LABELS: Record<string, string> = {
   "asset:create": "created asset",
   "variation:update_global": "updated variation",
   "variation:delete_global": "deleted variation",
+  "plugin:create": "created plugin",
+  "plugin:update": "updated plugin",
+  "plugin:delete": "deleted plugin",
+  "plugin:server_add": "added server to plugin",
+  "plugin:server_update": "updated plugin server",
+  "plugin:server_remove": "removed server from plugin",
+  "plugin:assignments_set": "updated plugin access",
+  "plugin:publish": "published plugins",
 };
 
 function getActionLabel(action: string): string {

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -112,6 +112,8 @@ function getResourceLabel(resource: string) {
       return "environment";
     case "mcp_metadata":
       return "MCP metadata";
+    case "plugin":
+      return "plugin";
     case "project":
       return "project";
     case "template":
@@ -166,6 +168,17 @@ function renderSubject(log: AuditLog, orgSlug: string) {
         className={cn(monoClass, "hover:underline")}
       >
         {log.subjectSlug}
+      </Link>
+    );
+  }
+
+  if (log.subjectType === "plugin" && log.projectSlug) {
+    return (
+      <Link
+        to={`/${orgSlug}/projects/${log.projectSlug}/plugins/${log.subjectId}`}
+        className={cn(monoClass, "hover:underline")}
+      >
+        {log.subjectSlug || log.subjectId}
       </Link>
     );
   }
@@ -289,6 +302,22 @@ function renderVerb(log: AuditLog): string {
       return "updated MCP metadata for";
     case "asset:create":
       return "uploaded asset";
+    case "plugin:create":
+      return "created plugin";
+    case "plugin:update":
+      return "updated plugin";
+    case "plugin:delete":
+      return "deleted plugin";
+    case "plugin:server_add":
+      return "added server to plugin";
+    case "plugin:server_update":
+      return "updated server on plugin";
+    case "plugin:server_remove":
+      return "removed server from plugin";
+    case "plugin:assignments_set":
+      return "updated plugin access assignments";
+    case "plugin:publish":
+      return "published plugins";
     default: {
       const [resource = "activity", verb = "updated"] = log.action.split(":");
       return `${verb.replace(/_/g, " ")} ${getResourceLabel(resource)}`;

--- a/server/internal/audit/events.go
+++ b/server/internal/audit/events.go
@@ -15,6 +15,7 @@ const (
 	subjectTypeCustomDomain    subjectType = "custom_domain"
 	subjectTypeDeployment      subjectType = "deployment"
 	subjectTypeEnvironment     subjectType = "environment"
+	subjectTypePlugin          subjectType = "plugin"
 	subjectTypeProject         subjectType = "project"
 	subjectTypeTemplate        subjectType = "template"
 	subjectTypeRemoteMcpServer subjectType = "remote_mcp_server"

--- a/server/internal/audit/plugins.go
+++ b/server/internal/audit/plugins.go
@@ -405,6 +405,7 @@ func LogPluginAssignmentsSet(ctx context.Context, dbtx repo.DBTX, event LogPlugi
 type LogPluginPublishEvent struct {
 	OrganizationID string
 	ProjectID      uuid.UUID
+	ProjectName    string
 	ProjectSlug    string
 
 	Actor            urn.Principal
@@ -441,7 +442,7 @@ func LogPluginPublish(ctx context.Context, dbtx repo.DBTX, event LogPluginPublis
 
 		SubjectID:          event.ProjectID.String(),
 		SubjectType:        string(subjectTypeProject),
-		SubjectDisplayName: conv.ToPGTextEmpty(event.ProjectSlug),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.ProjectName),
 		SubjectSlug:        conv.ToPGTextEmpty(event.ProjectSlug),
 
 		BeforeSnapshot: nil,

--- a/server/internal/audit/plugins.go
+++ b/server/internal/audit/plugins.go
@@ -1,0 +1,457 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/audit/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	ActionPluginCreate         Action = "plugin:create"
+	ActionPluginUpdate         Action = "plugin:update"
+	ActionPluginDelete         Action = "plugin:delete"
+	ActionPluginServerAdd      Action = "plugin:server_add"
+	ActionPluginServerUpdate   Action = "plugin:server_update"
+	ActionPluginServerRemove   Action = "plugin:server_remove"
+	ActionPluginAssignmentsSet Action = "plugin:assignments_set"
+	ActionPluginPublish        Action = "plugin:publish"
+)
+
+// PluginSnapshot captures the user-meaningful state of a plugin row for
+// before/after comparisons in audit log entries.
+type PluginSnapshot struct {
+	Name        string  `json:"name"`
+	Slug        string  `json:"slug"`
+	Description *string `json:"description,omitempty"`
+}
+
+type LogPluginCreateEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Plugin and migrate to PluginURN; pending team discussion
+	PluginName string
+	PluginSlug string
+}
+
+func LogPluginCreate(ctx context.Context, dbtx repo.DBTX, event LogPluginCreateEvent) error {
+	action := ActionPluginCreate
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.PluginID.String(),
+		SubjectType:        string(subjectTypePlugin),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.PluginName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.PluginSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogPluginUpdateEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginID       uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Plugin and migrate to PluginURN; pending team discussion
+	PluginName     string
+	PluginSlug     string
+	SnapshotBefore *PluginSnapshot
+	SnapshotAfter  *PluginSnapshot
+}
+
+func LogPluginUpdate(ctx context.Context, dbtx repo.DBTX, event LogPluginUpdateEvent) error {
+	action := ActionPluginUpdate
+
+	beforeSnapshot, err := marshalAuditPayload(event.SnapshotBefore)
+	if err != nil {
+		return fmt.Errorf("marshal %s before snapshot: %w", action, err)
+	}
+
+	afterSnapshot, err := marshalAuditPayload(event.SnapshotAfter)
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.PluginID.String(),
+		SubjectType:        string(subjectTypePlugin),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.PluginName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.PluginSlug),
+
+		BeforeSnapshot: beforeSnapshot,
+		AfterSnapshot:  afterSnapshot,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogPluginDeleteEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Plugin and migrate to PluginURN; pending team discussion
+	PluginName string
+	PluginSlug string
+}
+
+func LogPluginDelete(ctx context.Context, dbtx repo.DBTX, event LogPluginDeleteEvent) error {
+	action := ActionPluginDelete
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.PluginID.String(),
+		SubjectType:        string(subjectTypePlugin),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.PluginName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.PluginSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogPluginServerAddEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Plugin and migrate to PluginURN; pending team discussion
+	PluginName string
+	PluginSlug string
+
+	ServerID          uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.PluginServer and migrate to ServerURN; pending team discussion
+	ServerDisplayName string
+	ServerPolicy      string
+	ServerSortOrder   int32
+	ToolsetURN        urn.Toolset
+}
+
+func LogPluginServerAdd(ctx context.Context, dbtx repo.DBTX, event LogPluginServerAddEvent) error {
+	action := ActionPluginServerAdd
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"server_id":           event.ServerID.String(),
+		"server_display_name": event.ServerDisplayName,
+		"server_policy":       event.ServerPolicy,
+		"server_sort_order":   event.ServerSortOrder,
+		"toolset_urn":         event.ToolsetURN.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.PluginID.String(),
+		SubjectType:        string(subjectTypePlugin),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.PluginName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.PluginSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogPluginServerUpdateEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Plugin and migrate to PluginURN; pending team discussion
+	PluginName string
+	PluginSlug string
+
+	ServerID          uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.PluginServer and migrate to ServerURN; pending team discussion
+	ServerDisplayName string
+	ServerPolicy      string
+	ServerSortOrder   int32
+}
+
+func LogPluginServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogPluginServerUpdateEvent) error {
+	action := ActionPluginServerUpdate
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"server_id":           event.ServerID.String(),
+		"server_display_name": event.ServerDisplayName,
+		"server_policy":       event.ServerPolicy,
+		"server_sort_order":   event.ServerSortOrder,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.PluginID.String(),
+		SubjectType:        string(subjectTypePlugin),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.PluginName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.PluginSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogPluginServerRemoveEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Plugin and migrate to PluginURN; pending team discussion
+	PluginName string
+	PluginSlug string
+
+	ServerID uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.PluginServer and migrate to ServerURN; pending team discussion
+}
+
+func LogPluginServerRemove(ctx context.Context, dbtx repo.DBTX, event LogPluginServerRemoveEvent) error {
+	action := ActionPluginServerRemove
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"server_id": event.ServerID.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.PluginID.String(),
+		SubjectType:        string(subjectTypePlugin),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.PluginName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.PluginSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogPluginAssignmentsSetEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginID   uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.Plugin and migrate to PluginURN; pending team discussion
+	PluginName string
+	PluginSlug string
+
+	PrincipalURNs []string
+}
+
+func LogPluginAssignmentsSet(ctx context.Context, dbtx repo.DBTX, event LogPluginAssignmentsSetEvent) error {
+	action := ActionPluginAssignmentsSet
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"principal_urns": event.PrincipalURNs,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.PluginID.String(),
+		SubjectType:        string(subjectTypePlugin),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.PluginName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.PluginSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+// LogPluginPublishEvent records a single user-initiated publish of all
+// plugins in a project to GitHub. The event is project-scoped because the
+// publish creates one repo for all plugins together; per-plugin slugs are
+// captured in metadata.
+type LogPluginPublishEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	ProjectSlug    string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	PluginSlugs []string
+	RepoOwner   string
+	RepoName    string
+}
+
+func LogPluginPublish(ctx context.Context, dbtx repo.DBTX, event LogPluginPublishEvent) error {
+	action := ActionPluginPublish
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"plugin_slugs": event.PluginSlugs,
+		"repo_owner":   event.RepoOwner,
+		"repo_name":    event.RepoName,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.ProjectID.String(),
+		SubjectType:        string(subjectTypeProject),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.ProjectSlug),
+		SubjectSlug:        conv.ToPGTextEmpty(event.ProjectSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}

--- a/server/internal/plugins/audit_test.go
+++ b/server/internal/plugins/audit_test.go
@@ -1,0 +1,295 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/plugins"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+)
+
+func TestPluginsService_CreatePlugin_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginCreate)
+	require.NoError(t, err)
+
+	created, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit Create"})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginCreate)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginCreate)
+	require.NoError(t, err)
+	require.Equal(t, "plugin", rec.SubjectType)
+	require.Equal(t, created.Name, rec.SubjectDisplay)
+	require.Equal(t, created.Slug, rec.SubjectSlug)
+}
+
+func TestPluginsService_UpdatePlugin_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	created, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit Update"})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginUpdate)
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdatePlugin(ctx, &gen.UpdatePluginPayload{
+		ID:          created.ID,
+		Name:        "Audit Update Renamed",
+		Slug:        "audit-update-renamed",
+		Description: nil,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginUpdate)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginUpdate)
+	require.NoError(t, err)
+	require.Equal(t, "plugin", rec.SubjectType)
+	require.Equal(t, "audit-update-renamed", rec.SubjectSlug)
+	require.NotEmpty(t, rec.BeforeSnapshot)
+	require.NotEmpty(t, rec.AfterSnapshot)
+
+	beforeSnap, err := audittest.DecodeAuditData(rec.BeforeSnapshot)
+	require.NoError(t, err)
+	require.Equal(t, "Audit Update", beforeSnap["name"])
+	require.Equal(t, created.Slug, beforeSnap["slug"])
+
+	afterSnap, err := audittest.DecodeAuditData(rec.AfterSnapshot)
+	require.NoError(t, err)
+	require.Equal(t, "Audit Update Renamed", afterSnap["name"])
+	require.Equal(t, "audit-update-renamed", afterSnap["slug"])
+}
+
+func TestPluginsService_DeletePlugin_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	created, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit Delete"})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginDelete)
+	require.NoError(t, err)
+
+	require.NoError(t, ti.service.DeletePlugin(ctx, &gen.DeletePluginPayload{ID: created.ID}))
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginDelete)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginDelete)
+	require.NoError(t, err)
+	require.Equal(t, "plugin", rec.SubjectType)
+	require.Equal(t, created.Slug, rec.SubjectSlug)
+}
+
+func TestPluginsService_AddPluginServer_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit ServerAdd"})
+	require.NoError(t, err)
+	toolset := createTestToolset(t, ctx, ti.conn, "audit-add")
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+
+	server, err := ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
+		PluginID:    plugin.ID,
+		ToolsetID:   toolset.ID.String(),
+		DisplayName: "Server A",
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginServerAdd)
+	require.NoError(t, err)
+	require.Equal(t, "plugin", rec.SubjectType)
+	require.Equal(t, plugin.Slug, rec.SubjectSlug)
+
+	meta, err := audittest.DecodeAuditData(rec.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, server.ID, meta["server_id"])
+	require.Equal(t, "Server A", meta["server_display_name"])
+	require.Equal(t, "required", meta["server_policy"])
+}
+
+func TestPluginsService_UpdatePluginServer_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit ServerUpdate"})
+	require.NoError(t, err)
+	toolset := createTestToolset(t, ctx, ti.conn, "audit-update-srv")
+
+	server, err := ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
+		PluginID:    plugin.ID,
+		ToolsetID:   toolset.ID.String(),
+		DisplayName: "Original Server",
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerUpdate)
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdatePluginServer(ctx, &gen.UpdatePluginServerPayload{
+		ID:          server.ID,
+		PluginID:    plugin.ID,
+		DisplayName: "Renamed Server",
+		Policy:      "optional",
+		SortOrder:   5,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerUpdate)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginServerUpdate)
+	require.NoError(t, err)
+	require.Equal(t, "plugin", rec.SubjectType)
+
+	meta, err := audittest.DecodeAuditData(rec.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, "Renamed Server", meta["server_display_name"])
+	require.Equal(t, "optional", meta["server_policy"])
+}
+
+func TestPluginsService_RemovePluginServer_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit ServerRemove"})
+	require.NoError(t, err)
+	toolset := createTestToolset(t, ctx, ti.conn, "audit-remove-srv")
+
+	server, err := ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
+		PluginID:    plugin.ID,
+		ToolsetID:   toolset.ID.String(),
+		DisplayName: "Doomed Server",
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerRemove)
+	require.NoError(t, err)
+
+	require.NoError(t, ti.service.RemovePluginServer(ctx, &gen.RemovePluginServerPayload{
+		ID:       server.ID,
+		PluginID: plugin.ID,
+	}))
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerRemove)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginServerRemove)
+	require.NoError(t, err)
+	require.Equal(t, "plugin", rec.SubjectType)
+
+	meta, err := audittest.DecodeAuditData(rec.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, server.ID, meta["server_id"])
+}
+
+func TestPluginsService_SetPluginAssignments_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit Assignments"})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginAssignmentsSet)
+	require.NoError(t, err)
+
+	urns := []string{"role:engineering", "role:gtm"}
+	_, err = ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
+		PluginID:      plugin.ID,
+		PrincipalUrns: urns,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginAssignmentsSet)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginAssignmentsSet)
+	require.NoError(t, err)
+	require.Equal(t, "plugin", rec.SubjectType)
+	require.Equal(t, plugin.Slug, rec.SubjectSlug)
+
+	meta, err := audittest.DecodeAuditData(rec.Metadata)
+	require.NoError(t, err)
+	got, ok := meta["principal_urns"].([]any)
+	require.True(t, ok)
+	require.Len(t, got, 2)
+	require.Equal(t, "role:engineering", got[0])
+	require.Equal(t, "role:gtm", got[1])
+}
+
+func TestPluginsService_PublishPlugins_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Audit Publish"})
+	require.NoError(t, err)
+
+	toolset := createTestToolset(t, ctx, ti.conn, "audit-publish")
+	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
+		PluginID:    plugin.ID,
+		ToolsetID:   toolset.ID.String(),
+		DisplayName: "Publish Server",
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginPublish)
+	require.NoError(t, err)
+
+	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginPublish)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	rec, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionPluginPublish)
+	require.NoError(t, err)
+	require.Equal(t, "project", rec.SubjectType)
+
+	meta, err := audittest.DecodeAuditData(rec.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, "test-org", meta["repo_owner"])
+	slugs, ok := meta["plugin_slugs"].([]any)
+	require.True(t, ok)
+	require.Len(t, slugs, 1)
+	require.Equal(t, plugin.Slug, slugs[0])
+}

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -41,6 +41,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	ghclient "github.com/speakeasy-api/gram/server/internal/thirdparty/github"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -940,6 +941,11 @@ func (s *Service) PublishPlugins(ctx context.Context, payload *gen.PublishPlugin
 		return nil, oops.E(oops.CodeBadRequest, nil, "no plugins with servers to publish")
 	}
 
+	project, err := projectsrepo.New(s.db).GetProjectByID(ctx, *ac.ProjectID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "get project").Log(ctx, s.logger)
+	}
+
 	if payload.GithubUsername != nil && *payload.GithubUsername != "" && !validGitHubUsername.MatchString(*payload.GithubUsername) {
 		return nil, oops.E(oops.CodeBadRequest, nil, "invalid github username")
 	}
@@ -1005,7 +1011,7 @@ func (s *Service) PublishPlugins(ctx context.Context, payload *gen.PublishPlugin
 	// consumer credentials when GitHub fails. If this transaction itself
 	// fails, the published repo contains a key string with no DB record —
 	// re-publish overwrites it with a fresh valid key.
-	if err := s.persistPluginAPIKey(ctx, ac, candidate, repoOwner, repoName, pluginSlugs); err != nil {
+	if err := s.persistPluginAPIKey(ctx, ac, candidate, project.Name, repoOwner, repoName, pluginSlugs); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "persist plugin api key").Log(ctx, s.logger)
 	}
 
@@ -1055,6 +1061,7 @@ func (s *Service) persistPluginAPIKey(
 	ctx context.Context,
 	ac *contextvalues.AuthContext,
 	candidate pluginAPIKeyCandidate,
+	projectName string,
 	repoOwner, repoName string,
 	pluginSlugs []string,
 ) error {
@@ -1109,6 +1116,7 @@ func (s *Service) persistPluginAPIKey(
 	if err := audit.LogPluginPublish(ctx, tx, audit.LogPluginPublishEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
+		ProjectName:      projectName,
 		ProjectSlug:      projectSlug,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
 		ActorDisplayName: ac.Email,

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -284,7 +284,13 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 		return nil, oops.E(oops.CodeBadRequest, nil, "plugin name must produce a valid slug")
 	}
 
-	plugin, err := s.repo.CreatePlugin(ctx, repo.CreatePluginParams{
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	plugin, err := s.repo.WithTx(tx).CreatePlugin(ctx, repo.CreatePluginParams{
 		OrganizationID: ac.ActiveOrganizationID,
 		ProjectID:      *ac.ProjectID,
 		Name:           payload.Name,
@@ -297,6 +303,23 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 			return nil, oops.E(oops.CodeConflict, nil, "a plugin with this slug already exists")
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "create plugin").Log(ctx, s.logger)
+	}
+
+	if err := audit.LogPluginCreate(ctx, tx, audit.LogPluginCreateEvent{
+		OrganizationID:   ac.ActiveOrganizationID,
+		ProjectID:        *ac.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName: ac.Email,
+		ActorSlug:        nil,
+		PluginID:         plugin.ID,
+		PluginName:       plugin.Name,
+		PluginSlug:       plugin.Slug,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin create").Log(ctx, s.logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
 	}
 
 	return pluginToGen(plugin, nil, nil), nil
@@ -322,7 +345,27 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 		return nil, oops.E(oops.CodeBadRequest, nil, "invalid slug: must be non-empty and contain only lowercase alphanumeric characters and hyphens")
 	}
 
-	plugin, err := s.repo.UpdatePlugin(ctx, repo.UpdatePluginParams{
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	txRepo := s.repo.WithTx(tx)
+
+	before, err := txRepo.GetPlugin(ctx, repo.GetPluginParams{
+		ID:             pluginID,
+		OrganizationID: ac.ActiveOrganizationID,
+		ProjectID:      *ac.ProjectID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, oops.C(oops.CodeNotFound)
+		}
+		return nil, oops.E(oops.CodeUnexpected, err, "load plugin").Log(ctx, s.logger)
+	}
+
+	plugin, err := txRepo.UpdatePlugin(ctx, repo.UpdatePluginParams{
 		ID:             pluginID,
 		OrganizationID: ac.ActiveOrganizationID,
 		ProjectID:      *ac.ProjectID,
@@ -339,6 +382,33 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 			return nil, oops.E(oops.CodeConflict, nil, "a plugin with this slug already exists")
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "update plugin").Log(ctx, s.logger)
+	}
+
+	if err := audit.LogPluginUpdate(ctx, tx, audit.LogPluginUpdateEvent{
+		OrganizationID:   ac.ActiveOrganizationID,
+		ProjectID:        *ac.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName: ac.Email,
+		ActorSlug:        nil,
+		PluginID:         plugin.ID,
+		PluginName:       plugin.Name,
+		PluginSlug:       plugin.Slug,
+		SnapshotBefore: &audit.PluginSnapshot{
+			Name:        before.Name,
+			Slug:        before.Slug,
+			Description: conv.FromPGText[string](before.Description),
+		},
+		SnapshotAfter: &audit.PluginSnapshot{
+			Name:        plugin.Name,
+			Slug:        plugin.Slug,
+			Description: conv.FromPGText[string](plugin.Description),
+		},
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin update").Log(ctx, s.logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
 	}
 
 	servers, err := s.repo.ListPluginServers(ctx, pluginID)
@@ -370,7 +440,8 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 	}
 
 	// Verify the plugin belongs to this project before mutating.
-	if _, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID}); err != nil {
+	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
@@ -401,6 +472,19 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 		return oops.E(oops.CodeUnexpected, err, "delete plugin").Log(ctx, s.logger)
 	}
 
+	if err := audit.LogPluginDelete(ctx, tx, audit.LogPluginDeleteEvent{
+		OrganizationID:   ac.ActiveOrganizationID,
+		ProjectID:        *ac.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName: ac.Email,
+		ActorSlug:        nil,
+		PluginID:         plugin.ID,
+		PluginName:       plugin.Name,
+		PluginSlug:       plugin.Slug,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "audit log plugin delete").Log(ctx, s.logger)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
 	}
@@ -425,7 +509,8 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 	}
 
 	// Verify the plugin belongs to this project.
-	if _, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID}); err != nil {
+	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
@@ -452,7 +537,13 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 		return nil, oops.E(oops.CodeBadRequest, nil, "toolset does not have MCP enabled")
 	}
 
-	row, err := s.repo.AddPluginServer(ctx, repo.AddPluginServerParams{
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	row, err := s.repo.WithTx(tx).AddPluginServer(ctx, repo.AddPluginServerParams{
 		PluginID:    pluginID,
 		ToolsetID:   toolsetID,
 		DisplayName: payload.DisplayName,
@@ -465,6 +556,28 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 			return nil, oops.E(oops.CodeConflict, nil, "a server with this display name already exists in the plugin")
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "add plugin server").Log(ctx, s.logger)
+	}
+
+	if err := audit.LogPluginServerAdd(ctx, tx, audit.LogPluginServerAddEvent{
+		OrganizationID:    ac.ActiveOrganizationID,
+		ProjectID:         *ac.ProjectID,
+		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName:  ac.Email,
+		ActorSlug:         nil,
+		PluginID:          plugin.ID,
+		PluginName:        plugin.Name,
+		PluginSlug:        plugin.Slug,
+		ServerID:          row.ID,
+		ServerDisplayName: row.DisplayName,
+		ServerPolicy:      row.Policy,
+		ServerSortOrder:   row.SortOrder,
+		ToolsetURN:        urn.NewToolset(row.ToolsetID),
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin server add").Log(ctx, s.logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
 	}
 
 	return pluginServerToGen(row), nil
@@ -490,14 +603,21 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 	}
 
 	// Verify the plugin belongs to this project.
-	if _, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID}); err != nil {
+	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").Log(ctx, s.logger)
 	}
 
-	row, err := s.repo.UpdatePluginServer(ctx, repo.UpdatePluginServerParams{
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	row, err := s.repo.WithTx(tx).UpdatePluginServer(ctx, repo.UpdatePluginServerParams{
 		ID:          serverID,
 		PluginID:    pluginID,
 		DisplayName: payload.DisplayName,
@@ -509,6 +629,27 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 			return nil, oops.C(oops.CodeNotFound)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "update plugin server").Log(ctx, s.logger)
+	}
+
+	if err := audit.LogPluginServerUpdate(ctx, tx, audit.LogPluginServerUpdateEvent{
+		OrganizationID:    ac.ActiveOrganizationID,
+		ProjectID:         *ac.ProjectID,
+		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName:  ac.Email,
+		ActorSlug:         nil,
+		PluginID:          plugin.ID,
+		PluginName:        plugin.Name,
+		PluginSlug:        plugin.Slug,
+		ServerID:          row.ID,
+		ServerDisplayName: row.DisplayName,
+		ServerPolicy:      row.Policy,
+		ServerSortOrder:   row.SortOrder,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin server update").Log(ctx, s.logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
 	}
 
 	return pluginServerToGen(row), nil
@@ -534,18 +675,43 @@ func (s *Service) RemovePluginServer(ctx context.Context, payload *gen.RemovePlu
 	}
 
 	// Verify the plugin belongs to this project.
-	if _, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID}); err != nil {
+	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.C(oops.CodeNotFound)
 		}
 		return oops.E(oops.CodeUnexpected, err, "verify plugin ownership").Log(ctx, s.logger)
 	}
 
-	if err := s.repo.RemovePluginServer(ctx, repo.RemovePluginServerParams{
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	if err := s.repo.WithTx(tx).RemovePluginServer(ctx, repo.RemovePluginServerParams{
 		ID:       serverID,
 		PluginID: pluginID,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "remove plugin server").Log(ctx, s.logger)
+	}
+
+	if err := audit.LogPluginServerRemove(ctx, tx, audit.LogPluginServerRemoveEvent{
+		OrganizationID:   ac.ActiveOrganizationID,
+		ProjectID:        *ac.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName: ac.Email,
+		ActorSlug:        nil,
+		PluginID:         plugin.ID,
+		PluginName:       plugin.Name,
+		PluginSlug:       plugin.Slug,
+		ServerID:         serverID,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "audit log plugin server remove").Log(ctx, s.logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
 	}
 	return nil
 }
@@ -568,7 +734,8 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 	}
 
 	// Verify the plugin belongs to this project.
-	if _, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID}); err != nil {
+	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
@@ -604,6 +771,20 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 			return nil, oops.E(oops.CodeUnexpected, err, "add plugin assignment").Log(ctx, s.logger)
 		}
 		assignments = append(assignments, pluginAssignmentToGen(row))
+	}
+
+	if err := audit.LogPluginAssignmentsSet(ctx, tx, audit.LogPluginAssignmentsSetEvent{
+		OrganizationID:   ac.ActiveOrganizationID,
+		ProjectID:        *ac.ProjectID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName: ac.Email,
+		ActorSlug:        nil,
+		PluginID:         plugin.ID,
+		PluginName:       plugin.Name,
+		PluginSlug:       plugin.Slug,
+		PrincipalURNs:    payload.PrincipalUrns,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin assignments set").Log(ctx, s.logger)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -814,12 +995,17 @@ func (s *Service) PublishPlugins(ctx context.Context, payload *gen.PublishPlugin
 		}
 	}
 
-	// Persist the API key, audit log, and github connection atomically only
+	pluginSlugs := make([]string, 0, len(pluginInfos))
+	for _, p := range pluginInfos {
+		pluginSlugs = append(pluginSlugs, p.Slug)
+	}
+
+	// Persist the API key, audit logs, and github connection atomically only
 	// after the GitHub publish has succeeded. This prevents leaking valid
 	// consumer credentials when GitHub fails. If this transaction itself
 	// fails, the published repo contains a key string with no DB record —
 	// re-publish overwrites it with a fresh valid key.
-	if err := s.persistPluginAPIKey(ctx, ac, candidate, repoOwner, repoName); err != nil {
+	if err := s.persistPluginAPIKey(ctx, ac, candidate, repoOwner, repoName, pluginSlugs); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "persist plugin api key").Log(ctx, s.logger)
 	}
 
@@ -862,13 +1048,15 @@ func (s *Service) buildPluginAPIKeyCandidate() (pluginAPIKeyCandidate, error) {
 	}, nil
 }
 
-// persistPluginAPIKey atomically writes the API key, its audit log entry, and
-// the GitHub connection record in one transaction.
+// persistPluginAPIKey atomically writes the API key, its audit log entry,
+// the plugin publish audit log entry, and the GitHub connection record in
+// one transaction.
 func (s *Service) persistPluginAPIKey(
 	ctx context.Context,
 	ac *contextvalues.AuthContext,
 	candidate pluginAPIKeyCandidate,
 	repoOwner, repoName string,
+	pluginSlugs []string,
 ) error {
 	scopes := []string{auth.APIKeyScopeConsumer.String()}
 	projectID := uuid.NullUUID{UUID: *ac.ProjectID, Valid: true}
@@ -912,6 +1100,24 @@ func (s *Service) persistPluginAPIKey(
 		RepoName:       repoName,
 	}); err != nil {
 		return fmt.Errorf("upsert github connection: %w", err)
+	}
+
+	projectSlug := ""
+	if ac.ProjectSlug != nil {
+		projectSlug = *ac.ProjectSlug
+	}
+	if err := audit.LogPluginPublish(ctx, tx, audit.LogPluginPublishEvent{
+		OrganizationID:   ac.ActiveOrganizationID,
+		ProjectID:        *ac.ProjectID,
+		ProjectSlug:      projectSlug,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
+		ActorDisplayName: ac.Email,
+		ActorSlug:        nil,
+		PluginSlugs:      pluginSlugs,
+		RepoOwner:        repoOwner,
+		RepoName:         repoName,
+	}); err != nil {
+		return fmt.Errorf("audit log plugin publish: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {


### PR DESCRIPTION
Wire plugin mutations through the audit subsystem so create, update, delete, server add/update/remove, assignments, and publish all emit audit log entries inside the same transaction as the mutation. Adds a plugin subject type, a per-action `Log*Event`/`Log*` pair under `internal/audit/plugins.go`, dashboard label/icon mappings for the new actions, and tests that assert each handler records its event.