### PR TITLE
mig: correctly aggregate block reason

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260428192411_fix-block-reason-merge.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260428192411_fix-block-reason-merge.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `trace_summaries` MODIFY COLUMN `block_reason` SimpleAggregateFunction(any, String);

--- a/server/clickhouse/local/golang_migrate/20260428192411_fix-block-reason-merge.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260428192411_fix-block-reason-merge.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `trace_summaries` MODIFY COLUMN `block_reason` SimpleAggregateFunction(max, String);

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:U3ji6At/MZPzADSONAOPqrY24Ft5Eo5XFFjOYXVyAmg=
+h1:57xHxuDPyNWBsj2oSavXOKEXin1pIGRRQ6drvGtom+c=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -32,3 +32,4 @@ h1:U3ji6At/MZPzADSONAOPqrY24Ft5Eo5XFFjOYXVyAmg=
 20260416194404_add-cache-cost-metrics.up.sql h1:MrTbFKr0ieEKB7CQYuHTV0g1oVFYr7MHWcgQ0IB6rJg=
 20260423195357_trace-status-from-attributes.up.sql h1:sGtbt2CBDOPTZhPHl0A7Xoxd1DauF2391lckPQXzizw=
 20260427192006_add-hook-block-reason.up.sql h1:AYNAwIQG07w6OoCgLMKrgyuLi6n+9GoM3r9NPG/bZSo=
+20260428192411_fix-block-reason-merge.up.sql h1:wwVaPA93KqQ/rN62the3FDyQ2Blv4Z6F61q9w2oRjqE=

--- a/server/clickhouse/migrations/20260428192408_fix-block-reason-merge.sql
+++ b/server/clickhouse/migrations/20260428192408_fix-block-reason-merge.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `trace_summaries` MODIFY COLUMN `block_reason` SimpleAggregateFunction(max, String);

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:sfPUeak9CxzETaIVTHKTc1vWOG+LtnUY21vI2iPu+y8=
+h1:fS7efIeIhF+Nf5LskM9XFP1IyiFU+K7q1WB1XOE67tk=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -37,3 +37,4 @@ h1:sfPUeak9CxzETaIVTHKTc1vWOG+LtnUY21vI2iPu+y8=
 20260416194400_add-cache-cost-metrics.sql h1:cHzMEcEt2sP/FpsFEWrUJ5B/72bXI+hNE67cZfN3U/E=
 20260423195354_trace-status-from-attributes.sql h1:dxHrGPIllQdKbrf+VxG8WKVsQOy7FCdRS8mNRPCxggU=
 20260427192001_add-hook-block-reason.sql h1:z2tGtdozJRVWhCCyT4KYSNVvhg9/56LJS4GILZvsuxY=
+20260428192408_fix-block-reason-merge.sql h1:bwCGH0lNK9KN4Utw7Bet0CUhtol0LX0BnMgofKKjOCo=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -124,9 +124,12 @@ CREATE TABLE IF NOT EXISTS trace_summaries (
     -- time as: has_block → blocked, has_error → failure, has_result → success,
     -- otherwise pending.
     has_block SimpleAggregateFunction(max, UInt8),
-    -- The first non-empty block reason observed, surfaced in dashboards next
-    -- to the blocked status.
-    block_reason SimpleAggregateFunction(any, String)
+    -- The block reason surfaced in dashboards next to the blocked status.
+    -- Uses max() so empty strings ("") always lose to non-empty reasons during
+    -- part merges; any() is non-deterministic and can pick "" from a sibling
+    -- row (e.g. the original PreToolUse log) instead of the row that actually
+    -- carried the denial reason.
+    block_reason SimpleAggregateFunction(max, String)
 ) ENGINE = AggregatingMergeTree
 ORDER BY (gram_project_id, trace_id)
 TTL fromUnixTimestamp64Nano(start_time_unix_nano) + INTERVAL 30 DAY

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -1955,7 +1955,7 @@ func (q *Queries) ListHooksTraces(ctx context.Context, arg ListHooksTracesParams
 		"hook_source",
 		"skill_name",
 		"multiIf(max(has_block) = 1, 'blocked', max(has_error) = 1, 'failure', max(has_result) = 1, 'success', 'pending') as hook_status",
-		"anyIf(block_reason, block_reason != '') as block_reason",
+		"max(block_reason) as block_reason",
 	).
 		From("trace_summaries").
 		Where("gram_project_id = ?", arg.GramProjectID).


### PR DESCRIPTION
Fix for blocked tool calls. Now correctly prioritizes any actual block reason over the empty string, which was causing the UI to incorrectly show "no reason provided"