### PR TITLE
mig: add mcp_servers and mcp_endpoints tables

### DIFF
--- a/server/atlas.hcl
+++ b/server/atlas.hcl
@@ -17,4 +17,9 @@ lint {
       match = "drop_.+"
     }
   }
+  // PG110 reports non-optimal column alignment for byte padding.
+  // We don't reorder columns for alignment.
+  check "PG110" {
+    skip = true
+  }
 }

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1914,8 +1914,8 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_external_oauth_server_id_fkey FOREIGN KEY (external_oauth_server_id) REFERENCES external_oauth_server_metadata (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_oauth_proxy_server_id_fkey FOREIGN KEY (oauth_proxy_server_id) REFERENCES oauth_proxy_servers (id) ON DELETE SET NULL,
-  CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE SET NULL,
-  CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE RESTRICT,
+  CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
   -- Exactly one backend must be set: either a remote MCP server or a toolset.
   CONSTRAINT mcp_servers_backend_exclusivity_check CHECK ((remote_mcp_server_id IS NULL) != (toolset_id IS NULL))
 );

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1890,6 +1890,83 @@ CREATE UNIQUE INDEX IF NOT EXISTS remote_mcp_server_headers_remote_mcp_server_id
 ON remote_mcp_server_headers (remote_mcp_server_id, name)
 WHERE deleted IS FALSE;
 
