### PR TITLE
chore(server): standardize on testenv helpers in tests

### DIFF
--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -452,6 +452,7 @@ defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 - All test setup which includes spinning up databases, caches and background workers must go in `setup_test.go` files. Look for these across the codebase for inspiration and guidance.
 - NEVER write bare SQL queries in tests to insert test data. Use SQLc queries or service-level helpers instead. If test setup needs a query that does not exist yet, add the SQLc query rather than inlining raw SQL in the test.
 - Use `github.com/stretchr/testify/mock` for mocking third-party libraries in tests instead of ad hoc fakes around vendor types.
+- Use `testenv.NewLogger(t)`, `testenv.NewTracerProvider(t)`, and `testenv.NewMeterProvider(t)` instead of constructing loggers or noop OTel providers inline. `testenv.NewLogger(t)` discards in normal runs and emits pretty logs under `go test -v`, which inline `slog.New(slog.DiscardHandler)` and `slog.New(slog.NewTextHandler(os.Stdout, nil))` do not. Exception: tests that assert on log output should use a capturing handler over a `bytes.Buffer`.
 
 <bad-example>
 

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -108,6 +108,19 @@ linters:
         linters:
           - forbidigo
         text: GG001|GG002
+      # The testenv package is the canonical provider of the helpers that
+      # GG006/GG008/GG009 redirect tests to. It necessarily constructs the
+      # underlying primitives directly.
+      - path: internal/testenv/testing\.go
+        linters:
+          - forbidigo
+        text: GG006|GG008|GG009
+      # Production observability setup falls back to noop providers when
+      # no exporter is configured.
+      - path: internal/o11y/setup\.go
+        linters:
+          - forbidigo
+        text: GG008|GG009
   settings:
     custom:
       glint:
@@ -159,6 +172,18 @@ linters:
         - pattern: ^net\.Lookup(Addr|CNAME|Host|IP|MX|NS|Port|SRV|TXT)$
           pkg: ^net$
           msg: "GG005: Use dns.NewNetResolver() instead of net.Lookup* for testability."
+        - pattern: ^slog\.DiscardHandler$
+          pkg: ^log/slog$
+          msg: "GG006: Use testenv.NewLogger(t) in tests instead of slog.DiscardHandler. testenv.NewLogger discards by default and emits pretty logs under `go test -v`."
+        - pattern: ^slog\.Default$
+          pkg: ^log/slog$
+          msg: "GG007: Pass a logger explicitly. In tests use testenv.NewLogger(t)."
+        - pattern: ^noop\.NewTracerProvider$
+          pkg: ^go\.opentelemetry\.io/otel/trace/noop$
+          msg: "GG008: Use testenv.NewTracerProvider(t) in tests instead of constructing a noop tracer provider inline."
+        - pattern: ^noop\.NewMeterProvider$
+          pkg: ^go\.opentelemetry\.io/otel/metric/noop$
+          msg: "GG009: Use testenv.NewMeterProvider(t) in tests instead of constructing a noop meter provider inline."
     sloglint:
       no-mixed-args: true
       attr-only: true
@@ -254,6 +279,24 @@ linters:
               desc: V3 is not ready yet use github.com/urfave/cli/v2
             - pkg: "github.com/pkg/errors"
               desc: Should be replaced by standard lib errors package
