### PR TITLE
chore: reuse fly apps across assistant runtime lifecycle

### DIFF
--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -261,6 +261,20 @@ WHERE t.project_id = @project_id
         OR (r.state = @active_state AND (r.warm_until IS NULL OR r.warm_until > clock_timestamp()))
       )
   )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_runtimes lr
+    WHERE lr.project_id = t.project_id
+      AND lr.assistant_thread_id = t.id
+      AND lr.state = @failed_state
+      AND lr.updated_at > @admit_failure_backoff_cutoff
+      AND lr.created_at = (
+        SELECT MAX(rlatest.created_at)
+        FROM assistant_runtimes rlatest
+        WHERE rlatest.project_id = t.project_id
+          AND rlatest.assistant_thread_id = t.id
+      )
+  )
 ORDER BY (
   SELECT MIN(e.created_at)
   FROM assistant_thread_events e

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -520,6 +520,20 @@ WHERE t.project_id = $1
         OR (r.state = $5 AND (r.warm_until IS NULL OR r.warm_until > clock_timestamp()))
       )
   )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_runtimes lr
+    WHERE lr.project_id = t.project_id
+      AND lr.assistant_thread_id = t.id
+      AND lr.state = $6
+      AND lr.updated_at > $7
+      AND lr.created_at = (
+        SELECT MAX(rlatest.created_at)
+        FROM assistant_runtimes rlatest
+        WHERE rlatest.project_id = t.project_id
+          AND rlatest.assistant_thread_id = t.id
+      )
+  )
 ORDER BY (
   SELECT MIN(e.created_at)
   FROM assistant_thread_events e
@@ -528,17 +542,19 @@ ORDER BY (
     AND e.deleted IS FALSE
     AND e.status = $3
 ) ASC
-LIMIT $6
+LIMIT $8
 FOR UPDATE OF t SKIP LOCKED
 `
 
 type ListColdPendingThreadsForAdmitParams struct {
-	ProjectID     uuid.UUID
-	AssistantID   uuid.UUID
-	PendingStatus string
-	StartingState string
-	ActiveState   string
-	LimitCount    int32
+	ProjectID                 uuid.UUID
+	AssistantID               uuid.UUID
+	PendingStatus             string
+	StartingState             string
+	ActiveState               string
+	FailedState               string
+	AdmitFailureBackoffCutoff pgtype.Timestamptz
+	LimitCount                int32
 }
 
 type ListColdPendingThreadsForAdmitRow struct {
@@ -553,6 +569,8 @@ func (q *Queries) ListColdPendingThreadsForAdmit(ctx context.Context, arg ListCo
 		arg.PendingStatus,
 		arg.StartingState,
 		arg.ActiveState,
+		arg.FailedState,
+		arg.AdmitFailureBackoffCutoff,
 		arg.LimitCount,
 	)
 	if err != nil {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -80,6 +80,7 @@ type flyRuntimeFlapsClient interface {
 	Launch(ctx context.Context, appName string, input fly.LaunchMachineInput) (*fly.Machine, error)
 	List(ctx context.Context, appName, state string) ([]*fly.Machine, error)
 	Start(ctx context.Context, appName, machineID string, nonce string) (*fly.MachineStartResponse, error)
+	Stop(ctx context.Context, appName string, in fly.StopMachineInput, nonce string) error
 	Wait(ctx context.Context, appName string, machine *fly.Machine, state string, timeout time.Duration) error
 }
 
@@ -688,6 +689,8 @@ func (f *FlyRuntimeBackend) ServerURL(_ context.Context, runtime assistantRuntim
 	return &cloned, nil
 }
 
+// Stop pauses the machine but preserves the app, allocated IP, and backend
+// metadata so a subsequent admit can resume the same incarnation.
 func (f *FlyRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
 	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
 		return err
@@ -696,10 +699,21 @@ func (f *FlyRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRe
 	if err != nil {
 		return err
 	}
-	if metadata.AppName == "" {
+	if metadata.AppName == "" || metadata.MachineID == "" {
 		return nil
 	}
-	return f.deleteApp(ctx, metadata.AppName)
+
+	flapsClient, err := f.flapsFactory.New(ctx)
+	if err != nil {
+		return fmt.Errorf("create fly runtime flaps client: %w", err)
+	}
+
+	if err := flapsClient.Stop(ctx, metadata.AppName, fly.StopMachineInput{
+		ID: metadata.MachineID,
+	}, ""); err != nil && !isFlyNotFound(err) {
+		return fmt.Errorf("stop assistant fly runtime machine: %w", err)
+	}
+	return nil
 }
 
 func (f *FlyRuntimeBackend) deleteApp(ctx context.Context, appName string) error {

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -321,13 +321,12 @@ func TestFlyRuntimeBackendEnsureExistingAppAfterPartialCreateFailureClearsStaleM
 	require.Equal(t, 0, apiClient.deleteCalls, "partially created current app should not be torn down because metadata came from an older app incarnation")
 }
 
-func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
+func TestFlyRuntimeBackendStopWithoutMachineMetadataIsNoop(t *testing.T) {
 	t.Parallel()
 
 	server := newTestAssistantRuntimeServer(t, true)
-	backend, apiClient, _ := newTestFlyRuntimeBackend(t, server)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
 
-	apiClient.deleteErr = errors.New("not found")
 	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
 		AppName:    "gram-asst-test",
 		AppID:      "",
@@ -344,6 +343,60 @@ func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
 		BackendMetadataJSON: rawMetadata,
 	})
 	require.NoError(t, err)
+	require.Equal(t, 0, flapsClient.stopCalls, "stop is a no-op without a machine id to target")
+	require.Equal(t, 0, apiClient.deleteCalls, "stop must not delete the fly app")
+}
+
+func TestFlyRuntimeBackendStopStopsMachineKeepsApp(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		AppIP:      "",
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	err = backend.Stop(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, flapsClient.stopCalls, "stop must target the machine via flaps")
+	require.Equal(t, 0, apiClient.deleteCalls, "stop must not delete the fly app — reuse the next admit")
+}
+
+func TestFlyRuntimeBackendStopToleratesMissingMachine(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	flapsClient.stopErr = errors.New("not found")
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		AppIP:      "",
+		MachineID:  "machine-gone",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	err = backend.Stop(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, apiClient.deleteCalls, "stop must not fall back to delete-app when flaps reports missing")
 }
 
 func TestFlyRuntimeBackendServerURLRejectsLoopback(t *testing.T) {
@@ -423,6 +476,8 @@ type testFlyRuntimeFlapsClient struct {
 	launchMachine *fly.Machine
 	launchErr     error
 	startErr      error
+	stopErr       error
+	stopCalls     int
 	waitErr       error
 }
 
@@ -462,6 +517,17 @@ func (c *testFlyRuntimeFlapsClient) Start(_ context.Context, _ string, _ string,
 		c.machine.State = "started"
 	}
 	return &fly.MachineStartResponse{}, nil
+}
+
+func (c *testFlyRuntimeFlapsClient) Stop(_ context.Context, _ string, _ fly.StopMachineInput, _ string) error {
+	c.stopCalls++
+	if c.stopErr != nil {
+		return c.stopErr
+	}
+	if c.machine != nil {
+		c.machine.State = "stopped"
+	}
+	return nil
 }
 
 func (c *testFlyRuntimeFlapsClient) Wait(_ context.Context, _ string, _ *fly.Machine, _ string, _ time.Duration) error {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -60,6 +60,7 @@ const (
 	runtimeProcessingLeaseGrace  = 2 * time.Minute
 	eventProcessingRequeueGrace  = 3 * time.Minute
 	processingLeaseHeartbeatTick = 30 * time.Second
+	admitFailureBackoff          = 30 * time.Second
 )
 
 var errAssistantValidation = errors.New("assistant validation")
@@ -1036,12 +1037,14 @@ func (s *ServiceCore) AdmitPendingThreads(ctx context.Context, assistantID uuid.
 	available := max(assistant.MaxConcurrency-conv.SafeInt(activeCount), 0)
 	if available > 0 {
 		coldThreads, err := queries.ListColdPendingThreadsForAdmit(ctx, assistantrepo.ListColdPendingThreadsForAdmitParams{
-			ProjectID:     assistant.ProjectID,
-			AssistantID:   assistantID,
-			PendingStatus: eventStatusPending,
-			StartingState: runtimeStateStarting,
-			ActiveState:   runtimeStateActive,
-			LimitCount:    conv.SafeInt32(available),
+			ProjectID:                 assistant.ProjectID,
+			AssistantID:               assistantID,
+			PendingStatus:             eventStatusPending,
+			StartingState:             runtimeStateStarting,
+			ActiveState:               runtimeStateActive,
+			FailedState:               runtimeStateFailed,
+			AdmitFailureBackoffCutoff: conv.ToPGTimestamptz(time.Now().UTC().Add(-admitFailureBackoff)),
+			LimitCount:                conv.SafeInt32(available),
 		})
 		if err != nil {
 			return AdmitPendingThreadsResult{}, fmt.Errorf("select cold assistant threads: %w", err)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1177,7 +1177,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			// window so they flow through cleanly under a fresh VM.
 			if errors.Is(runErr, ErrRuntimeUnhealthy) {
 				_ = s.runtime.Stop(ctx, runtimeRecord)
-				_ = s.stopRuntimeRecord(ctx, thread.ProjectID, thread.ID, runtimeStateStopped)
+				_ = s.stopRuntimeRecord(ctx, thread.ProjectID, thread.ID, runtimeStateFailed)
 				return ProcessThreadEventsResult{
 					AssistantID:       assistant.ID,
 					WarmUntil:         time.Time{},

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -452,7 +452,7 @@ func TestServiceCoreProcessThreadEventsMarksRuntimeFailedOnUnhealthyTurn(t *test
 		runTurnErr: ErrRuntimeUnhealthy,
 		stopCalls:  &stopCalls,
 	}
-	core := NewServiceCore(logger, conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger))
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -432,6 +432,60 @@ WHERE assistant_thread_id = $1
 	require.Contains(t, lastError.String, "runtime RunTurn blew up")
 }
 
+func TestServiceCoreProcessThreadEventsMarksRuntimeFailedOnUnhealthyTurn(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_unhealthy_turn")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	var stopCalls atomic.Int64
+	logger := testenv.NewLogger(t)
+	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
+	backend := testRuntimeBackend{
+		backend:    runtimeBackendFlyIO,
+		runTurnErr: ErrRuntimeUnhealthy,
+		stopCalls:  &stopCalls,
+	}
+	core := NewServiceCore(logger, conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger))
+
+	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{threadID}, admitted.ThreadIDs)
+
+	result, err := core.ProcessThreadEvents(t.Context(), projectID, threadID)
+	require.NoError(t, err)
+	require.True(t, result.RetryAdmission)
+	require.False(t, result.RuntimeActive)
+	require.False(t, result.ProcessedAnyEvent)
+	require.Equal(t, int64(1), stopCalls.Load(), "unhealthy turn must tear the VM down")
+
+	var state string
+	var deleted bool
+	err = conn.QueryRow(t.Context(), `
+SELECT state, deleted
+FROM assistant_runtimes
+WHERE assistant_thread_id = $1
+`, threadID).Scan(&state, &deleted)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateFailed, state, "unhealthy turn must mark runtime failed so the admission backoff applies")
+	require.True(t, deleted)
+
+	var eventStatus string
+	err = conn.QueryRow(t.Context(), `
+SELECT status
+FROM assistant_thread_events
+WHERE assistant_thread_id = $1
+`, threadID).Scan(&eventStatus)
+	require.NoError(t, err)
+	require.Equal(t, eventStatusProcessing, eventStatus, "unhealthy turn leaves the event in processing for the reaper")
+}
+
 func TestServiceCoreProcessThreadEventsDoesNotStopRuntimeOnConfigureFailure(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -487,6 +487,19 @@ WHERE assistant_thread_id = $1
 	require.True(t, deleted)
 	require.JSONEq(t, string(backend.ensureResult.BackendMetadataJSON), string(metadata))
 
+	hotAdmit, err := core.AdmitPendingThreads(t.Context(), assistantID)
+	require.NoError(t, err)
+	require.Empty(t, hotAdmit.ThreadIDs, "admission backoff must block re-admit immediately after a setup failure")
+
+	// Simulate the backoff window elapsing so the next admit is eligible.
+	_, err = conn.Exec(t.Context(), `
+UPDATE assistant_runtimes
+SET updated_at = clock_timestamp() - INTERVAL '1 hour'
+WHERE assistant_thread_id = $1
+  AND state = $2
+`, threadID, runtimeStateFailed)
+	require.NoError(t, err)
+
 	admittedAgain, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
 	require.Equal(t, []uuid.UUID{threadID}, admittedAgain.ThreadIDs)


### PR DESCRIPTION
## Summary

- Change `FlyRuntimeBackend.Stop` to halt the machine via flaps instead of deleting the Fly app, so persisted backend metadata, app, and allocated IP are reused on the next admit. Destructive teardown stays reserved for confirmed corruption.
- Add a 30s `admitFailureBackoff` cutoff on `ListColdPendingThreadsForAdmit` so a thread whose latest runtime row is `failed` is held back from cold readmission until either the window elapses or a successful runtime supersedes it. Stops setup/configure failures from churning Fly (re-create app, re-allocate IP, re-launch machine) every coordinator tick.
- Tests cover stop-no-machine, stop-keeps-app, missing-machine tolerance, and the admit backoff window.

Linear: AGE-2073

✻ Clauded...
