### PR TITLE
fix: retry presidio test container startup on timeout

### DIFF
--- a/server/internal/testenv/presidio.go
+++ b/server/internal/testenv/presidio.go
@@ -15,25 +15,45 @@ import (
 type PresidioClientFunc func(t *testing.T) *risk_analysis.PresidioClient
 
 func NewTestPresidio(ctx context.Context) (testcontainers.Container, PresidioClientFunc, error) {
-	startedAt := time.Now()
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mcr.microsoft.com/presidio-analyzer:2.2.362",
-			ExposedPorts: []string{"3000/tcp"},
-			WaitingFor: wait.ForHTTP("/health").
-				WithPort("3000/tcp").
-				WithPollInterval(2 * time.Second).
-				WithStartupTimeout(480 * time.Second),
-		},
-		Started: true,
-		Logger:  NewTestcontainersLogger(),
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("start presidio container: %w", err)
-	}
-	log.Printf("presidio container ready in %s", time.Since(startedAt).Round(time.Millisecond))
+	// The presidio-analyzer image loads spaCy NLP models on startup, which is
+	// CPU-intensive and can exceed a single timeout on contended CI runners.
+	// Retry with a moderate per-attempt timeout so stuck containers fail fast
+	// but slow startups get a second chance.
+	const maxAttempts = 2
+	const startupTimeout = 300 * time.Second
 
-	return container, newPresidioClientFunc(container), nil
+	startedAt := time.Now()
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: testcontainers.ContainerRequest{
+				Image:        "mcr.microsoft.com/presidio-analyzer:2.2.362",
+				ExposedPorts: []string{"3000/tcp"},
+				WaitingFor: wait.ForHTTP("/health").
+					WithPort("3000/tcp").
+					WithPollInterval(2 * time.Second).
+					WithStartupTimeout(startupTimeout),
+			},
+			Started: true,
+			Logger:  NewTestcontainersLogger(),
+		})
+		if err == nil {
+			log.Printf("presidio container ready in %s (attempt %d/%d)", time.Since(startedAt).Round(time.Millisecond), attempt, maxAttempts)
+			return container, newPresidioClientFunc(container), nil
+		}
+
+		lastErr = err
+		log.Printf("presidio container attempt %d/%d failed after %s: %v", attempt, maxAttempts, time.Since(startedAt).Round(time.Millisecond), err)
+
+		if container != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = container.Terminate(cleanupCtx)
+			cancel()
+		}
+	}
+
+	return nil, nil, fmt.Errorf("start presidio container after %d attempts: %w", maxAttempts, lastErr)
 }
 
 func newPresidioClientFunc(container testcontainers.Container) PresidioClientFunc {

--- a/server/internal/testenv/presidio.go
+++ b/server/internal/testenv/presidio.go
@@ -22,7 +22,8 @@ func NewTestPresidio(ctx context.Context) (testcontainers.Container, PresidioCli
 			ExposedPorts: []string{"3000/tcp"},
 			WaitingFor: wait.ForHTTP("/health").
 				WithPort("3000/tcp").
-				WithStartupTimeout(300 * time.Second),
+				WithPollInterval(2 * time.Second).
+				WithStartupTimeout(480 * time.Second),
 		},
 		Started: true,
 		Logger:  NewTestcontainersLogger(),


### PR DESCRIPTION
## Summary

- Retry presidio-analyzer container startup (2 attempts × 300s) instead of a single long timeout
- Add 2s health check poll interval (was 100ms default) to reduce CPU overhead during spaCy model loading

## Context

The `risk_analysis` test suite intermittently fails in CI because the presidio-analyzer container takes >5 minutes to start under load. The container loads spaCy NLP models on startup, which is CPU-intensive and sensitive to noisy neighbors on shared CI runners.

A retry approach is preferable to extending the timeout: stuck containers still fail at the original 300s boundary, but slow startups get a second chance.

Example failure: https://github.com/speakeasy-api/gram/actions/runs/25100437330/job/73547999234

## Test plan

- [x] `go build ./internal/testenv/...` compiles clean
- [ ] CI `server-test` job passes without presidio timeout