### PR TITLE
feat: click-to-reveal for sensitive data in risk findings

### DIFF
--- a/.changeset/poor-scissors-clean.md
+++ b/.changeset/poor-scissors-clean.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+click-to-reveal for sensitive data in risk findings

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -182,6 +183,7 @@ function MessageItem({
 }) {
   const hasRisk = riskResults && riskResults.length > 0;
   const [expanded, setExpanded] = useState(false);
+  const [contentRevealed, setContentRevealed] = useState(false);
   const isCollapsed = collapseNonRisk && !hasRisk && !expanded;
 
   const parsedToolCalls: ToolCall[] | null = useMemo(() => {
@@ -260,26 +262,30 @@ function MessageItem({
                   <RiskBadgePopover results={riskResults} />
                 )}
               </div>
-              <div className="bg-background overflow-hidden rounded-lg border text-sm">
-                <div className="bg-muted/30 border-b p-3">
-                  <div className="flex items-center gap-2">
-                    <Icon name="zap" className="text-primary size-4" />
-                    <span className="font-semibold">
-                      {tc.function?.name || tc.name || "Tool Call"}
-                    </span>
+              {hasRisk && !contentRevealed ? (
+                <MaskedContent onReveal={() => setContentRevealed(true)} />
+              ) : (
+                <div className="bg-background overflow-hidden rounded-lg border text-sm">
+                  <div className="bg-muted/30 border-b p-3">
+                    <div className="flex items-center gap-2">
+                      <Icon name="zap" className="text-primary size-4" />
+                      <span className="font-semibold">
+                        {tc.function?.name || tc.name || "Tool Call"}
+                      </span>
+                    </div>
                   </div>
+                  {tc.function?.arguments && (
+                    <CodeBlock
+                      content={
+                        typeof tc.function.arguments === "string"
+                          ? tc.function.arguments
+                          : JSON.stringify(tc.function.arguments, null, 2)
+                      }
+                      maxHeight={300}
+                    />
+                  )}
                 </div>
-                {tc.function?.arguments && (
-                  <CodeBlock
-                    content={
-                      typeof tc.function.arguments === "string"
-                        ? tc.function.arguments
-                        : JSON.stringify(tc.function.arguments, null, 2)
-                    }
-                    maxHeight={300}
-                  />
-                )}
-              </div>
+              )}
             </div>
           </div>
         ))
@@ -328,7 +334,9 @@ function MessageItem({
                 <RiskBadgePopover results={riskResults} />
               )}
             </div>
-            {message.role === "system" ? (
+            {hasRisk && !contentRevealed ? (
+              <MaskedContent onReveal={() => setContentRevealed(true)} />
+            ) : message.role === "system" ? (
               <details className="bg-muted/30 group overflow-hidden rounded-lg border text-sm">
                 <summary className="text-muted-foreground hover:bg-muted/50 flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs select-none">
                   <Icon
@@ -566,6 +574,56 @@ function ToolCallsTab({
   );
 }
 
+function MaskedContent({ onReveal }: { onReveal: () => void }) {
+  return (
+    <div className="bg-muted/30 flex items-center gap-2 rounded-lg border border-dashed p-3">
+      <EyeOff className="text-muted-foreground h-4 w-4 shrink-0" />
+      <span className="text-muted-foreground text-sm">
+        This message contains sensitive data.
+      </span>
+      <button
+        type="button"
+        className="hover:text-foreground text-sm font-medium underline underline-offset-2"
+        onClick={onReveal}
+      >
+        Click to reveal
+      </button>
+    </div>
+  );
+}
+
+function MaskedMatchInline({ value }: { value: string }) {
+  const [revealed, setRevealed] = useState(false);
+
+  if (!revealed) {
+    return (
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground mt-1 inline-flex items-center gap-1 text-xs"
+        onClick={() => setRevealed(true)}
+      >
+        <EyeOff className="h-3 w-3" />
+        <span>Click to reveal</span>
+      </button>
+    );
+  }
+
+  return (
+    <span className="mt-1 inline-flex items-center gap-1">
+      <code className="bg-destructive/10 text-destructive inline-block rounded px-1.5 py-0.5 font-mono text-xs break-all">
+        {value}
+      </code>
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={() => setRevealed(false)}
+      >
+        <Eye className="h-3 w-3" />
+      </button>
+    </span>
+  );
+}
+
 function RiskBadgePopover({ results }: { results: RiskResult[] }) {
   return (
     <Popover>
@@ -601,11 +659,7 @@ function RiskBadgePopover({ results }: { results: RiskResult[] }) {
                     {r.description}
                   </p>
                 )}
-                {r.match && (
-                  <code className="bg-destructive/10 text-destructive mt-1 inline-block rounded px-1.5 py-0.5 font-mono text-xs break-all">
-                    {r.match}
-                  </code>
-                )}
+                {r.match && <MaskedMatchInline value={r.match} />}
                 {r.tags && r.tags.length > 0 && (
                   <div className="mt-1 flex flex-wrap gap-1">
                     {r.tags.map((tag) => (

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -299,7 +299,7 @@ function SecurityOverviewContent() {
                         <TableHead>Rule</TableHead>
                         <TableHead>Chat</TableHead>
                         <TableHead>User</TableHead>
-                        <TableHead>Match</TableHead>
+                        <TableHead className="w-[200px]">Match</TableHead>
                         <TableHead>Detected</TableHead>
                       </TableRow>
                     </TableHeader>
@@ -332,7 +332,7 @@ function SecurityOverviewContent() {
                           <TableCell className="text-muted-foreground text-xs">
                             {result.userId ?? "-"}
                           </TableCell>
-                          <TableCell className="max-w-xs truncate">
+                          <TableCell className="w-[200px] max-w-[200px] truncate">
                             <MaskedMatch value={result.match} />
                           </TableCell>
                           <TableCell className="text-muted-foreground text-xs">

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -10,9 +10,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useRoutes } from "@/routes";
-import { Shield } from "lucide-react";
+import { Eye, EyeOff, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRiskListPolicies } from "@gram/client/react-query/index.js";
@@ -43,6 +43,48 @@ export default function SecurityOverview() {
     <RequireScope scope="org:admin" level="page">
       <SecurityOverviewContent />
     </RequireScope>
+  );
+}
+
+function MaskedMatch({ value }: { value: string | undefined }) {
+  const [revealed, setRevealed] = useState(false);
+
+  if (!value) return <span>-</span>;
+
+  if (!revealed) {
+    return (
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
+        onClick={(e) => {
+          e.stopPropagation();
+          setRevealed(true);
+        }}
+      >
+        <EyeOff className="h-3 w-3" />
+        <span>Click to reveal</span>
+      </button>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="font-mono text-xs">
+        {value.length > 40
+          ? `${value.slice(0, 20)}...${value.slice(-10)}`
+          : value}
+      </span>
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={(e) => {
+          e.stopPropagation();
+          setRevealed(false);
+        }}
+      >
+        <Eye className="h-3 w-3" />
+      </button>
+    </span>
   );
 }
 
@@ -290,12 +332,8 @@ function SecurityOverviewContent() {
                           <TableCell className="text-muted-foreground text-xs">
                             {result.userId ?? "-"}
                           </TableCell>
-                          <TableCell className="max-w-xs truncate font-mono text-xs">
-                            {result.match
-                              ? result.match.length > 40
-                                ? `${result.match.slice(0, 20)}...${result.match.slice(-10)}`
-                                : result.match
-                              : "-"}
+                          <TableCell className="max-w-xs truncate">
+                            <MaskedMatch value={result.match} />
                           </TableCell>
                           <TableCell className="text-muted-foreground text-xs">
                             {result.createdAt


### PR DESCRIPTION
## Why

Customers flagged that detected secrets and PII are displayed in plaintext on the risk overview page. Since any org admin can access this page, sensitive data (API keys, tokens, PII) is visible at a glance without any friction, increasing the risk of shoulder-surfing and accidental exposure.

Resolves [AGE-1941](https://linear.app/speakeasy/issue/AGE-1941/feat-mask-credential-values-in-secret-scanning-ui)

## What changed

Added click-to-reveal masking for sensitive data across all risk finding surfaces in the dashboard.

### Before

- **Risk Overview table**: The Match column showed raw secret values (e.g. `sk_live_CkFM3A34DhSs...`)
- **Chat detail panel**: Messages flagged with risk findings displayed full message content including secrets
- **Risk badge popover**: The match field in the risk findings popover showed raw values

### After

- **Risk Overview table**: Match column shows an eye-off icon + "Click to reveal" button per row. Clicking reveals the value with an eye icon to re-hide. Uses `stopPropagation` so reveal clicks don't open the chat drawer.
- **Chat detail panel**: Messages with risk findings show a "This message contains sensitive data. Click to reveal" placeholder instead of the message content. Applies to both regular messages and tool call arguments.
- **Risk badge popover**: Match values in the popover are masked behind individual click-to-reveal toggles.

Note: Access control was already in place (backend `authz.ScopeOrgAdmin` + frontend `RequireScope`). This change adds visual friction for admins to prevent casual/accidental exposure.

https://github.com/user-attachments/assets/228476c8-adbf-42d7-b07d-ebba29d8f562


