### PR TITLE
fix(chat): skip empty assistant rows on both sides of generation matcher

### DIFF
--- a/server/internal/chat/hash.go
+++ b/server/internal/chat/hash.go
@@ -54,42 +54,13 @@ func buildSlot(role, content, toolCallID string, toolCallIDs []string) messageSl
 	}
 }
 
-// isStoredEmptyAsst reports whether a stored row collapses to an
-// "empty assistant" — role=assistant, no text, no tool_calls, no
-// tool_call_id. These rows arrive when the upstream model returns
-// finish_reason=stop with nothing to say (Anthropic Sonnet
-// extended-thinking blank stops, observed on prod chat
-// 6d5bee05-9809-5678-8512-b3b2fb390120). The runner-side transcript
-// (and other clients) treat such turns as no-ops and don't include
-// them on the next request, so the stored row has no counterpart.
-// The matcher steps over these so the asymmetry doesn't trip a
-// false-positive divergence.
-func isStoredEmptyAsst(role, content, toolCallID string, toolCallsJSON []byte) bool {
-	if role != "assistant" {
-		return false
-	}
-	if content != "" {
-		return false
-	}
-	if toolCallID != "" {
-		return false
-	}
-	return len(toolCallIDsFromStoredJSON(toolCallsJSON)) == 0
-}
-
-// isIncomingEmptyAsst is the wire-side counterpart to isStoredEmptyAsst:
-// an assistant message with no text, no tool_calls, no tool_call_id.
-// Defensive — the endpoint serves clients beyond the agentkit runner,
-// any of which may send the wire shape `{role:asst, content:null,
-// tool_calls:[]}` for a no-op turn.
-func isIncomingEmptyAsst(msg or.ChatMessages) bool {
-	if msg.Type != or.ChatMessagesTypeAssistant {
-		return false
-	}
-	if openrouter.GetText(msg) != "" {
-		return false
-	}
-	return len(toolCallIDsFromIncoming(msg)) == 0
+// isBlankAssistant reports whether the slot is a no-op assistant turn:
+// role=assistant with no text, no tool_call_id, no tool_calls. The server
+// can persist such a row (model returns an empty stop) while clients drop
+// it from subsequent wire requests, so the matcher steps over it on either
+// side rather than treating the asymmetry as divergence.
+func (s messageSlot) isBlankAssistant() bool {
+	return s == messageSlot{role: "assistant"}
 }
 
 func toolCallIDsFromIncoming(msg or.ChatMessages) []string {

--- a/server/internal/chat/hash.go
+++ b/server/internal/chat/hash.go
@@ -60,7 +60,7 @@ func buildSlot(role, content, toolCallID string, toolCallIDs []string) messageSl
 // it from subsequent wire requests, so the matcher steps over it on either
 // side rather than treating the asymmetry as divergence.
 func (s messageSlot) isBlankAssistant() bool {
-	return s == messageSlot{role: "assistant"}
+	return s == messageSlot{role: "assistant", content: "", toolCallID: "", toolCallIDs: ""}
 }
 
 func toolCallIDsFromIncoming(msg or.ChatMessages) []string {

--- a/server/internal/chat/hash.go
+++ b/server/internal/chat/hash.go
@@ -54,6 +54,44 @@ func buildSlot(role, content, toolCallID string, toolCallIDs []string) messageSl
 	}
 }
 
+// isStoredEmptyAsst reports whether a stored row collapses to an
+// "empty assistant" — role=assistant, no text, no tool_calls, no
+// tool_call_id. These rows arrive when the upstream model returns
+// finish_reason=stop with nothing to say (Anthropic Sonnet
+// extended-thinking blank stops, observed on prod chat
+// 6d5bee05-9809-5678-8512-b3b2fb390120). The runner-side transcript
+// (and other clients) treat such turns as no-ops and don't include
+// them on the next request, so the stored row has no counterpart.
+// The matcher steps over these so the asymmetry doesn't trip a
+// false-positive divergence.
+func isStoredEmptyAsst(role, content, toolCallID string, toolCallsJSON []byte) bool {
+	if role != "assistant" {
+		return false
+	}
+	if content != "" {
+		return false
+	}
+	if toolCallID != "" {
+		return false
+	}
+	return len(toolCallIDsFromStoredJSON(toolCallsJSON)) == 0
+}
+
+// isIncomingEmptyAsst is the wire-side counterpart to isStoredEmptyAsst:
+// an assistant message with no text, no tool_calls, no tool_call_id.
+// Defensive — the endpoint serves clients beyond the agentkit runner,
+// any of which may send the wire shape `{role:asst, content:null,
+// tool_calls:[]}` for a no-op turn.
+func isIncomingEmptyAsst(msg or.ChatMessages) bool {
+	if msg.Type != or.ChatMessagesTypeAssistant {
+		return false
+	}
+	if openrouter.GetText(msg) != "" {
+		return false
+	}
+	return len(toolCallIDsFromIncoming(msg)) == 0
+}
+
 func toolCallIDsFromIncoming(msg or.ChatMessages) []string {
 	if msg.Type != or.ChatMessagesTypeAssistant {
 		return nil

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -130,8 +130,12 @@ type matchResult struct {
 
 // matchIncomingAgainstStored walks the current generation's stored messages
 // against the incoming request to find the longest matching prefix by message
-// slot identity. The first slot mismatch (or a stored row past the end of
-// incoming) signals divergence and triggers a new generation.
+// slot identity. Empty-assistant rows are skipped on both sides so that a
+// no-op turn captured server-side (e.g. an Anthropic blank-stop response)
+// or replayed wire-side as `{content:null, tool_calls:[]}` doesn't
+// register as a divergence. Any other slot mismatch — or stored content
+// remaining after both sides have been drained of empties — signals
+// divergence and triggers a new generation.
 func (s *ChatMessageCaptureStrategy) matchIncomingAgainstStored(ctx context.Context, chatID uuid.UUID, incoming []or.ChatMessages) (matchResult, error) {
 	currentGen, err := s.repo.GetMaxGenerationForChat(ctx, chatID)
 	if err != nil {
@@ -148,23 +152,43 @@ func (s *ChatMessageCaptureStrategy) matchIncomingAgainstStored(ctx context.Cont
 		return matchResult{}, oops.E(oops.CodeUnexpected, err, "list chat messages for match")
 	}
 
-	matchedPrefix := 0
+	si, ii := 0, 0
 	diverged := false
-	for i, row := range stored {
-		if i >= len(incoming) {
+	for si < len(stored) && ii < len(incoming) {
+		if isStoredEmptyAsst(stored[si].Role, stored[si].Content, stored[si].ToolCallID.String, stored[si].ToolCalls) {
+			si++
+			continue
+		}
+		if isIncomingEmptyAsst(incoming[ii]) {
+			ii++
+			continue
+		}
+		if slotFromStored(stored[si].Role, stored[si].Content, stored[si].ToolCallID.String, stored[si].ToolCalls) != slotFromIncoming(incoming[ii]) {
 			diverged = true
 			break
 		}
-		if slotFromStored(row.Role, row.Content, row.ToolCallID.String, row.ToolCalls) != slotFromIncoming(incoming[i]) {
-			diverged = true
-			break
+		si++
+		ii++
+	}
+
+	if !diverged {
+		// Drain trailing empties so we can tell whether stored has a real
+		// row past the end of incoming, and so phantom empties at the head
+		// of the new tail don't get re-persisted by buildPendingRows.
+		for si < len(stored) && isStoredEmptyAsst(stored[si].Role, stored[si].Content, stored[si].ToolCallID.String, stored[si].ToolCalls) {
+			si++
 		}
-		matchedPrefix = i + 1
+		if si < len(stored) {
+			diverged = true
+		}
+		for ii < len(incoming) && isIncomingEmptyAsst(incoming[ii]) {
+			ii++
+		}
 	}
 
 	return matchResult{
 		generation:    currentGen,
-		matchedPrefix: matchedPrefix,
+		matchedPrefix: ii,
 		diverged:      diverged,
 	}, nil
 }

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -128,14 +128,11 @@ type matchResult struct {
 	diverged      bool
 }
 
-// matchIncomingAgainstStored walks the current generation's stored messages
-// against the incoming request to find the longest matching prefix by message
-// slot identity. Empty-assistant rows are skipped on both sides so that a
-// no-op turn captured server-side (e.g. an Anthropic blank-stop response)
-// or replayed wire-side as `{content:null, tool_calls:[]}` doesn't
-// register as a divergence. Any other slot mismatch — or stored content
-// remaining after both sides have been drained of empties — signals
-// divergence and triggers a new generation.
+// matchIncomingAgainstStored finds the longest matching prefix between
+// stored and incoming by slot identity. Blank-assistant slots are skipped
+// on both sides — the server may persist them while clients omit them on
+// replay. Any other mismatch, or stored content past the end of incoming,
+// signals divergence and triggers a new generation.
 func (s *ChatMessageCaptureStrategy) matchIncomingAgainstStored(ctx context.Context, chatID uuid.UUID, incoming []or.ChatMessages) (matchResult, error) {
 	currentGen, err := s.repo.GetMaxGenerationForChat(ctx, chatID)
 	if err != nil {
@@ -152,18 +149,25 @@ func (s *ChatMessageCaptureStrategy) matchIncomingAgainstStored(ctx context.Cont
 		return matchResult{}, oops.E(oops.CodeUnexpected, err, "list chat messages for match")
 	}
 
+	storedSlotAt := func(i int) messageSlot {
+		row := stored[i]
+		return slotFromStored(row.Role, row.Content, row.ToolCallID.String, row.ToolCalls)
+	}
+
 	si, ii := 0, 0
 	diverged := false
 	for si < len(stored) && ii < len(incoming) {
-		if isStoredEmptyAsst(stored[si].Role, stored[si].Content, stored[si].ToolCallID.String, stored[si].ToolCalls) {
+		storedSlot := storedSlotAt(si)
+		if storedSlot.isBlankAssistant() {
 			si++
 			continue
 		}
-		if isIncomingEmptyAsst(incoming[ii]) {
+		incomingSlot := slotFromIncoming(incoming[ii])
+		if incomingSlot.isBlankAssistant() {
 			ii++
 			continue
 		}
-		if slotFromStored(stored[si].Role, stored[si].Content, stored[si].ToolCallID.String, stored[si].ToolCalls) != slotFromIncoming(incoming[ii]) {
+		if storedSlot != incomingSlot {
 			diverged = true
 			break
 		}
@@ -172,17 +176,17 @@ func (s *ChatMessageCaptureStrategy) matchIncomingAgainstStored(ctx context.Cont
 	}
 
 	if !diverged {
-		// Drain trailing empties so we can tell whether stored has a real
-		// row past the end of incoming, and so phantom empties at the head
-		// of the new tail don't get re-persisted by buildPendingRows.
-		for si < len(stored) && isStoredEmptyAsst(stored[si].Role, stored[si].Content, stored[si].ToolCallID.String, stored[si].ToolCalls) {
+		// Drain trailing blanks on both sides: a real stored row past
+		// incoming must trip divergence, and phantom blanks at the head of
+		// the new tail must not be re-persisted by buildPendingRows.
+		for si < len(stored) && storedSlotAt(si).isBlankAssistant() {
 			si++
+		}
+		for ii < len(incoming) && slotFromIncoming(incoming[ii]).isBlankAssistant() {
+			ii++
 		}
 		if si < len(stored) {
 			diverged = true
-		}
-		for ii < len(incoming) && isIncomingEmptyAsst(incoming[ii]) {
-			ii++
 		}
 	}
 

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -63,6 +63,37 @@ func makeAssistantToolOnly(toolCalls ...or.ChatToolCall) or.ChatMessages {
 	})
 }
 
+// makeAssistantBlank builds an assistant wire message with no content, no
+// tool_calls, and no tool_call_id — the shape some clients send for a
+// no-op/blank-stop turn (e.g. agentkit 0.4.0 emits this when it has no
+// usable parts to encode).
+func makeAssistantBlank() or.ChatMessages {
+	return or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
+		Role:             or.ChatAssistantMessageRoleAssistant,
+		Content:          optionalnullable.From[or.ChatAssistantMessageContent](nil),
+		Name:             nil,
+		ToolCalls:        nil,
+		Refusal:          nil,
+		Reasoning:        nil,
+		ReasoningDetails: nil,
+		Images:           nil,
+		Audio:            nil,
+	})
+}
+
+// blankResponse mimics the Anthropic Sonnet "blank stop" we observed in prod:
+// finish_reason=stop, no content, no tool_calls. CaptureMessage still writes
+// a row, which the matcher must learn to step over.
+func blankResponse() openrouter.CompletionResponse {
+	stop := "stop"
+	return openrouter.CompletionResponse{
+		Content:      "",
+		Model:        "test-model",
+		MessageID:    "msg-blank",
+		FinishReason: &stop,
+	}
+}
+
 // runTurn threads a single request through StartOrResumeChat + CaptureMessage
 // the same way the unified client does — so tests exercise the session handoff.
 func runTurn(t *testing.T, ctx context.Context, s *chat.ChatMessageCaptureStrategy, req openrouter.CompletionRequest, resp openrouter.CompletionResponse) {
@@ -380,6 +411,195 @@ func TestMatcher_ToolResultBodyDriftDoesNotBumpGeneration(t *testing.T) {
 	for i, r := range rows {
 		require.Equal(t, int32(0), r.Generation, "row %d stays on gen 0 — tool result body drift is not part of identity", i)
 	}
+}
+
+// A blank-stop assistant response ends up in the DB as content="",
+// tool_calls=null. The next turn's wire request omits that turn (no useful
+// parts to encode). Pre-fix this asymmetry tripped a generation bump on
+// every follow-up — the bug behind the gram-asst-prod crash loop on chat
+// 6d5bee05-9809-5678-8512-b3b2fb390120.
+func TestMatcher_StoredEmptyAssistantSkippedOnFollowUp(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	// Turn 1: real user → blank-stop response. Server stores [user, asst-empty].
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("hi")),
+		blankResponse(),
+	)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Len(t, rows, 2, "blank stop still produces an audit row")
+	require.Equal(t, "assistant", rows[1].Role)
+	require.Empty(t, rows[1].Content)
+
+	// Turn 2: client sends [user, user_new] — the empty asst is silently
+	// dropped from the wire. Matcher must skip the stored empty so the new
+	// user is the only row appended on gen 0.
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("hi"),
+			openrouter.CreateMessageUser("still there?"),
+		),
+		makeResponse("yes"),
+	)
+
+	rows = listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Len(t, rows, 4)
+	for i, r := range rows {
+		require.Equal(t, int32(0), r.Generation, "row %d stays on gen 0 — empty asst no longer trips divergence", i)
+	}
+	require.Equal(t, []string{"user", "assistant", "user", "assistant"}, roles(rows))
+}
+
+// Defensive: a client that sends `{role:asst, content:null, tool_calls:[]}`
+// in the wire request should not trip divergence either, regardless of
+// whether stored has the corresponding row.
+func TestMatcher_IncomingEmptyAssistantSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("first")),
+		makeResponse("real-1"),
+	)
+
+	// Replay with a phantom blank assistant inserted between the matched
+	// prefix and the new user message. Nothing in stored corresponds to it;
+	// the matcher must walk past it without consuming a stored row.
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("first"),
+			openrouter.CreateMessageAssistant("real-1"),
+			makeAssistantBlank(),
+			openrouter.CreateMessageUser("second"),
+		),
+		makeResponse("real-2"),
+	)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Len(t, rows, 4, "phantom empty asst is dropped from persistence too")
+	for i, r := range rows {
+		require.Equal(t, int32(0), r.Generation, "row %d stays on gen 0", i)
+	}
+	require.Equal(t, []string{"user", "assistant", "user", "assistant"}, roles(rows))
+}
+
+// Empty asst rows in the middle of stored history (not just at the end)
+// must also be skipped over so a real row past them can still match.
+func TestMatcher_StoredEmptyAssistantInMiddleSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	// Turn 1: user → blank stop.
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("u1")),
+		blankResponse(),
+	)
+	// Turn 2: client appends a real user follow-up; matcher skips the stored
+	// empty and stays on gen 0.
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("u1"),
+			openrouter.CreateMessageUser("u2"),
+		),
+		makeResponse("real"),
+	)
+	// Turn 3: replay full so far. The stored empty asst sits between user
+	// rows — middle of history, not the trailing slot.
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("u1"),
+			openrouter.CreateMessageUser("u2"),
+			openrouter.CreateMessageAssistant("real"),
+			openrouter.CreateMessageUser("u3"),
+		),
+		makeResponse("done"),
+	)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	for i, r := range rows {
+		require.Equal(t, int32(0), r.Generation, "row %d stays on gen 0 — mid-history empty does not block prefix match", i)
+	}
+}
+
+// Empty asst on both sides at the same position is the symmetric case:
+// stored and incoming each have a no-op turn, server matcher should not
+// confuse the two and should still match the surrounding rows by identity.
+func TestMatcher_EmptyAssistantOnBothSides(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("u1")),
+		blankResponse(),
+	)
+
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("u1"),
+			makeAssistantBlank(),
+			openrouter.CreateMessageUser("u2"),
+		),
+		makeResponse("ok"),
+	)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	for i, r := range rows {
+		require.Equal(t, int32(0), r.Generation, "row %d stays on gen 0", i)
+	}
+}
+
+// A mismatched real slot past a stored empty must still trip divergence —
+// empty-skip should not paper over a genuine edit/compaction.
+func TestMatcher_MismatchAfterEmptyStillDiverges(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+	s := newCaptureStrategy(t, conn)
+	chatID := uuid.New()
+
+	// Turn 1: stored ends up [user, asst-real].
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID, openrouter.CreateMessageUser("original")),
+		makeResponse("answer"),
+	)
+	// Turn 2: stored becomes [user, asst-real, user, asst-empty] (blank stop).
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("original"),
+			openrouter.CreateMessageAssistant("answer"),
+			openrouter.CreateMessageUser("ping"),
+		),
+		blankResponse(),
+	)
+	// Turn 3: client edits the FIRST user — divergence at position 0,
+	// regardless of whatever empties live downstream.
+	runTurn(t, ctx, s,
+		makeRequest(chatID, projectID, orgID,
+			openrouter.CreateMessageUser("edited"),
+		),
+		makeResponse("new answer"),
+	)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	gens := map[int32]int{}
+	for _, r := range rows {
+		gens[r.Generation]++
+	}
+	require.Positive(t, gens[1], "edit at index 0 still bumps generation past empties")
 }
 
 func roles(rows []repo.ChatMessage) []string {

--- a/server/internal/chat/message_capture_strategy_test.go
+++ b/server/internal/chat/message_capture_strategy_test.go
@@ -63,10 +63,9 @@ func makeAssistantToolOnly(toolCalls ...or.ChatToolCall) or.ChatMessages {
 	})
 }
 
