### PR TITLE
chore: remove otel-tui from madprocs config

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -20,10 +20,6 @@ procs:
     cmd: ["mise", "run", "start:elements"]
     stop:
       send-keys: ["<C-c>"]
-  otel:
-    cmd: ["mise", "run", "start:oteltui"]
-    stop:
-      send-keys: ["<C-c>"]
   lima:
     cmd: ["mise", "run", "start:lima"]
     stop:


### PR DESCRIPTION
## Summary

- Remove `otel` (otel-tui) process entry from `mprocs.yaml`
- Was accidentally re-added by #2368 (assistant-runtime PR), which branched before #2400 (Jaeger replacement) merged — classic merge artifact
- Local tracing now uses Jaeger, otel-tui is no longer needed

## Test plan

- [x] `madprocs` starts without errors (no `otel` tab)
- [x] Remaining procs unaffected: mock-idp, server, worker, admin, dashboard, elements, lima, assistant-runtime