### PR TITLE
chore: add workos organization event handlers

### DIFF
--- a/server/internal/background/activities/process_workos_org_handlers.go
+++ b/server/internal/background/activities/process_workos_org_handlers.go
@@ -1,0 +1,97 @@
+package activities
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/workos/workos-go/v6/pkg/events"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/database"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+)
+
+// workosOrganizationEvent is the subset of the WorkOS organization event payload
+// needed by the org sync handlers.
+type workosOrganizationEvent struct {
+	ID         string `json:"id"`
+	Object     string `json:"object"`
+	Name       string `json:"name"`
+	ExternalID string `json:"external_id"`
+}
+
+// HandleWorkOSOrganizationEvent dispatches an organization.* WorkOS event to the
+// appropriate handler. The event must already be authenticated and decoded.
+// Caller is responsible for transaction lifecycle.
+func HandleWorkOSOrganizationEvent(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	switch event.Event {
+	case string(workos.EventKindOrganizationCreated),
+		string(workos.EventKindOrganizationUpdated):
+		return handleOrganizationCreatedOrUpdated(ctx, dbtx, event)
+	case string(workos.EventKindOrganizationDeleted):
+		return handleOrganizationDeleted(ctx, logger, dbtx, event)
+	}
+
+	return fmt.Errorf("unhandled workos organization event: %s", event.Event)
+}
+
+// handleOrganizationCreatedOrUpdated will create or update an organization internally.
+// It first looks up an existing Gram org mapped to the WorkOS organization ID. If it
+// cannot be found, it falls back to the WorkOS external_id (which Speakeasy is
+// expected to set to the Gram org UUID). It then upserts the metadata for that org.
+func handleOrganizationCreatedOrUpdated(ctx context.Context, dbtx database.DBTX, event events.Event) error {
+	var payload workosOrganizationEvent
+	if err := json.Unmarshal(event.Data, &payload); err != nil {
+		return fmt.Errorf("unmarshal organization event: %w", err)
+	}
+
+	repo := orgrepo.New(dbtx)
+
+	organizationID, err := repo.GetOrganizationIDByWorkosID(ctx, conv.ToPGText(payload.ID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// Not yet mapped to an internal org. external_id must be set by Speakeasy
+		// to the Gram org UUID. If empty we fail loudly — this is a wiring bug, not
+		// a graceful edge case.
+		if payload.ExternalID == "" {
+			return fmt.Errorf("workos organization %q has no external_id", payload.ID)
+		}
+		organizationID = payload.ExternalID
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", payload.ID, err)
+	}
+
+	if _, err := repo.UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:       organizationID,
+		Name:     payload.Name,
+		Slug:     conv.ToSlug(payload.Name),
+		WorkosID: conv.ToPGText(payload.ID),
+	}); err != nil {
+		return fmt.Errorf("upsert organization %q from workos event: %w", payload.ID, err)
+	}
+
+	return nil
+}
+
+func handleOrganizationDeleted(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	var payload workosOrganizationEvent
+	if err := json.Unmarshal(event.Data, &payload); err != nil {
+		return fmt.Errorf("unmarshal organization delete event: %w", err)
+	}
+
+	rows, err := orgrepo.New(dbtx).DisableOrganizationByWorkosID(ctx, conv.ToPGText(payload.ID))
+	if err != nil {
+		return fmt.Errorf("disable organization %q: %w", payload.ID, err)
+	}
+	if rows == 0 {
+		logger.DebugContext(ctx, "skipping organization delete for unknown org", attr.SlogWorkOSOrganizationID(payload.ID))
+	}
+
+	return nil
+}

