### PR TITLE
chore: harden fly.io assistant runtime retry

### DIFF
--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -286,7 +286,16 @@ INSERT INTO assistant_runtimes (
   @project_id,
   @backend,
   @state,
-  '{}'::jsonb
+  COALESCE((
+    SELECT r.backend_metadata_json
+    FROM assistant_runtimes r
+    WHERE r.project_id = @project_id
+      AND r.assistant_thread_id = @assistant_thread_id
+      AND r.backend = @backend
+      AND r.backend_metadata_json <> '{}'::jsonb
+    ORDER BY r.created_at DESC
+    LIMIT 1
+  ), '{}'::jsonb)
 )
 ON CONFLICT DO NOTHING;
 

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -974,7 +974,16 @@ INSERT INTO assistant_runtimes (
   $3,
   $4,
   $5,
-  '{}'::jsonb
+  COALESCE((
+    SELECT r.backend_metadata_json
+    FROM assistant_runtimes r
+    WHERE r.project_id = $3
+      AND r.assistant_thread_id = $1
+      AND r.backend = $4
+      AND r.backend_metadata_json <> '{}'::jsonb
+    ORDER BY r.created_at DESC
+    LIMIT 1
+  ), '{}'::jsonb)
 )
 ON CONFLICT DO NOTHING
 `

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -45,11 +45,19 @@ var errFlyAppCorrupted = errors.New("assistant fly runtime app corrupted")
 
 type flyRuntimeMetadata struct {
 	AppName    string `json:"app_name"`
+	AppID      string `json:"app_id,omitempty"`
 	AppURL     string `json:"app_url"`
 	AppIP      string `json:"app_ip,omitempty"`
 	MachineID  string `json:"machine_id"`
 	Region     string `json:"region"`
 	LastBootID string `json:"last_boot_id,omitempty"`
+}
+
+type flyRuntimeAppIdentity struct {
+	Name     string
+	ID       string
+	SharedIP string
+	Created  bool
 }
 
 type flyRuntimeStateResponse struct {
@@ -208,14 +216,16 @@ func (f *FlyRuntimeBackend) ensureExisting(
 		appURL = flyRuntimeAppURL(appName)
 	}
 
-	appIP, appCreated, err := f.ensureApp(ctx, appName)
+	app, err := f.ensureApp(ctx, appName)
 	if err != nil {
 		return RuntimeBackendEnsureResult{}, err
 	}
+	appIP := app.SharedIP
 	if appIP == "" {
 		appIP = metadata.AppIP
 	}
-	if appCreated {
+	sameAppIncarnation := metadata.AppID != "" && app.ID != "" && metadata.AppID == app.ID
+	if app.Created || (metadata.AppID != "" && app.ID != "" && metadata.AppID != app.ID) {
 		// Metadata may have been recovered from a prior runtime row after a
 		// failed/corrupted app was deleted. Once the app has been recreated,
 		// old machine/boot IDs describe the previous app incarnation and must
@@ -224,7 +234,7 @@ func (f *FlyRuntimeBackend) ensureExisting(
 		metadata.LastBootID = ""
 	}
 
-	machine, err := f.resolveMachine(ctx, flapsClient, appName, runtime.AssistantThreadID, metadata.MachineID, metadata.LastBootID)
+	machine, err := f.resolveMachine(ctx, flapsClient, appName, runtime.AssistantThreadID, metadata.MachineID, metadata.LastBootID, sameAppIncarnation)
 	if err != nil {
 		if errors.Is(err, errFlyAppCorrupted) {
 			f.logger.WarnContext(ctx,
@@ -287,6 +297,7 @@ func (f *FlyRuntimeBackend) ensureExisting(
 
 	nextMetadata := flyRuntimeMetadata{
 		AppName:    appName,
+		AppID:      app.ID,
 		AppURL:     appURL,
 		AppIP:      appIP,
 		MachineID:  machine.ID,
@@ -306,33 +317,37 @@ func (f *FlyRuntimeBackend) ensureExisting(
 	}, nil
 }
 
-// ensureApp returns the app's shared v4 IP so callers can dial it directly
-// instead of waiting on public DNS propagation (see flyRuntimeTarget). The
-// boolean reports whether this call created the app.
-func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (string, bool, error) {
+// ensureApp returns the app identity and shared v4 IP so callers can dial it
+// directly instead of waiting on public DNS propagation (see flyRuntimeTarget).
+func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (flyRuntimeAppIdentity, error) {
 	app, err := f.client.GetApp(ctx, appName)
 	switch {
 	case err == nil:
-		return app.SharedIPAddress, false, nil
+		return flyRuntimeAppIdentity{Name: app.Name, ID: app.ID, SharedIP: app.SharedIPAddress, Created: false}, nil
 	case isFlyNotFound(err):
 		org, err := f.client.GetOrganizationBySlug(ctx, f.config.DefaultFlyOrg)
 		if err != nil {
-			return "", false, fmt.Errorf("resolve assistant fly runtime organization: %w", err)
+			return flyRuntimeAppIdentity{}, fmt.Errorf("resolve assistant fly runtime organization: %w", err)
 		}
+		created := true
 		_, err = f.client.CreateApp(ctx, fly.CreateAppInput{
 			OrganizationID:  org.ID,
 			Name:            appName,
 			PreferredRegion: new(f.config.DefaultFlyRegion),
 		})
-		if err != nil && !isFlyAppNameTaken(err) {
-			return "", false, fmt.Errorf("create assistant fly runtime app: %w", err)
+		if err != nil {
+			if !isFlyAppNameTaken(err) {
+				return flyRuntimeAppIdentity{}, fmt.Errorf("create assistant fly runtime app: %w", err)
+			}
+			created = false
 		}
-		if _, getErr := f.client.GetApp(ctx, appName); getErr != nil {
-			return "", false, fmt.Errorf("verify assistant fly runtime app: %w", getErr)
+		verified, getErr := f.client.GetApp(ctx, appName)
+		if getErr != nil {
+			return flyRuntimeAppIdentity{}, fmt.Errorf("verify assistant fly runtime app: %w", getErr)
 		}
 		ip, err := f.client.AllocateSharedIPAddress(ctx, appName)
 		if err != nil && !isFlyIPAlreadyAssigned(err) {
-			return "", false, fmt.Errorf("allocate assistant fly runtime shared ip: %w", err)
+			return flyRuntimeAppIdentity{}, fmt.Errorf("allocate assistant fly runtime shared ip: %w", err)
 		}
 		ipStr := ""
 		if ip != nil {
@@ -343,7 +358,7 @@ func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (stri
 		// propagate, blowing past waitForRuntimeHealth's budget. Allocating
 		// a v6 forces an immediate DNS publish for both records.
 		if _, err := f.client.AllocateIPAddress(ctx, appName, "v6", "", org.ID, ""); err != nil && !isFlyIPAlreadyAssigned(err) {
-			return "", false, fmt.Errorf("allocate assistant fly runtime v6 ip: %w", err)
+			return flyRuntimeAppIdentity{}, fmt.Errorf("allocate assistant fly runtime v6 ip: %w", err)
 		}
 		if ipStr == "" {
 			// IP was already allocated previously (isFlyIPAlreadyAssigned path
@@ -352,9 +367,9 @@ func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (stri
 				ipStr = refreshed.SharedIPAddress
 			}
 		}
-		return ipStr, true, nil
+		return flyRuntimeAppIdentity{Name: verified.Name, ID: verified.ID, SharedIP: ipStr, Created: created}, nil
 	default:
-		return "", false, fmt.Errorf("load assistant fly runtime app: %w", err)
+		return flyRuntimeAppIdentity{}, fmt.Errorf("load assistant fly runtime app: %w", err)
 	}
 }
 
@@ -365,9 +380,10 @@ func (f *FlyRuntimeBackend) resolveMachine(
 	threadID uuid.UUID,
 	machineID string,
 	lastBootID string,
+	sameAppIncarnation bool,
 ) (*fly.Machine, error) {
 	wantThreadID := threadID.String()
-	hadPriorBoot := lastBootID != "" || machineID != ""
+	hadPriorBoot := sameAppIncarnation && (lastBootID != "" || machineID != "")
 
 	if machineID != "" {
 		machine, err := flapsClient.Get(ctx, appName, machineID)
@@ -750,6 +766,7 @@ func decodeFlyRuntimeMetadata(raw []byte) (flyRuntimeMetadata, error) {
 	if len(raw) == 0 {
 		return flyRuntimeMetadata{
 			AppName:    "",
+			AppID:      "",
 			AppURL:     "",
 			AppIP:      "",
 			MachineID:  "",

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -208,12 +208,20 @@ func (f *FlyRuntimeBackend) ensureExisting(
 		appURL = flyRuntimeAppURL(appName)
 	}
 
-	appIP, err := f.ensureApp(ctx, appName)
+	appIP, appCreated, err := f.ensureApp(ctx, appName)
 	if err != nil {
 		return RuntimeBackendEnsureResult{}, err
 	}
 	if appIP == "" {
 		appIP = metadata.AppIP
+	}
+	if appCreated {
+		// Metadata may have been recovered from a prior runtime row after a
+		// failed/corrupted app was deleted. Once the app has been recreated,
+		// old machine/boot IDs describe the previous app incarnation and must
+		// not make normal Machines propagation look like established drift.
+		metadata.MachineID = ""
+		metadata.LastBootID = ""
 	}
 
 	machine, err := f.resolveMachine(ctx, flapsClient, appName, runtime.AssistantThreadID, metadata.MachineID, metadata.LastBootID)
@@ -299,16 +307,17 @@ func (f *FlyRuntimeBackend) ensureExisting(
 }
 
 // ensureApp returns the app's shared v4 IP so callers can dial it directly
-// instead of waiting on public DNS propagation (see flyRuntimeTarget).
-func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (string, error) {
+// instead of waiting on public DNS propagation (see flyRuntimeTarget). The
+// boolean reports whether this call created the app.
+func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (string, bool, error) {
 	app, err := f.client.GetApp(ctx, appName)
 	switch {
 	case err == nil:
-		return app.SharedIPAddress, nil
+		return app.SharedIPAddress, false, nil
 	case isFlyNotFound(err):
 		org, err := f.client.GetOrganizationBySlug(ctx, f.config.DefaultFlyOrg)
 		if err != nil {
-			return "", fmt.Errorf("resolve assistant fly runtime organization: %w", err)
+			return "", false, fmt.Errorf("resolve assistant fly runtime organization: %w", err)
 		}
 		_, err = f.client.CreateApp(ctx, fly.CreateAppInput{
 			OrganizationID:  org.ID,
@@ -316,14 +325,14 @@ func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (stri
 			PreferredRegion: new(f.config.DefaultFlyRegion),
 		})
 		if err != nil && !isFlyAppNameTaken(err) {
-			return "", fmt.Errorf("create assistant fly runtime app: %w", err)
+			return "", false, fmt.Errorf("create assistant fly runtime app: %w", err)
 		}
 		if _, getErr := f.client.GetApp(ctx, appName); getErr != nil {
-			return "", fmt.Errorf("verify assistant fly runtime app: %w", getErr)
+			return "", false, fmt.Errorf("verify assistant fly runtime app: %w", getErr)
 		}
 		ip, err := f.client.AllocateSharedIPAddress(ctx, appName)
 		if err != nil && !isFlyIPAlreadyAssigned(err) {
-			return "", fmt.Errorf("allocate assistant fly runtime shared ip: %w", err)
+			return "", false, fmt.Errorf("allocate assistant fly runtime shared ip: %w", err)
 		}
 		ipStr := ""
 		if ip != nil {
@@ -334,7 +343,7 @@ func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (stri
 		// propagate, blowing past waitForRuntimeHealth's budget. Allocating
 		// a v6 forces an immediate DNS publish for both records.
 		if _, err := f.client.AllocateIPAddress(ctx, appName, "v6", "", org.ID, ""); err != nil && !isFlyIPAlreadyAssigned(err) {
-			return "", fmt.Errorf("allocate assistant fly runtime v6 ip: %w", err)
+			return "", false, fmt.Errorf("allocate assistant fly runtime v6 ip: %w", err)
 		}
 		if ipStr == "" {
 			// IP was already allocated previously (isFlyIPAlreadyAssigned path
@@ -343,9 +352,9 @@ func (f *FlyRuntimeBackend) ensureApp(ctx context.Context, appName string) (stri
 				ipStr = refreshed.SharedIPAddress
 			}
 		}
-		return ipStr, nil
+		return ipStr, true, nil
 	default:
-		return "", fmt.Errorf("load assistant fly runtime app: %w", err)
+		return "", false, fmt.Errorf("load assistant fly runtime app: %w", err)
 	}
 }
 

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -50,6 +50,7 @@ func TestFlyRuntimeBackendEnsureColdCreate(t *testing.T) {
 	require.Equal(t, "machine-1", metadata.MachineID)
 	require.Equal(t, "ord", metadata.Region)
 	require.NotEmpty(t, metadata.AppName)
+	require.NotEmpty(t, metadata.AppID)
 	require.Equal(t, "boot-1", metadata.LastBootID)
 }
 
@@ -60,7 +61,7 @@ func TestFlyRuntimeBackendEnsureWarmReuse(t *testing.T) {
 	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
 
 	threadID := uuid.New()
-	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
 	flapsClient.machine = &fly.Machine{
 		ID:         "machine-1",
 		State:      "started",
@@ -73,7 +74,9 @@ func TestFlyRuntimeBackendEnsureWarmReuse(t *testing.T) {
 
 	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
 		AppName:    "gram-asst-test",
+		AppID:      "app-1",
 		AppURL:     server.URL,
+		AppIP:      "",
 		MachineID:  "machine-1",
 		Region:     "iad",
 		LastBootID: "boot-1",
@@ -99,7 +102,7 @@ func TestFlyRuntimeBackendEnsureMachineUnconfigured(t *testing.T) {
 	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
 
 	threadID := uuid.New()
-	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
 	flapsClient.machine = &fly.Machine{
 		ID:         "machine-1",
 		State:      "started",
@@ -112,7 +115,9 @@ func TestFlyRuntimeBackendEnsureMachineUnconfigured(t *testing.T) {
 
 	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
 		AppName:    "gram-asst-test",
+		AppID:      "app-1",
 		AppURL:     server.URL,
+		AppIP:      "",
 		MachineID:  "machine-1",
 		Region:     "iad",
 		LastBootID: "boot-1",
@@ -139,13 +144,15 @@ func TestFlyRuntimeBackendEnsureFlapsNotFoundEstablishedTearsDown(t *testing.T) 
 
 	// ensureApp succeeds (GraphQL says app exists) but flaps Get + List both
 	// 404. Established runtime — LastBootID + MachineID set from a prior boot.
-	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
 	flapsClient.getErr = errors.New("not found")
 	flapsClient.listErr = errors.New("app not found")
 
 	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
 		AppName:    "gram-asst-test",
+		AppID:      "app-1",
 		AppURL:     server.URL,
+		AppIP:      "",
 		MachineID:  "machine-1",
 		Region:     "iad",
 		LastBootID: "boot-1",
@@ -172,13 +179,17 @@ func TestFlyRuntimeBackendEnsureFlapsNotFoundFreshAppPropagates(t *testing.T) {
 	// Fresh app — no prior boot recorded. flaps List 404 here is the
 	// propagation case isFlyAppPropagating + launchMachineWithRetry already
 	// cover; corruption detection must NOT trigger and tear the app down.
-	apiClient.app = &fly.App{Name: "gram-asst-test"}
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
 	flapsClient.listErr = errors.New("app not found")
 
 	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
-		AppName: "gram-asst-test",
-		AppURL:  server.URL,
-		Region:  "iad",
+		AppName:    "gram-asst-test",
+		AppID:      "",
+		AppURL:     server.URL,
+		AppIP:      "",
+		MachineID:  "",
+		Region:     "iad",
+		LastBootID: "",
 	})
 	require.NoError(t, err)
 
@@ -210,7 +221,9 @@ func TestFlyRuntimeBackendEnsureFreshlyRecreatedAppClearsPriorBootMetadata(t *te
 
 	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
 		AppName:    "gram-asst-test",
+		AppID:      "old-app",
 		AppURL:     server.URL,
+		AppIP:      "",
 		MachineID:  "machine-from-old-app",
 		Region:     "iad",
 		LastBootID: "boot-from-old-app",
@@ -229,6 +242,85 @@ func TestFlyRuntimeBackendEnsureFreshlyRecreatedAppClearsPriorBootMetadata(t *te
 	require.Equal(t, 0, apiClient.deleteCalls, "freshly recreated app must not be torn down because of stale prior boot metadata")
 }
 
+func TestFlyRuntimeBackendEnsureExistingAppWithLegacyMetadataDoesNotTreatPropagationAsCorruption(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
+	flapsClient.getErr = errors.New("not found")
+	flapsClient.listErr = errors.New("app not found")
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "",
+		AppURL:     server.URL,
+		AppIP:      "",
+		MachineID:  "machine-from-legacy-metadata",
+		Region:     "iad",
+		LastBootID: "boot-from-legacy-metadata",
+	})
+	require.NoError(t, err)
+
+	_, err = backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errFlyAppCorrupted)
+	require.Equal(t, 0, apiClient.deleteCalls, "legacy metadata without app_id is not proof that the current app had a prior boot")
+}
+
+func TestFlyRuntimeBackendEnsureExistingAppAfterPartialCreateFailureClearsStaleMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	apiClient.getAppErr = errors.New("not found")
+	apiClient.organization = &fly.Organization{ID: "org-123"}
+	apiClient.allocateSharedErr = errors.New("allocate shared ip failed")
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "old-app",
+		AppURL:     server.URL,
+		AppIP:      "",
+		MachineID:  "machine-from-old-app",
+		Region:     "iad",
+		LastBootID: "boot-from-old-app",
+	})
+	require.NoError(t, err)
+
+	_, err = backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.ErrorContains(t, err, "allocate assistant fly runtime shared ip")
+
+	apiClient.getAppErr = nil
+	apiClient.allocateSharedErr = nil
+	flapsClient.listErr = errors.New("app not found")
+
+	_, err = backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errFlyAppCorrupted)
+	require.Equal(t, 0, apiClient.deleteCalls, "partially created current app should not be torn down because metadata came from an older app incarnation")
+}
+
 func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
 	t.Parallel()
 
@@ -236,7 +328,15 @@ func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
 	backend, apiClient, _ := newTestFlyRuntimeBackend(t, server)
 
 	apiClient.deleteErr = errors.New("not found")
-	rawMetadata, err := json.Marshal(flyRuntimeMetadata{AppName: "gram-asst-test"})
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "",
+		AppURL:     "",
+		AppIP:      "",
+		MachineID:  "",
+		Region:     "",
+		LastBootID: "",
+	})
 	require.NoError(t, err)
 
 	err = backend.Stop(context.Background(), assistantRuntimeRecord{
@@ -261,15 +361,19 @@ func TestFlyRuntimeBackendServerURLRejectsLoopback(t *testing.T) {
 }
 
 type testFlyRuntimeAPIClient struct {
-	app          *fly.App
-	getAppErr    error
-	deleteErr    error
-	deleteCalls  int
-	createAppErr error
-	organization *fly.Organization
+	app               *fly.App
+	getAppErr         error
+	deleteErr         error
+	deleteCalls       int
+	createAppErr      error
+	allocateSharedErr error
+	organization      *fly.Organization
 }
 
 func (c *testFlyRuntimeAPIClient) AllocateSharedIPAddress(_ context.Context, _ string) (net.IP, error) {
+	if c.allocateSharedErr != nil {
+		return nil, c.allocateSharedErr
+	}
 	// Returning nil leaves AppIP empty so clientForTarget falls back to the
 	// default httpClient — tests point AppURL at a local httptest server that
 	// isn't reachable by the real shared-IP dialer.
@@ -284,7 +388,7 @@ func (c *testFlyRuntimeAPIClient) CreateApp(_ context.Context, input fly.CreateA
 	if c.createAppErr != nil {
 		return nil, c.createAppErr
 	}
-	c.app = &fly.App{Name: input.Name}
+	c.app = &fly.App{ID: "app-created", Name: input.Name}
 	c.getAppErr = nil
 	return c.app, nil
 }

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -194,6 +194,41 @@ func TestFlyRuntimeBackendEnsureFlapsNotFoundFreshAppPropagates(t *testing.T) {
 	require.Equal(t, 0, apiClient.deleteCalls, "fresh app must not be torn down on a propagation 404")
 }
 
+func TestFlyRuntimeBackendEnsureFreshlyRecreatedAppClearsPriorBootMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	// Metadata can be copied from a failed prior runtime row. If the app was
+	// deleted for confirmed corruption and ensureApp recreates it, those old
+	// machine IDs belong to the previous app incarnation and must not turn
+	// fresh Machines propagation into another corruption teardown.
+	apiClient.getAppErr = errors.New("not found")
+	apiClient.organization = &fly.Organization{ID: "org-123"}
+	flapsClient.listErr = errors.New("app not found")
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppURL:     server.URL,
+		MachineID:  "machine-from-old-app",
+		Region:     "iad",
+		LastBootID: "boot-from-old-app",
+	})
+	require.NoError(t, err)
+
+	_, err = backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   uuid.New(),
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errFlyAppCorrupted)
+	require.Equal(t, 0, apiClient.deleteCalls, "freshly recreated app must not be torn down because of stale prior boot metadata")
+}
+
 func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1108,7 +1108,6 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 		startupConfig, err := s.buildRuntimeStartupConfig(ctx, thread, runtimeRecord, assistant)
 		if err != nil {
 			s.logger.ErrorContext(ctx, "build runtime startup config failed", attr.SlogAssistantThreadID(thread.ID.String()), attr.SlogError(err))
-			_ = s.runtime.Stop(ctx, runtimeRecord)
 			_ = s.stopRuntimeRecord(ctx, thread.ProjectID, thread.ID, runtimeStateFailed)
 			return ProcessThreadEventsResult{
 				AssistantID:       assistant.ID,
@@ -1120,7 +1119,6 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 		}
 		if err := s.runtime.Configure(ctx, runtimeRecord, startupConfig); err != nil {
 			s.logger.ErrorContext(ctx, "configure assistant runtime failed", attr.SlogAssistantThreadID(thread.ID.String()), attr.SlogError(err))
-			_ = s.runtime.Stop(ctx, runtimeRecord)
 			_ = s.stopRuntimeRecord(ctx, thread.ProjectID, thread.ID, runtimeStateFailed)
 			return ProcessThreadEventsResult{
 				AssistantID:       assistant.ID,

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"net/url"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -430,9 +432,85 @@ WHERE assistant_thread_id = $1
 	require.Contains(t, lastError.String, "runtime RunTurn blew up")
 }
 
+func TestServiceCoreProcessThreadEventsDoesNotStopRuntimeOnConfigureFailure(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_config_fail")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	var stopCalls atomic.Int64
+	logger := testenv.NewLogger(t)
+	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
+	backend := testRuntimeBackend{
+		backend: runtimeBackendFlyIO,
+		ensureResult: RuntimeBackendEnsureResult{
+			ColdStart:      true,
+			NeedsConfigure: true,
+			BackendMetadataJSON: []byte(`{
+				"app_name": "gram-asst-test",
+				"app_url": "https://gram-asst-test.fly.dev",
+				"machine_id": "machine-1",
+				"last_boot_id": "boot-1"
+			}`),
+		},
+		configureErr: errors.New("runtime Configure blew up"),
+		stopCalls:    &stopCalls,
+	}
+	core := NewServiceCore(logger, conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger))
+
+	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{threadID}, admitted.ThreadIDs)
+
+	result, err := core.ProcessThreadEvents(t.Context(), projectID, threadID)
+	require.NoError(t, err)
+	require.True(t, result.RetryAdmission)
+	require.False(t, result.RuntimeActive)
+	require.Equal(t, int64(0), stopCalls.Load(), "configure failure should preserve the Fly app for reuse/recovery")
+
+	var state string
+	var deleted bool
+	var metadata []byte
+	err = conn.QueryRow(t.Context(), `
+SELECT state, deleted, backend_metadata_json
+FROM assistant_runtimes
+WHERE assistant_thread_id = $1
+`, threadID).Scan(&state, &deleted, &metadata)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateFailed, state)
+	require.True(t, deleted)
+	require.JSONEq(t, string(backend.ensureResult.BackendMetadataJSON), string(metadata))
+
+	admittedAgain, err := core.AdmitPendingThreads(t.Context(), assistantID)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{threadID}, admittedAgain.ThreadIDs)
+
+	var nextMetadata []byte
+	err = conn.QueryRow(t.Context(), `
+SELECT backend_metadata_json
+FROM assistant_runtimes
+WHERE assistant_thread_id = $1
+  AND deleted IS FALSE
+ORDER BY created_at DESC
+LIMIT 1
+`, threadID).Scan(&nextMetadata)
+	require.NoError(t, err)
+	require.JSONEq(t, string(backend.ensureResult.BackendMetadataJSON), string(nextMetadata))
+}
+
 type testRuntimeBackend struct {
-	backend    string
-	runTurnErr error
+	backend      string
+	ensureResult RuntimeBackendEnsureResult
+	ensureErr    error
+	configureErr error
+	runTurnErr   error
+	stopCalls    *atomic.Int64
 }
 
 func (t testRuntimeBackend) Backend() string {
@@ -444,11 +522,14 @@ func (t testRuntimeBackend) SupportsBackend(backend string) bool {
 }
 
 func (t testRuntimeBackend) Ensure(context.Context, assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
-	return RuntimeBackendEnsureResult{ColdStart: false, NeedsConfigure: false, BackendMetadataJSON: nil}, nil
+	if t.ensureErr != nil {
+		return RuntimeBackendEnsureResult{}, t.ensureErr
+	}
+	return t.ensureResult, nil
 }
 
 func (t testRuntimeBackend) Configure(context.Context, assistantRuntimeRecord, runtimeStartupConfig) error {
-	return nil
+	return t.configureErr
 }
 
 func (t testRuntimeBackend) RunTurn(context.Context, assistantRuntimeRecord, string, string, string) error {
@@ -456,9 +537,23 @@ func (t testRuntimeBackend) RunTurn(context.Context, assistantRuntimeRecord, str
 }
 
 func (t testRuntimeBackend) ServerURL(context.Context, assistantRuntimeRecord, *url.URL) (*url.URL, error) {
-	return nil, nil
+	parsed, err := url.Parse("https://gram.example.com")
+	if err != nil {
+		return nil, fmt.Errorf("parse test server url: %w", err)
+	}
+	return parsed, nil
 }
 
 func (t testRuntimeBackend) Stop(context.Context, assistantRuntimeRecord) error {
+	if t.stopCalls != nil {
+		t.stopCalls.Add(1)
+	}
 	return nil
+}
+
+func mustParseURLForServiceTest(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	return parsed
 }

--- a/server/internal/background/assistants.go
+++ b/server/internal/background/assistants.go
@@ -48,6 +48,12 @@ const assistantThreadMaxIterations = 500
 // re-bootstraps via SignalWithStart.
 const assistantCoordinatorIdleTimeout = 1 * time.Hour
 
+// assistantRetryAdmissionBackoff prevents setup/runtime failures that return
+// RetryAdmission from hot-looping through coordinator admission. The activity
+// returns nil in these cases, so Temporal's activity retry policy is not in
+// play.
+const assistantRetryAdmissionBackoff = 30 * time.Second
+
 func AssistantCoordinatorWorkflow(ctx workflow.Context, input AssistantCoordinatorWorkflowInput) error {
 	var a *Activities
 
@@ -145,6 +151,9 @@ func AssistantThreadWorkflow(ctx workflow.Context, input AssistantThreadWorkflow
 			return nil
 		}
 		if result.RetryAdmission {
+			if err := workflow.NewTimer(ctx, assistantRetryAdmissionBackoff).Get(ctx, nil); err != nil {
+				return err
+			}
 			return workflow.ExecuteActivity(ctx, a.SignalAssistantCoordinator, activities.SignalAssistantCoordinatorInput{
 				AssistantID: result.AssistantID,
 			}).Get(ctx, nil)

--- a/server/internal/background/assistants_workflow_test.go
+++ b/server/internal/background/assistants_workflow_test.go
@@ -1,0 +1,53 @@
+package background
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+)
+
+func TestAssistantThreadWorkflowBacksOffBeforeRetryAdmission(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	start := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(start)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ProcessAssistantThreadInput) (*activities.ProcessAssistantThreadResult, error) {
+			return &activities.ProcessAssistantThreadResult{
+				AssistantID:       "11111111-1111-1111-1111-111111111111",
+				WarmUntil:         "",
+				RuntimeActive:     false,
+				RetryAdmission:    true,
+				ProcessedAnyEvent: false,
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ProcessAssistantThread"},
+	)
+
+	var signalTime time.Time
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.SignalAssistantCoordinatorInput) error {
+			signalTime = env.Now()
+			return nil
+		},
+		activity.RegisterOptions{Name: "SignalAssistantCoordinator"},
+	)
+
+	env.ExecuteWorkflow(AssistantThreadWorkflow, AssistantThreadWorkflowInput{
+		ThreadID:  "22222222-2222-2222-2222-222222222222",
+		ProjectID: "33333333-3333-3333-3333-333333333333",
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.GreaterOrEqual(t, signalTime.Sub(start), assistantRetryAdmissionBackoff)
+}


### PR DESCRIPTION
## Problem

- `ProcessThreadEvents` returns `RetryAdmission: true` after setup failures while also stopping/deleting the runtime app on configure/build failures. The thread workflow then immediately signals the coordinator, which re-admits the same pending event with a fresh `{}` runtime row. A persistent setup failure can loop every few seconds, repeatedly creating/deleting the deterministic Fly app and amplifying the GraphQL/Flaps drift mode. Add admission backoff/attempt caps and avoid destructive teardown for configuration-time failures unless the runtime is known corrupt.
- The Fly corruption path only fires when metadata has `machine_id` or `last_boot_id`, but `ReserveAssistantRuntime` always inserts `backend_metadata_json = '{}'` for the new row after `StopAssistantRuntime` soft-deletes the old one. Once drift happens, retries arrive with empty `metadata`, so `resolveMachine` treats Flaps `404` as fresh propagation forever instead of deleting the corrupted app.

## What changed

- wait 30s before `RetryAdmission`
- config failures no longer `runtime.Stop`
- persist runtime `metadata` across re-creations
- fresh fly apps clear machine/boot IDs