### PR TITLE
chore(ci): block PRs mixing migrations with server changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -53,11 +53,13 @@ database-changes:
   - "server/migrations/**"
   - "server/clickhouse/**"
 
-# Excludes server/internal/database/** since SQLc-generated output legitimately
-# changes alongside schema.sql edits.
+# Excludes SQLc-generated output paths (per `server/database/sqlc.yaml` `out:`
+# directives) since they legitimately change alongside schema.sql edits.
 server-internal:
   - "server/internal/**"
   - "!server/internal/database/**"
+  - "!server/internal/**/repo/**"
+  - "!server/internal/testenv/testrepo/**"
 
 plog:
   - "go.mod"

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -48,6 +48,17 @@ migrations:
   - "server/migrations/**"
   - "server/clickhouse/migrations/**"
 
+database-changes:
+  - "server/database/**"
+  - "server/migrations/**"
+  - "server/clickhouse/**"
+
+# Excludes server/internal/database/** since SQLc-generated output legitimately
+# changes alongside schema.sql edits.
+server-internal:
+  - "server/internal/**"
+  - "!server/internal/database/**"
+
 plog:
   - "go.mod"
   - "go.sum"

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -43,6 +43,37 @@ jobs:
             exit 1
           fi
 
+      - name: Checkout
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
+
+      - name: Detect changed files
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: .github/filters.yaml
+          list-files: json
+
+      - name: Validate migration PR does not mix server changes
+        if: ${{ github.event_name != 'merge_group' && steps.filter.outputs.database-changes == 'true' && steps.filter.outputs.server-internal == 'true' }}
+        shell: bash
+        env:
+          DB_FILES: ${{ steps.filter.outputs.database-changes_files }}
+          INTERNAL_FILES: ${{ steps.filter.outputs.server-internal_files }}
+        run: |
+          set -e
+          echo "❌ This PR mixes database migration changes with other server changes."
+          echo ""
+          echo "Database migration files changed:"
+          echo "$DB_FILES" | jq -r '.[]' | sed 's/^/  - /'
+          echo ""
+          echo "Server implementation files changed:"
+          echo "$INTERNAL_FILES" | jq -r '.[]' | sed 's/^/  - /'
+          echo ""
+          echo "Database schema changes should be scheduled separately from business logic changes"
+          echo "so each can be reviewed and rolled out independently."
+          echo "Please move the non-migration changes to a separate PR."
+          exit 1
+
       - name: Check for significant changes
         id: check
         run: |
@@ -53,10 +84,6 @@ jobs:
           else
             echo "lint=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Checkout
-        if: ${{ steps.check.outputs.lint == 'true' }}
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
       # Check out both the base and head refs so changeset status can compare
       # against the base branch


### PR DESCRIPTION
## Summary

Adds a CI check that fails when a PR mixes database migration changes with other server implementation code, addressing [AGE-1682](https://linear.app/speakeasy/issue/AGE-1682/feat-add-ci-check-for-mixed-migrations-in-prs).

## Changes

- New `database-changes` filter in `.github/filters.yaml` matching `server/database/**`, `server/migrations/**`, and `server/clickhouse/**`.
- New `server-internal` filter in `.github/filters.yaml` matching `server/internal/**` with `!server/internal/database/**` negation, so SQLc-generated output is allowed alongside schema changes.
- New step in `.github/workflows/hygiene.yaml` that uses `dorny/paths-filter` (already used in `pr.yaml`) and fails the build when both filters detect changes in the same PR.

## Behavior

- Pure schema + SQLc regen → passes (`server-internal` excludes `server/internal/database/`).
- Pure ClickHouse migration → passes.
- Pure code change in `server/internal/` → passes.
- Schema change + handler code in same PR → **fails** with a message listing both buckets of files.

## Notes

- The check is path-based, not title-based — a developer can't bypass it by getting the PR title prefix wrong or right.
- Existing `migrations` filter (which gates Atlas lint/push jobs in `pr.yaml`) is untouched.