--- a/server/internal/background/activities/process_workos_org_handlers_test.go
+++ b/server/internal/background/activities/process_workos_org_handlers_test.go
@@ -1,0 +1,216 @@
+package activities_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/workos/workos-go/v6/pkg/events"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+)
+
+func newOrgHandlerTestConn(t *testing.T, name string) *pgxpool.Pool {
+	t.Helper()
+
+	conn, err := infra.CloneTestDatabase(t, name)
+	require.NoError(t, err)
+	return conn
+}
+
+func mustMarshalEventData(t *testing.T, payload any) json.RawMessage {
+	t.Helper()
+
+	bs, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return bs
+}
+
+func TestHandleWorkOSOrganizationEvent_CreatedLinksByExternalID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgHandlerTestConn(t, "workos_org_created_external")
+	logger := testenv.NewLogger(t)
+
+	gramOrgID := uuid.NewString()
+	const workosOrgID = "org_01HZTESTCREATED"
+
+	event := events.Event{
+		ID:        "event_01HZCREATE",
+		Event:     string(workos.EventKindOrganizationCreated),
+		CreatedAt: time.Now().UTC(),
+		Data: mustMarshalEventData(t, map[string]string{
+			"id":          workosOrgID,
+			"object":      "organization",
+			"name":        "Acme Inc",
+			"external_id": gramOrgID,
+		}),
+	}
+
+	require.NoError(t, activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, event))
+
+	gotID, err := orgrepo.New(conn).GetOrganizationIDByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, gramOrgID, gotID)
+
+	meta, err := orgrepo.New(conn).GetOrganizationMetadata(ctx, gramOrgID)
+	require.NoError(t, err)
+	require.Equal(t, "Acme Inc", meta.Name)
+	require.True(t, meta.WorkosID.Valid)
+	require.Equal(t, workosOrgID, meta.WorkosID.String)
+}
+
+func TestHandleWorkOSOrganizationEvent_UpdatedReusesExistingMapping(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgHandlerTestConn(t, "workos_org_updated_existing")
+	logger := testenv.NewLogger(t)
+
+	gramOrgID := uuid.NewString()
+	const workosOrgID = "org_01HZTESTUPDATE"
+
+	create := events.Event{
+		ID:        "event_01HZCREATE",
+		Event:     string(workos.EventKindOrganizationCreated),
+		CreatedAt: time.Now().UTC(),
+		Data: mustMarshalEventData(t, map[string]string{
+			"id":          workosOrgID,
+			"object":      "organization",
+			"name":        "Acme Inc",
+			"external_id": gramOrgID,
+		}),
+	}
+	require.NoError(t, activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, create))
+
+	update := events.Event{
+		ID:        "event_01HZUPDATE",
+		Event:     string(workos.EventKindOrganizationUpdated),
+		CreatedAt: time.Now().UTC(),
+		Data: mustMarshalEventData(t, map[string]string{
+			"id":     workosOrgID,
+			"object": "organization",
+			"name":   "Acme Renamed",
+			// external_id intentionally omitted to prove we use the existing mapping
+		}),
+	}
+	require.NoError(t, activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, update))
+
+	meta, err := orgrepo.New(conn).GetOrganizationMetadata(ctx, gramOrgID)
+	require.NoError(t, err)
+	require.Equal(t, "Acme Renamed", meta.Name)
+}
+
+func TestHandleWorkOSOrganizationEvent_CreatedRequiresExternalID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgHandlerTestConn(t, "workos_org_created_missing_ext")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZTESTNOEXT"
+
+	event := events.Event{
+		ID:        "event_01HZNOEXT",
+		Event:     string(workos.EventKindOrganizationCreated),
+		CreatedAt: time.Now().UTC(),
+		Data: mustMarshalEventData(t, map[string]string{
+			"id":     workosOrgID,
+			"object": "organization",
+			"name":   "Orphan Org",
+		}),
+	}
+
+	err := activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, event)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no external_id")
+}
+
+func TestHandleWorkOSOrganizationEvent_DeletedDisablesOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgHandlerTestConn(t, "workos_org_deleted")
+	logger := testenv.NewLogger(t)
+
+	gramOrgID := uuid.NewString()
+	const workosOrgID = "org_01HZTESTDELETE"
+
+	create := events.Event{
+		ID:        "event_01HZCREATEDEL",
+		Event:     string(workos.EventKindOrganizationCreated),
+		CreatedAt: time.Now().UTC(),
+		Data: mustMarshalEventData(t, map[string]string{
+			"id":          workosOrgID,
+			"object":      "organization",
+			"name":        "To Be Deleted",
+			"external_id": gramOrgID,
+		}),
+	}
+	require.NoError(t, activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, create))
+
+	del := events.Event{
+		ID:        "event_01HZDEL",
+		Event:     string(workos.EventKindOrganizationDeleted),
+		CreatedAt: time.Now().UTC(),
+		Data: mustMarshalEventData(t, map[string]string{
+			"id":     workosOrgID,
+			"object": "organization",
+			"name":   "To Be Deleted",
+		}),
+	}
+	require.NoError(t, activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, del))
+
+	meta, err := orgrepo.New(conn).GetOrganizationMetadata(ctx, gramOrgID)
+	require.NoError(t, err)
+	require.True(t, meta.DisabledAt.Valid)
+}
+
+func TestHandleWorkOSOrganizationEvent_DeletedUnknownOrgIsNoop(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgHandlerTestConn(t, "workos_org_deleted_unknown")
+	logger := testenv.NewLogger(t)
+
+	event := events.Event{
+		ID:        "event_01HZDELUNKNOWN",
+		Event:     string(workos.EventKindOrganizationDeleted),
+		CreatedAt: time.Now().UTC(),
+		Data: mustMarshalEventData(t, map[string]string{
+			"id":     "org_01HZUNKNOWN",
+			"object": "organization",
+			"name":   "Never Synced",
+		}),
+	}
+
+	require.NoError(t, activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, event))
+}
+
+func TestHandleWorkOSOrganizationEvent_UnsupportedEventErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgHandlerTestConn(t, "workos_org_unsupported")
+	logger := testenv.NewLogger(t)
+
+	event := events.Event{
+		ID:        "event_01HZUNSUPPORTED",
+		Event:     "organization_membership.created",
+		CreatedAt: time.Now().UTC(),
+		Data:      mustMarshalEventData(t, map[string]string{"id": "om_1"}),
+	}
+
+	err := activities.HandleWorkOSOrganizationEvent(ctx, logger, conn, event)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unhandled workos organization event")
+}

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -41,6 +41,39 @@ FROM organization_metadata
 WHERE workos_id = @workos_id
 LIMIT 1;
 
