### PR TITLE
fix: skip authz.Filter for admin impersonation in auth.Info

### DIFF
--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -417,9 +417,12 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 		}
 
 		allowedIDs := projectIDs
-		// Admins impersonating a customer org won't have grants resolved
-		// via the normal RBAC path (no organization_users row). Skip
-		// filtering so they see all projects, mirroring ListGrants.
+		// Admins impersonating a customer org have the customer org in
+		// userInfo.Organizations (Speakeasy returns all orgs for admins),
+		// so the loop reaches it and org.ID == activeOrg is true. However
+		// the admin has no organization_users row in Gram's DB, which
+		// means authz.Filter has no grants to resolve. Skip filtering so
+		// they see all projects — mirrors ListGrants (PR #2502).
 		_, hasAdminOverride := contextvalues.GetAdminOverrideFromContext(ctx)
 		skipFilter := userInfo.Admin && hasAdminOverride
 

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -417,7 +417,13 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 		}
 
 		allowedIDs := projectIDs
-		if len(projectIDs) > 0 && org.ID == authCtx.ActiveOrganizationID {
+		// Admins impersonating a customer org won't have grants resolved
+		// via the normal RBAC path (no organization_users row). Skip
+		// filtering so they see all projects, mirroring ListGrants.
+		_, hasAdminOverride := contextvalues.GetAdminOverrideFromContext(ctx)
+		skipFilter := userInfo.Admin && hasAdminOverride
+
+		if len(projectIDs) > 0 && org.ID == authCtx.ActiveOrganizationID && !skipFilter {
 			checks := make([]authz.Check, len(projectIDs))
 			for i, id := range projectIDs {
 				checks[i] = authz.Check{Scope: authz.ScopeProjectRead, ResourceID: id, ResourceKind: "", Dimensions: nil}

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -496,6 +496,39 @@ func TestService_Info_ProjectFiltering(t *testing.T) {
 		require.ErrorIs(t, err, authz.ErrMissingGrants)
 		require.Nil(t, result)
 	})
+
+	t.Run("admin impersonating returns all projects", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := adminMockUserInfo()
+		userInfo.UserID = "admin-impersonate-user"
+		userInfo.Email = "admin-impersonate@speakeasyapi.dev"
+		userInfo.Organizations[0].ID = "admin-impersonate-org"
+		_, instance := newTestAuthServiceWithAuthz(t, userInfo)
+		ctx := setupInfoCtx(t, instance, userInfo)
+
+		orgID := userInfo.Organizations[0].ID
+		p1, err := instance.createTestProject(ctx, orgID, "ProjectA", "project-a")
+		require.NoError(t, err)
+		p2, err := instance.createTestProject(ctx, orgID, "ProjectB", "project-b")
+		require.NoError(t, err)
+
+		// Set admin override in context — no grants configured, so authz.Filter
+		// would fail or return empty. The override must bypass filtering entirely.
+		ctx = contextvalues.SetAdminOverrideInContext(ctx, orgID)
+
+		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
+		require.NoError(t, err)
+		require.Len(t, result.Organizations, 1)
+		require.Len(t, result.Organizations[0].Projects, 2)
+
+		projectIDs := make(map[string]struct{}, 2)
+		for _, p := range result.Organizations[0].Projects {
+			projectIDs[p.ID] = struct{}{}
+		}
+		assert.Contains(t, projectIDs, p1.ID.String())
+		assert.Contains(t, projectIDs, p2.ID.String())
+	})
 }
 
 // TestService_Info_AdminVisitingCustomerOrgDoesNotUpsertRelationship verifies that


### PR DESCRIPTION
## Summary

- When an admin impersonates a customer org via admin override, `auth.Info` was filtering projects through `authz.Filter` — which fails because the admin has no `organization_users` row in the customer org (intentionally skipped to avoid polluting their data)
- Skip `authz.Filter` when `userInfo.Admin && hasAdminOverride`, returning all projects — mirrors the pattern from #2502 (`access.ListGrants`)

## Test plan

- [x] New test: `TestService_Info_ProjectFiltering/admin_impersonating_returns_all_projects` — admin with override set, no RBAC grants, verifies all projects returned
- [x] All existing `TestService_Info_ProjectFiltering` subtests still pass