+-- MCP Servers: user-facing MCP server configurations that link an MCP
+-- backend (either a toolset or a remote MCP server) to environment and
+-- OAuth settings. Each server is addressable via one or more mcp_endpoints.
+CREATE TABLE IF NOT EXISTS mcp_servers (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  environment_id uuid,
+  external_oauth_server_id uuid,
+  oauth_proxy_server_id uuid,
+  remote_mcp_server_id uuid,
+  toolset_id uuid,
+  visibility TEXT NOT NULL CHECK (visibility <> ''),
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT mcp_servers_pkey PRIMARY KEY (id),
+  CONSTRAINT mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_servers_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_servers_external_oauth_server_id_fkey FOREIGN KEY (external_oauth_server_id) REFERENCES external_oauth_server_metadata (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_servers_oauth_proxy_server_id_fkey FOREIGN KEY (oauth_proxy_server_id) REFERENCES oauth_proxy_servers (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE SET NULL,
+  -- Exactly one backend must be set: either a remote MCP server or a toolset.
+  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK ((remote_mcp_server_id IS NULL) != (toolset_id IS NULL))
+);
+
+CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx
+ON mcp_servers (project_id)
+WHERE deleted IS FALSE;
+
+-- MCP Endpoints: addressable slugs for an MCP server. A NULL custom_domain_id
+-- represents a Gram-hosted endpoint (resolved by slug alone); a non-NULL
+-- custom_domain_id represents a custom-domain endpoint (resolved by the
+-- composite (custom_domain_id, slug)).
+CREATE TABLE IF NOT EXISTS mcp_endpoints (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  custom_domain_id uuid,
+  mcp_server_id uuid NOT NULL,
+  slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 128),
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT mcp_endpoints_pkey PRIMARY KEY (id),
+  CONSTRAINT mcp_endpoints_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_endpoints_mcp_server_id_fkey FOREIGN KEY (mcp_server_id) REFERENCES mcp_servers (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_endpoints_custom_domain_id_fkey FOREIGN KEY (custom_domain_id) REFERENCES custom_domains (id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS mcp_endpoints_project_id_idx
+ON mcp_endpoints (project_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_endpoints_mcp_server_id_idx
+ON mcp_endpoints (mcp_server_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS mcp_endpoints_custom_domain_id_idx
+ON mcp_endpoints (custom_domain_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_endpoints_custom_domain_id_slug_key
+ON mcp_endpoints (custom_domain_id, slug)
+WHERE custom_domain_id IS NOT NULL AND deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_endpoints_slug_null_custom_domain_id_key
+ON mcp_endpoints (slug)
+WHERE custom_domain_id IS NULL AND deleted IS FALSE;
+
 -- Plugin definitions: project-scoped distributable bundles of MCP servers.
 -- Admins create plugins and assign them to roles for distribution.
 CREATE TABLE IF NOT EXISTS plugins (

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -564,6 +564,18 @@ type HttpToolDefinition struct {
 	Deleted             bool
 }
 
+type McpEndpoint struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	CustomDomainID uuid.NullUUID
+	McpServerID    uuid.UUID
+	Slug           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
+}
+
 type McpEnvironmentConfig struct {
 	ID                uuid.UUID
 	ProjectID         uuid.UUID
@@ -598,6 +610,21 @@ type McpRegistry struct {
 	UpdatedAt pgtype.Timestamptz
 	DeletedAt pgtype.Timestamptz
 	Deleted   bool
+}
+
+type McpServer struct {
+	ID                    uuid.UUID
+	ProjectID             uuid.UUID
+	EnvironmentID         uuid.NullUUID
+	ExternalOauthServerID uuid.NullUUID
+	OauthProxyServerID    uuid.NullUUID
+	RemoteMcpServerID     uuid.NullUUID
+	ToolsetID             uuid.NullUUID
+	Visibility            string
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	Deleted               bool
 }
 
 type OauthProxyClientInfo struct {

--- a/server/migrations/20260429123705_mcp_servers_and_endpoints.sql
+++ b/server/migrations/20260429123705_mcp_servers_and_endpoints.sql
@@ -1,0 +1,53 @@
+-- Create "mcp_servers" table
+CREATE TABLE "mcp_servers" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "environment_id" uuid NULL,
+  "external_oauth_server_id" uuid NULL,
+  "oauth_proxy_server_id" uuid NULL,
+  "remote_mcp_server_id" uuid NULL,
+  "toolset_id" uuid NULL,
+  "visibility" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "mcp_servers_environment_id_fkey" FOREIGN KEY ("environment_id") REFERENCES "environments" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_servers_external_oauth_server_id_fkey" FOREIGN KEY ("external_oauth_server_id") REFERENCES "external_oauth_server_metadata" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_servers_oauth_proxy_server_id_fkey" FOREIGN KEY ("oauth_proxy_server_id") REFERENCES "oauth_proxy_servers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_servers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "mcp_servers_remote_mcp_server_id_fkey" FOREIGN KEY ("remote_mcp_server_id") REFERENCES "remote_mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_servers_toolset_id_fkey" FOREIGN KEY ("toolset_id") REFERENCES "toolsets" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_servers_backend_exclusivity_check" CHECK ((remote_mcp_server_id IS NULL) <> (toolset_id IS NULL)),
+  CONSTRAINT "mcp_servers_visibility_check" CHECK (visibility <> ''::text)
+);
+-- Create index "mcp_servers_project_id_idx" to table: "mcp_servers"
+CREATE INDEX "mcp_servers_project_id_idx" ON "mcp_servers" ("project_id") WHERE (deleted IS FALSE);
+-- Create "mcp_endpoints" table
+CREATE TABLE "mcp_endpoints" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "custom_domain_id" uuid NULL,
+  "mcp_server_id" uuid NOT NULL,
+  "slug" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "mcp_endpoints_custom_domain_id_fkey" FOREIGN KEY ("custom_domain_id") REFERENCES "custom_domains" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_endpoints_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "mcp_endpoints_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "mcp_endpoints_slug_check" CHECK ((slug <> ''::text) AND (char_length(slug) <= 128))
+);
+-- Create index "mcp_endpoints_custom_domain_id_idx" to table: "mcp_endpoints"
+CREATE INDEX "mcp_endpoints_custom_domain_id_idx" ON "mcp_endpoints" ("custom_domain_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_endpoints_custom_domain_id_slug_key" to table: "mcp_endpoints"
+CREATE UNIQUE INDEX "mcp_endpoints_custom_domain_id_slug_key" ON "mcp_endpoints" ("custom_domain_id", "slug") WHERE ((custom_domain_id IS NOT NULL) AND (deleted IS FALSE));
+-- Create index "mcp_endpoints_mcp_server_id_idx" to table: "mcp_endpoints"
+CREATE INDEX "mcp_endpoints_mcp_server_id_idx" ON "mcp_endpoints" ("mcp_server_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_endpoints_project_id_idx" to table: "mcp_endpoints"
+CREATE INDEX "mcp_endpoints_project_id_idx" ON "mcp_endpoints" ("project_id") WHERE (deleted IS FALSE);
+-- Create index "mcp_endpoints_slug_null_custom_domain_id_key" to table: "mcp_endpoints"
+CREATE UNIQUE INDEX "mcp_endpoints_slug_null_custom_domain_id_key" ON "mcp_endpoints" ("slug") WHERE ((custom_domain_id IS NULL) AND (deleted IS FALSE));

--- a/server/migrations/20260429131558_mcp_servers_and_endpoints.sql
+++ b/server/migrations/20260429131558_mcp_servers_and_endpoints.sql
@@ -17,8 +17,8 @@ CREATE TABLE "mcp_servers" (
   CONSTRAINT "mcp_servers_external_oauth_server_id_fkey" FOREIGN KEY ("external_oauth_server_id") REFERENCES "external_oauth_server_metadata" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
   CONSTRAINT "mcp_servers_oauth_proxy_server_id_fkey" FOREIGN KEY ("oauth_proxy_server_id") REFERENCES "oauth_proxy_servers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
   CONSTRAINT "mcp_servers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
-  CONSTRAINT "mcp_servers_remote_mcp_server_id_fkey" FOREIGN KEY ("remote_mcp_server_id") REFERENCES "remote_mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
-  CONSTRAINT "mcp_servers_toolset_id_fkey" FOREIGN KEY ("toolset_id") REFERENCES "toolsets" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "mcp_servers_remote_mcp_server_id_fkey" FOREIGN KEY ("remote_mcp_server_id") REFERENCES "remote_mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT "mcp_servers_toolset_id_fkey" FOREIGN KEY ("toolset_id") REFERENCES "toolsets" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT,
   CONSTRAINT "mcp_servers_backend_exclusivity_check" CHECK ((remote_mcp_server_id IS NULL) <> (toolset_id IS NULL)),
   CONSTRAINT "mcp_servers_visibility_check" CHECK (visibility <> ''::text)
 );

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:jtxod77tF3J1cY2wiy03IgI1BE4Azw/zGSz8fBveQ+U=
+h1:GF/T8YyxPGYQlaGtTOqKdkgq1JXaycoBffAt07/c2XI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -147,4 +147,4 @@ h1:jtxod77tF3J1cY2wiy03IgI1BE4Azw/zGSz8fBveQ+U=
 20260428000001_deprecate-grant-resource-column.sql h1:6IJguq8/DX4gfSF4kP4DewDIIC2dOmP1macUDBSTubI=
 20260429084759_selector-indexes.sql h1:ESv55XcreTXC4wzd7Ui3k12dESUQwBy1yCiPWH74GBQ=
 20260429103554_drop_mcp_frontends_and_slugs.sql h1:gzlbVdjsiTS5Rcfe9ZarON+sjhOrKGFVdELohFxjoVI=
-20260429123705_mcp_servers_and_endpoints.sql h1:0rcL3hNiSTYzQpJ449FfiFIdJEAviuwxjjATC251oJg=
+20260429131558_mcp_servers_and_endpoints.sql h1:sNg8L6mZfYPnbP4xBreK4S9la7SwGzTBCw0Qe68h3DY=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Ht/CqVN9PjJuwdYVEEb3ZL5WNITFiSdJIvr20u2RW80=
+h1:jtxod77tF3J1cY2wiy03IgI1BE4Azw/zGSz8fBveQ+U=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -147,3 +147,4 @@ h1:Ht/CqVN9PjJuwdYVEEb3ZL5WNITFiSdJIvr20u2RW80=
 20260428000001_deprecate-grant-resource-column.sql h1:6IJguq8/DX4gfSF4kP4DewDIIC2dOmP1macUDBSTubI=
 20260429084759_selector-indexes.sql h1:ESv55XcreTXC4wzd7Ui3k12dESUQwBy1yCiPWH74GBQ=
 20260429103554_drop_mcp_frontends_and_slugs.sql h1:gzlbVdjsiTS5Rcfe9ZarON+sjhOrKGFVdELohFxjoVI=
+20260429123705_mcp_servers_and_endpoints.sql h1:0rcL3hNiSTYzQpJ449FfiFIdJEAviuwxjjATC251oJg=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-1879/mcp-frontends-and-slugs-database-migration

## Summary

- Phase 1 schema-only migration introducing the `mcp_servers` and `mcp_endpoints` tables.
- This is the exact migration originally introduced in #2336 (de5e71ecf) as `mcp_frontends`/`mcp_slugs` and dropped in #2493 (da77452a4), with the tables renamed to `mcp_servers` and `mcp_endpoints` and the `mcp_frontend_id` column/FK renamed to `mcp_server_id` to match.
- `mcp_servers` stores user-facing MCP server configurations linking an MCP backend (either a toolset or a remote MCP server, exactly one enforced via `CHECK`) to environment and OAuth settings.
- `mcp_endpoints` stores addressable slugs for an MCP server. Slug uniqueness is enforced via two partial unique indexes matching the existing `toolsets` precedent: one for custom-domain slugs keyed on `(custom_domain_id, slug)`, and one for Gram-hosted slugs keyed on `(slug)` where `custom_domain_id IS NULL`.