### PR TITLE
chore: route OTLP through OTel Collector for local metrics support

### DIFF
--- a/.agents/skills/jaeger/SKILL.md
+++ b/.agents/skills/jaeger/SKILL.md
@@ -5,7 +5,19 @@ description: Use the local Jaeger instance to inspect OpenTelemetry traces emitt
 
 # Jaeger — Local Trace Inspection
 
-Gram runs a local Jaeger All-in-One instance that collects all OpenTelemetry traces from `gram-server` and `gram-worker`. It starts automatically with `mise run infra:start`.
+Gram runs a local OpenTelemetry Collector that receives all OTLP signals from `gram-server` and `gram-worker`, routing traces to Jaeger and metrics to Prometheus. Everything starts automatically with `mise run infra:start`.
+
+## Architecture
+
+```
+App → OTLP :$OTLP_GRPC_PORT → OTel Collector → traces → Jaeger
+                                               → metrics → Prometheus (scrapes collector)
+                                               → spanmetrics connector → Prometheus (RED metrics from traces)
+```
+
+- **OTel Collector** receives all OTLP (traces + metrics) on `$OTLP_GRPC_PORT`
+- **Jaeger** receives traces from the collector (not directly from the app)
+- **Prometheus** scrapes the collector's metrics exporter and stores both app metrics and span-derived RED metrics
 
 ## Discovering Ports
 
@@ -93,15 +105,33 @@ Key attributes on spans:
 - `service.name` — `gram-server` or `gram-worker`
 - `error` — `true` if the span recorded an error
 
+## Prometheus — Local Metrics
+
+Prometheus is available at `http://localhost:$PROMETHEUS_PORT`. It stores:
+
+- **App metrics** — custom counters, histograms, gauges exported via OTLP from server/worker
+- **Span metrics** — RED metrics (rate, errors, duration) derived from traces by the OTel Collector's `spanmetrics` connector
+
+```bash
+# Prometheus UI
+echo $PROMETHEUS_PORT
+
+# Example PromQL queries
+# Request rate by service:    calls_total{service_name="gram-server"}
+# Error rate:                 calls_total{status_code="STATUS_CODE_ERROR"}
+# P99 latency:                histogram_quantile(0.99, sum(rate(duration_milliseconds_bucket[5m])) by (le, service_name))
+```
+
 ## Environment Variables
 
 Configured in `mise.toml`:
 
-| Variable                      | Default                 | Purpose                          |
-| ----------------------------- | ----------------------- | -------------------------------- |
-| `OTLP_GRPC_HOST`              | `localhost`             | OTLP receiver host               |
-| `OTLP_GRPC_PORT`              | `4317`                  | OTLP receiver port               |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | Full endpoint (auto-constructed) |
-| `JAEGER_WEB_PORT`             | `16686`                 | Jaeger UI/API port               |
-| `GRAM_ENABLE_OTEL_TRACES`     | `1`                     | Enable/disable trace export      |
-| `GRAM_ENABLE_OTEL_METRICS`    | `1`                     | Enable/disable metrics export    |
+| Variable                      | Default                 | Purpose                             |
+| ----------------------------- | ----------------------- | ----------------------------------- |
+| `OTLP_GRPC_HOST`              | `localhost`             | OTLP receiver host (OTel Collector) |
+| `OTLP_GRPC_PORT`              | `4317`                  | OTLP receiver port (OTel Collector) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | Full endpoint (auto-constructed)    |
+| `JAEGER_WEB_PORT`             | `16686`                 | Jaeger UI/API port (traces)         |
+| `PROMETHEUS_PORT`             | `9090`                  | Prometheus UI/API port (metrics)    |
+| `GRAM_ENABLE_OTEL_TRACES`     | `1`                     | Enable/disable trace export         |
+| `GRAM_ENABLE_OTEL_METRICS`    | `1`                     | Enable/disable metrics export       |

--- a/.agents/skills/jaeger/SKILL.md
+++ b/.agents/skills/jaeger/SKILL.md
@@ -132,6 +132,6 @@ Configured in `mise.toml`:
 | `OTLP_GRPC_PORT`              | `4317`                  | OTLP receiver port (OTel Collector) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | Full endpoint (auto-constructed)    |
 | `JAEGER_WEB_PORT`             | `16686`                 | Jaeger UI/API port (traces)         |
-| `PROMETHEUS_PORT`             | `9090`                  | Prometheus UI/API port (metrics)    |
+| `PROMETHEUS_PORT`             | `9099`                  | Prometheus UI/API port (metrics)    |
 | `GRAM_ENABLE_OTEL_TRACES`     | `1`                     | Enable/disable trace export         |
 | `GRAM_ENABLE_OTEL_METRICS`    | `1`                     | Enable/disable metrics export       |