+        # testenv exposes cross-cutting test primitives (loggers, OTel
+        # providers, encryption clients, infra launchers). It must not import
+        # domain packages, otherwise internal tests in those packages can no
+        # longer use testenv. Per-domain test helpers belong in sibling
+        # packages such as `externalmcptest` and `functionstest`.
+        testenv-no-domain-imports:
+          list-mode: lax
+          files:
+            - "**/internal/testenv/*.go"
+          deny:
+            - pkg: "github.com/speakeasy-api/gram/server/internal/externalmcp"
+              desc: Move helpers that need externalmcp to internal/externalmcptest.
+            - pkg: "github.com/speakeasy-api/gram/server/internal/functions"
+              desc: Move helpers that need functions to internal/functionstest.
+            - pkg: "github.com/speakeasy-api/gram/server/internal/assets"
+              desc: Move helpers that need assets to a per-domain test package.
+            - pkg: "github.com/speakeasy-api/gram/server/internal/authz"
+              desc: testenv must not depend on authz; tests in package authz import testenv.
     importas:
       no-unaliased: true
       alias:

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -476,7 +476,7 @@ func newWorkerCommand() *cli.Command {
 				logger,
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
-			chatWriter.AddObserver(risk.NewObserver(logger, db, riskSignaler))
+			chatWriter.AddObserver(risk.NewObserver(logger, tracerProvider, db, riskSignaler))
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,

--- a/server/internal/assistants/impl_test.go
+++ b/server/internal/assistants/impl_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace/noop"
 
 	gen "github.com/speakeasy-api/gram/server/gen/assistants"
 	"github.com/speakeasy-api/gram/server/gen/types"
@@ -139,7 +138,7 @@ VALUES ($1, 'Project', $2, 'org-test')
 	logger := testenv.NewLogger(t)
 	authzEngine := authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 	service := &Service{
-		tracer:   noop.NewTracerProvider().Tracer("test"),
+		tracer:   testenv.NewTracerProvider(t).Tracer("test"),
 		logger:   logger,
 		auth:     nil,
 		authz:    authzEngine,

--- a/server/internal/authz/context_test.go
+++ b/server/internal/authz/context_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/testinfra"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -21,7 +21,7 @@ func TestPrepareContext_loadsUserGrants(t *testing.T) {
 
 	ctx := enterpriseTestCtx(t.Context())
 	conn := newTestDB(t)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -44,7 +44,7 @@ func TestPrepareContext_skipsNonSessionAuth(t *testing.T) {
 
 	ctx := enterpriseTestCtx(t.Context())
 	conn := newTestDB(t)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -64,7 +64,7 @@ func TestPrepareContext_loadsAssistantPrincipalGrants(t *testing.T) {
 
 	ctx := enterpriseTestCtx(t.Context())
 	conn := newTestDB(t)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -92,7 +92,7 @@ func TestShouldEnforce_assistantPrincipalOnEnterpriseOrgEnforces(t *testing.T) {
 
 	ctx := enterpriseTestCtx(t.Context())
 	conn := newTestDB(t)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -115,7 +115,7 @@ func TestShouldEnforce_assistantPrincipalOnNonEnterpriseSkips(t *testing.T) {
 
 	ctx := enterpriseTestCtx(t.Context())
 	conn := newTestDB(t)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -137,7 +137,7 @@ func TestPrepareContext_skipsNonEnterpriseOrgs(t *testing.T) {
 
 	ctx := enterpriseTestCtx(t.Context())
 	conn := newTestDB(t)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	"github.com/speakeasy-api/gram/server/internal/testinfra"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
@@ -33,7 +33,7 @@ func failingRBAC(err error) IsRBACEnabled {
 func TestEngineRequire_requiresAuthContext(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 
 	err := engine.Require(t.Context(), Check{Scope: ScopeProjectRead, ResourceID: "proj_123"})
 	var oopsErr *oops.ShareableError
@@ -44,7 +44,7 @@ func TestEngineRequire_requiresAuthContext(t *testing.T) {
 func TestEngineRequire_skipsWhenRBACFeatureDisabled(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache)
 
 	err := engine.Require(enterpriseSessionCtx(t), Check{Scope: ScopeProjectRead, ResourceID: "proj_123"})
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestEngineRequire_skipsWhenRBACFeatureDisabled(t *testing.T) {
 func TestEngineRequire_mapsDeniedToForbidden(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), nil)
 
 	err := engine.Require(ctx, Check{Scope: ScopeProjectRead, ResourceID: "proj_123"})
@@ -65,7 +65,7 @@ func TestEngineRequire_mapsDeniedToForbidden(t *testing.T) {
 func TestEngineRequire_mapsMissingGrantsToUnexpected(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 
 	err := engine.Require(enterpriseSessionCtx(t), Check{Scope: ScopeProjectRead, ResourceID: "proj_123"})
 	var oopsErr *oops.ShareableError
@@ -77,7 +77,7 @@ func TestEngineRequire_mapsMissingGrantsToUnexpected(t *testing.T) {
 func TestEngineRequire_returnsUnexpectedWhenFeatureCheckFails(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, failingRBAC(errors.New("boom")), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, failingRBAC(errors.New("boom")), workos.NewStubClient(), cache.NoopCache)
 
 	err := engine.Require(enterpriseSessionCtx(t), Check{Scope: ScopeProjectRead, ResourceID: "proj_123"})
 	var oopsErr *oops.ShareableError
@@ -98,7 +98,7 @@ func TestResolveRoleSlug_cachesEmptyMembershipResult(t *testing.T) {
 	seedConnectedUser(t, ctx, conn, authCtx.ActiveOrganizationID, authCtx.UserID, "test@example.com", "Test User", "user_workos_test", "membership_test")
 
 	membership := &countingMembershipFetcher{}
-	engine := NewEngine(testinfra.NewLogger(t), conn, staticRBAC(true), membership, newMapCache())
+	engine := NewEngine(testenv.NewLogger(t), conn, staticRBAC(true), membership, newMapCache())
 
 	roleSlug, err := engine.resolveRoleSlug(ctx, authCtx.UserID, authCtx.ActiveOrganizationID)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestResolveRoleSlug_cachesEmptyMembershipResult(t *testing.T) {
 func TestEngineRequireAny_mapsDeniedToForbidden(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{NewGrant(ScopeMCPConnect, "tool_a")})
 
 	err := engine.RequireAny(ctx,
@@ -128,7 +128,7 @@ func TestEngineRequireAny_mapsDeniedToForbidden(t *testing.T) {
 func TestEngineFilter_returnsAllowedSubset(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{NewGrant(ScopeProjectRead, "proj_123")})
 
 	resourceIDs, err := engine.Filter(ctx, []Check{
@@ -142,7 +142,7 @@ func TestEngineFilter_returnsAllowedSubset(t *testing.T) {
 func TestEngineFilter_withDimensions(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{
 		{Scope: ScopeMCPConnect, Selector: Selector{
 			"resource_kind": "mcp",
@@ -163,7 +163,7 @@ func TestEngineFilter_withDimensions(t *testing.T) {
 func TestEngineFilter_withDisposition(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{
 		{Scope: ScopeMCPConnect, Selector: Selector{
 			"resource_kind": "mcp",
@@ -184,7 +184,7 @@ func TestEngineFilter_withDisposition(t *testing.T) {
 func TestEngineFilter_serverLevelGrantAllowsAllDimensions(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{
 		NewGrant(ScopeMCPConnect, "toolsetA"),
 	})
@@ -201,7 +201,7 @@ func TestEngineFilter_serverLevelGrantAllowsAllDimensions(t *testing.T) {
 func TestEngineRequire_rejectsInvalidCheck(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{NewGrant(ScopeProjectRead, WildcardResource)})
 
 	err := engine.Require(ctx, Check{Scope: ScopeProjectRead, ResourceID: ""})
@@ -214,7 +214,7 @@ func TestEngineRequire_rejectsInvalidCheck(t *testing.T) {
 func TestEngineRequire_requiresChecks(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{NewGrant(ScopeProjectRead, WildcardResource)})
 
 	err := engine.Require(ctx)
@@ -227,7 +227,7 @@ func TestEngineRequire_requiresChecks(t *testing.T) {
 func TestEngineRequire_skipsForAPIKeyAuth(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	sessionID := "session_123"
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID:  "org_123",
@@ -252,7 +252,7 @@ func TestEngineRequire_skipsForAPIKeyAuth(t *testing.T) {
 func TestEngineFilter_skipsForNonEnterpriseAccount(t *testing.T) {
 	t.Parallel()
 
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(true), workos.NewStubClient(), cache.NoopCache)
 	sessionID := "session_123"
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID:  "org_123",
@@ -386,7 +386,7 @@ func scopeOverrideCtx(t *testing.T, isAdmin bool, accountType string) context.Co
 
 func TestCanUseOverride_devPlusAdmin(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache, EngineOpts{DevMode: true})
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache, EngineOpts{DevMode: true})
 	ctx := scopeOverrideCtx(t, true, "pro")
 
 	enforce, err := engine.ShouldEnforce(ctx)
@@ -396,7 +396,7 @@ func TestCanUseOverride_devPlusAdmin(t *testing.T) {
 
 func TestCanUseOverride_devPlusNonAdmin(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache, EngineOpts{DevMode: true})
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache, EngineOpts{DevMode: true})
 	ctx := scopeOverrideCtx(t, false, "pro")
 
 	enforce, err := engine.ShouldEnforce(ctx)
@@ -406,7 +406,7 @@ func TestCanUseOverride_devPlusNonAdmin(t *testing.T) {
 
 func TestCanUseOverride_prodPlusAdmin(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache)
 	ctx := scopeOverrideCtx(t, true, "pro")
 
 	enforce, err := engine.ShouldEnforce(ctx)
@@ -416,7 +416,7 @@ func TestCanUseOverride_prodPlusAdmin(t *testing.T) {
 
 func TestCanUseOverride_prodPlusNonAdmin(t *testing.T) {
 	t.Parallel()
-	engine := NewEngine(testinfra.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), nil, staticRBAC(false), workos.NewStubClient(), cache.NoopCache)
 	ctx := scopeOverrideCtx(t, false, "pro")
 
 	enforce, err := engine.ShouldEnforce(ctx)

--- a/server/internal/authz/integration_test.go
+++ b/server/internal/authz/integration_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/oops"
-	"github.com/speakeasy-api/gram/server/internal/testinfra"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -29,7 +29,7 @@ func TestRequire_withLoadedGrantsFromContext(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx = GrantsToContext(ctx, grants)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	err = engine.Require(ctx,
 		Check{Scope: ScopeProjectRead, ResourceID: "proj:123"},
@@ -61,7 +61,7 @@ func TestFilter_withLoadedGrantsFromContext(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx = GrantsToContext(ctx, grants)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	projectIDs, err := engine.Filter(ctx, []Check{
 		{Scope: ScopeProjectRead, ResourceID: "proj:123"},
@@ -98,7 +98,7 @@ func TestFilter_withDimensions(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx = GrantsToContext(ctx, grants)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	results, err := engine.Filter(ctx, []Check{
 		MCPToolCallCheck("toolsetX", MCPToolCallDimensions{Tool: "allowed_tool", Disposition: ""}),

--- a/server/internal/authz/load_test.go
+++ b/server/internal/authz/load_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/testinfra"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -28,7 +28,7 @@ func TestLoadGrants_loadsUserAndRoleGrants(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx = GrantsToContext(ctx, grants)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 	require.NoError(t, engine.Require(ctx, Check{Scope: ScopeProjectRead, ResourceID: "proj:123"}))
 	require.NoError(t, engine.Require(ctx, Check{Scope: ScopeMCPConnect, ResourceID: "toolA"}))
 }
@@ -89,7 +89,7 @@ func TestLoadGrants_returnsEmptyGrantSetWhenNoRowsMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx = GrantsToContext(ctx, grants)
-	engine := NewEngine(testinfra.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	engine := NewEngine(testenv.NewLogger(t), conn, rbacAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 	projectIDs, err := engine.Filter(ctx, []Check{
 		{Scope: ScopeProjectRead, ResourceID: "proj:123"},
 	})

--- a/server/internal/background/throttled_signaler_test.go
+++ b/server/internal/background/throttled_signaler_test.go
@@ -2,7 +2,6 @@ package background
 
 import (
 	"context"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 type countingSignaler struct {
@@ -36,7 +37,7 @@ func TestThrottledSignaler_FirstCallFiresImmediately(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -52,7 +53,7 @@ func TestThrottledSignaler_CoalescesDuringCooldown(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -81,7 +82,7 @@ func TestThrottledSignaler_NoPendingNoTrailing(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -102,7 +103,7 @@ func TestThrottledSignaler_IndependentPerPolicy(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
 	policy1 := DrainRiskAnalysisParams{ProjectID: uuid.New(), RiskPolicyID: uuid.New()}
 	policy2 := DrainRiskAnalysisParams{ProjectID: uuid.New(), RiskPolicyID: uuid.New()}
@@ -118,7 +119,7 @@ func TestThrottledSignaler_ZeroCooldownDisablesThrottling(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 0, slog.Default())
+	throttled := NewThrottledSignaler(inner, 0, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -136,7 +137,7 @@ func TestThrottledSignaler_RecoversAfterCooldown(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -159,7 +160,7 @@ func TestThrottledSignaler_ConcurrentCallers(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -187,7 +188,7 @@ func TestThrottledSignaler_MultipleBursts(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 50*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -219,7 +220,7 @@ func TestThrottledSignaler_FirstCallErrorPropagates(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{err: assert.AnError}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -234,7 +235,7 @@ func TestThrottledSignaler_SuppressedCallsReturnNil(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, slog.Default())
+	throttled := NewThrottledSignaler(inner, 100*time.Millisecond, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),
@@ -252,7 +253,7 @@ func TestThrottledSignaler_NegativeCooldownDisablesThrottling(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingSignaler{}
-	throttled := NewThrottledSignaler(inner, -1*time.Second, slog.Default())
+	throttled := NewThrottledSignaler(inner, -1*time.Second, testenv.NewLogger(t))
 
 	params := DrainRiskAnalysisParams{
 		ProjectID:    uuid.New(),

--- a/server/internal/billing/stub.go
+++ b/server/internal/billing/stub.go
@@ -26,10 +26,6 @@ type StubClient struct {
 }
 
 func NewStubClient(logger *slog.Logger, tracerProvider trace.TracerProvider) *StubClient {
-	if logger == nil {
-		logger = slog.Default()
-	}
-
 	return &StubClient{
 		mut:    sync.Mutex{},
 		logger: logger.With(attr.SlogComponent("billing_stub")),

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
+	"github.com/speakeasy-api/gram/server/internal/externalmcptest"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/functionstest"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
@@ -75,8 +77,8 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	require.NoError(t, err)
 
 	enc := testenv.NewEncryptionClient(t)
-	funcs := testenv.NewFunctionsTestOrchestrator(t, assetStorage)
-	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
+	funcs := functionstest.NewOrchestrator(t, assetStorage)
+	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
 
 	f := &feature.InMemory{}
 

--- a/server/internal/externalmcp/registryclient_test.go
+++ b/server/internal/externalmcp/registryclient_test.go
@@ -3,7 +3,6 @@ package externalmcp
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,10 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	tracernoop "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 type PassthroughBackend struct{}
@@ -32,8 +31,8 @@ func (p *PassthroughBackend) Match(req *http.Request) bool {
 func TestListServers_FiltersDeletedServers(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
@@ -104,8 +103,8 @@ func TestListServers_FiltersDeletedServers(t *testing.T) {
 func TestListServers_PreservesRemoteHeadersAndVariables(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
@@ -198,8 +197,8 @@ func TestListServers_PreservesRemoteHeadersAndVariables(t *testing.T) {
 func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
@@ -246,8 +245,8 @@ func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 func TestGetServerDetails_OnlySSE(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
@@ -294,8 +293,8 @@ func TestGetServerDetails_OnlySSE(t *testing.T) {
 func TestGetServerDetails_PrefersStreamableHTTPOverSSE(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
@@ -343,8 +342,8 @@ func TestGetServerDetails_PrefersStreamableHTTPOverSSE(t *testing.T) {
 func TestGetServerDetails_SelectedRemotesFiltersToSSE(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
@@ -394,8 +393,8 @@ func TestGetServerDetails_SelectedRemotesFiltersToSSE(t *testing.T) {
 func TestGetServerDetails_SelectedRemotesStillPrefersStreamableHTTP(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 

--- a/server/internal/externalmcp/setup_test.go
+++ b/server/internal/externalmcp/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	"github.com/speakeasy-api/gram/server/internal/externalmcptest"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
@@ -70,7 +71,7 @@ func newTestExternalMCPService(t *testing.T) (context.Context, *testInstance) {
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
-	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
+	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
 
 	authzEngine := authz.NewEngine(logger, conn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 	svc := externalmcp.NewService(logger, tracerProvider, conn, sessionManager, mcpRegistryClient, authzEngine)

--- a/server/internal/externalmcptest/registryclient.go
+++ b/server/internal/externalmcptest/registryclient.go
@@ -13,7 +13,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 // NewRegistryClient builds an [externalmcp.RegistryClient] wired to a
@@ -29,7 +28,7 @@ func NewRegistryClient(t *testing.T, logger *slog.Logger, tracerProvider trace.T
 	require.NoError(t, err, "expected guardian policy to initialize without error")
 
 	return externalmcp.NewRegistryClient(
-		testenv.NewLogger(t),
+		logger,
 		tracerProvider,
 		guardianPolicy,
 		externalmcp.NewPulseBackend(pulseURL, "test-tenant-id", conv.NewSecret([]byte("test-api-key"))),

--- a/server/internal/externalmcptest/registryclient.go
+++ b/server/internal/externalmcptest/registryclient.go
@@ -1,0 +1,38 @@
+// Package externalmcptest provides helpers for constructing
+// [externalmcp.RegistryClient] instances in tests.
+package externalmcptest
+
+import (
+	"log/slog"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// NewRegistryClient builds an [externalmcp.RegistryClient] wired to a
+// pulsemcp.com URL with placeholder credentials, suitable for tests that
+// don't actually exercise the HTTP layer.
+func NewRegistryClient(t *testing.T, logger *slog.Logger, tracerProvider trace.TracerProvider) *externalmcp.RegistryClient {
+	t.Helper()
+
+	pulseURL, err := url.Parse("https://api.pulsemcp.com")
+	require.NoError(t, err, "expected pulse URL to parse")
+
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err, "expected guardian policy to initialize without error")
+
+	return externalmcp.NewRegistryClient(
+		testenv.NewLogger(t),
+		tracerProvider,
+		guardianPolicy,
+		externalmcp.NewPulseBackend(pulseURL, "test-tenant-id", conv.NewSecret([]byte("test-api-key"))),
+		nil,
+	)
+}

--- a/server/internal/functions/deploy_local_test.go
+++ b/server/internal/functions/deploy_local_test.go
@@ -1,4 +1,4 @@
-package functions
+package functions_test
 
 import (
 	"archive/zip"
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,28 +17,29 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
+	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
-	tracernoop "go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestLocalRunner_ToolCallAndReadResource(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	logger := slog.New(slog.DiscardHandler)
-	tracerProvider := tracernoop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
 
 	root, err := os.OpenRoot(t.TempDir())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, root.Close())
 	})
-	assetStore := assets.NewFSBlobStore(slog.New(slog.DiscardHandler), root)
+	assetStore := assets.NewFSBlobStore(testenv.NewLogger(t), root)
 	serverURL, err := url.Parse("https://localhost:8080")
 	require.NoError(t, err)
 
 	codeRoot := t.TempDir()
-	runner := NewLocalRunner(logger, tracerProvider, codeRoot, serverURL, assetStore)
+	runner := functions.NewLocalRunner(logger, tracerProvider, codeRoot, serverURL, assetStore)
 
 	archive := buildLocalRunnerArchive(t, `
 export async function handleToolCall({ name, input }) {
@@ -75,14 +75,14 @@ export async function handleResources({ uri, input }) {
 	functionID := uuid.New()
 	accessID := uuid.New()
 
-	_, err = runner.Deploy(ctx, RunnerDeployRequest{
+	_, err = runner.Deploy(ctx, functions.RunnerDeployRequest{
 		Version:      "dev",
 		ProjectID:    projectID,
 		DeploymentID: deploymentID,
 		FunctionID:   functionID,
 		AccessID:     accessID,
-		Runtime:      RuntimeNodeJS22,
-		Assets: []RunnerAsset{{
+		Runtime:      functions.RuntimeNodeJS22,
+		Assets: []functions.RunnerAsset{{
 			AssetID:       uuid.New(),
 			AssetURL:      assetURL,
 			GuestPath:     "/data/code.zip",
@@ -96,8 +96,8 @@ export async function handleResources({ uri, input }) {
 	require.NoError(t, err)
 
 	invocationID := uuid.New()
-	toolReq, err := runner.ToolCall(ctx, RunnerToolCallRequest{
-		RunnerBaseRequest: RunnerBaseRequest{
+	toolReq, err := runner.ToolCall(ctx, functions.RunnerToolCallRequest{
+		RunnerBaseRequest: functions.RunnerBaseRequest{
 			InvocationID:      invocationID,
 			OrganizationID:    "org-123",
 			OrganizationSlug:  "organization-123",
@@ -126,8 +126,8 @@ export async function handleResources({ uri, input }) {
 	require.Equal(t, invocationID.String(), toolResp.Header.Get("Gram-Invoke-ID"))
 	require.JSONEq(t, `{"query":"hello","ok":true}`, string(toolBody))
 
-	resourceReq, err := runner.ReadResource(ctx, RunnerResourceReadRequest{
-		RunnerBaseRequest: RunnerBaseRequest{
+	resourceReq, err := runner.ReadResource(ctx, functions.RunnerResourceReadRequest{
+		RunnerBaseRequest: functions.RunnerBaseRequest{
 			InvocationID:      invocationID,
 			OrganizationID:    "org-123",
 			OrganizationSlug:  "organization-123",
@@ -157,7 +157,7 @@ export async function handleResources({ uri, input }) {
 	require.Equal(t, "text/html;profile=mcp-app", resourceResp.Header.Get("Content-Type"))
 	require.Equal(t, invocationID.String(), resourceResp.Header.Get("Gram-Invoke-ID"))
 	require.Equal(t, "<html><body>hello</body></html>", string(resourceBody))
-	require.NotEmpty(t, resourceResp.Trailer.Get(FunctionsExecutionTimeHeader))
+	require.NotEmpty(t, resourceResp.Trailer.Get(functions.FunctionsExecutionTimeHeader))
 }
 
 func buildLocalRunnerArchive(t *testing.T, functionsJS string) []byte {

--- a/server/internal/functions/setup_test.go
+++ b/server/internal/functions/setup_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
+	"github.com/speakeasy-api/gram/server/internal/externalmcptest"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/functionstest"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -85,9 +87,9 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 	f := &feature.InMemory{}
 
 	assetStorage := assetstest.NewTestBlobStore(t)
-	funcs := testenv.NewFunctionsTestOrchestrator(t, assetStorage)
+	funcs := functionstest.NewOrchestrator(t, assetStorage)
 	tigrisStore := assets.NewTigrisStore(assetStorage)
-	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
+	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)
 	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))

--- a/server/internal/functionstest/orchestrator.go
+++ b/server/internal/functionstest/orchestrator.go
@@ -1,0 +1,20 @@
+// Package functionstest provides helpers for constructing
+// [functions.Orchestrator] instances in tests.
+package functionstest
+
+import (
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/assets"
+	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// NewOrchestrator builds a [functions.Orchestrator] backed by the local
+// runner and a temporary code root directory.
+func NewOrchestrator(t *testing.T, assetStore assets.BlobStore) functions.Orchestrator {
+	t.Helper()
+
+	codeRoot := t.TempDir()
+	return functions.NewLocalRunner(testenv.NewLogger(t), testenv.NewTracerProvider(t), codeRoot, testenv.DefaultSiteURL(t), assetStore)
+}

--- a/server/internal/gateway/filtering_test.go
+++ b/server/internal/gateway/filtering_test.go
@@ -4,18 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"log/slog"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestHandleResponseFiltering_NoFilter(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	mockResp := func() *http.Response {
 		return &http.Response{
@@ -50,7 +50,7 @@ func TestHandleResponseFiltering_NoFilter(t *testing.T) {
 func TestHandleResponseFiltering_NoFilterExpression(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -83,7 +83,7 @@ func TestHandleResponseFiltering_NoFilterExpression(t *testing.T) {
 func TestHandleResponseFiltering_ContentTypeMismatch(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -121,7 +121,7 @@ func TestHandleResponseFiltering_ContentTypeMismatch(t *testing.T) {
 func TestHandleResponseFiltering_StatusCodeMismatch(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -159,7 +159,7 @@ func TestHandleResponseFiltering_StatusCodeMismatch(t *testing.T) {
 func TestHandleResponseFiltering_InvalidJQFilter(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -197,7 +197,7 @@ func TestHandleResponseFiltering_InvalidJQFilter(t *testing.T) {
 func TestHandleResponseFiltering_SuccessfulJSONFilter(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -247,7 +247,7 @@ func TestHandleResponseFiltering_SuccessfulJSONFilter(t *testing.T) {
 func TestHandleResponseFiltering_SuccessfulYAMLFilter(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -300,7 +300,7 @@ meta:
 func TestHandleResponseFiltering_ComplexJQFilter(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -371,7 +371,7 @@ func TestHandleResponseFiltering_ComplexJQFilter(t *testing.T) {
 func TestHandleResponseFiltering_FilterError(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,
@@ -421,7 +421,7 @@ func TestHandleResponseFiltering_FilterError(t *testing.T) {
 func TestHandleResponseFiltering_ReadBodyError(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	config := &ResponseFilter{
 		Type:         FilterTypeJQ,

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -58,7 +57,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
-	tracerProvider := noop.NewTracerProvider()
+	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 

--- a/server/internal/mcp/dynamic_tool_calling_test.go
+++ b/server/internal/mcp/dynamic_tool_calling_test.go
@@ -2,17 +2,13 @@ package mcp
 
 import (
 	"encoding/json"
-	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
-
-func testLogger() *slog.Logger {
-	return slog.New(slog.DiscardHandler)
-}
 
 func TestBuildDynamicSearchToolsSchema(t *testing.T) {
 	t.Parallel()
@@ -166,7 +162,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("returns_error_for_empty_tool_names", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		toolset := &types.Toolset{
 			Tools: []*types.Tool{
@@ -185,7 +181,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("returns_error_for_missing_tool_names", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		toolset := &types.Toolset{
 			Tools: []*types.Tool{
@@ -203,7 +199,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("returns_error_for_invalid_json_args", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		toolset := &types.Toolset{}
 		argsRaw := json.RawMessage(`{invalid}`)
@@ -217,7 +213,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("describes_existing_tools", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		toolset := &types.Toolset{
 			Tools: []*types.Tool{
@@ -252,7 +248,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("handles_nonexistent_tool_names_gracefully", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		toolset := &types.Toolset{
 			Tools: []*types.Tool{
@@ -273,7 +269,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("returns_error_for_proxy_tools", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		proxyType := "proxy"
 		toolset := &types.Toolset{
@@ -293,7 +289,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("handles_multiple_tool_names", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		toolset := &types.Toolset{
 			Tools: []*types.Tool{
@@ -316,7 +312,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 	t.Run("trims_whitespace_from_tool_names", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
-		logger := testLogger()
+		logger := testenv.NewLogger(t)
 
 		toolset := &types.Toolset{
 			Tools: []*types.Tool{

--- a/server/internal/mcp/helpers_test.go
+++ b/server/internal/mcp/helpers_test.go
@@ -3,11 +3,12 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestIsMCPPassthrough(t *testing.T) {
@@ -241,7 +242,7 @@ func TestIsBinaryMimeType(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
+	logger := testenv.NewLogger(t)
 
 	t.Run("returns_true_for_image_types", func(t *testing.T) {
 		t.Parallel()

--- a/server/internal/mcp/metrics_test.go
+++ b/server/internal/mcp/metrics_test.go
@@ -2,12 +2,12 @@ package mcp
 
 import (
 	"context"
-	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestNewMetrics(t *testing.T) {
@@ -15,8 +15,8 @@ func TestNewMetrics(t *testing.T) {
 
 	t.Run("creates_metrics_with_valid_meter", func(t *testing.T) {
 		t.Parallel()
-		meter := noop.NewMeterProvider().Meter("test")
-		logger := slog.New(slog.DiscardHandler)
+		meter := testenv.NewMeterProvider(t).Meter("test")
+		logger := testenv.NewLogger(t)
 
 		m := newMetrics(meter, logger)
 		require.NotNil(t, m)
@@ -30,8 +30,8 @@ func TestMetrics_RecordMCPToolCall(t *testing.T) {
 
 	t.Run("records_tool_call_with_valid_counter", func(t *testing.T) {
 		t.Parallel()
-		meter := noop.NewMeterProvider().Meter("test")
-		logger := slog.New(slog.DiscardHandler)
+		meter := testenv.NewMeterProvider(t).Meter("test")
+		logger := testenv.NewLogger(t)
 		m := newMetrics(meter, logger)
 
 		// Should not panic
@@ -54,8 +54,8 @@ func TestMetrics_RecordMCPRequestDuration(t *testing.T) {
 
 	t.Run("records_duration_with_valid_histogram", func(t *testing.T) {
 		t.Parallel()
-		meter := noop.NewMeterProvider().Meter("test")
-		logger := slog.New(slog.DiscardHandler)
+		meter := testenv.NewMeterProvider(t).Meter("test")
+		logger := testenv.NewLogger(t)
 		m := newMetrics(meter, logger)
 
 		// Should not panic

--- a/server/internal/mcp/rpc_prompts_list_test.go
+++ b/server/internal/mcp/rpc_prompts_list_test.go
@@ -2,17 +2,18 @@ package mcp
 
 import (
 	"context"
-	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestParsePromptArgumentsFromJSONSchema(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	logger := slog.New(slog.DiscardHandler)
+	logger := testenv.NewLogger(t)
 
 	t.Run("parses_valid_schema_with_required_properties", func(t *testing.T) {
 		t.Parallel()

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 
 	keys_gen "github.com/speakeasy-api/gram/server/gen/keys"
@@ -84,7 +83,7 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
-	meterProvider := noop.NewMeterProvider()
+	meterProvider := testenv.NewMeterProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 

--- a/server/internal/mcp/wellknown_oauth_test.go
+++ b/server/internal/mcp/wellknown_oauth_test.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,12 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func Test_writeOAuthServerMetadataResponse_Static(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.DiscardHandler)
+	logger := testenv.NewLogger(t)
 	w := httptest.NewRecorder()
 
 	result := &wellknown.OAuthServerMetadataResult{
@@ -47,7 +47,7 @@ func Test_writeOAuthServerMetadataResponse_Static(t *testing.T) {
 func Test_writeOAuthServerMetadataResponse_Raw(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.DiscardHandler)
+	logger := testenv.NewLogger(t)
 	w := httptest.NewRecorder()
 
 	raw := json.RawMessage(`{"issuer":"https://example.test/raw"}`)
@@ -74,7 +74,7 @@ func Test_writeOAuthServerMetadataResponse_Raw(t *testing.T) {
 func Test_writeOAuthServerMetadataResponse_UnknownKind_DoesNotWriteResponse(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.DiscardHandler)
+	logger := testenv.NewLogger(t)
 	w := httptest.NewRecorder()
 
 	result := &wellknown.OAuthServerMetadataResult{
@@ -93,7 +93,7 @@ func Test_writeOAuthServerMetadataResponse_UnknownKind_DoesNotWriteResponse(t *t
 func Test_writeOAuthProtectedResourceMetadataResponse_Success(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.DiscardHandler)
+	logger := testenv.NewLogger(t)
 	w := httptest.NewRecorder()
 
 	metadata := &wellknown.OAuthProtectedResourceMetadata{

--- a/server/internal/oauth/impl_test.go
+++ b/server/internal/oauth/impl_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oauth"
 	"github.com/speakeasy-api/gram/server/internal/oauth/providers"
 	oauth_repo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
@@ -159,7 +160,7 @@ func TestRefreshProxyToken_UpstreamError(t *testing.T) {
 func TestRefreshProxyToken_GramProviderUnsupported(t *testing.T) {
 	t.Parallel()
 
-	provider := providers.NewGramProvider(newLogger(t), nil)
+	provider := providers.NewGramProvider(testenv.NewLogger(t), nil)
 	_, err := provider.RefreshToken(
 		context.Background(),
 		"some-refresh-token",

--- a/server/internal/oauth/providers/custom_test.go
+++ b/server/internal/oauth/providers/custom_test.go
@@ -3,7 +3,6 @@ package providers_test
 import (
 	"encoding/json"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,11 +12,13 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/oauth/providers"
 	oauth_repo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
-func newProvider() *providers.CustomProvider {
-	return providers.NewCustomProvider(slog.Default(), nil)
+func newProvider(t *testing.T) *providers.CustomProvider {
+	t.Helper()
+	return providers.NewCustomProvider(testenv.NewLogger(t), nil)
 }
 
 func baseProvider(tokenEndpoint string) oauth_repo.OauthProxyProvider {
@@ -42,7 +43,7 @@ func TestCustomProvider_RefreshToken_Success(t *testing.T) {
 	defer srv.Close()
 
 	prov := baseProvider(srv.URL + "/token")
-	result, err := newProvider().RefreshToken(t.Context(), "old-refresh", prov, &toolsets_repo.Toolset{})
+	result, err := newProvider(t).RefreshToken(t.Context(), "old-refresh", prov, &toolsets_repo.Toolset{})
 
 	require.NoError(t, err)
 	require.Equal(t, "new-access", result.AccessToken)
@@ -63,7 +64,7 @@ func TestCustomProvider_RefreshToken_NoRotation(t *testing.T) {
 	defer srv.Close()
 
 	prov := baseProvider(srv.URL + "/token")
-	result, err := newProvider().RefreshToken(t.Context(), "old-refresh", prov, &toolsets_repo.Toolset{})
+	result, err := newProvider(t).RefreshToken(t.Context(), "old-refresh", prov, &toolsets_repo.Toolset{})
 
 	require.NoError(t, err)
 	require.Equal(t, "new-access", result.AccessToken)
@@ -92,7 +93,7 @@ func TestCustomProvider_RefreshToken_BasicAuth(t *testing.T) {
 	prov := baseProvider(srv.URL + "/token")
 	prov.TokenEndpointAuthMethodsSupported = []string{"client_secret_basic"}
 
-	_, err := newProvider().RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
+	_, err := newProvider(t).RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
 	require.NoError(t, err)
 
 	require.Contains(t, gotAuth, "Basic ", "should use Basic auth header")
@@ -122,7 +123,7 @@ func TestCustomProvider_RefreshToken_PostAuth(t *testing.T) {
 	prov := baseProvider(srv.URL + "/token")
 	prov.TokenEndpointAuthMethodsSupported = []string{"client_secret_post"}
 
-	_, err := newProvider().RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
+	_, err := newProvider(t).RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
 	require.NoError(t, err)
 
 	require.Empty(t, gotAuth, "should NOT use Basic auth header for post auth")
@@ -140,7 +141,7 @@ func TestCustomProvider_RefreshToken_UpstreamError(t *testing.T) {
 	defer srv.Close()
 
 	prov := baseProvider(srv.URL + "/token")
-	_, err := newProvider().RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
+	_, err := newProvider(t).RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "401")
@@ -161,7 +162,7 @@ func TestCustomProvider_RefreshToken_CamelCaseResponse(t *testing.T) {
 	defer srv.Close()
 
 	prov := baseProvider(srv.URL + "/token")
-	result, err := newProvider().RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
+	result, err := newProvider(t).RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
 
 	require.NoError(t, err)
 	require.Equal(t, "new-camel", result.AccessToken)

--- a/server/internal/oauth/setup_test.go
+++ b/server/internal/oauth/setup_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
@@ -158,7 +157,7 @@ func newOAuthServiceTestEnv(t *testing.T) *oauthServiceTestEnv {
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
-	meterProvider := noop.NewMeterProvider()
+	meterProvider := testenv.NewMeterProvider(t)
 	enc := testenv.NewEncryptionClient(t)
 
 	redisClient, err := infra.NewRedisClient(t, 0)
@@ -190,9 +189,4 @@ func newOAuthServiceTestEnv(t *testing.T) *oauthServiceTestEnv {
 		},
 		service: svc,
 	}
-}
-
-func newLogger(t *testing.T) *slog.Logger {
-	t.Helper()
-	return testenv.NewLogger(t)
 }

--- a/server/internal/oauthtest/tokenissuer.go
+++ b/server/internal/oauthtest/tokenissuer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"log/slog"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/oauth"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 const (
@@ -43,7 +43,7 @@ type TokenIssuer struct {
 // will later validate tokens — otherwise lookups won't find issued tokens.
 func NewTokenIssuer(t *testing.T, cacheAdapter cache.Cache, enc *encryption.Client) *TokenIssuer {
 	t.Helper()
-	logger := slog.New(slog.DiscardHandler)
+	logger := testenv.NewLogger(t)
 	clientReg := oauth.NewClientRegistrationService(cacheAdapter, logger)
 	pkceService := oauth.NewPKCEService(logger)
 	grantMgr := oauth.NewGrantManager(cacheAdapter, clientReg, pkceService, logger, enc)

--- a/server/internal/openapi/responses_test.go
+++ b/server/internal/openapi/responses_test.go
@@ -2,14 +2,15 @@ package openapi
 
 import (
 	"bytes"
-	"log/slog"
 	"os"
 	"strings"
 	"testing"
 
-	"github.com/speakeasy-api/gram/server/internal/tools/repo/models"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/tools/repo/models"
 )
 
 type openapiFixture struct {
@@ -116,7 +117,7 @@ func TestContentTypeSpecificity(t *testing.T) {
 func TestGetResponseFilter_NilFilterType(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	schemaCache := newConcurrentSchemaCache()
 	td := newOpenAPIFixtureFromFile(t, "testdata/speakeasy-bar.yaml")
@@ -131,7 +132,7 @@ func TestGetResponseFilter_NilFilterType(t *testing.T) {
 func TestGetResponseFilter_NonJQFilterType(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	schemaCache := newConcurrentSchemaCache()
 	td := newOpenAPIFixtureFromFile(t, "testdata/speakeasy-bar.yaml")
@@ -147,7 +148,7 @@ func TestGetResponseFilter_NonJQFilterType(t *testing.T) {
 func TestGetResponseFilter_WithJQFilterType(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	// Create an OpenAPI spec with a simple response
 	spec := newOpenAPIFixture(t, `
@@ -197,7 +198,7 @@ paths:
 func TestSelectResponse_NoResponses(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	spec := newOpenAPIFixture(t, `
 openapi: 3.0.0
@@ -228,7 +229,7 @@ paths:
 func TestSelectResponse_WithMultipleStatusCodes(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	// Create an OpenAPI spec with multiple response codes
 	spec := newOpenAPIFixture(t, `
@@ -286,7 +287,7 @@ paths:
 func TestSelectResponse_PreferGenericContentType(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	// Create an OpenAPI spec with multiple content types for same schema
 	spec := newOpenAPIFixture(t, `
@@ -332,7 +333,7 @@ paths:
 func TestSelectResponse_YAMLAndJSON(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	logger := testenv.NewLogger(t)
 
 	// Create an OpenAPI spec with both YAML and JSON content types
 	spec := newOpenAPIFixture(t, `

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -17,7 +17,6 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-	tracenoop "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -31,13 +30,13 @@ const initializeRequest = `{"jsonrpc":"2.0","id":1,"method":"initialize","params
 func newProxyForTest(t *testing.T, upstreamURL string) *proxy.Proxy {
 	t.Helper()
 
-	policy, err := guardian.NewUnsafePolicy(tracenoop.NewTracerProvider(), nil)
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
 	require.NoError(t, err)
 
 	return &proxy.Proxy{
 		GuardianPolicy:       policy,
 		Logger:               testenv.NewLogger(t),
-		Tracer:               tracenoop.NewTracerProvider().Tracer("test"),
+		Tracer:               testenv.NewTracerProvider(t).Tracer("test"),
 		NonStreamingTimeout:  5 * time.Second,
 		StreamingTimeout:     5 * time.Second,
 		MaxBufferedBodyBytes: proxy.DefaultMaxBufferedBodyBytes,

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
-	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
 
@@ -61,9 +60,9 @@ var _ chat.MessageObserver = (*Service)(nil)
 // NewObserver creates a lightweight chat.MessageObserver that signals the risk
 // drain workflow when new messages are stored. Use this in contexts (e.g. the
 // worker process) where the full risk Service is not needed.
-func NewObserver(logger *slog.Logger, db *pgxpool.Pool, signaler RiskAnalysisSignaler) chat.MessageObserver {
+func NewObserver(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, signaler RiskAnalysisSignaler) chat.MessageObserver {
 	return &Service{
-		tracer:           tracenoop.NewTracerProvider().Tracer(""),
+		tracer:           tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
 		logger:           logger.With(attr.SlogComponent("risk")),
 		db:               db,
 		repo:             repo.New(db),

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -13,12 +13,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	tracernoop "go.opentelemetry.io/otel/trace/noop"
 
-	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
-	"github.com/speakeasy-api/gram/server/internal/externalmcp"
-	"github.com/speakeasy-api/gram/server/internal/functions"
-	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
@@ -29,13 +25,6 @@ func DefaultSiteURL(t *testing.T) *url.URL {
 	require.NoError(t, err, "expected default site URL to parse")
 	return parsed
 
-}
-
-func NewFunctionsTestOrchestrator(t *testing.T, assetStore assets.BlobStore) functions.Orchestrator {
-	t.Helper()
-
-	codeRoot := t.TempDir()
-	return functions.NewLocalRunner(NewLogger(t), NewTracerProvider(t), codeRoot, DefaultSiteURL(t), assetStore)
 }
 
 func NewEncryptionClient(t *testing.T) *encryption.Client {
@@ -76,25 +65,4 @@ func NewMeterProvider(t *testing.T) metric.MeterProvider {
 	t.Helper()
 
 	return metricnoop.NewMeterProvider()
-}
-
-func NewMCPRegistryClient(t *testing.T, logger *slog.Logger, tracerProvider trace.TracerProvider) *externalmcp.RegistryClient {
-	t.Helper()
-
-	pulseURL, err := url.Parse("https://api.pulsemcp.com")
-	require.NoError(t, err, "expected pulse URL to parse")
-
-	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
-	require.NoError(t, err, "expected guardian policy to initialize without error")
-
-	client := externalmcp.NewRegistryClient(
-		NewLogger(t),
-		tracerProvider,
-		guardianPolicy,
-		externalmcp.NewPulseBackend(pulseURL, "test-tenant-id", conv.NewSecret([]byte("test-api-key"))),
-		nil,
-	)
-	require.NoError(t, err, "expected mcp registry client to initialize without error")
-
-	return client
 }

--- a/server/internal/testinfra/logging.go
+++ b/server/internal/testinfra/logging.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
-	"testing"
 
 	"github.com/testcontainers/testcontainers-go/log"
 
@@ -28,18 +26,4 @@ func NewTestcontainersLogger(rawLevel string) log.Logger {
 			DataDogAttr: false,
 		})),
 	}
-}
-
-func NewLogger(t *testing.T) *slog.Logger {
-	t.Helper()
-
-	if testing.Verbose() {
-		return slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
-			RawLevel:    os.Getenv("LOG_LEVEL"),
-			Pretty:      true,
-			DataDogAttr: false,
-		}))
-	}
-
-	return slog.New(slog.DiscardHandler)
 }

--- a/server/internal/thirdparty/openrouter/response_captor_test.go
+++ b/server/internal/thirdparty/openrouter/response_captor_test.go
@@ -2,11 +2,12 @@ package openrouter
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestResponseCaptor_LineBuffering(t *testing.T) {
@@ -82,7 +83,7 @@ func TestResponseCaptor_LineBuffering(t *testing.T) {
 
 			reader := &streamingResponseReader{
 				ctx:                  context.Background(),
-				logger:               slog.Default(),
+				logger:               testenv.NewLogger(t),
 				messageContent:       &strings.Builder{},
 				lineBuf:              &strings.Builder{},
 				accumulatedToolCalls: make(map[int]ToolCall),
@@ -112,7 +113,7 @@ func TestResponseCaptor_ToolCallAccumulation(t *testing.T) {
 
 	reader := &streamingResponseReader{
 		ctx:                  context.Background(),
-		logger:               slog.Default(),
+		logger:               testenv.NewLogger(t),
 		lineBuf:              &strings.Builder{},
 		messageContent:       &strings.Builder{},
 		accumulatedToolCalls: make(map[int]ToolCall),
@@ -144,7 +145,7 @@ func TestResponseCaptor_MultipleToolCalls(t *testing.T) {
 
 	reader := &streamingResponseReader{
 		ctx:                  context.Background(),
-		logger:               slog.Default(),
+		logger:               testenv.NewLogger(t),
 		lineBuf:              &strings.Builder{},
 		messageContent:       &strings.Builder{},
 		accumulatedToolCalls: make(map[int]ToolCall),
@@ -180,7 +181,7 @@ func TestResponseCaptor_UsageTracking(t *testing.T) {
 
 	reader := &streamingResponseReader{
 		ctx:                  context.Background(),
-		logger:               slog.Default(),
+		logger:               testenv.NewLogger(t),
 		lineBuf:              &strings.Builder{},
 		messageContent:       &strings.Builder{},
 		accumulatedToolCalls: make(map[int]ToolCall),
@@ -216,7 +217,7 @@ func TestResponseCaptor_MixedContentAndToolCalls(t *testing.T) {
 
 	reader := &streamingResponseReader{
 		ctx:                  context.Background(),
-		logger:               slog.Default(),
+		logger:               testenv.NewLogger(t),
 		lineBuf:              &strings.Builder{},
 		messageContent:       &strings.Builder{},
 		accumulatedToolCalls: make(map[int]ToolCall),
@@ -287,7 +288,7 @@ func TestResponseCaptor_EdgeCases(t *testing.T) {
 
 			reader := &streamingResponseReader{
 				ctx:                  context.Background(),
-				logger:               slog.Default(),
+				logger:               testenv.NewLogger(t),
 				lineBuf:              &strings.Builder{},
 				messageContent:       &strings.Builder{},
 				accumulatedToolCalls: make(map[int]ToolCall),
@@ -317,7 +318,7 @@ func TestResponseCaptor_ToolCallFieldUpdates(t *testing.T) {
 
 	reader := &streamingResponseReader{
 		ctx:                  context.Background(),
-		logger:               slog.Default(),
+		logger:               testenv.NewLogger(t),
 		lineBuf:              &strings.Builder{},
 		messageContent:       &strings.Builder{},
 		accumulatedToolCalls: make(map[int]ToolCall),

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -212,7 +211,7 @@ func TestChatClient_GetCompletion(t *testing.T) {
 
 	// Create client
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
 		captureStrategy,
@@ -336,7 +335,7 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 
 	// Create client
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
 		captureStrategy,
@@ -452,7 +451,7 @@ func TestChatClient_GetCompletion_WithToolCalls(t *testing.T) {
 
 	// Create client
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
 		captureStrategy,
@@ -547,7 +546,7 @@ func TestChatClient_NormalizesMixedAssistantOnlyForOpenRouterRequest(t *testing.
 	require.NoError(t, err)
 
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		captureStrategy,
@@ -628,7 +627,7 @@ func TestChatClient_PassesMixedAssistantThroughWhenNormalizeFlagUnset(t *testing
 	require.NoError(t, err)
 
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		&mockMessageCaptureStrategy{},
@@ -710,7 +709,7 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 
 			// Create client
 			client := NewUnifiedClient(
-				slog.Default(),
+				testenv.NewLogger(t),
 				guardianPolicy,
 				provisioner,
 				captureStrategy,
@@ -782,7 +781,7 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 
 	// Create client
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
 		captureStrategy,
@@ -950,7 +949,7 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 
 	titleGenerator := &trackingTitleGenerator{}
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		&mockMessageCaptureStrategy{},
@@ -997,7 +996,7 @@ func TestChatClient_TitleGeneration_ScheduledPerCompletionWithValidChatID(t *tes
 	titleGenerator := &trackingTitleGenerator{}
 	tracker := newTrackingCaptureStrategy()
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		tracker,
@@ -1063,7 +1062,7 @@ func TestChatClient_ReloadChat_NoDuplicateMessages(t *testing.T) {
 
 	tracker := newTrackingCaptureStrategy()
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		tracker,
@@ -1193,7 +1192,7 @@ func TestChatClient_GetCompletion_WithJSONSchema(t *testing.T) {
 
 	// Create client
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
 		captureStrategy,
@@ -1310,7 +1309,7 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 
 	// Create client
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
 		captureStrategy,
@@ -1419,7 +1418,7 @@ func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
 	require.NoError(t, err)
 
 	client := NewUnifiedClient(
-		slog.Default(),
+		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
 		&mockMessageCaptureStrategy{},

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
+	"github.com/speakeasy-api/gram/server/internal/externalmcptest"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/functionstest"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
@@ -97,8 +99,8 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
 	enc := testenv.NewEncryptionClient(t)
-	funcs := testenv.NewFunctionsTestOrchestrator(t, assetStorage)
-	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
+	funcs := functionstest.NewOrchestrator(t, assetStorage)
+	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
 
 	f := &feature.InMemory{}
 

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
+	"github.com/speakeasy-api/gram/server/internal/externalmcptest"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/functionstest"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	packages "github.com/speakeasy-api/gram/server/internal/packages"
@@ -93,8 +95,8 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	assetStorage := assetstest.NewTestBlobStore(t)
 
 	enc := testenv.NewEncryptionClient(t)
-	funcs := testenv.NewFunctionsTestOrchestrator(t, assetStorage)
-	mcpRegistryClient := testenv.NewMCPRegistryClient(t, logger, tracerProvider)
+	funcs := functionstest.NewOrchestrator(t, assetStorage)
+	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
 
 	f := &feature.InMemory{}
 

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -3,7 +3,6 @@ package usage
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"testing"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace/noop"
 
 	gen "github.com/speakeasy-api/gram/server/gen/usage"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -19,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
@@ -120,8 +119,8 @@ func rbacDisabled(_ context.Context, _ string) (bool, error) { return false, nil
 
 func newTestService(t *testing.T, billingRepo billing.Repository, serverCount int64) *Service {
 	t.Helper()
-	logger := slog.Default()
-	tp := noop.NewTracerProvider()
+	logger := testenv.NewLogger(t)
+	tp := testenv.NewTracerProvider(t)
 	db := &mockDBTX{serverCount: serverCount}
 	authzEngine := authz.NewEngine(logger, db, rbacDisabled, workos.NewStubClient(), cache.NoopCache)
 

--- a/server/internal/xmcp/tool_usage_interceptor_test.go
+++ b/server/internal/xmcp/tool_usage_interceptor_test.go
@@ -3,7 +3,6 @@ package xmcp_test
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"net/http"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/xmcp"
 )
 
@@ -49,7 +49,7 @@ func newToolsCallRequestForInterceptor(t *testing.T, ctx context.Context) *proxy
 func TestToolUsageLimitsInterceptor_Name(t *testing.T) {
 	t.Parallel()
 
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(&fakeBillingRepo{storedUsage: nil, storedErr: nil}, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(&fakeBillingRepo{storedUsage: nil, storedErr: nil}, testenv.NewLogger(t))
 	require.Equal(t, "tool-usage-limits", interceptor.Name())
 }
 
@@ -59,7 +59,7 @@ func TestToolUsageLimitsInterceptor_NoAuthContextPassesThrough(t *testing.T) {
 	// Billing repo deliberately left without behavior: the interceptor must
 	// not reach it when auth context is missing.
 	repo := &fakeBillingRepo{storedUsage: nil, storedErr: errors.New("must not be called")}
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, testenv.NewLogger(t))
 
 	ctx := t.Context()
 	call := newToolsCallRequestForInterceptor(t, ctx)
@@ -71,7 +71,7 @@ func TestToolUsageLimitsInterceptor_NonBaseTierPassesThrough(t *testing.T) {
 	t.Parallel()
 
 	repo := &fakeBillingRepo{storedUsage: nil, storedErr: errors.New("must not be called")}
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, testenv.NewLogger(t))
 
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-pro",
@@ -88,7 +88,7 @@ func TestToolUsageLimitsInterceptor_BillingErrorPassesThrough(t *testing.T) {
 	// Billing cache miss must not take down tool invocation — the interceptor
 	// logs and continues.
 	repo := &fakeBillingRepo{storedUsage: nil, storedErr: errors.New("cache miss")}
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, testenv.NewLogger(t))
 
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-free",
@@ -110,7 +110,7 @@ func TestToolUsageLimitsInterceptor_ActiveSubscriptionPassesThrough(t *testing.T
 		},
 		storedErr: nil,
 	}
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, testenv.NewLogger(t))
 
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-free-with-sub",
@@ -133,7 +133,7 @@ func TestToolUsageLimitsInterceptor_UnderHardLimitPassesThrough(t *testing.T) {
 		},
 		storedErr: nil,
 	}
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, testenv.NewLogger(t))
 
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-free",
@@ -157,7 +157,7 @@ func TestToolUsageLimitsInterceptor_AtOrOverHardLimitRejects(t *testing.T) {
 		},
 		storedErr: nil,
 	}
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, testenv.NewLogger(t))
 
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-free",
@@ -185,7 +185,7 @@ func TestToolUsageLimitsInterceptor_ZeroIncludedUsesDefaultLimit(t *testing.T) {
 		},
 		storedErr: nil,
 	}
-	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, discardLogger(t))
+	interceptor := xmcp.NewToolUsageLimitsInterceptor(repo, testenv.NewLogger(t))
 
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-free",
@@ -198,9 +198,4 @@ func TestToolUsageLimitsInterceptor_ZeroIncludedUsesDefaultLimit(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
-}
-
-func discardLogger(t *testing.T) *slog.Logger {
-	t.Helper()
-	return slog.New(slog.DiscardHandler)
 }

--- a/server/internal/xmcp/tool_usage_tracking_interceptor_test.go
+++ b/server/internal/xmcp/tool_usage_tracking_interceptor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/xmcp"
 )
 
@@ -102,7 +103,7 @@ func newToolsCallResponseForInterceptor(t *testing.T, sessionID string) *proxy.T
 func TestToolUsageTrackingInterceptor_Name(t *testing.T) {
 	t.Parallel()
 
-	interceptor := xmcp.NewToolUsageTrackingInterceptor(newFakeBillingTracker(), discardLogger(t))
+	interceptor := xmcp.NewToolUsageTrackingInterceptor(newFakeBillingTracker(), testenv.NewLogger(t))
 	require.Equal(t, "tool-usage-tracking", interceptor.Name())
 }
 
@@ -110,7 +111,7 @@ func TestToolUsageTrackingInterceptor_NoAuthContextSkips(t *testing.T) {
 	t.Parallel()
 
 	tracker := newFakeBillingTracker()
-	interceptor := xmcp.NewToolUsageTrackingInterceptor(tracker, discardLogger(t))
+	interceptor := xmcp.NewToolUsageTrackingInterceptor(tracker, testenv.NewLogger(t))
 
 	call := newToolsCallResponseForInterceptor(t, "")
 
@@ -125,7 +126,7 @@ func TestToolUsageTrackingInterceptor_EmitsEventForBaseTier(t *testing.T) {
 	t.Parallel()
 
 	tracker := newFakeBillingTracker()
-	interceptor := xmcp.NewToolUsageTrackingInterceptor(tracker, discardLogger(t))
+	interceptor := xmcp.NewToolUsageTrackingInterceptor(tracker, testenv.NewLogger(t))
 
 	projectID := uuid.New()
 	projectSlug := "demo-project"
@@ -164,7 +165,7 @@ func TestToolUsageTrackingInterceptor_EmitsEventForPaidTier(t *testing.T) {
 	// Limits gating is a separate concern handled by the request-side
 	// interceptor.
 	tracker := newFakeBillingTracker()
-	interceptor := xmcp.NewToolUsageTrackingInterceptor(tracker, discardLogger(t))
+	interceptor := xmcp.NewToolUsageTrackingInterceptor(tracker, testenv.NewLogger(t))
 
 	projectID := uuid.New()
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{


### PR DESCRIPTION
Linear: [AGE-2027](https://linear.app/speakeasy/issue/AGE-2027/standardize-on-testenv-helpers-for-logging-tracing-and-metrics-in)

## Summary

Adds forbidigo rules `GG006`-`GG009` blocking inline `slog.DiscardHandler`, `slog.Default()`, and OTel noop tracer/meter providers, then migrates all existing test sites in `server/` to `testenv.NewLogger(t)`, `testenv.NewTracerProvider(t)`, and `testenv.NewMeterProvider(t)`. `testenv.NewLogger(t)` discards by default and emits pretty logs under `go test -v`.

Splits the heavy testenv helpers (`NewMCPRegistryClient`, `NewFunctionsTestOrchestrator`) into new sibling test packages — `internal/externalmcptest` and `internal/functionstest` — following the existing `oauthtest` precedent. This eliminates the testenv → externalmcp / functions import cycle and lets internal tests in those packages use testenv directly. A new `depguard` rule (`testenv-no-domain-imports`) prevents the cycle from reappearing.

`testinfra.NewLogger` (a duplicate of `testenv.NewLogger` introduced when `authz` was first extracted as a barebones package) is removed; the `package authz` internal tests now use `testenv.NewLogger` directly. The depguard rule is extended to deny testenv from importing `authz`.

## Collateral fixes

Two non-test sites flagged by the new rules are also fixed: `billing.NewStubClient` had an unreachable `slog.Default()` fallback for a nil logger that no caller passes; `risk.NewObserver` constructed a noop tracer inline despite the observer's only method not using the tracer field — it now takes a `tracerProvider` parameter consistent with `risk.NewService`.

## Behavior change to call out

Two test files in `gateway` and `openapi` previously used `slog.New(slog.NewTextHandler(os.Stdout, nil))` and printed log output during every test run. They now use `testenv.NewLogger(t)`, which discards by default and emits pretty logs under `go test -v`. Verified via `git blame` that the loggers were plumbing for downstream functions, not asserted on.

## Out of scope

Capturing-handler tests under `middleware`, `conv`, `oops`, and `openapi/extract` already use `slog.NewJSONHandler` over a `bytes.Buffer` and are not affected.

Production exclusions remaining in `.golangci.yaml`: testenv canonical helpers (`testenv/testing.go`) and `o11y/setup.go` noop fallback when no exporter is configured.