### PR TITLE
feat(dashboard): redesign plugin MCP server list with toolset metadata

### DIFF
--- a/.changeset/plugin-server-list-redesign.md
+++ b/.changeset/plugin-server-list-redesign.md
@@ -1,0 +1,9 @@
+---
+"dashboard": patch
+---
+
+Redesign the MCP servers list on the plugin detail page. Each entry now
+links to the underlying toolset and surfaces the tool count, MCP
+public/private/off state, policy, and last-updated time alongside icons
+that anchor the row, telegraph navigation, and distinguish the MCP state
+at a glance. Servers whose toolset has been deleted are flagged inline.

--- a/.changeset/plugin-server-list-redesign.md
+++ b/.changeset/plugin-server-list-redesign.md
@@ -2,8 +2,12 @@
 "dashboard": patch
 ---
 
-Redesign the MCP servers list on the plugin detail page. Each entry now
-links to the underlying toolset and surfaces the tool count, MCP
-public/private/off state, policy, and last-updated time alongside icons
-that anchor the row, telegraph navigation, and distinguish the MCP state
-at a glance. Servers whose toolset has been deleted are flagged inline.
+Redesign the MCP servers list on the plugin detail page so each entry
+matches the card pattern from the MCP list page: the Network icon in
+the dot-pattern sidebar, name plus tool-count badge in the header, and
+the Public / Private / Disabled status indicator on the footer left.
+The footer right has a trash icon button that removes the server from
+the plugin, and servers whose toolset has been deleted are flagged
+inline. Also extracts the shared status indicator from MCPCard,
+MCPTableRow, and the new card into a reusable
+`MCPStatusIndicator` component.

--- a/client/dashboard/src/components/mcp/MCPCard.tsx
+++ b/client/dashboard/src/components/mcp/MCPCard.tsx
@@ -3,8 +3,8 @@ import { DotCard } from "@/components/ui/dot-card";
 import { Button } from "@/components/ui/button";
 import { Type } from "@/components/ui/type";
 import { useMcpUrl } from "@/hooks/useToolsetUrl";
-import { cn } from "@/lib/utils";
 import { useRoutes } from "@/routes";
+import { MCPStatusIndicator } from "./MCPStatusIndicator";
 import { ToolsetEntry } from "@gram/client/models/components";
 import { useLatestDeployment } from "@gram/client/react-query";
 import {
@@ -54,50 +54,9 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
     }
   };
 
-  // Pulse indicator for status
-  const getStatusConfig = () => {
-    if (!toolset.mcpEnabled) {
-      return {
-        color: "bg-red-500",
-        pulseColor: "bg-red-400",
-        label: "Disabled",
-      };
-    }
-    return {
-      color: "bg-green-500",
-      pulseColor: "bg-green-400",
-      label: toolset.mcpIsPublic ? "Public" : "Private",
-    };
-  };
-
-  const status = getStatusConfig();
   const installSourceTooltip = toolset.origin?.registrySpecifier
     ? `Installed from ${toolset.origin.registrySpecifier}`
     : undefined;
