### PR TITLE
fix: assistant runtime wire contract (warm_ttl + history)

### DIFF
--- a/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
@@ -29,9 +29,65 @@ export type SlackEventBinding = {
 };
 
 export const SLACK_EVENT_BINDINGS: Record<string, SlackEventBinding> = {
+  app_home_opened: { bot_events: ["app_home_opened"], scopes: [] },
   app_mention: {
     bot_events: ["app_mention"],
     scopes: ["app_mentions:read"],
+  },
+  app_uninstalled: { bot_events: ["app_uninstalled"], scopes: [] },
+  channel_archive: {
+    bot_events: ["channel_archive"],
+    scopes: ["channels:read"],
+  },
+  channel_created: {
+    bot_events: ["channel_created"],
+    scopes: ["channels:read"],
+  },
+  channel_deleted: {
+    bot_events: ["channel_deleted"],
+    scopes: ["channels:read"],
+  },
+  channel_id_changed: {
+    bot_events: ["channel_id_changed"],
+    scopes: ["channels:read"],
+  },
+  channel_left: { bot_events: ["channel_left"], scopes: ["channels:read"] },
+  channel_rename: {
+    bot_events: ["channel_rename"],
+    scopes: ["channels:read"],
+  },
+  channel_unarchive: {
+    bot_events: ["channel_unarchive"],
+    scopes: ["channels:read"],
+  },
+  emoji_changed: { bot_events: ["emoji_changed"], scopes: ["emoji:read"] },
+  file_change: { bot_events: ["file_change"], scopes: ["files:read"] },
+  file_created: { bot_events: ["file_created"], scopes: ["files:read"] },
+  file_deleted: { bot_events: ["file_deleted"], scopes: ["files:read"] },
+  file_public: { bot_events: ["file_public"], scopes: ["files:read"] },
+  file_shared: { bot_events: ["file_shared"], scopes: ["files:read"] },
+  file_unshared: { bot_events: ["file_unshared"], scopes: ["files:read"] },
+  group_archive: { bot_events: ["group_archive"], scopes: ["groups:read"] },
+  group_close: { bot_events: ["group_close"], scopes: ["groups:read"] },
+  group_deleted: { bot_events: ["group_deleted"], scopes: ["groups:read"] },
+  group_left: { bot_events: ["group_left"], scopes: ["groups:read"] },
+  group_open: { bot_events: ["group_open"], scopes: ["groups:read"] },
+  group_rename: { bot_events: ["group_rename"], scopes: ["groups:read"] },
+  group_unarchive: {
+    bot_events: ["group_unarchive"],
+    scopes: ["groups:read"],
+  },
+  im_close: { bot_events: ["im_close"], scopes: ["im:read"] },
+  im_created: { bot_events: ["im_created"], scopes: ["im:read"] },
+  im_open: { bot_events: ["im_open"], scopes: ["im:read"] },
+  link_shared: { bot_events: ["link_shared"], scopes: ["links:read"] },
+  member_joined_channel: {
+    bot_events: ["member_joined_channel"],
+    scopes: ["channels:read", "groups:read"],
+  },
+  member_left_channel: {
+    bot_events: ["member_left_channel"],
+    scopes: ["channels:read", "groups:read"],
   },
   message: {
     bot_events: [
@@ -47,10 +103,19 @@ export const SLACK_EVENT_BINDINGS: Record<string, SlackEventBinding> = {
       "mpim:history",
     ],
   },
+  pin_added: { bot_events: ["pin_added"], scopes: ["pins:read"] },
+  pin_removed: { bot_events: ["pin_removed"], scopes: ["pins:read"] },
   reaction_added: {
     bot_events: ["reaction_added"],
     scopes: ["reactions:read"],
   },
+  reaction_removed: {
+    bot_events: ["reaction_removed"],
+    scopes: ["reactions:read"],
+  },
+  team_join: { bot_events: ["team_join"], scopes: ["users:read"] },
+  tokens_revoked: { bot_events: ["tokens_revoked"], scopes: [] },
+  user_change: { bot_events: ["user_change"], scopes: ["users:read"] },
 };
 
 const BASELINE_BOT_SCOPES: readonly string[] = [
@@ -59,12 +124,27 @@ const BASELINE_BOT_SCOPES: readonly string[] = [
   "users:read",
 ];
 
+// Slack manifests are static and the user can't easily edit them after
+// install, so subscribe to every event the trigger service supports up
+// front. The trigger config's `event_types` filters at delivery time.
+const ALL_EVENT_BOT_EVENTS: readonly string[] = Array.from(
+  new Set(
+    Object.values(SLACK_EVENT_BINDINGS).flatMap((b) =>
+      Array.from(b.bot_events),
+    ),
+  ),
+).sort();
+const ALL_EVENT_SCOPES: readonly string[] = Array.from(
+  new Set(
+    Object.values(SLACK_EVENT_BINDINGS).flatMap((b) => Array.from(b.scopes)),
+  ),
+).sort();
+
 const SLACK_DISPLAY_NAME_LIMIT = 35;
 
 export type SlackManifestInput = {
   appName: string;
   toolUrns?: readonly string[];
-  eventTypes?: readonly string[];
   webhookUrl?: string | undefined;
   extraScopes?: readonly string[];
   extraBotEvents?: readonly string[];
@@ -78,7 +158,6 @@ export type SlackManifestResult = {
   scopes: string[];
   botEvents: string[];
   unmappedToolUrns: string[];
-  unmappedEventTypes: string[];
   searchToolNeedsUserToken: boolean;
 };
 
@@ -99,10 +178,9 @@ export function buildSlackManifest(
     SLACK_DISPLAY_NAME_LIMIT,
   );
 
-  const scopes = new Set<string>(BASELINE_BOT_SCOPES);
-  const botEvents = new Set<string>();
+  const scopes = new Set<string>([...BASELINE_BOT_SCOPES, ...ALL_EVENT_SCOPES]);
+  const botEvents = new Set<string>(ALL_EVENT_BOT_EVENTS);
   const unmappedToolUrns: string[] = [];
-  const unmappedEventTypes: string[] = [];
   let searchToolNeedsUserToken = false;
 
   for (const urn of input.toolUrns ?? []) {
@@ -118,16 +196,6 @@ export function buildSlackManifest(
       continue;
     }
     unmappedToolUrns.push(urn);
-  }
-
-  for (const eventType of input.eventTypes ?? []) {
-    const binding = SLACK_EVENT_BINDINGS[eventType];
-    if (!binding) {
-      unmappedEventTypes.push(eventType);
-      continue;
-    }
-    for (const e of binding.bot_events) botEvents.add(e);
-    for (const s of binding.scopes) scopes.add(s);
   }
 
   for (const s of input.extraScopes ?? []) scopes.add(s);
@@ -168,7 +236,6 @@ export function buildSlackManifest(
     scopes: sortedScopes,
     botEvents: sortedEvents,
     unmappedToolUrns,
-    unmappedEventTypes,
     searchToolNeedsUserToken,
   };
 }

--- a/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
@@ -332,7 +332,6 @@ export function ShowSlackAppGuideComponent({ args }: ToolCallMessagePartProps) {
       buildSlackManifest({
         appName: a.app_name ?? assistantName ?? "Gram Assistant",
         toolUrns: derived.toolUrns,
-        eventTypes: derived.eventTypes,
         webhookUrl: a.webhook_url,
         extraScopes: a.bot_scopes,
         extraBotEvents: a.bot_events,
@@ -344,7 +343,6 @@ export function ShowSlackAppGuideComponent({ args }: ToolCallMessagePartProps) {
       a.bot_events,
       assistantName,
       derived.toolUrns,
-      derived.eventTypes,
     ],
   );
 

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -72,6 +72,8 @@ type runtimeStartupConfig struct {
 	CompletionsURL *string            `json:"completions_url,omitempty"`
 	ChatID         string             `json:"chat_id"`
 	MCPServers     []runtimeMCPServer `json:"mcp_servers"`
+	History        []runtimeMessage   `json:"history,omitempty"`
+	WarmTTLSeconds int                `json:"warm_ttl_seconds"`
 }
 
 type runtimeMCPServer struct {
@@ -98,9 +100,8 @@ type runtimeToolCall struct {
 }
 
 type runtimeTurnRequest struct {
-	History   []runtimeMessage `json:"history,omitempty"`
-	Input     string           `json:"input"`
-	AuthToken string           `json:"auth_token,omitempty"`
+	Input     string `json:"input"`
+	AuthToken string `json:"auth_token,omitempty"`
 }
 
 type runtimeHTTPRequest struct {
@@ -509,7 +510,6 @@ func (m *RuntimeManager) RunTurn(
 	runtime assistantRuntimeRecord,
 	idempotencyKey string,
 	authToken string,
-	history []runtimeMessage,
 	prompt string,
 ) error {
 	if err := validateRuntimeBackend(m, runtime.Backend); err != nil {
@@ -528,7 +528,6 @@ func (m *RuntimeManager) RunTurn(
 	}
 
 	reqBody, err := json.Marshal(runtimeTurnRequest{
-		History:   history,
 		Input:     prompt,
 		AuthToken: authToken,
 	})

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -17,7 +17,7 @@ type RuntimeBackend interface {
 	SupportsBackend(backend string) bool
 	Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error)
 	Configure(ctx context.Context, runtime assistantRuntimeRecord, config runtimeStartupConfig) error
-	RunTurn(ctx context.Context, runtime assistantRuntimeRecord, idempotencyKey string, authToken string, history []runtimeMessage, prompt string) error
+	RunTurn(ctx context.Context, runtime assistantRuntimeRecord, idempotencyKey string, authToken string, prompt string) error
 	ServerURL(ctx context.Context, runtime assistantRuntimeRecord, raw *url.URL) (*url.URL, error)
 	Stop(ctx context.Context, runtime assistantRuntimeRecord) error
 }

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -453,7 +453,7 @@ func (f *FlyRuntimeBackend) Configure(ctx context.Context, runtime assistantRunt
 	return nil
 }
 
-func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntimeRecord, idempotencyKey string, authToken string, history []runtimeMessage, prompt string) error {
+func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntimeRecord, idempotencyKey string, authToken string, prompt string) error {
 	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
 		return err
 	}
@@ -466,7 +466,6 @@ func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 	}
 
 	reqBody, err := json.Marshal(runtimeTurnRequest{
-		History:   history,
 		Input:     prompt,
 		AuthToken: authToken,
 	})

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -121,11 +121,10 @@ func (t *telemetryRuntimeBackend) RunTurn(
 	runtime assistantRuntimeRecord,
 	idempotencyKey string,
 	authToken string,
-	history []runtimeMessage,
 	prompt string,
 ) error {
 	t.emit(ctx, runtime, "runtime_turn", "runtime turn dispatched", "INFO", nil)
-	if err := t.inner.RunTurn(ctx, runtime, idempotencyKey, authToken, history, prompt); err != nil {
+	if err := t.inner.RunTurn(ctx, runtime, idempotencyKey, authToken, prompt); err != nil {
 		t.emit(ctx, runtime, "runtime_turn", "runtime turn errored", "ERROR", err)
 		return fmt.Errorf("runtime run turn: %w", err)
 	}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1104,7 +1104,6 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 		return ProcessThreadEventsResult{}, err
 	}
 
-	coldStart := ensureResult.ColdStart
 	if ensureResult.NeedsConfigure {
 		startupConfig, err := s.buildRuntimeStartupConfig(ctx, thread, runtimeRecord, assistant)
 		if err != nil {
@@ -1153,7 +1152,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 		s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "turn_start", "assistant turn started", "INFO", nil)
 
 		stopLeaseHeartbeat := s.startProcessingLeaseHeartbeat(turnCtx, thread.ProjectID, runtimeRecord.ID, event.ID)
-		runErr := s.processEventTurn(turnCtx, thread, assistant, runtimeRecord, event, coldStart)
+		runErr := s.processEventTurn(turnCtx, thread, assistant, runtimeRecord, event)
 		stopLeaseHeartbeat()
 		if runErr != nil {
 			s.logger.WarnContext(ctx, "assistant turn failed",
@@ -1249,7 +1248,6 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 		}
 		s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_completed", "assistant event completed", "INFO", nil)
 		processedAny = true
-		coldStart = false
 	}
 
 	warmUntil := time.Now().UTC().Add(time.Duration(assistant.WarmTTLSeconds) * time.Second)
@@ -1271,7 +1269,6 @@ func (s *ServiceCore) processEventTurn(
 	assistant assistantRecord,
 	runtime assistantRuntimeRecord,
 	event assistantThreadEventRecord,
-	includeHistory bool,
 ) error {
 	adapter, err := getSourceAdapter(thread.SourceKind)
 	if err != nil {
@@ -1281,18 +1278,11 @@ func (s *ServiceCore) processEventTurn(
 	if err != nil {
 		return fmt.Errorf("decode assistant turn: %w", err)
 	}
-	var history []runtimeMessage
-	if includeHistory {
-		history, err = s.loadChatHistory(ctx, thread.ChatID, thread.ProjectID)
-		if err != nil {
-			return err
-		}
-	}
 	turnToken, err := s.mintAssistantRuntimeToken(assistant, thread)
 	if err != nil {
 		return err
 	}
-	if err := s.runtime.RunTurn(ctx, runtime, event.ID.String(), turnToken, history, prompt); err != nil {
+	if err := s.runtime.RunTurn(ctx, runtime, event.ID.String(), turnToken, prompt); err != nil {
 		return fmt.Errorf("run assistant turn: %w", err)
 	}
 	return nil
@@ -1369,6 +1359,11 @@ func (s *ServiceCore) buildRuntimeStartupConfig(
 		return runtimeStartupConfig{}, fmt.Errorf("compose assistant instructions: %w", err)
 	}
 
+	history, err := s.loadChatHistory(ctx, thread.ChatID, thread.ProjectID)
+	if err != nil {
+		return runtimeStartupConfig{}, err
+	}
+
 	completionsURL := runtimeServerURL.JoinPath("chat", "completions").String()
 	return runtimeStartupConfig{
 		Model:          assistant.Model,
@@ -1377,6 +1372,8 @@ func (s *ServiceCore) buildRuntimeStartupConfig(
 		CompletionsURL: &completionsURL,
 		ChatID:         thread.ChatID.String(),
 		MCPServers:     mcpServers,
+		History:        history,
+		WarmTTLSeconds: assistant.WarmTTLSeconds,
 	}, nil
 }
 

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -451,7 +451,7 @@ func (t testRuntimeBackend) Configure(context.Context, assistantRuntimeRecord, r
 	return nil
 }
 
-func (t testRuntimeBackend) RunTurn(context.Context, assistantRuntimeRecord, string, string, []runtimeMessage, string) error {
+func (t testRuntimeBackend) RunTurn(context.Context, assistantRuntimeRecord, string, string, string) error {
 	return t.runTurnErr
 }
 


### PR DESCRIPTION
## Summary

Slack-triggered assistants couldn't boot a runtime VM. Two missing fields on the Go → Rust `/configure` payload, plus a Slack onboarding manifest that only bound `app_mention`.

### Wire contract fixes (`server/internal/assistants/`)

- **`warm_ttl_seconds`** — added to `runtimeStartupConfig`, populated from `assistant.WarmTTLSeconds`. Runner returns 400 `config error for key: warm_ttl` when absent (`agents/runner/src/runtime.rs:175-180`), causing `/configure` retry storms and downstream `list VMs: app not found` because the Fly app never gets created.
- **`history`** — moved from `/turn` to `/configure` to match the Rust runner's design. Runner expects prior transcript at configure time to prime the driver (`agents/runner/src/runtime.rs:165-173`); its `/turn` body has only `input` + `auth_token`. Go was sending history on `/turn`, where serde silently dropped it, so cold-spawned VMs lost prior conversation context.

`buildRuntimeStartupConfig` now calls `loadChatHistory`. `RuntimeBackend.RunTurn` (interface + Fly + telemetry wrappers + test mock) drops the `history` arg. `runtimeTurnRequest.History` removed. The obsolete `coldStart` flag (whose only consumer was the per-turn history gate in `processEventTurn`) is removed.

### Slack onboarding manifest (`client/dashboard/src/pages/assistants/onboarding/`)

Manifest now subscribes to the full superset of `bot_events` and `scopes` derived from `SLACK_EVENT_BINDINGS` (covers all 37 trigger event types from `definitions.go:206-245`). Slack manifests are static post-install, and the trigger service already filters at delivery via `event_types` config — so binding everything up front avoids the "user toggles a new event type and silently nothing arrives because the manifest doesn't include it" failure mode.

`buildSlackManifest` no longer takes `eventTypes`; `unmappedEventTypes` removed from the result type.

✻ Clauded...