### PR TITLE
fix(mcp): omit GRAM_KEY header from install snippets when OAuth is configured

### DIFF
--- a/.mise-tasks/start/assistant-runtime.mts
+++ b/.mise-tasks/start/assistant-runtime.mts
@@ -6,7 +6,8 @@
 
 import path from "node:path";
 import process from "node:process";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
 
 type RuntimeRow = {
   runtime_id: string;
@@ -17,9 +18,11 @@ type RuntimeRow = {
   machine_id: string;
 };
 
+type LogStreamProcess = ChildProcessByStdio<null, Readable, Readable>;
+
 type Subscriber = {
   runtime: RuntimeRow;
-  proc: ChildProcessWithoutNullStreams;
+  proc: LogStreamProcess;
   stopped: boolean;
 };
 
@@ -97,7 +100,7 @@ function writeLine(prefix: string, line: string) {
 
 function attachLinePrefixer(
   runtime: RuntimeRow,
-  proc: ChildProcessWithoutNullStreams,
+  proc: LogStreamProcess,
   stream: NodeJS.ReadableStream,
 ) {
   const prefix = linePrefix(runtime);
@@ -137,9 +140,7 @@ function sameTarget(left: RuntimeRow, right: RuntimeRow): boolean {
   );
 }
 
-function spawnLocalSubscriber(
-  runtime: RuntimeRow,
-): ChildProcessWithoutNullStreams {
+function spawnLocalSubscriber(runtime: RuntimeRow): LogStreamProcess {
   const logPath = localLogPath(runtime);
   return spawn(
     "bash",
@@ -156,9 +157,7 @@ function spawnLocalSubscriber(
   );
 }
 
-function spawnFlySubscriber(
-  runtime: RuntimeRow,
-): ChildProcessWithoutNullStreams {
+function spawnFlySubscriber(runtime: RuntimeRow): LogStreamProcess {
   const appName = flyAppName(runtime);
   const args = ["logs", "-a", appName];
   if (runtime.machine_id) {
@@ -173,7 +172,7 @@ function spawnFlySubscriber(
   });
 }
 
-function spawnSubscriber(runtime: RuntimeRow): ChildProcessWithoutNullStreams {
+function spawnSubscriber(runtime: RuntimeRow): LogStreamProcess {
   switch (runtime.backend) {
     case "local":
     case "firecracker":

--- a/client/dashboard/src/components/insights-sidebar.tsx
+++ b/client/dashboard/src/components/insights-sidebar.tsx
@@ -385,7 +385,6 @@ function PendingPromptBridge({
     try {
       assistantRuntime.thread.append(text);
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.error("Failed to send Explore prompt:", err);
     }
 

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1857,35 +1857,41 @@ export function MCPJson({
           : 1
       }
     >
-      <Grid.Item>
-        <Type className="font-medium">Pass-through Authentication</Type>
-        <Type muted small className="mb-2! max-w-3xl">
-          Pass API credentials directly to the MCP server.
-          <br />
-          <span
-            className={
-              requiresGramKey ? "text-warning-foreground font-medium" : "italic"
-            }
-          >
-            {requiresGramKey
-              ? "Requires a Gram API key."
-              : "No Gram API key required."}
-          </span>
-        </Type>
-        <CodeBlock onCopy={onCopy}>{mcpJsonPublic}</CodeBlock>
-      </Grid.Item>
-      {showManagedAuth && (
-        <Grid.Item>
-          <Type className="font-medium">Managed Authentication</Type>
+      {[
+        <Grid.Item key="passthrough">
+          <Type className="font-medium">Pass-through Authentication</Type>
           <Type muted small className="mb-2! max-w-3xl">
-            Manage API authentication with Gram environments.
+            Pass API credentials directly to the MCP server.
             <br />
-            Users need a single Gram API Key rather than bringing their own
-            keys.
+            <span
+              className={
+                requiresGramKey
+                  ? "text-warning-foreground font-medium"
+                  : "italic"
+              }
+            >
+              {requiresGramKey
+                ? "Requires a Gram API key."
+                : "No Gram API key required."}
+            </span>
           </Type>
-          <CodeBlock onCopy={onCopy}>{mcpJsonInternal}</CodeBlock>
-        </Grid.Item>
-      )}
+          <CodeBlock onCopy={onCopy}>{mcpJsonPublic}</CodeBlock>
+        </Grid.Item>,
+        ...(showManagedAuth
+          ? [
+              <Grid.Item key="managed">
+                <Type className="font-medium">Managed Authentication</Type>
+                <Type muted small className="mb-2! max-w-3xl">
+                  Manage API authentication with Gram environments.
+                  <br />
+                  Users need a single Gram API Key rather than bringing their
+                  own keys.
+                </Type>
+                <CodeBlock onCopy={onCopy}>{mcpJsonInternal}</CodeBlock>
+              </Grid.Item>,
+            ]
+          : []),
+      ]}
     </Grid>
   );
 }

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1835,6 +1835,7 @@ export function MCPJson({
     public: mcpJsonPublic,
     internal: mcpJsonInternal,
     requiresGramKey,
+    hasOAuth,
   } = useMcpConfigs(toolset);
 
   const onCopy = () => {
@@ -1844,11 +1845,17 @@ export function MCPJson({
     });
   };
 
+  const showManagedAuth = !hasOAuth;
+
   return (
     <Grid
       gap={4}
       className={cn("my-4!", className)}
-      columns={!fullWidth ? { xs: 1, md: 2, lg: 2, xl: 2, "2xl": 2 } : 1}
+      columns={
+        !fullWidth && showManagedAuth
+          ? { xs: 1, md: 2, lg: 2, xl: 2, "2xl": 2 }
+          : 1
+      }
     >
       <Grid.Item>
         <Type className="font-medium">Pass-through Authentication</Type>
@@ -1867,15 +1874,18 @@ export function MCPJson({
         </Type>
         <CodeBlock onCopy={onCopy}>{mcpJsonPublic}</CodeBlock>
       </Grid.Item>
-      <Grid.Item>
-        <Type className="font-medium">Managed Authentication</Type>
-        <Type muted small className="mb-2! max-w-3xl">
-          Manage API authentication with Gram environments.
-          <br />
-          Users need a single Gram API Key rather than bringing their own keys.
-        </Type>
-        <CodeBlock onCopy={onCopy}>{mcpJsonInternal}</CodeBlock>
-      </Grid.Item>
+      {showManagedAuth && (
+        <Grid.Item>
+          <Type className="font-medium">Managed Authentication</Type>
+          <Type muted small className="mb-2! max-w-3xl">
+            Manage API authentication with Gram environments.
+            <br />
+            Users need a single Gram API Key rather than bringing their own
+            keys.
+          </Type>
+          <CodeBlock onCopy={onCopy}>{mcpJsonInternal}</CodeBlock>
+        </Grid.Item>
+      )}
     </Grid>
   );
 }

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1831,8 +1831,11 @@ export function MCPJson({
 }) {
   const telemetry = useTelemetry();
 
-  const { public: mcpJsonPublic, internal: mcpJsonInternal } =
-    useMcpConfigs(toolset);
+  const {
+    public: mcpJsonPublic,
+    internal: mcpJsonInternal,
+    requiresGramKey,
+  } = useMcpConfigs(toolset);
 
   const onCopy = () => {
     telemetry.capture("mcp_event", {
@@ -1854,12 +1857,12 @@ export function MCPJson({
           <br />
           <span
             className={
-              !toolset.mcpIsPublic
-                ? "text-warning-foreground font-medium"
-                : "italic"
+              requiresGramKey ? "text-warning-foreground font-medium" : "italic"
             }
           >
-            Requires a Gram API key if the server is not public.
+            {requiresGramKey
+              ? "Requires a Gram API key."
+              : "No Gram API key required."}
           </span>
         </Type>
         <CodeBlock onCopy={onCopy}>{mcpJsonPublic}</CodeBlock>

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -49,7 +49,7 @@ import { PromptsTabContent } from "@/pages/toolsets/PromptsTab";
 import { ResourcesTabContent } from "@/pages/toolsets/resources/ResourcesTab";
 import { ServerTabContent } from "@/pages/toolsets/ServerTab";
 import { useRoutes } from "@/routes";
-import { Confirm, ToolsetEntry } from "@gram/client/models/components";
+import { Confirm } from "@gram/client/models/components";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
 import {
   invalidateAllGetPeriodUsage,
@@ -1825,7 +1825,7 @@ export function MCPJson({
   fullWidth = false,
   className,
 }: {
-  toolset: ToolsetEntry;
+  toolset: Toolset;
   fullWidth?: boolean; // If true, the code block will take up the full width of the page even when there's only one
   className?: string;
 }) {

--- a/client/dashboard/src/pages/mcp/mcp-details-utils.ts
+++ b/client/dashboard/src/pages/mcp/mcp-details-utils.ts
@@ -42,6 +42,13 @@ export const useMcpConfigs = (toolset: ToolsetEntry | undefined) => {
     return envVar.replace(/_/g, "-");
   };
 
+  // OAuth (Gram or external) handles identity auth at the HTTP layer, so the
+  // install snippet must not ask the user for a GRAM_KEY Authorization header.
+  const hasOAuth = Boolean(
+    toolset.oauthProxyServer || toolset.externalOauthServer,
+  );
+  const requiresGramKey = !toolset.mcpIsPublic && !hasOAuth;
+
   // Build the args array for public MCP config
   const mcpJsonPublicArgs = [
     "mcp-remote@0.1.25",
@@ -52,7 +59,7 @@ export const useMcpConfigs = (toolset: ToolsetEntry | undefined) => {
     ]),
   ];
 
-  if (!toolset.mcpIsPublic) {
+  if (requiresGramKey) {
     mcpJsonPublicArgs.push("--header", "Authorization:${GRAM_KEY}");
   }
 
@@ -68,7 +75,7 @@ export const useMcpConfigs = (toolset: ToolsetEntry | undefined) => {
     "Gram${toolset.slug.replace(/-/g, "").replace(/^./, (c) => c.toUpperCase())}": {
       "command": "npx",
       "args": ${argsStringIndented}${
-        !toolset.mcpIsPublic
+        requiresGramKey
           ? `,
       "env": {
         "GRAM_KEY": "Bearer <your-key-here>"

--- a/client/dashboard/src/pages/mcp/mcp-details-utils.ts
+++ b/client/dashboard/src/pages/mcp/mcp-details-utils.ts
@@ -22,7 +22,13 @@ export const useMcpConfigs = (toolset: Toolset | undefined) => {
     (header) => !header.toLowerCase().includes("token_url"),
   );
 
-  if (!toolset) return { public: "", internal: "", requiresGramKey: false };
+  if (!toolset)
+    return {
+      public: "",
+      internal: "",
+      requiresGramKey: false,
+      hasOAuth: false,
+    };
 
   // Build header names using display names when available
   // Display names make the config more user-friendly (e.g., "API-Key" instead of "X-RAPIDAPI-KEY")
@@ -104,7 +110,12 @@ export const useMcpConfigs = (toolset: Toolset | undefined) => {
   }
 }`;
 
-  return { public: mcpJsonPublic, internal: mcpJsonInternal, requiresGramKey };
+  return {
+    public: mcpJsonPublic,
+    internal: mcpJsonInternal,
+    requiresGramKey,
+    hasOAuth,
+  };
 };
 
 export function useMcpSlugValidation(

--- a/client/dashboard/src/pages/mcp/mcp-details-utils.ts
+++ b/client/dashboard/src/pages/mcp/mcp-details-utils.ts
@@ -2,11 +2,10 @@ import { useSdkClient } from "@/contexts/Sdk";
 import { useListTools } from "@/hooks/toolTypes";
 import { useToolsetEnvVars } from "@/hooks/useToolsetEnvVars";
 import { useMcpUrl } from "@/hooks/useToolsetUrl";
-import { isHttpTool } from "@/lib/toolTypes";
-import { ToolsetEntry } from "@gram/client/models/components";
+import { isHttpTool, Toolset } from "@/lib/toolTypes";
 import { useEffect, useState } from "react";
 
-export const useMcpConfigs = (toolset: ToolsetEntry | undefined) => {
+export const useMcpConfigs = (toolset: Toolset | undefined) => {
   const { url: mcpUrl } = useMcpUrl(toolset);
   const { data: tools } = useListTools();
 

--- a/client/dashboard/src/pages/mcp/mcp-details-utils.ts
+++ b/client/dashboard/src/pages/mcp/mcp-details-utils.ts
@@ -22,7 +22,7 @@ export const useMcpConfigs = (toolset: Toolset | undefined) => {
     (header) => !header.toLowerCase().includes("token_url"),
   );
 
-  if (!toolset) return { public: "", internal: "" };
+  if (!toolset) return { public: "", internal: "", requiresGramKey: false };
 
   // Build header names using display names when available
   // Display names make the config more user-friendly (e.g., "API-Key" instead of "X-RAPIDAPI-KEY")
@@ -104,7 +104,7 @@ export const useMcpConfigs = (toolset: Toolset | undefined) => {
   }
 }`;
 
-  return { public: mcpJsonPublic, internal: mcpJsonInternal };
+  return { public: mcpJsonPublic, internal: mcpJsonInternal, requiresGramKey };
 };
 
 export function useMcpSlugValidation(

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1095,14 +1095,16 @@ func (s *Service) loadToolsetFromContextAndSlug(ctx context.Context, mcpSlug str
 	return &toolset, nil
 }
 
-// resolveSecurityMode determines the security mode based on toolset configuration
-// Prefers oauth > gram > public
+// resolveSecurityMode determines the security mode based on toolset configuration.
+// OAuth wins regardless of public/private: when an OAuth proxy or external OAuth
+// server is attached, identity auth is delegated to the OAuth flow and the
+// install instructions must not ask the user for an Authorization/GRAM_KEY header.
 func (s *Service) resolveSecurityMode(toolset *toolsets_repo.Toolset) securityMode {
-	if toolset.McpIsPublic {
-		if toolset.OauthProxyServerID.Valid || toolset.ExternalOauthServerID.Valid {
-			return securityModeOAuth
-		}
+	if toolset.OauthProxyServerID.Valid || toolset.ExternalOauthServerID.Valid {
+		return securityModeOAuth
+	}
 
+	if toolset.McpIsPublic {
 		return securityModePublic
 	}
 

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
@@ -913,6 +914,43 @@ func TestServeInstallPage_ClaudeDesktop_WithSecurityInputs(t *testing.T) {
 	assert.Contains(t, body, "does not yet support custom HTTP headers", "should explain why the workaround is needed")
 	assert.NotContains(t, body, `"Add custom connector"`, "should not render the simple Add custom connector flow")
 	assert.NotContains(t, body, "For Teams &amp; Enterprise", "should not render the Teams & Enterprise admin connector footer")
+}
+
+// TestServeInstallPage_PrivateWithGramOAuth_NoAuthorizationHeader regression-tests
+// AGE-1962: a private MCP server with a Gram OAuth proxy attached must not render
+// the GRAM_KEY Authorization header (or gram-environment) in the install snippets.
+// OAuth handles identity auth at the HTTP layer, so the install command must not
+// instruct users to set those headers manually.
+func TestServeInstallPage_PrivateWithGramOAuth_NoAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	result := oauthtest.CreateProxyToolset(t, ctx, testInstance.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "private-gram-oauth",
+		IsPublic:     false,
+		ProviderType: "",
+	})
+	mcpSlug := result.Toolset.McpSlug.String
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err := testInstance.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.NotContains(t, body, "Authorization", "OAuth-protected install command must not reference an Authorization header")
+	assert.NotContains(t, body, "gram-key", "OAuth-protected install command must not reference the gram-key input")
+	assert.NotContains(t, body, "gram-environment", "OAuth-protected install command must not reference the gram-environment input")
+	assert.NotContains(t, body, "GRAM_KEY", "OAuth-protected install command must not reference the GRAM_KEY env var")
 }
 
 // TestServeInstallPage_NoDomain_AuthedUserWithOrgDomain verifies that a toolset


### PR DESCRIPTION
## Summary

- Reorder `resolveSecurityMode` (`server/internal/mcpmetadata/impl.go`) so an attached OAuth proxy or external OAuth server forces `securityModeOAuth` regardless of `mcpIsPublic`. Previously a private MCP with Gram OAuth fell through to `securityModeGram`, which injected the `Authorization: ${GRAM_KEY}` and `gram-environment` headers into every install snippet (Claude Code, Cursor, VS Code, Gemini CLI, Claude Desktop) and the McpExport SDK output.
- Fix the matching bug in the dashboard MCP Details "Pass-through Authentication" snippet (`mcp-details-utils.ts`): the `Authorization` header arg and the `"env": { "GRAM_KEY": … }` block now also check `!hasOAuth`, where `hasOAuth = toolset.oauthProxyServer || toolset.externalOauthServer`.
- Add a regression test (`TestServeInstallPage_PrivateWithGramOAuth_NoAuthorizationHeader`) using `oauthtest.CreateProxyToolset` to verify a private + Gram OAuth toolset never renders `Authorization`, `gram-key`, `gram-environment`, or `GRAM_KEY` on the install page.

Closes [AGE-1962](https://linear.app/speakeasy/issue/AGE-1962/bug-install-instructions-show-authorization-header-with-gram-oauth).

## Test plan

- [x] `mise lint:server`
- [x] `go test ./internal/mcpmetadata/...` (full package, including the new test)
- [x] `cd client/dashboard && npx tsc --noEmit`
- [x] `cd client/dashboard && pnpm test`
- [ ] Manual smoke (reviewer): private toolset + Gram OAuth → install page Claude Code tab shows `claude mcp add --transport http "<slug>" "<url>"` with no `--header 'Authorization:…'` and no `--header 'gram-environment:…'`. Same toolset in dashboard MCP Details → "Pass-through Authentication" snippet has no `Authorization` line and no `"env": { "GRAM_KEY": … }` block.
- [ ] Manual regression (reviewer): a private toolset **without** OAuth still shows `Authorization` + `GRAM_KEY` (unchanged); a public toolset with OAuth still omits `Authorization` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)