### PR TITLE
mig: enforce NOT NULL and tighter CHECK on principal_grants.selectors

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1782,7 +1782,7 @@ COMMENT ON COLUMN principal_grants.principal_urn IS 'URN identifying the princip
 COMMENT ON COLUMN principal_grants.principal_type IS 'Derived from principal_urn. The type prefix, e.g. "user", "role".';
 COMMENT ON COLUMN principal_grants.scope IS 'The scope being granted, e.g. "build:read". Validated in application code, not via FK.';
 COMMENT ON COLUMN principal_grants.drop_resource IS 'Deprecated. Formerly ''*'' = unrestricted. Nullable, scheduled for removal.';
-COMMENT ON COLUMN principal_grants.selectors IS 'Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.';
+COMMENT ON COLUMN principal_grants.selectors IS 'JSON selector constraints attached to a grant. Must be a non-empty JSONB object. Wildcard/unrestricted grants use {"resource_kind":"*","resource_id":"*"}.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_selector_key
 ON principal_grants (organization_id, principal_urn, scope, selectors);

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1766,14 +1766,14 @@ CREATE TABLE IF NOT EXISTS principal_grants (
   principal_type TEXT NOT NULL GENERATED ALWAYS AS (split_part(principal_urn, ':', 1)) STORED,
   scope TEXT NOT NULL,
   drop_resource TEXT,
-  selectors JSONB,
+  selectors JSONB NOT NULL,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT principal_grants_pkey PRIMARY KEY (id),
   CONSTRAINT principal_grants_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT principal_grants_selectors_check CHECK (selectors IS NULL OR jsonb_typeof(selectors) = 'object')
+  CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}')
 );
 
 COMMENT ON TABLE principal_grants IS 'RBAC grants. Normalized: one row per (org, principal, scope). Selectors can further constrain applicability.';

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -851,7 +851,7 @@ type PrincipalGrant struct {
 	Scope string
 	// Deprecated. Formerly '*' = unrestricted. Nullable, scheduled for removal.
 	DropResource pgtype.Text
-	// Optional JSON selector constraints refining when the grant applies. NULL means the grant has no selector constraints.
+	// JSON selector constraints attached to a grant. Must be a non-empty JSONB object. Wildcard/unrestricted grants use {"resource_kind":"*","resource_id":"*"}.
 	Selectors []byte
 	CreatedAt pgtype.Timestamptz
 	UpdatedAt pgtype.Timestamptz

--- a/server/migrations/20260429084759_selector-indexes.sql
+++ b/server/migrations/20260429084759_selector-indexes.sql
@@ -11,3 +11,5 @@ ALTER TABLE principal_grants ADD CONSTRAINT principal_grants_selectors_not_null 
 ALTER TABLE principal_grants VALIDATE CONSTRAINT principal_grants_selectors_not_null;
 ALTER TABLE principal_grants ALTER COLUMN selectors SET NOT NULL;
 ALTER TABLE principal_grants DROP CONSTRAINT principal_grants_selectors_not_null;
+
+COMMENT ON COLUMN principal_grants.selectors IS 'JSON selector constraints attached to a grant. Must be a non-empty JSONB object. Wildcard/unrestricted grants use {"resource_kind":"*","resource_id":"*"}.';

--- a/server/migrations/20260429084759_selector-indexes.sql
+++ b/server/migrations/20260429084759_selector-indexes.sql
@@ -1,0 +1,13 @@
+-- atlas:txmode none
+
+-- Replace the old CHECK with the tighter version. NOT VALID avoids ACCESS
+-- EXCLUSIVE during the scan; VALIDATE downgrades to SHARE UPDATE EXCLUSIVE.
+ALTER TABLE principal_grants DROP CONSTRAINT IF EXISTS principal_grants_selectors_check;
+ALTER TABLE principal_grants ADD CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}') NOT VALID;
+ALTER TABLE principal_grants VALIDATE CONSTRAINT principal_grants_selectors_check;
+
+-- Add a NOT NULL CHECK so Postgres can skip a full-table scan on SET NOT NULL.
+ALTER TABLE principal_grants ADD CONSTRAINT principal_grants_selectors_not_null CHECK (selectors IS NOT NULL) NOT VALID;
+ALTER TABLE principal_grants VALIDATE CONSTRAINT principal_grants_selectors_not_null;
+ALTER TABLE principal_grants ALTER COLUMN selectors SET NOT NULL;
+ALTER TABLE principal_grants DROP CONSTRAINT principal_grants_selectors_not_null;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PQQhOJoEvIk4DmVye1P98HTWTEbomGDFqkakv5wyjuY=
+h1:IRDesKKtbKVMf0Q9KXQDgu2z1DjN1F+lZNMPZ/259yo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -145,3 +145,4 @@ h1:PQQhOJoEvIk4DmVye1P98HTWTEbomGDFqkakv5wyjuY=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
 20260427000002_remove-noisy-pii-entities.sql h1:t4PebqHsToQv2WWEAiHCSnY3zaB5hGUSYHd1k2pfayk=
 20260428000001_deprecate-grant-resource-column.sql h1:6IJguq8/DX4gfSF4kP4DewDIIC2dOmP1macUDBSTubI=