-
-  const statusIndicator = (
-    <div className="flex items-center gap-2">
-      <div className="relative flex h-2.5 w-2.5">
-        {toolset.mcpEnabled && (
-          <span
-            className={cn(
-              "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
-              status.pulseColor,
-            )}
-          />
-        )}
-        <span
-          className={cn(
-            "relative inline-flex h-2.5 w-2.5 rounded-full",
-            status.color,
-          )}
-        />
-      </div>
-      <Type variant="small" muted>
-        {status.label}
-      </Type>
-    </div>
-  );
 
   return (
     <DotCard
@@ -165,7 +124,10 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
 
       {/* Footer row with status indicator and open link */}
       <div className="mt-auto flex items-center justify-between gap-2 pt-2">
-        {statusIndicator}
+        <MCPStatusIndicator
+          mcpEnabled={toolset.mcpEnabled}
+          mcpIsPublic={toolset.mcpIsPublic}
+        />
         {oauthStatus === "required-unconfigured" ? (
           <div className="text-warning flex items-center gap-1 text-sm">
             <span>Set up</span>

--- a/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
+++ b/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
@@ -1,0 +1,62 @@
+import { Type } from "@/components/ui/type";
+import { cn } from "@/lib/utils";
+
+interface MCPStatusIndicatorProps {
+  mcpEnabled: boolean | undefined;
+  mcpIsPublic: boolean | undefined;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+function getStatusConfig(
+  mcpEnabled: boolean | undefined,
+  mcpIsPublic: boolean | undefined,
+) {
+  if (!mcpEnabled) {
+    return {
+      color: "bg-red-500",
+      pulseColor: "bg-red-400",
+      label: "Disabled",
+    };
+  }
+  return {
+    color: "bg-green-500",
+    pulseColor: "bg-green-400",
+    label: mcpIsPublic ? "Public" : "Private",
+  };
+}
+
+export function MCPStatusIndicator({
+  mcpEnabled,
+  mcpIsPublic,
+  size = "md",
+  className,
+}: MCPStatusIndicatorProps) {
+  const status = getStatusConfig(mcpEnabled, mcpIsPublic);
+  const dotSize = size === "sm" ? "h-2 w-2" : "h-2.5 w-2.5";
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <div className={cn("relative flex", dotSize)}>
+        {mcpEnabled && (
+          <span
+            className={cn(
+              "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
+              status.pulseColor,
+            )}
+          />
+        )}
+        <span
+          className={cn(
+            "relative inline-flex rounded-full",
+            dotSize,
+            status.color,
+          )}
+        />
+      </div>
+      <Type variant="small" muted>
+        {status.label}
+      </Type>
+    </div>
+  );
+}

--- a/client/dashboard/src/components/mcp/MCPTableRow.tsx
+++ b/client/dashboard/src/components/mcp/MCPTableRow.tsx
@@ -3,8 +3,8 @@ import { DotRow } from "@/components/ui/dot-row";
 import { Button } from "@/components/ui/button";
 import { Type } from "@/components/ui/type";
 import { useMcpUrl } from "@/hooks/useToolsetUrl";
-import { cn } from "@/lib/utils";
 import { useRoutes } from "@/routes";
+import { MCPStatusIndicator } from "./MCPStatusIndicator";
 import { ToolsetEntry } from "@gram/client/models/components";
 import { useLatestDeployment } from "@gram/client/react-query";
 import { AlertTriangleIcon, Link2, Network, Package } from "lucide-react";
@@ -49,22 +49,6 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
     return { slug, logoUrl };
   }, [toolset.toolUrns, catalogIconMap, deploymentResult]);
 
-  const getStatusConfig = () => {
-    if (!toolset.mcpEnabled) {
-      return {
-        color: "bg-red-500",
-        pulseColor: "bg-red-400",
-        label: "Disabled",
-      };
-    }
-    return {
-      color: "bg-green-500",
-      pulseColor: "bg-green-400",
-      label: toolset.mcpIsPublic ? "Public" : "Private",
-    };
-  };
-
-  const status = getStatusConfig();
   const installSourceTooltip = toolset.origin?.registrySpecifier
     ? `Installed from ${toolset.origin.registrySpecifier}`
     : undefined;
@@ -109,27 +93,11 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
 
       {/* Status */}
       <td className="px-3 py-3">
-        <div className="flex items-center gap-2">
-          <div className="relative flex h-2 w-2">
-            {toolset.mcpEnabled && (
-              <span
-                className={cn(
-                  "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
-                  status.pulseColor,
-                )}
-              />
-            )}
-            <span
-              className={cn(
-                "relative inline-flex h-2 w-2 rounded-full",
-                status.color,
-              )}
-            />
-          </div>
-          <Type variant="small" muted>
-            {status.label}
-          </Type>
-        </div>
+        <MCPStatusIndicator
+          mcpEnabled={toolset.mcpEnabled}
+          mcpIsPublic={toolset.mcpIsPublic}
+          size="sm"
+        />
       </td>
 
       {/* URL */}

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -223,6 +223,7 @@ export default function PluginDetail() {
                 key={server.id}
                 server={server}
                 toolset={toolsetById.get(server.toolsetId)}
+                isLoadingToolset={isLoadingToolsets}
                 onRemove={() => handleRemoveServer(server)}
               />
             ))}
