### PR TITLE
fix: break if known fly app suddenly misbehaves

### DIFF
--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -34,6 +35,13 @@ const (
 	flyMachineMetadataRole          = "gram_role"
 	flyMachineMetadataRoleAssistant = "assistant_runtime"
 )
+
+// errFlyAppCorrupted signals the Fly Machines API reports the app missing on
+// an established runtime — i.e. flaps 404s after we previously launched a
+// machine on this app. GraphQL/orchestrator and the Machines backend have
+// drifted; the only reliable recovery is to destroy + recreate. Distinct from
+// the create-time propagation lag covered by isFlyAppPropagating.
+var errFlyAppCorrupted = errors.New("assistant fly runtime app corrupted")
 
 type flyRuntimeMetadata struct {
 	AppName    string `json:"app_name"`
@@ -208,8 +216,22 @@ func (f *FlyRuntimeBackend) ensureExisting(
 		appIP = metadata.AppIP
 	}
 
-	machine, err := f.resolveMachine(ctx, flapsClient, appName, runtime.AssistantThreadID, metadata.MachineID)
+	machine, err := f.resolveMachine(ctx, flapsClient, appName, runtime.AssistantThreadID, metadata.MachineID, metadata.LastBootID)
 	if err != nil {
+		if errors.Is(err, errFlyAppCorrupted) {
+			f.logger.WarnContext(ctx,
+				"assistant fly runtime app corrupted, tearing down for recreate",
+				attr.SlogFlyAppName(appName),
+				attr.SlogAssistantThreadID(runtime.AssistantThreadID.String()),
+			)
+			if delErr := f.deleteApp(ctx, appName); delErr != nil && !isFlyNotFound(delErr) {
+				f.logger.WarnContext(ctx,
+					"delete corrupted assistant fly runtime app failed",
+					attr.SlogFlyAppName(appName),
+					attr.SlogError(delErr),
+				)
+			}
+		}
 		return RuntimeBackendEnsureResult{}, err
 	}
 
@@ -333,8 +355,10 @@ func (f *FlyRuntimeBackend) resolveMachine(
 	appName string,
 	threadID uuid.UUID,
 	machineID string,
+	lastBootID string,
 ) (*fly.Machine, error) {
 	wantThreadID := threadID.String()
+	hadPriorBoot := lastBootID != "" || machineID != ""
 
 	if machineID != "" {
 		machine, err := flapsClient.Get(ctx, appName, machineID)
@@ -351,6 +375,12 @@ func (f *FlyRuntimeBackend) resolveMachine(
 
 	machines, err := flapsClient.List(ctx, appName, "")
 	if err != nil {
+		// Established runtime + flaps notFound = backend drift, not propagation
+		// lag. ensureApp just confirmed the app via GraphQL, so the two Fly
+		// backends disagree and only a destroy+recreate clears it.
+		if isFlyNotFound(err) && hadPriorBoot {
+			return nil, errFlyAppCorrupted
+		}
 		return nil, fmt.Errorf("list assistant fly runtime machines: %w", err)
 	}
 

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -131,6 +131,69 @@ func TestFlyRuntimeBackendEnsureMachineUnconfigured(t *testing.T) {
 	require.True(t, result.NeedsConfigure)
 }
 
+func TestFlyRuntimeBackendEnsureFlapsNotFoundEstablishedTearsDown(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	// ensureApp succeeds (GraphQL says app exists) but flaps Get + List both
+	// 404. Established runtime — LastBootID + MachineID set from a prior boot.
+	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	flapsClient.getErr = errors.New("not found")
+	flapsClient.listErr = errors.New("app not found")
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	_, err = backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.ErrorIs(t, err, errFlyAppCorrupted)
+	require.Equal(t, 1, apiClient.deleteCalls, "corrupted app must be torn down so the next ensure recreates it")
+}
+
+func TestFlyRuntimeBackendEnsureFlapsNotFoundFreshAppPropagates(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	// Fresh app — no prior boot recorded. flaps List 404 here is the
+	// propagation case isFlyAppPropagating + launchMachineWithRetry already
+	// cover; corruption detection must NOT trigger and tear the app down.
+	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	flapsClient.listErr = errors.New("app not found")
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName: "gram-asst-test",
+		AppURL:  server.URL,
+		Region:  "iad",
+	})
+	require.NoError(t, err)
+
+	_, err = backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errFlyAppCorrupted)
+	require.Equal(t, 0, apiClient.deleteCalls, "fresh app must not be torn down on a propagation 404")
+}
+
 func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
 	t.Parallel()
 
@@ -166,6 +229,7 @@ type testFlyRuntimeAPIClient struct {
 	app          *fly.App
 	getAppErr    error
 	deleteErr    error
+	deleteCalls  int
 	createAppErr error
 	organization *fly.Organization
 }
@@ -191,6 +255,7 @@ func (c *testFlyRuntimeAPIClient) CreateApp(_ context.Context, input fly.CreateA
 }
 
 func (c *testFlyRuntimeAPIClient) DeleteApp(_ context.Context, _ string) error {
+	c.deleteCalls++
 	return c.deleteErr
 }
 
@@ -215,6 +280,7 @@ type testFlyRuntimeFlapsClient struct {
 	machine       *fly.Machine
 	getErr        error
 	listMachines  []*fly.Machine
+	listErr       error
 	launchMachine *fly.Machine
 	launchErr     error
 	startErr      error
@@ -243,6 +309,9 @@ func (c *testFlyRuntimeFlapsClient) Launch(_ context.Context, _ string, _ fly.La
 }
 
 func (c *testFlyRuntimeFlapsClient) List(_ context.Context, _ string, _ string) ([]*fly.Machine, error) {
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
 	return c.listMachines, nil
 }
 


### PR DESCRIPTION
## What happen

Fly.io apps can transition into a state where `flaps` can no longer introspect them. Manifests as 404. We treat 404 as intermittent due to stand up time of apps.

## How fix

If app known to have stood up, treat "not found" as fatal.