### PR TITLE
mig: add user_message column to risk_policies

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2193,6 +2193,7 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   presidio_entities TEXT[],
   action TEXT NOT NULL DEFAULT 'flag',
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,
+  user_message TEXT,
   version BIGINT NOT NULL,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -989,6 +989,7 @@ type RiskPolicy struct {
 	PresidioEntities []string
 	Action           string
 	AutoName         bool
+	UserMessage      pgtype.Text
 	Version          int64
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -19,6 +19,7 @@ type RiskPolicy struct {
 	PresidioEntities []string
 	Action           string
 	AutoName         bool
+	UserMessage      pgtype.Text
 	Version          int64
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -19,7 +19,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -40,6 +40,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -145,7 +146,7 @@ VALUES (
   , $9
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -183,6 +184,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -313,7 +315,7 @@ func (q *Queries) GetMessageContentBatch(ctx context.Context, arg GetMessageCont
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -338,6 +340,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -366,7 +369,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -393,6 +396,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -410,7 +414,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -436,6 +440,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -453,7 +458,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -479,6 +484,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -831,7 +837,7 @@ SET name = $1
 WHERE id = $7
   AND project_id = $8
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -867,6 +873,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/migrations/20260430205315_risk-policies-user-message.sql
+++ b/server/migrations/20260430205315_risk-policies-user-message.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "user_message" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:B6DVNKzEJOgtvdi6DJGSIYJhGcmnjQbWcCRkg1OzqRQ=
+h1:zleYfz3S2cRoqSoJ3IKZKjvsa7ej9M8rmJHZPH68KSk=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -150,3 +150,4 @@ h1:B6DVNKzEJOgtvdi6DJGSIYJhGcmnjQbWcCRkg1OzqRQ=
 20260429131558_mcp_servers_and_endpoints.sql h1:sNg8L6mZfYPnbP4xBreK4S9la7SwGzTBCw0Qe68h3DY=
 20260430111449_add-workos-roles-and-sync-tables.sql h1:tIK7+g0gEt27jixmoso4bHI7GYAtxUzfL8l24k2Os8g=
 20260430201533_risk-policies-action-and-auto-name.sql h1:3tvGuQlzBnUX2gvFtad56YpeX1wpE9asgXh74ywEIhE=
+20260430205315_risk-policies-user-message.sql h1:b3myELZy6W5m08Wz7aqPV6pInYP5SB0KKj5uQ5VYBoQ=


### PR DESCRIPTION
Adds a nullable user_message column for customizing the text returned to the user when a policy blocks an action (or is surfaced in the UI for a flagged finding). Backwards-compatible: existing policies fall back to the default block message at render time.