### PR TITLE
fix: edit role dialog fixes

### DIFF
--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -26,7 +26,12 @@ import { useListScopes } from "@gram/client/react-query/listScopes.js";
 import { useUpdateRoleMutation } from "@gram/client/react-query/updateRole.js";
 import { Button } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowRight, ChevronRight, Loader2 } from "lucide-react";
+import { ArrowRight, ChevronRight, Info, Loader2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useMemo, useState } from "react";
 import { ScopePickerPopover } from "./ScopePickerPopover";
 import type {
@@ -37,6 +42,7 @@ import type {
   Selector,
 } from "./types";
 import { DISPOSITION_TO_ANNOTATION } from "./types";
+import { isSaveDisabled } from "./roleDialogState";
 
 interface CreateRoleDialogProps {
   open: boolean;
@@ -91,6 +97,10 @@ export function CreateRoleDialog({
   const [selectedMembers, setSelectedMembers] = useState<Set<string>>(
     new Set(),
   );
+  const [initialMembers, setInitialMembers] = useState<Set<string>>(new Set());
+  const [initialName, setInitialName] = useState("");
+  const [initialDescription, setInitialDescription] = useState("");
+  const [initialGrantKeys, setInitialGrantKeys] = useState("");
   const [showMembers, setShowMembers] = useState(false);
   const [showPermissions, setShowPermissions] = useState(true);
   const [initialized, setInitialized] = useState(false);
@@ -118,7 +128,7 @@ export function CreateRoleDialog({
   }, [scopesData]);
 
   // Pre-populate fields when editing — wait for async data so autoExpanded works correctly.
-  if (editingRole && !initialized && scopesData) {
+  if (editingRole && !initialized && scopesData && membersData) {
     setName(editingRole.name);
     setDescription(editingRole.description);
     const roleGrants = grantsFromRole(editingRole);
@@ -144,10 +154,14 @@ export function CreateRoleDialog({
       };
     }
     setGrants(roleGrants);
+    setInitialName(editingRole.name);
+    setInitialDescription(editingRole.description);
+    setInitialGrantKeys(Object.keys(roleGrants).sort().join(","));
     const assignedIds = new Set(
       members.filter((m) => m.roleId === editingRole.id).map((m) => m.id),
     );
     setSelectedMembers(assignedIds);
+    setInitialMembers(new Set(assignedIds));
     setInitialized(true);
   }
   if (!editingRole && initialized) {
@@ -179,6 +193,22 @@ export function CreateRoleDialog({
   const grantCount = Object.values(grants).filter(
     (g) => g.selectors === null || g.selectors.length > 0,
   ).length;
+
+  const saveDisabled = isSaveDisabled({
+    isMutating,
+    isEditing,
+    isSystemRole,
+    name,
+    description,
+    grants,
+    selectedMembers,
+    initial: {
+      name: initialName,
+      description: initialDescription,
+      grantKeys: initialGrantKeys,
+      members: initialMembers,
+    },
+  });
 
   const toggleScope = (scope: Scope) => {
     setGrants((prev) => {
@@ -297,6 +327,10 @@ export function CreateRoleDialog({
     setGrants({});
     setExpandedGroups(new Set());
     setSelectedMembers(new Set());
+    setInitialMembers(new Set());
+    setInitialName("");
+    setInitialDescription("");
+    setInitialGrantKeys("");
     setShowMembers(false);
     setShowPermissions(true);
     setInitialized(false);
@@ -363,6 +397,13 @@ export function CreateRoleDialog({
 
             {showPermissions && (
               <div className="mt-3 space-y-3">
+                {isSystemRole && (
+                  <div className="bg-muted/60 text-muted-foreground flex items-center gap-2 rounded-md px-3 py-2 text-xs">
+                    <Info className="h-3.5 w-3.5 shrink-0" />
+                    System role permissions are managed by Gram and cannot be
+                    changed.
+                  </div>
+                )}
                 {scopeGroups.map((group) => {
                   const selectedInGroup = group.scopes.filter(
                     (s) => grants[s.slug],
@@ -432,12 +473,22 @@ export function CreateRoleDialog({
                             const grant = grants[scopeDef.slug];
                             const isChecked = !!grant;
 
-                            return (
+                            const row = (
                               <div
                                 key={scopeDef.slug}
-                                className="hover:bg-muted/50 flex items-start gap-3 px-3 py-2.5"
+                                className={cn(
+                                  "hover:bg-muted/50 flex items-start gap-3 px-3 py-2.5",
+                                  isSystemRole && "cursor-default",
+                                )}
                               >
-                                <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-3">
+                                <label
+                                  className={cn(
+                                    "flex min-w-0 flex-1 items-start gap-3",
+                                    isSystemRole
+                                      ? "cursor-default"
+                                      : "cursor-pointer",
+                                  )}
+                                >
                                   <Checkbox
                                     disabled={isSystemRole}
                                     checked={isChecked}
@@ -496,6 +547,22 @@ export function CreateRoleDialog({
                                 </div>
                               </div>
                             );
+
+                            if (isSystemRole) {
+                              return (
+                                <Tooltip key={scopeDef.slug}>
+                                  <TooltipTrigger asChild>{row}</TooltipTrigger>
+                                  <TooltipContent
+                                    side="right"
+                                    className="max-w-48"
+                                  >
+                                    Cannot edit system role permissions
+                                  </TooltipContent>
+                                </Tooltip>
+                              );
+                            }
+
+                            return row;
                           })}
                         </div>
                       )}
@@ -621,15 +688,7 @@ export function CreateRoleDialog({
           <Button variant="secondary" onClick={handleClose}>
             Cancel
           </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={
-              isMutating ||
-              (isSystemRole
-                ? selectedMembers.size === 0
-                : !name.trim() || !description.trim() || grantCount === 0)
-            }
-          >
+          <Button onClick={handleSubmit} disabled={saveDisabled}>
             {isMutating && (
               <Button.LeftIcon>
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -42,7 +42,7 @@ import type {
   Selector,
 } from "./types";
 import { DISPOSITION_TO_ANNOTATION } from "./types";
-import { isSaveDisabled } from "./roleDialogState";
+import { grantsFingerprint, isSaveDisabled } from "./roleDialogState";
 
 interface CreateRoleDialogProps {
   open: boolean;
@@ -100,7 +100,7 @@ export function CreateRoleDialog({
   const [initialMembers, setInitialMembers] = useState<Set<string>>(new Set());
   const [initialName, setInitialName] = useState("");
   const [initialDescription, setInitialDescription] = useState("");
-  const [initialGrantKeys, setInitialGrantKeys] = useState("");
+  const [initialGrantsFingerprint, setInitialGrantsFingerprint] = useState("");
   const [showMembers, setShowMembers] = useState(false);
   const [showPermissions, setShowPermissions] = useState(true);
   const [initialized, setInitialized] = useState(false);
@@ -156,7 +156,7 @@ export function CreateRoleDialog({
     setGrants(roleGrants);
     setInitialName(editingRole.name);
     setInitialDescription(editingRole.description);
-    setInitialGrantKeys(Object.keys(roleGrants).sort().join(","));
+    setInitialGrantsFingerprint(grantsFingerprint(roleGrants));
     const assignedIds = new Set(
       members.filter((m) => m.roleId === editingRole.id).map((m) => m.id),
     );
@@ -205,7 +205,7 @@ export function CreateRoleDialog({
     initial: {
       name: initialName,
       description: initialDescription,
-      grantKeys: initialGrantKeys,
+      grantsFingerprint: initialGrantsFingerprint,
       members: initialMembers,
     },
   });
@@ -330,7 +330,7 @@ export function CreateRoleDialog({
     setInitialMembers(new Set());
     setInitialName("");
     setInitialDescription("");
-    setInitialGrantKeys("");
+    setInitialGrantsFingerprint("");
     setShowMembers(false);
     setShowPermissions(true);
     setInitialized(false);

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -42,7 +42,7 @@ import type {
   Selector,
 } from "./types";
 import { DISPOSITION_TO_ANNOTATION } from "./types";
-import { grantsFingerprint, isSaveDisabled } from "./roleDialogState";
+import { isSaveDisabled } from "./roleDialogState";
 
 interface CreateRoleDialogProps {
   open: boolean;
@@ -100,7 +100,7 @@ export function CreateRoleDialog({
   const [initialMembers, setInitialMembers] = useState<Set<string>>(new Set());
   const [initialName, setInitialName] = useState("");
   const [initialDescription, setInitialDescription] = useState("");
-  const [initialGrantsFingerprint, setInitialGrantsFingerprint] = useState("");
+  const [initialGrantKeys, setInitialGrantKeys] = useState("");
   const [showMembers, setShowMembers] = useState(false);
   const [showPermissions, setShowPermissions] = useState(true);
   const [initialized, setInitialized] = useState(false);
@@ -156,7 +156,7 @@ export function CreateRoleDialog({
     setGrants(roleGrants);
     setInitialName(editingRole.name);
     setInitialDescription(editingRole.description);
-    setInitialGrantsFingerprint(grantsFingerprint(roleGrants));
+    setInitialGrantKeys(Object.keys(roleGrants).sort().join(","));
     const assignedIds = new Set(
       members.filter((m) => m.roleId === editingRole.id).map((m) => m.id),
     );
@@ -205,7 +205,7 @@ export function CreateRoleDialog({
     initial: {
       name: initialName,
       description: initialDescription,
-      grantsFingerprint: initialGrantsFingerprint,
+      grantKeys: initialGrantKeys,
       members: initialMembers,
     },
   });
@@ -330,7 +330,7 @@ export function CreateRoleDialog({
     setInitialMembers(new Set());
     setInitialName("");
     setInitialDescription("");
-    setInitialGrantsFingerprint("");
+    setInitialGrantKeys("");
     setShowMembers(false);
     setShowPermissions(true);
     setInitialized(false);

--- a/client/dashboard/src/pages/access/roleDialogState.test.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from "vitest";
+import {
+  effectiveGrantCount,
+  grantKeysString,
+  hasFormChanges,
+  isSaveDisabled,
+  membersHaveChanged,
+  type SaveButtonInput,
+} from "./roleDialogState";
+import type { RoleGrant, Scope, Selector } from "./types";
+
+// --- Helpers ---
+
+function grant(scope: Scope, selectors: Selector[] | null = null): RoleGrant {
+  return { scope, selectors };
+}
+
+function makeInput(overrides: Partial<SaveButtonInput> = {}): SaveButtonInput {
+  return {
+    isMutating: false,
+    isEditing: true,
+    isSystemRole: false,
+    name: "Engineer",
+    description: "Can build things",
+    grants: {
+      "project:read": grant("project:read"),
+      "project:write": grant("project:write"),
+    },
+    selectedMembers: new Set(["m1", "m2"]),
+    initial: {
+      name: "Engineer",
+      description: "Can build things",
+      grantKeys: "project:read,project:write",
+      members: new Set(["m1", "m2"]),
+    },
+    ...overrides,
+  };
+}
+
+// --- effectiveGrantCount ---
+
+describe("effectiveGrantCount", () => {
+  it("counts grants with null selectors (unrestricted)", () => {
+    expect(
+      effectiveGrantCount({
+        "project:read": grant("project:read"),
+        "mcp:read": grant("mcp:read"),
+      }),
+    ).toBe(2);
+  });
+
+  it("excludes grants with empty selector arrays", () => {
+    expect(
+      effectiveGrantCount({
+        "project:read": grant("project:read"),
+        "mcp:read": grant("mcp:read", []),
+      }),
+    ).toBe(1);
+  });
+
+  it("returns 0 for empty grants", () => {
+    expect(effectiveGrantCount({})).toBe(0);
+  });
+});
+
+// --- membersHaveChanged ---
+
+describe("membersHaveChanged", () => {
+  it("same sets → false", () => {
+    expect(membersHaveChanged(new Set(["a", "b"]), new Set(["a", "b"]))).toBe(
+      false,
+    );
+  });
+
+  it("added member → true", () => {
+    expect(
+      membersHaveChanged(new Set(["a", "b", "c"]), new Set(["a", "b"])),
+    ).toBe(true);
+  });
+
+  it("removed member → true", () => {
+    expect(membersHaveChanged(new Set(["a"]), new Set(["a", "b"]))).toBe(true);
+  });
+
+  it("swapped member → true", () => {
+    expect(membersHaveChanged(new Set(["a", "c"]), new Set(["a", "b"]))).toBe(
+      true,
+    );
+  });
+
+  it("both empty → false", () => {
+    expect(membersHaveChanged(new Set(), new Set())).toBe(false);
+  });
+});
+
+// --- grantKeysString ---
+
+describe("grantKeysString", () => {
+  it("sorts keys and joins", () => {
+    expect(
+      grantKeysString({
+        "mcp:write": grant("mcp:write"),
+        "project:read": grant("project:read"),
+      }),
+    ).toBe("mcp:write,project:read");
+  });
+
+  it("empty grants → empty string", () => {
+    expect(grantKeysString({})).toBe("");
+  });
+});
+
+// --- hasFormChanges ---
+
+describe("hasFormChanges", () => {
+  it("no changes → false", () => {
+    expect(hasFormChanges(makeInput())).toBe(false);
+  });
+
+  it("name changed → true", () => {
+    expect(hasFormChanges(makeInput({ name: "Architect" }))).toBe(true);
+  });
+
+  it("description changed → true", () => {
+    expect(hasFormChanges(makeInput({ description: "New description" }))).toBe(
+      true,
+    );
+  });
+
+  it("grant added → true", () => {
+    expect(
+      hasFormChanges(
+        makeInput({
+          grants: {
+            "project:read": grant("project:read"),
+            "project:write": grant("project:write"),
+            "mcp:read": grant("mcp:read"),
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("member added → true", () => {
+    expect(
+      hasFormChanges(
+        makeInput({ selectedMembers: new Set(["m1", "m2", "m3"]) }),
+      ),
+    ).toBe(true);
+  });
+
+  it("member removed → true", () => {
+    expect(
+      hasFormChanges(makeInput({ selectedMembers: new Set(["m1"]) })),
+    ).toBe(true);
+  });
+
+  it("create mode → always true (no initial state to compare)", () => {
+    expect(hasFormChanges(makeInput({ isEditing: false }))).toBe(true);
+  });
+});
+
+// --- isSaveDisabled ---
+
+describe("isSaveDisabled", () => {
+  describe("create mode (non-system)", () => {
+    it("valid form → enabled", () => {
+      expect(isSaveDisabled(makeInput({ isEditing: false }))).toBe(false);
+    });
+
+    it("empty name → disabled", () => {
+      expect(isSaveDisabled(makeInput({ isEditing: false, name: "" }))).toBe(
+        true,
+      );
+    });
+
+    it("empty description → disabled", () => {
+      expect(
+        isSaveDisabled(makeInput({ isEditing: false, description: "" })),
+      ).toBe(true);
+    });
+
+    it("no grants → disabled", () => {
+      expect(isSaveDisabled(makeInput({ isEditing: false, grants: {} }))).toBe(
+        true,
+      );
+    });
+
+    it("mutating → disabled", () => {
+      expect(
+        isSaveDisabled(makeInput({ isEditing: false, isMutating: true })),
+      ).toBe(true);
+    });
+  });
+
+  describe("edit mode (non-system)", () => {
+    it("no changes → disabled", () => {
+      expect(isSaveDisabled(makeInput())).toBe(true);
+    });
+
+    it("name changed → enabled", () => {
+      expect(isSaveDisabled(makeInput({ name: "New Name" }))).toBe(false);
+    });
+
+    it("description changed → enabled", () => {
+      expect(isSaveDisabled(makeInput({ description: "Updated" }))).toBe(false);
+    });
+
+    it("grant added → enabled", () => {
+      expect(
+        isSaveDisabled(
+          makeInput({
+            grants: {
+              "project:read": grant("project:read"),
+              "project:write": grant("project:write"),
+              "mcp:read": grant("mcp:read"),
+            },
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("member added → enabled", () => {
+      expect(
+        isSaveDisabled(
+          makeInput({ selectedMembers: new Set(["m1", "m2", "m3"]) }),
+        ),
+      ).toBe(false);
+    });
+
+    it("member removed → enabled", () => {
+      expect(
+        isSaveDisabled(makeInput({ selectedMembers: new Set(["m1"]) })),
+      ).toBe(false);
+    });
+
+    it("only member changed, form still valid → enabled", () => {
+      expect(
+        isSaveDisabled(
+          makeInput({ selectedMembers: new Set(["m1", "m2", "m3"]) }),
+        ),
+      ).toBe(false);
+    });
+
+    it("member added on role with zero grants → enabled (role already exists)", () => {
+      expect(
+        isSaveDisabled(
+          makeInput({
+            grants: {},
+            selectedMembers: new Set(["m1", "m2", "m3"]),
+            initial: {
+              name: "Engineer",
+              description: "Can build things",
+              grantKeys: "",
+              members: new Set(["m1", "m2"]),
+            },
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("grants removed to zero AND member changed → enabled (backend validates)", () => {
+      expect(
+        isSaveDisabled(
+          makeInput({
+            grants: {},
+            selectedMembers: new Set(["m1", "m2", "m3"]),
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it("mutating → disabled even with changes", () => {
+      expect(
+        isSaveDisabled(makeInput({ name: "Changed", isMutating: true })),
+      ).toBe(true);
+    });
+  });
+
+  describe("edit mode (system role)", () => {
+    const systemBase = (): SaveButtonInput => makeInput({ isSystemRole: true });
+
+    it("no changes → disabled", () => {
+      expect(isSaveDisabled(systemBase())).toBe(true);
+    });
+
+    it("member added → enabled", () => {
+      expect(
+        isSaveDisabled({
+          ...systemBase(),
+          selectedMembers: new Set(["m1", "m2", "m3"]),
+        }),
+      ).toBe(false);
+    });
+
+    it("member removed → enabled", () => {
+      expect(
+        isSaveDisabled({
+          ...systemBase(),
+          selectedMembers: new Set(["m1"]),
+        }),
+      ).toBe(false);
+    });
+
+    it("enabled even with zero grants (system roles skip form validation)", () => {
+      expect(
+        isSaveDisabled({
+          ...systemBase(),
+          grants: {},
+          selectedMembers: new Set(["m1", "m2", "m3"]),
+        }),
+      ).toBe(false);
+    });
+
+    it("mutating → disabled", () => {
+      expect(
+        isSaveDisabled({
+          ...systemBase(),
+          selectedMembers: new Set(["m1", "m2", "m3"]),
+          isMutating: true,
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/client/dashboard/src/pages/access/roleDialogState.test.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   effectiveGrantCount,
-  grantsFingerprint,
+  grantKeysString,
   hasFormChanges,
   isSaveDisabled,
   membersHaveChanged,
@@ -15,11 +15,6 @@ function grant(scope: Scope, selectors: Selector[] | null = null): RoleGrant {
   return { scope, selectors };
 }
 
-const defaultGrants: Record<string, RoleGrant> = {
-  "project:read": grant("project:read"),
-  "project:write": grant("project:write"),
-};
-
 function makeInput(overrides: Partial<SaveButtonInput> = {}): SaveButtonInput {
   return {
     isMutating: false,
@@ -27,12 +22,15 @@ function makeInput(overrides: Partial<SaveButtonInput> = {}): SaveButtonInput {
     isSystemRole: false,
     name: "Engineer",
     description: "Can build things",
-    grants: defaultGrants,
+    grants: {
+      "project:read": grant("project:read"),
+      "project:write": grant("project:write"),
+    },
     selectedMembers: new Set(["m1", "m2"]),
     initial: {
       name: "Engineer",
       description: "Can build things",
-      grantsFingerprint: grantsFingerprint(defaultGrants),
+      grantKeys: "project:read,project:write",
       members: new Set(["m1", "m2"]),
     },
     ...overrides,
@@ -95,41 +93,20 @@ describe("membersHaveChanged", () => {
   });
 });
 
-// --- grantsFingerprint ---
+// --- grantKeysString ---
 
-describe("grantsFingerprint", () => {
-  it("sorts keys and includes selectors", () => {
-    const fp = grantsFingerprint({
-      "mcp:write": grant("mcp:write"),
-      "project:read": grant("project:read"),
-    });
-    expect(fp).toContain("mcp:write");
-    expect(fp).toContain("project:read");
-    // mcp:write should come before project:read (sorted)
-    expect(fp.indexOf("mcp:write")).toBeLessThan(fp.indexOf("project:read"));
+describe("grantKeysString", () => {
+  it("sorts keys and joins", () => {
+    expect(
+      grantKeysString({
+        "mcp:write": grant("mcp:write"),
+        "project:read": grant("project:read"),
+      }),
+    ).toBe("mcp:write,project:read");
   });
 
   it("empty grants → empty string", () => {
-    expect(grantsFingerprint({})).toBe("");
-  });
-
-  it("different selectors on same scope produce different fingerprints", () => {
-    const fpA = grantsFingerprint({
-      "mcp:connect": grant("mcp:connect", null),
-    });
-    const fpB = grantsFingerprint({
-      "mcp:connect": grant("mcp:connect", [
-        { resourceKind: "mcp", resourceId: "srv-1" },
-      ]),
-    });
-    expect(fpA).not.toBe(fpB);
-  });
-
-  it("same scope and selectors produce identical fingerprints", () => {
-    const sel: Selector[] = [{ resourceKind: "mcp", resourceId: "srv-1" }];
-    const fpA = grantsFingerprint({ "mcp:connect": grant("mcp:connect", sel) });
-    const fpB = grantsFingerprint({ "mcp:connect": grant("mcp:connect", sel) });
-    expect(fpA).toBe(fpB);
+    expect(grantKeysString({})).toBe("");
   });
 });
 
@@ -158,21 +135,6 @@ describe("hasFormChanges", () => {
             "project:read": grant("project:read"),
             "project:write": grant("project:write"),
             "mcp:read": grant("mcp:read"),
-          },
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it("selector changed on existing grant → true", () => {
-    expect(
-      hasFormChanges(
-        makeInput({
-          grants: {
-            "project:read": grant("project:read", [
-              { resourceKind: "mcp", resourceId: "srv-1" },
-            ]),
-            "project:write": grant("project:write"),
           },
         }),
       ),
@@ -258,21 +220,6 @@ describe("isSaveDisabled", () => {
       ).toBe(false);
     });
 
-    it("selector changed on existing grant → enabled", () => {
-      expect(
-        isSaveDisabled(
-          makeInput({
-            grants: {
-              "project:read": grant("project:read", [
-                { resourceKind: "mcp", resourceId: "srv-1" },
-              ]),
-              "project:write": grant("project:write"),
-            },
-          }),
-        ),
-      ).toBe(false);
-    });
-
     it("member added → enabled", () => {
       expect(
         isSaveDisabled(
@@ -295,7 +242,7 @@ describe("isSaveDisabled", () => {
       ).toBe(false);
     });
 
-    it("member added on role with zero grants → enabled (member-only change)", () => {
+    it("member added on role with zero grants → enabled (role already exists)", () => {
       expect(
         isSaveDisabled(
           makeInput({
@@ -304,7 +251,7 @@ describe("isSaveDisabled", () => {
             initial: {
               name: "Engineer",
               description: "Can build things",
-              grantsFingerprint: "",
+              grantKeys: "",
               members: new Set(["m1", "m2"]),
             },
           }),
@@ -312,12 +259,15 @@ describe("isSaveDisabled", () => {
       ).toBe(false);
     });
 
-    it("name blanked out → disabled (form invalid)", () => {
-      expect(isSaveDisabled(makeInput({ name: "" }))).toBe(true);
-    });
-
-    it("grants removed to zero → disabled (form invalid)", () => {
-      expect(isSaveDisabled(makeInput({ grants: {} }))).toBe(true);
+    it("grants removed to zero AND member changed → enabled (backend validates)", () => {
+      expect(
+        isSaveDisabled(
+          makeInput({
+            grants: {},
+            selectedMembers: new Set(["m1", "m2", "m3"]),
+          }),
+        ),
+      ).toBe(false);
     });
 
     it("mutating → disabled even with changes", () => {

--- a/client/dashboard/src/pages/access/roleDialogState.test.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   effectiveGrantCount,
-  grantKeysString,
+  grantsFingerprint,
   hasFormChanges,
   isSaveDisabled,
   membersHaveChanged,
@@ -15,6 +15,11 @@ function grant(scope: Scope, selectors: Selector[] | null = null): RoleGrant {
   return { scope, selectors };
 }
 
+const defaultGrants: Record<string, RoleGrant> = {
+  "project:read": grant("project:read"),
+  "project:write": grant("project:write"),
+};
+
 function makeInput(overrides: Partial<SaveButtonInput> = {}): SaveButtonInput {
   return {
     isMutating: false,
@@ -22,15 +27,12 @@ function makeInput(overrides: Partial<SaveButtonInput> = {}): SaveButtonInput {
     isSystemRole: false,
     name: "Engineer",
     description: "Can build things",
-    grants: {
-      "project:read": grant("project:read"),
-      "project:write": grant("project:write"),
-    },
+    grants: defaultGrants,
     selectedMembers: new Set(["m1", "m2"]),
     initial: {
       name: "Engineer",
       description: "Can build things",
-      grantKeys: "project:read,project:write",
+      grantsFingerprint: grantsFingerprint(defaultGrants),
       members: new Set(["m1", "m2"]),
     },
     ...overrides,
@@ -93,20 +95,41 @@ describe("membersHaveChanged", () => {
   });
 });
 
-// --- grantKeysString ---
+// --- grantsFingerprint ---
 
-describe("grantKeysString", () => {
-  it("sorts keys and joins", () => {
-    expect(
-      grantKeysString({
-        "mcp:write": grant("mcp:write"),
-        "project:read": grant("project:read"),
-      }),
-    ).toBe("mcp:write,project:read");
+describe("grantsFingerprint", () => {
+  it("sorts keys and includes selectors", () => {
+    const fp = grantsFingerprint({
+      "mcp:write": grant("mcp:write"),
+      "project:read": grant("project:read"),
+    });
+    expect(fp).toContain("mcp:write");
+    expect(fp).toContain("project:read");
+    // mcp:write should come before project:read (sorted)
+    expect(fp.indexOf("mcp:write")).toBeLessThan(fp.indexOf("project:read"));
   });
 
   it("empty grants → empty string", () => {
-    expect(grantKeysString({})).toBe("");
+    expect(grantsFingerprint({})).toBe("");
+  });
+
+  it("different selectors on same scope produce different fingerprints", () => {
+    const fpA = grantsFingerprint({
+      "mcp:connect": grant("mcp:connect", null),
+    });
+    const fpB = grantsFingerprint({
+      "mcp:connect": grant("mcp:connect", [
+        { resourceKind: "mcp", resourceId: "srv-1" },
+      ]),
+    });
+    expect(fpA).not.toBe(fpB);
+  });
+
+  it("same scope and selectors produce identical fingerprints", () => {
+    const sel: Selector[] = [{ resourceKind: "mcp", resourceId: "srv-1" }];
+    const fpA = grantsFingerprint({ "mcp:connect": grant("mcp:connect", sel) });
+    const fpB = grantsFingerprint({ "mcp:connect": grant("mcp:connect", sel) });
+    expect(fpA).toBe(fpB);
   });
 });
 
@@ -135,6 +158,21 @@ describe("hasFormChanges", () => {
             "project:read": grant("project:read"),
             "project:write": grant("project:write"),
             "mcp:read": grant("mcp:read"),
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("selector changed on existing grant → true", () => {
+    expect(
+      hasFormChanges(
+        makeInput({
+          grants: {
+            "project:read": grant("project:read", [
+              { resourceKind: "mcp", resourceId: "srv-1" },
+            ]),
+            "project:write": grant("project:write"),
           },
         }),
       ),
@@ -220,6 +258,21 @@ describe("isSaveDisabled", () => {
       ).toBe(false);
     });
 
+    it("selector changed on existing grant → enabled", () => {
+      expect(
+        isSaveDisabled(
+          makeInput({
+            grants: {
+              "project:read": grant("project:read", [
+                { resourceKind: "mcp", resourceId: "srv-1" },
+              ]),
+              "project:write": grant("project:write"),
+            },
+          }),
+        ),
+      ).toBe(false);
+    });
+
     it("member added → enabled", () => {
       expect(
         isSaveDisabled(
@@ -242,7 +295,7 @@ describe("isSaveDisabled", () => {
       ).toBe(false);
     });
 
-    it("member added on role with zero grants → enabled (role already exists)", () => {
+    it("member added on role with zero grants → enabled (member-only change)", () => {
       expect(
         isSaveDisabled(
           makeInput({
@@ -251,7 +304,7 @@ describe("isSaveDisabled", () => {
             initial: {
               name: "Engineer",
               description: "Can build things",
-              grantKeys: "",
+              grantsFingerprint: "",
               members: new Set(["m1", "m2"]),
             },
           }),
@@ -259,15 +312,12 @@ describe("isSaveDisabled", () => {
       ).toBe(false);
     });
 
-    it("grants removed to zero AND member changed → enabled (backend validates)", () => {
-      expect(
-        isSaveDisabled(
-          makeInput({
-            grants: {},
-            selectedMembers: new Set(["m1", "m2", "m3"]),
-          }),
-        ),
-      ).toBe(false);
+    it("name blanked out → disabled (form invalid)", () => {
+      expect(isSaveDisabled(makeInput({ name: "" }))).toBe(true);
+    });
+
+    it("grants removed to zero → disabled (form invalid)", () => {
+      expect(isSaveDisabled(makeInput({ grants: {} }))).toBe(true);
     });
 
     it("mutating → disabled even with changes", () => {

--- a/client/dashboard/src/pages/access/roleDialogState.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.ts
@@ -16,7 +16,7 @@ export interface SaveButtonInput {
   initial: {
     name: string;
     description: string;
-    grantsFingerprint: string;
+    grantKeys: string;
     members: Set<string>;
   };
 }
@@ -40,15 +40,9 @@ export function membersHaveChanged(
   return false;
 }
 
-/** Stable fingerprint of grants including selectors for dirty-checking */
-export function grantsFingerprint(grants: Record<string, RoleGrant>): string {
-  const entries = Object.keys(grants)
-    .sort()
-    .map((key) => {
-      const g = grants[key];
-      return `${key}:${JSON.stringify(g.selectors)}`;
-    });
-  return entries.join("|");
+/** Sorted, comma-joined grant keys for cheap equality check */
+export function grantKeysString(grants: Record<string, RoleGrant>): string {
+  return Object.keys(grants).sort().join(",");
 }
 
 /** Whether any field has changed from the initial state */
@@ -58,7 +52,7 @@ export function hasFormChanges(input: SaveButtonInput): boolean {
     membersHaveChanged(input.selectedMembers, input.initial.members) ||
     input.name !== input.initial.name ||
     input.description !== input.initial.description ||
-    grantsFingerprint(input.grants) !== input.initial.grantsFingerprint
+    grantKeysString(input.grants) !== input.initial.grantKeys
   );
 }
 
@@ -77,7 +71,7 @@ export function hasNonMemberChanges(input: SaveButtonInput): boolean {
   return (
     input.name !== input.initial.name ||
     input.description !== input.initial.description ||
-    grantsFingerprint(input.grants) !== input.initial.grantsFingerprint
+    grantKeysString(input.grants) !== input.initial.grantKeys
   );
 }
 
@@ -86,9 +80,7 @@ export function isSaveDisabled(input: SaveButtonInput): boolean {
   if (input.isMutating) return true;
   // Create mode: full form validation always applies
   if (!input.isEditing) return !isFormValid(input);
-  // Edit mode: require something changed AND form stays valid.
-  // Member-only changes skip form validation (role already exists with its current fields).
-  if (!hasFormChanges(input)) return true;
-  if (hasNonMemberChanges(input) && !isFormValid(input)) return true;
-  return false;
+  // Edit mode: just require something to have changed.
+  // The role already exists and was valid — backend validates on submit.
+  return !hasFormChanges(input);
 }

--- a/client/dashboard/src/pages/access/roleDialogState.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.ts
@@ -1,0 +1,86 @@
+import type { RoleGrant } from "./types";
+
+export interface SaveButtonInput {
+  /** True when a create/update mutation is in flight */
+  isMutating: boolean;
+  /** True when dialog was opened to edit an existing role (vs create) */
+  isEditing: boolean;
+  /** True when the role being edited is a system role (Member/Admin) */
+  isSystemRole: boolean;
+  /** Current form values */
+  name: string;
+  description: string;
+  grants: Record<string, RoleGrant>;
+  selectedMembers: Set<string>;
+  /** Snapshot of form values when the dialog opened for editing */
+  initial: {
+    name: string;
+    description: string;
+    grantKeys: string;
+    members: Set<string>;
+  };
+}
+
+/** Effective grant count — scopes with null (unrestricted) or non-empty selectors */
+export function effectiveGrantCount(grants: Record<string, RoleGrant>): number {
+  return Object.values(grants).filter(
+    (g) => g.selectors === null || g.selectors.length > 0,
+  ).length;
+}
+
+/** Whether the selected members differ from the initial snapshot */
+export function membersHaveChanged(
+  selected: Set<string>,
+  initial: Set<string>,
+): boolean {
+  if (selected.size !== initial.size) return true;
+  for (const id of selected) {
+    if (!initial.has(id)) return true;
+  }
+  return false;
+}
+
+/** Sorted, comma-joined grant keys for cheap equality check */
+export function grantKeysString(grants: Record<string, RoleGrant>): string {
+  return Object.keys(grants).sort().join(",");
+}
+
+/** Whether any field has changed from the initial state */
+export function hasFormChanges(input: SaveButtonInput): boolean {
+  if (!input.isEditing) return true; // create mode — always "dirty"
+  return (
+    membersHaveChanged(input.selectedMembers, input.initial.members) ||
+    input.name !== input.initial.name ||
+    input.description !== input.initial.description ||
+    grantKeysString(input.grants) !== input.initial.grantKeys
+  );
+}
+
+/** Whether the form fields are valid enough to submit */
+export function isFormValid(input: SaveButtonInput): boolean {
+  if (input.isSystemRole) return true; // system roles only change members
+  return (
+    input.name.trim().length > 0 &&
+    input.description.trim().length > 0 &&
+    effectiveGrantCount(input.grants) > 0
+  );
+}
+
+/** Whether non-member fields (name, description, grants) changed */
+export function hasNonMemberChanges(input: SaveButtonInput): boolean {
+  return (
+    input.name !== input.initial.name ||
+    input.description !== input.initial.description ||
+    grantKeysString(input.grants) !== input.initial.grantKeys
+  );
+}
+
+/** Returns true when the Save/Create button should be disabled */
+export function isSaveDisabled(input: SaveButtonInput): boolean {
+  if (input.isMutating) return true;
+  // Create mode: full form validation always applies
+  if (!input.isEditing) return !isFormValid(input);
+  // Edit mode: just require something to have changed.
+  // The role already exists and was valid — backend validates on submit.
+  return !hasFormChanges(input);
+}

--- a/client/dashboard/src/pages/access/roleDialogState.ts
+++ b/client/dashboard/src/pages/access/roleDialogState.ts
@@ -16,7 +16,7 @@ export interface SaveButtonInput {
   initial: {
     name: string;
     description: string;
-    grantKeys: string;
+    grantsFingerprint: string;
     members: Set<string>;
   };
 }
@@ -40,9 +40,15 @@ export function membersHaveChanged(
   return false;
 }
 
-/** Sorted, comma-joined grant keys for cheap equality check */
-export function grantKeysString(grants: Record<string, RoleGrant>): string {
-  return Object.keys(grants).sort().join(",");
+/** Stable fingerprint of grants including selectors for dirty-checking */
+export function grantsFingerprint(grants: Record<string, RoleGrant>): string {
+  const entries = Object.keys(grants)
+    .sort()
+    .map((key) => {
+      const g = grants[key];
+      return `${key}:${JSON.stringify(g.selectors)}`;
+    });
+  return entries.join("|");
 }
 
 /** Whether any field has changed from the initial state */
@@ -52,7 +58,7 @@ export function hasFormChanges(input: SaveButtonInput): boolean {
     membersHaveChanged(input.selectedMembers, input.initial.members) ||
     input.name !== input.initial.name ||
     input.description !== input.initial.description ||
-    grantKeysString(input.grants) !== input.initial.grantKeys
+    grantsFingerprint(input.grants) !== input.initial.grantsFingerprint
   );
 }
 
@@ -71,7 +77,7 @@ export function hasNonMemberChanges(input: SaveButtonInput): boolean {
   return (
     input.name !== input.initial.name ||
     input.description !== input.initial.description ||
-    grantKeysString(input.grants) !== input.initial.grantKeys
+    grantsFingerprint(input.grants) !== input.initial.grantsFingerprint
   );
 }
 
@@ -80,7 +86,9 @@ export function isSaveDisabled(input: SaveButtonInput): boolean {
   if (input.isMutating) return true;
   // Create mode: full form validation always applies
   if (!input.isEditing) return !isFormValid(input);
-  // Edit mode: just require something to have changed.
-  // The role already exists and was valid — backend validates on submit.
-  return !hasFormChanges(input);
+  // Edit mode: require something changed AND form stays valid.
+  // Member-only changes skip form validation (role already exists with its current fields).
+  if (!hasFormChanges(input)) return true;
+  if (hasNonMemberChanges(input) && !isFormValid(input)) return true;
+  return false;
 }


### PR DESCRIPTION
## Summary

- **System role scope tooltips**: Hovering scope rows on system roles (Member/Admin) shows "Cannot edit system role permissions" tooltip + info banner at top of permissions section
- **Save button dirty-checking**: Extracted disabled logic into a pure `isSaveDisabled()` function. Save button now correctly enables only when something has actually changed (name, description, grants, or member assignments)
- **Member assignment fix**: Previously, reassigning members on roles with zero grants wouldn't enable Save — the button incorrectly enforced form validation on edit when the role already exists

## Test plan

- [x] 37 unit tests for `isSaveDisabled` covering create, edit (system + non-system), member changes, grant changes, name/desc changes
- [ ] Manual: edit system role → verify tooltip on scope rows, info banner visible, Save disabled until members changed
- [ ] Manual: edit non-system role → change name only → Save enables
- [ ] Manual: edit non-system role → change member only → Save enables
- [ ] Manual: create new role → Save requires name + desc + grants