### PR TITLE
fix: return full scopes for admin impersonation in ListGrants

### DIFF
--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -679,21 +679,23 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 		return nil, err
 	}
 	if !enforce {
-		return &gen.ListUserGrantsResult{Grants: []*gen.ListRoleGrant{
-			{Scope: string(authz.ScopeOrgRead), Selectors: nil},
-			{Scope: string(authz.ScopeOrgAdmin), Selectors: nil},
-			{Scope: string(authz.ScopeProjectRead), Selectors: nil},
-			{Scope: string(authz.ScopeProjectWrite), Selectors: nil},
-			{Scope: string(authz.ScopeMCPRead), Selectors: nil},
-			{Scope: string(authz.ScopeMCPWrite), Selectors: nil},
-			{Scope: string(authz.ScopeMCPConnect), Selectors: nil},
-		}}, nil
+		return &gen.ListUserGrantsResult{Grants: allScopesGrants()}, nil
 	}
 
 	ac, workosOrgID, err := s.roleOrgContext(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	// Admins impersonating a customer org won't have an organization_users row
+	// (the Info endpoint intentionally skips that upsert). Return full scopes so
+	// the MembershipSyncGuard doesn't block the dashboard.
+	if ac.IsAdmin {
+		if _, hasOverride := contextvalues.GetAdminOverrideFromContext(ctx); hasOverride {
+			return &gen.ListUserGrantsResult{Grants: allScopesGrants()}, nil
+		}
+	}
+
 	logger := s.logger.With(
 		attr.SlogOrganizationID(ac.ActiveOrganizationID),
 		attr.SlogUserID(ac.UserID),
@@ -1090,6 +1092,20 @@ func scopedGrantToGenRoleGrant(g *authz.ScopedGrant) *gen.RoleGrant {
 		selectors = append(selectors, authzSelectorToGen(sel))
 	}
 	return &gen.RoleGrant{Scope: g.Scope, Selectors: selectors}
+}
+
+// allScopesGrants returns unrestricted grants for every known scope.
+// Used when RBAC is not enforced or for admin impersonation.
+func allScopesGrants() []*gen.ListRoleGrant {
+	return []*gen.ListRoleGrant{
+		{Scope: string(authz.ScopeOrgRead), Selectors: nil},
+		{Scope: string(authz.ScopeOrgAdmin), Selectors: nil},
+		{Scope: string(authz.ScopeProjectRead), Selectors: nil},
+		{Scope: string(authz.ScopeProjectWrite), Selectors: nil},
+		{Scope: string(authz.ScopeMCPRead), Selectors: nil},
+		{Scope: string(authz.ScopeMCPWrite), Selectors: nil},
+		{Scope: string(authz.ScopeMCPConnect), Selectors: nil},
+	}
 }
 
 func listRoleGrantsFromGrants(grants []authz.Grant) []*gen.ListRoleGrant {

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -105,6 +105,37 @@ func TestService_ListGrants_NotConnected(t *testing.T) {
 	require.Contains(t, err.Error(), "current user has not joined this organization")
 }
 
+func TestService_ListGrants_AdminImpersonatingReturnsFullAccess(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	// Enterprise org with RBAC enforced, admin user, admin override set,
+	// but NO organization_users row — mirrors real impersonation.
+	authCtx.AccountType = "enterprise"
+	authCtx.IsAdmin = true
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	ctx = contextvalues.SetAdminOverrideInContext(ctx, "customer-org")
+
+	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
+	require.NoError(t, err)
+	require.Len(t, result.Grants, len(expectedFullAccessScopes))
+
+	byScope := make(map[string]*gen.ListRoleGrant, len(result.Grants))
+	for _, grant := range result.Grants {
+		byScope[grant.Scope] = grant
+	}
+
+	for _, scope := range expectedFullAccessScopes {
+		grant, ok := byScope[scope]
+		require.True(t, ok)
+		require.Nil(t, grant.Selectors)
+	}
+}
+
 func TestService_ListGrants_NonEnterpriseReturnsFullAccess(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- When an admin impersonates a customer org (enterprise, RBAC enabled), `ListGrants` failed with a 404 because the admin has no `organization_users` row — the `Info` endpoint intentionally skips that upsert during impersonation
- This caused `MembershipSyncGuard` to show an "Organization sync required" banner blocking the entire dashboard
- Fix: detect admin + `gram_admin_override` after `roleOrgContext` and return unrestricted grants before reaching the `connectedUser` check
- Extracted `allScopesGrants()` helper to deduplicate the full-scope grant slice

Closes AGE-2014

## Test plan

- [x] New test `TestService_ListGrants_AdminImpersonatingReturnsFullAccess` — enterprise org, RBAC enforced, admin with override, no org membership row → returns full scopes
- [x] Existing `TestService_ListGrants_NotConnected` still passes — non-admin without membership still gets 404
- [x] All other `ListGrants` tests pass