### PR TITLE
chore: implement mcp server and endpoint fronting to /x/mcp endpoints

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -811,7 +811,7 @@ func newStartCommand() *cli.Command {
 			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger))
-			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, billingRepo, billingTracker), mcpService, mcpMetadataService)
+			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, encryptionClient, authzEngine, guardianPolicy, billingRepo, billingTracker, mcpService), mcpService, mcpMetadataService)
 			triggers.Attach(mux, triggers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, triggerApp, auditLogger))
 			tools.Attach(mux, tools.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			resources.Attach(mux, resources.NewService(logger, tracerProvider, db, sessionManager, authzEngine))

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -811,7 +811,7 @@ func newStartCommand() *cli.Command {
 			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger))
-			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, encryptionClient, authzEngine, guardianPolicy, billingRepo, billingTracker, mcpService), mcpService, mcpMetadataService)
+			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, encryptionClient, authzEngine, guardianPolicy, billingRepo, billingTracker, mcpService, serverURL), mcpMetadataService)
 			triggers.Attach(mux, triggers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, triggerApp, auditLogger))
 			tools.Attach(mux, tools.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			resources.Attach(mux, resources.NewService(logger, tracerProvider, db, sessionManager, authzEngine))

--- a/server/internal/mcp/http_headers.go
+++ b/server/internal/mcp/http_headers.go
@@ -8,12 +8,16 @@ import (
 // AuthorizationBearerToken returns the Bearer token from the request's
 // Authorization header with the "Bearer " prefix stripped. Prefix matching
 // is case-insensitive per RFC 7235 § 2.1 ("Bearer" / "BEARER" / "bearer").
-// Returns "" when the header is absent.
+// Returns "" when the header is absent or carries a non-Bearer scheme — a
+// non-empty return is always a Bearer token, never the raw header. This
+// matters for callers that synthesise an upstream Authorization header
+// from the result; forwarding a non-Bearer value would produce a malformed
+// "Bearer <other-scheme> ..." upstream.
 func AuthorizationBearerToken(r *http.Request) string {
 	const bearerPrefix = "Bearer "
 	token := r.Header.Get("Authorization")
 	if len(token) >= len(bearerPrefix) && strings.EqualFold(token[:len(bearerPrefix)], bearerPrefix) {
 		return token[len(bearerPrefix):]
 	}
-	return token
+	return ""
 }

--- a/server/internal/mcp/http_headers.go
+++ b/server/internal/mcp/http_headers.go
@@ -1,0 +1,19 @@
+package mcp
+
+import (
+	"net/http"
+	"strings"
+)
+
+// AuthorizationBearerToken returns the Bearer token from the request's
+// Authorization header with the "Bearer " prefix stripped. Prefix matching
+// is case-insensitive per RFC 7235 § 2.1 ("Bearer" / "BEARER" / "bearer").
+// Returns "" when the header is absent.
+func AuthorizationBearerToken(r *http.Request) string {
+	const bearerPrefix = "Bearer "
+	token := r.Header.Get("Authorization")
+	if len(token) >= len(bearerPrefix) && strings.EqualFold(token[:len(bearerPrefix)], bearerPrefix) {
+		return token[len(bearerPrefix):]
+	}
+	return token
+}

--- a/server/internal/mcp/http_headers.go
+++ b/server/internal/mcp/http_headers.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"net/http"
 	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
 // AuthorizationBearerToken returns the Bearer token from the request's
@@ -20,4 +22,17 @@ func AuthorizationBearerToken(r *http.Request) string {
 		return token[len(bearerPrefix):]
 	}
 	return ""
+}
+
+// AuthorizationOrChatSessionToken returns the caller's identity token,
+// drawn from the Authorization Bearer header when present, otherwise the
+// Gram-Chat-Session header. Returns "" when neither carries a value.
+// Bearer wins when both are set, matching the priority used by the MCP
+// identity-auth path; non-Bearer Authorization schemes are ignored (see
+// [AuthorizationBearerToken]) and fall through to Gram-Chat-Session.
+func AuthorizationOrChatSessionToken(r *http.Request) string {
+	if t := AuthorizationBearerToken(r); t != "" {
+		return t
+	}
+	return r.Header.Get(constants.ChatSessionsTokenHeader)
 }

--- a/server/internal/mcp/http_headers_test.go
+++ b/server/internal/mcp/http_headers_test.go
@@ -1,0 +1,84 @@
+package mcp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+)
+
+func newAuthRequest(t *testing.T, header string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if header != "" {
+		req.Header.Set("Authorization", header)
+	}
+	return req
+}
+
+func TestAuthorizationBearerToken_AbsentHeader(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "")))
+}
+
+func TestAuthorizationBearerToken_BearerCanonical(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "abc123", mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer abc123")))
+}
+
+func TestAuthorizationBearerToken_BearerLowercase(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "abc123", mcp.AuthorizationBearerToken(newAuthRequest(t, "bearer abc123")))
+}
+
+func TestAuthorizationBearerToken_BearerUppercase(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "abc123", mcp.AuthorizationBearerToken(newAuthRequest(t, "BEARER abc123")))
+}
+
+func TestAuthorizationBearerToken_BearerEmptyToken(t *testing.T) {
+	t.Parallel()
+
+	// "Bearer " with no token after the space is technically a valid prefix
+	// match but yields no token; callers treat empty returns as "no auth".
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer ")))
+}
+
+// TestAuthorizationBearerToken_BasicScheme is the regression test for the
+// non-Bearer fallthrough: returning the raw header would land "Basic abc123"
+// inside an upstream "Authorization: Bearer Basic abc123" — see the function
+// docstring for the proxy-forwarding rationale.
+func TestAuthorizationBearerToken_BasicScheme(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Basic abc123")))
+}
+
+func TestAuthorizationBearerToken_DigestScheme(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, `Digest username="u", realm="r"`)))
+}
+
+func TestAuthorizationBearerToken_BareWordBearerNoSpace(t *testing.T) {
+	t.Parallel()
+
+	// "Bearer" alone is shorter than the "Bearer " prefix and must not match.
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer")))
+}
+
+func TestAuthorizationBearerToken_BearerLikePrefix(t *testing.T) {
+	t.Parallel()
+
+	// A scheme that starts with the same letters but isn't "Bearer " must not
+	// match — guards against a hypothetical "Bearer-Like xyz" or similar.
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer-Like xyz")))
+}

--- a/server/internal/mcp/http_headers_test.go
+++ b/server/internal/mcp/http_headers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 )
 
@@ -16,6 +17,16 @@ func newAuthRequest(t *testing.T, header string) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	if header != "" {
 		req.Header.Set("Authorization", header)
+	}
+	return req
+}
+
+func newIdentityRequest(t *testing.T, authHeader, chatSession string) *http.Request {
+	t.Helper()
+
+	req := newAuthRequest(t, authHeader)
+	if chatSession != "" {
+		req.Header.Set(constants.ChatSessionsTokenHeader, chatSession)
 	}
 	return req
 }
@@ -81,4 +92,43 @@ func TestAuthorizationBearerToken_BearerLikePrefix(t *testing.T) {
 	// A scheme that starts with the same letters but isn't "Bearer " must not
 	// match — guards against a hypothetical "Bearer-Like xyz" or similar.
 	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer-Like xyz")))
+}
+
+func TestAuthorizationOrChatSessionToken_BothEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "", "")))
+}
+
+func TestAuthorizationOrChatSessionToken_BearerOnly(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Bearer abc123", "")))
+}
+
+func TestAuthorizationOrChatSessionToken_ChatSessionOnly(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "session-jwt", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "", "session-jwt")))
+}
+
+func TestAuthorizationOrChatSessionToken_BearerWinsWhenBothSet(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Bearer abc123", "session-jwt")))
+}
+
+// TestAuthorizationOrChatSessionToken_BasicSchemeFallsThrough guards the
+// interaction with [mcp.AuthorizationBearerToken]'s non-Bearer drop: a Basic
+// Authorization header must not block the chat-session fallback.
+func TestAuthorizationOrChatSessionToken_BasicSchemeFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "session-jwt", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Basic abc123", "session-jwt")))
+}
+
+func TestAuthorizationOrChatSessionToken_BasicSchemeAlone(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Basic abc123", "")))
 }

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -418,7 +418,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided")
 	}
 
-	toolset, customDomainCtx, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
+	toolset, _, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
 	switch {
 	case errors.Is(err, errToolsetNotFound):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
@@ -426,18 +426,31 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
 	}
 
