### PR TITLE
fix(triggers): decode polymorphic Slack event payloads

### DIFF
--- a/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
@@ -68,18 +68,13 @@ export const SLACK_EVENT_BINDINGS: Record<string, SlackEventBinding> = {
   file_shared: { bot_events: ["file_shared"], scopes: ["files:read"] },
   file_unshared: { bot_events: ["file_unshared"], scopes: ["files:read"] },
   group_archive: { bot_events: ["group_archive"], scopes: ["groups:read"] },
-  group_close: { bot_events: ["group_close"], scopes: ["groups:read"] },
   group_deleted: { bot_events: ["group_deleted"], scopes: ["groups:read"] },
   group_left: { bot_events: ["group_left"], scopes: ["groups:read"] },
-  group_open: { bot_events: ["group_open"], scopes: ["groups:read"] },
   group_rename: { bot_events: ["group_rename"], scopes: ["groups:read"] },
   group_unarchive: {
     bot_events: ["group_unarchive"],
     scopes: ["groups:read"],
   },
-  im_close: { bot_events: ["im_close"], scopes: ["im:read"] },
-  im_created: { bot_events: ["im_created"], scopes: ["im:read"] },
-  im_open: { bot_events: ["im_open"], scopes: ["im:read"] },
   link_shared: { bot_events: ["link_shared"], scopes: ["links:read"] },
   member_joined_channel: {
     bot_events: ["member_joined_channel"],

--- a/server/internal/assistants/source_adapter.go
+++ b/server/internal/assistants/source_adapter.go
@@ -39,6 +39,7 @@ type slackEventPayload struct {
 	ChannelID    string `json:"channel_id"`
 	ThreadID     string `json:"thread_id"`
 	UserID       string `json:"user_id,omitempty"`
+	InviterID    string `json:"inviter_id,omitempty"`
 	BotID        string `json:"bot_id,omitempty"`
 	AppID        string `json:"app_id,omitempty"`
 	Text         string `json:"text"`
@@ -91,6 +92,9 @@ func (slackAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error)
 	}
 	if payload.UserID != "" {
 		fmt.Fprintf(&b, "UserID: %s\n", payload.UserID)
+	}
+	if payload.InviterID != "" {
+		fmt.Fprintf(&b, "InviterID: %s\n", payload.InviterID)
 	}
 	if payload.Timestamp != "" {
 		fmt.Fprintf(&b, "Timestamp: %s\n", payload.Timestamp)

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -247,7 +247,21 @@ func decodeSlackEvent(raw json.RawMessage) (slackEventRequestBody, error) {
 		if err := json.Unmarshal(raw, &ev); err != nil {
 			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
 		}
-		return slackEventRequestBody{Type: ev.Type, User: ev.User.ID}, nil
+		return slackEventRequestBody{
+			Type:     ev.Type,
+			Subtype:  "",
+			Text:     "",
+			User:     ev.User.ID,
+			Inviter:  "",
+			BotID:    "",
+			AppID:    "",
+			Channel:  "",
+			ThreadTs: "",
+			Ts:       "",
+			Reaction: "",
+			ItemUser: "",
+			Item:     nil,
+		}, nil
 	case "channel_created":
 		var ev slackChannelObjectEventBody
 		if err := json.Unmarshal(raw, &ev); err != nil {
@@ -255,25 +269,81 @@ func decodeSlackEvent(raw json.RawMessage) (slackEventRequestBody, error) {
 		}
 		// channel_created carries the actor inside channel.creator; surface it
 		// as the normalized actor user so downstream consumers see a unified shape.
-		return slackEventRequestBody{Type: ev.Type, Channel: ev.Channel.ID, User: ev.Channel.Creator}, nil
+		return slackEventRequestBody{
+			Type:     ev.Type,
+			Subtype:  "",
+			Text:     "",
+			User:     ev.Channel.Creator,
+			Inviter:  "",
+			BotID:    "",
+			AppID:    "",
+			Channel:  ev.Channel.ID,
+			ThreadTs: "",
+			Ts:       "",
+			Reaction: "",
+			ItemUser: "",
+			Item:     nil,
+		}, nil
 	case "channel_rename", "group_rename":
 		var ev slackChannelObjectEventBody
 		if err := json.Unmarshal(raw, &ev); err != nil {
 			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
 		}
-		return slackEventRequestBody{Type: ev.Type, Channel: ev.Channel.ID}, nil
+		return slackEventRequestBody{
+			Type:     ev.Type,
+			Subtype:  "",
+			Text:     "",
+			User:     "",
+			Inviter:  "",
+			BotID:    "",
+			AppID:    "",
+			Channel:  ev.Channel.ID,
+			ThreadTs: "",
+			Ts:       "",
+			Reaction: "",
+			ItemUser: "",
+			Item:     nil,
+		}, nil
 	case "channel_id_changed":
 		var ev slackChannelIDChangedEventBody
 		if err := json.Unmarshal(raw, &ev); err != nil {
 			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
 		}
-		return slackEventRequestBody{Type: ev.Type, Channel: ev.NewChannelID}, nil
+		return slackEventRequestBody{
+			Type:     ev.Type,
+			Subtype:  "",
+			Text:     "",
+			User:     "",
+			Inviter:  "",
+			BotID:    "",
+			AppID:    "",
+			Channel:  ev.NewChannelID,
+			ThreadTs: "",
+			Ts:       "",
+			Reaction: "",
+			ItemUser: "",
+			Item:     nil,
+		}, nil
 	case "file_shared":
 		var ev slackFileSharedEventBody
 		if err := json.Unmarshal(raw, &ev); err != nil {
 			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
 		}
-		return slackEventRequestBody{Type: ev.Type, User: ev.UserID, Channel: ev.ChannelID}, nil
+		return slackEventRequestBody{
+			Type:     ev.Type,
+			Subtype:  "",
+			Text:     "",
+			User:     ev.UserID,
+			Inviter:  "",
+			BotID:    "",
+			AppID:    "",
+			Channel:  ev.ChannelID,
+			ThreadTs: "",
+			Ts:       "",
+			Reaction: "",
+			ItemUser: "",
+			Item:     nil,
+		}, nil
 	default:
 		var ev slackEventRequestBody
 		if err := json.Unmarshal(raw, &ev); err != nil {

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -142,19 +142,24 @@ type cronTriggerConfig struct {
 func (c cronTriggerConfig) Filter(_ any) (bool, error) { return true, nil }
 
 type slackEventRequest struct {
-	Type      string                `json:"type"`
-	Challenge string                `json:"challenge,omitempty"`
-	TeamID    string                `json:"team_id,omitempty"`
-	EventID   string                `json:"event_id,omitempty"`
-	EventTime int64                 `json:"event_time,omitempty"`
-	Event     slackEventRequestBody `json:"event"`
+	Type      string          `json:"type"`
+	Challenge string          `json:"challenge,omitempty"`
+	TeamID    string          `json:"team_id,omitempty"`
+	EventID   string          `json:"event_id,omitempty"`
+	EventTime int64           `json:"event_time,omitempty"`
+	Event     json.RawMessage `json:"event,omitempty"`
 }
 
+// slackEventRequestBody is the normalized intermediate shape produced by
+// decodeSlackEvent. JSON tags also let it deserialize directly from the
+// "string user / string channel" majority of Slack events; per-event-type
+// branches in decodeSlackEvent handle the polymorphic shapes.
 type slackEventRequestBody struct {
 	Type     string `json:"type"`
 	Subtype  string `json:"subtype,omitempty"`
 	Text     string `json:"text,omitempty"`
 	User     string `json:"user,omitempty"`
+	Inviter  string `json:"inviter,omitempty"`
 	BotID    string `json:"bot_id,omitempty"`
 	AppID    string `json:"app_id,omitempty"`
 	Channel  string `json:"channel,omitempty"`
@@ -169,10 +174,113 @@ type slackEventRequestBody struct {
 	Item     *slackEventItemBody `json:"item,omitempty"`
 }
 
+// slackUserChangeEventBody matches the team_join and user_change payloads,
+// where Slack sends event.user as a User object rather than a user ID.
+// See https://docs.slack.dev/reference/events/team_join and
+// https://docs.slack.dev/reference/events/user_change.
+type slackUserChangeEventBody struct {
+	Type string    `json:"type"`
+	User slackUser `json:"user"`
+}
+
+// slackUser models the subset of Slack's User object
+// (https://docs.slack.dev/reference/objects/user-object) that we surface
+// downstream.
+type slackUser struct {
+	ID string `json:"id"`
+}
+
+// slackChannelObjectEventBody matches channel_created, channel_rename, and
+// group_rename, where Slack sends event.channel as a channel object rather
+// than a channel ID. See https://docs.slack.dev/reference/events/channel_created,
+// https://docs.slack.dev/reference/events/channel_rename, and
+// https://docs.slack.dev/reference/events/group_rename.
+type slackChannelObjectEventBody struct {
+	Type    string             `json:"type"`
+	Channel slackChannelObject `json:"channel"`
+}
+
+type slackChannelObject struct {
+	ID      string `json:"id"`
+	Creator string `json:"creator,omitempty"`
+}
+
+// slackFileSharedEventBody matches file_shared, where the actor is carried in
+// `event.user_id` (not `event.user`) and the channel in `event.channel_id`.
+// See https://docs.slack.dev/reference/events/file_shared.
+type slackFileSharedEventBody struct {
+	Type      string `json:"type"`
+	UserID    string `json:"user_id,omitempty"`
+	ChannelID string `json:"channel_id,omitempty"`
+}
+
+// slackChannelIDChangedEventBody matches channel_id_changed, which carries
+// new_channel_id instead of an `event.channel` field.
+// See https://docs.slack.dev/reference/events/channel_id_changed.
+type slackChannelIDChangedEventBody struct {
+	Type         string `json:"type"`
+	OldChannelID string `json:"old_channel_id,omitempty"`
+	NewChannelID string `json:"new_channel_id,omitempty"`
+}
+
 type slackEventItemBody struct {
 	Type    string `json:"type,omitempty"`
 	Channel string `json:"channel,omitempty"`
 	Ts      string `json:"ts,omitempty"`
+}
+
+// decodeSlackEvent decodes the inner `event` payload of an event_callback,
+// dispatching by event type because Slack's `event.user` and `event.channel`
+// are sometimes objects (e.g. team_join, channel_rename) and sometimes string
+// IDs (e.g. message, app_mention). Each branch normalizes the payload back
+// into slackEventRequestBody for downstream code.
+func decodeSlackEvent(raw json.RawMessage) (slackEventRequestBody, error) {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return slackEventRequestBody{}, fmt.Errorf("event type: %w", err)
+	}
+	switch probe.Type {
+	case "team_join", "user_change":
+		var ev slackUserChangeEventBody
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
+		}
+		return slackEventRequestBody{Type: ev.Type, User: ev.User.ID}, nil
+	case "channel_created":
+		var ev slackChannelObjectEventBody
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
+		}
+		// channel_created carries the actor inside channel.creator; surface it
+		// as the normalized actor user so downstream consumers see a unified shape.
+		return slackEventRequestBody{Type: ev.Type, Channel: ev.Channel.ID, User: ev.Channel.Creator}, nil
+	case "channel_rename", "group_rename":
+		var ev slackChannelObjectEventBody
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
+		}
+		return slackEventRequestBody{Type: ev.Type, Channel: ev.Channel.ID}, nil
+	case "channel_id_changed":
+		var ev slackChannelIDChangedEventBody
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
+		}
+		return slackEventRequestBody{Type: ev.Type, Channel: ev.NewChannelID}, nil
+	case "file_shared":
+		var ev slackFileSharedEventBody
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return slackEventRequestBody{}, fmt.Errorf("%s event: %w", probe.Type, err)
+		}
+		return slackEventRequestBody{Type: ev.Type, User: ev.UserID, Channel: ev.ChannelID}, nil
+	default:
+		var ev slackEventRequestBody
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return slackEventRequestBody{}, fmt.Errorf("event: %w", err)
+		}
+		return ev, nil
+	}
 }
 
 type slackTriggerEvent struct {
@@ -182,11 +290,18 @@ type slackTriggerEvent struct {
 	TeamID       string `json:"team_id,omitempty" cel:"team_id"`
 	ChannelID    string `json:"channel_id,omitempty" cel:"channel_id"`
 	ThreadID     string `json:"thread_id,omitempty" cel:"thread_id"`
-	UserID       string `json:"user_id,omitempty" cel:"user_id"`
-	BotID        string `json:"bot_id,omitempty" cel:"bot_id"`
-	AppID        string `json:"app_id,omitempty" cel:"app_id"`
-	Text         string `json:"text,omitempty" cel:"text"`
-	Timestamp    string `json:"timestamp,omitempty" cel:"timestamp"`
+	// UserID is the normalized actor for the event: the user who took the
+	// action that produced it. Source varies by event type (event.user,
+	// event.user.id, event.user_id, event.channel.creator).
+	UserID string `json:"user_id,omitempty" cel:"user_id"`
+	// InviterID is set on member_joined_channel when the join was the result
+	// of an invitation. Empty if the user joined themselves or was added by
+	// default channel rules.
+	InviterID string `json:"inviter_id,omitempty" cel:"inviter_id"`
+	BotID     string `json:"bot_id,omitempty" cel:"bot_id"`
+	AppID     string `json:"app_id,omitempty" cel:"app_id"`
+	Text      string `json:"text,omitempty" cel:"text"`
+	Timestamp string `json:"timestamp,omitempty" cel:"timestamp"`
 
 	// Reaction-event fields exposed to CEL filters and the assistant adapter.
 	// Empty for non-reaction events.
@@ -222,15 +337,10 @@ var supportedSlackEventTypes = []string{
 	"file_shared",
 	"file_unshared",
 	"group_archive",
-	"group_close",
 	"group_deleted",
 	"group_left",
-	"group_open",
 	"group_rename",
 	"group_unarchive",
-	"im_close",
-	"im_created",
-	"im_open",
 	"link_shared",
 	"member_joined_channel",
 	"member_left_channel",
@@ -364,11 +474,19 @@ func newSlackDefinition() Definition {
 				}, nil
 			}
 
+			if len(req.Event) == 0 {
+				return nil, fmt.Errorf("decode slack payload: missing event")
+			}
+			event, err := decodeSlackEvent(req.Event)
+			if err != nil {
+				return nil, fmt.Errorf("decode slack payload: %w", err)
+			}
+
 			// thread_ts is only set for replies inside a thread. For top-level
 			// messages we key the correlation on the channel alone so a user
 			// sending multiple standalone messages in a DM or channel lands
 			// on a single Gram thread rather than spawning one per message.
-			threadID := req.Event.ThreadTs
+			threadID := event.ThreadTs
 
 			eventID := req.EventID
 			if eventID == "" {
@@ -378,15 +496,15 @@ func newSlackDefinition() Definition {
 			// Reaction events carry the channel + ts of the reacted-to message
 			// in `item`. Fall back to those so threading aligns with the
 			// originating message and CEL filters / correlation work.
-			channelID := req.Event.Channel
-			timestamp := req.Event.Ts
+			channelID := event.Channel
+			timestamp := event.Ts
 			var (
 				itemType, itemChannel, itemTs string
 			)
-			if req.Event.Item != nil {
-				itemType = req.Event.Item.Type
-				itemChannel = req.Event.Item.Channel
-				itemTs = req.Event.Item.Ts
+			if event.Item != nil {
+				itemType = event.Item.Type
+				itemChannel = event.Item.Channel
+				itemTs = event.Item.Ts
 				if channelID == "" {
 					channelID = itemChannel
 				}
@@ -400,18 +518,19 @@ func newSlackDefinition() Definition {
 
 			normalizedEvent := slackTriggerEvent{
 				EnvelopeType: req.Type,
-				EventType:    req.Event.Type,
-				Subtype:      req.Event.Subtype,
+				EventType:    event.Type,
+				Subtype:      event.Subtype,
 				TeamID:       req.TeamID,
 				ChannelID:    channelID,
 				ThreadID:     threadID,
-				UserID:       req.Event.User,
-				BotID:        req.Event.BotID,
-				AppID:        req.Event.AppID,
-				Text:         req.Event.Text,
+				UserID:       event.User,
+				InviterID:    event.Inviter,
+				BotID:        event.BotID,
+				AppID:        event.AppID,
+				Text:         event.Text,
 				Timestamp:    timestamp,
-				Reaction:     req.Event.Reaction,
-				ItemUserID:   req.Event.ItemUser,
+				Reaction:     event.Reaction,
+				ItemUserID:   event.ItemUser,
 				ItemChannel:  itemChannel,
 				ItemTs:       itemTs,
 				ItemType:     itemType,

--- a/server/internal/background/triggers/definitions_test.go
+++ b/server/internal/background/triggers/definitions_test.go
@@ -195,6 +195,101 @@ func TestSlackFilterRejectsDisabledEventType(t *testing.T) {
 	require.False(t, match)
 }
 
+func TestDecodeSlackEventStringUser(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"type":"app_mention","user":"U123","channel":"C1","ts":"1.0","text":"hi"}`)
+	got, err := decodeSlackEvent(raw)
+	require.NoError(t, err)
+	require.Equal(t, "app_mention", got.Type)
+	require.Equal(t, "U123", got.User)
+	require.Equal(t, "C1", got.Channel)
+	require.Equal(t, "hi", got.Text)
+}
+
+func TestDecodeSlackEventUserObject(t *testing.T) {
+	t.Parallel()
+
+	for _, eventType := range []string{"team_join", "user_change"} {
+		t.Run(eventType, func(t *testing.T) {
+			t.Parallel()
+
+			raw := json.RawMessage(fmt.Sprintf(
+				`{"type":%q,"user":{"id":"U999","team_id":"T1","name":"alice","real_name":"Alice","is_bot":false}}`,
+				eventType,
+			))
+			got, err := decodeSlackEvent(raw)
+			require.NoError(t, err)
+			require.Equal(t, eventType, got.Type)
+			require.Equal(t, "U999", got.User)
+		})
+	}
+}
+
+func TestDecodeSlackEventChannelObject(t *testing.T) {
+	t.Parallel()
+
+	for _, eventType := range []string{"channel_rename", "group_rename"} {
+		t.Run(eventType, func(t *testing.T) {
+			t.Parallel()
+
+			raw := json.RawMessage(fmt.Sprintf(
+				`{"type":%q,"channel":{"id":"C123","name":"new-name","created":1360782804}}`,
+				eventType,
+			))
+			got, err := decodeSlackEvent(raw)
+			require.NoError(t, err)
+			require.Equal(t, eventType, got.Type)
+			require.Equal(t, "C123", got.Channel)
+			require.Empty(t, got.User)
+		})
+	}
+}
+
+func TestDecodeSlackEventChannelCreated(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"type":"channel_created","channel":{"id":"C024BE91L","name":"fun","created":1360782804,"creator":"U024BE7LH"}}`)
+	got, err := decodeSlackEvent(raw)
+	require.NoError(t, err)
+	require.Equal(t, "channel_created", got.Type)
+	require.Equal(t, "C024BE91L", got.Channel)
+	require.Equal(t, "U024BE7LH", got.User)
+}
+
+func TestDecodeSlackEventChannelIDChanged(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"type":"channel_id_changed","old_channel_id":"G012Y48650T","new_channel_id":"C012Y48650T","event_ts":"1612206778.000000"}`)
+	got, err := decodeSlackEvent(raw)
+	require.NoError(t, err)
+	require.Equal(t, "channel_id_changed", got.Type)
+	require.Equal(t, "C012Y48650T", got.Channel)
+}
+
+func TestDecodeSlackEventFileShared(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"type":"file_shared","file_id":"F2147483862","user_id":"U0Z7K8SRH","channel_id":"C0Z7K8SRH","file":{"id":"F2147483862"},"event_ts":"1361482916.000004"}`)
+	got, err := decodeSlackEvent(raw)
+	require.NoError(t, err)
+	require.Equal(t, "file_shared", got.Type)
+	require.Equal(t, "U0Z7K8SRH", got.User)
+	require.Equal(t, "C0Z7K8SRH", got.Channel)
+}
+
+func TestDecodeSlackEventMemberJoinedChannel(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"type":"member_joined_channel","user":"W123ABC456","channel":"C0698JE0H","channel_type":"C","team":"T0E2GE343","inviter":"U123456789"}`)
+	got, err := decodeSlackEvent(raw)
+	require.NoError(t, err)
+	require.Equal(t, "member_joined_channel", got.Type)
+	require.Equal(t, "W123ABC456", got.User)
+	require.Equal(t, "C0698JE0H", got.Channel)
+	require.Equal(t, "U123456789", got.Inviter)
+}
+
 func TestCronFilterAlwaysReturnsTrue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Slack sends `event.user` as a User object on `team_join` / `user_change` and `event.channel` as a Channel object on `channel_created` / `channel_rename` / `group_rename`. The struct typed both as `string`, producing prod 500s on every webhook for a subscribed workspace event of the object-shaped variety: `cannot unmarshal object into Go struct field slackEventRequestBody.event.user of type string`. Trigger `019dddea-a4ba-76f9-a81b-ab47730b1458` was failing this on 2026-04-30 ~10:45 UTC.
- Switched the envelope's `event` field to `json.RawMessage` and added a typed decoder that dispatches per `supportedSlackEventTypes` against Slack's documented schema:
  - `team_join`, `user_change` → `user.id`
  - `channel_created` → `channel.id` + `channel.creator`
  - `channel_rename`, `group_rename` → `channel.id`
  - `channel_id_changed` → `new_channel_id`
  - `file_shared` → `user_id` + `channel_id` (not `user` / `channel`)
  - everything else decodes the existing string-shaped body unchanged
- Normalized the consumer-facing shape so the assistant adapter sees a unified contract regardless of which Slack event arrived: `UserID` is populated from whichever wire location carries the actor (`event.user`, `event.user.id`, `event.user_id`, `event.channel.creator`), and a new `InviterID` field surfaces `member_joined_channel.inviter`.
- Dropped `group_close`, `group_open`, `im_close`, `im_created`, `im_open` from the supported event list and the onboarding Slack manifest — these are RTM-only and aren't delivered over the Events API.

## Related

- [AGE-2028 — feat: support temporary auto-muting for noisy trigger alerts](https://linear.app/speakeasy/issue/AGE-2028/feat-support-temporary-auto-muting-for-noisy-trigger-alerts)

✻ Clauded...