@@ -367,14 +368,15 @@ export default function PluginDetail() {
 function PluginServerCard({
   server,
   toolset,
+  isLoadingToolset,
   onRemove,
 }: {
   server: PluginServer;
   toolset: ToolsetEntry | undefined;
+  isLoadingToolset: boolean;
   onRemove: () => void;
 }) {
   const routes = useRoutes();
-  const isMissing = !toolset;
 
   const handleClick = () => {
     if (toolset) routes.mcp.details.goTo(toolset.slug);
@@ -396,12 +398,14 @@ function PluginServerCard({
           {server.displayName}
         </Type>
         <div className="flex items-center gap-1">
-          {isMissing ? (
+          {toolset ? (
+            <ToolCollectionBadge toolNames={toolset.tools.map((t) => t.name)} />
+          ) : isLoadingToolset ? (
+            <Skeleton className="h-5 w-16" />
+          ) : (
             <Badge variant="destructive" className="text-xs">
               Toolset missing
             </Badge>
-          ) : (
-            <ToolCollectionBadge toolNames={toolset.tools.map((t) => t.name)} />
           )}
         </div>
       </div>
@@ -412,6 +416,8 @@ function PluginServerCard({
             mcpEnabled={toolset.mcpEnabled}
             mcpIsPublic={toolset.mcpIsPublic}
           />
+        ) : isLoadingToolset ? (
+          <Skeleton className="h-3.5 w-20" />
         ) : (
           <span />
         )}

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -2,6 +2,7 @@ import { InputField } from "@/components/moon/input-field";
 import { Page } from "@/components/page-layout";
 import { ToolCollectionBadge } from "@/components/tool-collection-badge";
 import { Badge } from "@/components/ui/badge";
+import { Button as UiButton } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { DotCard } from "@/components/ui/dot-card";
 import { Heading } from "@/components/ui/heading";
@@ -16,6 +17,7 @@ import {
 import { invalidateAllPlugins } from "@gram/client/react-query/plugins";
 import { useUpdatePluginMutation } from "@gram/client/react-query/updatePlugin";
 import { useAddPluginServerMutation } from "@gram/client/react-query/addPluginServer";
+import { useRemovePluginServerMutation } from "@gram/client/react-query/removePluginServer";
 import { useListToolsets } from "@gram/client/react-query/listToolsets";
 import {
   Button,
@@ -27,7 +29,7 @@ import {
   Stack,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowRight, Network } from "lucide-react";
+import { Network, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 import type {
@@ -72,6 +74,17 @@ export default function PluginDetail() {
       invalidateAll();
     },
   });
+
+  const removeServerMutation = useRemovePluginServerMutation({
+    onSuccess: () => invalidateAll(),
+  });
+
+  const handleRemoveServer = (server: PluginServer) => {
+    removeServerMutation.mutate({
+      security: { sessionHeaderGramSession: "" },
+      request: { id: server.id, pluginId: pluginId! },
+    });
+  };
 
   const handleUpdate: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
@@ -209,6 +222,7 @@ export default function PluginDetail() {
                 key={server.id}
                 server={server}
                 toolset={toolsetById.get(server.toolsetId)}
+                onRemove={() => handleRemoveServer(server)}
               />
             ))}
           </div>
@@ -352,9 +366,11 @@ export default function PluginDetail() {
 function PluginServerCard({
   server,
   toolset,
+  onRemove,
 }: {
   server: PluginServer;
   toolset: ToolsetEntry | undefined;
+  onRemove: () => void;
 }) {
   const routes = useRoutes();
   const isMissing = !toolset;
@@ -430,13 +446,21 @@ function PluginServerCard({
       </div>
 
       <div className="mt-auto flex items-center justify-between gap-2 pt-2">
-        {statusIndicator}
-        {toolset && (
-          <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
-            <span>Open</span>
-            <ArrowRight className="h-3.5 w-3.5" />
-          </div>
-        )}
+        {statusIndicator ?? <span />}
+        <UiButton
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          tooltip="Remove server"
+          aria-label="Remove server"
+          className="hover:text-destructive"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+        >
+          <Trash2 className="h-4 w-4" />
+        </UiButton>
       </div>
     </DotCard>
   );

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -5,10 +5,8 @@ import { Badge } from "@/components/ui/badge";
 import { Dialog } from "@/components/ui/dialog";
 import { DotCard } from "@/components/ui/dot-card";
 import { Heading } from "@/components/ui/heading";
-import { MoreActions } from "@/components/ui/more-actions";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
-import { UpdatedAt } from "@/components/updated-at";
 import { cn } from "@/lib/utils";
 import { useRoutes } from "@/routes";
 import {
@@ -18,7 +16,6 @@ import {
 import { invalidateAllPlugins } from "@gram/client/react-query/plugins";
 import { useUpdatePluginMutation } from "@gram/client/react-query/updatePlugin";
 import { useAddPluginServerMutation } from "@gram/client/react-query/addPluginServer";
-import { useRemovePluginServerMutation } from "@gram/client/react-query/removePluginServer";
 import { useListToolsets } from "@gram/client/react-query/listToolsets";
 import {
   Button,
@@ -30,7 +27,7 @@ import {
   Stack,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { Globe, Lock, Server, Unplug } from "lucide-react";
+import { ArrowRight, Network } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 import type {
@@ -76,10 +73,6 @@ export default function PluginDetail() {
     },
   });
 
-  const removeServerMutation = useRemovePluginServerMutation({
-    onSuccess: () => invalidateAll(),
-  });
-
   const handleUpdate: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     const fd = new FormData(e.currentTarget);
@@ -111,13 +104,6 @@ export default function PluginDetail() {
           policy: "required",
         },
       },
-    });
-  };
-
-  const handleRemoveServer = (server: PluginServer) => {
-    removeServerMutation.mutate({
-      security: { sessionHeaderGramSession: "" },
-      request: { id: server.id, pluginId: pluginId! },
     });
   };
 
@@ -223,7 +209,6 @@ export default function PluginDetail() {
                 key={server.id}
                 server={server}
                 toolset={toolsetById.get(server.toolsetId)}
-                onRemove={() => handleRemoveServer(server)}
               />
             ))}
           </div>
@@ -367,42 +352,52 @@ export default function PluginDetail() {
 function PluginServerCard({
   server,
   toolset,
-  onRemove,
 }: {
   server: PluginServer;
   toolset: ToolsetEntry | undefined;
-  onRemove: () => void;
 }) {
   const routes = useRoutes();
-  const toolNames = toolset?.tools.map((t) => t.name) ?? [];
   const isMissing = !toolset;
-  const isRequired = server.policy === "required";
 
-  const mcpBadge = (() => {
+  const status = (() => {
     if (!toolset) return null;
     if (!toolset.mcpEnabled) {
-      return (
-        <Badge variant="outline" className="text-muted-foreground">
-          <Unplug />
-          MCP off
-        </Badge>
-      );
+      return {
+        color: "bg-red-500",
+        pulseColor: "bg-red-400",
+        label: "Disabled",
+      };
     }
-    if (toolset.mcpIsPublic) {
-      return (
-        <Badge variant="secondary">
-          <Globe />
-          Public MCP
-        </Badge>
-      );
-    }
-    return (
-      <Badge variant="outline">
-        <Lock />
-        Private MCP
-      </Badge>
-    );
+    return {
+      color: "bg-green-500",
+      pulseColor: "bg-green-400",
+      label: toolset.mcpIsPublic ? "Public" : "Private",
+    };
   })();
+
+  const statusIndicator = status && (
+    <div className="flex items-center gap-2">
+      <div className="relative flex h-2.5 w-2.5">
+        {toolset?.mcpEnabled && (
+          <span
+            className={cn(
+              "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
+              status.pulseColor,
+            )}
+          />
+        )}
+        <span
+          className={cn(
+            "relative inline-flex h-2.5 w-2.5 rounded-full",
+            status.color,
+          )}
+        />
+      </div>
+      <Type variant="small" muted>
+        {status.label}
+      </Type>
+    </div>
+  );
 
   const handleClick = () => {
     if (toolset) routes.mcp.details.goTo(toolset.slug);
@@ -410,52 +405,37 @@ function PluginServerCard({
 
   return (
     <DotCard
-      className={cn("min-h-[112px]", toolset && "cursor-pointer")}
+      className={cn(toolset && "cursor-pointer")}
       onClick={toolset ? handleClick : undefined}
-      icon={<Server className="text-muted-foreground h-8 w-8" />}
+      icon={<Network className="text-muted-foreground h-8 w-8" />}
     >
       <div className="mb-2 flex items-start justify-between gap-2">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <Type
-            variant="subheading"
-            as="div"
-            className="text-md group-hover:text-primary truncate transition-colors"
-            title={server.displayName}
-          >
-            {server.displayName}
-          </Type>
-          {isMissing && (
-            <Badge variant="destructive" className="shrink-0 text-xs">
+        <Type
+          variant="subheading"
+          as="div"
+          className="text-md group-hover:text-primary flex-1 truncate transition-colors"
+          title={server.displayName}
+        >
+          {server.displayName}
+        </Type>
+        <div className="flex items-center gap-1">
+          {isMissing ? (
+            <Badge variant="destructive" className="text-xs">
               Toolset missing
             </Badge>
+          ) : (
+            <ToolCollectionBadge toolNames={toolset.tools.map((t) => t.name)} />
           )}
-        </div>
-        <div onClick={(e) => e.stopPropagation()} className="shrink-0">
-          <MoreActions
-            actions={[
-              {
-                label: "Remove",
-                onClick: onRemove,
-                destructive: true,
-                icon: "trash",
-              },
-            ]}
-          />
         </div>
       </div>
 
-      <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
-        {toolset && <ToolCollectionBadge toolNames={toolNames} />}
-        {mcpBadge}
-        <Badge variant={isRequired ? "secondary" : "outline"}>
-          {isRequired ? "Required" : "Optional"}
-        </Badge>
+      <div className="mt-auto flex items-center justify-between gap-2 pt-2">
+        {statusIndicator}
         {toolset && (
-          <UpdatedAt
-            date={new Date(toolset.updatedAt)}
-            italic={false}
-            className="ml-auto"
-          />
+          <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
+            <span>Open</span>
+            <ArrowRight className="h-3.5 w-3.5" />
+          </div>
         )}
       </div>
     </DotCard>

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -1,9 +1,13 @@
 import { InputField } from "@/components/moon/input-field";
 import { Page } from "@/components/page-layout";
+import { ToolCollectionBadge } from "@/components/tool-collection-badge";
+import { Badge } from "@/components/ui/badge";
 import { Dialog } from "@/components/ui/dialog";
 import { Heading } from "@/components/ui/heading";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
+import { UpdatedAt } from "@/components/updated-at";
+import { useRoutes } from "@/routes";
 import {
   invalidateAllPlugin,
   usePluginSuspense,
@@ -15,19 +19,20 @@ import { useRemovePluginServerMutation } from "@gram/client/react-query/removePl
 import { useListToolsets } from "@gram/client/react-query/listToolsets";
 import {
   Button,
-  Column,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   Icon,
   Stack,
-  Table,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams } from "react-router";
-import type { PluginServer } from "@gram/client/models/components";
+import type {
+  PluginServer,
+  ToolsetEntry,
+} from "@gram/client/models/components";
 import { useSdkClient } from "@/contexts/Sdk";
 import { toast } from "sonner";
 
@@ -43,7 +48,10 @@ export default function PluginDetail() {
   const client = useSdkClient();
   const { data: toolsetsData, isLoading: isLoadingToolsets } =
     useListToolsets();
-  const toolsets = toolsetsData?.toolsets ?? [];
+  const toolsets = useMemo(
+    () => toolsetsData?.toolsets ?? [],
+    [toolsetsData?.toolsets],
+  );
 
   const invalidateAll = async () => {
     await invalidateAllPlugin(queryClient);
@@ -130,40 +138,15 @@ export default function PluginDetail() {
     }
   };
 
-  const serverColumns: Column<PluginServer>[] = [
-    {
-      key: "displayName",
-      header: "Name",
-      width: "2fr",
-      render: (s) => <Type variant="body">{s.displayName}</Type>,
-    },
-    {
-      key: "policy",
-      header: "Policy",
-      width: "100px",
-      render: (s) => <Type variant="body">{s.policy}</Type>,
-    },
-    {
-      key: "actions",
-      header: "",
-      width: "80px",
-      render: (s) => (
-        <Button
-          variant="tertiary"
-          size="sm"
-          onClick={() => handleRemoveServer(s)}
-          className="hover:text-destructive"
-        >
-          <Button.LeftIcon>
-            <Icon name="trash-2" className="h-4 w-4" />
-          </Button.LeftIcon>
-          <Button.Text className="sr-only">Remove</Button.Text>
-        </Button>
-      ),
-    },
-  ];
+  const toolsetById = useMemo(() => {
+    const map = new Map<string, ToolsetEntry>();
+    for (const t of toolsets) map.set(t.id, t);
+    return map;
+  }, [toolsets]);
 
   if (!plugin) return null;
+
+  const servers = plugin.servers ?? [];
 
   return (
     <Page>
@@ -210,32 +193,37 @@ export default function PluginDetail() {
             Add Server
           </Button>
         </Stack>
-        <Table
-          columns={serverColumns}
-          data={plugin.servers ?? []}
-          rowKey={(row) => row.id}
-          noResultsMessage={
-            <Stack
-              gap={2}
-              className="bg-background h-full p-4"
-              align="center"
-              justify="center"
+        {servers.length === 0 ? (
+          <Stack
+            gap={2}
+            className="bg-background mb-8 rounded-md border p-8"
+            align="center"
+            justify="center"
+          >
+            <Type variant="body">No servers added yet</Type>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setIsAddServerOpen(true)}
             >
-              <Type variant="body">No servers added yet</Type>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => setIsAddServerOpen(true)}
-              >
-                <Button.LeftIcon>
-                  <Icon name="plus" className="h-4 w-4" />
-                </Button.LeftIcon>
-                <Button.Text>Add Server</Button.Text>
-              </Button>
-            </Stack>
-          }
-          className="mb-8"
-        />
+              <Button.LeftIcon>
+                <Icon name="plus" className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>Add Server</Button.Text>
+            </Button>
+          </Stack>
+        ) : (
+          <div className="mb-8 space-y-2">
+            {servers.map((server) => (
+              <PluginServerRow
+                key={server.id}
+                server={server}
+                toolset={toolsetById.get(server.toolsetId)}
+                onRemove={() => handleRemoveServer(server)}
+              />
+            ))}
+          </div>
+        )}
 
         {/* Download section */}
         <Heading variant="h5" className="mb-3">
@@ -369,5 +357,96 @@ export default function PluginDetail() {
         </Dialog>
       </Page.Body>
     </Page>
+  );
+}
+
+function PluginServerRow({
+  server,
+  toolset,
+  onRemove,
+}: {
+  server: PluginServer;
+  toolset: ToolsetEntry | undefined;
+  onRemove: () => void;
+}) {
+  const routes = useRoutes();
+  const toolNames = toolset?.tools.map((t) => t.name) ?? [];
+  const description = toolset?.description ?? null;
+  const isMissing = !toolset;
+  const isRequired = server.policy === "required";
+
+  const mcpBadge = (() => {
+    if (!toolset) return null;
+    if (!toolset.mcpEnabled) {
+      return (
+        <Badge variant="outline" className="text-muted-foreground">
+          MCP off
+        </Badge>
+      );
+    }
+    if (toolset.mcpIsPublic) {
+      return <Badge variant="secondary">Public MCP</Badge>;
+    }
+    return <Badge variant="outline">Private MCP</Badge>;
+  })();
+
+  const body = (
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <Type className="truncate font-medium">{server.displayName}</Type>
+        {isMissing && (
+          <Badge variant="destructive" className="text-xs">
+            Toolset missing
+          </Badge>
+        )}
+      </div>
+      {description && (
+        <Type className="text-muted-foreground line-clamp-1 text-sm">
+          {description}
+        </Type>
+      )}
+    </div>
+  );
+
+  const leftSide = toolset ? (
+    <routes.mcp.details.Link
+      params={[toolset.slug]}
+      className="hover:text-primary flex min-w-0 flex-1 items-center gap-3 hover:no-underline"
+    >
+      {body}
+    </routes.mcp.details.Link>
+  ) : (
+    <div className="flex min-w-0 flex-1 items-center gap-3">{body}</div>
+  );
+
+  return (
+    <div className="bg-surface-secondary hover:bg-surface-tertiary flex items-center gap-3 rounded-md border p-3 transition-colors">
+      {leftSide}
+      <div className="flex shrink-0 items-center gap-2">
+        {toolset && <ToolCollectionBadge toolNames={toolNames} />}
+        {mcpBadge}
+        <Badge variant={isRequired ? "secondary" : "outline"}>
+          {isRequired ? "Required" : "Optional"}
+        </Badge>
+        {toolset && (
+          <UpdatedAt
+            date={new Date(toolset.updatedAt)}
+            italic={false}
+            className="hidden md:flex"
+          />
+        )}
+        <Button
+          variant="tertiary"
+          size="sm"
+          onClick={onRemove}
+          className="hover:text-destructive"
+        >
+          <Button.LeftIcon>
+            <Icon name="trash-2" className="h-4 w-4" />
+          </Button.LeftIcon>
+          <Button.Text className="sr-only">Remove</Button.Text>
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -3,10 +3,13 @@ import { Page } from "@/components/page-layout";
 import { ToolCollectionBadge } from "@/components/tool-collection-badge";
 import { Badge } from "@/components/ui/badge";
 import { Dialog } from "@/components/ui/dialog";
+import { DotCard } from "@/components/ui/dot-card";
 import { Heading } from "@/components/ui/heading";
+import { MoreActions } from "@/components/ui/more-actions";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { UpdatedAt } from "@/components/updated-at";
+import { cn } from "@/lib/utils";
 import { useRoutes } from "@/routes";
 import {
   invalidateAllPlugin,
@@ -27,7 +30,7 @@ import {
   Stack,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { ChevronRight, Globe, Lock, Server, Unplug } from "lucide-react";
+import { Globe, Lock, Server, Unplug } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 import type {
@@ -214,9 +217,9 @@ export default function PluginDetail() {
             </Button>
           </Stack>
         ) : (
-          <div className="mb-8 space-y-2">
+          <div className="mb-8 space-y-3">
             {servers.map((server) => (
-              <PluginServerRow
+              <PluginServerCard
                 key={server.id}
                 server={server}
                 toolset={toolsetById.get(server.toolsetId)}
@@ -361,7 +364,7 @@ export default function PluginDetail() {
   );
 }
 
-function PluginServerRow({
+function PluginServerCard({
   server,
   toolset,
   onRemove,
@@ -372,7 +375,6 @@ function PluginServerRow({
 }) {
   const routes = useRoutes();
   const toolNames = toolset?.tools.map((t) => t.name) ?? [];
-  const description = toolset?.description ?? null;
   const isMissing = !toolset;
   const isRequired = server.policy === "required";
 
@@ -402,44 +404,47 @@ function PluginServerRow({
     );
   })();
 
-  const body = (
-    <div className="flex min-w-0 flex-1 flex-col gap-1">
-      <div className="flex items-center gap-2">
-        <Type className="truncate font-medium">{server.displayName}</Type>
-        {isMissing && (
-          <Badge variant="destructive" className="text-xs">
-            Toolset missing
-          </Badge>
-        )}
-      </div>
-      {description && (
-        <Type className="text-muted-foreground line-clamp-1 text-sm">
-          {description}
-        </Type>
-      )}
-    </div>
-  );
-
-  const leftSide = toolset ? (
-    <routes.mcp.details.Link
-      params={[toolset.slug]}
-      className="group hover:text-primary flex min-w-0 flex-1 items-center gap-3 hover:no-underline"
-    >
-      <Server className="text-muted-foreground size-5 shrink-0" />
-      {body}
-      <ChevronRight className="text-muted-foreground size-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
-    </routes.mcp.details.Link>
-  ) : (
-    <div className="flex min-w-0 flex-1 items-center gap-3">
-      <Server className="text-muted-foreground size-5 shrink-0" />
-      {body}
-    </div>
-  );
+  const handleClick = () => {
+    if (toolset) routes.mcp.details.goTo(toolset.slug);
+  };
 
   return (
-    <div className="bg-surface-secondary hover:bg-surface-tertiary flex items-center gap-3 rounded-md border p-3 transition-colors">
-      {leftSide}
-      <div className="flex shrink-0 items-center gap-2">
+    <DotCard
+      className={cn("min-h-[112px]", toolset && "cursor-pointer")}
+      onClick={toolset ? handleClick : undefined}
+      icon={<Server className="text-muted-foreground h-8 w-8" />}
+    >
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Type
+            variant="subheading"
+            as="div"
+            className="text-md group-hover:text-primary truncate transition-colors"
+            title={server.displayName}
+          >
+            {server.displayName}
+          </Type>
+          {isMissing && (
+            <Badge variant="destructive" className="shrink-0 text-xs">
+              Toolset missing
+            </Badge>
+          )}
+        </div>
+        <div onClick={(e) => e.stopPropagation()} className="shrink-0">
+          <MoreActions
+            actions={[
+              {
+                label: "Remove",
+                onClick: onRemove,
+                destructive: true,
+                icon: "trash",
+              },
+            ]}
+          />
+        </div>
+      </div>
+
+      <div className="mt-auto flex flex-wrap items-center gap-2 pt-2">
         {toolset && <ToolCollectionBadge toolNames={toolNames} />}
         {mcpBadge}
         <Badge variant={isRequired ? "secondary" : "outline"}>
@@ -449,21 +454,10 @@ function PluginServerRow({
           <UpdatedAt
             date={new Date(toolset.updatedAt)}
             italic={false}
-            className="hidden md:flex"
+            className="ml-auto"
           />
         )}
-        <Button
-          variant="tertiary"
-          size="sm"
-          onClick={onRemove}
-          className="hover:text-destructive"
-        >
-          <Button.LeftIcon>
-            <Icon name="trash-2" className="h-4 w-4" />
-          </Button.LeftIcon>
-          <Button.Text className="sr-only">Remove</Button.Text>
-        </Button>
       </div>
-    </div>
+    </DotCard>
   );
 }

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -217,7 +217,7 @@ export default function PluginDetail() {
             </Button>
           </Stack>
         ) : (
-          <div className="mb-8 space-y-3">
+          <div className="mb-8 grid grid-cols-1 gap-6 xl:grid-cols-2">
             {servers.map((server) => (
               <PluginServerCard
                 key={server.id}

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -27,6 +27,7 @@ import {
   Stack,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
+import { ChevronRight, Globe, Lock, Server, Unplug } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useParams } from "react-router";
 import type {
@@ -380,14 +381,25 @@ function PluginServerRow({
     if (!toolset.mcpEnabled) {
       return (
         <Badge variant="outline" className="text-muted-foreground">
+          <Unplug />
           MCP off
         </Badge>
       );
     }
     if (toolset.mcpIsPublic) {
-      return <Badge variant="secondary">Public MCP</Badge>;
+      return (
+        <Badge variant="secondary">
+          <Globe />
+          Public MCP
+        </Badge>
+      );
     }
-    return <Badge variant="outline">Private MCP</Badge>;
+    return (
+      <Badge variant="outline">
+        <Lock />
+        Private MCP
+      </Badge>
+    );
   })();
 
   const body = (
@@ -411,12 +423,17 @@ function PluginServerRow({
   const leftSide = toolset ? (
     <routes.mcp.details.Link
       params={[toolset.slug]}
-      className="hover:text-primary flex min-w-0 flex-1 items-center gap-3 hover:no-underline"
+      className="group hover:text-primary flex min-w-0 flex-1 items-center gap-3 hover:no-underline"
     >
+      <Server className="text-muted-foreground size-5 shrink-0" />
       {body}
+      <ChevronRight className="text-muted-foreground size-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
     </routes.mcp.details.Link>
   ) : (
-    <div className="flex min-w-0 flex-1 items-center gap-3">{body}</div>
+    <div className="flex min-w-0 flex-1 items-center gap-3">
+      <Server className="text-muted-foreground size-5 shrink-0" />
+      {body}
+    </div>
   );
 
   return (

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -1,5 +1,6 @@
 import { InputField } from "@/components/moon/input-field";
 import { Page } from "@/components/page-layout";
+import { MCPStatusIndicator } from "@/components/mcp/MCPStatusIndicator";
 import { ToolCollectionBadge } from "@/components/tool-collection-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button as UiButton } from "@/components/ui/button";
@@ -375,46 +376,6 @@ function PluginServerCard({
   const routes = useRoutes();
   const isMissing = !toolset;
 
-  const status = (() => {
-    if (!toolset) return null;
-    if (!toolset.mcpEnabled) {
-      return {
-        color: "bg-red-500",
-        pulseColor: "bg-red-400",
-        label: "Disabled",
-      };
-    }
-    return {
-      color: "bg-green-500",
-      pulseColor: "bg-green-400",
-      label: toolset.mcpIsPublic ? "Public" : "Private",
-    };
-  })();
-
-  const statusIndicator = status && (
-    <div className="flex items-center gap-2">
-      <div className="relative flex h-2.5 w-2.5">
-        {toolset?.mcpEnabled && (
-          <span
-            className={cn(
-              "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
-              status.pulseColor,
-            )}
-          />
-        )}
-        <span
-          className={cn(
-            "relative inline-flex h-2.5 w-2.5 rounded-full",
-            status.color,
-          )}
-        />
-      </div>
-      <Type variant="small" muted>
-        {status.label}
-      </Type>
-    </div>
-  );
-
   const handleClick = () => {
     if (toolset) routes.mcp.details.goTo(toolset.slug);
   };
@@ -446,7 +407,14 @@ function PluginServerCard({
       </div>
 
       <div className="mt-auto flex items-center justify-between gap-2 pt-2">
-        {statusIndicator ?? <span />}
+        {toolset ? (
+          <MCPStatusIndicator
+            mcpEnabled={toolset.mcpEnabled}
+            mcpIsPublic={toolset.mcpIsPublic}
+          />
+        ) : (
+          <span />
+        )}
         <UiButton
           type="button"
           variant="ghost"


### PR DESCRIPTION
Redesign Plugin MCP server list to be consistent with rest of the application.

<img width="1296" height="529" alt="Screenshot 2026-05-01 at 2 48 04 PM" src="https://github.com/user-attachments/assets/c75ef8ce-3b6f-4614-9cf2-e54607541bbf" />


