### PR TITLE
feat: audit log trigger instance create/update/delete/pause/resume

### DIFF
--- a/.agents/skills/gram-audit-logging/SKILL.md
+++ b/.agents/skills/gram-audit-logging/SKILL.md
@@ -50,16 +50,16 @@ Audit logging lives in `server/internal/audit/` with its management-API surface 
 
 ### Non-generated files
 
-| File                                                              | Purpose                                                                                                                                     |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `server/design/auditlogs/design.go`                               | Goa design for the `auditlogs` service. Regenerates `server/gen/auditlogs/` and `server/gen/http/auditlogs/` via `mise run gen:goa-server`. |
-| `server/internal/audit/<subject>.go`                              | One file per subject (e.g. `access.go`, `remotemcpservers.go`, `toolsets.go`).                                                              |
-| `server/internal/audit/audittest/helpers.go`                      | Test helpers other packages use to assert audit events.                                                                                     |
-| `server/internal/audit/audittest/queries.sql`                     | SQLc queries backing the test helpers. Regenerates `server/internal/audit/audittest/repo/` via `mise run gen:sqlc-server`.                  |
-| `server/internal/audit/events.go`                                 | Top-level declarations shared across every subject.                                                                                         |
-| `server/internal/audit/impl.go`                                   | Implementation of the `/rpc/auditlogs.*` Goa service (reads).                                                                               |
-| `server/internal/audit/queries.sql`                               | SQLc queries for the audit log table. Regenerates `server/internal/audit/repo/` via `mise run gen:sqlc-server`.                             |
-| `server/internal/audit/{setup_test,list_test,listfacets_test}.go` | Tests for the `auditlogs` management API.                                                                                                   |
+| File                                                                 | Purpose                                                                                                                                                                                                                |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/design/auditlogs/design.go`                                  | Goa design for the `auditlogs` service. Regenerates `server/gen/auditlogs/` and `server/gen/http/auditlogs/` via `mise run gen:goa-server`.                                                                            |
+| `server/internal/audit/<subject>.go`                                 | One file per subject (e.g. `access.go`, `remotemcpservers.go`, `toolsets.go`).                                                                                                                                         |
+| `server/internal/audit/audittest/helpers.go`                         | Test helpers other packages use to assert audit events.                                                                                                                                                                |
+| `server/internal/audit/audittest/queries.sql`                        | SQLc queries backing the test helpers. Regenerates `server/internal/audit/audittest/repo/` via `mise run gen:sqlc-server`.                                                                                             |
+| `server/internal/audit/events.go`                                    | Top-level declarations shared across every subject.                                                                                                                                                                    |
+| `server/internal/auditapi/impl.go`                                   | Implementation of the `/rpc/auditlogs.*` Goa service (reads). Lives in its own package to keep the `audit` writer surface free of `auth/sessions` and `mv` so any service can call `audit.Log*` without import cycles. |
+| `server/internal/audit/queries.sql`                                  | SQLc queries for the audit log table. Regenerates `server/internal/audit/repo/` via `mise run gen:sqlc-server`.                                                                                                        |
+| `server/internal/auditapi/{setup_test,list_test,listfacets_test}.go` | Tests for the `auditlogs` management API.                                                                                                                                                                              |
 
 ### Generated files
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -24,7 +24,7 @@ import (
 	"go.temporal.io/sdk/client"
 	goahttp "goa.design/goa/v3/http"
 
-	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/auditapi"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 
@@ -745,7 +745,7 @@ func newStartCommand() *cli.Command {
 			access.Attach(mux, access.NewService(logger, tracerProvider, db, sessionManager, roleClient, authzEngine, productFeatures))
 			assistants.Attach(mux, assistantsSvc)
 			hooks.Attach(mux, hooks.NewService(logger, db, tracerProvider, telemLogger, sessionManager, hooksCache, chatClient, temporalEnv, authzEngine, productFeatures, &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}, riskScanner, chatWriter))
-			audit.Attach(mux, audit.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
+			auditapi.Attach(mux, auditapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			auth.Attach(mux, auth.NewService(
 				logger,
 				tracerProvider,

--- a/server/internal/audit/events.go
+++ b/server/internal/audit/events.go
@@ -22,6 +22,7 @@ const (
 	subjectTypeTemplate        subjectType = "template"
 	subjectTypeRemoteMcpServer subjectType = "remote_mcp_server"
 	subjectTypeToolset         subjectType = "toolset"
+	subjectTypeTriggerInstance subjectType = "trigger_instance"
 	subjectTypeVariation       subjectType = "variation"
 	subjectTypeRiskPolicy      subjectType = "risk_policy"
 )

--- a/server/internal/audit/triggerinstances.go
+++ b/server/internal/audit/triggerinstances.go
@@ -1,0 +1,191 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/audit/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	ActionTriggerInstanceCreate Action = "trigger-instance:create"
+	ActionTriggerInstanceDelete Action = "trigger-instance:delete"
+	ActionTriggerInstancePause  Action = "trigger-instance:pause"
+	ActionTriggerInstanceResume Action = "trigger-instance:resume"
+)
+
+type LogTriggerInstanceCreateEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	TriggerInstanceURN urn.TriggerInstance
+	Name               string
+	DefinitionSlug     string
+}
+
+func LogTriggerInstanceCreate(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceCreateEvent) error {
+	action := ActionTriggerInstanceCreate
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.TriggerInstanceURN.ID.String(),
+		SubjectType:        string(subjectTypeTriggerInstance),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.Name),
+		SubjectSlug:        conv.ToPGTextEmpty(event.DefinitionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogTriggerInstanceDeleteEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	TriggerInstanceURN urn.TriggerInstance
+	Name               string
+	DefinitionSlug     string
+}
+
+func LogTriggerInstanceDelete(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceDeleteEvent) error {
+	action := ActionTriggerInstanceDelete
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.TriggerInstanceURN.ID.String(),
+		SubjectType:        string(subjectTypeTriggerInstance),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.Name),
+		SubjectSlug:        conv.ToPGTextEmpty(event.DefinitionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogTriggerInstancePauseEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	TriggerInstanceURN urn.TriggerInstance
+	Name               string
+	DefinitionSlug     string
+}
+
+func LogTriggerInstancePause(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstancePauseEvent) error {
+	action := ActionTriggerInstancePause
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.TriggerInstanceURN.ID.String(),
+		SubjectType:        string(subjectTypeTriggerInstance),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.Name),
+		SubjectSlug:        conv.ToPGTextEmpty(event.DefinitionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogTriggerInstanceResumeEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	TriggerInstanceURN urn.TriggerInstance
+	Name               string
+	DefinitionSlug     string
+}
+
+func LogTriggerInstanceResume(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceResumeEvent) error {
+	action := ActionTriggerInstanceResume
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.TriggerInstanceURN.ID.String(),
+		SubjectType:        string(subjectTypeTriggerInstance),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.Name),
+		SubjectSlug:        conv.ToPGTextEmpty(event.DefinitionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}

--- a/server/internal/audit/triggerinstances.go
+++ b/server/internal/audit/triggerinstances.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/audit/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -13,6 +14,7 @@ import (
 
 const (
 	ActionTriggerInstanceCreate Action = "trigger-instance:create"
+	ActionTriggerInstanceUpdate Action = "trigger-instance:update"
 	ActionTriggerInstanceDelete Action = "trigger-instance:delete"
 	ActionTriggerInstancePause  Action = "trigger-instance:pause"
 	ActionTriggerInstanceResume Action = "trigger-instance:resume"
@@ -51,6 +53,62 @@ func LogTriggerInstanceCreate(ctx context.Context, dbtx repo.DBTX, event LogTrig
 
 		BeforeSnapshot: nil,
 		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	if _, err := repo.New(dbtx).InsertAuditLog(ctx, entry); err != nil {
+		return fmt.Errorf("log %s: %w", action, err)
+	}
+
+	return nil
+}
+
+type LogTriggerInstanceUpdateEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	TriggerInstanceURN            urn.TriggerInstance
+	Name                          string
+	DefinitionSlug                string
+	TriggerInstanceSnapshotBefore *types.TriggerInstance
+	TriggerInstanceSnapshotAfter  *types.TriggerInstance
+}
+
+func LogTriggerInstanceUpdate(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceUpdateEvent) error {
+	action := ActionTriggerInstanceUpdate
+
+	beforeSnapshot, err := marshalAuditPayload(event.TriggerInstanceSnapshotBefore)
+	if err != nil {
+		return fmt.Errorf("marshal %s before snapshot: %w", action, err)
+	}
+
+	afterSnapshot, err := marshalAuditPayload(event.TriggerInstanceSnapshotAfter)
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.TriggerInstanceURN.ID.String(),
+		SubjectType:        string(subjectTypeTriggerInstance),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.Name),
+		SubjectSlug:        conv.ToPGTextEmpty(event.DefinitionSlug),
+
+		BeforeSnapshot: beforeSnapshot,
+		AfterSnapshot:  afterSnapshot,
 		Metadata:       nil,
 	}
 

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -1,4 +1,4 @@
-package audit
+package auditapi
 
 import (
 	"context"

--- a/server/internal/auditapi/list_test.go
+++ b/server/internal/auditapi/list_test.go
@@ -1,4 +1,4 @@
-package audit_test
+package auditapi_test
 
 import (
 	"context"

--- a/server/internal/auditapi/listfacets_test.go
+++ b/server/internal/auditapi/listfacets_test.go
@@ -1,4 +1,4 @@
-package audit_test
+package auditapi_test
 
 import (
 	"testing"

--- a/server/internal/auditapi/setup_test.go
+++ b/server/internal/auditapi/setup_test.go
@@ -1,4 +1,4 @@
-package audit_test
+package auditapi_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/auditapi"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 }
 
 type testInstance struct {
-	service        *audit.Service
+	service        *auditapi.Service
 	conn           *pgxpool.Pool
 	sessionManager *sessions.Manager
 }
@@ -71,7 +71,7 @@ func newTestAuditService(t *testing.T) (context.Context, *testInstance) {
 	authzEngine := authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	return ctx, &testInstance{
-		service:        audit.NewService(logger, tracerProvider, conn, sessionManager, authzEngine),
+		service:        auditapi.NewService(logger, tracerProvider, conn, sessionManager, authzEngine),
 		conn:           conn,
 		sessionManager: sessionManager,
 	}

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -113,6 +114,7 @@ func (l *triggerDeliveryLogger) LogTriggerDelivery(
 
 type App struct {
 	logger         *slog.Logger
+	db             *pgxpool.Pool
 	repo           *triggerrepo.Queries
 	envLoader      EnvironmentLoader
 	deliveryLogger DeliveryLogger
@@ -120,6 +122,11 @@ type App struct {
 	serverURL      *url.URL
 	dispatchers    map[string]Dispatcher
 }
+
+// InstanceDBHook runs inside the transaction that mutates a trigger instance,
+// after the primary repo write succeeds and before commit. Returning an error
+// rolls the entire mutation back.
+type InstanceDBHook func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error
 
 type CreateParams struct {
 	OrganizationID string
@@ -170,6 +177,7 @@ func NewApp(
 
 	return &App{
 		logger:         logger,
+		db:             db,
 		repo:           triggerrepo.New(db),
 		envLoader:      envLoader,
 		deliveryLogger: deliveryLogger,
@@ -202,7 +210,7 @@ func (a *App) GetInstance(ctx context.Context, projectID uuid.UUID, id uuid.UUID
 	return item, nil
 }
 
-func (a *App) Create(ctx context.Context, params CreateParams) (triggerrepo.TriggerInstance, error) {
+func (a *App) Create(ctx context.Context, params CreateParams, hooks ...InstanceDBHook) (triggerrepo.TriggerInstance, error) {
 	if err := ValidateTargetKind(params.TargetKind); err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
@@ -220,7 +228,13 @@ func (a *App) Create(ctx context.Context, params CreateParams) (triggerrepo.Trig
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("marshal trigger config: %w", err)
 	}
 
-	item, err := a.repo.CreateTriggerInstance(ctx, triggerrepo.CreateTriggerInstanceParams{
+	tx, err := a.db.Begin(ctx)
+	if err != nil {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("begin trigger create transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	item, err := triggerrepo.New(tx).CreateTriggerInstance(ctx, triggerrepo.CreateTriggerInstanceParams{
 		OrganizationID: params.OrganizationID,
 		ProjectID:      params.ProjectID,
 		DefinitionSlug: params.DefinitionSlug,
@@ -234,6 +248,16 @@ func (a *App) Create(ctx context.Context, params CreateParams) (triggerrepo.Trig
 	})
 	if err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("create trigger instance: %w", err)
+	}
+
+	for _, hook := range hooks {
+		if err := hook(ctx, tx, item); err != nil {
+			return triggerrepo.TriggerInstance{}, fmt.Errorf("trigger create hook: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("commit trigger create transaction: %w", err)
 	}
 
 	if err := a.reconcileSchedule(ctx, item, definition, config); err != nil {
@@ -296,13 +320,29 @@ func (a *App) Update(ctx context.Context, params UpdateParams) (triggerrepo.Trig
 	return item, nil
 }
 
-func (a *App) Delete(ctx context.Context, projectID uuid.UUID, id uuid.UUID) error {
-	item, err := a.repo.DeleteTriggerInstance(ctx, triggerrepo.DeleteTriggerInstanceParams{
+func (a *App) Delete(ctx context.Context, projectID uuid.UUID, id uuid.UUID, hooks ...InstanceDBHook) error {
+	tx, err := a.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin trigger delete transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	item, err := triggerrepo.New(tx).DeleteTriggerInstance(ctx, triggerrepo.DeleteTriggerInstanceParams{
 		ID:        id,
 		ProjectID: projectID,
 	})
 	if err != nil {
 		return fmt.Errorf("delete trigger instance: %w", err)
+	}
+
+	for _, hook := range hooks {
+		if err := hook(ctx, tx, item); err != nil {
+			return fmt.Errorf("trigger delete hook: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit trigger delete transaction: %w", err)
 	}
 
 	if err := a.deleteSchedule(ctx, item); err != nil {
@@ -312,14 +352,30 @@ func (a *App) Delete(ctx context.Context, projectID uuid.UUID, id uuid.UUID) err
 	return nil
 }
 
-func (a *App) SetStatus(ctx context.Context, projectID uuid.UUID, id uuid.UUID, status string) (triggerrepo.TriggerInstance, error) {
-	item, err := a.repo.SetTriggerInstanceStatus(ctx, triggerrepo.SetTriggerInstanceStatusParams{
+func (a *App) SetStatus(ctx context.Context, projectID uuid.UUID, id uuid.UUID, status string, hooks ...InstanceDBHook) (triggerrepo.TriggerInstance, error) {
+	tx, err := a.db.Begin(ctx)
+	if err != nil {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("begin trigger set-status transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	item, err := triggerrepo.New(tx).SetTriggerInstanceStatus(ctx, triggerrepo.SetTriggerInstanceStatusParams{
 		Status:    status,
 		ID:        id,
 		ProjectID: projectID,
 	})
 	if err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("set trigger status: %w", err)
+	}
+
+	for _, hook := range hooks {
+		if err := hook(ctx, tx, item); err != nil {
+			return triggerrepo.TriggerInstance{}, fmt.Errorf("trigger set-status hook: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("commit trigger set-status transaction: %w", err)
 	}
 
 	rawConfig, err := configJSONToMap(item.ConfigJson)

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -272,7 +272,7 @@ func (a *App) Create(ctx context.Context, params CreateParams, hooks ...Instance
 	return item, nil
 }
 
-func (a *App) Update(ctx context.Context, params UpdateParams) (triggerrepo.TriggerInstance, error) {
+func (a *App) Update(ctx context.Context, params UpdateParams, hooks ...InstanceDBHook) (triggerrepo.TriggerInstance, error) {
 	if err := ValidateTargetKind(params.TargetKind); err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
@@ -298,7 +298,13 @@ func (a *App) Update(ctx context.Context, params UpdateParams) (triggerrepo.Trig
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("marshal trigger config: %w", err)
 	}
 
-	item, err := a.repo.UpdateTriggerInstance(ctx, triggerrepo.UpdateTriggerInstanceParams{
+	tx, err := a.db.Begin(ctx)
+	if err != nil {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("begin trigger update transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	item, err := triggerrepo.New(tx).UpdateTriggerInstance(ctx, triggerrepo.UpdateTriggerInstanceParams{
 		Name:                conv.ToPGText(params.Name),
 		UpdateEnvironmentID: true,
 		EnvironmentID:       params.EnvironmentID,
@@ -312,6 +318,16 @@ func (a *App) Update(ctx context.Context, params UpdateParams) (triggerrepo.Trig
 	})
 	if err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("update trigger instance: %w", err)
+	}
+
+	for _, hook := range hooks {
+		if err := hook(ctx, tx, item); err != nil {
+			return triggerrepo.TriggerInstance{}, fmt.Errorf("trigger update hook: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return triggerrepo.TriggerInstance{}, fmt.Errorf("commit trigger update transaction: %w", err)
 	}
 
 	if err := a.reconcileSchedule(ctx, item, definition, config); err != nil {

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
@@ -232,7 +233,7 @@ func (a *App) Create(ctx context.Context, params CreateParams, hooks ...Instance
 	if err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("begin trigger create transaction: %w", err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	item, err := triggerrepo.New(tx).CreateTriggerInstance(ctx, triggerrepo.CreateTriggerInstanceParams{
 		OrganizationID: params.OrganizationID,
@@ -325,7 +326,7 @@ func (a *App) Delete(ctx context.Context, projectID uuid.UUID, id uuid.UUID, hoo
 	if err != nil {
 		return fmt.Errorf("begin trigger delete transaction: %w", err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	item, err := triggerrepo.New(tx).DeleteTriggerInstance(ctx, triggerrepo.DeleteTriggerInstanceParams{
 		ID:        id,
@@ -357,7 +358,7 @@ func (a *App) SetStatus(ctx context.Context, projectID uuid.UUID, id uuid.UUID, 
 	if err != nil {
 		return triggerrepo.TriggerInstance{}, fmt.Errorf("begin trigger set-status transaction: %w", err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	item, err := triggerrepo.New(tx).SetTriggerInstanceStatus(ctx, triggerrepo.SetTriggerInstanceStatusParams{
 		Status:    status,

--- a/server/internal/mv/trigger_instance.go
+++ b/server/internal/mv/trigger_instance.go
@@ -1,0 +1,41 @@
+package mv
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
+)
+
+// BuildTriggerInstanceView converts a repo trigger_instances row into the API
+// response type.
+func BuildTriggerInstanceView(instance triggerrepo.TriggerInstance, webhookURL *string) (*types.TriggerInstance, error) {
+	config := map[string]any{}
+	if len(instance.ConfigJson) > 0 {
+		if err := json.Unmarshal(instance.ConfigJson, &config); err != nil {
+			return nil, fmt.Errorf("decode trigger config: %w", err)
+		}
+		if config == nil {
+			config = map[string]any{}
+		}
+	}
+
+	return &types.TriggerInstance{
+		ID:             instance.ID.String(),
+		ProjectID:      instance.ProjectID.String(),
+		DefinitionSlug: instance.DefinitionSlug,
+		Name:           instance.Name,
+		EnvironmentID:  conv.Ternary(instance.EnvironmentID.Valid, conv.PtrEmpty(instance.EnvironmentID.UUID.String()), nil),
+		TargetKind:     instance.TargetKind,
+		TargetRef:      instance.TargetRef,
+		TargetDisplay:  instance.TargetDisplay,
+		Config:         config,
+		Status:         instance.Status,
+		WebhookURL:     webhookURL,
+		CreatedAt:      instance.CreatedAt.Time.Format(time.RFC3339),
+		UpdatedAt:      instance.UpdatedAt.Time.Format(time.RFC3339),
+	}, nil
+}

--- a/server/internal/platformtools/triggers/tools.go
+++ b/server/internal/platformtools/triggers/tools.go
@@ -10,9 +10,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -20,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 const (
@@ -394,6 +397,8 @@ func (t *ConfigureTrigger) upsertTrigger(
 	status := normalizeStatus(params.Status)
 	action := "created"
 
+	actorPrincipal := urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)
+
 	var item triggerrepo.TriggerInstance
 	if params.TriggerID == nil || strings.TrimSpace(*params.TriggerID) == "" {
 		item, err = t.app.Create(ctx, bgtriggers.CreateParams{
@@ -407,6 +412,17 @@ func (t *ConfigureTrigger) upsertTrigger(
 			TargetDisplay:  strings.TrimSpace(params.TargetDisplay),
 			Config:         params.Config,
 			Status:         status,
+		}, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
+			return audit.LogTriggerInstanceCreate(ctx, dbtx, audit.LogTriggerInstanceCreateEvent{
+				OrganizationID:     authCtx.ActiveOrganizationID,
+				ProjectID:          *authCtx.ProjectID,
+				Actor:              actorPrincipal,
+				ActorDisplayName:   authCtx.Email,
+				ActorSlug:          nil,
+				TriggerInstanceURN: urn.NewTriggerInstance(instance.ID),
+				Name:               instance.Name,
+				DefinitionSlug:     instance.DefinitionSlug,
+			})
 		})
 		if err != nil {
 			return nil, fmt.Errorf("create trigger instance: %w", err)
@@ -426,6 +442,11 @@ func (t *ConfigureTrigger) upsertTrigger(
 			return nil, fmt.Errorf("trigger %s is %q, expected %q", existing.ID.String(), existing.DefinitionSlug, params.DefinitionSlug)
 		}
 
+		beforeView, err := buildTriggerInstanceSnapshot(existing, t.app.WebhookURL(existing))
+		if err != nil {
+			return nil, fmt.Errorf("build trigger instance before-snapshot: %w", err)
+		}
+
 		item, err = t.app.Update(ctx, bgtriggers.UpdateParams{
 			ID:             triggerID,
 			ProjectID:      *authCtx.ProjectID,
@@ -437,6 +458,23 @@ func (t *ConfigureTrigger) upsertTrigger(
 			TargetDisplay:  strings.TrimSpace(params.TargetDisplay),
 			Config:         params.Config,
 			Status:         status,
+		}, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
+			afterView, err := buildTriggerInstanceSnapshot(instance, t.app.WebhookURL(instance))
+			if err != nil {
+				return fmt.Errorf("build trigger instance after-snapshot: %w", err)
+			}
+			return audit.LogTriggerInstanceUpdate(ctx, dbtx, audit.LogTriggerInstanceUpdateEvent{
+				OrganizationID:                authCtx.ActiveOrganizationID,
+				ProjectID:                     *authCtx.ProjectID,
+				Actor:                         actorPrincipal,
+				ActorDisplayName:              authCtx.Email,
+				ActorSlug:                     nil,
+				TriggerInstanceURN:            urn.NewTriggerInstance(instance.ID),
+				Name:                          instance.Name,
+				DefinitionSlug:                instance.DefinitionSlug,
+				TriggerInstanceSnapshotBefore: beforeView,
+				TriggerInstanceSnapshotAfter:  afterView,
+			})
 		})
 		if err != nil {
 			return nil, fmt.Errorf("update trigger instance: %w", err)
@@ -499,6 +537,34 @@ func buildTriggerToolView(
 		WebhookURL:      webhookURL,
 		CreatedAt:       item.CreatedAt.Time.UTC().Format(time.RFC3339),
 		UpdatedAt:       item.UpdatedAt.Time.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+func buildTriggerInstanceSnapshot(item triggerrepo.TriggerInstance, webhookURL *string) (*types.TriggerInstance, error) {
+	config := map[string]any{}
+	if len(item.ConfigJson) > 0 {
+		if err := json.Unmarshal(item.ConfigJson, &config); err != nil {
+			return nil, fmt.Errorf("decode trigger config: %w", err)
+		}
+		if config == nil {
+			config = map[string]any{}
+		}
+	}
+
+	return &types.TriggerInstance{
+		ID:             item.ID.String(),
+		ProjectID:      item.ProjectID.String(),
+		DefinitionSlug: item.DefinitionSlug,
+		Name:           item.Name,
+		EnvironmentID:  conv.Ternary(item.EnvironmentID.Valid, conv.PtrEmpty(item.EnvironmentID.UUID.String()), nil),
+		TargetKind:     item.TargetKind,
+		TargetRef:      item.TargetRef,
+		TargetDisplay:  item.TargetDisplay,
+		Config:         config,
+		Status:         item.Status,
+		WebhookURL:     webhookURL,
+		CreatedAt:      item.CreatedAt.Time.Format(time.RFC3339),
+		UpdatedAt:      item.UpdatedAt.Time.Format(time.RFC3339),
 	}, nil
 }
 

--- a/server/internal/triggers/audit_test.go
+++ b/server/internal/triggers/audit_test.go
@@ -82,6 +82,43 @@ func TestDeleteTriggerInstance_RecordsAuditEvent(t *testing.T) {
 	require.Equal(t, "slack", row.SubjectSlug)
 }
 
+func TestUpdateTriggerInstance_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateTriggerInstance(ctx, newCreatePayload(ti.environmentID, "audit-update-before"))
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceUpdate)
+	require.NoError(t, err)
+
+	updated, err := ti.service.UpdateTriggerInstance(ctx, &gen.UpdateTriggerInstancePayload{
+		ID:               created.ID,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Name:             conv.PtrEmpty("audit-update-after"),
+		EnvironmentID:    nil,
+		TargetKind:       conv.PtrEmpty(bgtriggers.TargetKindNoop),
+		TargetRef:        conv.PtrEmpty("noop-ref-updated"),
+		TargetDisplay:    conv.PtrEmpty("Noop Updated"),
+		Config:           map[string]any{},
+		Status:           nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "audit-update-after", updated.Name)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceUpdate)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	row, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionTriggerInstanceUpdate)
+	require.NoError(t, err)
+	require.Equal(t, "trigger_instance", row.SubjectType)
+	require.Equal(t, "audit-update-after", row.SubjectDisplay)
+	require.Equal(t, "slack", row.SubjectSlug)
+}
+
 func TestPauseTriggerInstance_RecordsAuditEvent(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/triggers/audit_test.go
+++ b/server/internal/triggers/audit_test.go
@@ -1,0 +1,155 @@
+package triggers_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/triggers"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+func newCreatePayload(envID uuid.UUID, name string) *gen.CreateTriggerInstancePayload {
+	envIDStr := envID.String()
+	return &gen.CreateTriggerInstancePayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		DefinitionSlug:   "slack",
+		Name:             name,
+		EnvironmentID:    &envIDStr,
+		TargetKind:       bgtriggers.TargetKindNoop,
+		TargetRef:        "noop-ref",
+		TargetDisplay:    "Noop",
+		Config:           map[string]any{},
+		Status:           nil,
+	}
+}
+
+func TestCreateTriggerInstance_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceCreate)
+	require.NoError(t, err)
+
+	result, err := ti.service.CreateTriggerInstance(ctx, newCreatePayload(ti.environmentID, "audit-create"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.ID)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceCreate)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	row, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionTriggerInstanceCreate)
+	require.NoError(t, err)
+	require.Equal(t, "trigger_instance", row.SubjectType)
+	require.Equal(t, "audit-create", row.SubjectDisplay)
+	require.Equal(t, "slack", row.SubjectSlug)
+}
+
+func TestDeleteTriggerInstance_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateTriggerInstance(ctx, newCreatePayload(ti.environmentID, "audit-delete"))
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceDelete)
+	require.NoError(t, err)
+
+	err = ti.service.DeleteTriggerInstance(ctx, &gen.DeleteTriggerInstancePayload{
+		ID:               created.ID,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceDelete)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	row, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionTriggerInstanceDelete)
+	require.NoError(t, err)
+	require.Equal(t, "trigger_instance", row.SubjectType)
+	require.Equal(t, "audit-delete", row.SubjectDisplay)
+	require.Equal(t, "slack", row.SubjectSlug)
+}
+
+func TestPauseTriggerInstance_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateTriggerInstance(ctx, newCreatePayload(ti.environmentID, "audit-pause"))
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstancePause)
+	require.NoError(t, err)
+
+	paused, err := ti.service.PauseTriggerInstance(ctx, &gen.PauseTriggerInstancePayload{
+		ID:               created.ID,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, bgtriggers.StatusPaused, paused.Status)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstancePause)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	row, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionTriggerInstancePause)
+	require.NoError(t, err)
+	require.Equal(t, "trigger_instance", row.SubjectType)
+	require.Equal(t, "audit-pause", row.SubjectDisplay)
+	require.Equal(t, "slack", row.SubjectSlug)
+}
+
+func TestResumeTriggerInstance_RecordsAuditEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateTriggerInstance(ctx, &gen.CreateTriggerInstancePayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		DefinitionSlug:   "slack",
+		Name:             "audit-resume",
+		EnvironmentID:    conv.PtrEmpty(ti.environmentID.String()),
+		TargetKind:       bgtriggers.TargetKindNoop,
+		TargetRef:        "noop-ref",
+		TargetDisplay:    "Noop",
+		Config:           map[string]any{},
+		Status:           conv.PtrEmpty(bgtriggers.StatusPaused),
+	})
+	require.NoError(t, err)
+	require.Equal(t, bgtriggers.StatusPaused, created.Status)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceResume)
+	require.NoError(t, err)
+
+	resumed, err := ti.service.ResumeTriggerInstance(ctx, &gen.ResumeTriggerInstancePayload{
+		ID:               created.ID,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, bgtriggers.StatusActive, resumed.Status)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionTriggerInstanceResume)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	row, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionTriggerInstanceResume)
+	require.NoError(t, err)
+	require.Equal(t, "trigger_instance", row.SubjectType)
+	require.Equal(t, "audit-resume", row.SubjectDisplay)
+	require.Equal(t, "slack", row.SubjectSlug)
+}

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -30,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
+	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
@@ -217,6 +217,11 @@ func (s *Service) UpdateTriggerInstance(ctx context.Context, payload *gen.Update
 		configMap = payload.Config
 	}
 
+	beforeView, err := buildTriggerView(existing, s.app.WebhookURL(existing))
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "build trigger instance view").Log(ctx, s.logger)
+	}
+
 	item, err := s.app.Update(ctx, bgtriggers.UpdateParams{
 		ID:             triggerID,
 		ProjectID:      *authCtx.ProjectID,
@@ -228,6 +233,23 @@ func (s *Service) UpdateTriggerInstance(ctx context.Context, payload *gen.Update
 		TargetDisplay:  valueOrDefault(payload.TargetDisplay, existing.TargetDisplay),
 		Config:         configMap,
 		Status:         valueOrDefault(payload.Status, existing.Status),
+	}, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
+		afterView, err := buildTriggerView(instance, s.app.WebhookURL(instance))
+		if err != nil {
+			return fmt.Errorf("build trigger instance after-snapshot: %w", err)
+		}
+		return audit.LogTriggerInstanceUpdate(ctx, dbtx, audit.LogTriggerInstanceUpdateEvent{
+			OrganizationID:                authCtx.ActiveOrganizationID,
+			ProjectID:                     *authCtx.ProjectID,
+			Actor:                         urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName:              authCtx.Email,
+			ActorSlug:                     nil,
+			TriggerInstanceURN:            urn.NewTriggerInstance(instance.ID),
+			Name:                          instance.Name,
+			DefinitionSlug:                instance.DefinitionSlug,
+			TriggerInstanceSnapshotBefore: beforeView,
+			TriggerInstanceSnapshotAfter:  afterView,
+		})
 	})
 	if err != nil {
 		return nil, toTriggerError(ctx, s.logger, err, "update trigger instance")
@@ -396,26 +418,11 @@ func configJSONToMap(raw []byte) (map[string]any, error) {
 }
 
 func buildTriggerView(instance triggerrepo.TriggerInstance, webhookURL *string) (*types.TriggerInstance, error) {
-	config, err := configJSONToMap(instance.ConfigJson)
+	view, err := mv.BuildTriggerInstanceView(instance, webhookURL)
 	if err != nil {
-		return nil, fmt.Errorf("decode trigger config: %w", err)
+		return nil, fmt.Errorf("build trigger instance view: %w", err)
 	}
-
-	return &types.TriggerInstance{
-		ID:             instance.ID.String(),
-		ProjectID:      instance.ProjectID.String(),
-		DefinitionSlug: instance.DefinitionSlug,
-		Name:           instance.Name,
-		EnvironmentID:  conv.Ternary(instance.EnvironmentID.Valid, conv.PtrEmpty(instance.EnvironmentID.UUID.String()), nil),
-		TargetKind:     instance.TargetKind,
-		TargetRef:      instance.TargetRef,
-		TargetDisplay:  instance.TargetDisplay,
-		Config:         config,
-		Status:         instance.Status,
-		WebhookURL:     webhookURL,
-		CreatedAt:      instance.CreatedAt.Time.Format(time.RFC3339),
-		UpdatedAt:      instance.UpdatedAt.Time.Format(time.RFC3339),
-	}, nil
+	return view, nil
 }
 
 func buildDefinitionView(definition bgtriggers.Definition) *types.TriggerDefinition {

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -22,6 +22,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/triggers"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -32,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type Service struct {
@@ -160,6 +162,17 @@ func (s *Service) CreateTriggerInstance(ctx context.Context, payload *gen.Create
 		TargetDisplay:  payload.TargetDisplay,
 		Config:         payload.Config,
 		Status:         normalizeTriggerStatus(payload.Status),
+	}, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
+		return audit.LogTriggerInstanceCreate(ctx, dbtx, audit.LogTriggerInstanceCreateEvent{
+			OrganizationID:     authCtx.ActiveOrganizationID,
+			ProjectID:          *authCtx.ProjectID,
+			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName:   authCtx.Email,
+			ActorSlug:          nil,
+			TriggerInstanceURN: urn.NewTriggerInstance(instance.ID),
+			Name:               instance.Name,
+			DefinitionSlug:     instance.DefinitionSlug,
+		})
 	})
 	if err != nil {
 		return nil, toTriggerError(ctx, s.logger, err, "create trigger instance")
@@ -238,7 +251,18 @@ func (s *Service) DeleteTriggerInstance(ctx context.Context, payload *gen.Delete
 		return oops.E(oops.CodeBadRequest, err, "invalid trigger id").Log(ctx, s.logger)
 	}
 
-	if err := s.app.Delete(ctx, *authCtx.ProjectID, triggerID); err != nil {
+	if err := s.app.Delete(ctx, *authCtx.ProjectID, triggerID, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
+		return audit.LogTriggerInstanceDelete(ctx, dbtx, audit.LogTriggerInstanceDeleteEvent{
+			OrganizationID:     authCtx.ActiveOrganizationID,
+			ProjectID:          *authCtx.ProjectID,
+			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName:   authCtx.Email,
+			ActorSlug:          nil,
+			TriggerInstanceURN: urn.NewTriggerInstance(instance.ID),
+			Name:               instance.Name,
+			DefinitionSlug:     instance.DefinitionSlug,
+		})
+	}); err != nil {
 		return toTriggerError(ctx, s.logger, err, "delete trigger instance")
 	}
 
@@ -246,25 +270,52 @@ func (s *Service) DeleteTriggerInstance(ctx context.Context, payload *gen.Delete
 }
 
 func (s *Service) PauseTriggerInstance(ctx context.Context, payload *gen.PauseTriggerInstancePayload) (*types.TriggerInstance, error) {
-	return s.setTriggerStatus(ctx, payload.ID, bgtriggers.StatusPaused)
-}
-
-func (s *Service) ResumeTriggerInstance(ctx context.Context, payload *gen.ResumeTriggerInstancePayload) (*types.TriggerInstance, error) {
-	return s.setTriggerStatus(ctx, payload.ID, bgtriggers.StatusActive)
-}
-
-func (s *Service) setTriggerStatus(ctx context.Context, id string, status string) (*types.TriggerInstance, error) {
 	authCtx, err := requireProjectAuthContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	return s.setTriggerStatus(ctx, authCtx, payload.ID, bgtriggers.StatusPaused, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
+		return audit.LogTriggerInstancePause(ctx, dbtx, audit.LogTriggerInstancePauseEvent{
+			OrganizationID:     authCtx.ActiveOrganizationID,
+			ProjectID:          *authCtx.ProjectID,
+			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName:   authCtx.Email,
+			ActorSlug:          nil,
+			TriggerInstanceURN: urn.NewTriggerInstance(instance.ID),
+			Name:               instance.Name,
+			DefinitionSlug:     instance.DefinitionSlug,
+		})
+	})
+}
+
+func (s *Service) ResumeTriggerInstance(ctx context.Context, payload *gen.ResumeTriggerInstancePayload) (*types.TriggerInstance, error) {
+	authCtx, err := requireProjectAuthContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.setTriggerStatus(ctx, authCtx, payload.ID, bgtriggers.StatusActive, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
+		return audit.LogTriggerInstanceResume(ctx, dbtx, audit.LogTriggerInstanceResumeEvent{
+			OrganizationID:     authCtx.ActiveOrganizationID,
+			ProjectID:          *authCtx.ProjectID,
+			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName:   authCtx.Email,
+			ActorSlug:          nil,
+			TriggerInstanceURN: urn.NewTriggerInstance(instance.ID),
+			Name:               instance.Name,
+			DefinitionSlug:     instance.DefinitionSlug,
+		})
+	})
+}
+
+func (s *Service) setTriggerStatus(ctx context.Context, authCtx *contextvalues.AuthContext, id string, status string, hooks ...bgtriggers.InstanceDBHook) (*types.TriggerInstance, error) {
 	triggerID, err := uuid.Parse(id)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid trigger id").Log(ctx, s.logger)
 	}
 
-	item, err := s.app.SetStatus(ctx, *authCtx.ProjectID, triggerID, status)
+	item, err := s.app.SetStatus(ctx, *authCtx.ProjectID, triggerID, status, hooks...)
 	if err != nil {
 		return nil, toTriggerError(ctx, s.logger, err, "set trigger status")
 	}

--- a/server/internal/triggers/setup_test.go
+++ b/server/internal/triggers/setup_test.go
@@ -1,0 +1,126 @@
+package triggers_test
+
+import (
+	"context"
+	"log"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	environmentsrepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+	"github.com/speakeasy-api/gram/server/internal/triggers"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+		os.Exit(1)
+	}
+
+	infra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("cleanup test infrastructure: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+type stubEnvLoader struct {
+	values map[string]string
+}
+
+func (s stubEnvLoader) Load(_ context.Context, _ uuid.UUID, _ toolconfig.SlugOrID) (map[string]string, error) {
+	return s.values, nil
+}
+
+type testInstance struct {
+	service       *triggers.Service
+	conn          *pgxpool.Pool
+	environmentID uuid.UUID
+}
+
+func newTestService(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	billingClient := billing.NewStubClient(logger, tracerProvider)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+
+	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	envRow, err := environmentsrepo.New(conn).CreateEnvironment(ctx, environmentsrepo.CreateEnvironmentParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		Name:           "test",
+		Slug:           "test-" + uuid.NewString()[:8],
+		Description:    pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	loader := stubEnvLoader{values: map[string]string{"SLACK_SIGNING_SECRET": "test-secret"}}
+
+	serverURL, err := url.Parse("https://gram.test.local")
+	require.NoError(t, err)
+
+	app := bgtriggers.NewApp(
+		logger,
+		conn,
+		nil,
+		loader,
+		bgtriggers.NewTriggerDeliveryLogger(func(_ context.Context, _ bgtriggers.TriggerDeliveryLog) {}),
+		serverURL,
+	)
+
+	svc := triggers.NewService(
+		logger,
+		tracerProvider,
+		conn,
+		sessionManager,
+		authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache),
+		app,
+	)
+
+	return ctx, &testInstance{
+		service:       svc,
+		conn:          conn,
+		environmentID: envRow.ID,
+	}
+}

--- a/server/internal/urn/trigger_instance.go
+++ b/server/internal/urn/trigger_instance.go
@@ -1,0 +1,156 @@
+package urn
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type TriggerInstance struct {
+	ID uuid.UUID
+
+	checked bool
+	err     error
+}
+
+func NewTriggerInstance(id uuid.UUID) TriggerInstance {
+	a := TriggerInstance{
+		ID:      id,
+		checked: false,
+		err:     nil,
+	}
+
+	_ = a.validate()
+
+	return a
+}
+
+func ParseTriggerInstance(value string) (TriggerInstance, error) {
+	if value == "" {
+		return TriggerInstance{}, fmt.Errorf("%w: empty string", ErrInvalid)
+	}
+
+	parts := strings.SplitN(value, delimiter, 2)
+	if len(parts) != 2 || parts[1] == "" || strings.Contains(parts[1], delimiter) {
+		return TriggerInstance{}, fmt.Errorf("%w: expected two segments (trigger-instance:<uuid>)", ErrInvalid)
+	}
+
+	if parts[0] != "trigger-instance" {
+		truncated := parts[0][:min(maxSegmentLength, len(parts[0]))]
+		return TriggerInstance{}, fmt.Errorf("%w: expected trigger-instance urn (got: %q)", ErrInvalid, truncated)
+	}
+
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return TriggerInstance{}, fmt.Errorf("%w: invalid trigger-instance uuid", ErrInvalid)
+	}
+
+	return NewTriggerInstance(id), nil
+}
+
+func (u TriggerInstance) IsZero() bool {
+	return u.ID == uuid.Nil
+}
+
+func (u TriggerInstance) String() string {
+	return "trigger-instance" + delimiter + u.ID.String()
+}
+
+func (u TriggerInstance) MarshalJSON() ([]byte, error) {
+	if err := u.validate(); err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(u.String())
+	if err != nil {
+		return nil, fmt.Errorf("trigger-instance urn to json: %w", err)
+	}
+
+	return b, nil
+}
+
+func (u *TriggerInstance) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("read trigger-instance urn string from json: %w", err)
+	}
+
+	parsed, err := ParseTriggerInstance(s)
+	if err != nil {
+		return fmt.Errorf("parse trigger-instance urn json string: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u *TriggerInstance) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("cannot scan %T into TriggerInstance", value)
+	}
+
+	parsed, err := ParseTriggerInstance(s)
+	if err != nil {
+		return fmt.Errorf("scan database value: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u TriggerInstance) Value() (driver.Value, error) {
+	if err := u.validate(); err != nil {
+		return nil, err
+	}
+
+	return u.String(), nil
+}
+
+func (u TriggerInstance) MarshalText() ([]byte, error) {
+	if err := u.validate(); err != nil {
+		return nil, fmt.Errorf("marshal trigger-instance urn text: %w", err)
+	}
+
+	return []byte(u.String()), nil
+}
+
+func (u *TriggerInstance) UnmarshalText(text []byte) error {
+	parsed, err := ParseTriggerInstance(string(text))
+	if err != nil {
+		return fmt.Errorf("unmarshal trigger-instance urn text: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u *TriggerInstance) validate() error {
+	if u.checked {
+		return u.err
+	}
+
+	u.checked = true
+
+	if u.ID == uuid.Nil {
+		u.err = fmt.Errorf("%w: empty id", ErrInvalid)
+		return u.err
+	}
+
+	return nil
+}

--- a/server/internal/urn/trigger_instance_test.go
+++ b/server/internal/urn/trigger_instance_test.go
@@ -1,0 +1,64 @@
+package urn_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggerInstanceRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	original := urn.NewTriggerInstance(id)
+
+	require.Equal(t, "trigger-instance:44444444-4444-4444-4444-444444444444", original.String())
+
+	parsed, err := urn.ParseTriggerInstance(original.String())
+	require.NoError(t, err)
+	require.Equal(t, original.ID, parsed.ID)
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	require.Equal(t, `"trigger-instance:44444444-4444-4444-4444-444444444444"`, string(data))
+
+	var fromJSON urn.TriggerInstance
+	err = json.Unmarshal(data, &fromJSON)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, fromJSON.ID)
+
+	text, err := original.MarshalText()
+	require.NoError(t, err)
+
+	var fromText urn.TriggerInstance
+	err = fromText.UnmarshalText(text)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, fromText.ID)
+
+	value, err := original.Value()
+	require.NoError(t, err)
+
+	var fromDB urn.TriggerInstance
+	err = fromDB.Scan(value)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, fromDB.ID)
+}
+
+func TestTriggerInstanceRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	_, err := urn.ParseTriggerInstance("")
+	require.ErrorIs(t, err, urn.ErrInvalid)
+
+	_, err = urn.ParseTriggerInstance("toolset:44444444-4444-4444-4444-444444444444")
+	require.ErrorIs(t, err, urn.ErrInvalid)
+
+	_, err = urn.ParseTriggerInstance("trigger-instance:not-a-uuid")
+	require.ErrorIs(t, err, urn.ErrInvalid)
+
+	_, err = urn.NewTriggerInstance(uuid.Nil).MarshalJSON()
+	require.ErrorIs(t, err, urn.ErrInvalid)
+}


### PR DESCRIPTION
## Summary

Audit-log coverage for trigger instance mutations across both the management API and the platform tools path: `CreateTriggerInstance`, `UpdateTriggerInstance`, `DeleteTriggerInstance`, `PauseTriggerInstance`, `ResumeTriggerInstance` ([AGE-1808](https://linear.app/speakeasy/issue/AGE-1808)).

## Changes

- New `urn.TriggerInstance` URN type.
- New `trigger_instance` audit subject with `create` / `update` / `delete` / `pause` / `resume` actions in `server/internal/audit/triggerinstances.go`. Update carries typed before/after `*types.TriggerInstance` snapshots.
- `bgtriggers.App.Create` / `Update` / `Delete` / `SetStatus` now run their repo writes inside a transaction and accept variadic `InstanceDBHook` callbacks executed pre-commit, so the audit insert commits atomically with the mutation. Schedule reconciliation (Temporal) stays post-commit. Rollbacks go through `o11y.NoLogDefer`.
- Management API handlers in `server/internal/triggers/impl.go` pass audit hooks into the App.
- `platformtools/triggers/tools.go` (the LLM-driven Configure tool) now also passes audit hooks for both create and update, using the caller's `authCtx.UserID` as actor — same model as the dashboard/CLI path.
- Trigger view builder moved to `mv.BuildTriggerInstanceView` so the management service and platform tools share the same conversion.
- Split the audit reader Goa service into a new `auditapi` package. The writer functions (`audit.LogXxx`) stay in `audit`. This breaks an import cycle that appeared once `platformtools/triggers` needed to call `audit.LogXxx`: `mv/toolset.go` already imports `platformtools`, so any audit caller below `platformtools` would close the loop through `audit → auth/sessions → mv → platformtools`. Splitting the reader out leaves the writer package as a leaf.

## Tests

- `server/internal/triggers/audit_test.go` covers create / update / delete / pause / resume end-to-end and asserts the audit row delta is exactly +1 with the expected subject type / display / slug.
- `urn.TriggerInstance` round-trip + invalid-input tests.
- Existing `auditapi` reader tests moved with the package; they still exercise `/rpc/auditlogs.list` and `listFacets`.

✻ Clauded...