### PR TITLE
feat(dashboard): show function memory and instances on source overview

### DIFF
--- a/.changeset/fresh-kiwis-love.md
+++ b/.changeset/fresh-kiwis-love.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Show function memory and instances on source overview

--- a/client/dashboard/src/pages/sources/SourceOverviewTab.tsx
+++ b/client/dashboard/src/pages/sources/SourceOverviewTab.tsx
@@ -27,6 +27,17 @@ function formatFileSize(bytes: number) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function formatMemory(mib: number) {
+  if (mib < 1024) return `${mib} MiB`;
+  const gib = mib / 1024;
+  return Number.isInteger(gib) ? `${gib} GiB` : `${gib.toFixed(1)} GiB`;
+}
+
+// Mirror server/internal/constants/functions.go — applied at deploy time when
+// the per-source value is NULL.
+const DEFAULT_FUNCTION_MEMORY_MIB = 1024;
+const DEFAULT_FUNCTION_SCALE = 2;
+
 function OverviewRow({
   label,
   children,
@@ -69,6 +80,9 @@ export function SourceOverviewTab({
       })
     : "Unknown";
 
+  const functionSource =
+    !isOpenAPI && source ? (source as DeploymentFunctions) : null;
+
   return (
     <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
       <div className="grid grid-cols-[280px_1fr] items-start gap-8">
@@ -100,11 +114,35 @@ export function SourceOverviewTab({
                 </Type>
               </OverviewRow>
             ) : (
-              <OverviewRow label="Runtime">
-                <Type className="text-sm">
-                  {source && "runtime" in source ? String(source.runtime) : "—"}
-                </Type>
-              </OverviewRow>
+              <>
+                <OverviewRow label="Runtime">
+                  <Type className="text-sm">
+                    {functionSource ? functionSource.runtime : "—"}
+                  </Type>
+                </OverviewRow>
+                <OverviewRow label="Memory">
+                  <Type className="text-sm">
+                    {formatMemory(
+                      functionSource?.memoryMib ?? DEFAULT_FUNCTION_MEMORY_MIB,
+                    )}
+                    {functionSource?.memoryMib == null && (
+                      <Type muted small as="span" className="ml-1">
+                        (default)
+                      </Type>
+                    )}
+                  </Type>
+                </OverviewRow>
+                <OverviewRow label="Instances">
+                  <Type className="text-sm">
+                    {functionSource?.scale ?? DEFAULT_FUNCTION_SCALE}
+                    {functionSource?.scale == null && (
+                      <Type muted small as="span" className="ml-1">
+                        (default)
+                      </Type>
+                    )}
+                  </Type>
+                </OverviewRow>
+              </>
             )}
             <OverviewRow label="File size">
               <Type className="text-sm">


### PR DESCRIPTION
## Summary

- Adds **Memory** and **Instances** rows to the function source overview table, surfacing the per-source compute config added in #2238.
- When the value is unset on the wire, the row displays the resolved platform default (1 GiB / 2 instances) with a muted "(default)" hint, instead of the previous "—" which incorrectly implied the field was unconfigured. The backend already applies these defaults at deploy time via `COALESCE` in `CloneDeploymentFunctionsAssets` (`server/internal/deployments/queries.sql:328-329`), so the UI now reflects what the function will actually run on.
- Adds a small `formatMemory` helper that promotes ≥1024 MiB to GiB so 1024 reads as "1 GiB" rather than a raw MiB count.

<img width="2280" height="1110" alt="CleanShot 2026-05-01 at 15 53 18@2x" src="https://github.com/user-attachments/assets/d31013e0-015d-4b8c-bf15-d2d839991059" />

## Test plan

- [x] Visit a function source's Overview tab where the source has explicit `memory_mib`/`scale` set — values render formatted (e.g. "2 GiB", "4")
- [x] Visit a function source where the values are NULL in the DB (legacy or unconfigured) — rows show "1 GiB (default)" and "2 (default)"
- [x] Visit an OpenAPI source — Memory/Instances rows are not shown, Format row remains
- [x] Check that the "Source ID", "File size", "Created", "Updated", and "Active deployment" rows still render correctly below the new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)