### PR TITLE
chore(ci): skip redundant validation jobs on push:main

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -517,7 +517,7 @@ jobs:
   cli-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.cli == 'true'
+    if: needs.changes.outputs.cli == 'true' && github.event_name != 'push'
     env:
       GOMAXPROCS: 4
     services:
@@ -585,7 +585,7 @@ jobs:
   plog-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.plog == 'true'
+    if: needs.changes.outputs.plog == 'true' && github.event_name != 'push'
     env:
       GOMAXPROCS: 4
     steps:
@@ -638,7 +638,7 @@ jobs:
   server-test:
     runs-on: blacksmith-8vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.server == 'true'
+    if: needs.changes.outputs.server == 'true' && github.event_name != 'push'
     env:
       GOMAXPROCS: 8
     steps:
@@ -769,7 +769,8 @@ jobs:
     if: |
       !cancelled() &&
       needs.sdk-gen-check.result != 'failure' &&
-      needs.changes.outputs.client == 'true'
+      needs.changes.outputs.client == 'true' &&
+      github.event_name != 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
@@ -817,7 +818,7 @@ jobs:
     name: Check SDK is up-to-date
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.sdk-gen == 'true'
+    if: needs.changes.outputs.sdk-gen == 'true' && github.event_name != 'push'
     env:
       SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
     steps:
@@ -870,7 +871,8 @@ jobs:
     if: |
       !cancelled() &&
       needs.sdk-gen-check.result != 'failure' &&
-      needs.changes.outputs.sdk == 'true'
+      needs.changes.outputs.sdk == 'true' &&
+      github.event_name != 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
@@ -1156,7 +1158,7 @@ jobs:
   ts-framework-test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes]
-    if: needs.changes.outputs.tsframework == 'true'
+    if: needs.changes.outputs.tsframework == 'true' && github.event_name != 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
@@ -1197,7 +1199,7 @@ jobs:
   elements-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.elements == 'true'
+    if: needs.changes.outputs.elements == 'true' && github.event_name != 'push'
     env:
       GRAM_GIT_SHA: "${{ github.sha }}"
     steps:
@@ -1246,7 +1248,7 @@ jobs:
   elements-test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.elements == 'true'
+    if: needs.changes.outputs.elements == 'true' && github.event_name != 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
@@ -1285,7 +1287,7 @@ jobs:
   elements-examples:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
-    if: needs.changes.outputs.elements == 'true'
+    if: needs.changes.outputs.elements == 'true' && github.event_name != 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -1341,7 +1343,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    if: always()
+    if: always() && github.event_name != 'push'
     needs:
       - changes
       - server-build-lint


### PR DESCRIPTION
## Summary

Skip 11 pure-validation jobs on `push:main` events now that the merge queue is stable. With the merge queue enabled, the `merge_group` event already validates the squashed commit before it lands on `main`, so the follow-up `push:main` run is redundant. Pure-validation jobs are not required status checks (required checks only apply to `pull_request` and `merge_group` events), so a failure on `push:main` is informational, not gating. Artifact-producing, registry-pushing, and release-dispatch jobs are unchanged and continue to run on `push:main`.

Resolves [AGE-2069](https://linear.app/speakeasy/issue/AGE-2069/skip-redundant-validation-jobs-on-pushmain-once-merge-queue-is-stable). Follow-up to [AGE-2009](https://linear.app/speakeasy/issue/AGE-2009/enable-merge-queue-in-speakeasy-apigram).

## Skipped on push:main

- `server-test`
- `client-build-lint`
- `cli-build-lint`
- `plog-build-lint`
- `sdk-gen-check`
- `ts-sdk-build-lint`
- `ts-framework-test`
- `elements-build-lint`
- `elements-test`
- `elements-examples`
- `ci-gate`

## Continues to run on push:main

- `changes` (gates everything)
- `server-build-lint` (produces `server-bin` artifact consumed by `docker-build-server`)
- `docker-build-server`, `docker-build-client` (push images to GCR)
- `atlas-push` (pushes migration tag to Atlas Registry)
- `functions-build-host` (produces packages consumed by `functions-image`)
- `functions-image`, `assistant-runtime-image` (push images to Fly registry)
- `dispatch-release` (triggers `gram-infra` prepare-release)

## Trade-off

Bypass actors on the "Merge to main" ruleset can push directly to `main` without going through the queue. For those pushes, `push:main` validation would have been the only signal — but even today these jobs aren't required status checks, so broken code would still ship. Acceptable since the queue is the canonical path post-AGE-2009.