### PR TITLE
chore: add nosqlerrnorows glint analyzer and migrate to pgx.ErrNoRows

### DIFF
--- a/docs/runbooks/writing-queries-with-sqlc.md
+++ b/docs/runbooks/writing-queries-with-sqlc.md
@@ -64,7 +64,7 @@ WHERE id = @id AND deleted IS FALSE;
 
 ### Query annotations
 
-- `:one` - Returns a single row (or `sql.ErrNoRows` if not found)
+- `:one` - Returns a single row (or `pgx.ErrNoRows` if not found)
 - `:many` - Returns multiple rows as a slice
 - `:exec` - Executes the query without returning data
 - `:execrows` - Executes and returns the number of affected rows
@@ -168,7 +168,7 @@ func (s *Service) CreateUser(ctx context.Context, name, email string) (*repo.Use
 func (s *Service) GetUser(ctx context.Context, id uuid.UUID) (*repo.User, error) {
     user, err := s.repo.GetUserByID(ctx, id)
     if err != nil {
-        if errors.Is(err, sql.ErrNoRows) {
+        if errors.Is(err, pgx.ErrNoRows) {
             return nil, oops.C(oops.CodeNotFound)
         }
         return nil, oops.E(oops.CodeUnexpected, err, "failed to get user")
@@ -228,7 +228,7 @@ Always handle SQLC errors appropriately:
 func (s *Service) GetUser(ctx context.Context, id uuid.UUID) (*repo.User, error) {
     user, err := s.repo.GetUserByID(ctx, id)
     if err != nil {
-        if errors.Is(err, sql.ErrNoRows) {
+        if errors.Is(err, pgx.ErrNoRows) {
             return nil, oops.C(oops.CodeNotFound, "user not found")
         }
         return nil, oops.E(oops.CodeUnexpected, err, "failed to get user")
@@ -334,7 +334,7 @@ GROUP BY p.id;
 
 1. **Query naming**: Use descriptive names that indicate the operation and return type
 2. **Parameter naming**: Use clear, descriptive parameter names with `@` prefix
-3. **Error handling**: Always handle `sql.ErrNoRows` appropriately
+3. **Error handling**: Always handle `pgx.ErrNoRows` appropriately
 4. **Transactions**: Use transactions for operations that need to be atomic
 5. **Soft deletes**: Always check `deleted IS FALSE` in queries
 6. **Timestamps**: Use `clock_timestamp()` over `now()` or `CURRENT_TIMESTAMP` for updates because it returns the actual current time at the point of execution of the SQL query, and its value changes within a transaction

--- a/glint/imports/imports.go
+++ b/glint/imports/imports.go
@@ -1,0 +1,92 @@
+// Package imports provides reusable helpers for emitting analysis.TextEdit
+// values that add or remove imports from a Go source file. They are intended
+// for use in glint analyzers' SuggestedFixes.
+package imports
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// LocalName looks up path in the file's imports and returns the name to use
+// when referencing path's exported identifiers. Aliased imports return the
+// alias; unaliased imports return defaultName. Blank ("_") and dot (".")
+// imports are treated as not present so callers can add an explicit import
+// rather than rely on a side-effect import. The second return value reports
+// whether path was found as a regular import; when false the returned name
+// is defaultName so callers can use it directly after pairing the returned
+// edit from Add.
+func LocalName(file *ast.File, path, defaultName string) (string, bool) {
+	for _, imp := range file.Imports {
+		importPath, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || importPath != path {
+			continue
+		}
+		if imp.Name == nil {
+			return defaultName, true
+		}
+		switch imp.Name.Name {
+		case "", "_", ".":
+			continue
+		default:
+			return imp.Name.Name, true
+		}
+	}
+	return defaultName, false
+}
+
+// Add emits a TextEdit that inserts a new import line into the first grouped
+// import block found in file. Returns false if the file has no grouped import
+// block (e.g. only single-line imports), in which case the caller should skip
+// the import edit and let a follow-up tool such as goimports add the import.
+//
+// The new line is appended at the end of the block; callers that need the
+// import block to remain canonically sorted should rely on a follow-up
+// formatter such as gofmt or goimports.
+func Add(file *ast.File, path string) (analysis.TextEdit, bool) {
+	for _, d := range file.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.IMPORT || !gd.Lparen.IsValid() {
+			continue
+		}
+		return analysis.TextEdit{
+			Pos:     gd.Rparen,
+			End:     gd.Rparen,
+			NewText: []byte("\t" + strconv.Quote(path) + "\n"),
+		}, true
+	}
+	return analysis.TextEdit{}, false
+}
+
+// Remove emits a TextEdit that deletes the entire line containing the import
+// spec for path, including its trailing newline. Returns false if the import
+// is not present in the file.
+func Remove(fset *token.FileSet, file *ast.File, path string) (analysis.TextEdit, bool) {
+	for _, imp := range file.Imports {
+		importPath, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || importPath != path {
+			continue
+		}
+		tokFile := fset.File(imp.Pos())
+		if tokFile == nil {
+			return analysis.TextEdit{}, false
+		}
+		line := tokFile.Line(imp.Pos())
+		lineStart := tokFile.LineStart(line)
+		var lineEnd token.Pos
+		if line < tokFile.LineCount() {
+			lineEnd = tokFile.LineStart(line + 1)
+		} else {
+			lineEnd = token.Pos(tokFile.Base() + tokFile.Size())
+		}
+		return analysis.TextEdit{
+			Pos:     lineStart,
+			End:     lineEnd,
+			NewText: nil,
+		}, true
+	}
+	return analysis.TextEdit{}, false
+}

--- a/glint/no_sql_err_no_rows.go
+++ b/glint/no_sql_err_no_rows.go
@@ -1,0 +1,119 @@
+package glint
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/speakeasy-api/gram/glint/imports"
+)
+
+const (
+	noSqlErrNoRowsAnalyzer       = "nosqlerrnorows"
+	noSqlErrNoRowsDefaultMessage = "use github.com/jackc/pgx/v5.ErrNoRows instead of database/sql.ErrNoRows"
+	noSqlErrNoRowsFixMessage     = "replace database/sql.ErrNoRows with github.com/jackc/pgx/v5.ErrNoRows"
+
+	sqlPkgPath          = "database/sql"
+	sqlErrNoRowsName    = "ErrNoRows"
+	pgxPkgPath          = "github.com/jackc/pgx/v5"
+	pgxDefaultLocalName = "pgx"
+)
+
+type noSqlErrNoRowsSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newNoSqlErrNoRowsAnalyzer(_ noSqlErrNoRowsSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: noSqlErrNoRowsAnalyzer,
+		Doc:  noSqlErrNoRowsDefaultMessage,
+		Run: func(pass *analysis.Pass) (any, error) {
+			for _, file := range pass.Files {
+				inspectFileForSqlErrNoRows(pass, file)
+			}
+			return nil, nil
+		},
+	}
+}
+
+// inspectFileForSqlErrNoRows walks file once, collecting database/sql.ErrNoRows
+// references and noting whether database/sql is used for any other symbol.
+// It then reports one diagnostic per occurrence with a SuggestedFix that
+// rewrites the selector to pgx.ErrNoRows and (when safe) updates imports.
+func inspectFileForSqlErrNoRows(pass *analysis.Pass, file *ast.File) {
+	var occurrences []*ast.SelectorExpr
+	otherSqlUsage := false
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.SelectorExpr:
+			if isSqlErrNoRows(pass, n.Sel) {
+				occurrences = append(occurrences, n)
+				return false
+			}
+		case *ast.Ident:
+			obj := pass.TypesInfo.Uses[n]
+			if obj != nil && obj.Pkg() != nil &&
+				obj.Pkg().Path() == sqlPkgPath && obj.Name() != sqlErrNoRowsName {
+				otherSqlUsage = true
+			}
+		}
+		return true
+	})
+
+	if len(occurrences) == 0 {
+		return
+	}
+
+	pgxLocalName, pgxImported := imports.LocalName(file, pgxPkgPath, pgxDefaultLocalName)
+	replacement := []byte(pgxLocalName + "." + sqlErrNoRowsName)
+
+	// importEdits is intentionally attached to every diagnostic's SuggestedFix
+	// rather than just the first. analysistest's three-way merge dedupes
+	// identical edits when --fix applies them all together. Splitting them
+	// across diagnostics would risk a different IDE quick-fix branch removing
+	// the import while sibling occurrences remained unfixed.
+	var importEdits []analysis.TextEdit
+	if !pgxImported {
+		if e, ok := imports.Add(file, pgxPkgPath); ok {
+			importEdits = append(importEdits, e)
+		}
+	}
+	if !otherSqlUsage {
+		if e, ok := imports.Remove(pass.Fset, file, sqlPkgPath); ok {
+			importEdits = append(importEdits, e)
+		}
+	}
+
+	for _, occ := range occurrences {
+		edits := make([]analysis.TextEdit, 0, 1+len(importEdits))
+		edits = append(edits, analysis.TextEdit{Pos: occ.Pos(), End: occ.End(), NewText: replacement})
+		edits = append(edits, importEdits...)
+
+		pass.Report(analysis.Diagnostic{
+			Pos:      occ.Pos(),
+			End:      occ.End(),
+			Category: noSqlErrNoRowsAnalyzer,
+			Message:  noSqlErrNoRowsDefaultMessage,
+			SuggestedFixes: []analysis.SuggestedFix{{
+				Message:   noSqlErrNoRowsFixMessage,
+				TextEdits: edits,
+			}},
+		})
+	}
+}
+
+// isSqlErrNoRows reports whether ident resolves to the database/sql.ErrNoRows
+// var via type information, so it works through aliased imports and avoids
+// matching unrelated identifiers that happen to be named ErrNoRows.
+func isSqlErrNoRows(pass *analysis.Pass, ident *ast.Ident) bool {
+	obj, ok := pass.TypesInfo.Uses[ident].(*types.Var)
+	if !ok {
+		return false
+	}
+	if obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == sqlPkgPath && obj.Name() == sqlErrNoRowsName
+}

--- a/glint/no_sql_err_no_rows_test.go
+++ b/glint/no_sql_err_no_rows_test.go
@@ -1,0 +1,32 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestNoSqlErrNoRows(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newNoSqlErrNoRowsAnalyzer(noSqlErrNoRowsSettings{}), "nosqlerrnorows")
+}
+
+func TestNoSqlErrNoRowsSuggestedFix(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.RunWithSuggestedFixes(t, testdata, newNoSqlErrNoRowsAnalyzer(noSqlErrNoRowsSettings{}), "nosqlerrnorows")
+}
+
+func TestBuildAnalyzersSkipsDisabledNoSqlErrNoRows(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Empty(t, analyzers)
+}

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -30,6 +30,7 @@ type ruleSettings struct {
 	AuditEventURNNaming        auditEventURNNamingSettings        `json:"audit-event-urn-naming"`
 	AuditEventURNTyping        auditEventURNTypingSettings        `json:"audit-event-urn-typing"`
 	NoDirectChatMessageInsert  noDirectChatMessageInsertSettings  `json:"no-direct-chat-message-insert"`
+	NoSqlErrNoRows             noSqlErrNoRowsSettings             `json:"no-sql-err-no-rows"`
 }
 
 type plugin struct {
@@ -76,6 +77,9 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	}
 	if !p.settings.Rules.NoDirectChatMessageInsert.Disabled {
 		analyzers = append(analyzers, newNoDirectChatMessageInsertAnalyzer(p.settings.Rules.NoDirectChatMessageInsert))
+	}
+	if !p.settings.Rules.NoSqlErrNoRows.Disabled {
+		analyzers = append(analyzers, newNoSqlErrNoRowsAnalyzer(p.settings.Rules.NoSqlErrNoRows))
 	}
 
 	return analyzers, nil