--- a/compose.yml
+++ b/compose.yml
@@ -56,12 +56,32 @@ services:
       timeout: 30s
       retries: 5
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.127.0
+    restart: unless-stopped
+    volumes:
+      - ./local/otel-collector/config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "${OTLP_GRPC_PORT}:4317"
+    depends_on:
+      - jaeger
+
   jaeger:
     image: jaegertracing/jaeger:2.17.0
     restart: unless-stopped
     ports:
-      - "${OTLP_GRPC_PORT}:4317"
       - "${JAEGER_WEB_PORT}:16686"
+
+  prometheus:
+    image: prom/prometheus:v3.4.0
+    restart: unless-stopped
+    volumes:
+      - ./local/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT}:9090"
+    depends_on:
+      - otel-collector
 
   clickhouse:
     build:
@@ -138,6 +158,8 @@ volumes:
   temporal_data:
     driver: local
   clickhouse_data:
+    driver: local
+  prometheus_data:
     driver: local
   mcp_registry_data:
     driver: local

--- a/local/otel-collector/config.yaml
+++ b/local/otel-collector/config.yaml
@@ -1,0 +1,30 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+connectors:
+  spanmetrics:
+
+exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/jaeger, spanmetrics]
+    metrics:
+      receivers: [otlp, spanmetrics]
+      processors: [batch]
+      exporters: [prometheus]

--- a/local/prometheus/prometheus.yml
+++ b/local/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: otel-collector
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/mise.toml
+++ b/mise.toml
@@ -150,6 +150,7 @@ GRAM_ENABLE_OTEL_METRICS = 1
 ## Local development settings ##
 ################################
 JAEGER_WEB_PORT = "16686"
+PROMETHEUS_PORT = "9091"
 GRAM_LOG_PRETTY = 1
 ## This config is used by the Elements SDK and CLI to point to the correct Gram
 ## API server

--- a/mise.toml
+++ b/mise.toml
@@ -150,7 +150,7 @@ GRAM_ENABLE_OTEL_METRICS = 1
 ## Local development settings ##
 ################################
 JAEGER_WEB_PORT = "16686"
-PROMETHEUS_PORT = "9091"
+PROMETHEUS_PORT = "9099"
 GRAM_LOG_PRETTY = 1
 ## This config is used by the Elements SDK and CLI to point to the correct Gram
 ## API server

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,5 +1,17 @@
 # mprocs configuration
 procs:
+  otel-collector:
+    cmd: ["docker", "compose", "logs", "-f", "otel-collector"]
+    stop:
+      send-keys: ["<C-c>"]
+  jaeger:
+    cmd: ["docker", "compose", "logs", "-f", "jaeger"]
+    stop:
+      send-keys: ["<C-c>"]
+  prometheus:
+    cmd: ["docker", "compose", "logs", "-f", "prometheus"]
+    stop:
+      send-keys: ["<C-c>"]
   mock-idp:
     cmd: ["mise", "run", "start:mock-idp"]
     stop:


### PR DESCRIPTION
## Summary

- Add OTel Collector between app and Jaeger to route traces and metrics to separate backends
- Add Prometheus for local metrics storage (scrapes collector on `:8889`)
- Jaeger only supports traces — sending metrics to it caused recurring `unknown service MetricsService` errors
- SpanMetrics connector derives RED metrics (rate, errors, duration) from traces automatically

## Architecture

```
App → OTLP :4317 → OTel Collector → traces → Jaeger (:16686)
                                   → metrics → Prometheus (:9099)
                                   → spanmetrics → Prometheus
```

## Changes

- `compose.yml` — add `otel-collector` and `prometheus` services, move Jaeger behind collector
- `local/otel-collector/config.yaml` — collector pipeline config
- `local/prometheus/prometheus.yml` — scrape config targeting collector
- `mise.toml` — add `PROMETHEUS_PORT=9099`
- `mprocs.yaml` — add log-tailing procs for collector, jaeger, prometheus
- `.agents/skills/jaeger/SKILL.md` — updated docs with new architecture and Prometheus queries

## Test plan

- [ ] `mise run infra:start` — all containers start cleanly
- [ ] No more `MetricsService` errors in server/admin/worker logs
- [ ] Jaeger UI (`localhost:16686`) still shows traces
- [ ] Prometheus UI (`localhost:9099`) shows app metrics and span-derived RED metrics
- [ ] madprocs shows otel-collector, jaeger, prometheus log tabs