### PR TITLE
chore: add workos sync utility helpers

### DIFF
--- a/server/internal/access/accesstest/checker.go
+++ b/server/internal/access/accesstest/checker.go
@@ -1,0 +1,15 @@
+package accesstest
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+)
+
+// AlwaysEnabledFeatureChecker is a FeatureChecker that reports every feature as enabled.
+// Use it in tests that need to pass a non-nil FeatureChecker to access.NewManager.
+type AlwaysEnabledFeatureChecker struct{}
+
+func (AlwaysEnabledFeatureChecker) IsFeatureEnabled(_ context.Context, _ string, _ productfeatures.Feature) (bool, error) {
+	return true, nil
+}

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -202,6 +202,8 @@ const (
 	ProjectIDKey                   = attribute.Key("gram.project.id")
 	ProjectNameKey                 = attribute.Key("gram.project.name")
 	ProjectSlugKey                 = attribute.Key("gram.project.slug")
+	RoleWorkOSIDKey                = attribute.Key("gram.role.workos_id")
+	RoleWorkOSSlugKey              = attribute.Key("gram.role.workos_slug")
 	RiskPolicyCountKey             = attribute.Key("gram.risk.policy_count")
 	RiskPolicyIDKey                = attribute.Key("gram.risk.policy_id")
 	RiskRuleIDKey                  = attribute.Key("gram.risk.rule_id")
@@ -301,6 +303,10 @@ const (
 	RemoteMCPProxyRemoteStatusClassKey = attribute.Key("gram.remote_mcp.proxy.remote_status_class")
 	RemoteMCPServerIDKey               = attribute.Key("gram.remote_mcp_server.id")
 	RemoteMCPServerURLKey              = attribute.Key("gram.remote_mcp_server.url")
+
+	WorkOSEventIDKey             = attribute.Key("gram.workos_event.id")
+	WorkOSEventTypeKey           = attribute.Key("gram.workos_event.type")
+	WorkOSEventOrganizationIDKey = attribute.Key("gram.workos_event.organization_id")
 
 	StatsToolCallCountKey  = attribute.Key("gram.stats.tool_call_count")
 	StatsMCPServerCountKey = attribute.Key("gram.stats.mcp_server_count")
@@ -885,6 +891,12 @@ func SlogProjectSlug(v string) slog.Attr      { return slog.String(string(Projec
 func ProjectName(v string) attribute.KeyValue { return ProjectNameKey.String(v) }
 func SlogProjectName(v string) slog.Attr      { return slog.String(string(ProjectNameKey), v) }
 
+func RoleWorkOSID(v string) attribute.KeyValue { return RoleWorkOSIDKey.String(v) }
+func SlogRoleWorkOSID(v string) slog.Attr      { return slog.String(string(RoleWorkOSIDKey), v) }
+
+func RoleWorkOSSlug(v string) attribute.KeyValue { return RoleWorkOSSlugKey.String(v) }
+func SlogRoleWorkOSSlug(v string) slog.Attr      { return slog.String(string(RoleWorkOSSlugKey), v) }
+
 func RemoteMCPServerID(v string) attribute.KeyValue { return RemoteMCPServerIDKey.String(v) }
 func SlogRemoteMCPServerID(v string) slog.Attr {
 	return slog.String(string(RemoteMCPServerIDKey), v)
@@ -1266,6 +1278,19 @@ func SlogLogSeverityText(v string) slog.Attr      { return slog.String(string(Lo
 
 func LogBody(v string) attribute.KeyValue { return LogBodyKey.String(v) }
 func SlogLogBody(v string) slog.Attr      { return slog.String(string(LogBodyKey), v) }
+
+func WorkOSEventID(v string) attribute.KeyValue { return WorkOSEventIDKey.String(v) }
+func SlogWorkOSEventID(v string) slog.Attr      { return slog.String(string(WorkOSEventIDKey), v) }
+
+func WorkOSEventType(v string) attribute.KeyValue { return WorkOSEventTypeKey.String(v) }
+func SlogWorkOSEventType(v string) slog.Attr      { return slog.String(string(WorkOSEventTypeKey), v) }
+
+func WorkOSEventOrganizationID(v string) attribute.KeyValue {
+	return WorkOSEventOrganizationIDKey.String(v)
+}
+func SlogWorkOSEventOrganizationID(v string) slog.Attr {
+	return slog.String(string(WorkOSEventOrganizationIDKey), v)
+}
 
 func StatsToolCallCount(v int) attribute.KeyValue { return StatsToolCallCountKey.Int(v) }
 func SlogStatsToolCallCount(v int) slog.Attr      { return slog.Int(string(StatsToolCallCountKey), v) }

--- a/server/internal/conv/from.go
+++ b/server/internal/conv/from.go
@@ -163,6 +163,16 @@ func PtrToPGTimestamptz(t *time.Time) pgtype.Timestamptz {
 	return pgtype.Timestamptz{Time: *t, Valid: true, InfinityModifier: pgtype.Finite}
 }
 
+// ToPGTimestamptzEmpty converts a time to a pgtype.Timestamptz that is only
+// valid when the input is non-zero.
+func ToPGTimestamptzEmpty(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{
+		Time:             t,
+		InfinityModifier: pgtype.Finite,
+		Valid:            !t.IsZero(),
+	}
+}
+
 // PtrToPGInt8 converts an int pointer to a pgtype.Int8. If the pointer is nil,
 // the result has Valid set to false.
 func PtrToPGInt8(v *int) pgtype.Int8 {


### PR DESCRIPTION
## Summary

Second chunk of the WorkOS sync split (originally [#2093](https://github.com/speakeasy-api/gram/pull/2093), follow-up to [#2515](https://github.com/speakeasy-api/gram/pull/2515)). Pure utility additions consumed by the upcoming sync code. No callers yet, no behavior change.

- \`conv.ToPGTimestamptzEmpty\` — converts a \`time.Time\` to a \`pgtype.Timestamptz\` that's only valid when the input is non-zero. Used by sync handlers when a WorkOS payload field (e.g. \`workos_deleted_at\`) may be absent.
- \`attr\` — five new OTel/slog attribute keys for sync instrumentation:
  - \`gram.role.workos_id\`, \`gram.role.workos_slug\`
  - \`gram.workos_event.id\`, \`gram.workos_event.type\`, \`gram.workos_event.organization_id\`
- \`access/accesstest.AlwaysEnabledFeatureChecker\` — test helper for any future tests that need to construct an \`access.Manager\` with a non-nil \`FeatureChecker\`.

## Follow-ups

- PR 2 — WorkOS client extensions + sqlc queries (will start using these helpers)
- PR 3 — pure event handlers + tests
- PR 4 — Temporal activities
- PR 5 — workflows + worker wiring
- PR 6 — \`/rpc/external.receiveWorkOSWebhook\` endpoint