--- a/glint/plugin_test.go
+++ b/glint/plugin_test.go
@@ -22,6 +22,7 @@ func disabledAllRulesPlugin() *plugin {
 				AuditEventURNNaming:        auditEventURNNamingSettings{Disabled: true},
 				AuditEventURNTyping:        auditEventURNTypingSettings{Disabled: true},
 				NoDirectChatMessageInsert:  noDirectChatMessageInsertSettings{Disabled: true},
+				NoSqlErrNoRows:             noSqlErrNoRowsSettings{Disabled: true},
 			},
 		},
 	}
@@ -42,5 +43,5 @@ func TestBuildAnalyzersAllEnabled(t *testing.T) {
 	p := &plugin{}
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
-	require.Len(t, analyzers, 10)
+	require.Len(t, analyzers, 11)
 }

--- a/glint/testdata/src/customerrnorows/customerrnorows.go
+++ b/glint/testdata/src/customerrnorows/customerrnorows.go
@@ -1,0 +1,5 @@
+package customerrnorows
+
+import "errors"
+
+var ErrNoRows = errors.New("custom no rows error unrelated to database/sql")

--- a/glint/testdata/src/github.com/jackc/pgx/v5/pgx.go
+++ b/glint/testdata/src/github.com/jackc/pgx/v5/pgx.go
@@ -1,0 +1,5 @@
+package pgx
+
+import "errors"
+
+var ErrNoRows = errors.New("no rows in result set")