+-- name: GetOrganizationIDByWorkosID :one
+SELECT id
+FROM organization_metadata
+WHERE workos_id = @workos_id
+LIMIT 1;
+
+-- name: UpsertOrganizationMetadataFromWorkOS :one
+INSERT INTO organization_metadata (
+    id,
+    name,
+    slug,
+    workos_id
+) VALUES (
+    @id,
+    @name,
+    @slug,
+    @workos_id
+)
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    slug = COALESCE(organization_metadata.slug, EXCLUDED.slug),
+    workos_id = EXCLUDED.workos_id,
+    disabled_at = NULL,
+    updated_at = clock_timestamp()
+RETURNING *;
+
+-- name: DisableOrganizationByWorkosID :execrows
+UPDATE organization_metadata
+SET disabled_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE workos_id = @workos_id
+  AND disabled_at IS NULL;
+
 -- name: UpsertOrganizationUserRelationship :one
 INSERT INTO organization_user_relationships (
     organization_id,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -59,6 +59,36 @@ func (q *Queries) DeleteOrganizationUserRelationship(ctx context.Context, arg De
 	return err
 }
 
+const disableOrganizationByWorkosID = `-- name: DisableOrganizationByWorkosID :execrows
+UPDATE organization_metadata
+SET disabled_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE workos_id = $1
+  AND disabled_at IS NULL
+`
+
+func (q *Queries) DisableOrganizationByWorkosID(ctx context.Context, workosID pgtype.Text) (int64, error) {
+	result, err := q.db.Exec(ctx, disableOrganizationByWorkosID, workosID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const getOrganizationIDByWorkosID = `-- name: GetOrganizationIDByWorkosID :one
+SELECT id
+FROM organization_metadata
+WHERE workos_id = $1
+LIMIT 1
+`
+
+func (q *Queries) GetOrganizationIDByWorkosID(ctx context.Context, workosID pgtype.Text) (string, error) {
+	row := q.db.QueryRow(ctx, getOrganizationIDByWorkosID, workosID)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getOrganizationMetadata = `-- name: GetOrganizationMetadata :one
 SELECT id, name, slug, gram_account_type, sso_connection_id, workos_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
 FROM organization_metadata
@@ -349,6 +379,59 @@ func (q *Queries) UpsertOrganizationMetadata(ctx context.Context, arg UpsertOrga
 		arg.Slug,
 		arg.WorkosID,
 		arg.Whitelisted,
+	)
+	var i OrganizationMetadatum
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.GramAccountType,
+		&i.SsoConnectionID,
+		&i.WorkosID,
+		&i.Whitelisted,
+		&i.FreeTrialStartedAt,
+		&i.FreeTrialEndsAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DisabledAt,
+	)
+	return i, err
+}
+
+const upsertOrganizationMetadataFromWorkOS = `-- name: UpsertOrganizationMetadataFromWorkOS :one
+INSERT INTO organization_metadata (
+    id,
+    name,
+    slug,
+    workos_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4
+)
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    slug = COALESCE(organization_metadata.slug, EXCLUDED.slug),
+    workos_id = EXCLUDED.workos_id,
+    disabled_at = NULL,
+    updated_at = clock_timestamp()
+RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+`
+
+type UpsertOrganizationMetadataFromWorkOSParams struct {
+	ID       string
+	Name     string
+	Slug     string
+	WorkosID pgtype.Text
+}
+
+func (q *Queries) UpsertOrganizationMetadataFromWorkOS(ctx context.Context, arg UpsertOrganizationMetadataFromWorkOSParams) (OrganizationMetadatum, error) {
+	row := q.db.QueryRow(ctx, upsertOrganizationMetadataFromWorkOS,
+		arg.ID,
+		arg.Name,
+		arg.Slug,
+		arg.WorkosID,
 	)
 	var i OrganizationMetadatum
 	err := row.Scan(

--- a/server/internal/thirdparty/workos/events.go
+++ b/server/internal/thirdparty/workos/events.go
@@ -1,0 +1,12 @@
+package workos
+
+// EventKind represents the type of events that come from the WorkOS Events API.
+// The list of events from the official SDK is missing a few key event types so
+// these are manually enumerated in this package.
+type EventKind string
+
+const (
+	EventKindOrganizationCreated EventKind = "organization.created"
+	EventKindOrganizationDeleted EventKind = "organization.deleted"
+	EventKindOrganizationUpdated EventKind = "organization.updated"
+)


### PR DESCRIPTION
## Summary

Continuing the WorkOS sync split (originally [#2093](https://github.com/speakeasy-api/gram/pull/2093), follow-up to [#2515](https://github.com/speakeasy-api/gram/pull/2515)). Scoped tightly: just the handler logic for \`organization.created\` / \`organization.updated\` / \`organization.deleted\` plus the queries it needs.

No Temporal wiring, no webhook routing, no membership/role handlers — those land in their own PRs alongside their queries and consumers.

## What's in here

- \`server/internal/thirdparty/workos/events.go\` (new) — \`EventKind\` type with the three org event constants. Other event kinds will be added in their respective PRs.
- \`server/internal/organizations/queries.sql\` — three additions consumed directly by the handler:
  - \`GetOrganizationIDByWorkosID\` — resolve existing Gram org from WorkOS org ID.
  - \`UpsertOrganizationMetadataFromWorkOS\` — create-or-update the Gram org row from a WorkOS event payload, clearing \`disabled_at\`.
  - \`DisableOrganizationByWorkosID\` — soft-disable on \`organization.deleted\`.
- \`server/internal/background/activities/process_workos_org_handlers.go\` — \`HandleWorkOSOrganizationEvent\` dispatcher and the two leaf handlers. Take \`database.DBTX\`, so callers control transactions.
- \`server/internal/background/activities/process_workos_org_handlers_test.go\` — covers create-via-\`external_id\`, update reuses existing mapping, missing \`external_id\` errors, delete disables, delete on unknown org is a noop, unsupported event errors.

## Behaviour notes

- On create/update: prefer an existing \`workos_id → id\` mapping; fall back to \`external_id\` (which Speakeasy is expected to set to the Gram org UUID). Empty \`external_id\` is treated as a wiring bug and errors loudly — not silently skipped.
- On delete: \`DisableOrganizationByWorkosID\` returns row count; zero rows is logged at debug level (already-disabled or unknown org) and is not an error.
- \`Member.CreatedAt\` / \`Role.CreatedAt\` types remain unchanged in this PR — those switches land with the membership/role handler PRs.

## Verification

- \`mise build:server\` clean
- \`mise test:server -count=1 ./internal/background/activities/...\` — 67 tests pass (6 new)

## Follow-ups

- PR for \`organization_membership.*\` handlers + their queries
- PR for \`organization_role.*\` handlers + their queries (with \`Role.CreatedAt time.Time\` switch)
- PR for sync cursor queries + Temporal activity wrappers
- PR for workflows + worker wiring
- PR for \`/rpc/external.receiveWorkOSWebhook\` endpoint