### PR TITLE
chore: prepare GitHub Actions workflows for merge queue

### DIFF
--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -59,7 +59,7 @@ runs:
       with:
         images: ${{ inputs.registry }}/${{ inputs.image }}
         tags: |
-          type=ref,event=branch
+          type=ref,event=branch,enable=${{ github.event_name != 'merge_group' }}
           type=ref,event=tag
           type=ref,event=pr
           type=raw,value=${{ steps.preview-tag.outputs.tag }},enable=${{ steps.preview-tag.outputs.enabled }}

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches:
       - main
+  merge_group:
 
 jobs:
   lint-pr:
@@ -18,8 +19,8 @@ jobs:
       - name: Validate PR title format
         shell: bash
         run: |
-          if [[ "$GIT_REF" ==  "refs/heads/main" ]]; then
-            echo "Skipping PR title validation on main."
+          if [[ "${{ github.event_name }}" == "merge_group" || "$GIT_REF" == "refs/heads/main" ]]; then
+            echo "Skipping PR title validation on $GIT_REF (event: ${{ github.event_name }})."
             exit 0
           fi
 
@@ -45,17 +46,13 @@ jobs:
       - name: Check for significant changes
         id: check
         run: |
-          if [[ "$GIT_REF" ==  "refs/heads/main" ]]; then
-            echo "Skipping changesets-lint job on main."
-            exit 0
-          fi
-
-          if [[ "$PR_TITLE" =~ ^(chore|mig)(\([a-zA-Z0-9_-]+\))?: ]]; then
+          if [[ "${{ github.event_name }}" == "merge_group" || "$GIT_REF" == "refs/heads/main" ]]; then
+            echo "Skipping changesets-lint job on $GIT_REF (event: ${{ github.event_name }})."
+          elif [[ "$PR_TITLE" =~ ^(chore|mig)(\([a-zA-Z0-9_-]+\))?: ]]; then
             echo "Skipping changesets-lint job for chore/mig PR."
-            exit 0
+          else
+            echo "lint=true" >> $GITHUB_OUTPUT
           fi
-
-          echo "lint=true" >> $GITHUB_OUTPUT
 
       - name: Checkout
         if: ${{ steps.check.outputs.lint == 'true' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 permissions:
   id-token: write
@@ -50,42 +51,42 @@ jobs:
           HAS_PREVIEW_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
           HAS_FULL_CI_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}
         run: |
-          if [[ "${{ steps.filter.outputs.server }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "$HAS_PREVIEW_LABEL" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.server }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_PREVIEW_LABEL" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "server=true" >> $GITHUB_OUTPUT
             echo "Server jobs will run."
           else
             echo "Server jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.client }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "$HAS_PREVIEW_LABEL" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.client }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_PREVIEW_LABEL" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "client=true" >> $GITHUB_OUTPUT
             echo "Client jobs will run."
           else
             echo "Client jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.cli }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.cli }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "cli=true" >> $GITHUB_OUTPUT
             echo "CLI jobs will run."
           else
             echo "CLI jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.functions }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.functions }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "functions=true" >> $GITHUB_OUTPUT
             echo "Functions jobs will run."
           else
             echo "Functions jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.tsframework }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.tsframework }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "tsframework=true" >> $GITHUB_OUTPUT
             echo "TypeScript framework jobs will run."
           else
             echo "TypeScript framework jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.elements }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.elements }}" == "true" || "${{ github.ref }}" ==  "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "elements=true" >> $GITHUB_OUTPUT
             echo "Elements jobs will run."
           else
@@ -99,21 +100,21 @@ jobs:
             echo "Migrations jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.plog }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.plog }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "plog=true" >> $GITHUB_OUTPUT
             echo "Plog jobs will run."
           else
             echo "Plog jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.sdk }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.sdk }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "sdk=true" >> $GITHUB_OUTPUT
             echo "SDK jobs will run."
           else
             echo "SDK jobs will be skipped."
           fi
 
-          if [[ "${{ steps.filter.outputs.sdk-gen }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "$HAS_PREVIEW_LABEL" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+          if [[ "${{ steps.filter.outputs.sdk-gen }}" == "true" || "${{ github.ref }}" == "refs/heads/main" || "${{ github.event_name }}" == "merge_group" || "$HAS_PREVIEW_LABEL" == "true" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
             echo "sdk-gen=true" >> $GITHUB_OUTPUT
             echo "SDK generation check will run."
           else
@@ -255,7 +256,7 @@ jobs:
         with:
           images: ${{ steps.assistantFlyCreateDev.outputs.flyAppRegistry }}
           tags: |
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ github.event_name != 'merge_group' }}
             type=ref,event=tag
             type=ref,event=pr
             type=raw,value=${{ steps.assistant-preview-tag.outputs.tag }},enable=${{ steps.assistant-preview-tag.outputs.enabled }}
@@ -284,7 +285,7 @@ jobs:
         with:
           images: ${{ steps.assistantFlyCreateProd.outputs.flyAppRegistry }}
           tags: |
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ github.event_name != 'merge_group' }}
             type=ref,event=tag
             type=ref,event=pr
             type=raw,value=${{ steps.assistant-preview-tag.outputs.tag }},enable=${{ steps.assistant-preview-tag.outputs.enabled }}
@@ -367,7 +368,7 @@ jobs:
     name: Push migrations to Atlas Registry
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes, server-build-lint]
-    if: needs.changes.outputs.server == 'true'
+    if: needs.changes.outputs.server == 'true' && github.event_name != 'merge_group'
     permissions:
       contents: read
       pull-requests: write
