### PR TITLE
mig: per-MCP-server scoped API keys for plugin manifests

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -255,6 +255,13 @@ CREATE TABLE IF NOT EXISTS api_keys (
   key_hash TEXT NOT NULL,
   scopes TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
 
+  -- Marks keys minted by Gram itself (e.g. plugin publishing) so they are
+  -- hidden from the user-managed keys UI and excluded from user-key quotas.
+  -- Per-key authorization scoping (e.g. binding a plugin-published key to
+  -- a single MCP server) lives in principal_grants on the api_key
+  -- principal — see rfc-plugin-scoped-keys.md.
+  system_managed BOOLEAN NOT NULL DEFAULT FALSE,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   deleted_at timestamptz,
@@ -2112,6 +2119,12 @@ CREATE TABLE IF NOT EXISTS plugin_servers (
   policy TEXT NOT NULL DEFAULT 'required',
   sort_order INT NOT NULL DEFAULT 0,
 
+  -- The plugin-minted, toolset-scoped api_keys row whose secret is embedded
+  -- in the published manifest entry for this server. NULL for public servers
+  -- (which use user-provided env-config auth) and for any server whose
+  -- plugin has never been published. Cleared on hard-delete of the api_key.
+  api_key_id uuid,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   deleted_at timestamptz,
@@ -2124,6 +2137,7 @@ CREATE TABLE IF NOT EXISTS plugin_servers (
   -- If a hard-delete path is added later, it must purge soft-deleted
   -- plugin_servers referencing the target first.
   CONSTRAINT plugin_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
+  CONSTRAINT plugin_servers_api_key_id_fkey FOREIGN KEY (api_key_id) REFERENCES api_keys (id) ON DELETE SET NULL,
   CONSTRAINT plugin_servers_policy_check CHECK (policy IN ('required', 'optional'))
 );
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -34,6 +34,7 @@ type ApiKey struct {
 	KeyPrefix       string
 	KeyHash         string
 	Scopes          []string
+	SystemManaged   bool
 	CreatedAt       pgtype.Timestamptz
 	UpdatedAt       pgtype.Timestamptz
 	DeletedAt       pgtype.Timestamptz
@@ -878,6 +879,7 @@ type PluginServer struct {
 	DisplayName string
 	Policy      string
 	SortOrder   int32
+	ApiKeyID    uuid.NullUUID
 	CreatedAt   pgtype.Timestamptz
 	UpdatedAt   pgtype.Timestamptz
 	DeletedAt   pgtype.Timestamptz

--- a/server/internal/keys/repo/models.go
+++ b/server/internal/keys/repo/models.go
@@ -18,6 +18,7 @@ type ApiKey struct {
 	KeyPrefix       string
 	KeyHash         string
 	Scopes          []string
+	SystemManaged   bool
 	CreatedAt       pgtype.Timestamptz
 	UpdatedAt       pgtype.Timestamptz
 	DeletedAt       pgtype.Timestamptz

--- a/server/internal/keys/repo/queries.sql.go
+++ b/server/internal/keys/repo/queries.sql.go
@@ -30,7 +30,7 @@ INSERT INTO api_keys (
   , $6
   , $7::text[]
 )
-RETURNING id, organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes, created_at, updated_at, deleted_at, deleted, last_accessed_at
+RETURNING id, organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes, system_managed, created_at, updated_at, deleted_at, deleted, last_accessed_at
 `
 
 type CreateAPIKeyParams struct {
@@ -63,6 +63,7 @@ func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (Api
 		&i.KeyPrefix,
 		&i.KeyHash,
 		&i.Scopes,
+		&i.SystemManaged,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -108,7 +109,7 @@ func (q *Queries) DeleteAPIKey(ctx context.Context, arg DeleteAPIKeyParams) (Del
 }
 
 const getAPIKeyByKeyHash = `-- name: GetAPIKeyByKeyHash :one
-SELECT api_keys.id, api_keys.organization_id, api_keys.project_id, api_keys.created_by_user_id, api_keys.name, api_keys.key_prefix, api_keys.key_hash, api_keys.scopes, api_keys.created_at, api_keys.updated_at, api_keys.deleted_at, api_keys.deleted, api_keys.last_accessed_at, users.email
+SELECT api_keys.id, api_keys.organization_id, api_keys.project_id, api_keys.created_by_user_id, api_keys.name, api_keys.key_prefix, api_keys.key_hash, api_keys.scopes, api_keys.system_managed, api_keys.created_at, api_keys.updated_at, api_keys.deleted_at, api_keys.deleted, api_keys.last_accessed_at, users.email
 FROM api_keys
 JOIN users ON users.id = api_keys.created_by_user_id
 WHERE key_hash = $1
@@ -124,6 +125,7 @@ type GetAPIKeyByKeyHashRow struct {
 	KeyPrefix       string
 	KeyHash         string
 	Scopes          []string
+	SystemManaged   bool
 	CreatedAt       pgtype.Timestamptz
 	UpdatedAt       pgtype.Timestamptz
 	DeletedAt       pgtype.Timestamptz
@@ -144,6 +146,7 @@ func (q *Queries) GetAPIKeyByKeyHash(ctx context.Context, keyHash string) (GetAP
 		&i.KeyPrefix,
 		&i.KeyHash,
 		&i.Scopes,
+		&i.SystemManaged,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -155,7 +158,7 @@ func (q *Queries) GetAPIKeyByKeyHash(ctx context.Context, keyHash string) (GetAP
 }
 
 const listAPIKeysByOrganization = `-- name: ListAPIKeysByOrganization :many
-SELECT id, organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes, created_at, updated_at, deleted_at, deleted, last_accessed_at
+SELECT id, organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes, system_managed, created_at, updated_at, deleted_at, deleted, last_accessed_at
 FROM api_keys
 WHERE organization_id = $1
   AND deleted IS FALSE
@@ -180,6 +183,7 @@ func (q *Queries) ListAPIKeysByOrganization(ctx context.Context, organizationID 
 			&i.KeyPrefix,
 			&i.KeyHash,
 			&i.Scopes,
+			&i.SystemManaged,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,

--- a/server/internal/plugins/repo/models.go
+++ b/server/internal/plugins/repo/models.go
@@ -48,6 +48,7 @@ type PluginServer struct {
 	DisplayName string
 	Policy      string
 	SortOrder   int32
+	ApiKeyID    uuid.NullUUID
 	CreatedAt   pgtype.Timestamptz
 	UpdatedAt   pgtype.Timestamptz
 	DeletedAt   pgtype.Timestamptz

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -49,7 +49,7 @@ VALUES (
   $4,
   $5
 )
-RETURNING id, plugin_id, toolset_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
+RETURNING id, plugin_id, toolset_id, display_name, policy, sort_order, api_key_id, created_at, updated_at, deleted_at, deleted
 `
 
 type AddPluginServerParams struct {
@@ -76,6 +76,7 @@ func (q *Queries) AddPluginServer(ctx context.Context, arg AddPluginServerParams
 		&i.DisplayName,
 		&i.Policy,
 		&i.SortOrder,
+		&i.ApiKeyID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -245,7 +246,7 @@ func (q *Queries) ListPluginAssignments(ctx context.Context, pluginID uuid.UUID)
 }
 
 const listPluginServers = `-- name: ListPluginServers :many
-SELECT id, plugin_id, toolset_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
+SELECT id, plugin_id, toolset_id, display_name, policy, sort_order, api_key_id, created_at, updated_at, deleted_at, deleted
 FROM plugin_servers
 WHERE plugin_id = $1
   AND deleted IS FALSE
@@ -268,6 +269,7 @@ func (q *Queries) ListPluginServers(ctx context.Context, pluginID uuid.UUID) ([]
 			&i.DisplayName,
 			&i.Policy,
 			&i.SortOrder,
+			&i.ApiKeyID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -519,7 +521,7 @@ SET display_name = $1,
 WHERE id = $4
   AND plugin_id = $5
   AND deleted IS FALSE
-RETURNING id, plugin_id, toolset_id, display_name, policy, sort_order, created_at, updated_at, deleted_at, deleted
+RETURNING id, plugin_id, toolset_id, display_name, policy, sort_order, api_key_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdatePluginServerParams struct {
@@ -546,6 +548,7 @@ func (q *Queries) UpdatePluginServer(ctx context.Context, arg UpdatePluginServer
 		&i.DisplayName,
 		&i.Policy,
 		&i.SortOrder,
+		&i.ApiKeyID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260501182626_plugin-scoped-keys.sql
+++ b/server/migrations/20260501182626_plugin-scoped-keys.sql
@@ -1,0 +1,4 @@
+-- Modify "api_keys" table
+ALTER TABLE "api_keys" ADD COLUMN "system_managed" boolean NOT NULL DEFAULT false;
+-- Modify "plugin_servers" table
+ALTER TABLE "plugin_servers" ADD COLUMN "api_key_id" uuid NULL, ADD CONSTRAINT "plugin_servers_api_key_id_fkey" FOREIGN KEY ("api_key_id") REFERENCES "api_keys" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zleYfz3S2cRoqSoJ3IKZKjvsa7ej9M8rmJHZPH68KSk=
+h1:+tXNN0jFH+heqYopGcVl0Tyc9ddgaerQhUWn8Yh8LyY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -151,3 +151,4 @@ h1:zleYfz3S2cRoqSoJ3IKZKjvsa7ej9M8rmJHZPH68KSk=
 20260430111449_add-workos-roles-and-sync-tables.sql h1:tIK7+g0gEt27jixmoso4bHI7GYAtxUzfL8l24k2Os8g=
 20260430201533_risk-policies-action-and-auto-name.sql h1:3tvGuQlzBnUX2gvFtad56YpeX1wpE9asgXh74ywEIhE=
 20260430205315_risk-policies-user-message.sql h1:b3myELZy6W5m08Wz7aqPV6pInYP5SB0KKj5uQ5VYBoQ=
+20260501182626_plugin-scoped-keys.sql h1:s+fZ+Ok0P1z2v80AW8G1YA3uIP32vfTzF518rt3sA6Q=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/2543 so the database changes can land independently.