+20260429084759_selector-indexes.sql h1:F50TJhn2zpcbu9XnXLUp8d5a4f+OHb4762Oq1z0xRRg=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:IRDesKKtbKVMf0Q9KXQDgu2z1DjN1F+lZNMPZ/259yo=
+h1:DWPK2fFaaTLAzNL0WBKaN+q228RYMGSd5wUcniwerj4=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -145,4 +145,4 @@ h1:IRDesKKtbKVMf0Q9KXQDgu2z1DjN1F+lZNMPZ/259yo=
 20260424180559_risk-policies-default-pii.sql h1:A+qKEtwSff7+mi6l0vTGLqv8kvIzStw9A98ydQjmJc0=
 20260427000002_remove-noisy-pii-entities.sql h1:t4PebqHsToQv2WWEAiHCSnY3zaB5hGUSYHd1k2pfayk=
 20260428000001_deprecate-grant-resource-column.sql h1:6IJguq8/DX4gfSF4kP4DewDIIC2dOmP1macUDBSTubI=
-20260429084759_selector-indexes.sql h1:F50TJhn2zpcbu9XnXLUp8d5a4f+OHb4762Oq1z0xRRg=
+20260429084759_selector-indexes.sql h1:ESv55XcreTXC4wzd7Ui3k12dESUQwBy1yCiPWH74GBQ=


### PR DESCRIPTION
## Summary

Re-adds the constraint changes from #2439 that were **not covered** by the fix PR #2469.

#2469 handled the `resource` column deprecation (rename to `drop_resource`, make nullable) and consolidated the partial indexes into non-partial ones. However it left `selectors` nullable with the old permissive CHECK constraint (`selectors IS NULL OR ...`).

This migration adds back the two remaining non-resource changes from #2439:

- **`selectors` → `NOT NULL`** — all rows already have selectors populated (PR #2357). Without this, the unique index on `(org, principal, scope, selectors)` can't enforce uniqueness for NULL rows, and `ON CONFLICT` in `UpsertPrincipalGrant` won't match them.
- **Tighter CHECK** — `jsonb_typeof(selectors) = 'object' AND selectors != '{}'` — rejects empty objects explicitly.

Uses `NOT VALID` + `VALIDATE CONSTRAINT` pattern throughout to minimise lock duration. `txmode none` ensures each statement commits independently so VALIDATE runs under SHARE UPDATE EXCLUSIVE (not ACCESS EXCLUSIVE).

## Test plan

- [ ] `mise db:diff` reports no drift
- [ ] `mise lint:migrations` passes
- [ ] Migration applies cleanly against a local DB with existing grant rows