### PR TITLE
fix: don't show system/omitted env vars in MCP install snippet

### DIFF
--- a/.changeset/fix-mcp-install-page-env-filter.md
+++ b/.changeset/fix-mcp-install-page-env-filter.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix MCP install page rendering required external MCP headers in the install snippet even when the operator had configured those env vars as System or Omit.

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1203,6 +1203,9 @@ func (s *Service) collectEnvironmentVariables(mode securityMode, toolsetDetails 
 			if !headerDef.Required {
 				continue
 			}
+			if isExplicitlyNotUserProvided(headerDef.Name) {
+				continue
+			}
 			if !seen[headerDef.Name] {
 				seen[headerDef.Name] = true
 				inputs = append(inputs, securityInput{

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	externalmcp_repo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	externalmcp_types "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	mcpmetadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
@@ -1022,4 +1025,150 @@ func TestServeInstallPage_NoDomain_AuthedUserWithOrgDomain(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Equal(t, "text/html", rr.Header().Get("Content-Type"))
+}
+
+// TestServeInstallPage_ExternalMCP_FiltersNonUserProvidedHeaders is a regression
+// test for a customer-reported bug: an external MCP server's required headers
+// were being rendered into the install snippet even when the operator had
+// configured those variables as "system" (provided server-side) or "none"
+// (omitted entirely). The bug was in collectEnvironmentVariables, where the
+// loop over ExternalMcpHeaderDefinitions skipped the isExplicitlyNotUserProvided
+// filter that the SecurityVariables and FunctionEnvironmentVariables loops
+// already applied. Only headers whose mcp_environment_configs entry is "user"
+// (or has no entry, for backwards compat) should appear in the install snippet.
+func TestServeInstallPage_ExternalMCP_FiltersNonUserProvidedHeaders(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	mcpSlug := "external-mcp-filter-" + uuid.New().String()[:8]
+	toolset, err := ti.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         orgID,
+		ProjectID:              projectID,
+		Name:                   "External MCP Filter Test",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("public toolset proxying an external MCP server with header configs"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.conn.Exec(ctx,
+		"UPDATE toolsets SET mcp_is_public = true WHERE id = $1", toolset.ID)
+	require.NoError(t, err)
+
+	var deploymentID uuid.UUID
+	err = ti.conn.QueryRow(ctx, `
+		INSERT INTO deployments (project_id, organization_id, user_id, idempotency_key)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`, projectID, orgID, "test-user", uuid.New().String()).Scan(&deploymentID)
+	require.NoError(t, err)
+
+	_, err = ti.conn.Exec(ctx, `
+		INSERT INTO deployment_statuses (deployment_id, status)
+		VALUES ($1, 'completed')
+	`, deploymentID)
+	require.NoError(t, err)
+
+	var registryID uuid.UUID
+	err = ti.conn.QueryRow(ctx, `
+		INSERT INTO mcp_registries (name, url)
+		VALUES ($1, $2)
+		RETURNING id
+	`, "test-registry-"+mcpSlug, "https://mcp.example.com/glyphic").Scan(&registryID)
+	require.NoError(t, err)
+
+	externalmcpRepo := externalmcp_repo.New(ti.conn)
+	attachmentSlug := "glyphic"
+	attachment, err := externalmcpRepo.CreateExternalMCPAttachment(ctx, externalmcp_repo.CreateExternalMCPAttachmentParams{
+		DeploymentID:            deploymentID,
+		RegistryID:              uuid.NullUUID{UUID: registryID, Valid: true},
+		Name:                    "Glyphic MCP Server",
+		Slug:                    attachmentSlug,
+		RegistryServerSpecifier: "test-server",
+	})
+	require.NoError(t, err)
+
+	// header_definitions JSON shape matches the unexported externalMCPHeaderDefinition
+	// struct in server/internal/mv/toolset.go. extractExternalMCPHeaderDefinitions
+	// produces variable names by snake-casing "<attachmentSlug>_<headerName>", so the
+	// resulting names here are GLYPHIC_X_API_KEY, GLYPHIC_AUTHORIZATION, GLYPHIC_TRACE_ID.
+	headerDefsJSON := []byte(`[
+		{"name":"X-Api-Key","isRequired":true,"isSecret":true},
+		{"name":"Authorization","isRequired":true,"isSecret":true},
+		{"name":"Trace-Id","isRequired":true,"isSecret":false}
+	]`)
+
+	toolURN := "tools:externalmcp:" + attachmentSlug + ":proxy"
+	_, err = externalmcpRepo.CreateExternalMCPToolDefinition(ctx, externalmcp_repo.CreateExternalMCPToolDefinitionParams{
+		ExternalMcpAttachmentID:    attachment.ID,
+		ToolUrn:                    toolURN,
+		Type:                       "proxy",
+		RemoteUrl:                  "https://mcp.example.com/glyphic",
+		TransportType:              externalmcp_types.TransportTypeStreamableHTTP,
+		RequiresOauth:              false,
+		OauthVersion:               "none",
+		OauthAuthorizationEndpoint: pgtype.Text{},
+		OauthTokenEndpoint:         pgtype.Text{},
+		OauthRegistrationEndpoint:  pgtype.Text{},
+		OauthScopesSupported:       []string{},
+		HeaderDefinitions:          headerDefsJSON,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.conn.Exec(ctx, `
+		INSERT INTO toolset_versions (toolset_id, version, tool_urns, resource_urns)
+		VALUES ($1, 1, $2, '{}')
+	`, toolset.ID, []string{toolURN})
+	require.NoError(t, err)
+
+	mcpRepo := mcpmetadata_repo.New(ti.conn)
+	metadata, err := mcpRepo.UpsertMetadata(ctx, mcpmetadata_repo.UpsertMetadataParams{
+		ToolsetID: toolset.ID,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+
+	// Mark X-Api-Key as system-provided and Authorization as omitted; leave Trace-Id
+	// without an env config (defaulting to user-provided) as the positive-case anchor.
+	_, err = mcpRepo.UpsertEnvironmentConfig(ctx, mcpmetadata_repo.UpsertEnvironmentConfigParams{
+		ProjectID:     projectID,
+		McpMetadataID: metadata.ID,
+		VariableName:  "GLYPHIC_X_API_KEY",
+		ProvidedBy:    "system",
+	})
+	require.NoError(t, err)
+	_, err = mcpRepo.UpsertEnvironmentConfig(ctx, mcpmetadata_repo.UpsertEnvironmentConfigParams{
+		ProjectID:     projectID,
+		McpMetadataID: metadata.ID,
+		VariableName:  "GLYPHIC_AUTHORIZATION",
+		ProvidedBy:    "none",
+	})
+	require.NoError(t, err)
+
+	installReq := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	installRctx := chi.NewRouteContext()
+	installRctx.URLParams.Add("mcpSlug", mcpSlug)
+	installReq = installReq.WithContext(context.WithValue(context.Background(), chi.RouteCtxKey, installRctx))
+
+	installRR := httptest.NewRecorder()
+	err = ti.service.ServeInstallPage(installRR, installReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, installRR.Code)
+
+	body := installRR.Body.String()
+	assert.NotContains(t, body, "GLYPHIC_X_API_KEY",
+		"system-provided external MCP header must not appear in the install snippet")
+	assert.NotContains(t, body, "GLYPHIC_AUTHORIZATION",
+		"omitted external MCP header must not appear in the install snippet")
+	assert.Contains(t, body, "GLYPHIC_TRACE_ID",
+		"user-provided external MCP header (no env config) must still appear in the install snippet")
 }

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1027,15 +1027,6 @@ func TestServeInstallPage_NoDomain_AuthedUserWithOrgDomain(t *testing.T) {
 	require.Equal(t, "text/html", rr.Header().Get("Content-Type"))
 }
 
-// TestServeInstallPage_ExternalMCP_FiltersNonUserProvidedHeaders is a regression
-// test for a customer-reported bug: an external MCP server's required headers
-// were being rendered into the install snippet even when the operator had
-// configured those variables as "system" (provided server-side) or "none"
-// (omitted entirely). The bug was in collectEnvironmentVariables, where the
-// loop over ExternalMcpHeaderDefinitions skipped the isExplicitlyNotUserProvided
-// filter that the SecurityVariables and FunctionEnvironmentVariables loops
-// already applied. Only headers whose mcp_environment_configs entry is "user"
-// (or has no entry, for backwards compat) should appear in the install snippet.
 func TestServeInstallPage_ExternalMCP_FiltersNonUserProvidedHeaders(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestMCPMetadataService(t)


### PR DESCRIPTION
## Summary

- Fixes a customer-reported bug where the MCP install page rendered required external-MCP headers (`--header 'X:${...}'` and corresponding `export` lines) even when the operator had configured those env vars as **System** (provided server-side) or **Omit** (not included).
- Root cause in `collectEnvironmentVariables` at `server/internal/mcpmetadata/impl.go`: the loop over `ExternalMcpHeaderDefinitions` skipped the `isExplicitlyNotUserProvided` filter that the `SecurityVariables` and `FunctionEnvironmentVariables` loops already applied. Adding the same filter brings external-MCP headers in line with the other two sources.
- Adds a regression test (`TestServeInstallPage_ExternalMCP_FiltersNonUserProvidedHeaders`) that mirrors the customer's setup: an external MCP attachment with three required headers, two configured as `system`/`none` and one left without an env config. Asserts the install page body excludes the first two while preserving the third.

## Test plan

- [x] New regression test passes with the fix in place
- [x] New regression test fails (on the two `NotContains` assertions) when the fix is reverted, confirming it would have caught this bug
- [x] Full `mcpmetadata` package test suite passes (`go test ./internal/mcpmetadata/...`)

