### PR TITLE
fix: route handling 404s so as to not hit the error boundary

### DIFF
--- a/.changeset/dashboard-route-not-found.md
+++ b/.changeset/dashboard-route-not-found.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Handle missing deployment and MCP detail routes with a not-found state instead of surfacing raw errors

--- a/client/dashboard/src/components/route-not-found-state.tsx
+++ b/client/dashboard/src/components/route-not-found-state.tsx
@@ -1,0 +1,36 @@
+import { Type } from "@/components/ui/type";
+import { Button, Icon, Stack } from "@speakeasy-api/moonshine";
+import type { ReactNode } from "react";
+
+type RouteNotFoundStateProps = {
+  title: string;
+  description: string;
+  action: ReactNode;
+};
+
+export function RouteNotFoundState({
+  title,
+  description,
+  action,
+}: RouteNotFoundStateProps) {
+  return (
+    <div className="flex min-h-[420px] w-full items-center justify-center">
+      <Stack gap={4} align="center" className="max-w-md text-center">
+        <Icon name="circle-alert" className="size-10" />
+        <Stack gap={2} align="center">
+          <Type variant="subheading">{title}</Type>
+          <Type muted>{description}</Type>
+        </Stack>
+        {action}
+      </Stack>
+    </div>
+  );
+}
+
+export function SecondaryRouteAction({ children }: { children: ReactNode }) {
+  return (
+    <Button variant="secondary">
+      <Button.Text>{children}</Button.Text>
+    </Button>
+  );
+}

--- a/client/dashboard/src/hooks/toolTypes.ts
+++ b/client/dashboard/src/hooks/toolTypes.ts
@@ -24,7 +24,11 @@ import {
   ListToolsQueryError,
   useListTools as useListToolsQuery,
 } from "@gram/client/react-query/listTools.js";
-import { useToolset as useToolsetQuery } from "@gram/client/react-query/toolset.js";
+import {
+  ToolsetQueryData,
+  ToolsetQueryError,
+  useToolset as useToolsetQuery,
+} from "@gram/client/react-query/toolset.js";
 
 export type ToolsetKind = "default" | "external-mcp-proxy";
 
@@ -37,9 +41,13 @@ function detectToolsetKind(tools: GeneratedTool[]): ToolsetKind {
   return hasExternalMcpProxy ? "external-mcp-proxy" : "default";
 }
 
