### PR TITLE
fix: downsize presidio concurrent interactions to reduce amplification storms

### DIFF
--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -52,14 +52,10 @@ const presidioMaxWorkers = 4
 // /analyze accepts a string or array; array returns ordered nested list. Bounds blast radius on retry-bisect.
 const presidioHTTPBatchSize = 50
 
-// presidioRetryBackoff is the base pause between retry-bisect attempts.
-// Backoff grows exponentially with split depth and is jittered to dampen
-// load amplification on transient 5xx storms.
-const presidioRetryBackoff = 500 * time.Millisecond
+// Keep jitter small: bisection is bounded, but sleeping still counts against the activity timeout.
+const presidioRetryBackoff = 100 * time.Millisecond
 
-// presidioRetryBackoffCap caps the per-attempt backoff so deep splits on a
-// poisoned batch still make progress within the activity timeout.
-const presidioRetryBackoffCap = 8 * time.Second
+const presidioRetryBackoffCap = 1 * time.Second
 
 // PresidioClient calls the Presidio Analyzer HTTP API.
 // Presidio is a trusted cluster-internal service, so the client uses an

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -31,7 +31,7 @@ type PIIScanner interface {
 
 // presidioRequest is the payload sent to POST /analyze.
 type presidioRequest struct {
-	Text     string   `json:"text"`
+	Text     []string `json:"text"`
 	Language string   `json:"language"`
 	ScoreMin float64  `json:"score_threshold"`
 	Entities []string `json:"entities,omitempty"`
@@ -45,10 +45,17 @@ type presidioResult struct {
 	Score      float64 `json:"score"`
 }
 
-// presidioMaxWorkers is the default concurrency limit for Presidio HTTP
-// requests. Presidio scanning is network-bound, not CPU-bound, so we use a
-// higher limit than runtime.NumCPU().
-const presidioMaxWorkers = 100
+// presidioMaxWorkers is the per-activity concurrency limit for Presidio HTTP
+// requests. Keep this deliberately small: background risk analysis already
+// runs under Temporal, and Presidio should be drained with backpressure rather
+// than flooded with one request per message.
+const presidioMaxWorkers = 4
+
+// presidioHTTPBatchSize is how many texts are sent in each Presidio /analyze
+// request. Presidio returns one result list per input text, preserving order.
+// Keep this below the container's BATCH_SIZE so one failed request only drops
+// a bounded number of messages.
+const presidioHTTPBatchSize = 50
 
 // PresidioClient calls the Presidio Analyzer HTTP API.
 // Presidio is a trusted cluster-internal service, so the client uses an
@@ -152,6 +159,7 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 
 	ctx, span := p.tracer.Start(ctx, "presidio.analyzeBatch", trace.WithAttributes(
 		attribute.Int("presidio.batch_size", n),
+		attribute.Int("presidio.http_batch_size", presidioHTTPBatchSize),
 	))
 	defer func() {
 		if err != nil {
@@ -161,35 +169,39 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	}()
 
 	results := make([][]Finding, n)
-	workers := min(p.maxWorkers, n)
+	batches := chunkTextIndexes(n, presidioHTTPBatchSize)
+	workers := min(p.maxWorkers, len(batches))
 
-	// Pre-fill a buffered channel with indices so workers can pull the next
-	// item without coordination. Closing it causes workers to exit when the
+	// Pre-fill a buffered channel with batches so workers can pull the next
+	// request without coordination. Closing it causes workers to exit when the
 	// channel drains.
-	ch := make(chan int, n)
-	for i := range n {
-		ch <- i
+	ch := make(chan indexRange, len(batches))
+	for _, batch := range batches {
+		ch <- batch
 	}
 	close(ch)
 
 	var wg sync.WaitGroup
 
 	// Fan out workers that each drain items from ch until it's empty.
-	// Individual failures are logged and skipped; results[idx] stays nil
-	// for that text, which the caller treats as "no findings".
+	// Individual request failures are logged and skipped; results[idx] stays
+	// nil for texts in the failed request, which the caller treats as "no
+	// findings".
 	for range workers {
 		wg.Go(func() {
-			for idx := range ch {
-				findings, err := p.analyze(ctx, texts[idx], entities)
+			for batch := range ch {
+				findings, err := p.analyze(ctx, texts[batch.start:batch.end], entities)
 				if err != nil {
-					p.logger.WarnContext(ctx, "presidio analyze failed for text, skipping",
+					p.logger.WarnContext(ctx, "presidio analyze failed for text batch, skipping",
 						attr.SlogError(err),
 					)
 					continue
 				}
-				results[idx] = findings
-				if onProgress != nil {
-					onProgress()
+				for i, f := range findings {
+					results[batch.start+i] = f
+					if onProgress != nil {
+						onProgress()
+					}
 				}
 			}
 		})
@@ -199,7 +211,24 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	return results, nil
 }
 
-func (p *PresidioClient) analyze(ctx context.Context, text string, entities []string) (_ []Finding, err error) {
+type indexRange struct {
+	start int
+	end   int
+}
+
+func chunkTextIndexes(n, size int) []indexRange {
+	if n == 0 {
+		return nil
+	}
+	var batches []indexRange
+	for start := 0; start < n; start += size {
+		end := min(start+size, n)
+		batches = append(batches, indexRange{start: start, end: end})
+	}
+	return batches
+}
+
+func (p *PresidioClient) analyze(ctx context.Context, texts []string, entities []string) (_ [][]Finding, err error) {
 	ctx, span := p.tracer.Start(ctx, "presidio.analyze")
 	start := time.Now()
 	defer func() {
@@ -217,7 +246,7 @@ func (p *PresidioClient) analyze(ctx context.Context, text string, entities []st
 	}()
 
 	body, err := json.Marshal(presidioRequest{
-		Text:     text,
+		Text:     texts,
 		Language: "en",
 		ScoreMin: 0.5,
 		Entities: entities,
@@ -242,11 +271,28 @@ func (p *PresidioClient) analyze(ctx context.Context, text string, entities []st
 		return nil, fmt.Errorf("presidio returned status %d", resp.StatusCode)
 	}
 
-	var results []presidioResult
+	var results [][]presidioResult
 	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
 		return nil, fmt.Errorf("decode presidio response: %w", err)
 	}
+	if len(results) != len(texts) {
+		return nil, fmt.Errorf("presidio returned %d result sets for %d texts", len(results), len(texts))
+	}
 
+	findings := make([][]Finding, len(texts))
+	findingsCount := 0
+	for i, text := range texts {
+		findings[i] = convertPresidioFindings(text, results[i])
+		findingsCount += len(findings[i])
+	}
+	span.SetAttributes(
+		attribute.Int("presidio.http_batch_size", len(texts)),
+		attribute.Int("presidio.findings_count", findingsCount),
+	)
+	return findings, nil
+}
+
+func convertPresidioFindings(text string, results []presidioResult) []Finding {
 	// Presidio returns character (rune) offsets, not byte offsets.
 	// Convert to runes for correct slicing, then map back to byte positions.
 	runes := []rune(text)
@@ -274,8 +320,7 @@ func (p *PresidioClient) analyze(ctx context.Context, text string, entities []st
 			Confidence:  r.Score,
 		})
 	}
-	span.SetAttributes(attribute.Int("presidio.findings_count", len(findings)))
-	return findings, nil
+	return findings
 }
 
 // StubPIIScanner is a no-op implementation for environments without Presidio.

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -45,16 +45,10 @@ type presidioResult struct {
 	Score      float64 `json:"score"`
 }
 
-// presidioMaxWorkers is the per-activity concurrency limit for Presidio HTTP
-// requests. Keep this deliberately small: background risk analysis already
-// runs under Temporal, and Presidio should be drained with backpressure rather
-// than flooded with one request per message.
+// 4 < Presidio capacity (1-2 pods x 2 workers x 4 threads). Was 100, caused 2026-04-30 WORKER TIMEOUT storm.
 const presidioMaxWorkers = 4
 
-// presidioHTTPBatchSize is how many texts are sent in each Presidio /analyze
-// request. Presidio returns one result list per input text, preserving order.
-// Keep this below the container's BATCH_SIZE so one failed request only drops
-// a bounded number of messages.
+// /analyze takes string or array; array returns nested list, ordered (image 2.2.362). 50 = bounded blast on retry, well under gunicorn --timeout=120. Unrelated to container BATCH_SIZE (spaCy nlp only).
 const presidioHTTPBatchSize = 50
 
 // PresidioClient calls the Presidio Analyzer HTTP API.
@@ -170,11 +164,8 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 
 	results := make([][]Finding, n)
 	batches := chunkTextIndexes(n, presidioHTTPBatchSize)
-	workers := min(p.maxWorkers, len(batches))
+	workers := min(max(1, p.maxWorkers), len(batches))
 
-	// Pre-fill a buffered channel with batches so workers can pull the next
-	// request without coordination. Closing it causes workers to exit when the
-	// channel drains.
 	ch := make(chan indexRange, len(batches))
 	for _, batch := range batches {
 		ch <- batch
@@ -182,33 +173,69 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	close(ch)
 
 	var wg sync.WaitGroup
-
-	// Fan out workers that each drain items from ch until it's empty.
-	// Individual request failures are logged and skipped; results[idx] stays
-	// nil for texts in the failed request, which the caller treats as "no
-	// findings".
 	for range workers {
 		wg.Go(func() {
 			for batch := range ch {
-				findings, err := p.analyze(ctx, texts[batch.start:batch.end], entities)
-				if err != nil {
-					p.logger.WarnContext(ctx, "presidio analyze failed for text batch, skipping",
-						attr.SlogError(err),
-					)
-					continue
-				}
-				for i, f := range findings {
-					results[batch.start+i] = f
-					if onProgress != nil {
-						onProgress()
-					}
-				}
+				p.analyzeRange(ctx, texts, entities, batch, results, onProgress)
 			}
 		})
 	}
 
 	wg.Wait()
 	return results, nil
+}
+
+func (p *PresidioClient) analyzeRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func()) {
+	if ok, err := p.tryAnalyzeRange(ctx, texts, entities, batch, results, onProgress); !ok {
+		p.splitFailedRange(ctx, texts, entities, batch, results, onProgress, err)
+	}
+}
+
+func (p *PresidioClient) tryAnalyzeRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func()) (bool, error) {
+	if onProgress != nil {
+		onProgress()
+	}
+
+	findings, err := p.analyze(ctx, texts[batch.start:batch.end], entities)
+	if err != nil {
+		return false, err
+	}
+
+	for i, f := range findings {
+		results[batch.start+i] = f
+		if onProgress != nil {
+			onProgress()
+		}
+	}
+	return true, nil
+}
+
+func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func(), cause error) {
+	if batch.end-batch.start == 1 {
+		p.logger.WarnContext(ctx, "presidio analyze failed for text, skipping",
+			attr.SlogError(cause),
+		)
+		if onProgress != nil {
+			onProgress()
+		}
+		return
+	}
+
+	p.logger.WarnContext(ctx, "presidio analyze failed for text batch, splitting",
+		attr.SlogError(cause),
+	)
+	mid := batch.start + ((batch.end - batch.start) / 2)
+	left := indexRange{start: batch.start, end: mid}
+	right := indexRange{start: mid, end: batch.end}
+
+	leftOK, leftErr := p.tryAnalyzeRange(ctx, texts, entities, left, results, onProgress)
+	rightOK, rightErr := p.tryAnalyzeRange(ctx, texts, entities, right, results, onProgress)
+	if !leftOK {
+		p.splitFailedRange(ctx, texts, entities, left, results, onProgress, leftErr)
+	}
+	if !rightOK {
+		p.splitFailedRange(ctx, texts, entities, right, results, onProgress, rightErr)
+	}
 }
 
 type indexRange struct {
@@ -229,6 +256,11 @@ func chunkTextIndexes(n, size int) []indexRange {
 }
 
 func (p *PresidioClient) analyze(ctx context.Context, texts []string, entities []string) (_ [][]Finding, err error) {
+	// /analyze 500s on empty array ("No text provided"). Short-circuit.
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
 	ctx, span := p.tracer.Start(ctx, "presidio.analyze")
 	start := time.Now()
 	defer func() {
@@ -327,9 +359,5 @@ func convertPresidioFindings(text string, results []presidioResult) []Finding {
 type StubPIIScanner struct{}
 
 func (s *StubPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ func()) ([][]Finding, error) {
-	results := make([][]Finding, len(texts))
-	for i := range texts {
-		results[i] = nil
-	}
-	return results, nil
+	return make([][]Finding, len(texts)), nil
 }

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 	"sync"
@@ -45,11 +46,20 @@ type presidioResult struct {
 	Score      float64 `json:"score"`
 }
 
-// 4 < Presidio capacity (1-2 pods x 2 workers x 4 threads). Was 100, caused 2026-04-30 WORKER TIMEOUT storm.
+// Tuned to Presidio capacity as-of 2026-05-01.
 const presidioMaxWorkers = 4
 
-// /analyze takes string or array; array returns nested list, ordered (image 2.2.362). 50 = bounded blast on retry, well under gunicorn --timeout=120. Unrelated to container BATCH_SIZE (spaCy nlp only).
+// /analyze accepts a string or array; array returns ordered nested list. Bounds blast radius on retry-bisect.
 const presidioHTTPBatchSize = 50
+
+// presidioRetryBackoff is the base pause between retry-bisect attempts.
+// Backoff grows exponentially with split depth and is jittered to dampen
+// load amplification on transient 5xx storms.
+const presidioRetryBackoff = 500 * time.Millisecond
+
+// presidioRetryBackoffCap caps the per-attempt backoff so deep splits on a
+// poisoned batch still make progress within the activity timeout.
+const presidioRetryBackoffCap = 8 * time.Second
 
 // PresidioClient calls the Presidio Analyzer HTTP API.
 // Presidio is a trusted cluster-internal service, so the client uses an
@@ -61,6 +71,7 @@ type PresidioClient struct {
 	tracer          trace.Tracer
 	logger          *slog.Logger
 	maxWorkers      int
+	retryBackoff    time.Duration
 	requestDuration metric.Float64Histogram
 	requestFailures metric.Int64Counter
 }
@@ -92,16 +103,19 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio"),
 		logger:          logger,
 		maxWorkers:      presidioMaxWorkers,
+		retryBackoff:    presidioRetryBackoff,
 		requestDuration: requestDuration,
 		requestFailures: requestFailures,
 	}
 }
 
 // NewPresidioClientWithWorkers is like NewPresidioClient but allows overriding
-// the concurrency limit. Used for benchmarking.
+// the concurrency limit. Used for benchmarking and tests; the retry backoff is
+// disabled so test sweeps don't pay 500ms per bisect step.
 func NewPresidioClientWithWorkers(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, maxWorkers int) *PresidioClient {
 	c := NewPresidioClient(baseURL, tracerProvider, meterProvider, logger)
 	c.maxWorkers = maxWorkers
+	c.retryBackoff = 0
 	return c
 }
 
@@ -187,7 +201,7 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 
 func (p *PresidioClient) analyzeRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func()) {
 	if ok, err := p.tryAnalyzeRange(ctx, texts, entities, batch, results, onProgress); !ok {
-		p.splitFailedRange(ctx, texts, entities, batch, results, onProgress, err)
+		p.splitFailedRange(ctx, texts, entities, batch, results, onProgress, err, 0)
 	}
 }
 
@@ -210,7 +224,10 @@ func (p *PresidioClient) tryAnalyzeRange(ctx context.Context, texts []string, en
 	return true, nil
 }
 
-func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func(), cause error) {
+func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func(), cause error, depth int) {
+	if ctx.Err() != nil {
+		return
+	}
 	if batch.end-batch.start == 1 {
 		p.logger.WarnContext(ctx, "presidio analyze failed for text, skipping",
 			attr.SlogError(cause),
@@ -224,6 +241,11 @@ func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, e
 	p.logger.WarnContext(ctx, "presidio analyze failed for text batch, splitting",
 		attr.SlogError(cause),
 	)
+
+	if !sleepCtx(ctx, computePresidioBackoff(p.retryBackoff, depth)) {
+		return
+	}
+
 	mid := batch.start + ((batch.end - batch.start) / 2)
 	left := indexRange{start: batch.start, end: mid}
 	right := indexRange{start: mid, end: batch.end}
@@ -231,10 +253,44 @@ func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, e
 	leftOK, leftErr := p.tryAnalyzeRange(ctx, texts, entities, left, results, onProgress)
 	rightOK, rightErr := p.tryAnalyzeRange(ctx, texts, entities, right, results, onProgress)
 	if !leftOK {
-		p.splitFailedRange(ctx, texts, entities, left, results, onProgress, leftErr)
+		p.splitFailedRange(ctx, texts, entities, left, results, onProgress, leftErr, depth+1)
 	}
 	if !rightOK {
-		p.splitFailedRange(ctx, texts, entities, right, results, onProgress, rightErr)
+		p.splitFailedRange(ctx, texts, entities, right, results, onProgress, rightErr, depth+1)
+	}
+}
+
+// computePresidioBackoff returns a full-jittered exponential backoff for the
+// given split depth: uniform in [0, min(cap, base*2^depth)). Returns 0 when
+// base is 0 (tests disable backoff that way).
+func computePresidioBackoff(base time.Duration, depth int) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	backoff := base
+	for range depth {
+		backoff *= 2
+		if backoff >= presidioRetryBackoffCap {
+			backoff = presidioRetryBackoffCap
+			break
+		}
+	}
+	return time.Duration(rand.Int64N(int64(backoff))) // #nosec G404 -- jitter, not security-sensitive
+}
+
+// sleepCtx pauses for d, returning false if ctx is cancelled before the
+// timer fires. A non-positive d is treated as no sleep.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -111,7 +111,7 @@ func TestPresidioAnalyzeBatchSplitsPoisonedBatch(t *testing.T) {
 		srv.URL,
 		otel.GetTracerProvider(),
 		otel.GetMeterProvider(),
-		slog.Default(),
+		testLogger(t),
 		1,
 	)
 
@@ -168,7 +168,7 @@ func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
 		srv.URL,
 		otel.GetTracerProvider(),
 		otel.GetMeterProvider(),
-		slog.Default(),
+		testLogger(t),
 		1,
 	)
 
@@ -195,4 +195,9 @@ func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
 		{"three"},
 		{"four"},
 	}, requests)
+}
+
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(t.Output(), nil))
 }

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -1,0 +1,199 @@
+package risk_analysis
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestChunkTextIndexes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		n    int
+		size int
+		want []indexRange
+	}{
+		{name: "empty", n: 0, size: 50, want: nil},
+		{name: "smaller than size", n: 7, size: 50, want: []indexRange{{0, 7}}},
+		{name: "exact multiple", n: 100, size: 50, want: []indexRange{{0, 50}, {50, 100}}},
+		{name: "uneven last batch", n: 125, size: 50, want: []indexRange{{0, 50}, {50, 100}, {100, 125}}},
+		{name: "size one", n: 3, size: 1, want: []indexRange{{0, 1}, {1, 2}, {2, 3}}},
+		{name: "single item", n: 1, size: 50, want: []indexRange{{0, 1}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := chunkTextIndexes(tc.n, tc.size)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestStubPIIScannerReturnsEmptyResults(t *testing.T) {
+	t.Parallel()
+
+	results, err := (&StubPIIScanner{}).AnalyzeBatch(t.Context(), []string{"one", "two"}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	for _, findings := range results {
+		assert.Empty(t, findings)
+	}
+}
+
+func TestPresidioAnalyzeBatchSplitsPoisonedBatch(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests [][]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want %s", r.Method, http.MethodPost)
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/analyze" {
+			t.Errorf("path = %s, want /analyze", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+
+		var req presidioRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		requests = append(requests, slices.Clone(req.Text))
+		mu.Unlock()
+
+		if slices.Contains(req.Text, "poison") {
+			http.Error(w, "poison text", http.StatusInternalServerError)
+			return
+		}
+
+		results := make([][]presidioResult, len(req.Text))
+		for i, text := range req.Text {
+			start := strings.Index(text, "alice@example.com")
+			if start < 0 {
+				continue
+			}
+			results[i] = []presidioResult{{
+				EntityType: "EMAIL_ADDRESS",
+				Start:      start,
+				End:        start + len("alice@example.com"),
+				Score:      1,
+			}}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(results); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewPresidioClientWithWorkers(
+		srv.URL,
+		tracenoop.NewTracerProvider(),
+		metricnoop.NewMeterProvider(),
+		slog.New(slog.DiscardHandler),
+		1,
+	)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"clean",
+		"contact alice@example.com",
+		"poison",
+		"backup alice@example.com",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+
+	assert.Empty(t, results[0])
+	require.Len(t, results[1], 1)
+	assert.Equal(t, "alice@example.com", results[1][0].Match)
+	assert.Empty(t, results[2])
+	require.Len(t, results[3], 1)
+	assert.Equal(t, "alice@example.com", results[3][0].Match)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, [][]string{
+		{"clean", "contact alice@example.com", "poison", "backup alice@example.com"},
+		{"clean", "contact alice@example.com"},
+		{"poison", "backup alice@example.com"},
+		{"poison"},
+		{"backup alice@example.com"},
+	}, requests)
+}
+
+func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests [][]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req presidioRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		requests = append(requests, slices.Clone(req.Text))
+		mu.Unlock()
+
+		http.Error(w, "presidio down", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewPresidioClientWithWorkers(
+		srv.URL,
+		tracenoop.NewTracerProvider(),
+		metricnoop.NewMeterProvider(),
+		slog.New(slog.DiscardHandler),
+		1,
+	)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"one",
+		"two",
+		"three",
+		"four",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+	for _, findings := range results {
+		assert.Empty(t, findings)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, [][]string{
+		{"one", "two", "three", "four"},
+		{"one", "two"},
+		{"three", "four"},
+		{"one"},
+		{"two"},
+		{"three"},
+		{"four"},
+	}, requests)
+}

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -12,8 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metricnoop "go.opentelemetry.io/otel/metric/noop"
-	tracenoop "go.opentelemetry.io/otel/trace/noop"
+	"go.opentelemetry.io/otel"
 )
 
 func TestChunkTextIndexes(t *testing.T) {
@@ -110,9 +109,9 @@ func TestPresidioAnalyzeBatchSplitsPoisonedBatch(t *testing.T) {
 
 	client := NewPresidioClientWithWorkers(
 		srv.URL,
-		tracenoop.NewTracerProvider(),
-		metricnoop.NewMeterProvider(),
-		slog.New(slog.DiscardHandler),
+		otel.GetTracerProvider(),
+		otel.GetMeterProvider(),
+		slog.Default(),
 		1,
 	)
 
@@ -167,9 +166,9 @@ func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
 
 	client := NewPresidioClientWithWorkers(
 		srv.URL,
-		tracenoop.NewTracerProvider(),
-		metricnoop.NewMeterProvider(),
-		slog.New(slog.DiscardHandler),
+		otel.GetTracerProvider(),
+		otel.GetMeterProvider(),
+		slog.Default(),
 		1,
 	)
 

--- a/server/internal/background/activities/risk_analysis/presidio_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_test.go
@@ -51,6 +51,33 @@ func TestPresidio_DetectsEmail(t *testing.T) {
 	}
 }
 
+func TestPresidio_BatchResultsMapBackToInputIndexes(t *testing.T) {
+	t.Parallel()
+	client := infra.NewPresidioClient(t)
+
+	messages := make([]string, 75)
+	emails := make([]string, len(messages))
+	for i := range messages {
+		emails[i] = fmt.Sprintf("remap%03d@example.com", i)
+		messages[i] = fmt.Sprintf("message %03d contact %s end", i, emails[i])
+	}
+
+	results, err := client.AnalyzeBatch(t.Context(), messages, []string{"EMAIL_ADDRESS"}, nil)
+	require.NoError(t, err)
+	require.Len(t, results, len(messages))
+
+	for i, findings := range results {
+		var got string
+		for _, f := range findings {
+			if f.RuleID == "EMAIL_ADDRESS" {
+				got = f.Match
+				break
+			}
+		}
+		assert.Equal(t, emails[i], got, "message %d mapped to wrong finding", i)
+	}
+}
+
 func TestPresidio_DetectsCreditCard(t *testing.T) {
 	t.Parallel()
 	client := infra.NewPresidioClient(t)

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -30,8 +30,9 @@ const (
 	drainBatchSize = 1_000
 
 	// drainMaxConcurrency is the maximum number of AnalyzeBatch activities
-	// running in parallel.
-	drainMaxConcurrency = 20
+	// running in parallel. Keep this low so the workflow drains Presidio at a
+	// controlled rate instead of amplifying small backlogs into request storms.
+	drainMaxConcurrency = 1
 )
 
 // DrainRiskAnalysisParams identifies the policy this workflow drains.

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -29,9 +29,7 @@ const (
 	// drainBatchSize is how many messages each AnalyzeBatch activity processes.
 	drainBatchSize = 1_000
 
-	// drainMaxConcurrency is the maximum number of AnalyzeBatch activities
-	// running in parallel. Keep this low so the workflow drains Presidio at a
-	// controlled rate instead of amplifying small backlogs into request storms.
+	// 1 = sequential. Demand ~0.05 RPS avg / ~0.2 RPS peak (24h 2026-05-01). Parallelism amplifies retry storms — see 2026-04-30 incident (1.6M failed reqs/hr).
 	drainMaxConcurrency = 1
 )
 

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -29,7 +29,7 @@ const (
 	// drainBatchSize is how many messages each AnalyzeBatch activity processes.
 	drainBatchSize = 1_000
 
-	// 1 = sequential. Demand ~0.05 RPS avg / ~0.2 RPS peak (24h 2026-05-01). Parallelism amplifies retry storms — see 2026-04-30 incident (1.6M failed reqs/hr).
+	// Tuned to demand as-of 2026-05-01.
 	drainMaxConcurrency = 1
 )
 


### PR DESCRIPTION
1. Batch Presidio analysis requests across multiple message texts, then map the nested results back to the original message indexes. This reduces per-message network overhead while preserving per-message findings.
2. Reduce Presidio fan-out significantly: the drain workflow now runs one analysis activity at a time, and each activity sends at most 4 concurrent Presidio HTTP batches instead of up to 2,000 concurrent single-message requests. Presidio runs in-cluster, so lower concurrency with larger request batches should be more stable while still handling current production volume.
3. Add jittered backoff on failed Presidio batch retries, plus retry-bisection so one bad text does not force the whole batch to be skipped.

Longer term, this should move toward a more queue-like architecture with explicit backpressure. This change is intended as a smaller production stability fix for the current incident.