### PR TITLE
feat(risk): batch presidio /analyze + periodic heartbeat

### DIFF
--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -29,9 +29,11 @@ type PIIScanner interface {
 	AnalyzeBatch(ctx context.Context, texts []string, entities []string, onProgress func()) ([][]Finding, error)
 }
 
-// presidioRequest is the payload sent to POST /analyze.
+// presidioRequest is the payload sent to POST /analyze. Text is sent as a
+// list so Presidio runs the whole batch through analyze_iterator with a
+// single recognizer load instead of reloading on every text.
 type presidioRequest struct {
-	Text     string   `json:"text"`
+	Text     []string `json:"text"`
 	Language string   `json:"language"`
 	ScoreMin float64  `json:"score_threshold"`
 	Entities []string `json:"entities,omitempty"`
@@ -45,27 +47,48 @@ type presidioResult struct {
 	Score      float64 `json:"score"`
 }
 
-// presidioMaxWorkers is the default concurrency limit for Presidio HTTP
-// requests. Presidio scanning is network-bound, not CPU-bound, so we use a
-// higher limit than runtime.NumCPU().
-const presidioMaxWorkers = 100
+const (
+	// presidioDefaultBatchSize is how many texts go into a single POST /analyze.
+	// Each call loads recognizers once and analyzes the batch with Presidio's
+	// internal multiprocessing, so larger batches mean less overhead per text.
+	presidioDefaultBatchSize = 50
+
+	// presidioDefaultMaxConcurrentRequests caps in-flight POST /analyze calls.
+	// Presidio's gunicorn worker is sync, so high concurrency just queues up
+	// and stalls until pods get killed; a small ceiling avoids that pile-up.
+	presidioDefaultMaxConcurrentRequests = 4
+
+	// presidioHeartbeatInterval is how often AnalyzeBatch fires onProgress
+	// while requests are in flight. Must be well under the Temporal activity
+	// HeartbeatTimeout (30s in DrainRiskAnalysisWorkflow) so a slow Presidio
+	// response doesn't trip the timeout.
+	presidioHeartbeatInterval = 10 * time.Second
+)
 
 // PresidioClient calls the Presidio Analyzer HTTP API.
 // Presidio is a trusted cluster-internal service, so the client uses an
 // unsafe guardian policy with an empty blocklist. The default policy blocks
 // RFC 1918 private ranges (10.0.0.0/8) which Kubernetes ClusterIPs fall into.
 type PresidioClient struct {
-	baseURL         string
-	httpClient      *guardian.HTTPClient
-	tracer          trace.Tracer
-	logger          *slog.Logger
-	maxWorkers      int
-	requestDuration metric.Float64Histogram
-	requestFailures metric.Int64Counter
+	baseURL               string
+	httpClient            *guardian.HTTPClient
+	tracer                trace.Tracer
+	logger                *slog.Logger
+	batchSize             int
+	maxConcurrentRequests int
+	requestDuration       metric.Float64Histogram
+	requestFailures       metric.Int64Counter
 }
 
 // NewPresidioClient creates a client pointing at the given base URL.
 func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger) *PresidioClient {
+	return NewPresidioClientWithLimits(baseURL, tracerProvider, meterProvider, logger, presidioDefaultBatchSize, presidioDefaultMaxConcurrentRequests)
+}
+
+// NewPresidioClientWithLimits is like NewPresidioClient but allows overriding
+// the batch size (texts per HTTP request) and max concurrent in-flight HTTP
+// requests. Non-positive values fall back to the package defaults.
+func NewPresidioClientWithLimits(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, batchSize, maxConcurrentRequests int) *PresidioClient {
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio")
 
 	requestDuration, _ := meter.Float64Histogram(
@@ -85,23 +108,23 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 	unsafePolicy, _ := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	httpClient := unsafePolicy.PooledClient()
 
-	return &PresidioClient{
-		baseURL:         strings.TrimRight(baseURL, "/"),
-		httpClient:      httpClient,
-		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio"),
-		logger:          logger,
-		maxWorkers:      presidioMaxWorkers,
-		requestDuration: requestDuration,
-		requestFailures: requestFailures,
+	if batchSize <= 0 {
+		batchSize = presidioDefaultBatchSize
 	}
-}
+	if maxConcurrentRequests <= 0 {
+		maxConcurrentRequests = presidioDefaultMaxConcurrentRequests
+	}
 
-// NewPresidioClientWithWorkers is like NewPresidioClient but allows overriding
-// the concurrency limit. Used for benchmarking.
-func NewPresidioClientWithWorkers(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, maxWorkers int) *PresidioClient {
-	c := NewPresidioClient(baseURL, tracerProvider, meterProvider, logger)
-	c.maxWorkers = maxWorkers
-	return c
+	return &PresidioClient{
+		baseURL:               strings.TrimRight(baseURL, "/"),
+		httpClient:            httpClient,
+		tracer:                tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio"),
+		logger:                logger,
+		batchSize:             batchSize,
+		maxConcurrentRequests: maxConcurrentRequests,
+		requestDuration:       requestDuration,
+		requestFailures:       requestFailures,
+	}
 }
 
 // presidioEntityBlacklist is the set of Presidio entity types we refuse to
@@ -151,7 +174,9 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	entities = filtered
 
 	ctx, span := p.tracer.Start(ctx, "presidio.analyzeBatch", trace.WithAttributes(
-		attribute.Int("presidio.batch_size", n),
+		attribute.Int("presidio.text_count", n),
+		attribute.Int("presidio.batch_size", p.batchSize),
+		attribute.Int("presidio.max_concurrent_requests", p.maxConcurrentRequests),
 	))
 	defer func() {
 		if err != nil {
@@ -160,47 +185,74 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 		span.End()
 	}()
 
-	results := make([][]Finding, n)
-	workers := min(p.maxWorkers, n)
-
-	// Pre-fill a buffered channel with indices so workers can pull the next
-	// item without coordination. Closing it causes workers to exit when the
-	// channel drains.
-	ch := make(chan int, n)
-	for i := range n {
-		ch <- i
-	}
-	close(ch)
-
-	var wg sync.WaitGroup
-
-	// Fan out workers that each drain items from ch until it's empty.
-	// Individual failures are logged and skipped; results[idx] stays nil
-	// for that text, which the caller treats as "no findings".
-	for range workers {
-		wg.Go(func() {
-			for idx := range ch {
-				findings, err := p.analyze(ctx, texts[idx], entities)
-				if err != nil {
-					p.logger.WarnContext(ctx, "presidio analyze failed for text, skipping",
-						attr.SlogError(err),
-					)
-					continue
-				}
-				results[idx] = findings
-				if onProgress != nil {
+	// Heartbeat ticker so Temporal activities calling AnalyzeBatch keep their
+	// heartbeat fresh while requests sit in flight. Without this, a slow
+	// Presidio response (e.g. queued behind a sync gunicorn worker) can blow
+	// past the activity HeartbeatTimeout.
+	if onProgress != nil {
+		ticker := time.NewTicker(presidioHeartbeatInterval)
+		done := make(chan struct{})
+		defer func() {
+			close(done)
+			ticker.Stop()
+		}()
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
 					onProgress()
 				}
 			}
-		})
+		}()
+	}
+
+	results := make([][]Finding, n)
+	sem := make(chan struct{}, p.maxConcurrentRequests)
+	var wg sync.WaitGroup
+
+	// Slice the input into batches and fan out batched HTTP calls. Individual
+	// chunk failures are logged and skipped; results[idx] stays nil for the
+	// affected texts, which the caller treats as "no findings".
+	for start := 0; start < n; start += p.batchSize {
+		end := min(start+p.batchSize, n)
+		chunk := texts[start:end]
+		offset := start
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
+			chunkFindings, err := p.analyzeChunk(ctx, chunk, entities)
+			if err != nil {
+				p.logger.WarnContext(ctx, "presidio analyze chunk failed, skipping",
+					attr.SlogError(err),
+				)
+				return
+			}
+			for i, f := range chunkFindings {
+				results[offset+i] = f
+			}
+		}()
 	}
 
 	wg.Wait()
 	return results, nil
 }
 
-func (p *PresidioClient) analyze(ctx context.Context, text string, entities []string) (_ []Finding, err error) {
-	ctx, span := p.tracer.Start(ctx, "presidio.analyze")
+// analyzeChunk POSTs a batch of texts to /analyze and decodes the per-text
+// findings list. Presidio returns one inner result list per input text when
+// the request body's text field is a list.
+func (p *PresidioClient) analyzeChunk(ctx context.Context, texts []string, entities []string) (_ [][]Finding, err error) {
+	ctx, span := p.tracer.Start(ctx, "presidio.analyze", trace.WithAttributes(
+		attribute.Int("presidio.chunk_size", len(texts)),
+	))
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start)
@@ -217,7 +269,7 @@ func (p *PresidioClient) analyze(ctx context.Context, text string, entities []st
 	}()
 
 	body, err := json.Marshal(presidioRequest{
-		Text:     text,
+		Text:     texts,
 		Language: "en",
 		ScoreMin: 0.5,
 		Entities: entities,
@@ -242,40 +294,49 @@ func (p *PresidioClient) analyze(ctx context.Context, text string, entities []st
 		return nil, fmt.Errorf("presidio returned status %d", resp.StatusCode)
 	}
 
-	var results []presidioResult
-	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+	var raw [][]presidioResult
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return nil, fmt.Errorf("decode presidio response: %w", err)
 	}
-
-	// Presidio returns character (rune) offsets, not byte offsets.
-	// Convert to runes for correct slicing, then map back to byte positions.
-	runes := []rune(text)
-
-	findings := make([]Finding, 0, len(results))
-	for _, r := range results {
-		// Clamp offsets to valid rune range to prevent out-of-bounds panics.
-		start := max(0, min(r.Start, len(runes)))
-		end := max(start, min(r.End, len(runes)))
-
-		match := string(runes[start:end])
-
-		// Convert rune offsets to byte offsets for storage.
-		startByte := len(string(runes[:start]))
-		endByte := len(string(runes[:end]))
-
-		findings = append(findings, Finding{
-			RuleID:      r.EntityType,
-			Description: "PII detected: " + r.EntityType,
-			Match:       match,
-			StartPos:    startByte,
-			EndPos:      endByte,
-			Tags:        []string{"pii", strings.ToLower(r.EntityType)},
-			Source:      "presidio",
-			Confidence:  r.Score,
-		})
+	if len(raw) != len(texts) {
+		return nil, fmt.Errorf("presidio response length mismatch: got %d entries for %d inputs", len(raw), len(texts))
 	}
-	span.SetAttributes(attribute.Int("presidio.findings_count", len(findings)))
-	return findings, nil
+
+	out := make([][]Finding, len(texts))
+	totalFindings := 0
+	for i, results := range raw {
+		// Presidio returns character (rune) offsets, not byte offsets.
+		// Convert to runes for correct slicing, then map back to byte positions.
+		runes := []rune(texts[i])
+
+		findings := make([]Finding, 0, len(results))
+		for _, r := range results {
+			// Clamp offsets to valid rune range to prevent out-of-bounds panics.
+			s := max(0, min(r.Start, len(runes)))
+			e := max(s, min(r.End, len(runes)))
+
+			match := string(runes[s:e])
+
+			// Convert rune offsets to byte offsets for storage.
+			startByte := len(string(runes[:s]))
+			endByte := len(string(runes[:e]))
+
+			findings = append(findings, Finding{
+				RuleID:      r.EntityType,
+				Description: "PII detected: " + r.EntityType,
+				Match:       match,
+				StartPos:    startByte,
+				EndPos:      endByte,
+				Tags:        []string{"pii", strings.ToLower(r.EntityType)},
+				Source:      "presidio",
+				Confidence:  r.Score,
+			})
+		}
+		out[i] = findings
+		totalFindings += len(findings)
+	}
+	span.SetAttributes(attribute.Int("presidio.findings_count", totalFindings))
+	return out, nil
 }
 
 // StubPIIScanner is a no-op implementation for environments without Presidio.


### PR DESCRIPTION
## Why

Risk analysis drain workflow was overwhelming the Presidio analyzer pod and triggering pod cycling, dropping in-flight ` /analyze` requests with `read tcp ...: read: connection reset by peer` and tripping Temporal heartbeat timeouts. Root causes from the prior incident:

1. The client sent **one HTTP request per text**. Presidio reloads every recognizer on each `/analyze` call when an `entities` filter is set, so a 1000-text batch generated 1000 recognizer-reload cycles.
2. The client fanned out **100 workers per activity**. With `drainMaxConcurrency: 20`, that was up to 2,000 concurrent `/analyze` calls hammering Presidio's single sync gunicorn worker, queuing for ~80s before TCP RST when the pod got SIGTERMed.
3. AnalyzeBatch only heartbeated **after** each per-text response. While requests sat queued behind the sync worker the activity went silent and risked hitting `HeartbeatTimeout: 30s`.

Sister PR (already merged) bumped Presidio's K8s memory limits to match the upstream Microsoft chart and cleared the OOMKilled cycle, but the stampede pattern remained. This PR removes the stampede.

## What changed

### Before

```go
type presidioRequest struct {
    Text     string ` + "`json:\"text\"`" + `   // single text per HTTP request
    ...
}

const presidioMaxWorkers = 100  // 100-way fanout per activity

// AnalyzeBatch:
//   - 100 workers, each calls analyze(text) for one text
//   - heartbeat fires only after each successful per-text response
```

### After

```go
type presidioRequest struct {
    Text     []string ` + "`json:\"text\"`" + ` // batch payload, Presidio runs analyze_iterator
    ...
}

const (
    presidioDefaultBatchSize             = 50  // texts per HTTP request
    presidioDefaultMaxConcurrentRequests = 4   // in-flight HTTP requests
    presidioHeartbeatInterval            = 10 * time.Second
)

// AnalyzeBatch:
//   - chunks input by batchSize, fans out chunks bounded by maxConcurrentRequests
//   - periodic ticker fires onProgress every 10s while requests are in flight,
//     so Temporal activity heartbeats stay fresh during slow Presidio responses
```

- ` + "`presidioMaxWorkers`" + ` renamed to ` + "`presidioDefaultMaxConcurrentRequests`" + `. The old name implied parallel server-side workers; this value is just a client-side cap on in-flight HTTP requests.
- ` + "`NewPresidioClientWithWorkers`" + ` replaced with ` + "`NewPresidioClientWithLimits(batchSize, maxConcurrentRequests)`" + `. Non-positive values fall back to defaults.
- Skip-on-error behavior **preserved**: a failed chunk logs a warning and leaves ` + "`results[idx]`" + ` nil for the affected texts; the activity still reports success and the message is marked analyzed (matching today's contract).

### Effect

For a typical 1000-text drain batch:

| | requests to Presidio | recognizer reloads | concurrent in-flight |
|---|---|---|---|
| Before | 1000 | 1000 | 100 |
| After | 20 | 20 | 4 |

## Follow-ups (separate PRs, not this one)

- **gram-infra**: longer ` + "`terminationGracePeriodSeconds`" + ` + ` + "`preStop` " + `sleep so Presidio can drain in-flight ` + "`/analyze`" + ` calls on SIGTERM.
- **gram-infra**: custom Presidio image with multi-worker gunicorn (` + "`--workers 4 --worker-class gthread`" + `) so ` + "`/health`" + ` stays responsive while one worker is busy.
- **gram-infra**: HPA ` + "`scaleDown.stabilizationWindowSeconds`" + ` bump to reduce flap.

## Test plan

- [x] ` + "`go test ./internal/background/...`" + ` passes locally
- [ ] Promote to dev, watch [Presidio failure metric](https://app.datadoghq.com/event/explorer?query=container_name%3Apresidio-analyzer%20status%3Aerror&from_ts=now-1h&to_ts=now): expect orders-of-magnitude drop
- [ ] Trigger drain on a project with backlog, confirm ` + "`AnalyzeBatch`" + ` activities complete without heartbeat timeouts
- [ ] Confirm trace shape: presidio.analyze spans should now correspond to chunks (size = batchSize) instead of one per text
- [ ] Promote to prod, monitor [274771871](https://app.datadoghq.com/monitors/274771871) returns to OK