-export function useToolset(toolsetSlug: string | undefined) {
+export function useToolset(
+  toolsetSlug: string | undefined,
+  options?: QueryHookOptions<ToolsetQueryData, ToolsetQueryError>,
+) {
   const result = useToolsetQuery({ slug: toolsetSlug! }, undefined, {
-    enabled: !!toolsetSlug,
+    ...options,
+    enabled: !!toolsetSlug && (options?.enabled ?? true),
   });
 
   const kind = detectToolsetKind(result.data?.tools ?? []);

--- a/client/dashboard/src/lib/route-errors.ts
+++ b/client/dashboard/src/lib/route-errors.ts
@@ -1,0 +1,32 @@
+import { GramError } from "@gram/client/models/errors/gramerror.js";
+
+export function getHttpStatusCode(error: unknown): number | undefined {
+  if (error instanceof GramError) {
+    return error.statusCode;
+  }
+
+  if (error && typeof error === "object") {
+    const statusCode = (error as { statusCode?: unknown }).statusCode;
+    if (typeof statusCode === "number") {
+      return statusCode;
+    }
+
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === "number") {
+      return status;
+    }
+  }
+
+  return undefined;
+}
+
+export function isNotFoundError(error: unknown): boolean {
+  return getHttpStatusCode(error) === 404;
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuidRouteParam(value: string | undefined): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}

--- a/client/dashboard/src/pages/deployments/deployment/Deployment.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/Deployment.tsx
@@ -1,9 +1,15 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import {
+  RouteNotFoundState,
+  SecondaryRouteAction,
+} from "@/components/route-not-found-state";
 import { Heading } from "@/components/ui/heading";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { dateTimeFormatters } from "@/lib/dates";
+import { isNotFoundError, isUuidRouteParam } from "@/lib/route-errors";
 import { cn } from "@/lib/utils";
+import { useRoutes } from "@/routes";
 import { useDeployment, useDeploymentSuspense } from "@gram/client/react-query";
 import { Button, Separator, Skeleton } from "@speakeasy-api/moonshine";
 import {
@@ -32,8 +38,47 @@ import {
 
 export default function DeploymentPage() {
   const { deploymentId } = useParams();
-  if (!deploymentId) {
-    return <p className="text-destructive">Error: Deployment ID is required</p>;
+
+  if (!isUuidRouteParam(deploymentId)) {
+    return <DeploymentRouteNotFound />;
+  }
+
+  return <DeploymentPageContent deploymentId={deploymentId} />;
+}
+
+function DeploymentPageContent({ deploymentId }: { deploymentId: string }) {
+  const {
+    data: deployment,
+    error,
+    isLoading,
+  } = useDeployment({ id: deploymentId }, undefined, {
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    throwOnError: false,
+  });
+
+  if (isNotFoundError(error)) {
+    return <DeploymentRouteNotFound />;
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  if (isLoading || !deployment) {
+    return (
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs />
+        </Page.Header>
+        <Page.Body>
+          <Skeleton>
+            <div className="h-4 w-1/3" />
+          </Skeleton>
+        </Page.Body>
+      </Page>
+    );
   }
 
   return (
@@ -45,6 +90,29 @@ export default function DeploymentPage() {
         <Suspense fallback={<div>Loading logs...</div>}>
           <DeploymentLogs deploymentId={deploymentId} />
         </Suspense>
+      </Page.Body>
+    </Page>
+  );
+}
+
+function DeploymentRouteNotFound() {
+  const routes = useRoutes();
+
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RouteNotFoundState
+          title="Deployment not found"
+          description="This deployment may have been deleted, or the link may be incomplete."
+          action={
+            <routes.deployments.Link>
+              <SecondaryRouteAction>Back to deployments</SecondaryRouteAction>
+            </routes.deployments.Link>
+          }
+        />
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -10,6 +10,10 @@ import { Textarea } from "@/components/moon/textarea";
 import { Page } from "@/components/page-layout";
 import { PublicMcpWarningDialog } from "@/components/public-mcp-warning-dialog";
 import { ServerEnableDialog } from "@/components/server-enable-dialog";
+import {
+  RouteNotFoundState,
+  SecondaryRouteAction,
+} from "@/components/route-not-found-state";
 import { useExternalMcpOAuthConfigStatus } from "@/components/sources/sources-hooks";
 import { ToolList } from "@/components/tool-list";
 import { Dialog } from "@/components/ui/dialog";
@@ -38,6 +42,7 @@ import { FeatureRequestModal } from "@/components/FeatureRequestModal";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
 import { useProductTier } from "@/hooks/useProductTier";
 import { useCustomDomain, useMcpUrl } from "@/hooks/useToolsetUrl";
+import { isNotFoundError } from "@/lib/route-errors";
 import { Tool, Toolset, useGroupedTools } from "@/lib/toolTypes";
 import { cn, getServerURL } from "@/lib/utils";
 import {
@@ -165,11 +170,63 @@ export function MCPDetailPage() {
 
 function MCPDetailPageInner() {
   const { toolsetSlug } = useParams();
+
+  const {
+    data: toolset,
+    error: toolsetError,
+    isLoading,
+  } = useToolset(toolsetSlug, { throwOnError: false });
+
+  if (!toolsetSlug || isNotFoundError(toolsetError)) {
+    return <MCPRouteNotFound />;
+  }
+
+  if (toolsetError) {
+    throw toolsetError;
+  }
+
+  if (isLoading || !toolset) {
+    return <MCPLoading />;
+  }
+
+  return <MCPDetailPageContent toolset={toolset} toolsetSlug={toolsetSlug} />;
+}
+
+function MCPRouteNotFound() {
+  const routes = useRoutes();
+
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RouteNotFoundState
+          title="MCP server not found"
+          description="This MCP server may have been deleted, renamed, or moved out of this project."
+          action={
+            <routes.mcp.Link>
+              <SecondaryRouteAction>Back to MCP servers</SecondaryRouteAction>
+            </routes.mcp.Link>
+          }
+        />
+      </Page.Body>
+    </Page>
+  );
+}
+
+type LoadedMcpToolset = NonNullable<ReturnType<typeof useToolset>["data"]>;
+
+function MCPDetailPageContent({
+  toolset,
+  toolsetSlug,
+}: {
+  toolset: LoadedMcpToolset;
+  toolsetSlug: string;
+}) {
   const routes = useRoutes();
   const telemetry = useTelemetry();
   const isRbacEnabled = telemetry.isFeatureEnabled("gram-rbac") ?? false;
-
-  const { data: toolset, isLoading } = useToolset(toolsetSlug);
 
   // Call hooks before any conditional returns
   const { url: mcpUrl } = useMcpUrl(toolset);
@@ -229,10 +286,6 @@ function MCPDetailPageInner() {
     useExternalMcpOAuthConfigStatus(toolsetSlug);
   const oauthRequiredUnconfigured =
     externalMcpOAuthConfigStatus === "required-unconfigured";
-
-  if (isLoading || !toolset) {
-    return <MCPLoading />;
-  }
 
   let statusBadge = null;
   if (!toolset.mcpEnabled) {


### PR DESCRIPTION
## Summary
  - Surface a friendly not-found state on the deployment and MCP detail pages when the route param is invalid or the API returns 404, instead of throwing into the global error boundary
  - Add a shared `RouteNotFoundState` component plus `route-errors.ts` helpers (`isNotFoundError`, `isUuidRouteParam`, `getHttpStatusCode`) so other detail routes can reuse the same pattern
  - Reduces RUM noise from 404s on stale or malformed `/deployments/:id` and `/mcp/:id` URLs

  ## Test plan
  - [x] Visit `/deployments/<bogus-uuid>` and confirm the not-found state renders with a "Back to deployments" action
  - [x] Visit `/deployments/not-a-uuid` and confirm it short-circuits to the not-found state without firing the API call
  - [x] Repeat for `/mcp/<bogus-uuid>` and `/mcp/not-a-uuid`
  - [x] Verify a valid deployment / MCP URL still loads normally
  - [ ] Confirm non-404 errors (e.g. 500) still propagate to the error boundary