-// makeAssistantBlank builds an assistant wire message with no content, no
-// tool_calls, and no tool_call_id — the shape some clients send for a
-// no-op/blank-stop turn (e.g. agentkit 0.4.0 emits this when it has no
-// usable parts to encode).
+// makeAssistantBlank builds an assistant wire message with null content,
+// no tool_calls, and no tool_call_id — the shape clients send for a no-op
+// turn.
 func makeAssistantBlank() or.ChatMessages {
 	return or.CreateChatMessagesAssistant(or.ChatAssistantMessage{
 		Role:             or.ChatAssistantMessageRoleAssistant,
@@ -81,9 +80,9 @@ func makeAssistantBlank() or.ChatMessages {
 	})
 }
 
-// blankResponse mimics the Anthropic Sonnet "blank stop" we observed in prod:
-// finish_reason=stop, no content, no tool_calls. CaptureMessage still writes
-// a row, which the matcher must learn to step over.
+// blankResponse builds a completion response with finish_reason=stop, no
+// content, and no tool_calls — the shape providers can emit for a no-op
+// turn. CaptureMessage still writes a row for it.
 func blankResponse() openrouter.CompletionResponse {
 	stop := "stop"
 	return openrouter.CompletionResponse{
@@ -413,11 +412,9 @@ func TestMatcher_ToolResultBodyDriftDoesNotBumpGeneration(t *testing.T) {
 	}
 }
 
-// A blank-stop assistant response ends up in the DB as content="",
-// tool_calls=null. The next turn's wire request omits that turn (no useful
-// parts to encode). Pre-fix this asymmetry tripped a generation bump on
-// every follow-up — the bug behind the gram-asst-prod crash loop on chat
-// 6d5bee05-9809-5678-8512-b3b2fb390120.
+// A blank-stop assistant row sits in stored as content="", tool_calls=null.
+// The next turn's wire request omits that turn entirely; the matcher must
+// step over the stored row instead of treating the asymmetry as divergence.
 func TestMatcher_StoredEmptyAssistantSkippedOnFollowUp(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes [AGE-2091](https://linear.app/speakeasy/issue/AGE-2091).

The chat-history generation matcher (`server/internal/chat/message_capture_strategy.go`) walked stored vs. incoming with a single shared index. A "blank stop" model response — Anthropic Sonnet extended thinking returning `finish_reason=stop` with no content, no tool_calls, and no usable reasoning — captured as an empty assistant row server-side but elided from the runner's next request (and any client that has no usable parts to encode). Treated as divergence, every blank-stop turn bumped the generation. Each divergence rewrote the full incoming as pending rows on the new generation, growing the cumulative snapshot quadratically until \`/configure\` exceeded axum's 2 MiB body limit and the fly machine crash-looped.

## Change

Two-pointer walk over `(stored, incoming)`:

- Skip empty stored row → advance stored only.
- Skip empty incoming row → advance incoming only (defensive — endpoint serves clients beyond agentkit).
- Both non-empty: compare slot. Mismatch → divergence; match → both advance.
- After the loop: drain trailing empties on both sides; remaining stored content → divergence; trailing incoming empties get folded into matchedPrefix so they aren't re-persisted by buildPendingRows.

Empty-asst predicate: `role=="assistant"` AND `content==""` AND no `tool_calls` AND no `tool_call_id`.

## Self-heal

Existing degenerate threads recover on the next user message: matcher walks the latest generation, steps over the stored empties, and attaches the new tail without bumping again. Old generation rows stay as audit history.

## Out of scope

- Suppressing CaptureMessage writes for blank-stop responses (keeps usage tracking + audit trail).
- Changing wire response delivered to runner.
- Persisting reasoning / thinking blocks (AGE-2093, investigation).
- Trimming old generations from \`/configure\` payload (AGE-2092, follow-up PR).

✻ Clauded...