### PR TITLE
chore(ci): correct server-internal filter exclusion semantics

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -53,14 +53,6 @@ database-changes:
   - "server/migrations/**"
   - "server/clickhouse/**"
 
-# Excludes SQLc-generated output paths (per `server/database/sqlc.yaml` `out:`
-# directives) since they legitimately change alongside schema.sql edits.
-server-internal:
-  - "server/internal/**"
-  - "!server/internal/database/**"
-  - "!server/internal/**/repo/**"
-  - "!server/internal/testenv/testrepo/**"
-
 plog:
   - "go.mod"
   - "go.sum"

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -53,12 +53,33 @@ jobs:
           filters: .github/filters.yaml
           list-files: json
 
+      # Run a second paths-filter pass with `predicate-quantifier: every` so
+      # the `!` patterns below act as exclusions (every pattern must match,
+      # which inverts negations into proper exclusions). The default `some`
+      # quantifier on the step above would treat each `!` as its own positive
+      # predicate, matching every file outside the negated path.
+      - name: Detect server-internal changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter-internal
+        with:
+          predicate-quantifier: every
+          list-files: json
+          # Excludes SQLc-generated output paths (per `server/database/sqlc.yaml`
+          # `out:` directives) since they legitimately change alongside
+          # schema.sql edits.
+          filters: |
+            server-internal:
+              - "server/internal/**"
+              - "!server/internal/database/**"
+              - "!server/internal/**/repo/**"
+              - "!server/internal/testenv/testrepo/**"
+
       - name: Validate migration PR does not mix server changes
-        if: ${{ github.event_name != 'merge_group' && steps.filter.outputs.database-changes == 'true' && steps.filter.outputs.server-internal == 'true' }}
+        if: ${{ github.event_name != 'merge_group' && steps.filter.outputs.database-changes == 'true' && steps.filter-internal.outputs.server-internal == 'true' }}
         shell: bash
         env:
           DB_FILES: ${{ steps.filter.outputs.database-changes_files }}
-          INTERNAL_FILES: ${{ steps.filter.outputs.server-internal_files }}
+          INTERNAL_FILES: ${{ steps.filter-internal.outputs.server-internal_files }}
         run: |
           set -e
           echo "❌ This PR mixes database migration changes with other server changes."


### PR DESCRIPTION
## Summary

`dorny/paths-filter` combines patterns within a filter using `some` semantics by default, which means `!server/internal/database/**` acts as its own positive predicate and matches every file outside that path — not as an exclusion. [PR #2547](https://github.com/speakeasy-api/gram/pull/2547) (a migration-only PR) hit this and was incorrectly flagged as mixing migrations with server changes.

This moves the `server-internal` filter into a dedicated `paths-filter` step configured with `predicate-quantifier: every`, so the `!` patterns now act as proper exclusions while the other filters keep their default `some` semantics.