### PR TITLE
fix(dashboard): edit log filter chips on click instead of deleting

### DIFF
--- a/.changeset/modern-lobsters-rush.md
+++ b/.changeset/modern-lobsters-rush.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Edit log filter chips on click instead of deleting

--- a/client/dashboard/src/pages/logs/LogFilterBar.tsx
+++ b/client/dashboard/src/pages/logs/LogFilterBar.tsx
@@ -1,4 +1,5 @@
 import { QuerySamplesPopover } from "@/components/QuerySamplesPopover";
+import { Button } from "@/components/ui/button";
 import {
   CommandEmpty,
   CommandGroup,
@@ -9,7 +10,15 @@ import {
   Popover,
   PopoverAnchor,
   PopoverContent,
+  PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { Operator as Op } from "@gram/client/models/components/logfilter";
 import { Command as CmdkRoot } from "cmdk";
@@ -19,6 +28,7 @@ import {
   type ActiveLogFilter,
   OP_LABELS,
   applyFilterAdd,
+  applyFilterEdit,
   parseOperatorSymbol,
   tryParseFilterExpression,
 } from "./log-filter-types";
@@ -131,9 +141,19 @@ export function LogFilterBar({
     [filters, onChange, onSearchInputChange, resetFlow],
   );
 
-  const removeFilter = (id: string) => {
-    onChange(filters.filter((f) => f.id !== id));
-  };
+  const removeFilter = useCallback(
+    (id: string) => {
+      onChange(filters.filter((f) => f.id !== id));
+    },
+    [filters, onChange],
+  );
+
+  const editFilter = useCallback(
+    (id: string, op: Op, value?: string) => {
+      onChange(applyFilterEdit(filters, id, { op, value }));
+    },
+    [filters, onChange],
+  );
 
   const clearAll = () => {
     onChange([]);
@@ -285,17 +305,12 @@ export function LogFilterBar({
           >
             <Search className="text-muted-foreground size-4 shrink-0" />
             {filters.map((filter) => (
-              <button
+              <EditableFilterChip
                 key={filter.id}
-                onClick={() => removeFilter(filter.id)}
-                className="border-border bg-accent text-accent-foreground hover:bg-accent/80 group inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors"
-              >
-                <span>
-                  {filter.path} {OP_LABELS[filter.op]}
-                  {filter.value !== undefined ? ` ${filter.value}` : ""}
-                </span>
-                <X className="text-muted-foreground group-hover:text-foreground size-3" />
-              </button>
+                filter={filter}
+                onEdit={editFilter}
+                onRemove={removeFilter}
+              />
             ))}
             {step === "operator" && (
               <span className="border-ring bg-accent text-accent-foreground inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs">
@@ -456,5 +471,144 @@ export function LogFilterBar({
         </PopoverContent>
       </Popover>
     </CmdkRoot>
+  );
+}
+
+interface EditableFilterChipProps {
+  filter: ActiveLogFilter;
+  onEdit: (id: string, op: Op, value?: string) => void;
+  onRemove: (id: string) => void;
+}
+
+function EditableFilterChip({
+  filter,
+  onEdit,
+  onRemove,
+}: EditableFilterChipProps) {
+  const [open, setOpen] = useState(false);
+  const [op, setOp] = useState<Op>(filter.op);
+  const [value, setValue] = useState(filter.value ?? "");
+
+  useEffect(() => {
+    if (open) {
+      setOp(filter.op);
+      setValue(filter.value ?? "");
+    }
+  }, [open, filter.op, filter.value]);
+
+  const save = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onEdit(filter.id, op, trimmed);
+    setOpen(false);
+  };
+
+  const valuePlaceholder = op === Op.In ? "value1, value2, ..." : "value";
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <span className="border-border bg-accent text-accent-foreground inline-flex shrink-0 items-center rounded-md border font-mono text-xs">
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Edit filter ${filter.path}`}
+            className="hover:bg-accent/60 cursor-pointer rounded-l-md py-0.5 pr-1 pl-2 transition-colors"
+          >
+            {filter.path} {OP_LABELS[filter.op]}
+            {filter.value !== undefined ? ` ${filter.value}` : ""}
+          </button>
+        </PopoverTrigger>
+        <button
+          type="button"
+          aria-label={`Remove filter ${filter.path}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(filter.id);
+          }}
+          className="text-muted-foreground hover:text-foreground hover:bg-accent/60 rounded-r-md px-1.5 py-0.5 transition-colors"
+        >
+          <X className="size-3" />
+        </button>
+      </span>
+      <PopoverContent
+        align="start"
+        className="w-[320px] p-3"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div
+          className="text-muted-foreground mb-2 font-mono text-xs break-all"
+          title={filter.path}
+        >
+          {filter.path}
+        </div>
+        <div className="mb-3 flex gap-2">
+          <Select value={op} onValueChange={(v) => setOp(v as Op)}>
+            <SelectTrigger className="!h-8 w-[120px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {OP_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  <span className="font-mono text-xs">
+                    {OP_LABELS[option.value]}
+                  </span>
+                  <span className="text-muted-foreground ml-2 text-xs">
+                    {option.label}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                save();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                setOpen(false);
+              }
+            }}
+            placeholder={valuePlaceholder}
+            className="border-border focus-visible:border-ring focus-visible:ring-ring/50 h-8 min-w-0 flex-1 rounded-md border bg-transparent px-2 font-mono text-xs outline-none focus-visible:ring-[3px]"
+            autoFocus
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <Button
+            type="button"
+            variant="destructiveGhost"
+            size="sm"
+            onClick={() => {
+              onRemove(filter.id);
+              setOpen(false);
+            }}
+          >
+            Remove
+          </Button>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={save}
+              disabled={!value.trim()}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/client/dashboard/src/pages/logs/log-filter-types.test.ts
+++ b/client/dashboard/src/pages/logs/log-filter-types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Operator } from "@gram/client/models/components/logfilter";
 import type { ActiveLogFilter } from "./log-filter-types";
-import { applyFilterAdd } from "./log-filter-types";
+import { applyFilterAdd, applyFilterEdit } from "./log-filter-types";
 
 function makeFilter(
   overrides: Partial<ActiveLogFilter> & { path: string; op: Operator },
@@ -89,5 +89,76 @@ describe("applyFilterAdd", () => {
       value: "1",
     });
     expect(result).toHaveLength(2);
+  });
+});
+
+describe("applyFilterEdit", () => {
+  it("updates op and value while preserving id and path", () => {
+    const existing = [
+      makeFilter({ id: "a", path: "x", op: Operator.Eq, value: "1" }),
+    ];
+    const result = applyFilterEdit(existing, "a", {
+      op: Operator.NotEq,
+      value: "2",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("a");
+    expect(result[0].path).toBe("x");
+    expect(result[0].op).toBe(Operator.NotEq);
+    expect(result[0].value).toBe("2");
+  });
+
+  it("preserves position in the list", () => {
+    const existing = [
+      makeFilter({ id: "a", path: "x", op: Operator.Eq, value: "1" }),
+      makeFilter({ id: "b", path: "y", op: Operator.Eq, value: "2" }),
+      makeFilter({ id: "c", path: "z", op: Operator.Eq, value: "3" }),
+    ];
+    const result = applyFilterEdit(existing, "b", {
+      op: Operator.Contains,
+      value: "yo",
+    });
+    expect(result.map((f) => f.id)).toEqual(["a", "b", "c"]);
+    expect(result[1].op).toBe(Operator.Contains);
+    expect(result[1].value).toBe("yo");
+  });
+
+  it("removes a colliding eq filter on the same path", () => {
+    const existing = [
+      makeFilter({ id: "a", path: "x", op: Operator.Eq, value: "1" }),
+      makeFilter({ id: "b", path: "x", op: Operator.NotEq, value: "2" }),
+    ];
+    // Editing 'b' to be eq=1 should collide with 'a' and drop it.
+    const result = applyFilterEdit(existing, "b", {
+      op: Operator.Eq,
+      value: "1",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("b");
+    expect(result[0].op).toBe(Operator.Eq);
+  });
+
+  it("does not collide when edit keeps a stacking op (not_eq)", () => {
+    const existing = [
+      makeFilter({ id: "a", path: "x", op: Operator.NotEq, value: "1" }),
+      makeFilter({ id: "b", path: "x", op: Operator.NotEq, value: "2" }),
+    ];
+    const result = applyFilterEdit(existing, "b", {
+      op: Operator.NotEq,
+      value: "3",
+    });
+    expect(result).toHaveLength(2);
+    expect(result.map((f) => f.value)).toEqual(["1", "3"]);
+  });
+
+  it("is a no-op when id is not found", () => {
+    const existing = [
+      makeFilter({ id: "a", path: "x", op: Operator.Eq, value: "1" }),
+    ];
+    const result = applyFilterEdit(existing, "missing", {
+      op: Operator.NotEq,
+      value: "2",
+    });
+    expect(result).toEqual(existing);
   });
 });

--- a/client/dashboard/src/pages/logs/log-filter-types.ts
+++ b/client/dashboard/src/pages/logs/log-filter-types.ts
@@ -67,13 +67,13 @@ export function applyFilterEdit(
   id: string,
   next: { op: Op; value?: string },
 ): ActiveLogFilter[] {
+  const target = current.find((c) => c.id === id);
+  if (!target) return current;
   return current.flatMap((f) => {
     if (f.id === id) {
       return [{ ...f, op: next.op, value: next.value }];
     }
-    const target = current.find((c) => c.id === id);
     if (
-      target &&
       (next.op === Operator.Eq || next.op === Operator.In) &&
       f.path === target.path &&
       f.op === next.op

--- a/client/dashboard/src/pages/logs/log-filter-types.ts
+++ b/client/dashboard/src/pages/logs/log-filter-types.ts
@@ -57,6 +57,34 @@ export function applyFilterAdd(
 }
 
 /**
+ * Edit an existing filter in place, preserving its position and id while
+ * applying the same dedup rules as `applyFilterAdd` against the rest of
+ * the list. If the edited filter would collide with another eq/in filter
+ * on the same path+op, the colliding one is removed.
+ */
+export function applyFilterEdit(
+  current: ActiveLogFilter[],
+  id: string,
+  next: { op: Op; value?: string },
+): ActiveLogFilter[] {
+  return current.flatMap((f) => {
+    if (f.id === id) {
+      return [{ ...f, op: next.op, value: next.value }];
+    }
+    const target = current.find((c) => c.id === id);
+    if (
+      target &&
+      (next.op === Operator.Eq || next.op === Operator.In) &&
+      f.path === target.path &&
+      f.op === next.op
+    ) {
+      return [];
+    }
+    return [f];
+  });
+}
+
+/**
  * Try to parse a freeform filter expression like `http.response.status_code != 200`.
  * Returns an `{ key, op, value }` triple on success, or `null` when the input
  * doesn't look like a filter expression (so the caller can fall through to


### PR DESCRIPTION
## Summary
- Clicking a filter chip in the MCP logs filter bar now opens an inline edit popover (operator + value, with Save / Cancel / Remove) instead of silently deleting the filter.
- The chip's `X` icon remains the explicit delete affordance and uses `stopPropagation()` so it doesn't open the popover.
- Adds a pure `applyFilterEdit` helper alongside `applyFilterAdd`, preserving id/position and applying the same eq/in dedup rules.

Resolves [AGE-1983](https://linear.app/speakeasy/issue/AGE-1983/feat-filter-click-behavior-in-mcp-logs-needs-improvement) — "when you click on the filter it just disappears. It doesn't open up the edit mode like you'd expect" 

## Test plan
- [x] Unit tests for `applyFilterEdit` — 5 new cases (basic edit, position preservation, eq collision drop, not_eq stacking, missing-id no-op)
- [x] `pnpm vitest run src/pages/logs/log-filter-types.test.ts` → 12/12 pass
- [x] `pnpm tsc -p tsconfig.app.json --noEmit` → no new errors in changed files
- [x] `oxfmt --check` and `eslint` clean on changed files
- [ ] Manual smoke on `/logs`: add a filter via the input, click the chip body → edit popover opens with current op/value; change op + value, hit Enter → chip updates inline; click chip's X → chip removed without opening popover; press Escape in popover → cancels without saving
- [ ] Verify URL state still reflects edited filters after refresh

## Notes
HTML structure is a non-interactive `<span>` wrapper containing two sibling `<button>` children (`PopoverTrigger` body + remove). No nested-button issue. Path is read-only in the popover (matches Datadog/Linear conventions and avoids invalid path edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)