### PR TITLE
chore: return 401 on webhook auth failure

### DIFF
--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -27,7 +27,10 @@ const (
 	StatusPaused        = "paused"
 )
 
-var ErrBadRequest = errors.New("trigger bad request")
+var (
+	ErrBadRequest = errors.New("trigger bad request")
+	ErrAuthFailed = errors.New("trigger webhook authentication failed")
+)
 
 type DeliveryStatus string
 
@@ -372,7 +375,7 @@ func (a *App) ProcessWebhook(ctx context.Context, instanceID uuid.UUID, body []b
 	}
 
 	if err := definition.AuthenticateWebhook(body, headers, envMap, config); err != nil {
-		return nil, fmt.Errorf("authenticate webhook: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrAuthFailed, err)
 	}
 
 	result, err := definition.HandleWebhook(body, headers, config)

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -397,6 +397,8 @@ func toTriggerError(ctx context.Context, logger *slog.Logger, err error, message
 		// self-correct. The chain is already user-actionable: it's only
 		// reached when the input fails validation.
 		public = fmt.Sprintf("%s: %s", message, err.Error())
+	case errors.Is(err, bgtriggers.ErrAuthFailed):
+		code = oops.CodeUnauthorized
 	case errors.Is(err, sql.ErrNoRows):
 		code = oops.CodeNotFound
 	}


### PR DESCRIPTION
## Summary

- Misconfigured Slack triggers (e.g. missing `SLACK_SIGNING_SECRET`) and signature-mismatch failures all flowed through `CodeUnexpected` → 500. Slack treats 5xx as transient and retried, generating noisy error spikes (see prod 17:15:13–17:16:24 UTC, 2026-04-30).
- Add `ErrAuthFailed` sentinel in `background/triggers/app.go`, wrap `AuthenticateWebhook` errors with it, and map to `CodeUnauthorized` (401) in `toTriggerError`.
- Slack stops retrying on any 4xx, and the response code now reflects what actually happened (we couldn't authenticate the webhook).

✻ Clauded...