+	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "/mcp/")
+}
+
+// ServeToolsetResolved serves an MCP runtime request after the slug has
+// already been resolved to a toolset. It is exported so other runtime
+// surfaces (currently /x/mcp) can delegate the toolset-backed serving body
+// without re-implementing the OAuth/visibility/RBAC and tool dispatch flow.
+//
+// mcpSlug and oauthMetadataPathPrefix are used to build the
+// WWW-Authenticate resource_metadata URL (e.g. "/mcp/" or "/x/mcp/").
+//
+// The caller is responsible for closing r.Body.
+func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, oauthMetadataPathPrefix string) error {
+	ctx := r.Context()
+	var err error
+
 	baseURL := s.serverURL.String()
-	if customDomainCtx != nil {
+	if customDomainCtx := customdomains.FromContext(ctx); customDomainCtx != nil {
 		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
 	}
 
 	// Extract tokens from headers separately:
 	// - authToken: from Authorization header (for OAuth flows)
 	// - sessionToken: from Gram-Chat-Session header (for chat session fallback on non-OAuth endpoints)
-	authToken := r.Header.Get("Authorization")
-	authToken = strings.TrimPrefix(authToken, "Bearer ")
-	authToken = strings.TrimPrefix(authToken, "bearer ")
-	chatSessionJwt := r.Header.Get(constants.ChatSessionsTokenHeader)
+	authToken := AuthorizationBearerToken(r)
 
 	var tokenInputs []oauthTokenInputs
 
@@ -469,6 +482,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	// Private MCPs still enforce identity auth at this level since that's user
 	// identity, not per-tool security.
 	oauthRequired := toolset.ExternalOauthServerID.Valid || (oAuthProxyProvider != nil)
+	oauthProtectedResourceURL := baseURL + "/.well-known/oauth-protected-resource" + oauthMetadataPathPrefix + mcpSlug
 	switch {
 	case toolset.McpIsPublic && toolset.ExternalOauthServerID.Valid:
 		// External OAuth server flow — collect token if present
@@ -513,42 +527,15 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 			}
 		}
 	case !toolset.McpIsPublic:
-		// Private MCP — identity auth is required at HTTP level
 		isOAuthCapable := oAuthProxyProvider != nil && oAuthProxyProvider.ProviderType == "gram"
-		token := authToken
-		if token == "" {
-			token = chatSessionJwt
+		ctx, err = s.RequirePrivateIdentityAuth(ctx, w, r, isOAuthCapable, toolset.ID, oauthProtectedResourceURL)
+		if err != nil {
+			return err
 		}
-
-		ctx, err = s.authenticateToken(ctx, token, toolset.ID, isOAuthCapable)
-		if err == nil {
-			break
-		}
-
-		if isOAuthCapable {
-			w.Header().Set(
-				"WWW-Authenticate",
-				fmt.Sprintf(`Bearer resource_metadata="%s"`, baseURL+"/.well-known/oauth-protected-resource/mcp/"+mcpSlug),
-			)
-		}
-
-		return oops.E(oops.CodeUnauthorized, nil, "expired or invalid access token")
 	default:
-		// Public MCP without OAuth — allow chatSessionJwt fallback
-		token := authToken
-		if token == "" {
-			token = chatSessionJwt
-		}
-		if token != "" {
-			ctx, err = s.authenticateToken(ctx, token, toolset.ID, false)
-			if err != nil {
-				return err
-			}
-
-			authCtx, ok := contextvalues.GetAuthContext(ctx)
-			if !ok || authCtx == nil {
-				return oops.E(oops.CodeUnauthorized, nil, "no auth context found").Log(ctx, s.logger)
-			}
+		ctx, err = s.TryPublicIdentityAuth(ctx, r, false, toolset.ID)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -671,7 +658,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 		if oauthRequired {
 			w.Header().Set(
 				"WWW-Authenticate",
-				fmt.Sprintf(`Bearer resource_metadata="%s"`, baseURL+"/.well-known/oauth-protected-resource/mcp/"+mcpSlug),
+				fmt.Sprintf(`Bearer resource_metadata="%s"`, oauthProtectedResourceURL),
 			)
 		}
 		return oops.C(oops.CodeUnauthorized)
@@ -930,7 +917,92 @@ func parseMcpSessionID(headers http.Header) string {
 	return session
 }
 
-func (s *Service) authenticateToken(ctx context.Context, token string, toolsetID uuid.UUID, isOAuthCapable bool) (context.Context, error) {
+// ResolveOAuthProxyUpstreamToken validates the caller's Gram-issued
+// Bearer for the supplied OAuth proxy server, refreshing stored upstream
+// credentials when needed, and returns the upstream Bearer that should
+// replace the caller's on the outgoing request to the remote MCP server.
+//
+// Returns ("", nil) when no upstream token is available — the caller
+// supplied no Bearer, the lookup found no stored upstream credentials,
+// or token validation failed in a non-fatal way. Callers should fall
+// through to "forward with no Authorization." A non-nil error is fatal
+// and the caller should reject the request.
+//
+// TODO: this method is currently a stub that always returns ("", nil).
+// The supporting oauth machinery (oauthService.ValidateAccessToken,
+// RefreshProxyToken, and the underlying ExternalSecret storage) is keyed
+// by toolset_id today; generalising the resource model so it can be
+// keyed by mcp_servers.id is a prerequisite to wiring this up. Until
+// that lands, OAuth-proxy-backed mcp_servers behave like a public
+// no-token flow at this layer (the upstream remote MCP returns 401 if
+// it requires auth).
+func (s *Service) ResolveOAuthProxyUpstreamToken(_ context.Context, _, _ uuid.UUID, _ string) (string, error) {
+	return "", nil
+}
+
+// RequirePrivateIdentityAuth runs identity authentication for a non-public
+// MCP. It tries the Authorization header first, then the
+// Gram-Chat-Session header, returning the authenticated context on success.
+// On failure, when isOAuthCapable, it sets a WWW-Authenticate header with
+// the supplied resource_metadata URL so MCP clients can initiate OAuth, and
+// returns 401.
+func (s *Service) RequirePrivateIdentityAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, isOAuthCapable bool, oauthResourceID uuid.UUID, wwwAuthResourceMetadataURL string) (context.Context, error) {
+	authToken := AuthorizationBearerToken(r)
+	chatSessionJwt := r.Header.Get(constants.ChatSessionsTokenHeader)
+
+	token := authToken
+	if token == "" {
+		token = chatSessionJwt
+	}
+
+	authedCtx, err := s.authenticateToken(ctx, token, oauthResourceID, isOAuthCapable)
+	if err == nil {
+		return authedCtx, nil
+	}
+
+	if isOAuthCapable {
+		w.Header().Set(
+			"WWW-Authenticate",
+			fmt.Sprintf(`Bearer resource_metadata="%s"`, wwwAuthResourceMetadataURL),
+		)
+	}
+
+	return ctx, oops.E(oops.CodeUnauthorized, nil, "expired or invalid access token")
+}
+
+// TryPublicIdentityAuth optionally authenticates a public MCP request when
+// the caller supplies an Authorization or Gram-Chat-Session token. Missing
+// tokens are not an error; an invalid supplied token is.
+func (s *Service) TryPublicIdentityAuth(ctx context.Context, r *http.Request, isOAuthCapable bool, oauthResourceID uuid.UUID) (context.Context, error) {
+	authToken := AuthorizationBearerToken(r)
+	chatSessionJwt := r.Header.Get(constants.ChatSessionsTokenHeader)
+
+	token := authToken
+	if token == "" {
+		token = chatSessionJwt
+	}
+	if token == "" {
+		return ctx, nil
+	}
+
+	authedCtx, err := s.authenticateToken(ctx, token, oauthResourceID, isOAuthCapable)
+	if err != nil {
+		return ctx, err
+	}
+
+	if authCtx, ok := contextvalues.GetAuthContext(authedCtx); !ok || authCtx == nil {
+		return ctx, oops.E(oops.CodeUnauthorized, nil, "no auth context found").Log(ctx, s.logger)
+	}
+	return authedCtx, nil
+}
+
+// authenticateToken authenticates the caller using the supplied token across
+// several strategies (assistant tokens, gram OAuth via oauthResourceID, API
+// keys, chat sessions). oauthResourceID is consumed only when isOAuthCapable
+// is true — today that path is exercised only by toolset-backed flows so
+// the resource is a toolset id; remote-backend callers pass false and the
+// id is decorative.
+func (s *Service) authenticateToken(ctx context.Context, token string, oauthResourceID uuid.UUID, isOAuthCapable bool) (context.Context, error) {
 	if token == "" {
 		return ctx, oops.C(oops.CodeUnauthorized)
 	}
@@ -942,7 +1014,7 @@ func (s *Service) authenticateToken(ctx context.Context, token string, toolsetID
 	var oAuthToken *oauth.Token
 	var err error
 	if isOAuthCapable {
-		oAuthToken, err = s.oauthService.ValidateAccessToken(ctx, toolsetID, token)
+		oAuthToken, err = s.oauthService.ValidateAccessToken(ctx, oauthResourceID, token)
 	}
 	if err == nil && oAuthToken != nil {
 		// OAuth token validated, authenticate with session
@@ -960,7 +1032,7 @@ func (s *Service) authenticateToken(ctx context.Context, token string, toolsetID
 			return ctx, oops.E(oops.CodeUnauthorized, nil, "no auth context found")
 		}
 
-		s.logger.InfoContext(ctx, "authenticated via gram OAuth", attr.SlogToolsetID(toolsetID.String()))
+		s.logger.InfoContext(ctx, "authenticated via gram OAuth", attr.SlogToolsetID(oauthResourceID.String()))
 		return ctx, nil
 	}
 

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -214,8 +214,8 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	o11y.AttachHandler(mux, "GET", "/mcp/install-page-{hash}.js", oops.ErrHandle(service.logger, metadataService.ServeInstallPageScript).ServeHTTP)
 
 	// OAuth 2.1 Authorization Server Metadata
-	o11y.AttachHandler(mux, "GET", "/.well-known/oauth-authorization-server/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthServerMetadata).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/.well-known/oauth-protected-resource/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthProtectedResourceMetadata).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", wellknown.OAuthAuthorizationServerPath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthServerMetadata).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", wellknown.OAuthProtectedResourcePath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthProtectedResourceMetadata).ServeHTTP)
 }
 
 // HandleGetServer handles GET requests to /mcp/{mcpSlug}, checking for HTML requests
@@ -425,7 +425,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
 	}
 
-	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "/mcp/")
+	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp")
 }
 
 // ServeToolsetResolved serves an MCP runtime request after the slug has
@@ -433,11 +433,13 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 // surfaces (currently /x/mcp) can delegate the toolset-backed serving body
 // without re-implementing the OAuth/visibility/RBAC and tool dispatch flow.
 //
-// mcpSlug and oauthMetadataPathPrefix are used to build the
-// WWW-Authenticate resource_metadata URL (e.g. "/mcp/" or "/x/mcp/").
+// mcpSlug and mcpRouteBase are used to build the WWW-Authenticate
+// resource_metadata URL. mcpRouteBase is the route segment that sits
+// between the well-known prefix and the slug — "mcp" for /mcp/{slug} or
+// "x/mcp" for /x/mcp/{slug}, no leading or trailing slashes.
 //
 // The caller is responsible for closing r.Body.
-func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, oauthMetadataPathPrefix string) error {
+func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string) error {
 	ctx := r.Context()
 	var err error
 
@@ -481,7 +483,10 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	// Private MCPs still enforce identity auth at this level since that's user
 	// identity, not per-tool security.
 	oauthRequired := toolset.ExternalOauthServerID.Valid || (oAuthProxyProvider != nil)
-	oauthProtectedResourceURL := baseURL + "/.well-known/oauth-protected-resource" + oauthMetadataPathPrefix + mcpSlug
+	oauthProtectedResourceURL, err := url.JoinPath(baseURL, wellknown.OAuthProtectedResourcePath, mcpRouteBase, mcpSlug)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to build OAuth protected resource URL").Log(ctx, s.logger)
+	}
 	switch {
 	case toolset.McpIsPublic && toolset.ExternalOauthServerID.Valid:
 		// External OAuth server flow — collect token if present
@@ -946,13 +951,7 @@ func (s *Service) ResolveOAuthProxyUpstreamToken(_ context.Context, _, _ uuid.UU
 // the supplied resource_metadata URL so MCP clients can initiate OAuth, and
 // returns 401.
 func (s *Service) RequirePrivateIdentityAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, isOAuthCapable bool, oauthResourceID uuid.UUID, wwwAuthResourceMetadataURL string) (context.Context, error) {
-	authToken := AuthorizationBearerToken(r)
-	chatSessionJwt := r.Header.Get(constants.ChatSessionsTokenHeader)
-
-	token := authToken
-	if token == "" {
-		token = chatSessionJwt
-	}
+	token := AuthorizationOrChatSessionToken(r)
 
 	authedCtx, err := s.authenticateToken(ctx, token, oauthResourceID, isOAuthCapable)
 	if err == nil {
@@ -973,13 +972,7 @@ func (s *Service) RequirePrivateIdentityAuth(ctx context.Context, w http.Respons
 // the caller supplies an Authorization or Gram-Chat-Session token. Missing
 // tokens are not an error; an invalid supplied token is.
 func (s *Service) TryPublicIdentityAuth(ctx context.Context, r *http.Request, isOAuthCapable bool, oauthResourceID uuid.UUID) (context.Context, error) {
-	authToken := AuthorizationBearerToken(r)
-	chatSessionJwt := r.Header.Get(constants.ChatSessionsTokenHeader)
-
-	token := authToken
-	if token == "" {
-		token = chatSessionJwt
-	}
+	token := AuthorizationOrChatSessionToken(r)
 	if token == "" {
 		return ctx, nil
 	}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -374,8 +374,7 @@ func (s *Service) HandleWellKnownOAuthProtectedResourceMetadata(w http.ResponseW
 		s.db,
 		&s.toolsetCache,
 		toolset,
-		baseURL,
-		mcpSlug,
+		baseURL+"/mcp/"+mcpSlug,
 	)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, s.logger)

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -202,7 +202,7 @@ func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpoin
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid custom_domain_id").Log(ctx, s.logger)
 	}
 
-	row, err := txRepo.GetMCPEndpointByCustomDomainIDAndSlug(ctx, repo.GetMCPEndpointByCustomDomainIDAndSlugParams{
+	row, err := txRepo.GetMCPEndpointByProjectAndCustomDomainAndSlug(ctx, repo.GetMCPEndpointByProjectAndCustomDomainAndSlugParams{
 		ProjectID:      *authCtx.ProjectID,
 		Slug:           string(*payload.Slug),
 		CustomDomainID: customDomainID,

--- a/server/internal/mcpendpoints/queries.sql
+++ b/server/internal/mcpendpoints/queries.sql
@@ -18,11 +18,23 @@ SELECT *
 FROM mcp_endpoints
 WHERE id = @id AND project_id = @project_id AND deleted IS FALSE;
 
--- name: GetMCPEndpointByCustomDomainIDAndSlug :one
+-- name: GetMCPEndpointByProjectAndCustomDomainAndSlug :one
+-- Resolve an endpoint by its (project_id, custom_domain_id, slug) triple.
+-- This is intended for management use, to ensure the resolved endpoint belongs
+-- to the correct project.
 SELECT *
 FROM mcp_endpoints
 WHERE project_id = @project_id
   AND slug = @slug
+  AND custom_domain_id IS NOT DISTINCT FROM @custom_domain_id
+  AND deleted IS FALSE;
+
+-- name: GetMCPEndpointByCustomDomainAndSlug :one
+-- Resolve an endpoint by its globally-unique (custom_domain_id, slug) pair.
+-- This is intended for use in the public-facing endpoint resolution path.
+SELECT *
+FROM mcp_endpoints
+WHERE slug = @slug
   AND custom_domain_id IS NOT DISTINCT FROM @custom_domain_id
   AND deleted IS FALSE;
 

--- a/server/internal/mcpendpoints/repo/queries.sql.go
+++ b/server/internal/mcpendpoints/repo/queries.sql.go
@@ -85,23 +85,23 @@ func (q *Queries) DeleteMCPEndpoint(ctx context.Context, arg DeleteMCPEndpointPa
 	return i, err
 }
 
-const getMCPEndpointByCustomDomainIDAndSlug = `-- name: GetMCPEndpointByCustomDomainIDAndSlug :one
+const getMCPEndpointByCustomDomainAndSlug = `-- name: GetMCPEndpointByCustomDomainAndSlug :one
 SELECT id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
 FROM mcp_endpoints
-WHERE project_id = $1
-  AND slug = $2
-  AND custom_domain_id IS NOT DISTINCT FROM $3
+WHERE slug = $1
+  AND custom_domain_id IS NOT DISTINCT FROM $2
   AND deleted IS FALSE
 `
 
-type GetMCPEndpointByCustomDomainIDAndSlugParams struct {
-	ProjectID      uuid.UUID
+type GetMCPEndpointByCustomDomainAndSlugParams struct {
 	Slug           string
 	CustomDomainID uuid.NullUUID
 }
 
-func (q *Queries) GetMCPEndpointByCustomDomainIDAndSlug(ctx context.Context, arg GetMCPEndpointByCustomDomainIDAndSlugParams) (McpEndpoint, error) {
-	row := q.db.QueryRow(ctx, getMCPEndpointByCustomDomainIDAndSlug, arg.ProjectID, arg.Slug, arg.CustomDomainID)
+// Resolve an endpoint by its globally-unique (custom_domain_id, slug) pair.
+// This is intended for use in the public-facing endpoint resolution path.
+func (q *Queries) GetMCPEndpointByCustomDomainAndSlug(ctx context.Context, arg GetMCPEndpointByCustomDomainAndSlugParams) (McpEndpoint, error) {
+	row := q.db.QueryRow(ctx, getMCPEndpointByCustomDomainAndSlug, arg.Slug, arg.CustomDomainID)
 	var i McpEndpoint
 	err := row.Scan(
 		&i.ID,
@@ -130,6 +130,41 @@ type GetMCPEndpointByIDParams struct {
 
 func (q *Queries) GetMCPEndpointByID(ctx context.Context, arg GetMCPEndpointByIDParams) (McpEndpoint, error) {
 	row := q.db.QueryRow(ctx, getMCPEndpointByID, arg.ID, arg.ProjectID)
+	var i McpEndpoint
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.CustomDomainID,
+		&i.McpServerID,
+		&i.Slug,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
+const getMCPEndpointByProjectAndCustomDomainAndSlug = `-- name: GetMCPEndpointByProjectAndCustomDomainAndSlug :one
+SELECT id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+FROM mcp_endpoints
+WHERE project_id = $1
+  AND slug = $2
+  AND custom_domain_id IS NOT DISTINCT FROM $3
+  AND deleted IS FALSE
+`
+
+type GetMCPEndpointByProjectAndCustomDomainAndSlugParams struct {
+	ProjectID      uuid.UUID
+	Slug           string
+	CustomDomainID uuid.NullUUID
+}
+
+// Resolve an endpoint by its (project_id, custom_domain_id, slug) triple.
+// This is intended for management use, to ensure the resolved endpoint belongs
+// to the correct project.
+func (q *Queries) GetMCPEndpointByProjectAndCustomDomainAndSlug(ctx context.Context, arg GetMCPEndpointByProjectAndCustomDomainAndSlugParams) (McpEndpoint, error) {
+	row := q.db.QueryRow(ctx, getMCPEndpointByProjectAndCustomDomainAndSlug, arg.ProjectID, arg.Slug, arg.CustomDomainID)
 	var i McpEndpoint
 	err := row.Scan(
 		&i.ID,

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -72,6 +72,16 @@ type OAuthRepo interface {
 	ListOAuthProxyProvidersByServer(ctx context.Context, arg repo.ListOAuthProxyProvidersByServerParams) ([]repo.OauthProxyProvider, error)
 }
 
+// ResolveOAuthServerMetadataFromToolset returns OAuth Authorization Server
+// metadata for a toolset, or nil if the toolset is not OAuth-configured.
+//
+// oauthSlug is the slug used to address the Gram-hosted OAuth endpoints
+// (`/oauth/{oauthSlug}/...`). Today the OAuth machinery is keyed by
+// `toolsets.mcp_slug`, so callers should pass that value. The /x/mcp
+// experimental endpoint uses the same OAuth flow under the hood, so it
+// also passes `toolset.mcp_slug` here even though its protected-resource
+// URL uses an `mcp_endpoints.slug` instead — see the companion
+// resourceURL argument on [ResolveOAuthProtectedResourceFromToolset].
 func ResolveOAuthServerMetadataFromToolset(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -80,7 +90,7 @@ func ResolveOAuthServerMetadataFromToolset(
 	toolsetCache *cache.TypedCacheObject[mv.ToolsetBaseContents],
 	toolset *toolsets_repo.Toolset,
 	baseURL string,
-	mcpSlug string,
+	oauthSlug string,
 ) (*OAuthServerMetadataResult, error) {
 	if toolset.OauthProxyServerID.Valid {
 		providers, err := oauthRepo.ListOAuthProxyProvidersByServer(ctx, repo.ListOAuthProxyProvidersByServerParams{
@@ -114,10 +124,10 @@ func ResolveOAuthServerMetadataFromToolset(
 		return &OAuthServerMetadataResult{
 			Kind: OAuthServerMetadataResultKindStatic,
 			Static: &OAuthServerMetadata{
-				Issuer:                        baseURL + "/oauth/" + mcpSlug,
-				AuthorizationEndpoint:         baseURL + "/oauth/" + mcpSlug + "/authorize",
-				TokenEndpoint:                 baseURL + "/oauth/" + mcpSlug + "/token",
-				RegistrationEndpoint:          baseURL + "/oauth/" + mcpSlug + "/register",
+				Issuer:                        baseURL + "/oauth/" + oauthSlug,
+				AuthorizationEndpoint:         baseURL + "/oauth/" + oauthSlug + "/authorize",
+				TokenEndpoint:                 baseURL + "/oauth/" + oauthSlug + "/token",
+				RegistrationEndpoint:          baseURL + "/oauth/" + oauthSlug + "/register",
 				ScopesSupported:               scopes,
 				ResponseTypesSupported:        []string{"code"},
 				GrantTypesSupported:           []string{"authorization_code", "refresh_token"},
@@ -148,22 +158,28 @@ func ResolveOAuthServerMetadataFromToolset(
 	return nil, nil
 }
 
-// ResolveOAuthProtectedResourceFromToolset returns OAuth Protected Resource Metadata for a toolset,
-// or nil if the toolset is not OAuth-protected.
+// ResolveOAuthProtectedResourceFromToolset returns OAuth Protected Resource
+// Metadata for a toolset, or nil if the toolset is not OAuth-protected.
+//
+// resourceURL is the absolute URL of the protected resource (the runtime MCP
+// endpoint). For /mcp callers this is `<baseURL>/mcp/<toolset.mcp_slug>`; for
+// /x/mcp callers this is `<baseURL>/x/mcp/<mcp_endpoint.slug>`. It is used
+// verbatim for both `resource` and `authorization_servers` so that the
+// `/.well-known/...` discovery path on the protected resource resolves back
+// to the Gram-hosted authorization server metadata.
 func ResolveOAuthProtectedResourceFromToolset(
 	ctx context.Context,
 	logger *slog.Logger,
 	db mv.DBTX,
 	toolsetCache *cache.TypedCacheObject[mv.ToolsetBaseContents],
 	toolset *toolsets_repo.Toolset,
-	baseURL string,
-	mcpSlug string,
+	resourceURL string,
 ) (*OAuthProtectedResourceMetadata, error) {
 	// Check for OAuth proxy server or external OAuth server configuration
 	if toolset.OauthProxyServerID.Valid || toolset.ExternalOauthServerID.Valid {
 		return &OAuthProtectedResourceMetadata{
-			Resource:             baseURL + "/mcp/" + mcpSlug,
-			AuthorizationServers: []string{baseURL + "/mcp/" + mcpSlug},
+			Resource:             resourceURL,
+			AuthorizationServers: []string{resourceURL},
 			ScopesSupported:      nil,
 		}, nil
 	}

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -33,6 +33,18 @@ import (
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
+// OAuthAuthorizationServerPath is the well-known URI path for OAuth 2.0
+// Authorization Server Metadata as defined by RFC 8414.
+//
+// https://datatracker.ietf.org/doc/html/rfc8414
+const OAuthAuthorizationServerPath = "/.well-known/oauth-authorization-server"
+
+// OAuthProtectedResourcePath is the well-known URI path for OAuth 2.0
+// Protected Resource Metadata as defined by RFC 9728.
+//
+// https://datatracker.ietf.org/doc/html/rfc9728
+const OAuthProtectedResourcePath = "/.well-known/oauth-protected-resource"
+
 // OAuthProtectedResourceMetadata represents OAuth 2.0 Protected Resource Metadata (RFC 9728).
 type OAuthProtectedResourceMetadata struct {
 	Resource             string   `json:"resource"`

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -16,9 +16,11 @@ const (
 
 // isSkippedRequestHeader returns true for headers that should never be
 // forwarded verbatim from the user request to the remote MCP server:
-// hop-by-hop headers (RFC 7230 § 6.1), Host (set by the HTTP client from the
-// remote URL), and Authorization (carries the Gram API key, which is not
-// valid upstream).
+// hop-by-hop headers (RFC 7230 § 6.1) and Host (set by the HTTP client
+// from the remote URL).
+//
+// Authorization is end-to-end and is handled separately by
+// [Proxy.applyRequestHeaders] based on [Proxy.AuthorizationOverride].
 func isSkippedRequestHeader(name string) bool {
 	switch strings.ToLower(name) {
 	case
@@ -81,6 +83,12 @@ func applyResponseHeaders(w http.ResponseWriter, remoteResp *http.Response) {
 // applyRequestHeaders populates the upstream request headers by copying forward-safe
 // headers from the user request and overlaying the configured static and
 // pass-through headers. Configured headers win on conflict.
+//
+// The user's Authorization header is always dropped — Gram-issued
+// credentials (API keys, Gram-managed OAuth tokens, chat-session JWTs)
+// are not meaningful upstream. When [Proxy.AuthorizationOverride] is
+// non-empty, the proxy emits its own "Authorization: Bearer <override>"
+// upstream; configured headers may further override that.
 func (p *Proxy) applyRequestHeaders(ctx context.Context, userReq *http.Request, remoteReq *http.Request) error {
 	for name, values := range userReq.Header {
 		if isSkippedRequestHeader(name) {
@@ -89,6 +97,10 @@ func (p *Proxy) applyRequestHeaders(ctx context.Context, userReq *http.Request, 
 		for _, v := range values {
 			remoteReq.Header.Add(name, v)
 		}
+	}
+
+	if p.AuthorizationOverride != "" {
+		remoteReq.Header.Set("Authorization", "Bearer "+p.AuthorizationOverride)
 	}
 
 	for _, h := range p.Headers {

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -124,6 +124,23 @@ type Proxy struct {
 	// constructing the upstream request.
 	Headers []ConfiguredHeader
 
+	// AuthorizationOverride is the Bearer token to set on the outgoing
+	// Authorization header. The caller's incoming Authorization is
+	// always dropped (Gram-issued credentials — API keys, OAuth tokens,
+	// chat-session JWTs — are not meaningful upstream); when this field
+	// is non-empty the proxy emits "Authorization: Bearer <override>"
+	// instead. Use it for two flows:
+	//
+	//   - External OAuth: forward the caller's Bearer verbatim by
+	//     setting this to the caller's own token (the upstream MCP
+	//     server is the AS).
+	//   - OAuth-proxy token swap: set this to a stored upstream
+	//     credential resolved from the caller's Gram-issued OAuth
+	//     token.
+	//
+	// Leave empty (default) to send no Authorization upstream.
+	AuthorizationOverride string
+
 	UserRequestInterceptors []UserRequestInterceptor
 
 	// RemoteMessageInterceptors run for each JSON-RPC message arriving

--- a/server/internal/xmcp/handler.go
+++ b/server/internal/xmcp/handler.go
@@ -1,6 +1,7 @@
 package xmcp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -49,43 +50,14 @@ func (s *Service) ServeMCP(w http.ResponseWriter, r *http.Request) error {
 
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(slug))
 
-	var customDomainID uuid.NullUUID
-	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
-		customDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
-	}
-
-	endpoint, err := mcpendpointsrepo.New(s.db).GetMCPEndpointByCustomDomainAndSlug(ctx, mcpendpointsrepo.GetMCPEndpointByCustomDomainAndSlugParams{
-		Slug:           slug,
-		CustomDomainID: customDomainID,
-	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeNotFound, err, "mcp endpoint not found")
-	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "load mcp endpoint").Log(ctx, logger)
-	}
-
-	mcpServer, err := mcpserversrepo.New(s.db).GetMCPServerByID(ctx, mcpserversrepo.GetMCPServerByIDParams{
-		ID:        endpoint.McpServerID,
-		ProjectID: endpoint.ProjectID,
-	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeNotFound, err, "mcp server not found")
-	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "load mcp server").Log(ctx, logger)
-	}
-
-	// Disabled MCP servers are unreachable at runtime regardless of caller
-	// identity. Return the same not-found shape the public path uses so we
-	// don't leak existence to unauthenticated callers.
-	if mcpServer.Visibility == visibilityDisabled {
-		return oops.C(oops.CodeNotFound)
+	endpoint, mcpServer, err := s.resolveMCPEndpointAndServer(ctx, logger, slug)
+	if err != nil {
+		return err
 	}
 
 	switch {
 	case mcpServer.RemoteMcpServerID.Valid:
-		return s.serveRemoteBackend(w, r, logger, &endpoint, &mcpServer)
+		return s.serveRemoteBackend(w, r, logger, endpoint, mcpServer)
 	case mcpServer.ToolsetID.Valid:
 		// AGE-1902: toolset-backed branch still reads runtime config from the
 		// toolsets row (visibility, OAuth, default environment). Once
@@ -113,6 +85,47 @@ func (s *Service) ServeMCP(w http.ResponseWriter, r *http.Request) error {
 		// exactly one backend is set; this is defensive.
 		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
 	}
+}
+
+// resolveMCPEndpointAndServer walks the runtime addressing chain shared by
+// /x/mcp/{slug} and the .well-known routes: it scopes the lookup to the
+// request's customdomains.Context, loads the mcp_endpoint by (slug, custom
+// domain), then loads the linked mcp_server. Disabled servers and missing
+// rows both surface as 404 to avoid leaking existence to unauthenticated
+// callers. logger should already carry the slug attribute.
+func (s *Service) resolveMCPEndpointAndServer(ctx context.Context, logger *slog.Logger, slug string) (*mcpendpointsrepo.McpEndpoint, *mcpserversrepo.McpServer, error) {
+	var customDomainID uuid.NullUUID
+	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
+		customDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
+	}
+
+	endpoint, err := mcpendpointsrepo.New(s.db).GetMCPEndpointByCustomDomainAndSlug(ctx, mcpendpointsrepo.GetMCPEndpointByCustomDomainAndSlugParams{
+		Slug:           slug,
+		CustomDomainID: customDomainID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found")
+	case err != nil:
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp endpoint").Log(ctx, logger)
+	}
+
+	mcpServer, err := mcpserversrepo.New(s.db).GetMCPServerByID(ctx, mcpserversrepo.GetMCPServerByIDParams{
+		ID:        endpoint.McpServerID,
+		ProjectID: endpoint.ProjectID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, nil, oops.E(oops.CodeNotFound, err, "mcp server not found")
+	case err != nil:
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp server").Log(ctx, logger)
+	}
+
+	if mcpServer.Visibility == visibilityDisabled {
+		return nil, nil, oops.C(oops.CodeNotFound)
+	}
+
+	return &endpoint, &mcpServer, nil
 }
 
 // serveRemoteBackend handles /x/mcp/{slug} for an mcp_server backed by a

--- a/server/internal/xmcp/handler.go
+++ b/server/internal/xmcp/handler.go
@@ -1,60 +1,235 @@
 package xmcp
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"goa.design/goa/v3/security"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/authz"
-	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
-	"github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
-// ServeMCP handles DELETE, GET, and POST on /x/mcp/{remoteMcpServerId}. It
-// authenticates the caller with a Gram API key, loads the configured Remote
-// MCP Server, and delegates the actual forwarding work to the
-// remotemcp/proxy package.
+const (
+	visibilityPublic   = "public"
+	visibilityPrivate  = "private"
+	visibilityDisabled = "disabled"
+)
+
+// ServeMCP handles DELETE, GET, and POST on /x/mcp/{slug}. It resolves the
+// slug (and optional custom domain context) to an mcp_endpoint, loads the
+// associated mcp_server, and dispatches to the backend implementation:
+// Remote MCP proxy when remote_mcp_server_id is set, or the existing
+// toolset-backed serving body when toolset_id is set.
 func (s *Service) ServeMCP(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
+	defer o11y.LogDefer(ctx, s.logger, func() error {
+		return r.Body.Close()
+	})
 
-	serverIDStr := chi.URLParam(r, "remoteMcpServerId")
-	serverID, err := uuid.Parse(serverIDStr)
-	if err != nil {
-		return oops.E(oops.CodeBadRequest, err, "invalid remote mcp server id")
+	slug := chi.URLParam(r, "slug")
+	if slug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided")
 	}
 
-	logger := s.logger.With(attr.SlogRemoteMCPServerID(serverID.String()))
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(slug))
 
-	ctx, err = s.authenticate(ctx, r)
-	if err != nil {
-		return err
+	var customDomainID uuid.NullUUID
+	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
+		customDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
 	}
 
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		return oops.C(oops.CodeUnauthorized)
+	endpoint, err := mcpendpointsrepo.New(s.db).GetMCPEndpointByCustomDomainAndSlug(ctx, mcpendpointsrepo.GetMCPEndpointByCustomDomainAndSlugParams{
+		Slug:           slug,
+		CustomDomainID: customDomainID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeNotFound, err, "mcp endpoint not found")
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "load mcp endpoint").Log(ctx, logger)
 	}
 
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeMCPConnect, ResourceKind: "", ResourceID: serverID.String(), Dimensions: nil}); err != nil {
-		return err
+	mcpServer, err := mcpserversrepo.New(s.db).GetMCPServerByID(ctx, mcpserversrepo.GetMCPServerByIDParams{
+		ID:        endpoint.McpServerID,
+		ProjectID: endpoint.ProjectID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeNotFound, err, "mcp server not found")
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "load mcp server").Log(ctx, logger)
 	}
 
-	server, err := repo.New(s.db).GetServerByID(ctx, repo.GetServerByIDParams{
-		ID:        serverID,
-		ProjectID: *authCtx.ProjectID,
+	// Disabled MCP servers are unreachable at runtime regardless of caller
+	// identity. Return the same not-found shape the public path uses so we
+	// don't leak existence to unauthenticated callers.
+	if mcpServer.Visibility == visibilityDisabled {
+		return oops.C(oops.CodeNotFound)
+	}
+
+	switch {
+	case mcpServer.RemoteMcpServerID.Valid:
+		return s.serveRemoteBackend(w, r, logger, &endpoint, &mcpServer)
+	case mcpServer.ToolsetID.Valid:
+		// AGE-1902: toolset-backed branch still reads runtime config from the
+		// toolsets row (visibility, OAuth, default environment). Once
+		// /mcp/{mcpSlug} is migrated to source these from the linked
+		// mcp_servers row instead, this branch should switch to passing the
+		// mcp_server config into ServeToolsetResolved (or its successor) and
+		// the toolset load below can be dropped.
+		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
+			ID:        mcpServer.ToolsetID.UUID,
+			ProjectID: endpoint.ProjectID,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			return oops.E(oops.CodeNotFound, err, "toolset not found")
+		case err != nil:
+			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
+		}
+
+		if err := s.mcpService.ServeToolsetResolved(w, r, &toolset, slug, "/x/mcp/"); err != nil {
+			return fmt.Errorf("serve toolset-backed mcp: %w", err)
+		}
+		return nil
+	default:
+		// CHECK constraint mcp_servers_backend_exclusivity_check guarantees
+		// exactly one backend is set; this is defensive.
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+	}
+}
+
+// serveRemoteBackend handles /x/mcp/{slug} for an mcp_server backed by a
+// remote_mcp_server. Auth and visibility come from the mcp_servers row;
+// AuthN flow mirrors a strict subset of /mcp's identity-auth handling
+// (skipping OAuth-proxy refresh, custom-OAuth validation, and per-tool
+// security since those are toolset-only concerns — the upstream Remote
+// MCP server handles its own OAuth where applicable).
+func (s *Service) serveRemoteBackend(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	endpoint *mcpendpointsrepo.McpEndpoint,
+	mcpServer *mcpserversrepo.McpServer,
+) error {
+	ctx := r.Context()
+	logger = logger.With(attr.SlogRemoteMCPServerID(mcpServer.RemoteMcpServerID.UUID.String()))
+
+	// authorizationOverride is the Bearer token to set on the outgoing
+	// upstream request. The caller's Authorization is always dropped by
+	// the proxy (Gram credentials don't apply upstream); this value
+	// replaces it. Empty means send no Authorization upstream.
+	var authorizationOverride string
+
+	// Identity auth + access checks, mirroring the relevant cases of
+	// mcp.ServeToolsetResolved. Unrecognised visibility values fail closed
+	// in the default branch — disabled was already filtered upstream in
+	// ServeMCP.
+	switch mcpServer.Visibility {
+	case visibilityPrivate:
+		// Private mcp_servers require identity auth, that the caller's
+		// active org owns the project that owns the server, and an
+		// mcp:connect grant. RBAC enforcement only applies to RBAC-gated
+		// callers — API keys bypass RBAC by design (they have their own
+		// scoping), so the org-membership check is the meaningful gate
+		// for API-key callers.
+		//
+		// TODO: when mcpServer.OauthProxyServerID is set with a "gram"
+		// provider, isOAuthCapable below should be true so the caller's
+		// Bearer is validated as a Gram-issued OAuth token (rather than
+		// only as an API key / chat session). Today it's hardcoded to
+		// false because the supporting oauth machinery is keyed by
+		// toolset_id and needs generalising to mcp_servers.id first
+		// (same blocker as ResolveOAuthProxyUpstreamToken). When
+		// isOAuthCapable becomes true, wwwAuthResourceMetadataURL must
+		// also be plumbed through (see /x/mcp .well-known route).
+		var err error
+		ctx, err = s.mcpService.RequirePrivateIdentityAuth(ctx, w, r, false, mcpServer.ID, "")
+		if err != nil {
+			return fmt.Errorf("private identity auth: %w", err)
+		}
+
+		project, err := projectsrepo.New(s.db).GetProjectByID(ctx, endpoint.ProjectID)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "load mcp server project").Log(ctx, logger)
+		}
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		if !ok || authCtx == nil || project.OrganizationID != authCtx.ActiveOrganizationID {
+			return oops.C(oops.CodeUnauthorized)
+		}
+
+		ctx, err = s.authz.PrepareContext(ctx)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "load access grants").Log(ctx, logger)
+		}
+		if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeMCPConnect, ResourceKind: "", ResourceID: mcpServer.ID.String(), Dimensions: nil}); err != nil {
+			return err
+		}
+	case visibilityPublic:
+		switch {
+		case mcpServer.OauthProxyServerID.Valid:
+			// Public + OAuth proxy ("custom" provider): the caller's
+			// Bearer is a Gram-issued OAuth token; resolve it to the
+			// user's stored upstream credential and forward that to the
+			// remote MCP server.
+			//
+			// TODO: ResolveOAuthProxyUpstreamToken is currently a stub
+			// returning ("", nil) until the OAuth resource model is
+			// generalised from toolset_id to mcp_servers.id. For now
+			// this branch behaves like a no-token public flow — the
+			// upstream receives no Authorization and may reject. Once
+			// the stub is implemented, callers with a valid Gram OAuth
+			// token will get their stored upstream credential forwarded
+			// automatically.
+			var err error
+			authorizationOverride, err = s.mcpService.ResolveOAuthProxyUpstreamToken(
+				ctx,
+				mcpServer.OauthProxyServerID.UUID,
+				mcpServer.ID,
+				mcp.AuthorizationBearerToken(r),
+			)
+			if err != nil {
+				return fmt.Errorf("resolve oauth proxy upstream token: %w", err)
+			}
+		case mcpServer.ExternalOauthServerID.Valid:
+			// Public + external OAuth: the caller's Bearer is intended
+			// for the upstream remote MCP server (Gram is not the AS in
+			// this configuration), so forward it verbatim.
+			authorizationOverride = mcp.AuthorizationBearerToken(r)
+		default:
+			// Public, no OAuth: optionally probe Gram identity if the
+			// caller supplied an Authorization or Gram-Chat-Session
+			// token so authenticated callers carry the right context
+			// downstream. Nothing meaningful to forward upstream.
+			var err error
+			ctx, err = s.mcpService.TryPublicIdentityAuth(ctx, r, false, mcpServer.ID)
+			if err != nil {
+				return fmt.Errorf("public identity auth: %w", err)
+			}
+		}
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "unrecognized mcp server visibility %q", mcpServer.Visibility).Log(ctx, logger)
+	}
+
+	server, err := remotemcprepo.New(s.db).GetServerByID(ctx, remotemcprepo.GetServerByIDParams{
+		ID:        mcpServer.RemoteMcpServerID.UUID,
+		ProjectID: endpoint.ProjectID,
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
@@ -68,7 +243,7 @@ func (s *Service) ServeMCP(w http.ResponseWriter, r *http.Request) error {
 		return oops.E(oops.CodeUnexpected, err, "load remote mcp server headers").Log(ctx, logger)
 	}
 
-	p := s.buildProxy(logger, &server, headers)
+	p := s.buildProxy(logger, &server, headers, authorizationOverride)
 
 	r = r.WithContext(ctx)
 
@@ -95,36 +270,12 @@ func (s *Service) ServeMCP(w http.ResponseWriter, r *http.Request) error {
 	}
 }
 
-// authenticate extracts the Bearer token from the Authorization header,
-// verifies it as a Gram API key, and returns a context carrying the
-// authenticated principal plus loaded RBAC grants.
-func (s *Service) authenticate(ctx context.Context, r *http.Request) (context.Context, error) {
-	token := r.Header.Get("Authorization")
-	if token == "" {
-		return ctx, oops.C(oops.CodeUnauthorized)
-	}
-	const bearerPrefix = "Bearer "
-	if len(token) >= len(bearerPrefix) && strings.EqualFold(token[:len(bearerPrefix)], bearerPrefix) {
-		token = token[len(bearerPrefix):]
-	}
-
-	scheme := &security.APIKeyScheme{
-		Name:           constants.KeySecurityScheme,
-		Scopes:         nil,
-		RequiredScopes: []string{auth.APIKeyScopeConsumer.String()},
-	}
-
-	ctx, err := s.auth.Authorize(ctx, token, scheme)
-	if err != nil {
-		return ctx, err
-	}
-
-	return ctx, nil
-}
-
 // buildProxy converts the loaded DB types into the typed configuration
-// expected by the remotemcp/proxy package.
-func (s *Service) buildProxy(logger *slog.Logger, server *repo.RemoteMcpServer, headers []repo.RemoteMcpServerHeader) *proxy.Proxy {
+// expected by the remotemcp/proxy package. authorizationOverride is the
+// Bearer token to set on the outgoing upstream request — leave empty to
+// send no Authorization. The caller's incoming Authorization header is
+// always dropped by the proxy regardless of this value.
+func (s *Service) buildProxy(logger *slog.Logger, server *remotemcprepo.RemoteMcpServer, headers []remotemcprepo.RemoteMcpServerHeader, authorizationOverride string) *proxy.Proxy {
 	configured := make([]proxy.ConfiguredHeader, 0, len(headers))
 	for _, h := range headers {
 		configured = append(configured, proxy.ConfiguredHeader{
@@ -146,6 +297,7 @@ func (s *Service) buildProxy(logger *slog.Logger, server *repo.RemoteMcpServer, 
 		ServerID:                  server.ID.String(),
 		RemoteURL:                 server.Url,
 		Headers:                   configured,
+		AuthorizationOverride:     authorizationOverride,
 		UserRequestInterceptors:   nil,
 		RemoteMessageInterceptors: nil,
 		ToolsCallRequestInterceptors: []proxy.ToolsCallRequestInterceptor{

--- a/server/internal/xmcp/handler.go
+++ b/server/internal/xmcp/handler.go
@@ -76,7 +76,7 @@ func (s *Service) ServeMCP(w http.ResponseWriter, r *http.Request) error {
 			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
 		}
 
-		if err := s.mcpService.ServeToolsetResolved(w, r, &toolset, slug, "/x/mcp/"); err != nil {
+		if err := s.mcpService.ServeToolsetResolved(w, r, &toolset, slug, "x/mcp"); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil

--- a/server/internal/xmcp/serveruntime_test.go
+++ b/server/internal/xmcp/serveruntime_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/testmcp"
@@ -25,13 +26,13 @@ const initializeBody = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
 
 // runHandlerWithHeaders is a generalized variant of runHandler that threads
 // extra request headers (e.g. Mcp-Session-Id) onto the test request.
-func runHandlerWithHeaders(t *testing.T, ctx context.Context, ti *testInstance, method, serverID, authorization string, body []byte, extraHeaders map[string]string) *httptest.ResponseRecorder {
+func runHandlerWithHeaders(t *testing.T, ctx context.Context, ti *testInstance, method, slug, authorization string, body []byte, extraHeaders map[string]string) *httptest.ResponseRecorder {
 	t.Helper()
 
 	mux := chi.NewMux()
 	mux.MethodFunc(method, xmcp.RuntimePath, oops.ErrHandle(ti.logger, ti.service.ServeMCP).ServeHTTP)
 
-	req := httptest.NewRequestWithContext(ctx, method, "/x/mcp/"+serverID, bytes.NewReader(body))
+	req := httptest.NewRequestWithContext(ctx, method, "/x/mcp/"+slug, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if authorization != "" {
 		req.Header.Set("Authorization", authorization)
@@ -60,51 +61,73 @@ func insertProject(t *testing.T, ctx context.Context, ti *testInstance, organiza
 	return p.ID
 }
 
-func TestServeRuntime_MissingAuthReturns401(t *testing.T) {
+func TestServeRuntime_SlugNotFoundReturns404(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
 
-	rr := runHandler(t, ctx, ti, http.MethodPost, uuid.NewString(), "", []byte(initializeBody))
-	require.Equal(t, http.StatusUnauthorized, rr.Code)
-}
-
-func TestServeRuntime_InvalidAuthReturns401(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestService(t)
-
-	rr := runHandler(t, ctx, ti, http.MethodPost, uuid.NewString(), bearer("gram_test_not_a_real_key"), []byte(initializeBody))
-	require.Equal(t, http.StatusUnauthorized, rr.Code)
-}
-
-func TestServeRuntime_InvalidServerIDReturns400(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
-
-	rr := runHandler(t, ctx, ti, http.MethodPost, "not-a-uuid", bearer(key), []byte(initializeBody))
-	require.Equal(t, http.StatusBadRequest, rr.Code)
-}
-
-func TestServeRuntime_NonExistentServerReturns404(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
-
-	rr := runHandler(t, ctx, ti, http.MethodPost, uuid.NewString(), bearer(key), []byte(initializeBody))
+	rr := runHandler(t, ctx, ti, http.MethodPost, "no-such-slug", "", []byte(initializeBody))
 	require.Equal(t, http.StatusNotFound, rr.Code)
 }
 
-func TestServeRuntime_Post_ForwardsToRemoteMCPServer(t *testing.T) {
+func TestServeRuntime_PrivateMissingAuthReturns401(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mockServer := testmcp.NewStreamableHTTPServer(t, &testmcp.Server{Tools: nil})
+	t.Cleanup(mockServer.Close)
+
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, mockServer.URL, "private")
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, "", []byte(initializeBody))
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestServeRuntime_PrivateInvalidAuthReturns401(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mockServer := testmcp.NewStreamableHTTPServer(t, &testmcp.Server{Tools: nil})
+	t.Cleanup(mockServer.Close)
+
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, mockServer.URL, "private")
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer("gram_test_not_a_real_key"), []byte(initializeBody))
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestServeRuntime_DisabledReturns404(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mockServer := testmcp.NewStreamableHTTPServer(t, &testmcp.Server{Tools: nil})
+	t.Cleanup(mockServer.Close)
+
+	// Even with valid auth a disabled server should look exactly like a
+	// missing one — visibility is the runtime kill-switch.
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, mockServer.URL, "disabled")
+	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(key), []byte(initializeBody))
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestServeRuntime_PublicNoAuth_ForwardsToRemoteMCPServer(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -121,9 +144,7 @@ func TestServeRuntime_Post_ForwardsToRemoteMCPServer(t *testing.T) {
 				"required": []any{"location"},
 			},
 			Response: testmcp.ToolResponse{
-				Content: []map[string]any{
-					{"type": "text", "text": "San Francisco: sunny, 72F"},
-				},
+				Content: []map[string]any{{"type": "text", "text": "San Francisco: sunny, 72F"}},
 			},
 		}},
 	})
@@ -131,23 +152,23 @@ func TestServeRuntime_Post_ForwardsToRemoteMCPServer(t *testing.T) {
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
-	projectID := authCtx.ProjectID
-	require.NotNil(t, projectID)
+	require.NotNil(t, authCtx.ProjectID)
 
-	server := seedRemoteMCPServer(t, ctx, ti, *projectID, mockServer.URL)
-	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, projectID, []string{auth.APIKeyScopeConsumer.String()})
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, mockServer.URL, "public")
 
-	initResp := runHandler(t, ctx, ti, http.MethodPost, server.ID.String(), bearer(key), []byte(initializeBody))
+	// Public + no external OAuth + no caller-supplied token: the server is
+	// open to anonymous traffic.
+	initResp := runHandler(t, ctx, ti, http.MethodPost, slug, "", []byte(initializeBody))
 	require.Equal(t, http.StatusOK, initResp.Code, "initialize body=%s", initResp.Body.String())
 
-	// The MCP SDK allocates a session id on initialize and returns it in the
-	// Mcp-Session-Id header. The proxy must relay that back to the caller so
-	// subsequent requests can be bound to the same session.
 	sessionID := initResp.Header().Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID, "proxy must relay Mcp-Session-Id from upstream")
 }
 
-func TestServeRuntime_Post_ProjectIsolationReturns404(t *testing.T) {
+// API key callers bypass RBAC (they have their own scoping); a private
+// mcp_server in the API key's own org is reachable as long as the key's
+// principal authenticates.
+func TestServeRuntime_PrivateAPIKeySameOrgReachable(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -157,15 +178,13 @@ func TestServeRuntime_Post_ProjectIsolationReturns404(t *testing.T) {
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
 
-	otherProjectID := insertProject(t, ctx, ti, authCtx.ActiveOrganizationID)
-
-	// Server belongs to a different project than the API key's.
-	server := seedRemoteMCPServer(t, ctx, ti, otherProjectID, mockServer.URL)
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, mockServer.URL, "private")
 	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
 
-	rr := runHandler(t, ctx, ti, http.MethodPost, server.ID.String(), bearer(key), []byte(initializeBody))
-	require.Equal(t, http.StatusNotFound, rr.Code, "servers in other projects must not be reachable")
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(key), []byte(initializeBody))
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
 }
 
 func TestServeRuntime_Post_AppliesStaticSecretHeader(t *testing.T) {
@@ -185,17 +204,16 @@ func TestServeRuntime_Post_AppliesStaticSecretHeader(t *testing.T) {
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
 
-	server := seedRemoteMCPServer(t, ctx, ti, *authCtx.ProjectID, upstream.URL, remotemcprepo.CreateHeaderParams{
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, upstream.URL, "public", remotemcprepo.CreateHeaderParams{
 		Name:       "X-Upstream-Api-Key",
 		Value:      pgtype.Text{String: "upstream-secret", Valid: true},
 		IsRequired: true,
 		IsSecret:   true,
 	})
 
-	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
-
-	rr := runHandler(t, ctx, ti, http.MethodPost, server.ID.String(), bearer(key), []byte(initializeBody))
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, "", []byte(initializeBody))
 	<-done
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Equal(t, "upstream-secret", gotAPIKey, "secret static header must be decrypted and forwarded")
@@ -218,18 +236,20 @@ func TestServeRuntime_Delete_ForwardsSessionTermination(t *testing.T) {
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
 
-	server := seedRemoteMCPServer(t, ctx, ti, *authCtx.ProjectID, upstream.URL)
-	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, upstream.URL, "public")
 
-	rr := runHandlerWithHeaders(t, ctx, ti, http.MethodDelete, server.ID.String(), bearer(key), nil, map[string]string{"Mcp-Session-Id": "abc-session"})
+	rr := runHandlerWithHeaders(t, ctx, ti, http.MethodDelete, slug, "", nil, map[string]string{"Mcp-Session-Id": "abc-session"})
 	<-done
 	require.Equal(t, http.StatusNoContent, rr.Code)
 	require.Equal(t, http.MethodDelete, gotMethod)
 	require.Equal(t, "abc-session", gotSession)
 }
 
-func TestServeRuntime_StripsAuthorizationHeaderFromUpstream(t *testing.T) {
+// Private mcp_server: the caller's Authorization is a Gram API key used
+// for identity auth and must never reach the upstream MCP server.
+func TestServeRuntime_PrivateStripsAuthorizationFromUpstream(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -246,11 +266,223 @@ func TestServeRuntime_StripsAuthorizationHeaderFromUpstream(t *testing.T) {
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
-	server := seedRemoteMCPServer(t, ctx, ti, *authCtx.ProjectID, upstream.URL)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, upstream.URL, "private")
 	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
 
-	rr := runHandler(t, ctx, ti, http.MethodPost, server.ID.String(), bearer(key), []byte(initializeBody))
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(key), []byte(initializeBody))
 	<-done
-	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
 	require.Empty(t, gotAuth, "Gram API key must never leak to the remote MCP server")
+}
+
+// Public mcp_server with no external_oauth_server_id and no caller auth:
+// upstream sees no Authorization header (nothing to forward).
+func TestServeRuntime_PublicNoCallerAuthSendsNoAuthorizationUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	var gotAuth string
+	done := make(chan struct{}, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		done <- struct{}{}
+	}))
+	t.Cleanup(upstream.Close)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, upstream.URL, "public")
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, "", []byte(initializeBody))
+	<-done
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.Empty(t, gotAuth)
+}
+
+// Public mcp_server + external_oauth_server_id + caller Bearer: the
+// caller's Authorization is intended for the upstream MCP server (Gram is
+// not the AS in this configuration), so the proxy must forward it
+// verbatim.
+func TestServeRuntime_PublicExternalOAuthForwardsAuthorizationUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	var gotAuth string
+	done := make(chan struct{}, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		done <- struct{}{}
+	}))
+	t.Cleanup(upstream.Close)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := seedRemoteMCPEndpointWithExternalOAuth(t, ctx, ti, *authCtx.ProjectID, upstream.URL)
+
+	const upstreamToken = "upstream-issued-bearer-token"
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(upstreamToken), []byte(initializeBody))
+	<-done
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.Equal(t, "Bearer "+upstreamToken, gotAuth, "external-OAuth Bearer must reach the upstream verbatim")
+}
+
+// Public mcp_server + external_oauth_server_id + no caller Bearer:
+// upstream sees no Authorization header (the caller didn't supply one).
+func TestServeRuntime_PublicExternalOAuthNoCallerTokenSendsNoAuthorizationUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	var gotAuth string
+	done := make(chan struct{}, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		done <- struct{}{}
+	}))
+	t.Cleanup(upstream.Close)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := seedRemoteMCPEndpointWithExternalOAuth(t, ctx, ti, *authCtx.ProjectID, upstream.URL)
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, "", []byte(initializeBody))
+	<-done
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.Empty(t, gotAuth)
+}
+
+// Public mcp_server + oauth_proxy_server_id: the resolver
+// (mcp.Service.ResolveOAuthProxyUpstreamToken) is currently a stub that
+// returns ("", nil), so the upstream sees no Authorization regardless of
+// the caller's Bearer. This test pins that stub behavior; once the real
+// resolver lands and a stored upstream credential is seeded, the
+// upstream should observe the swapped Bearer instead.
+func TestServeRuntime_PublicOAuthProxyStubSendsNoAuthorizationUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	var gotAuth string
+	done := make(chan struct{}, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		done <- struct{}{}
+	}))
+	t.Cleanup(upstream.Close)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := seedRemoteMCPEndpointWithOAuthProxy(t, ctx, ti, *authCtx.ProjectID, upstream.URL)
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer("gram_test_anything"), []byte(initializeBody))
+	<-done
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.Empty(t, gotAuth, "stub resolver returns empty override; upstream sees no Authorization")
+}
+
+// Public mcp_server (no external OAuth) + caller Bearer that authenticates
+// as a Gram identity: the token was probed as a Gram credential and must
+// not be forwarded upstream.
+func TestServeRuntime_PublicGramAPIKeyStripsAuthorizationFromUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	var gotAuth string
+	done := make(chan struct{}, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+		done <- struct{}{}
+	}))
+	t.Cleanup(upstream.Close)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, upstream.URL, "public")
+	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(key), []byte(initializeBody))
+	<-done
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+	require.Empty(t, gotAuth, "Gram API key must never leak even on a public mcp_server")
+}
+
+// Same-org cross-project access to a private mcp_server is allowed: the
+// org-membership check passes (caller and server share the active org)
+// and the API key bypasses RBAC scope checking. This mirrors /mcp.
+func TestServeRuntime_PrivateSameOrgCrossProjectReachable(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	mockServer := testmcp.NewStreamableHTTPServer(t, &testmcp.Server{Tools: nil})
+	t.Cleanup(mockServer.Close)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	otherProjectID := insertProject(t, ctx, ti, authCtx.ActiveOrganizationID)
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, otherProjectID, mockServer.URL, "private")
+	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(key), []byte(initializeBody))
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+}
+
+// Cross-org access to a private mcp_server is rejected at the org-membership
+// gate before RBAC even runs, matching /mcp behavior.
+func TestServeRuntime_PrivateCrossOrgReturns401(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	mockServer := testmcp.NewStreamableHTTPServer(t, &testmcp.Server{Tools: nil})
+	t.Cleanup(mockServer.Close)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	otherOrgID := "org_" + uuid.NewString()
+	_, err := organizationsrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, organizationsrepo.UpsertOrganizationMetadataParams{
+		ID:          otherOrgID,
+		Name:        "other-org",
+		Slug:        "other-org-" + uuid.NewString()[:8],
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	otherProjectID := insertProject(t, ctx, ti, otherOrgID)
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, otherProjectID, mockServer.URL, "private")
+
+	// API key is in the original (caller's) org; mcp_server is in a foreign
+	// org. The org-membership check rejects.
+	key := seedAPIKey(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, authCtx.ProjectID, []string{auth.APIKeyScopeConsumer.String()})
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(key), []byte(initializeBody))
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
 }

--- a/server/internal/xmcp/service.go
+++ b/server/internal/xmcp/service.go
@@ -1,12 +1,16 @@
-// Package xmcp implements the experimental Remote MCP Server runtime endpoint
-// at /x/mcp/{remoteMcpServerId}. It is a temporary path used to prove out the
-// Remote MCP Server proxy plumbing; once the MCP Frontend work lands, Remote
-// MCP Server runtime handling will move under /mcp/... and use slug-based
-// routing.
+// Package xmcp implements the experimental MCP runtime endpoint at
+// /x/mcp/{slug}. It is a temporary path used to prove out the
+// MCP Servers / MCP Endpoints fronting model — slug + optional custom
+// domain → mcp_endpoint → mcp_server → backend dispatch (Remote MCP proxy
+// vs. existing toolset-backed serving). Once the model is exercised here,
+// runtime handling will move under /mcp/... per AGE-1902.
 //
-// This package owns the HTTP lifecycle (routing, auth, DB load, header
-// decryption) and delegates the actual forwarding work to
-// [github.com/speakeasy-api/gram/server/internal/remotemcp/proxy].
+// This package owns the HTTP lifecycle (routing, slug resolution, auth, DB
+// loads) for the experimental endpoint and delegates the actual serving
+// work to either [github.com/speakeasy-api/gram/server/internal/remotemcp/proxy]
+// (Remote MCP backend) or
+// [github.com/speakeasy-api/gram/server/internal/mcp.Service.ServeToolsetResolved]
+// (toolset backend).
 package xmcp
 
 import (
@@ -19,8 +23,6 @@ import (
 	goahttp "goa.design/goa/v3/http"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/auth"
-	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
@@ -34,16 +36,16 @@ import (
 )
 
 // RuntimePath is the experimental runtime path served by this package.
-const RuntimePath = "/x/mcp/{remoteMcpServerId}"
+const RuntimePath = "/x/mcp/{slug}"
 
-// Service owns dependencies for the Remote MCP Server runtime endpoint.
+// Service owns dependencies for the experimental MCP runtime endpoint.
 type Service struct {
 	logger                       *slog.Logger
 	tracer                       trace.Tracer
 	db                           *pgxpool.Pool
 	enc                          *encryption.Client
-	auth                         *auth.Auth
 	authz                        *authz.Engine
+	mcpService                   *mcp.Service
 	guardianPolicy               *guardian.Policy
 	proxyMetrics                 *proxy.Metrics
 	toolUsageLimitsInterceptor   *ToolUsageLimitsInterceptor
@@ -56,12 +58,12 @@ func NewService(
 	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
 	db *pgxpool.Pool,
-	sessionManager *sessions.Manager,
 	enc *encryption.Client,
 	authzEngine *authz.Engine,
 	guardianPolicy *guardian.Policy,
 	billingRepo billing.Repository,
 	billingTracker billing.Tracker,
+	mcpService *mcp.Service,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("xmcp"))
 
@@ -72,8 +74,8 @@ func NewService(
 		tracer:                       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/xmcp"),
 		db:                           db,
 		enc:                          enc,
-		auth:                         auth.New(logger, db, sessionManager, authzEngine),
 		authz:                        authzEngine,
+		mcpService:                   mcpService,
 		guardianPolicy:               guardianPolicy,
 		proxyMetrics:                 proxy.NewMetrics(meter, logger),
 		toolUsageLimitsInterceptor:   NewToolUsageLimitsInterceptor(billingRepo, logger),
@@ -81,10 +83,10 @@ func NewService(
 	}
 }
 
-// Attach registers the experimental Remote MCP Server runtime handler for all
-// supported HTTP methods. DELETE, GET, and POST are required by the MCP
-// Streamable HTTP transport (see spec § Session Management for DELETE and
-// § Listening for Messages from the Server for GET).
+// Attach registers the experimental MCP runtime handler for all supported
+// HTTP methods. DELETE, GET, and POST are required by the MCP Streamable
+// HTTP transport (see spec § Session Management for DELETE and § Listening
+// for Messages from the Server for GET).
 //
 // Attach also registers /x/mcp aliases for the install page and OAuth
 // .well-known metadata routes, delegating to the existing mcp and mcpmetadata

--- a/server/internal/xmcp/service.go
+++ b/server/internal/xmcp/service.go
@@ -16,6 +16,7 @@ package xmcp
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/metric"
@@ -46,6 +47,7 @@ type Service struct {
 	enc                          *encryption.Client
 	authz                        *authz.Engine
 	mcpService                   *mcp.Service
+	serverURL                    *url.URL
 	guardianPolicy               *guardian.Policy
 	proxyMetrics                 *proxy.Metrics
 	toolUsageLimitsInterceptor   *ToolUsageLimitsInterceptor
@@ -64,6 +66,7 @@ func NewService(
 	billingRepo billing.Repository,
 	billingTracker billing.Tracker,
 	mcpService *mcp.Service,
+	serverURL *url.URL,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("xmcp"))
 
@@ -76,6 +79,7 @@ func NewService(
 		enc:                          enc,
 		authz:                        authzEngine,
 		mcpService:                   mcpService,
+		serverURL:                    serverURL,
 		guardianPolicy:               guardianPolicy,
 		proxyMetrics:                 proxy.NewMetrics(meter, logger),
 		toolUsageLimitsInterceptor:   NewToolUsageLimitsInterceptor(billingRepo, logger),
@@ -89,9 +93,10 @@ func NewService(
 // for Messages from the Server for GET).
 //
 // Attach also registers /x/mcp aliases for the install page and OAuth
-// .well-known metadata routes, delegating to the existing mcp and mcpmetadata
-// service handlers so the experimental endpoint has parity with /mcp.
-func Attach(mux goahttp.Muxer, service *Service, mcpService *mcp.Service, metadataService *mcpmetadata.Service) {
+// .well-known metadata routes. The install page delegates to mcpmetadata
+// for parity with /mcp; the .well-known routes are owned by xmcp directly
+// so they can dispatch per-backend (see [Service.HandleWellKnownOAuthServerMetadata]).
+func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Service) {
 	handler := oops.ErrHandle(service.logger, service.ServeMCP).ServeHTTP
 	o11y.AttachHandler(mux, http.MethodDelete, RuntimePath, handler)
 	o11y.AttachHandler(mux, http.MethodGet, RuntimePath, handler)
@@ -106,8 +111,8 @@ func Attach(mux goahttp.Muxer, service *Service, mcpService *mcp.Service, metada
 	// from /x/mcp to /mcp.
 	// o11y.AttachHandler(mux, http.MethodGet, "/mcp/install-page-{hash}.js", oops.ErrHandle(service.logger, metadataService.ServeInstallPageScript).ServeHTTP)
 
-	o11y.AttachHandler(mux, http.MethodGet, "/.well-known/oauth-authorization-server/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, mcpService.HandleWellKnownOAuthServerMetadata).ServeHTTP)
-	o11y.AttachHandler(mux, http.MethodGet, "/.well-known/oauth-protected-resource/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, mcpService.HandleWellKnownOAuthProtectedResourceMetadata).ServeHTTP)
+	o11y.AttachHandler(mux, http.MethodGet, "/.well-known/oauth-authorization-server/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthServerMetadata).ServeHTTP)
+	o11y.AttachHandler(mux, http.MethodGet, "/.well-known/oauth-protected-resource/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthProtectedResourceMetadata).ServeHTTP)
 }
 
 // newHeadersRepo returns a per-request headers wrapper bound to the service

--- a/server/internal/xmcp/service.go
+++ b/server/internal/xmcp/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
@@ -111,8 +112,8 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	// from /x/mcp to /mcp.
 	// o11y.AttachHandler(mux, http.MethodGet, "/mcp/install-page-{hash}.js", oops.ErrHandle(service.logger, metadataService.ServeInstallPageScript).ServeHTTP)
 
-	o11y.AttachHandler(mux, http.MethodGet, "/.well-known/oauth-authorization-server/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthServerMetadata).ServeHTTP)
-	o11y.AttachHandler(mux, http.MethodGet, "/.well-known/oauth-protected-resource/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthProtectedResourceMetadata).ServeHTTP)
+	o11y.AttachHandler(mux, http.MethodGet, wellknown.OAuthAuthorizationServerPath+"/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthServerMetadata).ServeHTTP)
+	o11y.AttachHandler(mux, http.MethodGet, wellknown.OAuthProtectedResourcePath+"/x/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthProtectedResourceMetadata).ServeHTTP)
 }
 
 // newHeadersRepo returns a per-request headers wrapper bound to the service

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -18,26 +19,45 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
+	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
+	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/environments"
+	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	mcpmetadatarepo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/oauth"
+	oauthrepo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/rag"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/xmcp"
 )
 
-var infra *testenv.Environment
+var (
+	infra *testenv.Environment
+	funcs functions.ToolCaller
+)
 
 func TestMain(m *testing.M) {
-	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true})
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true, Temporal: true})
 	if err != nil {
 		log.Fatalf("launch test infrastructure: %v", err)
 		os.Exit(1)
@@ -57,6 +77,7 @@ func TestMain(m *testing.M) {
 
 type testInstance struct {
 	service        *xmcp.Service
+	mcpService     *mcp.Service
 	conn           *pgxpool.Pool
 	sessionManager *sessions.Manager
 	logger         *slog.Logger
@@ -86,15 +107,42 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
+	serverURL, err := url.Parse("http://0.0.0.0")
+	require.NoError(t, err)
+
 	enc := testenv.NewEncryptionClient(t)
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient(), cache.NoopCache)
 
-	svc := xmcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, enc, authzEngine, guardianPolicy, billingClient, billingClient)
+	mcpMetadataRepo := mcpmetadatarepo.New(conn)
+	env := environments.NewEnvironmentEntries(logger, conn, enc, mcpMetadataRepo)
+	posthogClient := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
+	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
+	oauthService := oauth.NewService(logger, tracerProvider, meterProvider, conn, serverURL, cacheAdapter, enc, env, sessionManager, guardianPolicy)
+	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
+	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, nil, nil, nil, nil, nil)
+	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
+	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
+	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
+	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return false, nil }
+	sessionCaptureEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
+
+	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled)
+	telemService := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
+
+	temporalEnv, _ := infra.NewTemporalEnv(t)
+
+	assistantTokens := assistanttokens.New("test-jwt-secret", conn, authzEngine)
+	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter)
+	auditLogger := audit.NewLogger()
+	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger)
+
+	svc := xmcp.NewService(logger, tracerProvider, meterProvider, conn, enc, authzEngine, guardianPolicy, billingClient, billingClient, mcpService)
 
 	return ctx, &testInstance{
 		service:        svc,
+		mcpService:     mcpService,
 		conn:           conn,
 		sessionManager: sessionManager,
 		logger:         logger,
@@ -166,15 +214,152 @@ func seedRemoteMCPServer(t *testing.T, ctx context.Context, ti *testInstance, pr
 	return server
 }
 
+// randomSlug returns a unique mcp_endpoints.slug suitable for parallel
+// tests. Full UUID entropy keeps collisions out of birthday range even
+// at high parallelism.
+func randomSlug() string {
+	return "xmcp-test-" + uuid.NewString()
+}
+
+// seedRemoteMCPEndpoint wires up a full /x/mcp/{slug} resolution chain for a
+// remote-backed mcp_server: a remote_mcp_servers row + an mcp_servers row
+// pointing at it + an mcp_endpoints row exposing it via the returned slug.
+// visibility must be "public", "private", or "disabled".
+func seedRemoteMCPEndpoint(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, upstreamURL, visibility string, headers ...remotemcprepo.CreateHeaderParams) (slug string, mcpServer mcpserversrepo.McpServer, remoteServer remotemcprepo.RemoteMcpServer) {
+	t.Helper()
+
+	remoteServer = seedRemoteMCPServer(t, ctx, ti, projectID, upstreamURL, headers...)
+	mcpServer, err := mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ProjectID:             projectID,
+		EnvironmentID:         uuid.NullUUID{},
+		ExternalOauthServerID: uuid.NullUUID{},
+		OauthProxyServerID:    uuid.NullUUID{},
+		RemoteMcpServerID:     uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+		ToolsetID:             uuid.NullUUID{},
+		Visibility:            visibility,
+	})
+	require.NoError(t, err)
+
+	slug = randomSlug()
+	_, err = mcpendpointsrepo.New(ti.conn).CreateMCPEndpoint(ctx, mcpendpointsrepo.CreateMCPEndpointParams{
+		ProjectID:      projectID,
+		CustomDomainID: uuid.NullUUID{},
+		McpServerID:    mcpServer.ID,
+		Slug:           slug,
+	})
+	require.NoError(t, err)
+
+	return slug, mcpServer, remoteServer
+}
+
+// seedExternalOAuthServer inserts a minimal external_oauth_server_metadata
+// row in the given project so that an mcp_server can reference it via
+// external_oauth_server_id.
+func seedExternalOAuthServer(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	row, err := oauthrepo.New(ti.conn).CreateExternalOAuthServerMetadata(ctx, oauthrepo.CreateExternalOAuthServerMetadataParams{
+		ProjectID: projectID,
+		Slug:      "ext-" + uuid.NewString()[:8],
+		Metadata:  []byte(`{}`),
+	})
+	require.NoError(t, err)
+	return row.ID
+}
+
+// seedRemoteMCPEndpointWithExternalOAuth wires up the same chain as
+// seedRemoteMCPEndpoint but additionally attaches an
+// external_oauth_server_id to the mcp_server, exercising the public +
+// external-OAuth runtime path where the caller's Authorization header is
+// expected to be forwarded to the upstream MCP server.
+func seedRemoteMCPEndpointWithExternalOAuth(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, upstreamURL string) (slug string) {
+	t.Helper()
+
+	remoteServer := seedRemoteMCPServer(t, ctx, ti, projectID, upstreamURL)
+	externalOAuthID := seedExternalOAuthServer(t, ctx, ti, projectID)
+
+	mcpServer, err := mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ProjectID:             projectID,
+		EnvironmentID:         uuid.NullUUID{},
+		ExternalOauthServerID: uuid.NullUUID{UUID: externalOAuthID, Valid: true},
+		OauthProxyServerID:    uuid.NullUUID{},
+		RemoteMcpServerID:     uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+		ToolsetID:             uuid.NullUUID{},
+		Visibility:            "public",
+	})
+	require.NoError(t, err)
+
+	slug = randomSlug()
+	_, err = mcpendpointsrepo.New(ti.conn).CreateMCPEndpoint(ctx, mcpendpointsrepo.CreateMCPEndpointParams{
+		ProjectID:      projectID,
+		CustomDomainID: uuid.NullUUID{},
+		McpServerID:    mcpServer.ID,
+		Slug:           slug,
+	})
+	require.NoError(t, err)
+
+	return slug
+}
+
+// seedOAuthProxyServer inserts a minimal oauth_proxy_servers row in the
+// given project so that an mcp_server can reference it via
+// oauth_proxy_server_id.
+func seedOAuthProxyServer(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	row, err := oauthrepo.New(ti.conn).UpsertOAuthProxyServer(ctx, oauthrepo.UpsertOAuthProxyServerParams{
+		ProjectID: projectID,
+		Slug:      "proxy-" + uuid.NewString()[:8],
+		Audience:  pgtype.Text{String: "https://example.invalid", Valid: true},
+	})
+	require.NoError(t, err)
+	return row.ID
+}
+
+// seedRemoteMCPEndpointWithOAuthProxy wires up a remote-backed mcp_server
+// configured for the OAuth-proxy token-swap flow. The proxy resolution
+// is currently stubbed in mcp.Service.ResolveOAuthProxyUpstreamToken
+// (returns "", nil), so this seeding is enough to drive the auth-switch
+// branch in xmcp; once the resolver is implemented it will exercise the
+// full token-swap path.
+func seedRemoteMCPEndpointWithOAuthProxy(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, upstreamURL string) (slug string) {
+	t.Helper()
+
+	remoteServer := seedRemoteMCPServer(t, ctx, ti, projectID, upstreamURL)
+	oauthProxyServerID := seedOAuthProxyServer(t, ctx, ti, projectID)
+
+	mcpServer, err := mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ProjectID:             projectID,
+		EnvironmentID:         uuid.NullUUID{},
+		ExternalOauthServerID: uuid.NullUUID{},
+		OauthProxyServerID:    uuid.NullUUID{UUID: oauthProxyServerID, Valid: true},
+		RemoteMcpServerID:     uuid.NullUUID{UUID: remoteServer.ID, Valid: true},
+		ToolsetID:             uuid.NullUUID{},
+		Visibility:            "public",
+	})
+	require.NoError(t, err)
+
+	slug = randomSlug()
+	_, err = mcpendpointsrepo.New(ti.conn).CreateMCPEndpoint(ctx, mcpendpointsrepo.CreateMCPEndpointParams{
+		ProjectID:      projectID,
+		CustomDomainID: uuid.NullUUID{},
+		McpServerID:    mcpServer.ID,
+		Slug:           slug,
+	})
+	require.NoError(t, err)
+
+	return slug
+}
+
 // runHandler invokes the xmcp handler against a custom method/path with chi
 // URL params populated.
-func runHandler(t *testing.T, ctx context.Context, ti *testInstance, method, serverID, authorization string, body []byte) *httptest.ResponseRecorder {
+func runHandler(t *testing.T, ctx context.Context, ti *testInstance, method, slug, authorization string, body []byte) *httptest.ResponseRecorder {
 	t.Helper()
 
 	mux := chi.NewMux()
 	mux.MethodFunc(method, xmcp.RuntimePath, oops.ErrHandle(ti.logger, ti.service.ServeMCP).ServeHTTP)
 
-	req := httptest.NewRequestWithContext(ctx, method, "/x/mcp/"+serverID, bytes.NewReader(body))
+	req := httptest.NewRequestWithContext(ctx, method, "/x/mcp/"+slug, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	// MCP Streamable HTTP § Sending Messages to the Server (step 2) requires
 	// clients to list both application/json and text/event-stream on POST.

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/functions"
@@ -48,6 +49,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/xmcp"
 )
 
@@ -138,7 +140,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	auditLogger := audit.NewLogger()
 	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger)
 
-	svc := xmcp.NewService(logger, tracerProvider, meterProvider, conn, enc, authzEngine, guardianPolicy, billingClient, billingClient, mcpService)
+	svc := xmcp.NewService(logger, tracerProvider, meterProvider, conn, enc, authzEngine, guardianPolicy, billingClient, billingClient, mcpService, serverURL)
 
 	return ctx, &testInstance{
 		service:        svc,
@@ -349,6 +351,73 @@ func seedRemoteMCPEndpointWithOAuthProxy(t *testing.T, ctx context.Context, ti *
 	require.NoError(t, err)
 
 	return slug
+}
+
+// seedToolsetMCPEndpoint wires up a full /x/mcp/{slug} resolution chain for
+// a toolset-backed mcp_server: an mcp_servers row pointing at the given
+// toolset + an mcp_endpoints row exposing it under the toolset's mcp_slug.
+// The endpoint slug intentionally mirrors the toolset's mcp_slug — the
+// production model assumes the two stay aligned until OAuth handling is
+// migrated off toolsets onto mcp_servers (AGE-1902).
+func seedToolsetMCPEndpoint(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, toolset toolsetsrepo.Toolset, visibility string) (slug string, mcpServer mcpserversrepo.McpServer) {
+	t.Helper()
+	return seedToolsetMCPEndpointOnDomain(t, ctx, ti, projectID, toolset, visibility, uuid.NullUUID{})
+}
+
+// seedToolsetMCPEndpointOnDomain is the custom-domain-aware variant of
+// seedToolsetMCPEndpoint. Pass a Valid customDomainID to scope the
+// resulting mcp_endpoint to that domain so it resolves only when a request
+// arrives with a matching customdomains.Context.
+func seedToolsetMCPEndpointOnDomain(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, toolset toolsetsrepo.Toolset, visibility string, customDomainID uuid.NullUUID) (slug string, mcpServer mcpserversrepo.McpServer) {
+	t.Helper()
+
+	mcpServer, err := mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ProjectID:             projectID,
+		EnvironmentID:         uuid.NullUUID{},
+		ExternalOauthServerID: uuid.NullUUID{},
+		OauthProxyServerID:    uuid.NullUUID{},
+		RemoteMcpServerID:     uuid.NullUUID{},
+		ToolsetID:             uuid.NullUUID{UUID: toolset.ID, Valid: true},
+		Visibility:            visibility,
+	})
+	require.NoError(t, err)
+
+	slug = toolset.McpSlug.String
+	_, err = mcpendpointsrepo.New(ti.conn).CreateMCPEndpoint(ctx, mcpendpointsrepo.CreateMCPEndpointParams{
+		ProjectID:      projectID,
+		CustomDomainID: customDomainID,
+		McpServerID:    mcpServer.ID,
+		Slug:           slug,
+	})
+	require.NoError(t, err)
+
+	return slug, mcpServer
+}
+
+// seedCustomDomain creates a verified+activated custom_domains row in the
+// caller's organization. Verification is forced on so the row is treated as
+// active by the runtime resolution code paths.
+func seedCustomDomain(t *testing.T, ctx context.Context, ti *testInstance, organizationID, domainName string) customdomainsrepo.CustomDomain {
+	t.Helper()
+
+	r := customdomainsrepo.New(ti.conn)
+	domain, err := r.CreateCustomDomain(ctx, customdomainsrepo.CreateCustomDomainParams{
+		OrganizationID: organizationID,
+		Domain:         domainName,
+		IngressName:    pgtype.Text{String: "", Valid: false},
+		CertSecretName: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	domain, err = r.UpdateCustomDomain(ctx, customdomainsrepo.UpdateCustomDomainParams{
+		ID:             domain.ID,
+		Verified:       true,
+		Activated:      true,
+		IngressName:    pgtype.Text{String: "", Valid: false},
+		CertSecretName: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+	return domain
 }
 
 // runHandler invokes the xmcp handler against a custom method/path with chi

--- a/server/internal/xmcp/wellknown.go
+++ b/server/internal/xmcp/wellknown.go
@@ -1,0 +1,248 @@
+package xmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/oauth/repo"
+	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+// baseURLForRequest returns the appropriate base URL for well-known metadata
+// responses, switching to the custom domain when the request was resolved
+// through one.
+func (s *Service) baseURLForRequest(r *http.Request) string {
+	if domainCtx := customdomains.FromContext(r.Context()); domainCtx != nil {
+		return fmt.Sprintf("https://%s", domainCtx.Domain)
+	}
+	return s.serverURL.String()
+}
+
+// HandleWellKnownOAuthServerMetadata serves
+// /.well-known/oauth-authorization-server/x/mcp/{mcpSlug}.
+//
+// Resolution mirrors the runtime path: slug → mcp_endpoint → mcp_server.
+// Dispatch is per-backend so each backend can source OAuth state from the
+// model that fits it best:
+//
+//   - Toolset-backed: load the linked toolset by ID and reuse the existing
+//     toolset-keyed wellknown resolver. The OAuth flow itself is still
+//     keyed by toolsets.mcp_slug today; the production model assumes
+//     mcp_endpoints.slug == toolsets.mcp_slug for these servers, and a
+//     separate upcoming OAuth migration (tracked independently of
+//     AGE-1902) will re-key the OAuth machinery onto mcp_servers.id, at
+//     which point the dependency on toolsets.mcp_slug drops entirely.
+//   - Remote-backed: returns 404 today. Remote MCP servers publish their
+//     own .well-known and Gram does not yet act as an authorization server
+//     for them. Once that upcoming OAuth migration generalises the
+//     machinery off toolset_id, this branch will source from mcp_servers /
+//     oauth_proxy_servers.
+func (s *Service) HandleWellKnownOAuthServerMetadata(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	slug := chi.URLParam(r, "mcpSlug")
+	if slug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided")
+	}
+
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(slug))
+
+	endpoint, mcpServer, err := s.resolveMCPEndpointAndServer(ctx, logger, slug)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case mcpServer.RemoteMcpServerID.Valid:
+		// The upcoming OAuth migration (separate from AGE-1902) will
+		// surface OAuth metadata from mcp_servers / oauth_proxy_servers
+		// directly. Until then there is no Gram-hosted authorization
+		// server for remote-backed mcp_servers — the upstream remote MCP
+		// server publishes its own .well-known.
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	case mcpServer.ToolsetID.Valid:
+		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
+			ID:        mcpServer.ToolsetID.UUID,
+			ProjectID: endpoint.ProjectID,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			return oops.E(oops.CodeNotFound, err, "toolset not found")
+		case err != nil:
+			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
+		}
+
+		// Today's OAuth machinery (issuance, callback, token exchange) is
+		// still keyed by toolsets.mcp_slug, so the issuer family points at
+		// /oauth/{toolset.mcp_slug}/... — see the function comment for
+		// the upcoming OAuth migration that will re-key onto mcp_servers.
+		oauthSlug := toolset.McpSlug.String
+		if oauthSlug == "" {
+			return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+		}
+
+		baseURL := s.baseURLForRequest(r)
+		result, err := wellknown.ResolveOAuthServerMetadataFromToolset(
+			ctx,
+			logger,
+			s.db,
+			repo.New(s.db),
+			nil,
+			&toolset,
+			baseURL,
+			oauthSlug,
+		)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").Log(ctx, logger)
+		}
+
+		if result == nil {
+			return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+		}
+
+		return writeOAuthServerMetadata(ctx, w, r, logger, result)
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+	}
+}
+
+// HandleWellKnownOAuthProtectedResourceMetadata serves
+// /.well-known/oauth-protected-resource/x/mcp/{mcpSlug}.
+//
+// The resource URL embedded in the response is the runtime URL the caller
+// is actually addressing — `<baseURL>/x/mcp/<mcp_endpoint.slug>`. See
+// [Service.HandleWellKnownOAuthServerMetadata] for the dispatch rationale.
+func (s *Service) HandleWellKnownOAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	slug := chi.URLParam(r, "mcpSlug")
+	if slug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided")
+	}
+
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(slug))
+
+	endpoint, mcpServer, err := s.resolveMCPEndpointAndServer(ctx, logger, slug)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case mcpServer.RemoteMcpServerID.Valid:
+		// See HandleWellKnownOAuthServerMetadata for the rationale —
+		// remote-backed Gram-hosted OAuth metadata is gated on the
+		// upcoming OAuth migration.
+		return oops.E(oops.CodeNotFound, nil, "not found")
+	case mcpServer.ToolsetID.Valid:
+		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
+			ID:        mcpServer.ToolsetID.UUID,
+			ProjectID: endpoint.ProjectID,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			return oops.E(oops.CodeNotFound, err, "toolset not found")
+		case err != nil:
+			return oops.E(oops.CodeUnexpected, err, "load toolset").Log(ctx, logger)
+		}
+
+		resourceURL := s.baseURLForRequest(r) + "/x/mcp/" + endpoint.Slug
+		metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(
+			ctx,
+			logger,
+			s.db,
+			nil,
+			&toolset,
+			resourceURL,
+		)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, logger)
+		}
+
+		if metadata == nil {
+			return oops.E(oops.CodeNotFound, nil, "not found")
+		}
+
+		// Marshal before committing the 200 — see writeOAuthServerMetadata.
+		body, err := json.Marshal(metadata)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth protected resource metadata").Log(ctx, logger)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(body); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+		}
+		return nil
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").Log(ctx, logger)
+	}
+}
+
+// writeOAuthServerMetadata serialises a resolver result onto the response,
+// dispatching the proxy variant via httputil.ReverseProxy.
+func writeOAuthServerMetadata(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	result *wellknown.OAuthServerMetadataResult,
+) error {
+	if result.Kind == wellknown.OAuthServerMetadataResultKindProxy {
+		target, err := url.Parse(result.ProxyURL)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to parse well-known URL").Log(ctx, logger)
+		}
+
+		proxy := &httputil.ReverseProxy{
+			Director: nil,
+			Rewrite: func(pr *httputil.ProxyRequest) {
+				pr.SetURL(target)
+			},
+			Transport:      nil,
+			FlushInterval:  0,
+			ErrorLog:       nil,
+			BufferPool:     nil,
+			ModifyResponse: nil,
+			ErrorHandler:   nil,
+		}
+		proxy.ServeHTTP(w, r)
+		return nil
+	}
+
+	// Resolve the response body before committing the 200 status. Once
+	// WriteHeader is called we lose the ability to surface a downstream
+	// failure (marshalling, unexpected kind) as a proper error response,
+	// so any work that can fail must happen first.
+	var body []byte
+	switch result.Kind {
+	case wellknown.OAuthServerMetadataResultKindRaw:
+		body = result.Raw
+	case wellknown.OAuthServerMetadataResultKindStatic:
+		marshalled, err := json.Marshal(result.Static)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to marshal OAuth server metadata").Log(ctx, logger)
+		}
+		body = marshalled
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "unexpected OAuth server metadata result kind").Log(ctx, logger)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+	}
+	return nil
+}

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -1,0 +1,431 @@
+// wellknown_test.go covers the experimental /.well-known/.../x/mcp/{slug}
+// routes. The xmcp handlers walk slug → mcp_endpoint → mcp_server and
+// dispatch per-backend (toolset vs remote), so these tests exercise:
+//
+//   - Path validation (missing slug, unknown slug, disabled server).
+//   - Remote-backed dispatch returning 404 — gated on a separate upcoming
+//     OAuth migration (independent of AGE-1902).
+//   - Toolset-backed dispatch reusing the existing wellknown resolvers, with
+//     proxy and external-OAuth happy paths covered.
+//
+// The production model assumes mcp_endpoints.slug == toolsets.mcp_slug for
+// toolset-backed servers until the upcoming OAuth migration moves the OAuth
+// machinery onto mcp_servers. seedToolsetMCPEndpoint mirrors that assumption.
+package xmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+// runWellKnown invokes the supplied xmcp well-known handler with the chi
+// `mcpSlug` URL param set to slug. The empty slug case is supported by
+// passing slug="" — chi.URLParam returns "" both when the param is missing
+// and when it is explicitly empty, which matches production routing.
+func runWellKnown(
+	t *testing.T,
+	ctx context.Context,
+	handler func(http.ResponseWriter, *http.Request) error,
+	path, slug string,
+) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", slug)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	err := handler(w, req)
+	return w, err
+}
+
+// seedBareToolset creates a toolset with the given mcp_slug and no OAuth
+// configuration. Used for the "no OAuth configured" branches.
+func seedBareToolset(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, organizationID, mcpSlug string) toolsetsrepo.Toolset {
+	t.Helper()
+
+	toolset, err := toolsetsrepo.New(ti.conn).CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID:         organizationID,
+		ProjectID:              projectID,
+		Name:                   "xmcp-bare-" + mcpSlug,
+		Slug:                   mcpSlug,
+		Description:            conv.ToPGText("xmcp wellknown_test bare toolset"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText(mcpSlug),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+	return toolset
+}
+
+// ---------------------------------------------------------------------------
+// HandleWellKnownOAuthServerMetadata
+// ---------------------------------------------------------------------------
+
+func TestHandleWellKnownOAuthServerMetadata_MissingSlug(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+
+	w, err := runWellKnown(t, t.Context(), ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp slug must be provided")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthServerMetadata_EndpointNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+
+	w, err := runWellKnown(t, t.Context(), ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/none", "definitely-missing-"+uuid.NewString()[:8])
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp endpoint not found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthServerMetadata_DisabledServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp", "disabled")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.Error(t, err)
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthServerMetadata_RemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	// Even a remote-backed mcp_server with an oauth_proxy attached returns
+	// 404 today. Sourcing OAuth metadata from mcp_servers / oauth_proxy_servers
+	// directly is gated on a separate upcoming OAuth migration (independent
+	// of AGE-1902); until that lands, the upstream remote MCP server
+	// publishes its own .well-known and Gram doesn't act as the AS.
+	slug := seedRemoteMCPEndpointWithOAuthProxy(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no OAuth configuration found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthServerMetadata_ToolsetBackendWithoutOAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := seedBareToolset(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, "ts-noauth-"+uuid.NewString()[:8])
+	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, toolset, "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no OAuth configuration found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthServerMetadata_ToolsetBackendWithProxy(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "xmcp-srv-proxy",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, proxy.Toolset, "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedIssuer := "http://0.0.0.0/oauth/" + slug
+	require.Equal(t, expectedIssuer, metadata["issuer"])
+	require.Equal(t, expectedIssuer+"/authorize", metadata["authorization_endpoint"])
+	require.Equal(t, expectedIssuer+"/token", metadata["token_endpoint"])
+	require.Equal(t, expectedIssuer+"/register", metadata["registration_endpoint"])
+
+	// The Gram-issued offline_access scope is always advertised so RFC 8414
+	// scopes_supported never disappears.
+	scopes, ok := metadata["scopes_supported"].([]any)
+	require.True(t, ok)
+	require.Contains(t, scopes, "offline_access")
+
+	grants, ok := metadata["grant_types_supported"].([]any)
+	require.True(t, ok)
+	require.Contains(t, grants, "authorization_code")
+	require.Contains(t, grants, "refresh_token")
+}
+
+func TestHandleWellKnownOAuthServerMetadata_ToolsetBackendOnCustomDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	domain := seedCustomDomain(t, ctx, ti, authCtx.ActiveOrganizationID, "xmcp-srv-cd-"+uuid.NewString()[:8]+".example.com")
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "xmcp-srv-cd",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug, _ := seedToolsetMCPEndpointOnDomain(t, ctx, ti, *authCtx.ProjectID, proxy.Toolset, "public", uuid.NullUUID{UUID: domain.ID, Valid: true})
+
+	domainCtx := customdomains.WithContext(ctx, &customdomains.Context{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domain.Domain,
+		DomainID:       domain.ID,
+	})
+
+	w, err := runWellKnown(t, domainCtx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	// Custom-domain requests must produce metadata URLs rooted at the
+	// custom domain (https), not the platform serverURL — clients will
+	// reject discovery responses whose host doesn't match the resource
+	// they were directed to.
+	expectedIssuer := "https://" + domain.Domain + "/oauth/" + slug
+	require.Equal(t, expectedIssuer, metadata["issuer"])
+	require.Equal(t, expectedIssuer+"/authorize", metadata["authorization_endpoint"])
+	require.Equal(t, expectedIssuer+"/token", metadata["token_endpoint"])
+	require.Equal(t, expectedIssuer+"/register", metadata["registration_endpoint"])
+}
+
+func TestHandleWellKnownOAuthServerMetadata_ToolsetBackendWithExternalOAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+		Slug:       "xmcp-srv-external",
+		IsPublic:   true,
+		Metadata:   nil,
+		AuthServer: nil,
+	})
+	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, external.Toolset, "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	// External OAuth toolsets surface the upstream provider's metadata
+	// verbatim — confirm we passed the stored JSON through unmodified.
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.Equal(t, "https://test-oauth-server.example.com", metadata["issuer"])
+}
+
+// ---------------------------------------------------------------------------
+// HandleWellKnownOAuthProtectedResourceMetadata
+// ---------------------------------------------------------------------------
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_MissingSlug(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+
+	w, err := runWellKnown(t, t.Context(), ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp slug must be provided")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_EndpointNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+
+	w, err := runWellKnown(t, t.Context(), ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/none", "definitely-missing-"+uuid.NewString()[:8])
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mcp endpoint not found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_DisabledServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp", "disabled")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.Error(t, err)
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_RemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := seedRemoteMCPEndpointWithExternalOAuth(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithoutOAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := seedBareToolset(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, "ts-prnoauth-"+uuid.NewString()[:8])
+	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, toolset, "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+	require.Empty(t, w.Body.String())
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithProxy(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "xmcp-pr-proxy",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, proxy.Toolset, "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedResource := "http://0.0.0.0/x/mcp/" + slug
+	require.Equal(t, expectedResource, metadata["resource"])
+
+	// authorization_servers points at the same resource so .well-known
+	// discovery loops back to /.well-known/oauth-authorization-server/x/mcp/{slug}.
+	authServers, ok := metadata["authorization_servers"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{expectedResource}, authServers)
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendOnCustomDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	domain := seedCustomDomain(t, ctx, ti, authCtx.ActiveOrganizationID, "xmcp-pr-cd-"+uuid.NewString()[:8]+".example.com")
+	proxy := oauthtest.CreateProxyToolset(t, ctx, ti.conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "xmcp-pr-cd",
+		IsPublic:     true,
+		ProviderType: "",
+	})
+	slug, _ := seedToolsetMCPEndpointOnDomain(t, ctx, ti, *authCtx.ProjectID, proxy.Toolset, "public", uuid.NullUUID{UUID: domain.ID, Valid: true})
+
+	domainCtx := customdomains.WithContext(ctx, &customdomains.Context{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domain.Domain,
+		DomainID:       domain.ID,
+	})
+
+	w, err := runWellKnown(t, domainCtx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedResource := "https://" + domain.Domain + "/x/mcp/" + slug
+	require.Equal(t, expectedResource, metadata["resource"])
+
+	authServers, ok := metadata["authorization_servers"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{expectedResource}, authServers)
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithExternalOAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+		Slug:       "xmcp-pr-external",
+		IsPublic:   true,
+		Metadata:   nil,
+		AuthServer: nil,
+	})
+	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, external.Toolset, "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.Equal(t, "http://0.0.0.0/x/mcp/"+slug, metadata["resource"])
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-1971/feat-implement-mcp-server-and-endpoint-fronting-to-xmcp-endpoints

Switches `/x/mcp` from `{remoteMcpServerId}` UUID routing to `{slug}` routing driven by the new `mcp_servers` + `mcp_endpoints` tables. The handler resolves slug+custom_domain → endpoint → mcp_server and branches on backend: remote-MCP-backed servers run through the existing proxy with visibility / org-membership / RBAC gating, toolset-backed servers delegate to a newly-exported `mcp.Service.ServeToolsetResolved`.

Refactors `mcp.ServePublic` so the post-slug body is reusable across runtime surfaces, and splits the auth switch into independent helpers (`RequirePrivateIdentityAuth`, `TryPublicIdentityAuth`, `AuthorizationBearerToken`). Adds `proxy.AuthorizationOverride` so the verbatim-forward (external OAuth) and OAuth-proxy token-swap cases share a single mechanism for setting the upstream `Authorization` header.

Authentication and authorization configurations on `/x/mcp/{slug}` for remote-MCP-backed `mcp_servers`:

**Supported:**

- `visibility=disabled` — 404 regardless of caller identity (runtime kill switch).
- `visibility=private`, no OAuth columns set — caller must present a valid Gram identity (API key or `Gram-Chat-Session` JWT); caller's active org must own the `mcp_server`'s project; `mcp:connect` grant on `mcp_server.id` (API-key callers bypass RBAC by design — the org-membership check is the meaningful gate). The caller's `Authorization` is not forwarded upstream.
- `visibility=public`, no OAuth columns set — optional Gram identity probe so authenticated callers carry context downstream. The caller's `Authorization` is not forwarded upstream.
- `visibility=public`, `external_oauth_server_id` set — Gram is not the AS; the caller's Bearer is forwarded verbatim to the upstream remote MCP server, which validates it.

**Stubbed / not yet supported:**

- `visibility=public`, `oauth_proxy_server_id` set (intended for the `custom` provider token-swap path) — branch is wired and calls `mcp.Service.ResolveOAuthProxyUpstreamToken`, which currently returns an empty override. Upstream sees no `Authorization` until the swap is implemented.
- `visibility=private`, `oauth_proxy_server_id` set (intended for the `gram` provider Gram-as-AS path) — falls through to the non-OAuth private identity path today; the caller's Bearer is not yet validated as a Gram-issued OAuth token (`isOAuthCapable=false`).

Both stubbed cases are blocked on generalizing the oauth machinery (`ValidateAccessToken` / `RefreshProxyToken` / `ExternalSecret` storage) from `toolset_id` to `mcp_servers.id` — tracked as a separate follow-up. AGE-1902 covers migrating `/mcp`'s toolset-backed flow to source runtime config from the linked `mcp_servers` row.

For toolset-backed `mcp_servers` the runtime body is delegated to `mcp.Service.ServeToolsetResolved`, so all auth modes the existing `/mcp` endpoint supports (external OAuth, OAuth proxy `custom` and `gram` providers, public/private visibility, chat-session JWT fallback) work as-is.