### PR TITLE
chore: fix source assets conflicts

### DIFF
--- a/client/dashboard/src/components/sources/RemoveSourceDialogContent.tsx
+++ b/client/dashboard/src/components/sources/RemoveSourceDialogContent.tsx
@@ -32,8 +32,8 @@ export function RemoveSourceDialogContent({
 
   const handleConfirm = async () => {
     setPending(true);
-    // For external MCPs, pass the slug; for others, pass the asset ID
-    const identifier = asset.type === "externalmcp" ? asset.slug : asset.id;
+    const identifier =
+      asset.type === "externalmcp" ? asset.slug : asset.deploymentAssetId;
     try {
       await onConfirmRemoval(identifier, asset.type);
     } finally {

--- a/client/dashboard/src/components/upload-asset/deploy-step.tsx
+++ b/client/dashboard/src/components/upload-asset/deploy-step.tsx
@@ -39,14 +39,17 @@ export default function DeployStep() {
   const toolsetCreationAttempted = React.useRef(false);
 
   const { toolCount, toolUrns } = React.useMemo(() => {
-    const { deployment, uploadResult } = stepper.meta.current;
-    if (!toolsList.data || !deployment || !uploadResult) {
+    const { deployment, uploadResult, assetName } = stepper.meta.current;
+    if (!toolsList.data || !deployment || !uploadResult || !assetName) {
       return { toolCount: 0, toolUrns: [] as string[] };
     }
 
-    const documentId = deployment!.openapiv3Assets.find(
-      (doc) => doc.assetId === uploadResult?.asset.id,
-    )?.id;
+    const sourceSlug = slugify(assetName);
+    const documentId =
+      deployment.openapiv3Assets.find((doc) => doc.slug === sourceSlug)?.id ??
+      deployment.openapiv3Assets.find(
+        (doc) => doc.assetId === uploadResult.asset.id,
+      )?.id;
 
     const matchingTools = toolsList.data.tools.filter(
       (tool) => tool.type === "http" && tool.openapiv3DocumentId === documentId,

--- a/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
+++ b/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
@@ -18,6 +18,7 @@ import UploadAssetStepper from "@/components/upload-asset/stepper";
 import { useStepper } from "@/components/upload-asset/stepper/use-stepper";
 import UploadFileStep from "@/components/upload-asset/upload-file-step";
 import { useListTools } from "@/hooks/toolTypes";
+import { slugify } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { useRoutes } from "@/routes";
 import { Deployment } from "@gram/client/models/components";
@@ -160,15 +161,17 @@ function FooterActions() {
 
 const useAssetNumtools = (
   assetId: string | undefined,
+  sourceName: string | undefined,
   deployment: Deployment | undefined,
 ) => {
   const { data: tools } = useListTools({
     deploymentId: deployment?.id,
   });
 
-  const documentId = deployment?.openapiv3Assets.find(
-    (doc) => doc.assetId === assetId,
-  )?.id;
+  const sourceSlug = sourceName ? slugify(sourceName) : undefined;
+  const documentId =
+    deployment?.openapiv3Assets.find((doc) => doc.slug === sourceSlug)?.id ??
+    deployment?.openapiv3Assets.find((doc) => doc.assetId === assetId)?.id;
 
   return documentId
     ? tools?.tools.filter(
@@ -203,7 +206,11 @@ export function UploadOpenAPIContent({
   } = useUploadOpenAPISteps();
   const routes = useRoutes();
 
-  const numtools = useAssetNumtools(asset?.asset.id, createdDeployment);
+  const numtools = useAssetNumtools(
+    asset?.asset.id,
+    apiName,
+    createdDeployment,
+  );
 
   const steps: StepProps[] = [
     {

--- a/server/internal/deployments/evolve_test.go
+++ b/server/internal/deployments/evolve_test.go
@@ -507,6 +507,80 @@ func TestDeploymentsService_Evolve_ExcludeOpenAPIv3(t *testing.T) {
 	require.Equal(t, "doc-2", evolved.Deployment.Openapiv3Assets[0].Name, "wrong asset remained")
 }
 
+func TestDeploymentsService_Evolve_ExcludeSingleOpenAPIv3SourceSharingAsset(t *testing.T) {
+	t.Parallel()
+
+	assetStorage := assetstest.NewTestBlobStore(t)
+	ctx, ti := newTestDeploymentService(t, assetStorage)
+
+	bs := bytes.NewBuffer(testenv.ReadFixture(t, "fixtures/todo-valid.yaml"))
+	ares, err := ti.assets.UploadOpenAPIv3(ctx, &agen.UploadOpenAPIv3Form{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		ContentType:      "application/x-yaml",
+		ContentLength:    int64(bs.Len()),
+	}, io.NopCloser(bs))
+	require.NoError(t, err, "upload openapi v3 asset")
+
+	initial, err := ti.service.CreateDeployment(ctx, &gen.CreateDeploymentPayload{
+		IdempotencyKey: "test-initial-deployment-exclude-shared-openapi-source",
+		Openapiv3Assets: []*gen.AddOpenAPIv3DeploymentAssetForm{
+			{
+				AssetID: ares.Asset.ID,
+				Name:    "doc-1",
+				Slug:    "doc-1",
+			},
+			{
+				AssetID: ares.Asset.ID,
+				Name:    "doc-2",
+				Slug:    "doc-2",
+			},
+		},
+		Functions:        []*gen.AddFunctionsForm{},
+		Packages:         []*gen.AddDeploymentPackageForm{},
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		GithubRepo:       nil,
+		GithubPr:         nil,
+		GithubSha:        nil,
+		ExternalID:       nil,
+		ExternalURL:      nil,
+	})
+	require.NoError(t, err, "create initial deployment")
+	require.Len(t, initial.Deployment.Openapiv3Assets, 2, "expected 2 sources in initial deployment")
+
+	var excludeSourceID string
+	for _, source := range initial.Deployment.Openapiv3Assets {
+		require.Equal(t, ares.Asset.ID, source.AssetID, "expected sources to share the same underlying asset")
+		if source.Name == "doc-1" {
+			excludeSourceID = source.ID
+		}
+	}
+	require.NotEmpty(t, excludeSourceID, "could not find source ID to exclude")
+
+	evolved, err := ti.service.Evolve(ctx, &gen.EvolvePayload{
+		ApikeyToken:            nil,
+		SessionToken:           nil,
+		ProjectSlugInput:       nil,
+		DeploymentID:           nil,
+		UpsertOpenapiv3Assets:  []*gen.AddOpenAPIv3DeploymentAssetForm{},
+		UpsertFunctions:        []*gen.AddFunctionsForm{},
+		UpsertPackages:         []*gen.AddPackageForm{},
+		ExcludeOpenapiv3Assets: []string{excludeSourceID},
+		ExcludeFunctions:       []string{},
+		ExcludePackages:        []string{},
+	})
+	require.NoError(t, err, "evolve deployment")
+
+	require.NotEqual(t, initial.Deployment.ID, evolved.Deployment.ID, "evolved deployment should have different ID")
+	require.Equal(t, "completed", evolved.Deployment.Status, "deployment status is not completed")
+	require.Len(t, evolved.Deployment.Openapiv3Assets, 1, "expected only the selected source to be excluded")
+	require.Equal(t, "doc-2", evolved.Deployment.Openapiv3Assets[0].Name, "wrong source remained")
+	require.Equal(t, ares.Asset.ID, evolved.Deployment.Openapiv3Assets[0].AssetID, "remaining source should keep the shared asset")
+}
+
 func TestDeploymentsService_Evolve_ExcludeAllOpenAPIv3(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/deployments/queries.sql
+++ b/server/internal/deployments/queries.sql
@@ -306,6 +306,7 @@ SELECT
 FROM deployments_openapiv3_assets as current
 WHERE current.deployment_id = @original_deployment_id
   AND current.asset_id <> ALL (@excluded_ids::uuid[])
+  AND current.id <> ALL (@excluded_ids::uuid[])
 RETURNING id;
 
 -- name: CloneDeploymentFunctionsAssets :many
@@ -329,6 +330,7 @@ SELECT
 FROM deployments_functions as current
 WHERE current.deployment_id = @original_deployment_id
   AND current.asset_id <> ALL (@excluded_ids::uuid[])
+  AND current.id <> ALL (@excluded_ids::uuid[])
 RETURNING id;
 
 -- name: CloneDeploymentToolFunctions :many

--- a/server/internal/deployments/repo/queries.sql.go
+++ b/server/internal/deployments/repo/queries.sql.go
@@ -150,6 +150,7 @@ SELECT
 FROM deployments_functions as current
 WHERE current.deployment_id = $4
   AND current.asset_id <> ALL ($5::uuid[])
+  AND current.id <> ALL ($5::uuid[])
 RETURNING id
 `
 
@@ -202,6 +203,7 @@ SELECT
 FROM deployments_openapiv3_assets as current
 WHERE current.deployment_id = $2
   AND current.asset_id <> ALL ($3::uuid[])
+  AND current.id <> ALL ($3::uuid[])
 RETURNING id
 `
 


### PR DESCRIPTION
This PR fixes two issues that happened when multiple sources pointed at the same underlying OpenAPI asset.

First, newly created MCP/toolsets now associate tools with the specific deployment source that was just added, instead of accidentally picking up tools from another source sharing the same asset. This keeps generated toolsets and MCP configuration tied to the intended source.

Second, deleting a source now removes only that source attachment from the deployment. Previously, deleting one source could remove every source backed by the same asset; the exclusion logic now distinguishes the deployment source ID from the shared asset ID.