### PR TITLE
chore: decouple MCP lifecycle from assistant runtime

### DIFF
--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -4,9 +4,7 @@ version = 4
 
 [[package]]
 name = "agentkit-adapter-completions"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d35e23e1e440ee78d0cd76d782a034c617cb7b6822c62c1847a08d1164949ce"
+version = "0.5.0"
 dependencies = [
  "agentkit-core",
  "agentkit-http",
@@ -23,9 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentkit-capabilities"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585b817b9afd02364d1eed29e6402db4aa3b5a01f85bf7021da89e3beca0dbe"
+version = "0.5.0"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -36,9 +32,7 @@ dependencies = [
 
 [[package]]
 name = "agentkit-compaction"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059ea229af00eab22249969eafacf79bb7925387aea6a12fa6be8b0e3a587ec5"
+version = "0.5.0"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -48,9 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentkit-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007e65131075df30197ff19b9b8713b2610b5c2c9e79ee3494d0b7dbb5d47f13"
+version = "0.5.0"
 dependencies = [
  "futures-timer",
  "serde",
@@ -60,9 +52,7 @@ dependencies = [
 
 [[package]]
 name = "agentkit-http"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f6146d599cebbb557abacd3ab53d5ee8af9f1dbf46e6f9d93e35429fab88b3"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -77,9 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentkit-loop"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd315eadf6bfef3c761efda18a4bf3961ea947399f8898a3c7820d3c9c7db78"
+version = "0.5.0"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-compaction",
@@ -93,30 +81,26 @@ dependencies = [
 
 [[package]]
 name = "agentkit-mcp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e9da02b6ace1c4dfb691477345a9d11a062459b51fbf0dfdb7b4797187b234"
+version = "0.5.0"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
- "agentkit-http",
  "agentkit-tools-core",
  "async-trait",
  "futures-util",
+ "http",
  "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
- "tokio-util",
- "url",
 ]
 
 [[package]]
 name = "agentkit-provider-openrouter"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c410400eb08d8f8f559dd65acac8b19ee3c336212c1109d28aca460e274fad28"
+version = "0.5.0"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",
@@ -126,13 +110,12 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "agentkit-reporting"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b718d001a0be945a960008273d24d90ef03495dc662faafc5135667c054d8c76"
+version = "0.5.0"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -144,9 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agentkit-task-manager"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc86b053198edc5a85adb66434bf5265d16979f25e8ad696ada4b50d0284bda6"
+version = "0.5.0"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -157,9 +138,7 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25603adbc32b315a944d1bef9dc34d88bebc67a702a8c1b179ebaa319e8b32a7"
+version = "0.5.0"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -167,6 +146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -353,6 +333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +392,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -497,6 +487,35 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -668,6 +687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +743,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
+ "rmcp",
  "serde",
  "serde_json",
  "tempfile",
@@ -1177,6 +1207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1234,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -1281,6 +1342,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,7 +1385,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1353,12 +1428,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1368,7 +1464,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1490,7 +1595,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -1505,6 +1610,31 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "http",
+ "oauth2",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1727,6 +1857,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +1912,19 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1968,6 +2122,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2287,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2135,6 +2307,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2291,6 +2469,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,6 +2500,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2330,6 +2540,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -2442,6 +2662,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -5,6 +5,7 @@ version = 4
 [[package]]
 name = "agentkit-adapter-completions"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-core",
  "agentkit-http",
@@ -22,6 +23,7 @@ dependencies = [
 [[package]]
 name = "agentkit-capabilities"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -33,6 +35,7 @@ dependencies = [
 [[package]]
 name = "agentkit-compaction"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -43,6 +46,7 @@ dependencies = [
 [[package]]
 name = "agentkit-core"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "futures-timer",
  "serde",
@@ -53,6 +57,7 @@ dependencies = [
 [[package]]
 name = "agentkit-http"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -68,6 +73,7 @@ dependencies = [
 [[package]]
 name = "agentkit-loop"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-compaction",
@@ -84,6 +90,7 @@ dependencies = [
 [[package]]
 name = "agentkit-mcp"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -103,6 +110,7 @@ dependencies = [
 [[package]]
 name = "agentkit-provider-openrouter"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",
@@ -118,6 +126,7 @@ dependencies = [
 [[package]]
 name = "agentkit-reporting"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -130,6 +139,7 @@ dependencies = [
 [[package]]
 name = "agentkit-task-manager"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -141,6 +151,7 @@ dependencies = [
 [[package]]
 name = "agentkit-tools-core"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -155,6 +166,7 @@ dependencies = [
 [[package]]
 name = "agentkit-tools-derive"
 version = "0.5.0"
+source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -5,7 +5,8 @@ version = 4
 [[package]]
 name = "agentkit-adapter-completions"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50009fd2d365dbb85549c06e9d3288bd2a64082b2a91d8f9386aa458305ec42b"
 dependencies = [
  "agentkit-core",
  "agentkit-http",
@@ -23,7 +24,8 @@ dependencies = [
 [[package]]
 name = "agentkit-capabilities"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479efd0d4054009a658e4f3681e9357ac1ef14c876f56ac488d9fe2ca35eb517"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -35,7 +37,8 @@ dependencies = [
 [[package]]
 name = "agentkit-compaction"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47993c44f2248e06c08bef7f376a4dfdd057eaf5f45455a72abaff012deb5ab6"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -46,7 +49,8 @@ dependencies = [
 [[package]]
 name = "agentkit-core"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fd0dc81f6c8b46b906ba4a897241dac44aa50a6df6b119321355090d6c4a60"
 dependencies = [
  "futures-timer",
  "serde",
@@ -57,7 +61,8 @@ dependencies = [
 [[package]]
 name = "agentkit-http"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e4e38c0cbb41b73f309efd4b56dfbc5ab1ec325eac7a1b292f67a33a7b79d3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -73,7 +78,8 @@ dependencies = [
 [[package]]
 name = "agentkit-loop"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5036a24359084af3a84428a707ddaf5db75c8441cc51f03260d7ddb048af2dc"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-compaction",
@@ -90,7 +96,8 @@ dependencies = [
 [[package]]
 name = "agentkit-mcp"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49810dc39bf10bb1d040bec14813502f98cfb41476b48833d3f822a66c688621"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -110,7 +117,8 @@ dependencies = [
 [[package]]
 name = "agentkit-provider-openrouter"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd7b9a3a1a439159bf2779d9b7f3482d81d556c7f6785a1756bddbdf3cc4158"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",
@@ -126,7 +134,8 @@ dependencies = [
 [[package]]
 name = "agentkit-reporting"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f63e996fa82d775847a62f91ea90ec319840cd378048345073db2dc1c9f6ba"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -139,7 +148,8 @@ dependencies = [
 [[package]]
 name = "agentkit-task-manager"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd72b0dd33a82f149b1573915ef184317bf7a34857d00afdc3fb6f06d4f6487"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -149,9 +159,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentkit-tool-fs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950fa82e4ff35281269935379505b1bf4e1a6a3ed16447945c9ab49d86713322"
+dependencies = [
+ "agentkit-core",
+ "agentkit-tools-core",
+ "async-fs",
+ "async-trait",
+ "futures-lite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "agentkit-tools-core"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d4bf392659aa60e655050b69ea514b6258b603e71b1eb94e3257d1163c85d1"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -166,7 +193,8 @@ dependencies = [
 [[package]]
 name = "agentkit-tools-derive"
 version = "0.5.0"
-source = "git+https://github.com/danielkov/agentkit.git?rev=32b313b#32b313bb2692bd4a7903374dca781df91f9c14f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e91d6e4b0844187cf75384aefffe50613df461801c5453308e77caec81ec1a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -248,6 +276,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,9 +340,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -282,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -352,9 +420,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -363,6 +431,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -379,21 +460,15 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -487,6 +562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +604,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -590,6 +680,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +717,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -669,6 +786,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -748,9 +878,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -764,6 +907,7 @@ dependencies = [
  "agentkit-mcp",
  "agentkit-provider-openrouter",
  "agentkit-reporting",
+ "agentkit-tool-fs",
  "agentkit-tools-core",
  "agentkit-tools-derive",
  "async-trait",
@@ -802,6 +946,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -885,15 +1038,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1031,6 +1183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1058,7 +1216,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1091,27 +1251,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1145,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1162,10 +1327,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.184"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1306,6 +1477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1524,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1550,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1417,7 +1615,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1459,6 +1657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1565,9 +1769,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -1647,7 +1851,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1696,6 +1900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1736,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1746,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -1773,9 +1986,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1866,6 +2079,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1981,6 +2200,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,7 +2327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2174,9 +2409,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2360,6 +2595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,18 +2670,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2451,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2461,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2471,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2484,11 +2734,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2502,6 +2774,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2520,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2540,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2670,15 +2954,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2702,21 +2977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2763,12 +3023,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2781,12 +3035,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2796,12 +3044,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2829,12 +3071,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2844,12 +3080,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2865,12 +3095,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2880,12 +3104,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2904,6 +3122,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -76,7 +76,9 @@ dependencies = [
  "agentkit-tools-core",
  "async-trait",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -143,10 +145,20 @@ dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
  "async-trait",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "agentkit-tools-derive"
+version = "0.5.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -535,6 +547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +753,7 @@ dependencies = [
  "agentkit-provider-openrouter",
  "agentkit-reporting",
  "agentkit-tools-core",
+ "agentkit-tools-derive",
  "async-trait",
  "axum",
  "chrono",
@@ -744,6 +763,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -1495,6 +1515,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1802,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1879,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -2,22 +2,22 @@
 name = "gram-assistant-runner"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.95"
 
 [[bin]]
 name = "gram-assistant-runner"
 path = "src/main.rs"
 
 [dependencies]
-agentkit-adapter-completions = { path = "../../../../agentkit/crates/agentkit-adapter-completions" }
-agentkit-core = { path = "../../../../agentkit/crates/agentkit-core" }
-agentkit-http = { path = "../../../../agentkit/crates/agentkit-http", features = ["reqwest-middleware-client"] }
-agentkit-loop = { path = "../../../../agentkit/crates/agentkit-loop" }
-agentkit-mcp = { path = "../../../../agentkit/crates/agentkit-mcp" }
-agentkit-provider-openrouter = { path = "../../../../agentkit/crates/agentkit-provider-openrouter" }
-agentkit-reporting = { path = "../../../../agentkit/crates/agentkit-reporting", features = ["tracing"] }
-agentkit-tools-core = { path = "../../../../agentkit/crates/agentkit-tools-core", features = ["schemars"] }
-agentkit-tools-derive = { path = "../../../../agentkit/crates/agentkit-tools-derive" }
+agentkit-adapter-completions = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
+agentkit-core = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
+agentkit-http = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b", features = ["reqwest-middleware-client"] }
+agentkit-loop = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
+agentkit-mcp = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
+agentkit-provider-openrouter = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
+agentkit-reporting = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b", features = ["tracing"] }
+agentkit-tools-core = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b", features = ["schemars"] }
+agentkit-tools-derive = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
 rmcp = { version = "1.5.0", default-features = false, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -16,7 +16,8 @@ agentkit-loop = { path = "../../../../agentkit/crates/agentkit-loop" }
 agentkit-mcp = { path = "../../../../agentkit/crates/agentkit-mcp" }
 agentkit-provider-openrouter = { path = "../../../../agentkit/crates/agentkit-provider-openrouter" }
 agentkit-reporting = { path = "../../../../agentkit/crates/agentkit-reporting", features = ["tracing"] }
-agentkit-tools-core = { path = "../../../../agentkit/crates/agentkit-tools-core" }
+agentkit-tools-core = { path = "../../../../agentkit/crates/agentkit-tools-core", features = ["schemars"] }
+agentkit-tools-derive = { path = "../../../../agentkit/crates/agentkit-tools-derive" }
 rmcp = { version = "1.5.0", default-features = false, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
@@ -29,6 +30,7 @@ http = "1"
 reqwest = "0.13.2"
 reqwest-middleware = "0.5"
 reqwest-retry = "0.9.1"
+schemars = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -2,21 +2,22 @@
 name = "gram-assistant-runner"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.92"
 
 [[bin]]
 name = "gram-assistant-runner"
 path = "src/main.rs"
 
 [dependencies]
-agentkit-adapter-completions = "0.4.0"
-agentkit-core = "0.4.0"
-agentkit-http = { version = "0.4.0", features = ["reqwest-middleware-client"] }
-agentkit-loop = "0.4.0"
-agentkit-mcp = "0.4.0"
-agentkit-provider-openrouter = "0.4.0"
-agentkit-reporting = { version = "0.4.0", features = ["tracing"] }
-agentkit-tools-core = "0.4.0"
+agentkit-adapter-completions = { path = "../../../../agentkit/crates/agentkit-adapter-completions" }
+agentkit-core = { path = "../../../../agentkit/crates/agentkit-core" }
+agentkit-http = { path = "../../../../agentkit/crates/agentkit-http", features = ["reqwest-middleware-client"] }
+agentkit-loop = { path = "../../../../agentkit/crates/agentkit-loop" }
+agentkit-mcp = { path = "../../../../agentkit/crates/agentkit-mcp" }
+agentkit-provider-openrouter = { path = "../../../../agentkit/crates/agentkit-provider-openrouter" }
+agentkit-reporting = { path = "../../../../agentkit/crates/agentkit-reporting", features = ["tracing"] }
+agentkit-tools-core = { path = "../../../../agentkit/crates/agentkit-tools-core" }
+rmcp = { version = "1.5.0", default-features = false, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -9,15 +9,16 @@ name = "gram-assistant-runner"
 path = "src/main.rs"
 
 [dependencies]
-agentkit-adapter-completions = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
-agentkit-core = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
-agentkit-http = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b", features = ["reqwest-middleware-client"] }
-agentkit-loop = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
-agentkit-mcp = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
-agentkit-provider-openrouter = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
-agentkit-reporting = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b", features = ["tracing"] }
-agentkit-tools-core = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b", features = ["schemars"] }
-agentkit-tools-derive = { git = "https://github.com/danielkov/agentkit.git", rev = "32b313b" }
+agentkit-adapter-completions = "0.5.0"
+agentkit-core = "0.5.0"
+agentkit-http = { version = "0.5.0", features = ["reqwest-middleware-client"] }
+agentkit-loop = "0.5.0"
+agentkit-mcp = "0.5.0"
+agentkit-provider-openrouter = "0.5.0"
+agentkit-reporting = { version = "0.5.0", features = ["tracing"] }
+agentkit-tool-fs = "0.5.0"
+agentkit-tools-core = { version = "0.5.0", features = ["schemars"] }
+agentkit-tools-derive = "0.5.0"
 rmcp = { version = "1.5.0", default-features = false, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/agents/runner/src/errors.rs
+++ b/agents/runner/src/errors.rs
@@ -76,9 +76,9 @@ impl RunnerError {
             | RunnerError::MissingToolCallId
             | RunnerError::ToolCallArguments { .. }
             | RunnerError::ConfigError { .. } => StatusCode::BAD_REQUEST,
-            RunnerError::AgentBuild(_)
-            | RunnerError::Loop(_)
-            | RunnerError::SubmitInput(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            RunnerError::AgentBuild(_) | RunnerError::Loop(_) | RunnerError::SubmitInput(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
         }
     }
 }

--- a/agents/runner/src/errors.rs
+++ b/agents/runner/src/errors.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use http::StatusCode;
 use thiserror::Error;
 
@@ -33,23 +31,11 @@ pub enum RunnerError {
     #[error("agent build failed: {0}")]
     AgentBuild(String),
 
-    #[error("mcp connect failed: {0}")]
-    McpConnect(String),
-
-    #[error("mcp connect timed out after {0:?}")]
-    McpConnectTimeout(Duration),
-
     #[error("agent session start failed: {0}")]
     AgentStart(String),
 
-    #[error("agent session start timed out after {0:?}")]
-    AgentStartTimeout(Duration),
-
     #[error("loop error: {0}")]
     Loop(String),
-
-    #[error("unexpected mcp auth interrupt — token likely expired or backend returned 403")]
-    McpAuthInterrupt,
 
     #[error("unsupported history role: {0}")]
     UnsupportedHistoryRole(String),
@@ -80,12 +66,9 @@ impl From<agentkit_loop::LoopError> for RunnerError {
 impl RunnerError {
     pub fn configure_status_code(&self) -> StatusCode {
         match self {
-            RunnerError::McpConnectTimeout(_) | RunnerError::AgentStartTimeout(_) => {
-                StatusCode::GATEWAY_TIMEOUT
+            RunnerError::AgentStart(_) | RunnerError::HttpClient(_) => {
+                StatusCode::SERVICE_UNAVAILABLE
             }
-            RunnerError::McpConnect(_)
-            | RunnerError::AgentStart(_)
-            | RunnerError::HttpClient(_) => StatusCode::SERVICE_UNAVAILABLE,
             RunnerError::McpHeaderName { .. }
             | RunnerError::McpHeaderValue { .. }
             | RunnerError::HeaderValue { .. }
@@ -95,7 +78,6 @@ impl RunnerError {
             | RunnerError::ConfigError { .. } => StatusCode::BAD_REQUEST,
             RunnerError::AgentBuild(_)
             | RunnerError::Loop(_)
-            | RunnerError::McpAuthInterrupt
             | RunnerError::SubmitInput(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/agents/runner/src/http_layer.rs
+++ b/agents/runner/src/http_layer.rs
@@ -114,9 +114,7 @@ impl McpRotatingClient {
         mut custom: HashMap<HeaderName, HeaderValue>,
     ) -> HashMap<HeaderName, HeaderValue> {
         for (name, value) in self.static_headers.iter() {
-            custom
-                .entry(name.clone())
-                .or_insert_with(|| value.clone());
+            custom.entry(name.clone()).or_insert_with(|| value.clone());
         }
         custom
     }
@@ -138,8 +136,15 @@ impl McpHttpClient for McpRotatingClient {
     ) -> Result<McpStreamableHttpPostResponse, McpStreamableHttpError<reqwest::Error>> {
         let token = self.current_token();
         let headers = self.merged_headers(custom_headers);
-        RmcpStreamableHttpClient::post_message(&self.inner, uri, message, session_id, token, headers)
-            .await
+        RmcpStreamableHttpClient::post_message(
+            &self.inner,
+            uri,
+            message,
+            session_id,
+            token,
+            headers,
+        )
+        .await
     }
 
     async fn delete_session(

--- a/agents/runner/src/http_layer.rs
+++ b/agents/runner/src/http_layer.rs
@@ -1,10 +1,17 @@
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use agentkit_http::Http;
+use agentkit_mcp::{
+    ClientJsonRpcMessage, McpHttpClient, McpSseStream, McpStreamableHttpError,
+    McpStreamableHttpPostResponse,
+};
 use async_trait::async_trait;
+use http::{HeaderMap, HeaderName, HeaderValue};
 use reqwest_middleware::{ClientBuilder, Middleware, Next};
 use reqwest_retry::RetryTransientMiddleware;
 use reqwest_retry::policies::ExponentialBackoff;
+use rmcp::transport::streamable_http_client::StreamableHttpClient as RmcpStreamableHttpClient;
 use thiserror::Error;
 
 use crate::errors::RunnerError;
@@ -40,6 +47,14 @@ impl TokenRegistry {
         *slot = next.into();
         Ok(())
     }
+
+    fn current(&self) -> Result<String, RunnerError> {
+        Ok(self
+            .inner
+            .read()
+            .map_err(|_| RunnerError::Loop("token registry read lock poisoned".into()))?
+            .clone())
+    }
 }
 
 #[async_trait]
@@ -62,32 +77,6 @@ impl Middleware for TokenRegistry {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct StaticHeaders {
-    headers: http::HeaderMap,
-}
-
-impl StaticHeaders {
-    pub fn new(headers: http::HeaderMap) -> Self {
-        Self { headers }
-    }
-}
-
-#[async_trait]
-impl Middleware for StaticHeaders {
-    async fn handle(
-        &self,
-        mut req: reqwest::Request,
-        extensions: &mut http::Extensions,
-        next: Next<'_>,
-    ) -> reqwest_middleware::Result<reqwest::Response> {
-        for (name, value) in &self.headers {
-            req.headers_mut().insert(name.clone(), value.clone());
-        }
-        next.run(req, extensions).await
-    }
-}
-
 pub fn build_http(client: reqwest::Client, registry: TokenRegistry) -> Http {
     let client = ClientBuilder::new(client)
         .with(retry_middleware())
@@ -96,20 +85,93 @@ pub fn build_http(client: reqwest::Client, registry: TokenRegistry) -> Http {
     Http::new(client)
 }
 
-pub fn build_http_with_static(
-    client: reqwest::Client,
-    registry: TokenRegistry,
-    static_headers: http::HeaderMap,
-) -> Http {
-    let client = ClientBuilder::new(client)
-        .with(retry_middleware())
-        .with(StaticHeaders::new(static_headers))
-        .with(registry)
-        .build();
-    Http::new(client)
-}
-
 fn retry_middleware() -> RetryTransientMiddleware<ExponentialBackoff> {
     let policy = ExponentialBackoff::builder().build_with_max_retries(HTTP_MAX_RETRIES);
     RetryTransientMiddleware::new_with_policy(policy).with_retry_log_level(tracing::Level::INFO)
+}
+
+/// `McpHttpClient` impl that mints a fresh bearer token per request from a
+/// shared [`TokenRegistry`]. Replaces the static `bearer_token` path in
+/// [`agentkit_mcp::StreamableHttpTransportConfig`] so token rotation does
+/// not require a reconnect.
+pub struct McpRotatingClient {
+    inner: reqwest::Client,
+    tokens: TokenRegistry,
+    static_headers: HeaderMap,
+}
+
+impl McpRotatingClient {
+    pub fn new(inner: reqwest::Client, tokens: TokenRegistry, static_headers: HeaderMap) -> Self {
+        Self {
+            inner,
+            tokens,
+            static_headers,
+        }
+    }
+
+    fn merged_headers(
+        &self,
+        mut custom: HashMap<HeaderName, HeaderValue>,
+    ) -> HashMap<HeaderName, HeaderValue> {
+        for (name, value) in self.static_headers.iter() {
+            custom
+                .entry(name.clone())
+                .or_insert_with(|| value.clone());
+        }
+        custom
+    }
+
+    fn current_token(&self) -> Option<String> {
+        self.tokens.current().ok()
+    }
+}
+
+#[async_trait]
+impl McpHttpClient for McpRotatingClient {
+    async fn post_message(
+        &self,
+        uri: Arc<str>,
+        message: ClientJsonRpcMessage,
+        session_id: Option<Arc<str>>,
+        _auth_header: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<McpStreamableHttpPostResponse, McpStreamableHttpError<reqwest::Error>> {
+        let token = self.current_token();
+        let headers = self.merged_headers(custom_headers);
+        RmcpStreamableHttpClient::post_message(&self.inner, uri, message, session_id, token, headers)
+            .await
+    }
+
+    async fn delete_session(
+        &self,
+        uri: Arc<str>,
+        session_id: Arc<str>,
+        _auth_header: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<(), McpStreamableHttpError<reqwest::Error>> {
+        let token = self.current_token();
+        let headers = self.merged_headers(custom_headers);
+        RmcpStreamableHttpClient::delete_session(&self.inner, uri, session_id, token, headers).await
+    }
+
+    async fn get_stream(
+        &self,
+        uri: Arc<str>,
+        session_id: Arc<str>,
+        last_event_id: Option<String>,
+        _auth_header: Option<String>,
+        custom_headers: HashMap<HeaderName, HeaderValue>,
+    ) -> Result<McpSseStream, McpStreamableHttpError<reqwest::Error>> {
+        let token = self.current_token();
+        let headers = self.merged_headers(custom_headers);
+        RmcpStreamableHttpClient::get_stream(
+            &self.inner,
+            uri,
+            session_id,
+            last_event_id,
+            token,
+            headers,
+        )
+        .await
+    }
 }

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -5,6 +5,7 @@ mod runtime;
 mod server;
 mod tools;
 mod wire;
+mod workdir;
 
 use std::net::SocketAddr;
 use std::process::ExitCode;

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -51,8 +51,11 @@ fn init_tracing() {
     // `assistant-runtime` log. RUST_LOG tunes the filter; default shows info+.
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,agentkit=trace")),
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new(
+                    "info,agentkit=trace,agentkit_loop=trace,agentkit_reporting=trace,agentkit_mcp=trace",
+                )
+            }),
         )
         .with_writer(std::io::stderr)
         .with_target(true)

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -13,7 +13,10 @@ use agentkit_mcp::{
 };
 use agentkit_provider_openrouter::{OpenRouterConfig, OpenRouterProvider};
 use agentkit_reporting::TracingReporter;
-use agentkit_tools_core::{PermissionChecker, ToolRegistry};
+use agentkit_tool_fs::{FileSystemToolPolicy, FileSystemToolResources};
+use agentkit_tools_core::{
+    CompositePermissionChecker, PathPolicy, PermissionDecision, ToolRegistry,
+};
 use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
@@ -23,6 +26,7 @@ use crate::http_layer::{McpRotatingClient, TokenRegistry, build_http};
 use crate::idempotency::IdempotencyCache;
 use crate::tools;
 use crate::wire::{McpServer, RunnerConfig, RunnerMessage, RunnerRequest};
+use crate::workdir::ASSISTANT_WORKDIR;
 
 const MCP_CMD_CAPACITY: usize = 32;
 
@@ -106,17 +110,6 @@ fn fingerprint(config: &RunnerConfig) -> u64 {
     hasher.finish()
 }
 
-struct AllowAll;
-
-impl PermissionChecker for AllowAll {
-    fn evaluate(
-        &self,
-        _request: &dyn agentkit_tools_core::PermissionRequest,
-    ) -> agentkit_tools_core::PermissionDecision {
-        agentkit_tools_core::PermissionDecision::Allow
-    }
-}
-
 pub async fn build_runtime(
     config: &RunnerConfig,
     shutdown: Arc<Notify>,
@@ -155,6 +148,19 @@ pub async fn build_runtime(
         tools::mcp_force_reconnect::McpForceReconnectTool::new(mcp_cmd_tx.clone()),
     );
 
+    // Sandbox helpers stay readable so user code can `import` them, but writes
+    // to those paths must fail so an assistant can't shadow `browser.ts` etc.
+    let permissions = CompositePermissionChecker::new(PermissionDecision::Allow).with_policy(
+        PathPolicy::new()
+            .allow_root(ASSISTANT_WORKDIR)
+            .read_only_root(format!("{ASSISTANT_WORKDIR}/node_modules"))
+            .read_only_root(format!("{ASSISTANT_WORKDIR}/browser.ts"))
+            .read_only_root(format!("{ASSISTANT_WORKDIR}/package.json")),
+    );
+
+    let fs_resources = FileSystemToolResources::new()
+        .with_policy(FileSystemToolPolicy::new().require_read_before_write(true));
+
     let base_url = config
         .completions_url
         .clone()
@@ -176,8 +182,10 @@ pub async fn build_runtime(
     let agent = Agent::builder()
         .model(adapter)
         .add_tool_source(native_tools)
+        .add_tool_source(agentkit_tool_fs::registry())
         .add_tool_source(mcp_source)
-        .permissions(AllowAll)
+        .permissions(permissions)
+        .resources(fs_resources)
         .observer(TracingReporter::new())
         .transcript(transcript)
         .build()

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -24,7 +24,6 @@ use crate::idempotency::IdempotencyCache;
 use crate::tools;
 use crate::wire::{McpServer, RunnerConfig, RunnerMessage, RunnerRequest};
 
-const SHUTDOWN_GRACE: Duration = Duration::from_secs(60);
 const MCP_CMD_CAPACITY: usize = 32;
 
 pub type AppState = Arc<AsyncMutex<RuntimeHost>>;
@@ -55,7 +54,10 @@ pub struct RuntimeHost {
 pub struct ConfiguredRuntime {
     tokens: TokenRegistry,
     inbox_tx: UnboundedSender<String>,
-    last_active: Arc<Mutex<Instant>>,
+    /// `None` while a turn is in flight; `Some(t)` when idle since `t`. The two
+    /// signals are inherently exclusive — a single optional instant prevents
+    /// representing "in-flight AND idle since X" by construction.
+    idle_since: Arc<Mutex<Option<Instant>>>,
     // Non-rotating fields of the RunnerConfig this runtime was built from.
     // `auth_token` is excluded — it rolls on every /turn — so a caller retrying
     // /configure with a refreshed token is still treated as an identical config.
@@ -65,11 +67,12 @@ pub struct ConfiguredRuntime {
 }
 
 impl ConfiguredRuntime {
-    pub fn last_active_ago(&self) -> Option<Duration> {
-        self.last_active
-            .lock()
-            .ok()
-            .map(|last| Instant::now().saturating_duration_since(*last))
+    pub fn idle_for(&self) -> Option<Duration> {
+        let guard = self.idle_since.lock().ok()?;
+        Some(match *guard {
+            None => Duration::ZERO,
+            Some(t) => Instant::now().saturating_duration_since(t),
+        })
     }
 
     pub fn rotate_token(&self, token: &str) -> Result<(), RunnerError> {
@@ -83,7 +86,11 @@ impl ConfiguredRuntime {
     pub fn enqueue(&self, request: RunnerRequest) -> Result<(), RunnerError> {
         self.inbox_tx
             .send(request.input)
-            .map_err(|_| RunnerError::SubmitInput("loop inbox closed".into()))
+            .map_err(|_| RunnerError::SubmitInput("loop inbox closed".into()))?;
+        // Mark busy synchronously so /state can't report a stale idle window
+        // between enqueue and the loop's mark_busy on AwaitingInput.
+        mark_busy(&self.idle_since);
+        Ok(())
     }
 }
 
@@ -96,7 +103,6 @@ fn fingerprint(config: &RunnerConfig) -> u64 {
     config.chat_id.hash(&mut hasher);
     config.mcp_servers.hash(&mut hasher);
     config.history.hash(&mut hasher);
-    config.warm_ttl_seconds.hash(&mut hasher);
     hasher.finish()
 }
 
@@ -145,11 +151,9 @@ pub async fn build_runtime(
     let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::channel(MCP_CMD_CAPACITY);
     let mcp_actor = tokio::spawn(run_mcp_actor(manager, mcp_cmd_rx));
 
-    let native_tools = ToolRegistry::new()
-        .with(tools::bun_run::bun_run)
-        .with(tools::mcp_force_reconnect::McpForceReconnectTool::new(
-            mcp_cmd_tx.clone(),
-        ));
+    let native_tools = ToolRegistry::new().with(tools::bun_run::bun_run).with(
+        tools::mcp_force_reconnect::McpForceReconnectTool::new(mcp_cmd_tx.clone()),
+    );
 
     let base_url = config
         .completions_url
@@ -187,19 +191,13 @@ pub async fn build_runtime(
         .await
         .map_err(|e| RunnerError::AgentStart(e.to_string()))?;
 
-    let warm_ttl = config
-        .warm_ttl_seconds
-        .map(Duration::from_secs)
-        .ok_or_else(|| RunnerError::ConfigError {
-            key: "warm_ttl".to_string(),
-        })?;
-    let last_active = Arc::new(Mutex::new(Instant::now()));
+    let idle_since = Arc::new(Mutex::new(Some(Instant::now())));
 
     let (inbox_tx, inbox_rx) = mpsc::unbounded_channel::<String>();
 
-    let loop_last_active = Arc::clone(&last_active);
+    let loop_idle_since = Arc::clone(&idle_since);
     let loop_handle = tokio::spawn(async move {
-        let outcome = run_loop(driver, inbox_rx, loop_last_active, warm_ttl).await;
+        let outcome = run_loop(driver, inbox_rx, loop_idle_since).await;
         match outcome {
             Ok(reason) => tracing::info!(reason = %reason, "loop exited"),
             Err(err) => tracing::error!(error = %err, "loop exited with error"),
@@ -212,7 +210,7 @@ pub async fn build_runtime(
     Ok(ConfiguredRuntime {
         tokens,
         inbox_tx,
-        last_active,
+        idle_since,
         fingerprint: fingerprint(config),
         _mcp_actor: mcp_actor,
         _loop_handle: loop_handle,
@@ -233,13 +231,12 @@ fn build_mcp_server_config(
                 source,
             }
         })?;
-        let value = http::HeaderValue::from_str(v).map_err(|source| {
-            RunnerError::McpHeaderValue {
+        let value =
+            http::HeaderValue::from_str(v).map_err(|source| RunnerError::McpHeaderValue {
                 server: server.id.clone(),
                 name: k.clone(),
                 source,
-            }
-        })?;
+            })?;
         server_headers.insert(name, value);
     }
     let mcp_http = Arc::new(McpRotatingClient::new(
@@ -292,18 +289,19 @@ async fn run_mcp_actor(mut manager: McpServerManager, mut cmd_rx: mpsc::Receiver
     }
 }
 
-/// Drives the agent loop until warm TTL + grace elapse idle, or a fatal
-/// error occurs. Input arrives via `inbox`; `/turn` pushes there and returns
-/// immediately. The driver's transcript is preloaded with instructions +
-/// history, so the very first `next()` yields `AwaitingInput` and the first
-/// /turn supplies the first user message — same code path as every later turn.
+/// Drives the agent loop until the inbox closes or a fatal error occurs.
+/// Lifecycle (warm-window eviction, shutdown) is owned by the backend, which
+/// polls `/state` for `idle_seconds` and stops the runner externally.
+///
+/// Input arrives via `inbox`; `/turn` pushes there and returns immediately.
+/// The driver's transcript is preloaded with instructions + history, so the
+/// very first `next()` yields `AwaitingInput` and the first `/turn` supplies
+/// the first user message — same code path as every later turn.
 ///
 /// Agent loop events the runner cares about:
-/// - `LoopStep::Finished`: turn ended. Loop back into `next()`; the driver
-///   will yield `AwaitingInput` once it has nothing pending, where we wait.
-/// - `LoopInterrupt::AwaitingInput`: drain queued inputs and submit. If none,
-///   race a timer (warm_ttl + 60s grace) against the next inbox arrival.
-///   Timer wins -> exit.
+/// - `LoopStep::Finished`: turn ended. Mark idle and loop back into `next()`.
+/// - `LoopInterrupt::AwaitingInput`: drain queued inputs and submit, or block
+///   on the inbox until the next message (or close).
 /// - `LoopInterrupt::AfterToolResult`: cooperative mid-turn yield. Drain any
 ///   queued inputs and submit before the next model call.
 /// - `LoopInterrupt::ApprovalRequest`: tools in this environment should not
@@ -311,43 +309,32 @@ async fn run_mcp_actor(mut manager: McpServerManager, mut cmd_rx: mpsc::Receiver
 async fn run_loop<S>(
     mut driver: LoopDriver<S>,
     mut inbox: UnboundedReceiver<String>,
-    last_active: Arc<Mutex<Instant>>,
-    warm_ttl: Duration,
+    idle_since: Arc<Mutex<Option<Instant>>>,
 ) -> Result<&'static str, RunnerError>
 where
     S: ModelSession,
 {
-    bump(&last_active);
     loop {
         match driver.next().await? {
             LoopStep::Finished(_turn) => {
-                bump(&last_active);
+                mark_idle(&idle_since);
             }
             LoopStep::Interrupt(LoopInterrupt::AwaitingInput(req)) => {
                 let drained = drain(&mut inbox);
                 if !drained.is_empty() {
+                    mark_busy(&idle_since);
                     req.submit(&mut driver, drained_into_items(drained))?;
-                    bump(&last_active);
                     continue;
                 }
-                let wait_budget = warm_ttl + SHUTDOWN_GRACE;
-                tokio::select! {
-                    maybe = inbox.recv() => {
-                        match maybe {
-                            Some(msg) => {
-                                req.submit(&mut driver, vec![Item::text(ItemKind::User, &msg)])?;
-                                bump(&last_active);
-                            }
-                            None => return Ok("inbox closed"),
-                        }
+                match inbox.recv().await {
+                    Some(msg) => {
+                        mark_busy(&idle_since);
+                        req.submit(&mut driver, vec![Item::text(ItemKind::User, &msg)])?;
                     }
-                    _ = tokio::time::sleep(wait_budget) => {
-                        return Ok("warm ttl elapsed");
-                    }
+                    None => return Ok("inbox closed"),
                 }
             }
             LoopStep::Interrupt(LoopInterrupt::AfterToolResult(info)) => {
-                bump(&last_active);
                 let drained = drain(&mut inbox);
                 if !drained.is_empty() {
                     info.submit(&mut driver, drained_into_items(drained))?;
@@ -379,9 +366,15 @@ fn drain(inbox: &mut UnboundedReceiver<String>) -> Vec<String> {
     out
 }
 
-fn bump(last_active: &Arc<Mutex<Instant>>) {
-    if let Ok(mut slot) = last_active.lock() {
-        *slot = Instant::now();
+fn mark_busy(idle_since: &Arc<Mutex<Option<Instant>>>) {
+    if let Ok(mut slot) = idle_since.lock() {
+        *slot = None;
+    }
+}
+
+fn mark_idle(idle_since: &Arc<Mutex<Option<Instant>>>) {
+    if let Ok(mut slot) = idle_since.lock() {
+        *slot = Some(Instant::now());
     }
 }
 

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -146,7 +146,7 @@ pub async fn build_runtime(
     let mcp_actor = tokio::spawn(run_mcp_actor(manager, mcp_cmd_rx));
 
     let native_tools = ToolRegistry::new()
-        .with(tools::bun_run::BunRunTool::default())
+        .with(tools::bun_run::bun_run)
         .with(tools::mcp_force_reconnect::McpForceReconnectTool::new(
             mcp_cmd_tx.clone(),
         ));
@@ -163,26 +163,27 @@ pub async fn build_runtime(
     let completions_http = build_http(http_client.clone(), tokens.clone());
     let adapter = CompletionsAdapter::with_client(provider, completions_http);
 
-    let agent = Agent::builder()
-        .model(adapter)
-        .add_tool_source(native_tools)
-        .add_tool_source(mcp_source)
-        .permissions(AllowAll)
-        .observer(TracingReporter::new())
-        .build()
-        .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
-
     let mut transcript = Vec::new();
     if let Some(instructions) = &config.instructions {
         transcript.push(Item::text(ItemKind::System, instructions));
     }
     transcript.extend(normalize_history(&config.history)?);
 
+    let agent = Agent::builder()
+        .model(adapter)
+        .add_tool_source(native_tools)
+        .add_tool_source(mcp_source)
+        .permissions(AllowAll)
+        .observer(TracingReporter::new())
+        .transcript(transcript)
+        .build()
+        .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
+
     let session = SessionConfig::new(config.chat_id.clone())
         .with_cache(PromptCacheRequest::automatic().with_retention(PromptCacheRetention::Short));
 
     let driver = agent
-        .start(session, transcript)
+        .start(session)
         .await
         .map_err(|e| RunnerError::AgentStart(e.to_string()))?;
 

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -4,30 +4,44 @@ use std::time::{Duration, Instant};
 use agentkit_adapter_completions::CompletionsAdapter;
 use agentkit_core::{Item, ItemKind, Part, TextPart, ToolCallPart, ToolOutput, ToolResultPart};
 use agentkit_loop::{
-    Agent, LoopDriver, LoopInterrupt, LoopStep, PromptCacheRequest, PromptCacheRetention,
-    SessionConfig,
+    Agent, LoopDriver, LoopInterrupt, LoopStep, ModelSession, PromptCacheRequest,
+    PromptCacheRetention, SessionConfig,
 };
 use agentkit_mcp::{
-    McpServerConfig, McpServerManager, McpTransportBinding, StreamableHttpTransportConfig,
+    McpServerConfig, McpServerId, McpServerManager, McpTransportBinding,
+    StreamableHttpTransportConfig,
 };
 use agentkit_provider_openrouter::{OpenRouterConfig, OpenRouterProvider};
 use agentkit_reporting::TracingReporter;
-use agentkit_tools_core::PermissionChecker;
+use agentkit_tools_core::{PermissionChecker, ToolRegistry};
 use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tokio::sync::{Mutex as AsyncMutex, Notify};
+use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
 
 use crate::errors::RunnerError;
-use crate::http_layer::{TokenRegistry, build_http, build_http_with_static};
+use crate::http_layer::{McpRotatingClient, TokenRegistry, build_http};
 use crate::idempotency::IdempotencyCache;
 use crate::tools;
 use crate::wire::{McpServer, RunnerConfig, RunnerMessage, RunnerRequest};
 
-const MCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-const AGENT_START_TIMEOUT: Duration = Duration::from_secs(30);
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(60);
+const MCP_CMD_CAPACITY: usize = 32;
 
 pub type AppState = Arc<AsyncMutex<RuntimeHost>>;
+
+/// Commands routed to the MCP manager actor task. Instead of sharing the
+/// `McpServerManager` behind a mutex, we keep it private to a single task and
+/// drive it through this channel; the parent only ever sees the read-side
+/// [`agentkit_tools_core::CatalogReader`] returned by `manager.source()`.
+pub enum McpCmd {
+    /// Force a server to disconnect and reconnect from scratch. Surfaced to
+    /// the assistant via the `mcp_force_reconnect` tool so the model can
+    /// recover from transport-level errors without operator intervention.
+    ForceReconnect {
+        server_id: McpServerId,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+}
 
 pub struct RuntimeHost {
     pub runtime: Option<ConfiguredRuntime>,
@@ -46,10 +60,7 @@ pub struct ConfiguredRuntime {
     // `auth_token` is excluded — it rolls on every /turn — so a caller retrying
     // /configure with a refreshed token is still treated as an identical config.
     fingerprint: u64,
-    // Held so MCP transports outlive the session; dropping the manager would
-    // disconnect the streamable-http transports the tool registry references.
-    _mcp_manager: McpServerManager,
-    // Loop task handle; dropping aborts the task on runtime drop.
+    _mcp_actor: tokio::task::JoinHandle<()>,
     _loop_handle: tokio::task::JoinHandle<()>,
 }
 
@@ -125,8 +136,20 @@ pub async fn build_runtime(
         .default_headers(default_headers)
         .build()?;
 
-    let manager =
-        connect_mcp_servers(&config.mcp_servers, http_client.clone(), tokens.clone()).await?;
+    let mut manager = McpServerManager::new();
+    for server in &config.mcp_servers {
+        manager.register_server(build_mcp_server_config(server, &http_client, &tokens)?);
+    }
+    let mcp_source = manager.source();
+
+    let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::channel(MCP_CMD_CAPACITY);
+    let mcp_actor = tokio::spawn(run_mcp_actor(manager, mcp_cmd_rx));
+
+    let native_tools = ToolRegistry::new()
+        .with(tools::bun_run::BunRunTool::default())
+        .with(tools::mcp_force_reconnect::McpForceReconnectTool::new(
+            mcp_cmd_tx.clone(),
+        ));
 
     let base_url = config
         .completions_url
@@ -137,40 +160,31 @@ pub async fn build_runtime(
     let openrouter_config =
         OpenRouterConfig::new(String::new(), config.model.clone()).with_base_url(base_url);
     let provider = OpenRouterProvider::from(openrouter_config);
-    let completions_http = build_http(http_client, tokens.clone());
+    let completions_http = build_http(http_client.clone(), tokens.clone());
     let adapter = CompletionsAdapter::with_client(provider, completions_http);
 
-    let combined = tools::bun_run::registry().merge(manager.tool_registry());
     let agent = Agent::builder()
         .model(adapter)
-        .tools(combined)
+        .add_tool_source(native_tools)
+        .add_tool_source(mcp_source)
         .permissions(AllowAll)
         .observer(TracingReporter::new())
         .build()
         .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
 
+    let mut transcript = Vec::new();
+    if let Some(instructions) = &config.instructions {
+        transcript.push(Item::text(ItemKind::System, instructions));
+    }
+    transcript.extend(normalize_history(&config.history)?);
+
     let session = SessionConfig::new(config.chat_id.clone())
         .with_cache(PromptCacheRequest::automatic().with_retention(PromptCacheRetention::Short));
-    let mut driver = match tokio::time::timeout(AGENT_START_TIMEOUT, agent.start(session)).await {
-        Ok(Ok(driver)) => driver,
-        Ok(Err(e)) => return Err(RunnerError::AgentStart(e.to_string())),
-        Err(_) => return Err(RunnerError::AgentStartTimeout(AGENT_START_TIMEOUT)),
-    };
 
-    // Prime the driver with instructions + persisted transcript once, here.
-    // submit_input only stages items — the model isn't called until the loop
-    // calls next(), which happens after the first /turn arrives. So the loop
-    // comes up already hydrated; /turn carries only new user input.
-    let mut priming = Vec::new();
-    if let Some(instructions) = &config.instructions {
-        priming.push(Item::text(ItemKind::System, instructions));
-    }
-    priming.extend(normalize_history(&config.history)?);
-    if !priming.is_empty() {
-        driver
-            .submit_input(priming)
-            .map_err(|e| RunnerError::SubmitInput(e.to_string()))?;
-    }
+    let driver = agent
+        .start(session, transcript)
+        .await
+        .map_err(|e| RunnerError::AgentStart(e.to_string()))?;
 
     let warm_ttl = config
         .warm_ttl_seconds
@@ -199,76 +213,98 @@ pub async fn build_runtime(
         inbox_tx,
         last_active,
         fingerprint: fingerprint(config),
-        _mcp_manager: manager,
+        _mcp_actor: mcp_actor,
         _loop_handle: loop_handle,
     })
 }
 
-async fn connect_mcp_servers(
-    servers: &[McpServer],
-    http_client: reqwest::Client,
-    tokens: TokenRegistry,
-) -> Result<McpServerManager, RunnerError> {
-    let mut manager = McpServerManager::new();
-    for server in servers {
-        let static_headers = server
-            .headers
-            .iter()
-            .map(|(k, v)| {
-                let name = http::HeaderName::from_bytes(k.as_bytes()).map_err(|source| {
-                    RunnerError::McpHeaderName {
-                        server: server.id.clone(),
-                        name: k.clone(),
-                        source,
-                    }
-                })?;
-                let value = http::HeaderValue::from_str(v).map_err(|source| {
-                    RunnerError::McpHeaderValue {
-                        server: server.id.clone(),
-                        name: k.clone(),
-                        source,
-                    }
-                })?;
-                Ok::<_, RunnerError>((name, value))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+fn build_mcp_server_config(
+    server: &McpServer,
+    http_client: &reqwest::Client,
+    tokens: &TokenRegistry,
+) -> Result<McpServerConfig, RunnerError> {
+    let mut server_headers = http::HeaderMap::new();
+    for (k, v) in &server.headers {
+        let name = http::HeaderName::from_bytes(k.as_bytes()).map_err(|source| {
+            RunnerError::McpHeaderName {
+                server: server.id.clone(),
+                name: k.clone(),
+                source,
+            }
+        })?;
+        let value = http::HeaderValue::from_str(v).map_err(|source| {
+            RunnerError::McpHeaderValue {
+                server: server.id.clone(),
+                name: k.clone(),
+                source,
+            }
+        })?;
+        server_headers.insert(name, value);
+    }
+    let mcp_http = Arc::new(McpRotatingClient::new(
+        http_client.clone(),
+        tokens.clone(),
+        server_headers,
+    ));
+    let transport = StreamableHttpTransportConfig::new(&server.url).with_http_client(mcp_http);
+    Ok(McpServerConfig::new(
+        &server.id,
+        McpTransportBinding::StreamableHttp(transport),
+    ))
+}
 
-        let mut server_headers = http::HeaderMap::new();
-        for (name, value) in static_headers {
-            server_headers.insert(name, value);
-        }
-        let http = build_http_with_static(http_client.clone(), tokens.clone(), server_headers);
-        let transport = StreamableHttpTransportConfig::new(&server.url).with_client(http);
-        manager = manager.with_server(McpServerConfig::new(
-            &server.id,
-            McpTransportBinding::StreamableHttp(transport),
-        ));
+/// Owns the [`McpServerManager`] for the lifetime of a runtime. Connects every
+/// registered server in the background — `/configure` does not wait — and
+/// processes [`McpCmd`]s serially so the manager never needs to be shared.
+async fn run_mcp_actor(mut manager: McpServerManager, mut cmd_rx: mpsc::Receiver<McpCmd>) {
+    match manager.connect_all().await {
+        Ok(handles) => tracing::info!(servers = handles.len(), "mcp connect_all ok"),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "mcp connect_all failed; affected tools will surface errors and the model can call mcp_force_reconnect"
+        ),
     }
 
-    match tokio::time::timeout(MCP_CONNECT_TIMEOUT, manager.connect_all()).await {
-        Ok(Ok(handles)) => {
-            tracing::info!(servers = handles.len(), "mcp connect_all ok");
-            Ok(manager)
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            McpCmd::ForceReconnect { server_id, reply } => {
+                if let Err(e) = manager.disconnect_server(&server_id).await {
+                    tracing::debug!(server_id = %server_id, error = %e, "disconnect during force reconnect");
+                }
+                let result = match manager.connect_server(&server_id).await {
+                    Ok(handle) => {
+                        tracing::info!(
+                            server_id = %server_id,
+                            tools = handle.snapshot().tools.len(),
+                            "mcp force reconnect ok"
+                        );
+                        Ok(())
+                    }
+                    Err(e) => {
+                        tracing::warn!(server_id = %server_id, error = %e, "mcp force reconnect failed");
+                        Err(e.to_string())
+                    }
+                };
+                let _ = reply.send(result);
+            }
         }
-        Ok(Err(e)) => Err(RunnerError::McpConnect(e.to_string())),
-        Err(_) => Err(RunnerError::McpConnectTimeout(MCP_CONNECT_TIMEOUT)),
     }
 }
 
-/// Runs the agent loop continuously until warm TTL + grace elapse idle, or
-/// a fatal error occurs. Input arrives via `inbox`; `/turn` pushes there and
-/// returns immediately. The driver is already primed with instructions and
-/// history from `build_runtime`, so the loop just wraps each String as a user
-/// Item and submits.
+/// Drives the agent loop until warm TTL + grace elapse idle, or a fatal
+/// error occurs. Input arrives via `inbox`; `/turn` pushes there and returns
+/// immediately. The driver's transcript is preloaded with instructions +
+/// history, so the very first `next()` yields `AwaitingInput` and the first
+/// /turn supplies the first user message — same code path as every later turn.
 ///
 /// Agent loop events the runner cares about:
-/// - `LoopStep::Finished`: turn ended. Drain any queued inputs and submit; if
-///   the queue was empty, race a timer (warm_ttl + 60s grace) against the next
-///   inbox arrival. Timer wins -> exit.
-/// - `LoopInterrupt::AfterToolResult`: cooperative mid-turn yield (agentkit
-///   0.4+). Drain any queued inputs and submit before the next model call.
-/// - `LoopInterrupt::AuthRequest`: backend token rotation is the correct fix
-///   for expired MCP auth; we cannot resolve it here. Warn and bail.
+/// - `LoopStep::Finished`: turn ended. Loop back into `next()`; the driver
+///   will yield `AwaitingInput` once it has nothing pending, where we wait.
+/// - `LoopInterrupt::AwaitingInput`: drain queued inputs and submit. If none,
+///   race a timer (warm_ttl + 60s grace) against the next inbox arrival.
+///   Timer wins -> exit.
+/// - `LoopInterrupt::AfterToolResult`: cooperative mid-turn yield. Drain any
+///   queued inputs and submit before the next model call.
 /// - `LoopInterrupt::ApprovalRequest`: tools in this environment should not
 ///   require approval. Warn and auto-approve so we don't deadlock.
 async fn run_loop<S>(
@@ -278,32 +314,27 @@ async fn run_loop<S>(
     warm_ttl: Duration,
 ) -> Result<&'static str, RunnerError>
 where
-    S: agentkit_loop::ModelSession,
+    S: ModelSession,
 {
-    let Some(first) = inbox.recv().await else {
-        return Ok("inbox closed before first input");
-    };
-    submit_user(&mut driver, first)?;
     bump(&last_active);
-
     loop {
         match driver.next().await? {
             LoopStep::Finished(_turn) => {
                 bump(&last_active);
+            }
+            LoopStep::Interrupt(LoopInterrupt::AwaitingInput(req)) => {
                 let drained = drain(&mut inbox);
                 if !drained.is_empty() {
-                    for msg in drained {
-                        submit_user(&mut driver, msg)?;
-                    }
+                    req.submit(&mut driver, drained_into_items(drained))?;
+                    bump(&last_active);
                     continue;
                 }
                 let wait_budget = warm_ttl + SHUTDOWN_GRACE;
-                // Race: new input vs shutdown timer.
                 tokio::select! {
                     maybe = inbox.recv() => {
                         match maybe {
                             Some(msg) => {
-                                submit_user(&mut driver, msg)?;
+                                req.submit(&mut driver, vec![Item::text(ItemKind::User, &msg)])?;
                                 bump(&last_active);
                             }
                             None => return Ok("inbox closed"),
@@ -314,39 +345,29 @@ where
                     }
                 }
             }
-            LoopStep::Interrupt(LoopInterrupt::AfterToolResult(_info)) => {
+            LoopStep::Interrupt(LoopInterrupt::AfterToolResult(info)) => {
                 bump(&last_active);
                 let drained = drain(&mut inbox);
-                for msg in drained {
-                    submit_user(&mut driver, msg)?;
+                if !drained.is_empty() {
+                    info.submit(&mut driver, drained_into_items(drained))?;
                 }
             }
-            LoopStep::Interrupt(LoopInterrupt::ApprovalRequest(_req)) => {
+            LoopStep::Interrupt(LoopInterrupt::ApprovalRequest(pending)) => {
                 tracing::warn!(
                     "unexpected approval request — runner auto-approves; tools should \
                      not require approval in this environment"
                 );
-                driver.resolve_approval(agentkit_tools_core::ApprovalDecision::Approve)?;
+                pending.approve(&mut driver)?;
             }
-            LoopStep::Interrupt(LoopInterrupt::AuthRequest(req)) => {
-                tracing::warn!(
-                    "unexpected mcp auth interrupt — token likely expired or backend returned 403"
-                );
-                driver.resolve_auth(agentkit_tools_core::AuthResolution::cancelled(req.request))?;
-                return Err(RunnerError::McpAuthInterrupt);
-            }
-            LoopStep::Interrupt(LoopInterrupt::AwaitingInput(_)) => {}
         }
     }
 }
 
-fn submit_user<S>(driver: &mut LoopDriver<S>, input: String) -> Result<(), RunnerError>
-where
-    S: agentkit_loop::ModelSession,
-{
-    driver
-        .submit_input(vec![Item::text(ItemKind::User, &input)])
-        .map_err(|e| RunnerError::SubmitInput(e.to_string()))
+fn drained_into_items(drained: Vec<String>) -> Vec<Item> {
+    drained
+        .into_iter()
+        .map(|s| Item::text(ItemKind::User, &s))
+        .collect()
 }
 
 fn drain(inbox: &mut UnboundedReceiver<String>) -> Vec<String> {

--- a/agents/runner/src/server.rs
+++ b/agents/runner/src/server.rs
@@ -46,10 +46,10 @@ async fn state_handler(State(state): State<AppState>) -> Json<RunnerStateRespons
     let guard = state.lock().await;
     Json(RunnerStateResponse {
         configured: guard.runtime.is_some(),
-        last_active_seconds_ago: guard
+        idle_seconds: guard
             .runtime
             .as_ref()
-            .and_then(|rt| rt.last_active_ago())
+            .and_then(|rt| rt.idle_for())
             .map(|d| d.as_secs()),
     })
 }
@@ -143,6 +143,6 @@ mod tests {
         let Json(response) = state_handler(State(state_value)).await;
 
         assert!(!response.configured);
-        assert!(response.last_active_seconds_ago.is_none());
+        assert!(response.idle_seconds.is_none());
     }
 }

--- a/agents/runner/src/tools/bun_run.rs
+++ b/agents/runner/src/tools/bun_run.rs
@@ -2,10 +2,9 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use agentkit_core::{MetadataMap, ToolOutput, ToolResultPart};
-use agentkit_tools_core::{
-    Tool, ToolAnnotations, ToolContext, ToolError, ToolName, ToolRequest, ToolResult, ToolSpec,
-};
-use async_trait::async_trait;
+use agentkit_tools_core::{ToolError, ToolResult};
+use agentkit_tools_derive::tool;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
 use tempfile::TempDir;
@@ -18,17 +17,18 @@ const STDERR_LIMIT: usize = 10_000;
 const SCRIPT_NAME: &str = "script.ts";
 const SANDBOX_ROOT: &str = "/tmp/bun-sandbox";
 
-#[derive(Clone, Debug)]
-pub struct BunRunTool {
-    spec: ToolSpec,
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct BunRunInput {
+    /// JavaScript or TypeScript source to execute via Bun.
+    pub code: String,
+    /// Optional per-call wall-clock timeout in milliseconds. Defaults to 600_000.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
 }
 
-impl Default for BunRunTool {
-    fn default() -> Self {
-        Self {
-            spec: ToolSpec {
-                name: ToolName::new("bun_run"),
-                description: "Execute JavaScript or TypeScript code using the Bun runtime. \
+#[tool(
+    destructive,
+    description = "Execute JavaScript or TypeScript code using the Bun runtime. \
 Working directory is a fresh per-call tempdir; `playwright-core` is preinstalled. \
 A headless Chromium-compatible browser (lightpanda) is available — prefer \
 `import { withContext } from './browser'` and run page work inside the callback \
@@ -39,99 +39,59 @@ For LLM-friendly page reading, `import { markdown } from './browser'` and call \
 `markdown(page)` to get `{ title, byline, markdown }`; it runs Readability over \
 the page HTML and serializes to Markdown. Pass `{ readable: false }` for non-article \
 pages (list/index pages) where Readability extraction is not helpful."
-                    .into(),
-                input_schema: json!({
-                    "type": "object",
-                    "properties": {
-                        "code": { "type": "string" },
-                        "timeout_ms": { "type": "integer", "minimum": 1 }
-                    },
-                    "required": ["code"],
-                    "additionalProperties": false
-                }),
-                annotations: ToolAnnotations {
-                    destructive_hint: true,
-                    needs_approval_hint: false,
-                    ..ToolAnnotations::default()
-                },
-                metadata: MetadataMap::new(),
-            },
-        }
-    }
-}
+)]
+pub async fn bun_run(input: BunRunInput) -> Result<ToolResult, ToolError> {
+    let workdir = TempDir::with_prefix("bun-sandbox-")
+        .map_err(|e| ToolError::ExecutionFailed(format!("tempdir failed: {e}")))?;
 
-#[derive(Debug, Deserialize)]
-struct BunRunInput {
-    code: String,
-    timeout_ms: Option<u64>,
-}
+    link_sandbox_assets(workdir.path())?;
+    let file_path = workdir.path().join(SCRIPT_NAME);
 
-#[async_trait]
-impl Tool for BunRunTool {
-    fn spec(&self) -> &ToolSpec {
-        &self.spec
-    }
+    tokio::fs::write(&file_path, &input.code)
+        .await
+        .map_err(|e| ToolError::ExecutionFailed(format!("write failed: {e}")))?;
 
-    async fn invoke(
-        &self,
-        request: ToolRequest,
-        _ctx: &mut ToolContext<'_>,
-    ) -> Result<ToolResult, ToolError> {
-        let input: BunRunInput = serde_json::from_value(request.input.clone())
-            .map_err(|e| ToolError::InvalidInput(format!("invalid bun_run input: {e}")))?;
+    let dur = input
+        .timeout_ms
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_TIMEOUT);
 
-        let workdir = TempDir::with_prefix("bun-sandbox-")
-            .map_err(|e| ToolError::ExecutionFailed(format!("tempdir failed: {e}")))?;
+    let start = Instant::now();
 
-        link_sandbox_assets(workdir.path())?;
-        let file_path = workdir.path().join(SCRIPT_NAME);
+    let mut cmd = Command::new("/usr/local/bin/bun");
+    cmd.arg("run").arg(SCRIPT_NAME).current_dir(workdir.path());
+    cmd.env("NO_COLOR", "1");
+    cmd.kill_on_drop(true);
 
-        tokio::fs::write(&file_path, &input.code)
-            .await
-            .map_err(|e| ToolError::ExecutionFailed(format!("write failed: {e}")))?;
+    let output = timeout(dur, cmd.output())
+        .await
+        .map_err(|_| {
+            ToolError::ExecutionFailed(format!("bun timed out after {}ms", dur.as_millis()))
+        })?
+        .map_err(|e| ToolError::ExecutionFailed(format!("spawn failed: {e}")))?;
 
-        let dur = input
-            .timeout_ms
-            .map(Duration::from_millis)
-            .unwrap_or(DEFAULT_TIMEOUT);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout_truncated = stdout.len() > STDOUT_LIMIT;
+    let stderr_truncated = stderr.len() > STDERR_LIMIT;
+    let exit_code = output.status.code();
 
-        let start = Instant::now();
-
-        let mut cmd = Command::new("/usr/local/bin/bun");
-        cmd.arg("run").arg(SCRIPT_NAME).current_dir(workdir.path());
-        cmd.env("NO_COLOR", "1");
-        cmd.kill_on_drop(true);
-
-        let output = timeout(dur, cmd.output())
-            .await
-            .map_err(|_| {
-                ToolError::ExecutionFailed(format!("bun timed out after {}ms", dur.as_millis()))
-            })?
-            .map_err(|e| ToolError::ExecutionFailed(format!("spawn failed: {e}")))?;
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout_truncated = stdout.len() > STDOUT_LIMIT;
-        let stderr_truncated = stderr.len() > STDERR_LIMIT;
-        let exit_code = output.status.code();
-
-        Ok(ToolResult {
-            result: ToolResultPart {
-                call_id: request.call_id,
-                output: ToolOutput::Structured(json!({
-                    "stdout": &stdout[..stdout.floor_char_boundary(STDOUT_LIMIT)],
-                    "stderr": &stderr[..stderr.floor_char_boundary(STDERR_LIMIT)],
-                    "truncated": stdout_truncated || stderr_truncated,
-                    "exit_code": exit_code,
-                    "success": output.status.success(),
-                })),
-                is_error: !output.status.success(),
-                metadata: MetadataMap::new(),
-            },
-            duration: Some(start.elapsed()),
+    Ok(ToolResult {
+        result: ToolResultPart {
+            call_id: Default::default(),
+            output: ToolOutput::Structured(json!({
+                "stdout": &stdout[..stdout.floor_char_boundary(STDOUT_LIMIT)],
+                "stderr": &stderr[..stderr.floor_char_boundary(STDERR_LIMIT)],
+                "truncated": stdout_truncated || stderr_truncated,
+                "exit_code": exit_code,
+                "success": output.status.success(),
+            })),
+            is_error: !output.status.success(),
             metadata: MetadataMap::new(),
-        })
-    }
+        },
+        duration: Some(start.elapsed()),
+        metadata: MetadataMap::new(),
+    })
 }
 
 fn link_sandbox_assets(workdir: &Path) -> Result<(), ToolError> {

--- a/agents/runner/src/tools/bun_run.rs
+++ b/agents/runner/src/tools/bun_run.rs
@@ -3,8 +3,7 @@ use std::time::{Duration, Instant};
 
 use agentkit_core::{MetadataMap, ToolOutput, ToolResultPart};
 use agentkit_tools_core::{
-    Tool, ToolAnnotations, ToolContext, ToolError, ToolName, ToolRegistry, ToolRequest, ToolResult,
-    ToolSpec,
+    Tool, ToolAnnotations, ToolContext, ToolError, ToolName, ToolRequest, ToolResult, ToolSpec,
 };
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -18,10 +17,6 @@ const STDOUT_LIMIT: usize = 50_000;
 const STDERR_LIMIT: usize = 10_000;
 const SCRIPT_NAME: &str = "script.ts";
 const SANDBOX_ROOT: &str = "/tmp/bun-sandbox";
-
-pub fn registry() -> ToolRegistry {
-    ToolRegistry::new().with(BunRunTool::default())
-}
 
 #[derive(Clone, Debug)]
 pub struct BunRunTool {

--- a/agents/runner/src/tools/bun_run.rs
+++ b/agents/runner/src/tools/bun_run.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use agentkit_core::{MetadataMap, ToolOutput, ToolResultPart};
@@ -7,20 +8,29 @@ use agentkit_tools_derive::tool;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
-use tempfile::TempDir;
 use tokio::process::Command;
 use tokio::time::timeout;
+
+use crate::workdir::{ASSISTANT_WORKDIR, canonicalize_inside_workdir};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
 const STDOUT_LIMIT: usize = 50_000;
 const STDERR_LIMIT: usize = 10_000;
-const SCRIPT_NAME: &str = "script.ts";
-const SANDBOX_ROOT: &str = "/tmp/bun-sandbox";
+
+// Per-call counter so concurrent inline `bun_run` calls don't trample each
+// other's source file in the persistent workdir.
+static INLINE_SEQ: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct BunRunInput {
-    /// JavaScript or TypeScript source to execute via Bun.
-    pub code: String,
+    /// Inline JavaScript or TypeScript source to execute. Mutually exclusive
+    /// with `file`; exactly one of the two must be supplied.
+    #[serde(default)]
+    pub code: Option<String>,
+    /// Absolute path to a JavaScript or TypeScript file inside the assistant
+    /// workdir. The file is run by Bun as-is. Mutually exclusive with `code`.
+    #[serde(default)]
+    pub file: Option<String>,
     /// Optional per-call wall-clock timeout in milliseconds. Defaults to 600_000.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
@@ -28,28 +38,24 @@ pub struct BunRunInput {
 
 #[tool(
     destructive,
-    description = "Execute JavaScript or TypeScript code using the Bun runtime. \
-Working directory is a fresh per-call tempdir; `playwright-core` is preinstalled. \
-A headless Chromium-compatible browser (lightpanda) is available — prefer \
-`import { withContext } from './browser'` and run page work inside the callback \
-so each invocation gets a fresh, auto-disposed BrowserContext. The helper \
-module and its `node_modules` are symlinked into the tempdir for each call. \
-Use `getBrowser()` from the same module only when you need the raw Browser handle. \
-For LLM-friendly page reading, `import { markdown } from './browser'` and call \
-`markdown(page)` to get `{ title, byline, markdown }`; it runs Readability over \
-the page HTML and serializes to Markdown. Pass `{ readable: false }` for non-article \
-pages (list/index pages) where Readability extraction is not helpful."
+    description = "Execute JavaScript or TypeScript with the Bun runtime. \
+Working directory is the persistent assistant workdir; files written there \
+via the filesystem tools persist across calls for the lifetime of the \
+assistant VM. Pass `file` (an absolute path inside the workdir) to execute \
+an existing file, or `code` to run inline source. Exactly one of the two is \
+required. \
+`playwright-core` is preinstalled and a headless Chromium-compatible browser \
+(lightpanda) is available — prefer `import { withContext } from './browser'` \
+and run page work inside the callback so each invocation gets a fresh, \
+auto-disposed BrowserContext. Use `getBrowser()` from the same module only \
+when you need the raw Browser handle. For LLM-friendly page reading, \
+`import { markdown } from './browser'` and call `markdown(page)` to get \
+`{ title, byline, markdown }`; it runs Readability over the page HTML and \
+serializes to Markdown. Pass `{ readable: false }` for non-article pages \
+(list/index pages) where Readability extraction is not helpful."
 )]
 pub async fn bun_run(input: BunRunInput) -> Result<ToolResult, ToolError> {
-    let workdir = TempDir::with_prefix("bun-sandbox-")
-        .map_err(|e| ToolError::ExecutionFailed(format!("tempdir failed: {e}")))?;
-
-    link_sandbox_assets(workdir.path())?;
-    let file_path = workdir.path().join(SCRIPT_NAME);
-
-    tokio::fs::write(&file_path, &input.code)
-        .await
-        .map_err(|e| ToolError::ExecutionFailed(format!("write failed: {e}")))?;
+    let script = resolve_script(&input).await?;
 
     let dur = input
         .timeout_ms
@@ -59,7 +65,9 @@ pub async fn bun_run(input: BunRunInput) -> Result<ToolResult, ToolError> {
     let start = Instant::now();
 
     let mut cmd = Command::new("/usr/local/bin/bun");
-    cmd.arg("run").arg(SCRIPT_NAME).current_dir(workdir.path());
+    cmd.arg("run")
+        .arg(script.path())
+        .current_dir(ASSISTANT_WORKDIR);
     cmd.env("NO_COLOR", "1");
     cmd.kill_on_drop(true);
 
@@ -94,31 +102,83 @@ pub async fn bun_run(input: BunRunInput) -> Result<ToolResult, ToolError> {
     })
 }
 
-fn link_sandbox_assets(workdir: &Path) -> Result<(), ToolError> {
-    for name in ["browser.ts", "package.json", "node_modules"] {
-        let src = Path::new(SANDBOX_ROOT).join(name);
-        let dst = workdir.join(name);
-        symlink(&src, &dst).map_err(|e| {
-            ToolError::ExecutionFailed(format!(
-                "link sandbox asset {} -> {} failed: {e}",
-                src.display(),
-                dst.display()
-            ))
-        })?;
+/// Resolved script path with optional cleanup for inline writes. Inline calls
+/// drop the temp file after the bun process exits so the persistent workdir
+/// doesn't accumulate `.bun-inline-*.ts` cruft.
+#[derive(Debug)]
+enum Script {
+    Inline(PathBuf),
+    File(PathBuf),
+}
+
+impl Script {
+    fn path(&self) -> &Path {
+        match self {
+            Script::Inline(p) | Script::File(p) => p,
+        }
     }
-    Ok(())
 }
 
-#[cfg(unix)]
-fn symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(src, dst)
+impl Drop for Script {
+    fn drop(&mut self) {
+        if let Script::Inline(path) = self {
+            let _ = std::fs::remove_file(path);
+        }
+    }
 }
 
-#[cfg(windows)]
-fn symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
-    if src.is_dir() {
-        std::fs::symlink_dir(src, dst)
-    } else {
-        std::fs::symlink_file(src, dst)
+async fn resolve_script(input: &BunRunInput) -> Result<Script, ToolError> {
+    match (&input.code, &input.file) {
+        (Some(_), Some(_)) => Err(ToolError::InvalidInput(
+            "bun_run accepts exactly one of `code` or `file`, not both".into(),
+        )),
+        (None, None) => Err(ToolError::InvalidInput(
+            "bun_run requires either `code` or `file`".into(),
+        )),
+        (Some(code), None) => {
+            let seq = INLINE_SEQ.fetch_add(1, Ordering::Relaxed);
+            let path =
+                PathBuf::from(ASSISTANT_WORKDIR).join(format!(".bun-inline-{seq}.ts"));
+            tokio::fs::write(&path, code)
+                .await
+                .map_err(|e| ToolError::ExecutionFailed(format!("write inline script: {e}")))?;
+            Ok(Script::Inline(path))
+        }
+        (None, Some(file)) => {
+            canonicalize_inside_workdir(Path::new(file)).map(Script::File)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_input_with_both_code_and_file() {
+        let input = BunRunInput {
+            code: Some("console.log(1)".into()),
+            file: Some("/tmp/x.ts".into()),
+            timeout_ms: None,
+        };
+        let err = resolve_script(&input).await.expect_err("both must be rejected");
+        match err {
+            ToolError::InvalidInput(msg) => assert!(msg.contains("not both")),
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_input_with_neither_code_nor_file() {
+        let input = BunRunInput {
+            code: None,
+            file: None,
+            timeout_ms: None,
+        };
+        let err = resolve_script(&input).await.expect_err("neither must be rejected");
+        match err {
+            ToolError::InvalidInput(msg) => assert!(msg.contains("requires")),
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
     }
 }

--- a/agents/runner/src/tools/bun_run.rs
+++ b/agents/runner/src/tools/bun_run.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use agentkit_core::{MetadataMap, ToolOutput, ToolResultPart};
@@ -8,6 +7,7 @@ use agentkit_tools_derive::tool;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
+use tempfile::NamedTempFile;
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -16,10 +16,6 @@ use crate::workdir::{ASSISTANT_WORKDIR, canonicalize_inside_workdir};
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
 const STDOUT_LIMIT: usize = 50_000;
 const STDERR_LIMIT: usize = 10_000;
-
-// Per-call counter so concurrent inline `bun_run` calls don't trample each
-// other's source file in the persistent workdir.
-static INLINE_SEQ: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct BunRunInput {
@@ -102,27 +98,19 @@ pub async fn bun_run(input: BunRunInput) -> Result<ToolResult, ToolError> {
     })
 }
 
-/// Resolved script path with optional cleanup for inline writes. Inline calls
-/// drop the temp file after the bun process exits so the persistent workdir
-/// doesn't accumulate `.bun-inline-*.ts` cruft.
 #[derive(Debug)]
 enum Script {
-    Inline(PathBuf),
+    /// O_EXCL temp file inside the persistent workdir; deleted on Drop so
+    /// inline calls don't accumulate `.bun-inline-*.ts` cruft.
+    Inline(NamedTempFile),
     File(PathBuf),
 }
 
 impl Script {
     fn path(&self) -> &Path {
         match self {
-            Script::Inline(p) | Script::File(p) => p,
-        }
-    }
-}
-
-impl Drop for Script {
-    fn drop(&mut self) {
-        if let Script::Inline(path) = self {
-            let _ = std::fs::remove_file(path);
+            Script::Inline(f) => f.path(),
+            Script::File(p) => p,
         }
     }
 }
@@ -136,13 +124,17 @@ async fn resolve_script(input: &BunRunInput) -> Result<Script, ToolError> {
             "bun_run requires either `code` or `file`".into(),
         )),
         (Some(code), None) => {
-            let seq = INLINE_SEQ.fetch_add(1, Ordering::Relaxed);
-            let path =
-                PathBuf::from(ASSISTANT_WORKDIR).join(format!(".bun-inline-{seq}.ts"));
-            tokio::fs::write(&path, code)
+            let tmp = tempfile::Builder::new()
+                .prefix(".bun-inline-")
+                .suffix(".ts")
+                .tempfile_in(ASSISTANT_WORKDIR)
+                .map_err(|e| {
+                    ToolError::ExecutionFailed(format!("create inline script: {e}"))
+                })?;
+            tokio::fs::write(tmp.path(), code)
                 .await
                 .map_err(|e| ToolError::ExecutionFailed(format!("write inline script: {e}")))?;
-            Ok(Script::Inline(path))
+            Ok(Script::Inline(tmp))
         }
         (None, Some(file)) => {
             canonicalize_inside_workdir(Path::new(file)).map(Script::File)

--- a/agents/runner/src/tools/mcp_force_reconnect.rs
+++ b/agents/runner/src/tools/mcp_force_reconnect.rs
@@ -1,70 +1,40 @@
 use agentkit_core::{MetadataMap, ToolOutput, ToolResultPart};
 use agentkit_mcp::McpServerId;
-use agentkit_tools_core::{
-    Tool, ToolAnnotations, ToolContext, ToolError, ToolName, ToolRequest, ToolResult, ToolSpec,
-};
-use async_trait::async_trait;
+use agentkit_tools_core::{ToolError, ToolResult};
+use agentkit_tools_derive::tool;
+use schemars::JsonSchema;
 use serde::Deserialize;
-use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::runtime::McpCmd;
 
-#[derive(Clone)]
 pub struct McpForceReconnectTool {
     cmd_tx: mpsc::Sender<McpCmd>,
-    spec: ToolSpec,
 }
 
 impl McpForceReconnectTool {
     pub fn new(cmd_tx: mpsc::Sender<McpCmd>) -> Self {
-        Self {
-            cmd_tx,
-            spec: ToolSpec {
-                name: ToolName::new("mcp_force_reconnect"),
-                description:
-                    "Disconnect and reconnect a registered MCP server. Use this when a tool from \
-that server returns a connection-related error (timeout, transport closed, auth failure that the \
-backend has since refreshed). The argument is the server id as it appears in the tool name prefix \
-`mcp_<server_id>_<tool>`. Safe to retry; succeeds even if the server was not previously connected."
-                        .into(),
-                input_schema: json!({
-                    "type": "object",
-                    "properties": {
-                        "server_id": { "type": "string" }
-                    },
-                    "required": ["server_id"],
-                    "additionalProperties": false
-                }),
-                annotations: ToolAnnotations::default()
-                    .with_idempotent(true)
-                    .with_destructive(false),
-                metadata: MetadataMap::new(),
-            },
-        }
+        Self { cmd_tx }
     }
 }
 
-#[derive(Deserialize)]
-struct Input {
-    server_id: String,
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct McpForceReconnectInput {
+    /// Server id as it appears in the tool name prefix `mcp_<server_id>_<tool>`.
+    pub server_id: String,
 }
 
-#[async_trait]
-impl Tool for McpForceReconnectTool {
-    fn spec(&self) -> &ToolSpec {
-        &self.spec
-    }
-
-    async fn invoke(
-        &self,
-        request: ToolRequest,
-        _ctx: &mut ToolContext<'_>,
-    ) -> Result<ToolResult, ToolError> {
-        let input: Input = serde_json::from_value(request.input.clone()).map_err(|e| {
-            ToolError::InvalidInput(format!("invalid mcp_force_reconnect input: {e}"))
-        })?;
-
+#[tool(
+    name = "mcp_force_reconnect",
+    idempotent,
+    description = "Disconnect and reconnect a registered MCP server. Use this when a tool \
+from that server returns a connection-related error (timeout, transport closed, auth failure \
+that the backend has since refreshed). The argument is the server id as it appears in the \
+tool name prefix `mcp_<server_id>_<tool>`. Safe to retry; succeeds even if the server was \
+not previously connected."
+)]
+impl McpForceReconnectTool {
+    async fn run(&self, input: McpForceReconnectInput) -> Result<ToolResult, ToolError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let server_id = McpServerId::new(input.server_id.clone());
         self.cmd_tx
@@ -92,7 +62,7 @@ impl Tool for McpForceReconnectTool {
 
         Ok(ToolResult {
             result: ToolResultPart {
-                call_id: request.call_id,
+                call_id: Default::default(),
                 output: ToolOutput::text(text),
                 is_error,
                 metadata: MetadataMap::new(),

--- a/agents/runner/src/tools/mcp_force_reconnect.rs
+++ b/agents/runner/src/tools/mcp_force_reconnect.rs
@@ -50,10 +50,7 @@ impl McpForceReconnectTool {
             .map_err(|_| ToolError::ExecutionFailed("mcp actor dropped reply".into()))?;
 
         let (text, is_error) = match outcome {
-            Ok(()) => (
-                format!("reconnected mcp server {}", input.server_id),
-                false,
-            ),
+            Ok(()) => (format!("reconnected mcp server {}", input.server_id), false),
             Err(e) => (
                 format!("failed to reconnect mcp server {}: {e}", input.server_id),
                 true,

--- a/agents/runner/src/tools/mcp_force_reconnect.rs
+++ b/agents/runner/src/tools/mcp_force_reconnect.rs
@@ -1,0 +1,104 @@
+use agentkit_core::{MetadataMap, ToolOutput, ToolResultPart};
+use agentkit_mcp::McpServerId;
+use agentkit_tools_core::{
+    Tool, ToolAnnotations, ToolContext, ToolError, ToolName, ToolRequest, ToolResult, ToolSpec,
+};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::json;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::runtime::McpCmd;
+
+#[derive(Clone)]
+pub struct McpForceReconnectTool {
+    cmd_tx: mpsc::Sender<McpCmd>,
+    spec: ToolSpec,
+}
+
+impl McpForceReconnectTool {
+    pub fn new(cmd_tx: mpsc::Sender<McpCmd>) -> Self {
+        Self {
+            cmd_tx,
+            spec: ToolSpec {
+                name: ToolName::new("mcp_force_reconnect"),
+                description:
+                    "Disconnect and reconnect a registered MCP server. Use this when a tool from \
+that server returns a connection-related error (timeout, transport closed, auth failure that the \
+backend has since refreshed). The argument is the server id as it appears in the tool name prefix \
+`mcp_<server_id>_<tool>`. Safe to retry; succeeds even if the server was not previously connected."
+                        .into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "server_id": { "type": "string" }
+                    },
+                    "required": ["server_id"],
+                    "additionalProperties": false
+                }),
+                annotations: ToolAnnotations::default()
+                    .with_idempotent(true)
+                    .with_destructive(false),
+                metadata: MetadataMap::new(),
+            },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Input {
+    server_id: String,
+}
+
+#[async_trait]
+impl Tool for McpForceReconnectTool {
+    fn spec(&self) -> &ToolSpec {
+        &self.spec
+    }
+
+    async fn invoke(
+        &self,
+        request: ToolRequest,
+        _ctx: &mut ToolContext<'_>,
+    ) -> Result<ToolResult, ToolError> {
+        let input: Input = serde_json::from_value(request.input.clone()).map_err(|e| {
+            ToolError::InvalidInput(format!("invalid mcp_force_reconnect input: {e}"))
+        })?;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let server_id = McpServerId::new(input.server_id.clone());
+        self.cmd_tx
+            .send(McpCmd::ForceReconnect {
+                server_id,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| ToolError::ExecutionFailed("mcp actor channel closed".into()))?;
+
+        let outcome = reply_rx
+            .await
+            .map_err(|_| ToolError::ExecutionFailed("mcp actor dropped reply".into()))?;
+
+        let (text, is_error) = match outcome {
+            Ok(()) => (
+                format!("reconnected mcp server {}", input.server_id),
+                false,
+            ),
+            Err(e) => (
+                format!("failed to reconnect mcp server {}: {e}", input.server_id),
+                true,
+            ),
+        };
+
+        Ok(ToolResult {
+            result: ToolResultPart {
+                call_id: request.call_id,
+                output: ToolOutput::text(text),
+                is_error,
+                metadata: MetadataMap::new(),
+            },
+            duration: None,
+            metadata: MetadataMap::new(),
+        })
+    }
+}

--- a/agents/runner/src/tools/mod.rs
+++ b/agents/runner/src/tools/mod.rs
@@ -1,1 +1,2 @@
 pub mod bun_run;
+pub mod mcp_force_reconnect;

--- a/agents/runner/src/wire.rs
+++ b/agents/runner/src/wire.rs
@@ -16,11 +16,6 @@ pub struct RunnerConfig {
     /// comes up already hydrated; /turn carries only new user input after that.
     #[serde(default)]
     pub history: Vec<RunnerMessage>,
-    /// Target warm window in seconds. After the driver yields LoopStep::Finished
-    /// and no further input arrives within warm_ttl_seconds + 60s of grace, the
-    /// loop exits and the runtime marks itself not-running.
-    #[serde(default)]
-    pub warm_ttl_seconds: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Hash)]
@@ -96,9 +91,9 @@ impl RunnerResponse {
 #[derive(Debug, Serialize)]
 pub struct RunnerStateResponse {
     pub configured: bool,
-    /// Seconds since the loop last made forward progress. Backend reapers read
-    /// this to refresh TTL instead of `/turn` return time. Absent when the
-    /// runner has never been /configured.
+    /// Seconds the loop has been idle (between turns). `0` while a turn is in
+    /// flight. Backend reapers read this to decide TTL eviction. Absent when
+    /// the runner has never been /configured.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_active_seconds_ago: Option<u64>,
+    pub idle_seconds: Option<u64>,
 }

--- a/agents/runner/src/workdir.rs
+++ b/agents/runner/src/workdir.rs
@@ -1,0 +1,78 @@
+use std::path::{Path, PathBuf};
+
+use agentkit_tools_core::ToolError;
+
+/// Persistent working directory for the assistant inside the guest VM. Backed
+/// by a fixed-size loop-mounted ext4 image so disk usage is hard-capped.
+pub const ASSISTANT_WORKDIR: &str = "/var/lib/gram-assistant/work";
+
+/// Canonicalizes `path` and rejects anything that does not resolve to a
+/// location inside [`ASSISTANT_WORKDIR`]. `bun_run` shells out and so bypasses
+/// the agentkit `PathPolicy`; this resolves symlinks (which `PathPolicy` does
+/// not) so an in-tree link pointing outside is caught before bun reads it.
+pub fn canonicalize_inside_workdir(path: &Path) -> Result<PathBuf, ToolError> {
+    canonicalize_inside(path, Path::new(ASSISTANT_WORKDIR))
+}
+
+fn canonicalize_inside(path: &Path, workdir: &Path) -> Result<PathBuf, ToolError> {
+    let workdir = std::fs::canonicalize(workdir).map_err(|e| {
+        ToolError::ExecutionFailed(format!(
+            "canonicalize workdir {}: {e}",
+            workdir.display()
+        ))
+    })?;
+    let resolved = std::fs::canonicalize(path)
+        .map_err(|e| ToolError::InvalidInput(format!("resolve {}: {e}", path.display())))?;
+    if !resolved.starts_with(&workdir) {
+        return Err(ToolError::InvalidInput(format!(
+            "path {} resolves outside the assistant workdir",
+            path.display()
+        )));
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_path_outside_workdir() {
+        let workdir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::NamedTempFile::new().expect("outside file");
+
+        let err = canonicalize_inside(outside.path(), workdir.path())
+            .expect_err("path outside workdir must be rejected");
+        match err {
+            ToolError::InvalidInput(_) => {}
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn allows_path_inside_workdir() {
+        let workdir = tempfile::tempdir().expect("tempdir");
+        let inside = workdir.path().join("script.ts");
+        std::fs::write(&inside, b"// hi").expect("write");
+
+        let resolved =
+            canonicalize_inside(&inside, workdir.path()).expect("inside path must be allowed");
+        assert!(resolved.starts_with(std::fs::canonicalize(workdir.path()).expect("canonical")));
+    }
+
+    #[test]
+    fn rejects_symlink_pointing_outside_workdir() {
+        let workdir = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::NamedTempFile::new().expect("outside");
+        let link = workdir.path().join("escape");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(outside.path(), &link).expect("symlink");
+
+        let err = canonicalize_inside(&link, workdir.path())
+            .expect_err("symlink-to-outside must be rejected");
+        match err {
+            ToolError::InvalidInput(_) => {}
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+}

--- a/agents/runner/src/workdir.rs
+++ b/agents/runner/src/workdir.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use agentkit_tools_core::ToolError;
 
@@ -11,19 +12,25 @@ pub const ASSISTANT_WORKDIR: &str = "/var/lib/gram-assistant/work";
 /// the agentkit `PathPolicy`; this resolves symlinks (which `PathPolicy` does
 /// not) so an in-tree link pointing outside is caught before bun reads it.
 pub fn canonicalize_inside_workdir(path: &Path) -> Result<PathBuf, ToolError> {
-    canonicalize_inside(path, Path::new(ASSISTANT_WORKDIR))
+    static CANONICAL_WORKDIR: OnceLock<PathBuf> = OnceLock::new();
+    let workdir = match CANONICAL_WORKDIR.get() {
+        Some(p) => p,
+        None => {
+            let p = std::fs::canonicalize(ASSISTANT_WORKDIR).map_err(|e| {
+                ToolError::ExecutionFailed(format!(
+                    "canonicalize workdir {ASSISTANT_WORKDIR}: {e}"
+                ))
+            })?;
+            CANONICAL_WORKDIR.get_or_init(|| p)
+        }
+    };
+    canonicalize_inside(path, workdir)
 }
 
-fn canonicalize_inside(path: &Path, workdir: &Path) -> Result<PathBuf, ToolError> {
-    let workdir = std::fs::canonicalize(workdir).map_err(|e| {
-        ToolError::ExecutionFailed(format!(
-            "canonicalize workdir {}: {e}",
-            workdir.display()
-        ))
-    })?;
+fn canonicalize_inside(path: &Path, canonical_workdir: &Path) -> Result<PathBuf, ToolError> {
     let resolved = std::fs::canonicalize(path)
         .map_err(|e| ToolError::InvalidInput(format!("resolve {}: {e}", path.display())))?;
-    if !resolved.starts_with(&workdir) {
+    if !resolved.starts_with(canonical_workdir) {
         return Err(ToolError::InvalidInput(format!(
             "path {} resolves outside the assistant workdir",
             path.display()
@@ -36,12 +43,18 @@ fn canonicalize_inside(path: &Path, workdir: &Path) -> Result<PathBuf, ToolError
 mod tests {
     use super::*;
 
+    fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let canonical = std::fs::canonicalize(dir.path()).expect("canonical");
+        (dir, canonical)
+    }
+
     #[test]
     fn rejects_path_outside_workdir() {
-        let workdir = tempfile::tempdir().expect("tempdir");
+        let (_workdir, canonical) = canonical_tempdir();
         let outside = tempfile::NamedTempFile::new().expect("outside file");
 
-        let err = canonicalize_inside(outside.path(), workdir.path())
+        let err = canonicalize_inside(outside.path(), &canonical)
             .expect_err("path outside workdir must be rejected");
         match err {
             ToolError::InvalidInput(_) => {}
@@ -51,24 +64,24 @@ mod tests {
 
     #[test]
     fn allows_path_inside_workdir() {
-        let workdir = tempfile::tempdir().expect("tempdir");
+        let (workdir, canonical) = canonical_tempdir();
         let inside = workdir.path().join("script.ts");
         std::fs::write(&inside, b"// hi").expect("write");
 
         let resolved =
-            canonicalize_inside(&inside, workdir.path()).expect("inside path must be allowed");
-        assert!(resolved.starts_with(std::fs::canonicalize(workdir.path()).expect("canonical")));
+            canonicalize_inside(&inside, &canonical).expect("inside path must be allowed");
+        assert!(resolved.starts_with(&canonical));
     }
 
     #[test]
     fn rejects_symlink_pointing_outside_workdir() {
-        let workdir = tempfile::tempdir().expect("tempdir");
+        let (workdir, canonical) = canonical_tempdir();
         let outside = tempfile::NamedTempFile::new().expect("outside");
         let link = workdir.path().join("escape");
         #[cfg(unix)]
         std::os::unix::fs::symlink(outside.path(), &link).expect("symlink");
 
-        let err = canonicalize_inside(&link, workdir.path())
+        let err = canonicalize_inside(&link, &canonical)
             .expect_err("symlink-to-outside must be rejected");
         match err {
             ToolError::InvalidInput(_) => {}

--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -30,6 +30,19 @@ RUN target=node_modules/playwright-core/lib/utilsBundle.js \
  && sed -i "s|const ws = exports.ws = require('./utilsBundleImpl').ws;|const ws = exports.ws = 'Bun' in globalThis ? require('ws') : require('./utilsBundleImpl').ws;|" "$target" \
  && grep -q "'Bun' in globalThis ? require('ws')" "$target"
 
+FROM debian:bookworm-slim AS workdir-template
+# 256 MiB hard cap on assistant workspace + bundled sandbox helpers.
+ARG WORKDIR_IMAGE_SIZE=268435456
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends e2fsprogs util-linux \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /staging
+COPY agents/runtime-image/sandbox/package.json /staging/package.json
+COPY agents/runtime-image/sandbox/browser.ts /staging/browser.ts
+COPY --from=sandbox-deps /sandbox/node_modules /staging/node_modules
+RUN fallocate -l "${WORKDIR_IMAGE_SIZE}" /workdir-template.ext4 \
+ && mke2fs -t ext4 -d /staging -F /workdir-template.ext4
+
 FROM debian:bookworm-slim AS lightpanda
 ARG TARGETARCH
 ARG LIGHTPANDA_VERSION=0.2.8
@@ -57,7 +70,9 @@ RUN apt-get update \
     iproute2 \
     libcurl4 \
     libssl3 \
+    mount \
     procps \
+    util-linux \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=runner-builder /src/agents/runner/target/release/gram-assistant-runner /usr/local/bin/gram-assistant-runner
@@ -66,9 +81,10 @@ COPY --from=lightpanda /lightpanda /usr/local/bin/lightpanda
 COPY agents/runtime-image/lightpanda-supervise.sh /usr/local/bin/lightpanda-supervise
 COPY agents/runtime-image/init.sh /init
 
-COPY agents/runtime-image/sandbox/package.json /tmp/bun-sandbox/package.json
-COPY agents/runtime-image/sandbox/browser.ts /tmp/bun-sandbox/browser.ts
-COPY --from=sandbox-deps /sandbox/node_modules /tmp/bun-sandbox/node_modules
+# Fixed-size ext4 prepopulated with the sandbox helpers; init.sh loop-mounts
+# it at /var/lib/gram-assistant/work so the assistant has a persistent
+# workdir whose disk usage is hard-capped by the image size.
+COPY --from=workdir-template /workdir-template.ext4 /usr/share/gram/workdir-template.ext4
 
 RUN chmod 0755 /init /usr/local/bin/gram-assistant-runner /usr/local/bin/bun /usr/local/bin/lightpanda /usr/local/bin/lightpanda-supervise
 

--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91-bookworm AS runner-builder
+FROM rust:1.95-bookworm AS runner-builder
 
 WORKDIR /src
 COPY agents/runner/Cargo.toml agents/runner/Cargo.lock ./agents/runner/

--- a/agents/runtime-image/init.sh
+++ b/agents/runtime-image/init.sh
@@ -8,6 +8,15 @@ mount -t devtmpfs dev /dev || true
 mkdir -p /dev/pts /run /tmp
 mount -t devpts devpts /dev/pts || true
 
+# Provision the assistant workdir from the prebuilt ext4 template. The rootfs
+# is per-VM (FC) or per-machine (Fly) so we can mount the template directly —
+# any mutations stay isolated to this VM and the loop mount enforces the hard
+# size cap baked into the template at image build time.
+workdir_image=/usr/share/gram/workdir-template.ext4
+workdir_mount=/var/lib/gram-assistant/work
+mkdir -p "$workdir_mount"
+mount -o loop "$workdir_image" "$workdir_mount"
+
 ip link set lo up || true
 cat >/etc/resolv.conf <<'EOF'
 nameserver 1.1.1.1

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -13,6 +13,11 @@ WHERE deleted IS FALSE
       AND warm_until < @warm_cutoff
       AND COALESCE(last_heartbeat_at, updated_at) < @heartbeat_cutoff
     )
+    -- Backstop for ExpireThreadRuntime activities that exhaust Temporal's
+    -- retry budget after CAS active->expiring but before Stop or Revert.
+    -- Without this the row stays in `expiring` indefinitely, blocking the
+    -- partial unique index that ReserveAssistantRuntime relies on.
+    OR (state = @expiring_state AND updated_at < @expiring_cutoff)
   )
 RETURNING assistant_id;
 
@@ -499,18 +504,21 @@ WHERE id = @runtime_id
   AND project_id = @project_id;
 
 -- name: BeginExpireAssistantRuntime :one
--- Atomic CAS active -> expiring on a single thread's runtime row, returning
--- the row needed to drive backend Status/Stop. ErrNoRows means another actor
--- (Stop, reaper, manual API) already moved the row, so the caller should not
--- subsequently call Stop. Relies on the partial unique index on
--- (assistant_thread_id) WHERE deleted IS FALSE AND ended IS FALSE.
+-- Atomic CAS to `expiring` on a single thread's runtime row, returning the row
+-- needed to drive backend Status/Stop. Accepts both `active` (first attempt)
+-- and `expiring` (Temporal-retried attempt after a previous Stop failure) so
+-- the caller can re-enter the Status/Stop path idempotently. ErrNoRows means
+-- another actor (Stop, reaper, manual API) moved the row to a terminal state,
+-- so the caller should not subsequently call Stop. Relies on the partial
+-- unique index on (assistant_thread_id) WHERE deleted IS FALSE AND ended IS
+-- FALSE.
 UPDATE assistant_runtimes
 SET
   state = @expiring_state,
   updated_at = clock_timestamp()
 WHERE project_id = @project_id
   AND assistant_thread_id = @thread_id
-  AND state = @active_state
+  AND state IN (@active_state, @expiring_state)
   AND deleted IS FALSE
   AND ended IS FALSE
 RETURNING id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until;

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -375,17 +375,6 @@ WHERE t.id = @thread_id
 ORDER BY r.created_at DESC
 LIMIT 1;
 
--- name: LoadActiveRuntimeRecord :one
-SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
-FROM assistant_runtimes
-WHERE project_id = @project_id
-  AND assistant_thread_id = @thread_id
-  AND deleted IS FALSE
-  AND ended IS FALSE
-  AND state IN (@starting_state, @active_state)
-ORDER BY created_at DESC
-LIMIT 1;
-
 -- name: ClaimNextPendingEvent :one
 WITH next_event AS (
   SELECT e.id
@@ -464,7 +453,7 @@ WHERE project_id = @project_id
   AND assistant_thread_id = @thread_id
   AND deleted IS FALSE
   AND ended IS FALSE
-  AND state IN (@starting_state, @active_state);
+  AND state IN (@starting_state, @active_state, @expiring_state);
 
 -- name: ListAssistantRuntimesForReap :many
 -- Returns every runtime row for an assistant that still carries backend
@@ -508,3 +497,35 @@ SET state = @reaped_state,
     deleted_at = COALESCE(deleted_at, clock_timestamp())
 WHERE id = @runtime_id
   AND project_id = @project_id;
+
+-- name: BeginExpireAssistantRuntime :one
+-- Atomic CAS active -> expiring on a single thread's runtime row, returning
+-- the row needed to drive backend Status/Stop. ErrNoRows means another actor
+-- (Stop, reaper, manual API) already moved the row, so the caller should not
+-- subsequently call Stop. Relies on the partial unique index on
+-- (assistant_thread_id) WHERE deleted IS FALSE AND ended IS FALSE.
+UPDATE assistant_runtimes
+SET
+  state = @expiring_state,
+  updated_at = clock_timestamp()
+WHERE project_id = @project_id
+  AND assistant_thread_id = @thread_id
+  AND state = @active_state
+  AND deleted IS FALSE
+  AND ended IS FALSE
+RETURNING id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until;
+
+-- name: RevertExpireAssistantRuntimeToActive :exec
+-- Reverts an expiring runtime back to active when the post-CAS status re-poll
+-- finds the runner busy (a turn slipped in between the warm-TTL timer and the
+-- CAS commit). Bumps warm_until so the workflow can re-arm its timer with the
+-- remaining warm window.
+UPDATE assistant_runtimes
+SET
+  state = @active_state,
+  warm_until = @warm_until,
+  last_heartbeat_at = clock_timestamp(),
+  updated_at = clock_timestamp()
+WHERE id = @runtime_id
+  AND project_id = @project_id
+  AND state = @expiring_state;

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -13,10 +13,9 @@ WHERE deleted IS FALSE
       AND warm_until < @warm_cutoff
       AND COALESCE(last_heartbeat_at, updated_at) < @heartbeat_cutoff
     )
-    -- Backstop for ExpireThreadRuntime activities that exhaust Temporal's
-    -- retry budget after CAS active->expiring but before Stop or Revert.
-    -- Without this the row stays in `expiring` indefinitely, blocking the
-    -- partial unique index that ReserveAssistantRuntime relies on.
+    -- Backstop for activities that exhaust Temporal's retry budget after CAS
+    -- active->expiring without reaching Stop. Without this the partial unique
+    -- index on (assistant_thread_id) blocks new admits indefinitely.
     OR (state = @expiring_state AND updated_at < @expiring_cutoff)
   )
 RETURNING assistant_id;
@@ -504,14 +503,10 @@ WHERE id = @runtime_id
   AND project_id = @project_id;
 
 -- name: BeginExpireAssistantRuntime :one
--- Atomic CAS to `expiring` on a single thread's runtime row, returning the row
--- needed to drive backend Status/Stop. Accepts both `active` (first attempt)
--- and `expiring` (Temporal-retried attempt after a previous Stop failure) so
--- the caller can re-enter the Status/Stop path idempotently. ErrNoRows means
--- another actor (Stop, reaper, manual API) moved the row to a terminal state,
--- so the caller should not subsequently call Stop. Relies on the partial
--- unique index on (assistant_thread_id) WHERE deleted IS FALSE AND ended IS
--- FALSE.
+-- Accepts both `active` and `expiring` so a Temporal-retried attempt (after
+-- Stop failed mid-flight) re-enters the Status/Stop path idempotently.
+-- ErrNoRows means another actor (Stop, reaper, manual API) already finalized
+-- the row; callers must not then call Stop.
 UPDATE assistant_runtimes
 SET
   state = @expiring_state,
@@ -524,10 +519,6 @@ WHERE project_id = @project_id
 RETURNING id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until;
 
 -- name: RevertExpireAssistantRuntimeToActive :exec
--- Reverts an expiring runtime back to active when the post-CAS status re-poll
--- finds the runner busy (a turn slipped in between the warm-TTL timer and the
--- CAS commit). Bumps warm_until so the workflow can re-arm its timer with the
--- remaining warm window.
 UPDATE assistant_runtimes
 SET
   state = @active_state,

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -19,6 +19,63 @@ type AddAssistantToolsetsParams struct {
 	ProjectID     uuid.UUID
 }
 
+const beginExpireAssistantRuntime = `-- name: BeginExpireAssistantRuntime :one
+UPDATE assistant_runtimes
+SET
+  state = $1,
+  updated_at = clock_timestamp()
+WHERE project_id = $2
+  AND assistant_thread_id = $3
+  AND state = $4
+  AND deleted IS FALSE
+  AND ended IS FALSE
+RETURNING id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
+`
+
+type BeginExpireAssistantRuntimeParams struct {
+	ExpiringState string
+	ProjectID     uuid.UUID
+	ThreadID      uuid.UUID
+	ActiveState   string
+}
+
+type BeginExpireAssistantRuntimeRow struct {
+	ID                  uuid.UUID
+	AssistantThreadID   uuid.UUID
+	AssistantID         uuid.UUID
+	ProjectID           uuid.UUID
+	Backend             string
+	BackendMetadataJson []byte
+	State               string
+	WarmUntil           pgtype.Timestamptz
+}
+
+// Atomic CAS active -> expiring on a single thread's runtime row, returning
+// the row needed to drive backend Status/Stop. ErrNoRows means another actor
+// (Stop, reaper, manual API) already moved the row, so the caller should not
+// subsequently call Stop. Relies on the partial unique index on
+// (assistant_thread_id) WHERE deleted IS FALSE AND ended IS FALSE.
+func (q *Queries) BeginExpireAssistantRuntime(ctx context.Context, arg BeginExpireAssistantRuntimeParams) (BeginExpireAssistantRuntimeRow, error) {
+	row := q.db.QueryRow(ctx, beginExpireAssistantRuntime,
+		arg.ExpiringState,
+		arg.ProjectID,
+		arg.ThreadID,
+		arg.ActiveState,
+	)
+	var i BeginExpireAssistantRuntimeRow
+	err := row.Scan(
+		&i.ID,
+		&i.AssistantThreadID,
+		&i.AssistantID,
+		&i.ProjectID,
+		&i.Backend,
+		&i.BackendMetadataJson,
+		&i.State,
+		&i.WarmUntil,
+	)
+	return i, err
+}
+
 const claimNextPendingEvent = `-- name: ClaimNextPendingEvent :one
 WITH next_event AS (
   SELECT e.id
@@ -775,57 +832,6 @@ func (q *Queries) ListWarmPendingThreads(ctx context.Context, arg ListWarmPendin
 	return items, nil
 }
 
-const loadActiveRuntimeRecord = `-- name: LoadActiveRuntimeRecord :one
-SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
-FROM assistant_runtimes
-WHERE project_id = $1
-  AND assistant_thread_id = $2
-  AND deleted IS FALSE
-  AND ended IS FALSE
-  AND state IN ($3, $4)
-ORDER BY created_at DESC
-LIMIT 1
-`
-
-type LoadActiveRuntimeRecordParams struct {
-	ProjectID     uuid.UUID
-	ThreadID      uuid.UUID
-	StartingState string
-	ActiveState   string
-}
-
-type LoadActiveRuntimeRecordRow struct {
-	ID                  uuid.UUID
-	AssistantThreadID   uuid.UUID
-	AssistantID         uuid.UUID
-	ProjectID           uuid.UUID
-	Backend             string
-	BackendMetadataJson []byte
-	State               string
-	WarmUntil           pgtype.Timestamptz
-}
-
-func (q *Queries) LoadActiveRuntimeRecord(ctx context.Context, arg LoadActiveRuntimeRecordParams) (LoadActiveRuntimeRecordRow, error) {
-	row := q.db.QueryRow(ctx, loadActiveRuntimeRecord,
-		arg.ProjectID,
-		arg.ThreadID,
-		arg.StartingState,
-		arg.ActiveState,
-	)
-	var i LoadActiveRuntimeRecordRow
-	err := row.Scan(
-		&i.ID,
-		&i.AssistantThreadID,
-		&i.AssistantID,
-		&i.ProjectID,
-		&i.Backend,
-		&i.BackendMetadataJson,
-		&i.State,
-		&i.WarmUntil,
-	)
-	return i, err
-}
-
 const loadAssistantToolsets = `-- name: LoadAssistantToolsets :many
 SELECT
   at.assistant_id,
@@ -1295,6 +1301,41 @@ func (q *Queries) ResolveToolsetsForWrite(ctx context.Context, arg ResolveToolse
 	return items, nil
 }
 
+const revertExpireAssistantRuntimeToActive = `-- name: RevertExpireAssistantRuntimeToActive :exec
+UPDATE assistant_runtimes
+SET
+  state = $1,
+  warm_until = $2,
+  last_heartbeat_at = clock_timestamp(),
+  updated_at = clock_timestamp()
+WHERE id = $3
+  AND project_id = $4
+  AND state = $5
+`
+
+type RevertExpireAssistantRuntimeToActiveParams struct {
+	ActiveState   string
+	WarmUntil     pgtype.Timestamptz
+	RuntimeID     uuid.UUID
+	ProjectID     uuid.UUID
+	ExpiringState string
+}
+
+// Reverts an expiring runtime back to active when the post-CAS status re-poll
+// finds the runner busy (a turn slipped in between the warm-TTL timer and the
+// CAS commit). Bumps warm_until so the workflow can re-arm its timer with the
+// remaining warm window.
+func (q *Queries) RevertExpireAssistantRuntimeToActive(ctx context.Context, arg RevertExpireAssistantRuntimeToActiveParams) error {
+	_, err := q.db.Exec(ctx, revertExpireAssistantRuntimeToActive,
+		arg.ActiveState,
+		arg.WarmUntil,
+		arg.RuntimeID,
+		arg.ProjectID,
+		arg.ExpiringState,
+	)
+	return err
+}
+
 const setAssistantRuntimeActive = `-- name: SetAssistantRuntimeActive :exec
 UPDATE assistant_runtimes
 SET
@@ -1334,7 +1375,7 @@ WHERE project_id = $2
   AND assistant_thread_id = $3
   AND deleted IS FALSE
   AND ended IS FALSE
-  AND state IN ($4, $5)
+  AND state IN ($4, $5, $6)
 `
 
 type StopAssistantRuntimeParams struct {
@@ -1343,6 +1384,7 @@ type StopAssistantRuntimeParams struct {
 	ThreadID      uuid.UUID
 	StartingState string
 	ActiveState   string
+	ExpiringState string
 }
 
 func (q *Queries) StopAssistantRuntime(ctx context.Context, arg StopAssistantRuntimeParams) error {
@@ -1352,6 +1394,7 @@ func (q *Queries) StopAssistantRuntime(ctx context.Context, arg StopAssistantRun
 		arg.ThreadID,
 		arg.StartingState,
 		arg.ActiveState,
+		arg.ExpiringState,
 	)
 	return err
 }

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -26,7 +26,7 @@ SET
   updated_at = clock_timestamp()
 WHERE project_id = $2
   AND assistant_thread_id = $3
-  AND state = $4
+  AND state IN ($4, $1)
   AND deleted IS FALSE
   AND ended IS FALSE
 RETURNING id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
@@ -50,11 +50,14 @@ type BeginExpireAssistantRuntimeRow struct {
 	WarmUntil           pgtype.Timestamptz
 }
 
-// Atomic CAS active -> expiring on a single thread's runtime row, returning
-// the row needed to drive backend Status/Stop. ErrNoRows means another actor
-// (Stop, reaper, manual API) already moved the row, so the caller should not
-// subsequently call Stop. Relies on the partial unique index on
-// (assistant_thread_id) WHERE deleted IS FALSE AND ended IS FALSE.
+// Atomic CAS to `expiring` on a single thread's runtime row, returning the row
+// needed to drive backend Status/Stop. Accepts both `active` (first attempt)
+// and `expiring` (Temporal-retried attempt after a previous Stop failure) so
+// the caller can re-enter the Status/Stop path idempotently. ErrNoRows means
+// another actor (Stop, reaper, manual API) moved the row to a terminal state,
+// so the caller should not subsequently call Stop. Relies on the partial
+// unique index on (assistant_thread_id) WHERE deleted IS FALSE AND ended IS
+// FALSE.
 func (q *Queries) BeginExpireAssistantRuntime(ctx context.Context, arg BeginExpireAssistantRuntimeParams) (BeginExpireAssistantRuntimeRow, error) {
 	row := q.db.QueryRow(ctx, beginExpireAssistantRuntime,
 		arg.ExpiringState,
@@ -1061,6 +1064,11 @@ WHERE deleted IS FALSE
       AND warm_until < $5
       AND COALESCE(last_heartbeat_at, updated_at) < $6
     )
+    -- Backstop for ExpireThreadRuntime activities that exhaust Temporal's
+    -- retry budget after CAS active->expiring but before Stop or Revert.
+    -- Without this the row stays in ` + "`" + `expiring` + "`" + ` indefinitely, blocking the
+    -- partial unique index that ReserveAssistantRuntime relies on.
+    OR (state = $7 AND updated_at < $8)
   )
 RETURNING assistant_id
 `
@@ -1072,6 +1080,8 @@ type ReapStuckAssistantRuntimesParams struct {
 	ActiveState     string
 	WarmCutoff      pgtype.Timestamptz
 	HeartbeatCutoff pgtype.Timestamptz
+	ExpiringState   string
+	ExpiringCutoff  pgtype.Timestamptz
 }
 
 func (q *Queries) ReapStuckAssistantRuntimes(ctx context.Context, arg ReapStuckAssistantRuntimesParams) ([]uuid.UUID, error) {
@@ -1082,6 +1092,8 @@ func (q *Queries) ReapStuckAssistantRuntimes(ctx context.Context, arg ReapStuckA
 		arg.ActiveState,
 		arg.WarmCutoff,
 		arg.HeartbeatCutoff,
+		arg.ExpiringState,
+		arg.ExpiringCutoff,
 	)
 	if err != nil {
 		return nil, err

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -50,14 +50,10 @@ type BeginExpireAssistantRuntimeRow struct {
 	WarmUntil           pgtype.Timestamptz
 }
 
-// Atomic CAS to `expiring` on a single thread's runtime row, returning the row
-// needed to drive backend Status/Stop. Accepts both `active` (first attempt)
-// and `expiring` (Temporal-retried attempt after a previous Stop failure) so
-// the caller can re-enter the Status/Stop path idempotently. ErrNoRows means
-// another actor (Stop, reaper, manual API) moved the row to a terminal state,
-// so the caller should not subsequently call Stop. Relies on the partial
-// unique index on (assistant_thread_id) WHERE deleted IS FALSE AND ended IS
-// FALSE.
+// Accepts both `active` and `expiring` so a Temporal-retried attempt (after
+// Stop failed mid-flight) re-enters the Status/Stop path idempotently.
+// ErrNoRows means another actor (Stop, reaper, manual API) already finalized
+// the row; callers must not then call Stop.
 func (q *Queries) BeginExpireAssistantRuntime(ctx context.Context, arg BeginExpireAssistantRuntimeParams) (BeginExpireAssistantRuntimeRow, error) {
 	row := q.db.QueryRow(ctx, beginExpireAssistantRuntime,
 		arg.ExpiringState,
@@ -1064,10 +1060,9 @@ WHERE deleted IS FALSE
       AND warm_until < $5
       AND COALESCE(last_heartbeat_at, updated_at) < $6
     )
-    -- Backstop for ExpireThreadRuntime activities that exhaust Temporal's
-    -- retry budget after CAS active->expiring but before Stop or Revert.
-    -- Without this the row stays in ` + "`" + `expiring` + "`" + ` indefinitely, blocking the
-    -- partial unique index that ReserveAssistantRuntime relies on.
+    -- Backstop for activities that exhaust Temporal's retry budget after CAS
+    -- active->expiring without reaching Stop. Without this the partial unique
+    -- index on (assistant_thread_id) blocks new admits indefinitely.
     OR (state = $7 AND updated_at < $8)
   )
 RETURNING assistant_id
@@ -1333,10 +1328,6 @@ type RevertExpireAssistantRuntimeToActiveParams struct {
 	ExpiringState string
 }
 
-// Reverts an expiring runtime back to active when the post-CAS status re-poll
-// finds the runner busy (a turn slipped in between the warm-TTL timer and the
-// CAS commit). Bumps warm_until so the workflow can re-arm its timer with the
-// remaining warm window.
 func (q *Queries) RevertExpireAssistantRuntimeToActive(ctx context.Context, arg RevertExpireAssistantRuntimeToActiveParams) error {
 	_, err := q.db.Exec(ctx, revertExpireAssistantRuntimeToActive,
 		arg.ActiveState,

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -429,6 +429,32 @@ func (m *RuntimeManager) Configure(ctx context.Context, runtime assistantRuntime
 	return nil
 }
 
+func (m *RuntimeManager) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	if err := validateRuntimeBackend(m, runtime.Backend); err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	state, err := m.getRuntime(runtime.AssistantThreadID)
+	if err != nil {
+		return RuntimeBackendStatus{}, fmt.Errorf("%w: %w", ErrRuntimeUnhealthy, err)
+	}
+	body, err := m.runtimeRequest(ctx, state, runtimeHTTPRequest{
+		Method:         http.MethodGet,
+		Path:           "/state",
+		ContentType:    "",
+		Body:           nil,
+		MaxTimeSeconds: 0,
+		IdempotencyKey: "",
+	})
+	if err != nil {
+		return RuntimeBackendStatus{}, fmt.Errorf("%w: load assistant runtime state: %w", ErrRuntimeUnhealthy, err)
+	}
+	var resp runnerStateResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return RuntimeBackendStatus{}, fmt.Errorf("decode assistant runtime state: %w", err)
+	}
+	return RuntimeBackendStatus(resp), nil
+}
+
 func (m *RuntimeManager) Stop(_ context.Context, runtime assistantRuntimeRecord) error {
 	if err := validateRuntimeBackend(m, runtime.Backend); err != nil {
 		return err

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -73,7 +73,6 @@ type runtimeStartupConfig struct {
 	ChatID         string             `json:"chat_id"`
 	MCPServers     []runtimeMCPServer `json:"mcp_servers"`
 	History        []runtimeMessage   `json:"history,omitempty"`
-	WarmTTLSeconds int                `json:"warm_ttl_seconds"`
 }
 
 type runtimeMCPServer struct {

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -19,6 +19,7 @@ type RuntimeBackend interface {
 	Configure(ctx context.Context, runtime assistantRuntimeRecord, config runtimeStartupConfig) error
 	RunTurn(ctx context.Context, runtime assistantRuntimeRecord, idempotencyKey string, authToken string, prompt string) error
 	ServerURL(ctx context.Context, runtime assistantRuntimeRecord, raw *url.URL) (*url.URL, error)
+	Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error)
 	// Stop halts the active runtime so it can be re-admitted later. Backends
 	// may keep persisted state (e.g. Fly app + IP) intact for warm reuse.
 	Stop(ctx context.Context, runtime assistantRuntimeRecord) error
@@ -32,6 +33,14 @@ type RuntimeBackendEnsureResult struct {
 	ColdStart           bool
 	NeedsConfigure      bool
 	BackendMetadataJSON []byte
+}
+
+// RuntimeBackendStatus mirrors the runner's `/state` response. IdleSeconds is
+// nil while a turn is in flight; the runner sets it to None synchronously on
+// /turn enqueue so this signal does not lag the request that started work.
+type RuntimeBackendStatus struct {
+	Configured  bool
+	IdleSeconds *uint64
 }
 
 func validateRuntimeBackend(runtime RuntimeBackend, backend string) error {

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -36,8 +36,9 @@ type RuntimeBackendEnsureResult struct {
 }
 
 // RuntimeBackendStatus mirrors the runner's `/state` response. IdleSeconds is
-// nil while a turn is in flight; the runner sets it to None synchronously on
-// /turn enqueue so this signal does not lag the request that started work.
+// `&0` while a turn is in flight (the runner clears its idle clock
+// synchronously on /turn enqueue so this signal does not lag the request that
+// started work) and `nil` only when the runner has never been /configured.
 type RuntimeBackendStatus struct {
 	Configured  bool
 	IdleSeconds *uint64

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -63,8 +63,9 @@ type flyRuntimeAppIdentity struct {
 }
 
 // runnerStateResponse mirrors agents/runner/src/wire.rs::RunnerStateResponse.
-// IdleSeconds is omitted while a turn is in flight; the runner clears it on
-// /turn enqueue, so this is the same source the manager polls to gate expiry.
+// IdleSeconds is `0` while a turn is in flight (the runner clears its idle
+// clock on /turn enqueue) and absent only when the runner has never been
+// /configured. Both shapes are the source the manager polls to gate expiry.
 type runnerStateResponse struct {
 	Configured  bool    `json:"configured"`
 	IdleSeconds *uint64 `json:"idle_seconds,omitempty"`

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -62,8 +62,12 @@ type flyRuntimeAppIdentity struct {
 	Created  bool
 }
 
-type flyRuntimeStateResponse struct {
-	Configured bool `json:"configured"`
+// runnerStateResponse mirrors agents/runner/src/wire.rs::RunnerStateResponse.
+// IdleSeconds is omitted while a turn is in flight; the runner clears it on
+// /turn enqueue, so this is the same source the manager polls to gate expiry.
+type runnerStateResponse struct {
+	Configured  bool    `json:"configured"`
+	IdleSeconds *uint64 `json:"idle_seconds,omitempty"`
 }
 
 type flyRuntimeAPIClient interface {
@@ -603,7 +607,7 @@ func (f *FlyRuntimeBackend) tracedWaitHealth(ctx context.Context, target flyRunt
 	return f.waitForRuntimeHealth(ctx, target)
 }
 
-func (f *FlyRuntimeBackend) tracedRuntimeState(ctx context.Context, target flyRuntimeTarget, coldStart bool) (state flyRuntimeStateResponse, err error) {
+func (f *FlyRuntimeBackend) tracedRuntimeState(ctx context.Context, target flyRuntimeTarget, coldStart bool) (state runnerStateResponse, err error) {
 	ctx, span := f.tracer.Start(ctx, "assistants.runtime.runtimeState",
 		trace.WithAttributes(attr.AssistantColdStart(coldStart)),
 	)
@@ -687,6 +691,24 @@ func (f *FlyRuntimeBackend) ServerURL(_ context.Context, runtime assistantRuntim
 
 	cloned := *candidate
 	return &cloned, nil
+}
+
+func (f *FlyRuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	metadata, err := decodeFlyRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return RuntimeBackendStatus{}, err
+	}
+	if metadata.AppURL == "" {
+		return RuntimeBackendStatus{}, fmt.Errorf("assistant fly runtime app url is not available")
+	}
+	state, err := f.runtimeState(ctx, targetFromMetadata(metadata))
+	if err != nil {
+		return RuntimeBackendStatus{}, fmt.Errorf("load assistant fly runtime state: %w", err)
+	}
+	return RuntimeBackendStatus(state), nil
 }
 
 // Stop pauses the machine but preserves the app, allocated IP, and backend
@@ -831,7 +853,7 @@ func (f *FlyRuntimeBackend) waitForRuntimeHealth(ctx context.Context, target fly
 	}
 }
 
-func (f *FlyRuntimeBackend) runtimeState(ctx context.Context, target flyRuntimeTarget) (flyRuntimeStateResponse, error) {
+func (f *FlyRuntimeBackend) runtimeState(ctx context.Context, target flyRuntimeTarget) (runnerStateResponse, error) {
 	body, err := f.runtimeRequest(ctx, target, runtimeHTTPRequest{
 		Method:         http.MethodGet,
 		Path:           "/state",
@@ -841,11 +863,11 @@ func (f *FlyRuntimeBackend) runtimeState(ctx context.Context, target flyRuntimeT
 		IdempotencyKey: "",
 	})
 	if err != nil {
-		return flyRuntimeStateResponse{}, err
+		return runnerStateResponse{}, err
 	}
-	var state flyRuntimeStateResponse
+	var state runnerStateResponse
 	if err := json.Unmarshal(body, &state); err != nil {
-		return flyRuntimeStateResponse{}, fmt.Errorf("decode assistant fly runtime state: %w", err)
+		return runnerStateResponse{}, fmt.Errorf("decode assistant fly runtime state: %w", err)
 	}
 	return state, nil
 }

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -616,7 +616,7 @@ func newTestAssistantRuntimeServer(t *testing.T, configured bool) *httptest.Serv
 	})
 	mux.HandleFunc("/state", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(flyRuntimeStateResponse{Configured: configured})
+		_ = json.NewEncoder(w).Encode(runnerStateResponse{Configured: configured})
 	})
 	mux.HandleFunc("/configure", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -140,6 +140,15 @@ func (t *telemetryRuntimeBackend) ServerURL(ctx context.Context, runtime assista
 	return u, nil
 }
 
+func (t *telemetryRuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	status, err := t.inner.Status(ctx, runtime)
+	if err != nil {
+		t.emit(ctx, runtime, "runtime_status", "runtime status failed", "ERROR", err)
+		return status, fmt.Errorf("runtime status: %w", err)
+	}
+	return status, nil
+}
+
 func (t *telemetryRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRecord) error {
 	err := t.inner.Stop(ctx, runtime)
 	if err != nil {

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -143,7 +143,9 @@ func (t *telemetryRuntimeBackend) ServerURL(ctx context.Context, runtime assista
 func (t *telemetryRuntimeBackend) Status(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendStatus, error) {
 	status, err := t.inner.Status(ctx, runtime)
 	if err != nil {
-		t.emit(ctx, runtime, "runtime_status", "runtime status failed", "ERROR", err)
+		// Status is a probe; failures during expire are an expected race
+		// (runner already gone), not a fatal — keep the signal but at WARN.
+		t.emit(ctx, runtime, "runtime_status", "runtime status failed", "WARN", err)
 		return status, fmt.Errorf("runtime status: %w", err)
 	}
 	return status, nil

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1620,7 +1620,6 @@ func (s *ServiceCore) buildRuntimeStartupConfig(
 		ChatID:         thread.ChatID.String(),
 		MCPServers:     mcpServers,
 		History:        history,
-		WarmTTLSeconds: assistant.WarmTTLSeconds,
 	}, nil
 }
 

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -41,6 +41,7 @@ const (
 	sourceKindCron       = "cron"
 	runtimeStateStarting = "starting"
 	runtimeStateActive   = "active"
+	runtimeStateExpiring = "expiring"
 	runtimeStateStopped  = "stopped"
 	runtimeStateFailed   = "failed"
 	runtimeStateReaped   = "reaped"
@@ -241,9 +242,18 @@ type EnqueueResult struct {
 type ProcessThreadEventsResult struct {
 	AssistantID       uuid.UUID
 	WarmUntil         time.Time
+	WarmTTLSeconds    int
 	RuntimeActive     bool
 	RetryAdmission    bool
 	ProcessedAnyEvent bool
+}
+
+// ExpireThreadRuntimeResult reports the outcome of an expire attempt.
+// Stopped=false + RemainingSeconds means a turn slipped in past the warm
+// timer; the workflow should re-arm with that window and try again.
+type ExpireThreadRuntimeResult struct {
+	Stopped          bool
+	RemainingSeconds int
 }
 
 type ServiceCore struct {
@@ -415,18 +425,11 @@ func (s *ServiceCore) ReapStuckRuntimes(ctx context.Context) (ReapStuckRuntimesR
 	return out, nil
 }
 
-// HandleUnexpectedRuntimeExit is invoked by the runtime backend when a VM
-// terminates without a Stop() call. Marks the DB runtime row stopped and
-// soft-deletes it so admit can re-provision a fresh row on the next event;
-// without this the partial unique index on (assistant_thread_id) WHERE
-// deleted IS FALSE AND ended IS FALSE silently blocks admit's ON CONFLICT
-// DO NOTHING insert and the thread wedges.
-// NewUnexpectedRuntimeExitHandler returns a callback suitable for
-// RuntimeManagerConfig.OnUnexpectedExit. It only needs the db pool and a
-// logger, so it can be wired at deps.go time without creating an artificial
-// dep on ServiceCore. The handler reconciles the DB runtime row when a VM
-// dies without a Stop() call so admit can re-provision the thread on its
-// next event.
+// NewUnexpectedRuntimeExitHandler returns an OnUnexpectedExit callback that
+// reconciles the DB runtime row when a VM dies without a Stop() call. Without
+// this the partial unique index on (assistant_thread_id) WHERE deleted IS
+// FALSE AND ended IS FALSE blocks admit's ON CONFLICT DO NOTHING insert and
+// the thread wedges.
 func NewUnexpectedRuntimeExitHandler(logger *slog.Logger, db *pgxpool.Pool) func(threadID uuid.UUID) {
 	return func(threadID uuid.UUID) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -445,6 +448,7 @@ func NewUnexpectedRuntimeExitHandler(logger *slog.Logger, db *pgxpool.Pool) func
 			ThreadID:      threadID,
 			StartingState: runtimeStateStarting,
 			ActiveState:   runtimeStateActive,
+			ExpiringState: runtimeStateExpiring,
 		})
 		if err != nil {
 			logger.ErrorContext(ctx, "reconcile assistant runtime after unexpected exit failed",
@@ -453,6 +457,19 @@ func NewUnexpectedRuntimeExitHandler(logger *slog.Logger, db *pgxpool.Pool) func
 			)
 		}
 	}
+}
+
+// warmRemainingSeconds returns the seconds left before the runner's reported
+// idle window crosses ttl. Returns 0 if the runner is busy (idle = nil), if
+// idle has already met or exceeded ttl, or if ttl is non-positive.
+func warmRemainingSeconds(idleSeconds *uint64, ttlSeconds int) int {
+	if idleSeconds == nil || ttlSeconds <= 0 {
+		return 0
+	}
+	if *idleSeconds >= uint64(ttlSeconds) {
+		return 0
+	}
+	return ttlSeconds - int(*idleSeconds) //nolint:gosec // bounded above by ttlSeconds (int)
 }
 
 func normalizeWarmTTLSeconds(v *int) int {
@@ -1251,6 +1268,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 		return ProcessThreadEventsResult{
 			AssistantID:       assistant.ID,
 			WarmUntil:         time.Time{},
+			WarmTTLSeconds:    assistant.WarmTTLSeconds,
 			RuntimeActive:     false,
 			RetryAdmission:    true,
 			ProcessedAnyEvent: false,
@@ -1268,6 +1286,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			return ProcessThreadEventsResult{
 				AssistantID:       assistant.ID,
 				WarmUntil:         time.Time{},
+				WarmTTLSeconds:    assistant.WarmTTLSeconds,
 				RuntimeActive:     false,
 				RetryAdmission:    true,
 				ProcessedAnyEvent: false,
@@ -1279,6 +1298,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			return ProcessThreadEventsResult{
 				AssistantID:       assistant.ID,
 				WarmUntil:         time.Time{},
+				WarmTTLSeconds:    assistant.WarmTTLSeconds,
 				RuntimeActive:     false,
 				RetryAdmission:    true,
 				ProcessedAnyEvent: false,
@@ -1329,6 +1349,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 				return ProcessThreadEventsResult{
 					AssistantID:       assistant.ID,
 					WarmUntil:         time.Time{},
+					WarmTTLSeconds:    assistant.WarmTTLSeconds,
 					RuntimeActive:     false,
 					RetryAdmission:    true,
 					ProcessedAnyEvent: processedAny,
@@ -1352,6 +1373,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 				return ProcessThreadEventsResult{
 					AssistantID:       assistant.ID,
 					WarmUntil:         warmUntil,
+					WarmTTLSeconds:    assistant.WarmTTLSeconds,
 					RuntimeActive:     true,
 					RetryAdmission:    false,
 					ProcessedAnyEvent: processedAny,
@@ -1372,6 +1394,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 				return ProcessThreadEventsResult{
 					AssistantID:       assistant.ID,
 					WarmUntil:         warmUntil,
+					WarmTTLSeconds:    assistant.WarmTTLSeconds,
 					RuntimeActive:     true,
 					RetryAdmission:    false,
 					ProcessedAnyEvent: processedAny,
@@ -1391,6 +1414,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 			return ProcessThreadEventsResult{
 				AssistantID:       assistant.ID,
 				WarmUntil:         warmUntil,
+				WarmTTLSeconds:    assistant.WarmTTLSeconds,
 				RuntimeActive:     true,
 				RetryAdmission:    true,
 				ProcessedAnyEvent: processedAny,
@@ -1411,6 +1435,7 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 	return ProcessThreadEventsResult{
 		AssistantID:       assistant.ID,
 		WarmUntil:         warmUntil,
+		WarmTTLSeconds:    assistant.WarmTTLSeconds,
 		RuntimeActive:     true,
 		RetryAdmission:    false,
 		ProcessedAnyEvent: processedAny,
@@ -1671,21 +1696,73 @@ func (s *ServiceCore) ProcessThreadEventsByThreadID(ctx context.Context, project
 	return s.ProcessThreadEvents(ctx, projectID, threadID)
 }
 
-func (s *ServiceCore) ExpireThreadRuntime(ctx context.Context, projectID, threadID uuid.UUID) error {
-	runtimeRecord, err := s.loadActiveRuntimeRecord(ctx, projectID, threadID)
+// ExpireThreadRuntime tears down an idle runtime, guarding the TOCTOU between
+// the workflow's warm timer and a new turn being dispatched. The CAS to
+// `expiring` blocks new dispatches; the post-CAS /state poll catches any turn
+// that slipped in (the runner clears idle_seconds synchronously inside /turn).
+func (s *ServiceCore) ExpireThreadRuntime(ctx context.Context, projectID, threadID uuid.UUID, warmTTLSeconds int) (ExpireThreadRuntimeResult, error) {
+	q := assistantrepo.New(s.db)
+
+	row, err := q.BeginExpireAssistantRuntime(ctx, assistantrepo.BeginExpireAssistantRuntimeParams{
+		ExpiringState: runtimeStateExpiring,
+		ProjectID:     projectID,
+		ThreadID:      threadID,
+		ActiveState:   runtimeStateActive,
+	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil
+		// No active row, or another actor (Stop, reaper, manual API) moved it
+		// before us. The runtime is going away regardless — report stopped so
+		// the workflow exits its expiry loop.
+		return ExpireThreadRuntimeResult{Stopped: true, RemainingSeconds: 0}, nil
 	case err != nil:
-		return err
+		return ExpireThreadRuntimeResult{}, fmt.Errorf("begin expire assistant runtime: %w", err)
 	}
+
+	runtimeRecord := assistantRuntimeRecord{
+		ID:                  row.ID,
+		AssistantThreadID:   row.AssistantThreadID,
+		AssistantID:         row.AssistantID,
+		ProjectID:           row.ProjectID,
+		Backend:             row.Backend,
+		BackendMetadataJSON: row.BackendMetadataJson,
+		State:               row.State,
+		WarmUntil:           row.WarmUntil,
+	}
+
+	status, statusErr := s.runtime.Status(ctx, runtimeRecord)
+	if statusErr != nil {
+		// Runtime is already gone or unhealthy — fall through to Stop so the
+		// row + backend resources get cleaned up.
+		s.logger.WarnContext(ctx, "runtime status failed during expire; tearing down",
+			attr.SlogAssistantThreadID(threadID.String()),
+			attr.SlogError(statusErr),
+		)
+	} else if remaining := warmRemainingSeconds(status.IdleSeconds, warmTTLSeconds); remaining > 0 {
+		// A turn slipped in between the workflow's warm timer and our CAS.
+		// Revert to active and let the workflow re-arm with the remaining
+		// window measured against the runner's current idle.
+		warmUntil := time.Now().UTC().Add(time.Duration(remaining) * time.Second)
+		revertErr := q.RevertExpireAssistantRuntimeToActive(ctx, assistantrepo.RevertExpireAssistantRuntimeToActiveParams{
+			ActiveState:   runtimeStateActive,
+			WarmUntil:     conv.ToPGTimestamptz(warmUntil),
+			RuntimeID:     runtimeRecord.ID,
+			ProjectID:     projectID,
+			ExpiringState: runtimeStateExpiring,
+		})
+		if revertErr != nil {
+			return ExpireThreadRuntimeResult{}, fmt.Errorf("revert expire assistant runtime: %w", revertErr)
+		}
+		return ExpireThreadRuntimeResult{Stopped: false, RemainingSeconds: remaining}, nil
+	}
+
 	if err := s.runtime.Stop(ctx, runtimeRecord); err != nil {
-		return fmt.Errorf("stop assistant runtime backend: %w", err)
+		return ExpireThreadRuntimeResult{}, fmt.Errorf("stop assistant runtime backend: %w", err)
 	}
 	if err := s.stopRuntimeRecord(ctx, projectID, threadID, runtimeStateStopped); err != nil {
-		return err
+		return ExpireThreadRuntimeResult{}, err
 	}
-	return nil
+	return ExpireThreadRuntimeResult{Stopped: true, RemainingSeconds: 0}, nil
 }
 
 func (s *ServiceCore) loadThreadContext(ctx context.Context, projectID, threadID uuid.UUID) (assistantThreadRecord, assistantRecord, assistantRuntimeRecord, error) {
@@ -1740,28 +1817,6 @@ func (s *ServiceCore) loadThreadContext(ctx context.Context, projectID, threadID
 	}
 	assistant.Toolsets = refs[assistant.ID]
 	return thread, assistant, runtime, nil
-}
-
-func (s *ServiceCore) loadActiveRuntimeRecord(ctx context.Context, projectID, threadID uuid.UUID) (assistantRuntimeRecord, error) {
-	row, err := assistantrepo.New(s.db).LoadActiveRuntimeRecord(ctx, assistantrepo.LoadActiveRuntimeRecordParams{
-		ProjectID:     projectID,
-		ThreadID:      threadID,
-		StartingState: runtimeStateStarting,
-		ActiveState:   runtimeStateActive,
-	})
-	if err != nil {
-		return assistantRuntimeRecord{}, fmt.Errorf("load active assistant runtime: %w", err)
-	}
-	return assistantRuntimeRecord{
-		ID:                  row.ID,
-		AssistantThreadID:   row.AssistantThreadID,
-		AssistantID:         row.AssistantID,
-		ProjectID:           row.ProjectID,
-		Backend:             row.Backend,
-		BackendMetadataJSON: row.BackendMetadataJson,
-		State:               row.State,
-		WarmUntil:           row.WarmUntil,
-	}, nil
 }
 
 func (s *ServiceCore) loadChatHistory(ctx context.Context, chatID uuid.UUID, projectID uuid.UUID) ([]runtimeMessage, error) {
@@ -1954,6 +2009,7 @@ func (s *ServiceCore) stopRuntimeRecord(ctx context.Context, projectID, threadID
 		ThreadID:      threadID,
 		StartingState: runtimeStateStarting,
 		ActiveState:   runtimeStateActive,
+		ExpiringState: runtimeStateExpiring,
 	})
 	if err != nil {
 		return fmt.Errorf("stop assistant runtime: %w", err)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -459,12 +459,12 @@ func NewUnexpectedRuntimeExitHandler(logger *slog.Logger, db *pgxpool.Pool) func
 	}
 }
 
-// warmRemainingSeconds returns the seconds left before the runner's reported
-// idle window crosses ttl. Returns 0 if the runner is busy (idle = nil), if
-// idle has already met or exceeded ttl, or if ttl is non-positive.
 func warmRemainingSeconds(idleSeconds *uint64, ttlSeconds int) int {
-	if idleSeconds == nil || ttlSeconds <= 0 {
+	if ttlSeconds <= 0 {
 		return 0
+	}
+	if idleSeconds == nil {
+		return ttlSeconds
 	}
 	if *idleSeconds >= uint64(ttlSeconds) {
 		return 0

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -57,9 +57,16 @@ const (
 	// loop forever.
 	maxEventAttempts = 5
 
-	runtimeStartupReapGrace      = 2 * time.Minute
-	runtimeWarmExpiryReapGrace   = 1 * time.Minute
-	runtimeProcessingLeaseGrace  = 2 * time.Minute
+	runtimeStartupReapGrace     = 2 * time.Minute
+	runtimeWarmExpiryReapGrace  = 1 * time.Minute
+	runtimeProcessingLeaseGrace = 2 * time.Minute
+	// runtimeExpiringReapGrace is the cushion the reaper waits before
+	// reclaiming a row stuck in `expiring`. It must exceed the worst-case
+	// total budget of the ExpireThreadRuntime activity (Temporal
+	// ScheduleToCloseTimeout = 25m) so a still-retrying activity isn't
+	// stomped mid-flight; the row only becomes reapable after Temporal
+	// gives up.
+	runtimeExpiringReapGrace     = 30 * time.Minute
 	eventProcessingRequeueGrace  = 3 * time.Minute
 	processingLeaseHeartbeatTick = 30 * time.Second
 	admitFailureBackoff          = 30 * time.Second
@@ -375,12 +382,17 @@ func (s *ServiceCore) ReapStuckRuntimes(ctx context.Context) (ReapStuckRuntimesR
 	affected := map[uuid.UUID]struct{}{}
 
 	// 1. Retire runtime rows whose liveness markers indicate the owning
-	// process is gone:
+	// process is gone or its driving workflow has given up:
 	//   - 'starting' rows that never transitioned to active within the
 	//     startup grace window (usually server crashed mid-boot).
 	//   - 'active' rows whose warm_until passed a grace window ago (usually
 	//     server crashed after a turn; unexpected-exit callback didn't fire
 	//     because the whole process died).
+	//   - 'expiring' rows whose updated_at is older than the activity's full
+	//     retry budget — the ExpireThreadRuntime activity exhausted Temporal
+	//     attempts after CAS active->expiring without reaching Stop or
+	//     Revert. Without this the row blocks the partial unique index
+	//     ReserveAssistantRuntime depends on.
 	queries := assistantrepo.New(s.db)
 	runtimeAssistantIDs, err := queries.ReapStuckAssistantRuntimes(ctx, assistantrepo.ReapStuckAssistantRuntimesParams{
 		StoppedState:    runtimeStateStopped,
@@ -389,6 +401,8 @@ func (s *ServiceCore) ReapStuckRuntimes(ctx context.Context) (ReapStuckRuntimesR
 		ActiveState:     runtimeStateActive,
 		WarmCutoff:      conv.ToPGTimestamptz(now.Add(-runtimeWarmExpiryReapGrace)),
 		HeartbeatCutoff: conv.ToPGTimestamptz(now.Add(-runtimeProcessingLeaseGrace)),
+		ExpiringState:   runtimeStateExpiring,
+		ExpiringCutoff:  conv.ToPGTimestamptz(now.Add(-runtimeExpiringReapGrace)),
 	})
 	if err != nil {
 		return out, fmt.Errorf("reap stuck assistant runtimes: %w", err)

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -69,6 +69,65 @@ WHERE assistant_thread_id = $1
 	require.Equal(t, runtimeBackendFlyIO, backend)
 }
 
+func TestWarmRemainingSecondsKeepsBusyRunnerAlive(t *testing.T) {
+	t.Parallel()
+
+	// idle == nil is the runner's "turn in flight" signal (see RuntimeBackendStatus
+	// and runnerStateResponse). It must never collapse to a Stop decision.
+	got := warmRemainingSeconds(nil, 300)
+	require.Positive(t, got, "busy runner (idle=nil) must keep a positive warm window so ExpireThreadRuntime reverts instead of stopping")
+}
+
+func TestServiceCoreExpireThreadRuntimeRevertsWhenTurnInFlight(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_expire_busy")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	runtimeID := uuid.New()
+	warmUntil := time.Now().UTC().Add(-1 * time.Second)
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistant_runtimes (
+  id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until, last_heartbeat_at, updated_at
+) VALUES (
+  $1, $2, $3, $4, $5, '{}'::jsonb, $6, $7, clock_timestamp(), clock_timestamp()
+)
+`, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, runtimeStateActive, warmUntil)
+	require.NoError(t, err)
+
+	var stopCalls atomic.Int64
+	logger := testenv.NewLogger(t)
+	backend := testRuntimeBackend{
+		backend:      runtimeBackendFlyIO,
+		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: nil},
+		stopCalls:    &stopCalls,
+	}
+	core := NewServiceCore(logger, conn, backend, nil, nil, nil, telemetry.NewStub(logger))
+
+	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
+	require.NoError(t, err)
+	require.False(t, result.Stopped, "runner reports turn in flight (idle=nil); expiry must revert, not tear down")
+	require.Positive(t, result.RemainingSeconds, "revert path must hand back a positive warm window for the workflow to re-arm")
+	require.Equal(t, int64(0), stopCalls.Load(), "Stop must not be invoked while a turn is executing")
+
+	var state string
+	var deleted bool
+	err = conn.QueryRow(t.Context(), `
+SELECT state, deleted
+FROM assistant_runtimes
+WHERE id = $1
+`, runtimeID).Scan(&state, &deleted)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateActive, state, "runtime row must be reverted from expiring back to active")
+	require.False(t, deleted)
+}
+
 func TestServiceCoreReapStuckRuntimesSkipsLiveProcessingLease(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -72,10 +72,15 @@ WHERE assistant_thread_id = $1
 func TestWarmRemainingSecondsKeepsBusyRunnerAlive(t *testing.T) {
 	t.Parallel()
 
-	// idle == nil is the runner's "turn in flight" signal (see RuntimeBackendStatus
-	// and runnerStateResponse). It must never collapse to a Stop decision.
-	got := warmRemainingSeconds(nil, 300)
-	require.Positive(t, got, "busy runner (idle=nil) must keep a positive warm window so ExpireThreadRuntime reverts instead of stopping")
+	// The runner sends idle_seconds=0 while a turn is in flight (see
+	// agents/runner/src/wire.rs::RunnerStateResponse) and omits the field
+	// entirely only when never /configured. ExpireThreadRuntime must treat
+	// both shapes as "do not stop": the &0 case covers the production race,
+	// and the nil case is a defensive guard against an unconfigured backend
+	// row sneaking past the CAS.
+	zero := uint64(0)
+	require.Positive(t, warmRemainingSeconds(&zero, 300), "busy runner (idle=&0) must keep a positive warm window")
+	require.Positive(t, warmRemainingSeconds(nil, 300), "missing idle (never configured) must not collapse to a Stop decision")
 }
 
 func TestServiceCoreExpireThreadRuntimeRevertsWhenTurnInFlight(t *testing.T) {
@@ -103,16 +108,17 @@ INSERT INTO assistant_runtimes (
 
 	var stopCalls atomic.Int64
 	logger := testenv.NewLogger(t)
+	busyIdle := uint64(0)
 	backend := testRuntimeBackend{
 		backend:      runtimeBackendFlyIO,
-		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: nil},
+		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: &busyIdle},
 		stopCalls:    &stopCalls,
 	}
 	core := NewServiceCore(logger, conn, backend, nil, nil, nil, telemetry.NewStub(logger))
 
 	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.NoError(t, err)
-	require.False(t, result.Stopped, "runner reports turn in flight (idle=nil); expiry must revert, not tear down")
+	require.False(t, result.Stopped, "runner reports turn in flight (idle=&0); expiry must revert, not tear down")
 	require.Positive(t, result.RemainingSeconds, "revert path must hand back a positive warm window for the workflow to re-arm")
 	require.Equal(t, int64(0), stopCalls.Load(), "Stop must not be invoked while a turn is executing")
 
@@ -126,6 +132,154 @@ WHERE id = $1
 	require.NoError(t, err)
 	require.Equal(t, runtimeStateActive, state, "runtime row must be reverted from expiring back to active")
 	require.False(t, deleted)
+}
+
+// TestServiceCoreExpireThreadRuntimeRetryAfterStopFailureIsIdempotent guards
+// the Temporal-retry path: if the first ExpireThreadRuntime attempt CAS'd the
+// row from active->expiring but then Stop() failed, the activity returns an
+// error and Temporal retries. The retry must reuse the existing expiring row
+// and complete the teardown rather than treating the CAS miss as "another
+// actor handled it" (which would leak the backend VM and wedge the thread on
+// the partial unique index).
+func TestServiceCoreExpireThreadRuntimeRetryAfterStopFailureIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_expire_retry")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	runtimeID := uuid.New()
+	warmUntil := time.Now().UTC().Add(-1 * time.Second)
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistant_runtimes (
+  id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until, last_heartbeat_at, updated_at
+) VALUES (
+  $1, $2, $3, $4, $5, '{}'::jsonb, $6, $7, clock_timestamp(), clock_timestamp()
+)
+`, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, runtimeStateActive, warmUntil)
+	require.NoError(t, err)
+
+	var stopCalls atomic.Int64
+	logger := testenv.NewLogger(t)
+	failingBackend := testRuntimeBackend{
+		backend:      runtimeBackendFlyIO,
+		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: new(uint64(DefaultWarmTTLSeconds + 60))},
+		stopErr:      errors.New("fly delete app blew up"),
+		stopCalls:    &stopCalls,
+	}
+	core := NewServiceCore(logger, conn, failingBackend, nil, nil, nil, telemetry.NewStub(logger))
+
+	_, err = core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
+	require.Error(t, err, "first attempt with failing Stop must surface the error so Temporal retries")
+	require.Equal(t, int64(1), stopCalls.Load())
+
+	var state string
+	err = conn.QueryRow(t.Context(), `SELECT state FROM assistant_runtimes WHERE id = $1`, runtimeID).Scan(&state)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateExpiring, state, "row must remain in expiring after Stop failure")
+
+	healingBackend := testRuntimeBackend{
+		backend:      runtimeBackendFlyIO,
+		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: new(uint64(DefaultWarmTTLSeconds + 60))},
+		stopCalls:    &stopCalls,
+	}
+	core = NewServiceCore(logger, conn, healingBackend, nil, nil, nil, telemetry.NewStub(logger))
+
+	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
+	require.NoError(t, err, "retry must drive the existing expiring row to a terminal state")
+	require.True(t, result.Stopped, "retry must report stopped only after Stop actually succeeded")
+	require.Equal(t, int64(2), stopCalls.Load(), "retry must invoke Stop a second time, not fall through ErrNoRows")
+
+	var deleted bool
+	err = conn.QueryRow(t.Context(), `SELECT state, deleted FROM assistant_runtimes WHERE id = $1`, runtimeID).Scan(&state, &deleted)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateStopped, state)
+	require.True(t, deleted)
+}
+
+// TestServiceCoreReapStuckRuntimesCleansUpStuckExpiring covers the safety net
+// for ExpireThreadRuntime activities that exhaust Temporal's retry budget
+// after CAS active->expiring. Without reaper coverage the row stays in
+// `expiring` indefinitely and blocks the partial unique index
+// ReserveAssistantRuntime relies on.
+func TestServiceCoreReapStuckRuntimesCleansUpStuckExpiring(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_reap_expiring")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	runtimeID := uuid.New()
+	staleUpdatedAt := time.Now().UTC().Add(-(runtimeExpiringReapGrace + time.Minute))
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistant_runtimes (
+  id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until, last_heartbeat_at, updated_at
+) VALUES (
+  $1, $2, $3, $4, $5, '{}'::jsonb, $6, NULL, clock_timestamp(), $7
+)
+`, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, runtimeStateExpiring, staleUpdatedAt)
+	require.NoError(t, err)
+
+	core := NewServiceCore(testenv.NewLogger(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	result, err := core.ReapStuckRuntimes(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, result.StaleRuntimesStopped)
+
+	var state string
+	var deletedAt sql.NullTime
+	err = conn.QueryRow(t.Context(), `SELECT state, deleted_at FROM assistant_runtimes WHERE id = $1`, runtimeID).Scan(&state, &deletedAt)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateStopped, state, "stuck expiring row must be reclaimed by the reaper")
+	require.True(t, deletedAt.Valid)
+}
+
+// TestServiceCoreReapStuckRuntimesLeavesFreshExpiring verifies the grace
+// window: an expiring row that is still within the activity's retry budget
+// must NOT be touched by the reaper, otherwise an in-flight retry would race
+// the reaper for the same row.
+func TestServiceCoreReapStuckRuntimesLeavesFreshExpiring(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_reap_expiring_fresh")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	runtimeID := uuid.New()
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistant_runtimes (
+  id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until, last_heartbeat_at, updated_at
+) VALUES (
+  $1, $2, $3, $4, $5, '{}'::jsonb, $6, NULL, clock_timestamp(), clock_timestamp()
+)
+`, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, runtimeStateExpiring)
+	require.NoError(t, err)
+
+	core := NewServiceCore(testenv.NewLogger(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	result, err := core.ReapStuckRuntimes(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 0, result.StaleRuntimesStopped, "fresh expiring row must remain so an in-flight retry can complete")
+
+	var state string
+	err = conn.QueryRow(t.Context(), `SELECT state FROM assistant_runtimes WHERE id = $1`, runtimeID).Scan(&state)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateExpiring, state)
 }
 
 func TestServiceCoreReapStuckRuntimesSkipsLiveProcessingLease(t *testing.T) {
@@ -1025,6 +1179,7 @@ type testRuntimeBackend struct {
 	runTurnErr   error
 	statusResult RuntimeBackendStatus
 	statusErr    error
+	stopErr      error
 	stopCalls    *atomic.Int64
 	reapCalls    *atomic.Int64
 	reapErr      error
@@ -1072,7 +1227,12 @@ func (t testRuntimeBackend) Stop(context.Context, assistantRuntimeRecord) error 
 	if t.stopCalls != nil {
 		t.stopCalls.Add(1)
 	}
-	return nil
+	return t.stopErr
+}
+
+//go:fix inline
+func ptrUint64ForServiceTest(v uint64) *uint64 {
+	return new(v)
 }
 
 func (t testRuntimeBackend) Reap(context.Context, assistantRuntimeRecord) error {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -964,6 +964,8 @@ type testRuntimeBackend struct {
 	ensureErr    error
 	configureErr error
 	runTurnErr   error
+	statusResult RuntimeBackendStatus
+	statusErr    error
 	stopCalls    *atomic.Int64
 	reapCalls    *atomic.Int64
 	reapErr      error
@@ -998,6 +1000,13 @@ func (t testRuntimeBackend) ServerURL(context.Context, assistantRuntimeRecord, *
 		return nil, fmt.Errorf("parse test server url: %w", err)
 	}
 	return parsed, nil
+}
+
+func (t testRuntimeBackend) Status(context.Context, assistantRuntimeRecord) (RuntimeBackendStatus, error) {
+	if t.statusErr != nil {
+		return RuntimeBackendStatus{}, t.statusErr
+	}
+	return t.statusResult, nil
 }
 
 func (t testRuntimeBackend) Stop(context.Context, assistantRuntimeRecord) error {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -114,7 +114,7 @@ INSERT INTO assistant_runtimes (
 		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: &busyIdle},
 		stopCalls:    &stopCalls,
 	}
-	core := NewServiceCore(logger, conn, backend, nil, nil, nil, telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(logger))
 
 	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ INSERT INTO assistant_runtimes (
 		stopErr:      errors.New("fly delete app blew up"),
 		stopCalls:    &stopCalls,
 	}
-	core := NewServiceCore(logger, conn, failingBackend, nil, nil, nil, telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, failingBackend, nil, nil, nil, telemetry.NewStub(logger))
 
 	_, err = core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.Error(t, err, "first attempt with failing Stop must surface the error so Temporal retries")
@@ -188,7 +188,7 @@ INSERT INTO assistant_runtimes (
 		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: new(uint64(DefaultWarmTTLSeconds + 60))},
 		stopCalls:    &stopCalls,
 	}
-	core = NewServiceCore(logger, conn, healingBackend, nil, nil, nil, telemetry.NewStub(logger))
+	core = NewServiceCore(logger, testenv.NewTracerProvider(t), conn, healingBackend, nil, nil, nil, telemetry.NewStub(logger))
 
 	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.NoError(t, err, "retry must drive the existing expiring row to a terminal state")
@@ -230,7 +230,7 @@ INSERT INTO assistant_runtimes (
 `, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, runtimeStateExpiring, staleUpdatedAt)
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
 
 	result, err := core.ReapStuckRuntimes(t.Context())
 	require.NoError(t, err)
@@ -270,7 +270,7 @@ INSERT INTO assistant_runtimes (
 `, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, runtimeStateExpiring)
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
 
 	result, err := core.ReapStuckRuntimes(t.Context())
 	require.NoError(t, err)
@@ -1228,11 +1228,6 @@ func (t testRuntimeBackend) Stop(context.Context, assistantRuntimeRecord) error 
 		t.stopCalls.Add(1)
 	}
 	return t.stopErr
-}
-
-//go:fix inline
-func ptrUint64ForServiceTest(v uint64) *uint64 {
-	return new(v)
 }
 
 func (t testRuntimeBackend) Reap(context.Context, assistantRuntimeRecord) error {

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -288,7 +288,7 @@ func (a *Activities) ProcessAssistantThread(ctx context.Context, input activitie
 	return a.processAssistantThread.Do(ctx, input)
 }
 
-func (a *Activities) ExpireAssistantThreadRuntime(ctx context.Context, input activities.ExpireAssistantThreadRuntimeInput) error {
+func (a *Activities) ExpireAssistantThreadRuntime(ctx context.Context, input activities.ExpireAssistantThreadRuntimeInput) (*activities.ExpireAssistantThreadRuntimeResult, error) {
 	return a.expireAssistantThreadRuntime.Do(ctx, input)
 }
 

--- a/server/internal/background/activities/assistants.go
+++ b/server/internal/background/activities/assistants.go
@@ -28,14 +28,24 @@ type ProcessAssistantThreadInput struct {
 type ProcessAssistantThreadResult struct {
 	AssistantID       string
 	WarmUntil         string
+	WarmTTLSeconds    int
 	RuntimeActive     bool
 	RetryAdmission    bool
 	ProcessedAnyEvent bool
 }
 
 type ExpireAssistantThreadRuntimeInput struct {
-	ThreadID  string
-	ProjectID string
+	ThreadID       string
+	ProjectID      string
+	WarmTTLSeconds int
+}
+
+// ExpireAssistantThreadRuntimeResult reports the outcome of an expire attempt.
+// Stopped=false + RemainingSeconds means a turn slipped in past the warm
+// timer; the workflow should re-arm with that window and try again.
+type ExpireAssistantThreadRuntimeResult struct {
+	Stopped          bool
+	RemainingSeconds int
 }
 
 type SignalAssistantCoordinatorInput struct {
@@ -154,6 +164,7 @@ func (a *ProcessAssistantThread) Do(ctx context.Context, input ProcessAssistantT
 	out := &ProcessAssistantThreadResult{
 		AssistantID:       result.AssistantID.String(),
 		WarmUntil:         "",
+		WarmTTLSeconds:    result.WarmTTLSeconds,
 		RuntimeActive:     result.RuntimeActive,
 		RetryAdmission:    result.RetryAdmission,
 		ProcessedAnyEvent: result.ProcessedAnyEvent,
@@ -180,19 +191,23 @@ func (a *ReapStuckAssistantRuntimes) Do(ctx context.Context) (*ReapStuckAssistan
 	}, nil
 }
 
-func (a *ExpireAssistantThreadRuntime) Do(ctx context.Context, input ExpireAssistantThreadRuntimeInput) error {
+func (a *ExpireAssistantThreadRuntime) Do(ctx context.Context, input ExpireAssistantThreadRuntimeInput) (*ExpireAssistantThreadRuntimeResult, error) {
 	threadID, err := uuid.Parse(input.ThreadID)
 	if err != nil {
-		return fmt.Errorf("parse thread id: %w", err)
+		return nil, fmt.Errorf("parse thread id: %w", err)
 	}
 	projectID, err := uuid.Parse(input.ProjectID)
 	if err != nil {
-		return fmt.Errorf("parse project id: %w", err)
+		return nil, fmt.Errorf("parse project id: %w", err)
 	}
-	if err := a.core.ExpireThreadRuntime(ctx, projectID, threadID); err != nil {
-		return fmt.Errorf("expire assistant thread runtime: %w", err)
+	result, err := a.core.ExpireThreadRuntime(ctx, projectID, threadID, input.WarmTTLSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("expire assistant thread runtime: %w", err)
 	}
-	return nil
+	return &ExpireAssistantThreadRuntimeResult{
+		Stopped:          result.Stopped,
+		RemainingSeconds: result.RemainingSeconds,
+	}, nil
 }
 
 func (a *SignalAssistantCoordinator) Do(ctx context.Context, input SignalAssistantCoordinatorInput) error {

--- a/server/internal/background/assistants.go
+++ b/server/internal/background/assistants.go
@@ -171,27 +171,48 @@ func AssistantThreadWorkflow(ctx workflow.Context, input AssistantThreadWorkflow
 			waitFor = max(warmUntil.Sub(workflow.Now(ctx).UTC()), 0)
 		}
 
-		expired := false
-		selector := workflow.NewSelector(ctx)
-		selector.AddFuture(workflow.NewTimer(ctx, waitFor), func(workflow.Future) {
-			expired = true
-		})
-		selector.AddReceive(signalCh, func(c workflow.ReceiveChannel, more bool) {
-			var ignored struct{}
-			c.Receive(ctx, &ignored)
-		})
-		selector.Select(ctx)
+		// Wait for the warm window to elapse, then ask the manager to expire
+		// the runtime. The manager guards a TOCTOU between this timer firing
+		// and a new turn being dispatched: if it observes a turn slipped in,
+		// it returns Stopped=false + RemainingSeconds and we re-arm here.
+		runtimeStopped := false
+		for {
+			timerFired := false
+			selector := workflow.NewSelector(ctx)
+			selector.AddFuture(workflow.NewTimer(ctx, waitFor), func(workflow.Future) {
+				timerFired = true
+			})
+			selector.AddReceive(signalCh, func(c workflow.ReceiveChannel, more bool) {
+				var ignored struct{}
+				c.Receive(ctx, &ignored)
+			})
+			selector.Select(ctx)
 
-		if !expired {
+			if !timerFired {
+				// Signal arrived first — drop back to ProcessAssistantThread
+				// to drain any queued events. Runtime stays active.
+				break
+			}
+
+			var expireResult activities.ExpireAssistantThreadRuntimeResult
+			if err := workflow.ExecuteActivity(ctx, a.ExpireAssistantThreadRuntime, activities.ExpireAssistantThreadRuntimeInput{
+				ThreadID:       input.ThreadID,
+				ProjectID:      input.ProjectID,
+				WarmTTLSeconds: result.WarmTTLSeconds,
+			}).Get(ctx, &expireResult); err != nil {
+				return err
+			}
+			if expireResult.Stopped {
+				runtimeStopped = true
+				break
+			}
+			waitFor = time.Duration(expireResult.RemainingSeconds) * time.Second
+		}
+
+		if !runtimeStopped {
 			continue
 		}
 
-		if err := workflow.ExecuteActivity(ctx, a.ExpireAssistantThreadRuntime, activities.ExpireAssistantThreadRuntimeInput{
-			ThreadID:  input.ThreadID,
-			ProjectID: input.ProjectID,
-		}).Get(ctx, nil); err != nil {
-			return err
-		}
 		if err := workflow.ExecuteActivity(ctx, a.SignalAssistantCoordinator, activities.SignalAssistantCoordinatorInput{
 			AssistantID: result.AssistantID,
 		}).Get(ctx, nil); err != nil {

--- a/server/internal/background/assistants.go
+++ b/server/internal/background/assistants.go
@@ -194,8 +194,9 @@ func AssistantThreadWorkflow(ctx workflow.Context, input AssistantThreadWorkflow
 			}
 
 			if err := workflow.ExecuteActivity(ctx, a.ExpireAssistantThreadRuntime, activities.ExpireAssistantThreadRuntimeInput{
-				ThreadID:  input.ThreadID,
-				ProjectID: input.ProjectID,
+				ThreadID:       input.ThreadID,
+				ProjectID:      input.ProjectID,
+				WarmTTLSeconds: 0, // v0 disables the revert path; activity falls through to Stop.
 			}).Get(ctx, nil); err != nil {
 				return err
 			}

--- a/server/internal/background/assistants.go
+++ b/server/internal/background/assistants.go
@@ -171,10 +171,42 @@ func AssistantThreadWorkflow(ctx workflow.Context, input AssistantThreadWorkflow
 			waitFor = max(warmUntil.Sub(workflow.Now(ctx).UTC()), 0)
 		}
 
-		// Wait for the warm window to elapse, then ask the manager to expire
-		// the runtime. The manager guards a TOCTOU between this timer firing
-		// and a new turn being dispatched: if it observes a turn slipped in,
-		// it returns Stopped=false + RemainingSeconds and we re-arm here.
+		// Workflows that started on the previous code (single-shot timer +
+		// expire + signal) replay through DefaultVersion to keep history
+		// deterministic. New starts use v1, which adds a re-arm loop so the
+		// expire activity can revert to active when its post-CAS status poll
+		// finds a turn slipped in past the warm timer.
+		v := workflow.GetVersion(ctx, "expire-toctou-revert", workflow.DefaultVersion, 1)
+		if v == workflow.DefaultVersion {
+			expired := false
+			selector := workflow.NewSelector(ctx)
+			selector.AddFuture(workflow.NewTimer(ctx, waitFor), func(workflow.Future) {
+				expired = true
+			})
+			selector.AddReceive(signalCh, func(c workflow.ReceiveChannel, more bool) {
+				var ignored struct{}
+				c.Receive(ctx, &ignored)
+			})
+			selector.Select(ctx)
+
+			if !expired {
+				continue
+			}
+
+			if err := workflow.ExecuteActivity(ctx, a.ExpireAssistantThreadRuntime, activities.ExpireAssistantThreadRuntimeInput{
+				ThreadID:  input.ThreadID,
+				ProjectID: input.ProjectID,
+			}).Get(ctx, nil); err != nil {
+				return err
+			}
+			if err := workflow.ExecuteActivity(ctx, a.SignalAssistantCoordinator, activities.SignalAssistantCoordinatorInput{
+				AssistantID: result.AssistantID,
+			}).Get(ctx, nil); err != nil {
+				return err
+			}
+			return nil
+		}
+
 		runtimeStopped := false
 		for {
 			timerFired := false
@@ -189,8 +221,6 @@ func AssistantThreadWorkflow(ctx workflow.Context, input AssistantThreadWorkflow
 			selector.Select(ctx)
 
 			if !timerFired {
-				// Signal arrived first — drop back to ProcessAssistantThread
-				// to drain any queued events. Runtime stays active.
 				break
 			}
 

--- a/server/internal/background/assistants_workflow_test.go
+++ b/server/internal/background/assistants_workflow_test.go
@@ -2,6 +2,7 @@ package background
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -50,4 +51,62 @@ func TestAssistantThreadWorkflowBacksOffBeforeRetryAdmission(t *testing.T) {
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	require.GreaterOrEqual(t, signalTime.Sub(start), assistantRetryAdmissionBackoff)
+}
+
+// Pins the v1 expire-toctou-revert branch: when ExpireAssistantThreadRuntime
+// reports a turn slipped in past the warm timer, the workflow must re-arm and
+// retry instead of falling through to SignalAssistantCoordinator.
+func TestAssistantThreadWorkflowRearmsOnExpireRevert(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	start := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	env.SetStartTime(start)
+
+	warmUntil := start.Add(60 * time.Second).Format(time.RFC3339Nano)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ProcessAssistantThreadInput) (*activities.ProcessAssistantThreadResult, error) {
+			return &activities.ProcessAssistantThreadResult{
+				AssistantID:       "11111111-1111-1111-1111-111111111111",
+				WarmUntil:         warmUntil,
+				WarmTTLSeconds:    60,
+				RuntimeActive:     true,
+				RetryAdmission:    false,
+				ProcessedAnyEvent: true,
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ProcessAssistantThread"},
+	)
+
+	var expireCalls atomic.Int32
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ExpireAssistantThreadRuntimeInput) (*activities.ExpireAssistantThreadRuntimeResult, error) {
+			n := expireCalls.Add(1)
+			if n == 1 {
+				return &activities.ExpireAssistantThreadRuntimeResult{Stopped: false, RemainingSeconds: 30}, nil
+			}
+			return &activities.ExpireAssistantThreadRuntimeResult{Stopped: true}, nil
+		},
+		activity.RegisterOptions{Name: "ExpireAssistantThreadRuntime"},
+	)
+
+	var signalCalls atomic.Int32
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.SignalAssistantCoordinatorInput) error {
+			signalCalls.Add(1)
+			return nil
+		},
+		activity.RegisterOptions{Name: "SignalAssistantCoordinator"},
+	)
+
+	env.ExecuteWorkflow(AssistantThreadWorkflow, AssistantThreadWorkflowInput{
+		ThreadID:  "22222222-2222-2222-2222-222222222222",
+		ProjectID: "33333333-3333-3333-3333-333333333333",
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, int32(2), expireCalls.Load(), "second expire must run after revert re-arm")
+	require.Equal(t, int32(1), signalCalls.Load(), "coordinator signal fires once after the runtime is finally stopped")
 }


### PR DESCRIPTION
Closes [AGE-2072](https://linear.app/speakeasy/issue/AGE-2072/decouple-mcp-management-from-assistant-runtime-lifecycle).

## MCP lifecycle decoupling (AGE-2072)

- MCP server manager moved behind a dedicated actor task (`run_mcp_actor`) spawned at runtime build. `/configure` now returns as soon as the manager + driver are wired; connections proceed in the background instead of blocking cold-start.
- Dropped `MCP_CONNECT_TIMEOUT` / `AGENT_START_TIMEOUT` from the critical path.
- New `mcp_force_reconnect` tool lets the model recover a single misbehaving server in isolation via `McpCmd::ForceReconnect`, without tearing down the runtime.
- Token rotation is independent from reconnects — `McpRotatingClient` mints fresh tokens per MCP request, so warm token rotation no longer requires rebuilding the runtime or reconnecting all servers.

## Runner ↔ server message normalization

- `RunnerConfig.warm_ttl_seconds` removed; TTL is owned by the backend and supplied per-turn.
- `RunnerStateResponse.last_active_seconds_ago` → `idle_seconds`. Semantics flipped: cumulative idle time between turns, with `0` meaning busy. This gives the warm-expiry workflow a precise TOCTOU guard.
- `http_layer.rs`: removed the standalone `StaticHeaders` middleware; static headers + rotating auth tokens are unified inside `McpRotatingClient`, minted per MCP request rather than per HTTP request.

## Tool capabilities for long-running workflows

- New `workdir.rs` + persistent `/var/lib/gram-assistant/work`: replaces per-call temp sandboxes so files written by user code survive across `bun_run` invocations for the VM lifetime.
- `bun_run` refactored onto the `#[tool]` macro (agentkit 0.5.0). Now accepts either inline `code` or a `file` path inside the workdir, enabling cross-tool collaboration on persistent state.
- `canonicalize_inside_workdir()` resolves symlinks before Bun sees the path (Bun shells out, so `PathPolicy` can't gate it).

## Persistent volume prep

- Dockerfile gains a `workdir-template` stage that builds a 256 MiB ext4 image prepopulated with `package.json`, `browser.ts`, and `node_modules`.
- `init.sh` loop-mounts the prebuilt template at `/var/lib/gram-assistant/work`. Disk-usage cap is enforced by the image size rather than soft limits — sets us up to swap in a real persistent volume without reshaping the runner.

## Warm-TTL TOCTOU fix

- `ExpireThreadRuntime` now takes `warmTTLSeconds` and returns `{Stopped, RemainingSeconds}`. Atomic CAS `active → expiring` via new `BeginExpireAssistantRuntime` SQL; post-CAS re-poll reverts to `active` if a turn slipped in (`RevertExpireAssistantRuntimeToActive`).
- Workflow eviction loop re-arms with `RemainingSeconds` on revert; breaks on signal or successful stop.
- Runner side: `idle_since: Option<Instant>` replaces `last_active`; `mark_busy()` / `mark_idle()` fire synchronously on enqueue / turn-completion so `idle_seconds == nil` unambiguously means in-flight.

✻ Clauded...