### PR TITLE
feat(dashboard): add select-all checkbox to role member assignment

### DIFF
--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -279,6 +279,26 @@ export function CreateRoleDialog({
     });
   };
 
+  const toggleAllMembers = () => {
+    const selectableMembers = members.filter(
+      (m) => !(isEditing && m.roleId === editingRole?.id),
+    );
+    const allSelected = selectableMembers.every((m) =>
+      selectedMembers.has(m.id),
+    );
+    setSelectedMembers((prev) => {
+      const next = new Set(prev);
+      for (const m of selectableMembers) {
+        if (allSelected) {
+          next.delete(m.id);
+        } else {
+          next.add(m.id);
+        }
+      }
+      return next;
+    });
+  };
+
   const handleSubmit = () => {
     const sdkGrants = Object.values(grants)
       // Drop scopes with an empty selector list — the user switched to
@@ -596,6 +616,38 @@ export function CreateRoleDialog({
 
             {showMembers && (
               <div className="border-border divide-border mt-3 divide-y rounded-md border">
+                {/* Select-all header */}
+                {(() => {
+                  const selectableMembers = members.filter(
+                    (m) => !(isEditing && m.roleId === editingRole?.id),
+                  );
+                  const allSelected =
+                    selectableMembers.length > 0 &&
+                    selectableMembers.every((m) => selectedMembers.has(m.id));
+                  const someSelected =
+                    !allSelected &&
+                    selectableMembers.some((m) => selectedMembers.has(m.id));
+                  return (
+                    <label className="bg-muted/60 flex cursor-pointer items-center gap-3 px-3 py-2">
+                      <Checkbox
+                        checked={
+                          allSelected
+                            ? true
+                            : someSelected
+                              ? "indeterminate"
+                              : false
+                        }
+                        onCheckedChange={() => toggleAllMembers()}
+                      />
+                      <Type
+                        variant="body"
+                        className="text-muted-foreground text-sm font-medium"
+                      >
+                        Select all
+                      </Type>
+                    </label>
+                  );
+                })()}
                 {members.map((member) => {
                   const alreadyHasRole =
                     isEditing && member.roleId === editingRole?.id;

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -252,9 +252,8 @@ export function CreateRoleDialog({
     const group = scopeGroups.find((g) => g.label === label);
     if (!group) return;
 
-    const allSelected = group.scopes.every((s) => grants[s.slug]);
-
     setGrants((prev) => {
+      const allSelected = group.scopes.every((s) => prev[s.slug]);
       const next = { ...prev };
       for (const scope of group.scopes) {
         if (allSelected) {

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -283,10 +283,8 @@ export function CreateRoleDialog({
     const selectableMembers = members.filter(
       (m) => !(isEditing && m.roleId === editingRole?.id),
     );
-    const allSelected = selectableMembers.every((m) =>
-      selectedMembers.has(m.id),
-    );
     setSelectedMembers((prev) => {
+      const allSelected = selectableMembers.every((m) => prev.has(m.id));
       const next = new Set(prev);
       for (const m of selectableMembers) {
         if (allSelected) {


### PR DESCRIPTION
## Summary
- Adds a grey header row with a "Select all" checkbox at the top of the members list in the create/edit role dialog
- Supports checked, unchecked, and indeterminate states
- Correctly skips members already assigned to the role being edited (disabled rows)

## Test plan
- [ ] Open create role dialog → expand Assign Members → verify grey header with "Select all" checkbox appears
- [ ] Click "Select all" → all members checked
- [ ] Click again → all members unchecked
- [ ] Select some members manually → checkbox shows indeterminate state
- [ ] Edit existing role → members already assigned (disabled) are not toggled by select-all