@@ -1110,7 +1111,7 @@ jobs:
             ${{ steps.flyCreateDev.outputs.flyAppRegistry }}
             ${{ steps.flyCreateProd.outputs.flyAppRegistry }}
           tags: |
-            type=ref,event=branch,prefix=,suffix=-${{ matrix.runtime }}
+            type=ref,event=branch,prefix=,suffix=-${{ matrix.runtime }},enable=${{ github.event_name != 'merge_group' }}
             type=ref,event=tag,prefix=,suffix=-${{ matrix.runtime }}
             type=schedule,pattern=nightly,prefix=,suffix=-${{ matrix.runtime }}
             type=sha,prefix=,suffix=-${{ matrix.runtime }}


### PR DESCRIPTION
[AGE-2009](https://linear.app/speakeasy/issue/AGE-2009/enable-merge-queue-in-speakeasy-apigram)

## Summary

Adds `merge_group` event support to the GitHub Actions workflows whose status checks gate merges to `main`, in preparation for enabling GitHub's merge queue on this repo.

## Workflow changes

- **`.github/workflows/pr.yaml`** — added `merge_group:` trigger; OR'd `merge_group` into the `changes` job's full-CI gates (server, client, cli, functions, tsframework, elements, plog, sdk, sdk-gen) so queue runs exercise the same matrix as `push:main`; skipped `atlas-push` on `merge_group` (queue would push redundant Atlas registry tags); gated `type=ref,event=branch` on `assistant-runtime-image` and `functions-image` so queue runs don't push image tags derived from the synthetic `gh-readonly-queue/...` ref.
- **`.github/workflows/composite/build-push/action.yaml`** — same `type=ref,event=branch` gate as above.
- **`.github/workflows/hygiene.yaml`** — added `merge_group:` trigger; both lint steps short-circuit on `merge_group` so the `Lint PR Title and Changesets` required check reports green without altering its PR-side enforcement (the same `required_status_checks` rule applies to both PR and `merge_group` events).

## Out of scope (intentional)

- `atlas-lint` stays PR-only — enabling on `merge_group` would need extra reasoning about the `ariga/atlas-action/migrate/lint` action's behavior when there's no PR to comment on.
- `plugin-version-check.yml` stays PR-only — adding `merge_group` would require gating the version-bump comparison on whether `hooks/plugin-claude/**` actually changed in the queue ref (the `paths:` filter doesn't apply to `merge_group`). It is not a required check, so this is non-blocking.

## Follow-up (out of repo)

Once this merges, the `merge_queue` rule still needs to be added to the existing "Merge to main" ruleset (id `7225590`) via Settings → Rules → Rulesets → Merge to main → Add rule → Require merge queue. Squash merge method matches the existing `pull_request` rule's `allowed_merge_methods: ["squash"]`. Until that ruleset change lands, these workflow changes are inert.