--- a/glint/testdata/src/nosqlerrnorows/aliased.go
+++ b/glint/testdata/src/nosqlerrnorows/aliased.go
@@ -1,0 +1,10 @@
+package nosqlerrnorows
+
+import (
+	sqlx "database/sql"
+	"errors"
+)
+
+func aliasedErrorsIs(err error) bool {
+	return errors.Is(err, sqlx.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/glint/testdata/src/nosqlerrnorows/aliased.go.golden
+++ b/glint/testdata/src/nosqlerrnorows/aliased.go.golden
@@ -1,0 +1,10 @@
+package nosqlerrnorows
+
+import (
+	"errors"
+	"github.com/jackc/pgx/v5"
+)
+
+func aliasedErrorsIs(err error) bool {
+	return errors.Is(err, pgx.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/glint/testdata/src/nosqlerrnorows/direct.go
+++ b/glint/testdata/src/nosqlerrnorows/direct.go
@@ -1,0 +1,14 @@
+package nosqlerrnorows
+
+import (
+	"database/sql"
+	"errors"
+)
+
+func directComparison(err error) bool {
+	return err == sql.ErrNoRows // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}
+
+func errorsIs(err error) bool {
+	return errors.Is(err, sql.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/glint/testdata/src/nosqlerrnorows/direct.go.golden
+++ b/glint/testdata/src/nosqlerrnorows/direct.go.golden
@@ -1,0 +1,14 @@
+package nosqlerrnorows
+
+import (
+	"errors"
+	"github.com/jackc/pgx/v5"
+)
+
+func directComparison(err error) bool {
+	return err == pgx.ErrNoRows // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}
+
+func errorsIs(err error) bool {
+	return errors.Is(err, pgx.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/glint/testdata/src/nosqlerrnorows/good.go
+++ b/glint/testdata/src/nosqlerrnorows/good.go
@@ -1,0 +1,17 @@
+package nosqlerrnorows
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"customerrnorows"
+)
+
+func goodPgx(err error) bool {
+	return errors.Is(err, pgx.ErrNoRows)
+}
+
+func goodCustomPackage(err error) bool {
+	return errors.Is(err, customerrnorows.ErrNoRows)
+}

--- a/glint/testdata/src/nosqlerrnorows/mixedusage.go
+++ b/glint/testdata/src/nosqlerrnorows/mixedusage.go
@@ -1,0 +1,14 @@
+package nosqlerrnorows
+
+import (
+	"database/sql"
+	"errors"
+)
+
+// keepSqlImport ensures the SuggestedFix does not delete the database/sql
+// import when the file uses sql for symbols other than ErrNoRows.
+var _ *sql.DB
+
+func mixedUsage(err error) bool {
+	return errors.Is(err, sql.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/glint/testdata/src/nosqlerrnorows/mixedusage.go.golden
+++ b/glint/testdata/src/nosqlerrnorows/mixedusage.go.golden
@@ -1,0 +1,15 @@
+package nosqlerrnorows
+
+import (
+	"database/sql"
+	"errors"
+	"github.com/jackc/pgx/v5"
+)
+
+// keepSqlImport ensures the SuggestedFix does not delete the database/sql
+// import when the file uses sql for symbols other than ErrNoRows.
+var _ *sql.DB
+
+func mixedUsage(err error) bool {
+	return errors.Is(err, pgx.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/glint/testdata/src/nosqlerrnorows/pgxalreadyimported.go
+++ b/glint/testdata/src/nosqlerrnorows/pgxalreadyimported.go
@@ -1,0 +1,15 @@
+package nosqlerrnorows
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// pgxAlreadyImported ensures the SuggestedFix reuses an existing pgx import
+// rather than adding a duplicate.
+func pgxAlreadyImported(err error) bool {
+	_ = pgx.ErrNoRows
+	return errors.Is(err, sql.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/glint/testdata/src/nosqlerrnorows/pgxalreadyimported.go.golden
+++ b/glint/testdata/src/nosqlerrnorows/pgxalreadyimported.go.golden
@@ -1,0 +1,14 @@
+package nosqlerrnorows
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// pgxAlreadyImported ensures the SuggestedFix reuses an existing pgx import
+// rather than adding a duplicate.
+func pgxAlreadyImported(err error) bool {
+	_ = pgx.ErrNoRows
+	return errors.Is(err, pgx.ErrNoRows) // want `use github.com/jackc/pgx/v5\.ErrNoRows instead of database/sql\.ErrNoRows`
+}

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"database/sql"
-
 	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
@@ -1197,7 +1196,7 @@ func (s *Service) DisableRBAC(ctx context.Context, _ *gen.DisableRBACPayload) er
 		OrganizationID: ac.ActiveOrganizationID,
 		FeatureName:    string(productfeatures.FeatureRBAC),
 	}); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			// Already disabled — no active feature row to soft-delete.
 			return nil
 		}

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -20,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -141,7 +141,7 @@ func (s *Service) ServeImage(ctx context.Context, payload *gen.ServeImageForm) (
 
 	row, err := s.repo.GetImageAssetURL(ctx, assetID)
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get image asset url: %w", err), "error loading asset")
@@ -596,7 +596,7 @@ func (s *Service) findExistingAsset(ctx context.Context, params *findAssetParams
 		ProjectID: params.projectID,
 		Sha256:    params.hash,
 	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("find project asset by hash: %w", err), "error loading document data")
 	}
 	if asset.ID != uuid.Nil {
@@ -749,7 +749,7 @@ func (s *Service) ServeOpenAPIv3(ctx context.Context, payload *gen.ServeOpenAPIv
 		ProjectID: projectID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get openapiv3 asset url: %w", err), "error loading asset").Log(ctx, logger)
@@ -1014,7 +1014,7 @@ func (s *Service) ServeFunction(ctx context.Context, payload *gen.ServeFunctionF
 		ProjectID: projectID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get function asset url: %w", err), "error loading asset").Log(ctx, logger)
@@ -1209,7 +1209,7 @@ func (s *Service) ServeChatAttachment(ctx context.Context, payload *gen.ServeCha
 		ProjectID: projectID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").Log(ctx, logger)
@@ -1283,7 +1283,7 @@ func (s *Service) CreateSignedChatAttachmentURL(ctx context.Context, payload *ge
 		ProjectID: projectID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").Log(ctx, logger)
@@ -1348,7 +1348,7 @@ func (s *Service) ServeChatAttachmentSigned(ctx context.Context, payload *gen.Se
 		ProjectID: projectID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, nil, oops.E(oops.CodeUnexpected, fmt.Errorf("get chat attachment asset url: %w", err), "error loading asset").Log(ctx, logger)

--- a/server/internal/audit/impl.go
+++ b/server/internal/audit/impl.go
@@ -2,7 +2,6 @@ package audit
 
 import (
 	"context"
-	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
@@ -179,7 +179,7 @@ func (s *Service) resolveProjectID(ctx context.Context, organizationID string, p
 		OrganizationID: organizationID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return uuid.NullUUID{}, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return uuid.NullUUID{}, oops.E(oops.CodeUnexpected, err, "error getting project by slug").Log(ctx, s.logger, attr.SlogProjectSlug(projectSlug), attr.SlogOrganizationID(organizationID))

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -2,12 +2,12 @@ package auth
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"goa.design/goa/v3/security"
 
@@ -80,7 +80,7 @@ func (s *Auth) checkProjectAccess(ctx context.Context, logger *slog.Logger, proj
 
 	projects, err := s.repo.ListProjectsByOrganization(ctx, authCtx.ActiveOrganizationID)
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return ctx, oops.E(oops.CodeForbidden, nil, "no projects found")
 	case err != nil:
 		return ctx, oops.E(oops.CodeUnexpected, err, "error checking project access").Log(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
@@ -125,7 +125,7 @@ func (s *Auth) CheckProjectAccess(ctx context.Context, logger *slog.Logger, proj
 		ProjectID:      projectID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return oops.C(oops.CodeForbidden).Log(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "error checking project access").Log(ctx, logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))

--- a/server/internal/auth/key.go
+++ b/server/internal/auth/key.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"errors"
 	"log/slog"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -109,7 +109,7 @@ func (k *ByKey) KeyBasedAuth(ctx context.Context, key string, requiredScopes []s
 
 	apiKey, err := k.keyDB.GetAPIKeyByKeyHash(ctx, keyHash)
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return ctx, oops.E(oops.CodeUnauthorized, err, "unauthorized: api key not found")
 	case err != nil:
 		return ctx, oops.E(oops.CodeUnexpected, err, "error loading api key details")

--- a/server/internal/background/activities/chat_resolutions/get_user_feedback.go
+++ b/server/internal/background/activities/chat_resolutions/get_user_feedback.go
@@ -2,11 +2,11 @@ package resolution_activities
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
@@ -42,7 +42,7 @@ type GetUserFeedbackForChatResult struct {
 func (g *GetUserFeedbackForChat) Do(ctx context.Context, args GetUserFeedbackForChatArgs) (*GetUserFeedbackForChatResult, error) {
 	feedback, err := g.repo.ListUserFeedbackForChat(ctx, args.ChatID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			// No user feedback exists
 			return &GetUserFeedbackForChatResult{
 				UserFeedback: []UserFeedback{},

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
@@ -497,7 +497,7 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 
 	chat, err := s.repo.GetChat(ctx, chatID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.C(oops.CodeNotFound)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").Log(ctx, s.logger)
@@ -873,7 +873,7 @@ func (s *Service) GenerateTitle(ctx context.Context, payload *gen.GenerateTitleP
 	// Load the chat to verify access
 	chat, err := s.repo.GetChat(ctx, chatID)
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").Log(ctx, s.logger)
@@ -928,7 +928,7 @@ func (s *Service) SubmitFeedback(ctx context.Context, payload *gen.SubmitFeedbac
 	// Load the chat to verify access
 	chat, err := s.repo.GetChat(ctx, chatID)
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").Log(ctx, s.logger)

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -1,7 +1,6 @@
 package customdomains
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -9,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	domainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
@@ -52,7 +52,7 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 
 			domain, err := domainsRepo.GetCustomDomainByDomain(ctx, host)
 			switch {
-			case errors.Is(err, sql.ErrNoRows):
+			case errors.Is(err, pgx.ErrNoRows):
 				http.Error(w, "invalid domain", http.StatusForbidden)
 				return
 			case err != nil:

--- a/server/internal/deployments/crud.go
+++ b/server/internal/deployments/crud.go
@@ -2,11 +2,11 @@ package deployments
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -98,7 +98,7 @@ func createDeployment(
 		ExternalID:  conv.ToPGTextEmpty(fields.externalID),
 		ExternalUrl: conv.ToPGTextEmpty(fields.externalURL),
 	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return uuid.Nil, oops.E(oops.CodeUnexpected, err, "error creating deployment").Log(ctx, logger)
 	}
 
@@ -262,7 +262,7 @@ func amendDeployment(
 			Name:         a.name,
 			Slug:         a.slug,
 		})
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeUnexpected, err, "error adding deployment openapi v3 asset").Log(ctx, logger)
 		}
 	}
@@ -289,7 +289,7 @@ func amendDeployment(
 			MemoryMib:    mem,
 			Scale:        scale,
 		})
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeUnexpected, err, "error adding deployment functions asset").Log(ctx, logger)
 		}
 	}
@@ -300,7 +300,7 @@ func amendDeployment(
 			PackageID:    p.packageID,
 			VersionID:    p.versionID,
 		})
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeUnexpected, err, "error adding deployment package").Log(ctx, logger)
 		}
 	}
@@ -315,7 +315,7 @@ func amendDeployment(
 			RegistryServerSpecifier:             e.registryServerSpecifier,
 			SelectedRemotes:                     e.selectedRemotes,
 		})
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeUnexpected, err, "error adding deployment external mcp").Log(ctx, logger)
 		}
 	}

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -2,13 +2,13 @@ package deployments
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"net/url"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
@@ -253,7 +253,7 @@ func (s *Service) GetLatestDeployment(ctx context.Context, _ *gen.GetLatestDeplo
 
 	id, err := tx.GetLatestDeploymentID(ctx, *authCtx.ProjectID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return &gen.GetLatestDeploymentResult{
 				Deployment: nil,
 			}, nil
@@ -299,7 +299,7 @@ func (s *Service) GetActiveDeployment(ctx context.Context, _ *gen.GetActiveDeplo
 
 	id, err := tx.GetActiveDeploymentID(ctx, *authCtx.ProjectID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return &gen.GetActiveDeploymentResult{
 				Deployment: nil,
 			}, nil
@@ -708,7 +708,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 	latestDeploymentID, err := tx.GetLatestDeploymentID(ctx, projectID)
 	switch {
 	// 1️⃣ Project has no deployments, we need to create an initial one instead of cloning
-	case errors.Is(err, sql.ErrNoRows), latestDeploymentID == uuid.Nil:
+	case errors.Is(err, pgx.ErrNoRows), latestDeploymentID == uuid.Nil:
 		newID, err := createDeployment(
 			ctx, s.tracer, logger, tx,
 			IdempotencyKey(nil),
@@ -950,7 +950,7 @@ func (s *Service) resolvePackages(ctx context.Context, tx *packagesRepo.Queries,
 
 		if version == "" {
 			row, err := tx.PeekLatestPackageVersionByName(ctx, name)
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, oops.E(oops.CodeBadRequest, err, "no versions found for package: %s", name).Log(ctx, s.logger, attr.SlogPackageName(name))
 			}
 			if err != nil {
@@ -978,7 +978,7 @@ func (s *Service) resolvePackages(ctx context.Context, tx *packagesRepo.Queries,
 				Prerelease: conv.ToPGTextEmpty(semver.Prerelease),
 				Build:      conv.ToPGTextEmpty(semver.Build),
 			})
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, oops.E(oops.CodeBadRequest, err, "package version not found: %s@%s", name, version).Log(ctx, s.logger, attr.SlogPackageName(name), attr.SlogPackageVersion(version))
 			}
 			if err != nil {

--- a/server/internal/environments/impl.go
+++ b/server/internal/environments/impl.go
@@ -3,13 +3,13 @@ package environments
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
@@ -344,7 +344,7 @@ func (s *Service) DeleteEnvironment(ctx context.Context, payload *gen.DeleteEnvi
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
 		return oops.E(oops.CodeUnexpected, err, "failed to delete environment").Log(ctx, logger)
@@ -456,7 +456,7 @@ func (s *Service) DeleteSourceEnvironmentLink(ctx context.Context, payload *gen.
 		SourceSlug: payload.SourceSlug,
 		ProjectID:  *authCtx.ProjectID,
 	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return oops.E(oops.CodeUnexpected, err, "failed to delete source environment link").Log(ctx, s.logger)
 	}
 
@@ -480,7 +480,7 @@ func (s *Service) GetSourceEnvironment(ctx context.Context, payload *gen.GetSour
 	})
 
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "environment not found for source").Log(ctx, s.logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment for source").Log(ctx, s.logger)
@@ -579,7 +579,7 @@ func (s *Service) DeleteToolsetEnvironmentLink(ctx context.Context, payload *gen
 		ToolsetID: toolsetID,
 		ProjectID: *authCtx.ProjectID,
 	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return oops.E(oops.CodeUnexpected, err, "failed to delete toolset environment link").Log(ctx, s.logger)
 	}
 
@@ -607,7 +607,7 @@ func (s *Service) GetToolsetEnvironment(ctx context.Context, payload *gen.GetToo
 	})
 
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "environment not found for toolset").Log(ctx, s.logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get environment for toolset").Log(ctx, s.logger)

--- a/server/internal/environments/shared.go
+++ b/server/internal/environments/shared.go
@@ -2,13 +2,13 @@ package environments
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments/repo"
@@ -45,7 +45,7 @@ func (e *EnvironmentEntries) Load(ctx context.Context, projectID uuid.UUID, envI
 			Slug:      strings.ToLower(envIDOrSlug.Slug),
 		})
 		switch {
-		case errors.Is(err, sql.ErrNoRows):
+		case errors.Is(err, pgx.ErrNoRows):
 			return nil, toolconfig.ErrNotFound
 		case err != nil:
 			return nil, fmt.Errorf("get environment by slug: %w", err)
@@ -77,7 +77,7 @@ func (e *EnvironmentEntries) LoadSourceEnv(ctx context.Context, projectID uuid.U
 		ProjectID:  projectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return map[string]string{}, nil
 		}
 		return nil, fmt.Errorf("get environment for source: %w", err)
@@ -101,7 +101,7 @@ func (e *EnvironmentEntries) LoadToolsetEnv(ctx context.Context, projectID uuid.
 		ProjectID: projectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("get environment for toolset: %w", err)
@@ -128,7 +128,7 @@ func (e *EnvironmentEntries) LoadMCPAttachedEnvironment(
 ) (map[string]string, error) {
 	mcpMetadata, err := e.mcpMetadataRepo.GetMetadataForToolset(ctx, toolsetID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return map[string]string{}, nil
 		}
 		return nil, fmt.Errorf("get metadata for toolset: %w", err)

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -3,7 +3,6 @@ package functions
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -19,6 +18,7 @@ import (
 
 	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	slogmulti "github.com/samber/slog-multi"
@@ -149,7 +149,7 @@ func (f *FlyRunner) prepareFunctionAuth(ctx context.Context, logger *slog.Logger
 		AccessID:     baseReq.FunctionsAccessID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return "", nil, oops.E(oops.CodeNotFound, err, "no function runner available").Log(ctx, logger)
 	case err != nil:
 		return "", nil, oops.E(oops.CodeUnexpected, err, "failed to fetch function runner").Log(ctx, logger)
@@ -556,7 +556,7 @@ func (f *FlyRunner) reap(ctx context.Context, logger *slog.Logger, appsRepo *rep
 		FunctionID:   req.FunctionID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
 		return fmt.Errorf("get existing app name: %w", err)

--- a/server/internal/functions/impl.go
+++ b/server/internal/functions/impl.go
@@ -2,13 +2,13 @@ package functions
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"net/url"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -90,7 +90,7 @@ func (s *Service) GetSignedAssetURL(ctx context.Context, p *gen.GetSignedAssetUR
 		AssetID:      assetID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get function asset url").Log(ctx, logger)

--- a/server/internal/integrations/impl.go
+++ b/server/internal/integrations/impl.go
@@ -2,13 +2,13 @@ package integrations
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"slices"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -92,7 +92,7 @@ func (s *Service) Get(ctx context.Context, form *gen.GetPayload) (res *gen.GetIn
 		PackageName: pname,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "error getting integration").Log(ctx, s.logger)
@@ -111,7 +111,7 @@ func (s *Service) Get(ctx context.Context, form *gen.GetPayload) (res *gen.GetIn
 		PackageID:   pid,
 		PackageName: pname,
 	})
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, oops.E(oops.CodeUnexpected, err, "error listing integration versions").Log(ctx, s.logger)
 	}
 

--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -3,7 +3,6 @@ package keys
 import (
 	"context"
 	"crypto/rand"
-	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -247,7 +247,7 @@ func (s *Service) RevokeKey(ctx context.Context, payload *gen.RevokeKeyPayload) 
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "error revoking api key").Log(ctx, s.logger)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"database/sql"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
@@ -541,7 +541,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ActiveOrganizationID != "" {
 		projects, err := s.authRepo.ListProjectsByOrganization(ctx, authCtx.ActiveOrganizationID)
 		switch {
-		case errors.Is(err, sql.ErrNoRows):
+		case errors.Is(err, pgx.ErrNoRows):
 			return oops.E(oops.CodeForbidden, nil, "no projects found").Log(ctx, s.logger)
 		case err != nil:
 			return oops.E(oops.CodeUnexpected, err, "error checking project access").Log(ctx, s.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
@@ -782,7 +782,7 @@ func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*
 	}
 
 	switch {
-	case errors.Is(toolsetErr, sql.ErrNoRows):
+	case errors.Is(toolsetErr, pgx.ErrNoRows):
 		return nil, nil, errToolsetNotFound
 	case toolsetErr != nil:
 		return nil, nil, fmt.Errorf("lookup toolset: %w", toolsetErr)

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -650,7 +650,7 @@ func filterOmittedEnvVars(
 	rawMetadata, err := repo.GetMetadataForToolset(ctx, toolsetID)
 	if err != nil {
 		// Fallback behavior for backwards compatibility
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
 		return fmt.Errorf("get metadata for toolset: %w", err)

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -2,7 +2,6 @@ package mcpendpoints
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -180,7 +179,7 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 			ProjectID: *authCtx.ProjectID,
 		})
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, s.logger)
 			}
 			return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").Log(ctx, s.logger)
@@ -200,7 +199,7 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 		CustomDomainID: customDomainID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, s.logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").Log(ctx, s.logger)
@@ -291,7 +290,7 @@ func (s *Service) UpdateMcpEndpoint(ctx context.Context, payload *gen.UpdateMcpE
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp endpoint").Log(ctx, logger)
@@ -311,7 +310,7 @@ func (s *Service) UpdateMcpEndpoint(ctx context.Context, payload *gen.UpdateMcpE
 		ProjectID:      *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, logger)
 		}
 		var pgErr *pgconn.PgError
@@ -374,7 +373,7 @@ func (s *Service) DeleteMcpEndpoint(ctx context.Context, payload *gen.DeleteMcpE
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "mcp endpoint not found").Log(ctx, logger)
 		}
 		return oops.E(oops.CodeUnexpected, err, "delete mcp endpoint").Log(ctx, logger)
@@ -432,7 +431,7 @@ func verifyEndpointReferenceOwnership(
 		ID:        mcpServerID,
 		ProjectID: projectID,
 	}); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("mcp_server_id does not reference a resource in this project")
 		}
 		return fmt.Errorf("check mcp server ownership: %w", err)
@@ -446,7 +445,7 @@ func verifyEndpointReferenceOwnership(
 		ID:             customDomainID.UUID,
 		OrganizationID: organizationID,
 	}); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("custom_domain_id does not reference a resource in this organization")
 		}
 		return fmt.Errorf("check custom domain ownership: %w", err)

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -2,7 +2,6 @@ package mcpservers
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -166,7 +165,7 @@ func (s *Service) GetMcpServer(ctx context.Context, payload *gen.GetMcpServerPay
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, s.logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").Log(ctx, s.logger)
@@ -240,7 +239,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").Log(ctx, logger)
@@ -263,7 +262,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		ProjectID:             *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "update mcp server").Log(ctx, logger)
@@ -321,7 +320,7 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "mcp server not found").Log(ctx, logger)
 		}
 		return oops.E(oops.CodeUnexpected, err, "delete mcp server").Log(ctx, logger)
@@ -450,7 +449,7 @@ func verifyServerReferenceOwnership(
 			ID:        ids.EnvironmentID.UUID,
 			ProjectID: projectID,
 		}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return fmt.Errorf("environment_id does not reference a resource in this project")
 			}
 			return fmt.Errorf("check environment ownership: %w", err)
@@ -462,7 +461,7 @@ func verifyServerReferenceOwnership(
 			ProjectID: projectID,
 			ID:        ids.ExternalOAuthServerID.UUID,
 		}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return fmt.Errorf("external_oauth_server_id does not reference a resource in this project")
 			}
 			return fmt.Errorf("check external oauth server ownership: %w", err)
@@ -474,7 +473,7 @@ func verifyServerReferenceOwnership(
 			ProjectID: projectID,
 			ID:        ids.OAuthProxyServerID.UUID,
 		}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return fmt.Errorf("oauth_proxy_server_id does not reference a resource in this project")
 			}
 			return fmt.Errorf("check oauth proxy server ownership: %w", err)
@@ -486,7 +485,7 @@ func verifyServerReferenceOwnership(
 			ID:        ids.RemoteMcpServerID.UUID,
 			ProjectID: projectID,
 		}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return fmt.Errorf("remote_mcp_server_id does not reference a resource in this project")
 			}
 			return fmt.Errorf("check remote mcp server ownership: %w", err)
@@ -498,7 +497,7 @@ func verifyServerReferenceOwnership(
 			ID:        ids.ToolsetID.UUID,
 			ProjectID: projectID,
 		}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return fmt.Errorf("toolset_id does not reference a resource in this project")
 			}
 			return fmt.Errorf("check toolset ownership: %w", err)

--- a/server/internal/mv/deployment.go
+++ b/server/internal/mv/deployment.go
@@ -2,12 +2,12 @@ package mv
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/deployments/repo"
@@ -22,7 +22,7 @@ func DescribeDeployment(ctx context.Context, logger *slog.Logger, depRepo *repo.
 		ProjectID: uuid.UUID(projectID),
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows), err == nil && len(rows) == 0:
+	case errors.Is(err, pgx.ErrNoRows), err == nil && len(rows) == 0:
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "error getting deployment with assets").Log(ctx, logger)

--- a/server/internal/mv/templates.go
+++ b/server/internal/mv/templates.go
@@ -2,12 +2,12 @@ package mv
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -46,7 +46,7 @@ func DescribePromptTemplate(
 		return nil, oops.E(oops.CodeBadRequest, err, "id or name is required to lookup template").Log(ctx, logger)
 	}
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, nil, "template not found")
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").Log(ctx, logger)

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -2,7 +2,6 @@ package mv
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/ettle/strcase"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -81,7 +81,7 @@ func DescribeToolsetEntry(
 		ProjectID: pid,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset").Log(ctx, logger)
@@ -358,7 +358,7 @@ func DescribeToolset(
 		ProjectID: pid,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset").Log(ctx, logger)
@@ -367,7 +367,7 @@ func DescribeToolset(
 	// TODO: It would be better if every query below accepted a deployment ID as a parameter to guarantee cache consistency.
 	activeDeploymentID, err := deploymentRepo.GetActiveDeploymentID(ctx, pid)
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		logger.WarnContext(ctx, "no active deployment id", attr.SlogError(err))
 	case err != nil:
 		logger.ErrorContext(ctx, "failed to get active deployment id", attr.SlogError(err))
@@ -450,7 +450,7 @@ func DescribeToolset(
 			ProjectID: pid,
 			ID:        toolset.ExternalOauthServerID.UUID,
 		})
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to get external oauth server metadata").Log(ctx, logger)
 		}
 		if len(externalOauthMetadata.Metadata) > 0 {
@@ -475,7 +475,7 @@ func DescribeToolset(
 			ProjectID: pid,
 			ID:        toolset.OauthProxyServerID.UUID,
 		})
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to get oauth proxy server").Log(ctx, logger)
 		}
 		if err == nil {
@@ -1206,7 +1206,7 @@ func getToolsetOrigin(
 		ToolsetID:      toolsetID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load toolset origin").Log(ctx, logger)

--- a/server/internal/packages/impl.go
+++ b/server/internal/packages/impl.go
@@ -2,12 +2,12 @@ package packages
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -262,7 +262,7 @@ func (s *Service) UpdatePackage(ctx context.Context, form *gen.UpdatePackagePayl
 		ImageAssetID:    imageAssetID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "error updating package").Log(ctx, logger)

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -2,7 +2,6 @@ package projects
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -90,7 +89,7 @@ func (s *Service) GetProject(ctx context.Context, payload *gen.GetProjectPayload
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.C(oops.CodeNotFound)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "error getting project by slug").Log(ctx, s.logger, attr.SlogProjectSlug(slug), attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
@@ -456,7 +455,7 @@ func (s *Service) DeleteProject(ctx context.Context, payload *gen.DeleteProjectP
 
 	_, err = pr.DeleteProject(ctx, projectID)
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil // Return successfully even if the project was already deleted
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "error deleting project").Log(ctx, s.logger, attr.SlogProjectID(payload.ID))

--- a/server/internal/remotemcp/impl.go
+++ b/server/internal/remotemcp/impl.go
@@ -2,13 +2,13 @@ package remotemcp
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -220,7 +220,7 @@ func (s *Service) GetServer(ctx context.Context, payload *gen.GetServerPayload) 
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").Log(ctx, s.logger)
 		}
 
@@ -280,7 +280,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").Log(ctx, logger)
 		}
 
@@ -440,7 +440,7 @@ func (s *Service) DeleteServer(ctx context.Context, payload *gen.DeleteServerPay
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
 

--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -3,7 +3,6 @@ package templates
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"github.com/cbroglie/mustache"
 	"github.com/google/uuid"
 	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
@@ -208,7 +208,7 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 		ID:        id,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "template not found").Log(ctx, logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").Log(ctx, logger)
@@ -280,7 +280,7 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 	case err == nil:
 		updated = true
 		nextid = newid
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		// No change, so we can use the existing id
 	default:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to update template").Log(ctx, logger)
@@ -371,7 +371,7 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 			ID:        id,
 		})
 		switch {
-		case errors.Is(err, sql.ErrNoRows):
+		case errors.Is(err, pgx.ErrNoRows):
 			return nil
 		case err != nil:
 			return oops.E(oops.CodeUnexpected, err, "failed to delete template by id").Log(ctx, logger)
@@ -388,7 +388,7 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 			Name:      name,
 		})
 		switch {
-		case errors.Is(err, sql.ErrNoRows):
+		case errors.Is(err, pgx.ErrNoRows):
 			return nil
 		case err != nil:
 			return oops.E(oops.CodeUnexpected, err, "failed to delete template by name").Log(ctx, logger)
@@ -511,7 +511,7 @@ func (s *Service) RenderTemplateByID(ctx context.Context, payload *gen.RenderTem
 		ID:        id,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "template not found").Log(ctx, logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to get template").Log(ctx, logger)

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -3,7 +3,6 @@ package openrouter
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 
@@ -157,7 +157,7 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string) (string,
 
 	key, err := o.repo.GetOpenRouterAPIKey(ctx, orgID)
 	switch {
-	case errors.Is(err, sql.ErrNoRows), key.Key == "":
+	case errors.Is(err, pgx.ErrNoRows), key.Key == "":
 		org, err := o.orgRepo.GetOrganizationMetadata(ctx, orgID)
 		if err != nil {
 			return "", oops.E(oops.CodeUnexpected, err, "failed to get organization").Log(ctx, o.logger)

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -2,7 +2,6 @@ package triggers
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -399,7 +399,7 @@ func toTriggerError(ctx context.Context, logger *slog.Logger, err error, message
 		public = fmt.Sprintf("%s: %s", message, err.Error())
 	case errors.Is(err, bgtriggers.ErrAuthFailed):
 		code = oops.CodeUnauthorized
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		code = oops.CodeNotFound
 	}
 	return oops.E(code, err, "%s", public).Log(ctx, logger)

--- a/server/internal/variations/impl.go
+++ b/server/internal/variations/impl.go
@@ -2,12 +2,12 @@ package variations
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
@@ -134,11 +134,11 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 	tx := s.repo.WithTx(dbtx)
 
 	groupID, err := tx.PokeGlobalToolVariationsGroup(ctx, projectID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, oops.E(oops.CodeUnexpected, err, "error poking global tool variations group").Log(ctx, logger)
 	}
 
-	if errors.Is(err, sql.ErrNoRows) || groupID == uuid.Nil {
+	if errors.Is(err, pgx.ErrNoRows) || groupID == uuid.Nil {
 		groupID, err = tx.InitGlobalToolVariationsGroup(ctx, repo.InitGlobalToolVariationsGroupParams{
 			ProjectID:   projectID,
 			Name:        "Global tool variations",
@@ -252,7 +252,7 @@ func (s *Service) DeleteGlobal(ctx context.Context, payload *gen.DeleteGlobalPay
 		ProjectID: *authCtx.ProjectID,
 	})
 	switch {
-	case errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "global tool variation not found").Log(ctx, s.logger)
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "error deleting global tool variation").Log(ctx, s.logger)


### PR DESCRIPTION
Closes [AGE-2010](https://linear.app/speakeasy/issue/AGE-2010/create-glint-analyzer-for-reporting-sqlerrnorows-usage).

## Why

Agents have repeatedly flagged `sql.ErrNoRows` usage in this codebase and suggested `pgx.ErrNoRows` instead. Encoding the rule once in our `glint` golangci-lint plugin gives us authoritative enforcement and automated `--fix` support, preventing those false positives.

## What's in this PR

A new `nosqlerrnorows` `go/analysis` analyzer in [`glint/no_sql_err_no_rows.go`](glint/no_sql_err_no_rows.go), wired into the glint plugin and covered by `analysistest` (diagnostics + `RunWithSuggestedFixes` golden files). Detection is type-aware via `pass.TypesInfo` so it works through aliased imports of `database/sql` and does not match unrelated identifiers named `ErrNoRows`. The `SuggestedFix` rewrites the selector to `pgx.ErrNoRows` and updates imports — adds `github.com/jackc/pgx/v5` and removes `database/sql` when the file uses `sql` only for `ErrNoRows`. Reusable import-edit helpers (`Add`, `Remove`, `LocalName`) are extracted into a new [`glint/imports`](glint/imports/) subpackage so future analyzers can share them.

The 30 existing `sql.ErrNoRows` call sites across the server were migrated by running the analyzer's own `SuggestedFix` via `golangci-lint --fix`; the `writing-queries-with-sqlc.md` runbook was then updated to match. No behavior change: `pgx.ErrNoRows` aliases the same sentinel error as `sql.ErrNoRows`.

Commits are split (analyzer → migration → runbook) for easier review.