### PR TITLE
chore(assistants): reap orphan Fly apps on delete + janitor

### DIFF
--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -451,3 +451,45 @@ WHERE project_id = @project_id
   AND deleted IS FALSE
   AND ended IS FALSE
   AND state IN (@starting_state, @active_state);
+
+-- name: ListAssistantRuntimesForReap :many
+-- Returns every runtime row for an assistant that still carries backend
+-- metadata, regardless of soft-delete state. A stopped row whose Fly app
+-- was not collected leaves its app_name in metadata and would otherwise
+-- be invisible to deleted-aware queries.
+SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
+FROM assistant_runtimes
+WHERE assistant_id = @assistant_id
+  AND project_id = @project_id
+  AND backend_metadata_json <> '{}'::jsonb;
+
+-- name: ListInactiveAssistantRuntimesForReap :many
+-- Returns runtime rows that still carry backend metadata and whose owning
+-- assistant has had no runtime activity since @inactive_before. Active and
+-- starting rows are excluded so a long-running session that updated_at
+-- recently is never collected mid-flight.
+SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
+FROM assistant_runtimes r
+WHERE r.backend_metadata_json <> '{}'::jsonb
+  AND r.state NOT IN (@starting_state, @active_state)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_runtimes r2
+    WHERE r2.assistant_id = r.assistant_id
+      AND r2.updated_at >= @inactive_before
+  )
+ORDER BY r.updated_at ASC
+LIMIT @limit_count;
+
+-- name: MarkAssistantRuntimeReaped :exec
+-- Records that the backend resource (e.g. Fly app) for this runtime has
+-- been torn down. Clearing backend_metadata_json removes it from the reap
+-- candidate set so the janitor stops re-scanning it.
+UPDATE assistant_runtimes
+SET state = @reaped_state,
+    backend_metadata_json = '{}'::jsonb,
+    updated_at = clock_timestamp(),
+    ended_at = COALESCE(ended_at, clock_timestamp()),
+    deleted_at = COALESCE(deleted_at, clock_timestamp())
+WHERE id = @runtime_id
+  AND project_id = @project_id;

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -477,6 +477,7 @@ WHERE r.backend_metadata_json <> '{}'::jsonb
     FROM assistant_runtimes r2
     WHERE r2.assistant_id = r.assistant_id
       AND r2.updated_at >= @inactive_before
+      AND r2.backend_metadata_json <> '{}'::jsonb
   )
 ORDER BY r.updated_at ASC
 LIMIT @limit_count;

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -640,6 +640,7 @@ WHERE r.backend_metadata_json <> '{}'::jsonb
     FROM assistant_runtimes r2
     WHERE r2.assistant_id = r.assistant_id
       AND r2.updated_at >= $3
+      AND r2.backend_metadata_json <> '{}'::jsonb
   )
 ORDER BY r.updated_at ASC
 LIMIT $4

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -436,6 +436,63 @@ func (q *Queries) InsertAssistantThreadEvent(ctx context.Context, arg InsertAssi
 	return id, err
 }
 
+const listAssistantRuntimesForReap = `-- name: ListAssistantRuntimesForReap :many
+SELECT id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, warm_until
+FROM assistant_runtimes
+WHERE assistant_id = $1
+  AND project_id = $2
+  AND backend_metadata_json <> '{}'::jsonb
+`
+
+type ListAssistantRuntimesForReapParams struct {
+	AssistantID uuid.UUID
+	ProjectID   uuid.UUID
+}
+
+type ListAssistantRuntimesForReapRow struct {
+	ID                  uuid.UUID
+	AssistantThreadID   uuid.UUID
+	AssistantID         uuid.UUID
+	ProjectID           uuid.UUID
+	Backend             string
+	BackendMetadataJson []byte
+	State               string
+	WarmUntil           pgtype.Timestamptz
+}
+
+// Returns every runtime row for an assistant that still carries backend
+// metadata, regardless of soft-delete state. A stopped row whose Fly app
+// was not collected leaves its app_name in metadata and would otherwise
+// be invisible to deleted-aware queries.
+func (q *Queries) ListAssistantRuntimesForReap(ctx context.Context, arg ListAssistantRuntimesForReapParams) ([]ListAssistantRuntimesForReapRow, error) {
+	rows, err := q.db.Query(ctx, listAssistantRuntimesForReap, arg.AssistantID, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAssistantRuntimesForReapRow
+	for rows.Next() {
+		var i ListAssistantRuntimesForReapRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AssistantThreadID,
+			&i.AssistantID,
+			&i.ProjectID,
+			&i.Backend,
+			&i.BackendMetadataJson,
+			&i.State,
+			&i.WarmUntil,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAssistants = `-- name: ListAssistants :many
 SELECT id, project_id, organization_id, created_by_user_id, name, model, instructions, warm_ttl_seconds, max_concurrency, status, created_at, updated_at, deleted_at
 FROM assistants
@@ -563,6 +620,77 @@ func (q *Queries) ListColdPendingThreadsForAdmit(ctx context.Context, arg ListCo
 	for rows.Next() {
 		var i ListColdPendingThreadsForAdmitRow
 		if err := rows.Scan(&i.ID, &i.ProjectID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listInactiveAssistantRuntimesForReap = `-- name: ListInactiveAssistantRuntimesForReap :many
+SELECT r.id, r.assistant_thread_id, r.assistant_id, r.project_id, r.backend, r.backend_metadata_json, r.state, r.warm_until
+FROM assistant_runtimes r
+WHERE r.backend_metadata_json <> '{}'::jsonb
+  AND r.state NOT IN ($1, $2)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM assistant_runtimes r2
+    WHERE r2.assistant_id = r.assistant_id
+      AND r2.updated_at >= $3
+  )
+ORDER BY r.updated_at ASC
+LIMIT $4
+`
+
+type ListInactiveAssistantRuntimesForReapParams struct {
+	StartingState  string
+	ActiveState    string
+	InactiveBefore pgtype.Timestamptz
+	LimitCount     int32
+}
+
+type ListInactiveAssistantRuntimesForReapRow struct {
+	ID                  uuid.UUID
+	AssistantThreadID   uuid.UUID
+	AssistantID         uuid.UUID
+	ProjectID           uuid.UUID
+	Backend             string
+	BackendMetadataJson []byte
+	State               string
+	WarmUntil           pgtype.Timestamptz
+}
+
+// Returns runtime rows that still carry backend metadata and whose owning
+// assistant has had no runtime activity since @inactive_before. Active and
+// starting rows are excluded so a long-running session that updated_at
+// recently is never collected mid-flight.
+func (q *Queries) ListInactiveAssistantRuntimesForReap(ctx context.Context, arg ListInactiveAssistantRuntimesForReapParams) ([]ListInactiveAssistantRuntimesForReapRow, error) {
+	rows, err := q.db.Query(ctx, listInactiveAssistantRuntimesForReap,
+		arg.StartingState,
+		arg.ActiveState,
+		arg.InactiveBefore,
+		arg.LimitCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListInactiveAssistantRuntimesForReapRow
+	for rows.Next() {
+		var i ListInactiveAssistantRuntimesForReapRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AssistantThreadID,
+			&i.AssistantID,
+			&i.ProjectID,
+			&i.Backend,
+			&i.BackendMetadataJson,
+			&i.State,
+			&i.WarmUntil,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -866,6 +994,31 @@ func (q *Queries) LoadThreadContext(ctx context.Context, arg LoadThreadContextPa
 		&i.WarmUntil,
 	)
 	return i, err
+}
+
+const markAssistantRuntimeReaped = `-- name: MarkAssistantRuntimeReaped :exec
+UPDATE assistant_runtimes
+SET state = $1,
+    backend_metadata_json = '{}'::jsonb,
+    updated_at = clock_timestamp(),
+    ended_at = COALESCE(ended_at, clock_timestamp()),
+    deleted_at = COALESCE(deleted_at, clock_timestamp())
+WHERE id = $2
+  AND project_id = $3
+`
+
+type MarkAssistantRuntimeReapedParams struct {
+	ReapedState string
+	RuntimeID   uuid.UUID
+	ProjectID   uuid.UUID
+}
+
+// Records that the backend resource (e.g. Fly app) for this runtime has
+// been torn down. Clearing backend_metadata_json removes it from the reap
+// candidate set so the janitor stops re-scanning it.
+func (q *Queries) MarkAssistantRuntimeReaped(ctx context.Context, arg MarkAssistantRuntimeReapedParams) error {
+	_, err := q.db.Exec(ctx, markAssistantRuntimeReaped, arg.ReapedState, arg.RuntimeID, arg.ProjectID)
+	return err
 }
 
 const reapStuckAssistantRuntimes = `-- name: ReapStuckAssistantRuntimes :many

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -454,6 +454,12 @@ func (m *RuntimeManager) Stop(_ context.Context, runtime assistantRuntimeRecord)
 	return nil
 }
 
+// Reap on the local Firecracker manager has the same effect as Stop: there
+// is no out-of-process resource that survives Stop, so cleanup is identical.
+func (m *RuntimeManager) Reap(ctx context.Context, runtime assistantRuntimeRecord) error {
+	return m.Stop(ctx, runtime)
+}
+
 func (m *RuntimeManager) ServerURL(_ context.Context, runtime assistantRuntimeRecord, raw *url.URL) (*url.URL, error) {
 	if err := validateRuntimeBackend(m, runtime.Backend); err != nil {
 		return nil, err

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -19,7 +19,13 @@ type RuntimeBackend interface {
 	Configure(ctx context.Context, runtime assistantRuntimeRecord, config runtimeStartupConfig) error
 	RunTurn(ctx context.Context, runtime assistantRuntimeRecord, idempotencyKey string, authToken string, prompt string) error
 	ServerURL(ctx context.Context, runtime assistantRuntimeRecord, raw *url.URL) (*url.URL, error)
+	// Stop halts the active runtime so it can be re-admitted later. Backends
+	// may keep persisted state (e.g. Fly app + IP) intact for warm reuse.
 	Stop(ctx context.Context, runtime assistantRuntimeRecord) error
+	// Reap permanently tears down all backend resources tied to the runtime
+	// (e.g. deletes the Fly app). Idempotent: must succeed when the resource
+	// is already gone. Distinct from Stop, which may preserve state for reuse.
+	Reap(ctx context.Context, runtime assistantRuntimeRecord) error
 }
 
 type RuntimeBackendEnsureResult struct {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -702,6 +702,20 @@ func (f *FlyRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRe
 	return f.deleteApp(ctx, metadata.AppName)
 }
 
+func (f *FlyRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRecord) error {
+	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
+		return err
+	}
+	metadata, err := decodeFlyRuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return err
+	}
+	if metadata.AppName == "" {
+		return nil
+	}
+	return f.deleteApp(ctx, metadata.AppName)
+}
+
 func (f *FlyRuntimeBackend) deleteApp(ctx context.Context, appName string) error {
 	if err := f.client.DeleteApp(ctx, appName); err != nil && !isFlyNotFound(err) {
 		return fmt.Errorf("delete assistant fly runtime app: %w", err)

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -346,6 +346,70 @@ func TestFlyRuntimeBackendStopIgnoresMissingApp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestFlyRuntimeBackendReapDeletesAppByMetadataName(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, _ := newTestFlyRuntimeBackend(t, server)
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-orphan",
+		AppID:      "",
+		AppURL:     "",
+		AppIP:      "",
+		MachineID:  "",
+		Region:     "",
+		LastBootID: "",
+	})
+	require.NoError(t, err)
+
+	err = backend.Reap(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, apiClient.deleteCalls)
+}
+
+func TestFlyRuntimeBackendReapWithoutMetadataIsNoop(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, _ := newTestFlyRuntimeBackend(t, server)
+
+	err := backend.Reap(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, apiClient.deleteCalls)
+}
+
+func TestFlyRuntimeBackendReapTreatsAppNotFoundAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, _ := newTestFlyRuntimeBackend(t, server)
+
+	apiClient.deleteErr = errors.New("not found")
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-already-gone",
+		AppID:      "",
+		AppURL:     "",
+		AppIP:      "",
+		MachineID:  "",
+		Region:     "",
+		LastBootID: "",
+	})
+	require.NoError(t, err)
+
+	err = backend.Reap(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+}
+
 func TestFlyRuntimeBackendServerURLRejectsLoopback(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -150,6 +150,16 @@ func (t *telemetryRuntimeBackend) Stop(ctx context.Context, runtime assistantRun
 	return nil
 }
 
+func (t *telemetryRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRecord) error {
+	err := t.inner.Reap(ctx, runtime)
+	if err != nil {
+		t.emit(ctx, runtime, "runtime_reap", "runtime reap failed", "ERROR", err)
+		return fmt.Errorf("runtime reap: %w", err)
+	}
+	t.emit(ctx, runtime, "runtime_reap", "runtime reaped", "INFO", nil)
+	return nil
+}
+
 func (t *telemetryRuntimeBackend) emit(
 	ctx context.Context,
 	runtime assistantRuntimeRecord,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -43,6 +43,7 @@ const (
 	runtimeStateActive   = "active"
 	runtimeStateStopped  = "stopped"
 	runtimeStateFailed   = "failed"
+	runtimeStateReaped   = "reaped"
 
 	eventStatusPending    = "pending"
 	eventStatusProcessing = "processing"
@@ -844,7 +845,154 @@ func (s *ServiceCore) DeleteAssistant(ctx context.Context, projectID uuid.UUID, 
 	if err != nil {
 		return fmt.Errorf("delete assistant: %w", err)
 	}
+
+	// Best-effort: tear down per-assistant backend resources (e.g. Fly app)
+	// inline so the common case does not wait for the janitor. Failures here
+	// must not roll back the soft-delete; the long-inactivity janitor is the
+	// safety net.
+	if reapResult, reapErr := s.ReapAssistantRuntimes(ctx, projectID, assistantID); reapErr != nil {
+		s.logger.WarnContext(ctx, "reap assistant runtimes on delete failed",
+			attr.SlogAssistantID(assistantID.String()),
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogError(reapErr),
+		)
+	} else if reapResult.Reaped > 0 || reapResult.Errors > 0 {
+		s.logger.InfoContext(ctx, "reaped assistant runtimes on delete",
+			attr.SlogAssistantID(assistantID.String()),
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogVisibilityInternal(),
+		)
+	}
+
 	return nil
+}
+
+// ReapAssistantRuntimesResult summarises the outcome of one reap pass —
+// counted at the runtime-row level, not the backend-app level. A row whose
+// backend resource was already gone (404 from the Fly API, no in-memory
+// state for local) still counts as Reaped.
+type ReapAssistantRuntimesResult struct {
+	Reaped int
+	Errors int
+}
+
+// ReapAssistantRuntimes tears down backend resources for every runtime row
+// belonging to the given assistant that still carries metadata. Used by the
+// assistant-delete handler so a deletion cleans up the corresponding Fly app
+// without waiting for the janitor.
+func (s *ServiceCore) ReapAssistantRuntimes(ctx context.Context, projectID, assistantID uuid.UUID) (ReapAssistantRuntimesResult, error) {
+	rows, err := assistantrepo.New(s.db).ListAssistantRuntimesForReap(ctx, assistantrepo.ListAssistantRuntimesForReapParams{
+		AssistantID: assistantID,
+		ProjectID:   projectID,
+	})
+	if err != nil {
+		return ReapAssistantRuntimesResult{}, fmt.Errorf("list assistant runtimes for reap: %w", err)
+	}
+
+	result := ReapAssistantRuntimesResult{Reaped: 0, Errors: 0}
+	for _, row := range rows {
+		if s.reapRuntimeRow(ctx, assistantRuntimeRecord{
+			ID:                  row.ID,
+			AssistantThreadID:   row.AssistantThreadID,
+			AssistantID:         row.AssistantID,
+			ProjectID:           row.ProjectID,
+			Backend:             row.Backend,
+			BackendMetadataJSON: row.BackendMetadataJson,
+			State:               row.State,
+			WarmUntil:           row.WarmUntil,
+		}) {
+			result.Reaped++
+		} else {
+			result.Errors++
+		}
+	}
+	return result, nil
+}
+
+// ReapInactiveAssistantRuntimesParams configures one janitor sweep.
+type ReapInactiveAssistantRuntimesParams struct {
+	// InactivityThreshold is the minimum quiet period before an assistant's
+	// runtime rows become candidates for collection. The query compares
+	// against r.updated_at across all of an assistant's rows so a normal
+	// cold-warm-cold cycle keeps the assistant out of the candidate set.
+	InactivityThreshold time.Duration
+	// BatchSize caps how many runtime rows one sweep will reap. Keeps the
+	// activity duration bounded under Temporal's StartToCloseTimeout.
+	BatchSize int32
+}
+
+// ReapInactiveAssistantRuntimes drives the long-inactivity janitor. It picks
+// runtime rows whose owning assistant has had no recorded activity within
+// InactivityThreshold and tears down the corresponding backend resources.
+// Active and starting rows are filtered out at the SQL layer so an in-flight
+// admit is never collected mid-flight.
+func (s *ServiceCore) ReapInactiveAssistantRuntimes(ctx context.Context, params ReapInactiveAssistantRuntimesParams) (ReapAssistantRuntimesResult, error) {
+	if params.InactivityThreshold <= 0 {
+		return ReapAssistantRuntimesResult{}, fmt.Errorf("inactivity threshold must be positive")
+	}
+	if params.BatchSize <= 0 {
+		return ReapAssistantRuntimesResult{}, fmt.Errorf("batch size must be positive")
+	}
+
+	rows, err := assistantrepo.New(s.db).ListInactiveAssistantRuntimesForReap(ctx, assistantrepo.ListInactiveAssistantRuntimesForReapParams{
+		StartingState:  runtimeStateStarting,
+		ActiveState:    runtimeStateActive,
+		InactiveBefore: conv.ToPGTimestamptz(time.Now().UTC().Add(-params.InactivityThreshold)),
+		LimitCount:     params.BatchSize,
+	})
+	if err != nil {
+		return ReapAssistantRuntimesResult{}, fmt.Errorf("list inactive assistant runtimes for reap: %w", err)
+	}
+
+	result := ReapAssistantRuntimesResult{Reaped: 0, Errors: 0}
+	for _, row := range rows {
+		if s.reapRuntimeRow(ctx, assistantRuntimeRecord{
+			ID:                  row.ID,
+			AssistantThreadID:   row.AssistantThreadID,
+			AssistantID:         row.AssistantID,
+			ProjectID:           row.ProjectID,
+			Backend:             row.Backend,
+			BackendMetadataJSON: row.BackendMetadataJson,
+			State:               row.State,
+			WarmUntil:           row.WarmUntil,
+		}) {
+			result.Reaped++
+		} else {
+			result.Errors++
+		}
+	}
+	return result, nil
+}
+
+// reapRuntimeRow tears down the backend resource for one row and records the
+// outcome in DB. Returns true on success (including idempotent no-op when
+// the resource was already gone). Errors are logged here so callers can
+// keep the loop simple.
+func (s *ServiceCore) reapRuntimeRow(ctx context.Context, record assistantRuntimeRecord) bool {
+	if err := s.runtime.Reap(ctx, record); err != nil {
+		s.logger.WarnContext(ctx, "reap runtime backend failed",
+			attr.SlogAssistantID(record.AssistantID.String()),
+			attr.SlogAssistantThreadID(record.AssistantThreadID.String()),
+			attr.SlogAssistantRuntimeID(record.ID.String()),
+			attr.SlogAssistantRuntimeBackend(record.Backend),
+			attr.SlogError(err),
+		)
+		return false
+	}
+
+	if err := assistantrepo.New(s.db).MarkAssistantRuntimeReaped(ctx, assistantrepo.MarkAssistantRuntimeReapedParams{
+		ReapedState: runtimeStateReaped,
+		RuntimeID:   record.ID,
+		ProjectID:   record.ProjectID,
+	}); err != nil {
+		s.logger.WarnContext(ctx, "mark assistant runtime reaped failed",
+			attr.SlogAssistantID(record.AssistantID.String()),
+			attr.SlogAssistantRuntimeID(record.ID.String()),
+			attr.SlogError(err),
+		)
+		return false
+	}
+	return true
 }
 
 func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Task) (EnqueueResult, error) {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -504,6 +504,295 @@ LIMIT 1
 	require.JSONEq(t, string(backend.ensureResult.BackendMetadataJSON), string(nextMetadata))
 }
 
+// insertReapableProject inserts an isolated project + assistant + thread so a
+// single test can host several independent fixtures without colliding on the
+// project slug or the per-thread-active runtime unique index.
+func insertReapableProject(t *testing.T, conn *pgxpool.Pool, slug string) (projectID, assistantID, threadID uuid.UUID) {
+	t.Helper()
+
+	projectID = uuid.New()
+	assistantID = uuid.New()
+	chatID := uuid.New()
+	threadID = uuid.New()
+
+	_, err := conn.Exec(t.Context(), `
+INSERT INTO projects (id, name, slug, organization_id) VALUES ($1, $2, $3, 'org-test')
+`, projectID, slug, slug)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistants (id, project_id, organization_id, name, model, instructions, warm_ttl_seconds, max_concurrency, status)
+VALUES ($1, $2, 'org-test', 'Assistant', 'openai/gpt-4o-mini', '', 300, 1, 'active')
+`, assistantID, projectID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(t.Context(), `INSERT INTO chats (id, project_id, organization_id) VALUES ($1, $2, 'org-test')`, chatID, projectID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistant_threads (id, assistant_id, project_id, correlation_id, chat_id, source_kind, source_ref_json, last_event_at)
+VALUES ($1, $2, $3, $4, $5, 'slack', '{}'::jsonb, clock_timestamp())
+`, threadID, assistantID, projectID, "corr-"+slug, chatID)
+	require.NoError(t, err)
+
+	return projectID, assistantID, threadID
+}
+
+// insertReapableRuntimeRow seeds an assistant_runtimes row with non-empty
+// backend metadata so the reap queries can find it. ended_at is set so
+// multiple rows can coexist on the same thread without colliding on the
+// active-runtime unique index.
+func insertReapableRuntimeRow(
+	t *testing.T,
+	conn *pgxpool.Pool,
+	projectID, assistantID, threadID uuid.UUID,
+	state string,
+	appName string,
+	updatedAt time.Time,
+) uuid.UUID {
+	t.Helper()
+
+	runtimeID := uuid.New()
+	metadata := fmt.Sprintf(`{"app_name":%q}`, appName)
+	endedAt := pgNullTimeFor(state, updatedAt)
+	_, err := conn.Exec(t.Context(), `
+INSERT INTO assistant_runtimes (
+  id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state, updated_at, ended_at
+) VALUES (
+  $1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9
+)
+`, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, metadata, state, updatedAt, endedAt)
+	require.NoError(t, err)
+	return runtimeID
+}
+
+func pgNullTimeFor(state string, updatedAt time.Time) sql.NullTime {
+	switch state {
+	case runtimeStateActive, runtimeStateStarting:
+		return sql.NullTime{Time: time.Time{}, Valid: false}
+	default:
+		return sql.NullTime{Time: updatedAt, Valid: true}
+	}
+}
+
+func TestServiceCoreDeleteAssistantReapsRuntimes(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "delete_assistant_reaps")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	runtimeID := insertReapableRuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateStopped, "gram-asst-delete-target", time.Now().UTC().Add(-time.Hour))
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID))
+	require.EqualValues(t, 1, reapCalls.Load())
+
+	var state, metadataJSON string
+	err = conn.QueryRow(t.Context(), `SELECT state, backend_metadata_json::text FROM assistant_runtimes WHERE id = $1`, runtimeID).Scan(&state, &metadataJSON)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateReaped, state)
+	require.JSONEq(t, `{}`, metadataJSON)
+
+	var deletedAt sql.NullTime
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT deleted_at FROM assistants WHERE id = $1`, assistantID).Scan(&deletedAt))
+	require.True(t, deletedAt.Valid)
+}
+
+func TestServiceCoreDeleteAssistantSucceedsEvenWhenReapErrors(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "delete_assistant_reap_error")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+	insertReapableRuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateStopped, "gram-asst-flaky", time.Now().UTC().Add(-time.Hour))
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{
+		backend:   runtimeBackendFlyIO,
+		reapCalls: reapCalls,
+		reapErr:   errors.New("fly api 503"),
+	}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID))
+	require.EqualValues(t, 1, reapCalls.Load())
+
+	// Soft-delete still landed; the janitor will retry the orphan later.
+	var deletedAt sql.NullTime
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT deleted_at FROM assistants WHERE id = $1`, assistantID).Scan(&deletedAt))
+	require.True(t, deletedAt.Valid)
+}
+
+func TestServiceCoreReapAssistantRuntimesCallsBackendAndClearsMetadata(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_assistant_runtimes")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	runtimeID := insertReapableRuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateStopped, "gram-asst-orphan", time.Now().UTC().Add(-time.Hour))
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	result, err := core.ReapAssistantRuntimes(t.Context(), projectID, assistantID)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Reaped)
+	require.Equal(t, 0, result.Errors)
+	require.EqualValues(t, 1, reapCalls.Load())
+
+	var state string
+	var metadataJSON string
+	err = conn.QueryRow(t.Context(), `
+SELECT state, backend_metadata_json::text
+FROM assistant_runtimes
+WHERE id = $1
+`, runtimeID).Scan(&state, &metadataJSON)
+	require.NoError(t, err)
+	require.Equal(t, runtimeStateReaped, state)
+	require.JSONEq(t, `{}`, metadataJSON)
+}
+
+func TestServiceCoreReapAssistantRuntimesSkipsRowsWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_assistant_runtimes_skip")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	runtimeID := uuid.New()
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistant_runtimes (id, assistant_thread_id, assistant_id, project_id, backend, backend_metadata_json, state)
+VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, $6)
+`, runtimeID, threadID, assistantID, projectID, runtimeBackendFlyIO, runtimeStateStopped)
+	require.NoError(t, err)
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	result, err := core.ReapAssistantRuntimes(t.Context(), projectID, assistantID)
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Reaped)
+	require.EqualValues(t, 0, reapCalls.Load())
+}
+
+func TestServiceCoreReapInactiveAssistantRuntimesCollectsOnlyInactive(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_inactive_runtimes")
+	require.NoError(t, err)
+
+	stale, staleAssistantID, staleThreadID := insertReapableProject(t, conn, "stale")
+	staleRuntimeID := insertReapableRuntimeRow(t, conn, stale, staleAssistantID, staleThreadID, runtimeStateStopped, "gram-asst-stale", time.Now().UTC().Add(-30*24*time.Hour))
+
+	fresh, freshAssistantID, freshThreadID := insertReapableProject(t, conn, "fresh")
+	freshRuntimeID := insertReapableRuntimeRow(t, conn, fresh, freshAssistantID, freshThreadID, runtimeStateStopped, "gram-asst-fresh", time.Now().UTC().Add(-time.Hour))
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
+		InactivityThreshold: 7 * 24 * time.Hour,
+		BatchSize:           10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Reaped)
+	require.Equal(t, 0, result.Errors)
+	require.EqualValues(t, 1, reapCalls.Load())
+
+	var staleState, freshState string
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT state FROM assistant_runtimes WHERE id = $1`, staleRuntimeID).Scan(&staleState))
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT state FROM assistant_runtimes WHERE id = $1`, freshRuntimeID).Scan(&freshState))
+	require.Equal(t, runtimeStateReaped, staleState)
+	require.Equal(t, runtimeStateStopped, freshState)
+}
+
+func TestServiceCoreReapInactiveAssistantRuntimesSkipsAssistantWithRecentActivity(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_inactive_recent_activity")
+	require.NoError(t, err)
+
+	projectID := uuid.New()
+	assistantID := uuid.New()
+	chatID := uuid.New()
+	threadID := uuid.New()
+	insertAssistantFixture(t, conn, projectID, assistantID, chatID, threadID)
+
+	// Old runtime row + a fresh row on the same assistant. The recent
+	// activity must keep the entire assistant out of the candidate set.
+	oldRuntimeID := insertReapableRuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateStopped, "gram-asst-old", time.Now().UTC().Add(-30*24*time.Hour))
+	insertReapableRuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateStopped, "gram-asst-recent", time.Now().UTC().Add(-time.Hour))
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
+		InactivityThreshold: 7 * 24 * time.Hour,
+		BatchSize:           10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Reaped)
+	require.EqualValues(t, 0, reapCalls.Load())
+
+	var oldState string
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT state FROM assistant_runtimes WHERE id = $1`, oldRuntimeID).Scan(&oldState))
+	require.Equal(t, runtimeStateStopped, oldState)
+}
+
+func TestServiceCoreReapInactiveAssistantRuntimesIgnoresActiveAndStarting(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_inactive_state_filter")
+	require.NoError(t, err)
+
+	projectID, assistantID, threadID := insertReapableProject(t, conn, "active-state")
+	insertReapableRuntimeRow(t, conn, projectID, assistantID, threadID, runtimeStateActive, "gram-asst-active", time.Now().UTC().Add(-30*24*time.Hour))
+
+	startingProject, startingAssistantID, startingThreadID := insertReapableProject(t, conn, "starting-state")
+	insertReapableRuntimeRow(t, conn, startingProject, startingAssistantID, startingThreadID, runtimeStateStarting, "gram-asst-starting", time.Now().UTC().Add(-30*24*time.Hour))
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
+		InactivityThreshold: 7 * 24 * time.Hour,
+		BatchSize:           10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.Reaped)
+	require.EqualValues(t, 0, reapCalls.Load())
+}
+
 type testRuntimeBackend struct {
 	backend      string
 	ensureResult RuntimeBackendEnsureResult
@@ -511,6 +800,8 @@ type testRuntimeBackend struct {
 	configureErr error
 	runTurnErr   error
 	stopCalls    *atomic.Int64
+	reapCalls    *atomic.Int64
+	reapErr      error
 }
 
 func (t testRuntimeBackend) Backend() string {
@@ -549,6 +840,13 @@ func (t testRuntimeBackend) Stop(context.Context, assistantRuntimeRecord) error 
 		t.stopCalls.Add(1)
 	}
 	return nil
+}
+
+func (t testRuntimeBackend) Reap(context.Context, assistantRuntimeRecord) error {
+	if t.reapCalls != nil {
+		t.reapCalls.Add(1)
+	}
+	return t.reapErr
 }
 
 func mustParseURLForServiceTest(t *testing.T, raw string) *url.URL {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -768,6 +768,51 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsAssistantWithRecentActivit
 	require.Equal(t, runtimeStateStopped, oldState)
 }
 
+func TestServiceCoreReapInactiveAssistantRuntimesReapsSiblingsAcrossSweeps(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "reap_inactive_siblings")
+	require.NoError(t, err)
+
+	// Two stale runtime rows on the same assistant (different threads so the
+	// active-runtime unique index doesn't collide). The first sweep reaps one
+	// and bumps its updated_at — without the metadata-cleared filter on the
+	// NOT EXISTS guard, that bump would block the sibling for another full
+	// inactivity window.
+	projectID, assistantID, threadA := insertReapableProject(t, conn, "siblings")
+	threadB := uuid.New()
+	chatB := uuid.New()
+	_, err = conn.Exec(t.Context(), `INSERT INTO chats (id, project_id, organization_id) VALUES ($1, $2, 'org-test')`, chatB, projectID)
+	require.NoError(t, err)
+	_, err = conn.Exec(t.Context(), `
+INSERT INTO assistant_threads (id, assistant_id, project_id, correlation_id, chat_id, source_kind, source_ref_json, last_event_at)
+VALUES ($1, $2, $3, 'corr-siblings-b', $4, 'slack', '{}'::jsonb, clock_timestamp())
+`, threadB, assistantID, projectID, chatB)
+	require.NoError(t, err)
+
+	insertReapableRuntimeRow(t, conn, projectID, assistantID, threadA, runtimeStateStopped, "gram-asst-sibling-a", time.Now().UTC().Add(-30*24*time.Hour))
+	insertReapableRuntimeRow(t, conn, projectID, assistantID, threadB, runtimeStateStopped, "gram-asst-sibling-b", time.Now().UTC().Add(-30*24*time.Hour))
+
+	reapCalls := &atomic.Int64{}
+	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+
+	first, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
+		InactivityThreshold: 7 * 24 * time.Hour,
+		BatchSize:           1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, first.Reaped)
+
+	second, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
+		InactivityThreshold: 7 * 24 * time.Hour,
+		BatchSize:           10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, second.Reaped, "sibling row must remain a candidate after the first reap")
+	require.EqualValues(t, 2, reapCalls.Load())
+}
+
 func TestServiceCoreReapInactiveAssistantRuntimesIgnoresActiveAndStarting(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -1276,6 +1276,16 @@ func SlogStatsToolCallCount(v int) slog.Attr      { return slog.Int(string(Stats
 func StatsMCPServerCount(v int) attribute.KeyValue { return StatsMCPServerCountKey.Int(v) }
 func SlogStatsMCPServerCount(v int) slog.Attr      { return slog.Int(string(StatsMCPServerCountKey), v) }
 
+func AssistantID(v string) attribute.KeyValue { return AssistantIDKey.String(v) }
+func SlogAssistantID(v string) slog.Attr      { return slog.String(string(AssistantIDKey), v) }
+
+func AssistantRuntimeBackend(v string) attribute.KeyValue {
+	return AssistantRuntimeBackendKey.String(v)
+}
+func SlogAssistantRuntimeBackend(v string) slog.Attr {
+	return slog.String(string(AssistantRuntimeBackendKey), v)
+}
+
 func AssistantThreadID(v string) attribute.KeyValue { return AssistantThreadIDKey.String(v) }
 func SlogAssistantThreadID(v string) slog.Attr      { return slog.String(string(AssistantThreadIDKey), v) }
 

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -68,6 +68,7 @@ type Activities struct {
 	processAssistantThread        *activities.ProcessAssistantThread
 	expireAssistantThreadRuntime  *activities.ExpireAssistantThreadRuntime
 	reapStuckAssistantRuntimes    *activities.ReapStuckAssistantRuntimes
+	reapInactiveAssistantRuntimes *activities.ReapInactiveAssistantRuntimes
 	signalAssistantCoordinator    *activities.SignalAssistantCoordinator
 	signalAssistantThread         *activities.SignalAssistantThread
 }
@@ -136,6 +137,7 @@ func NewActivities(
 		processAssistantThread:        activities.NewProcessAssistantThread(assistantsCore),
 		expireAssistantThreadRuntime:  activities.NewExpireAssistantThreadRuntime(assistantsCore),
 		reapStuckAssistantRuntimes:    activities.NewReapStuckAssistantRuntimes(assistantsCore),
+		reapInactiveAssistantRuntimes: activities.NewReapInactiveAssistantRuntimes(logger, assistantsCore),
 		signalAssistantCoordinator:    activities.NewSignalAssistantCoordinator(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		signalAssistantThread:         activities.NewSignalAssistantThread(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 	}
@@ -292,6 +294,10 @@ func (a *Activities) ExpireAssistantThreadRuntime(ctx context.Context, input act
 
 func (a *Activities) ReapStuckAssistantRuntimes(ctx context.Context) (*activities.ReapStuckAssistantRuntimesResult, error) {
 	return a.reapStuckAssistantRuntimes.Do(ctx)
+}
+
+func (a *Activities) ReapInactiveAssistantRuntimes(ctx context.Context, req activities.ReapInactiveAssistantRuntimesRequest) (*activities.ReapInactiveAssistantRuntimesResult, error) {
+	return a.reapInactiveAssistantRuntimes.Do(ctx, req)
 }
 
 func (a *Activities) SignalAssistantCoordinator(ctx context.Context, input activities.SignalAssistantCoordinatorInput) error {

--- a/server/internal/background/activities/reap_assistant_runtimes.go
+++ b/server/internal/background/activities/reap_assistant_runtimes.go
@@ -1,0 +1,60 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/assistants"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// ReapInactiveAssistantRuntimesRequest carries one janitor sweep's
+// configuration over the Temporal activity boundary.
+type ReapInactiveAssistantRuntimesRequest struct {
+	InactivityThreshold time.Duration
+	BatchSize           int32
+}
+
+type ReapInactiveAssistantRuntimesResult struct {
+	Reaped int
+	Errors int
+}
+
+type ReapInactiveAssistantRuntimes struct {
+	logger *slog.Logger
+	core   *assistants.ServiceCore
+}
+
+func NewReapInactiveAssistantRuntimes(logger *slog.Logger, core *assistants.ServiceCore) *ReapInactiveAssistantRuntimes {
+	return &ReapInactiveAssistantRuntimes{
+		logger: logger.With(attr.SlogComponent("assistant_runtime_janitor")),
+		core:   core,
+	}
+}
+
+func (r *ReapInactiveAssistantRuntimes) Do(ctx context.Context, req ReapInactiveAssistantRuntimesRequest) (*ReapInactiveAssistantRuntimesResult, error) {
+	if r.core == nil {
+		return nil, fmt.Errorf("assistants core not configured")
+	}
+
+	result, err := r.core.ReapInactiveAssistantRuntimes(ctx, assistants.ReapInactiveAssistantRuntimesParams{
+		InactivityThreshold: req.InactivityThreshold,
+		BatchSize:           req.BatchSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reap inactive assistant runtimes: %w", err)
+	}
+
+	if result.Reaped > 0 || result.Errors > 0 {
+		r.logger.InfoContext(ctx, fmt.Sprintf("assistant runtime janitor swept reaped=%d errors=%d", result.Reaped, result.Errors),
+			attr.SlogVisibilityInternal(),
+		)
+	}
+
+	return &ReapInactiveAssistantRuntimesResult{
+		Reaped: result.Reaped,
+		Errors: result.Errors,
+	}, nil
+}

--- a/server/internal/background/assistant_runtime_janitor.go
+++ b/server/internal/background/assistant_runtime_janitor.go
@@ -1,0 +1,125 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	assistantRuntimeJanitorWorkflowID = "v1:assistant-runtime-janitor"
+	assistantRuntimeJanitorScheduleID = "v1:assistant-runtime-janitor-schedule"
+
+	// AssistantRuntimeJanitorInterval is how often the janitor sweeps. The
+	// task is bounded per run by AssistantRuntimeJanitorBatchSize, so a
+	// hourly cadence with a 200-row batch keeps each sweep short while
+	// covering up to 4800 rows/day on the steady state.
+	AssistantRuntimeJanitorInterval = time.Hour
+
+	// AssistantRuntimeJanitorBatchSize caps rows reaped per sweep. The
+	// activity makes one external API call per row (e.g. Fly DeleteApp)
+	// so the bound also keeps the Temporal activity within its
+	// StartToCloseTimeout.
+	AssistantRuntimeJanitorBatchSize int32 = 200
+
+	// AssistantRuntimeJanitorInactivityThreshold is the quiet period an
+	// assistant must have before its backend resources become eligible
+	// for collection. Long enough that a project's normal cold-warm-cold
+	// rhythm keeps it out of the candidate set; short enough that
+	// abandoned tenants don't sit on Fly apps for weeks.
+	AssistantRuntimeJanitorInactivityThreshold = 7 * 24 * time.Hour
+)
+
+// AssistantRuntimeJanitorWorkflowParams lets operators override the bake-in
+// defaults per scheduled run, e.g. shorten the threshold during incident
+// remediation. Empty fields fall back to the package constants.
+type AssistantRuntimeJanitorWorkflowParams struct {
+	InactivityThreshold time.Duration
+	BatchSize           int32
+}
+
+type AssistantRuntimeJanitorWorkflowResult struct {
+	Reaped int
+	Errors int
+}
+
+// AssistantRuntimeJanitorWorkflow reaps backend resources (Fly apps,
+// long-lived runner state) belonging to assistants that have had no runtime
+// activity for AssistantRuntimeJanitorInactivityThreshold. Active and
+// starting runtimes are filtered out at the SQL layer so an in-flight
+// admit is never collected mid-flight.
+func AssistantRuntimeJanitorWorkflow(ctx workflow.Context, params AssistantRuntimeJanitorWorkflowParams) (*AssistantRuntimeJanitorWorkflowResult, error) {
+	var a *Activities
+
+	threshold := params.InactivityThreshold
+	if threshold <= 0 {
+		threshold = AssistantRuntimeJanitorInactivityThreshold
+	}
+	batchSize := params.BatchSize
+	if batchSize <= 0 {
+		batchSize = AssistantRuntimeJanitorBatchSize
+	}
+
+	logger := workflow.GetLogger(ctx)
+
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			MaximumInterval:    1 * time.Minute,
+			BackoffCoefficient: 2,
+		},
+	})
+
+	var result activities.ReapInactiveAssistantRuntimesResult
+	if err := workflow.ExecuteActivity(ctx, a.ReapInactiveAssistantRuntimes, activities.ReapInactiveAssistantRuntimesRequest{
+		InactivityThreshold: threshold,
+		BatchSize:           batchSize,
+	}).Get(ctx, &result); err != nil {
+		return nil, fmt.Errorf("reap inactive assistant runtimes: %w", err)
+	}
+
+	logger.Info("assistant runtime janitor completed",
+		"reaped", result.Reaped,
+		"errors", result.Errors,
+	)
+
+	return &AssistantRuntimeJanitorWorkflowResult{
+		Reaped: result.Reaped,
+		Errors: result.Errors,
+	}, nil
+}
+
+func AddAssistantRuntimeJanitorSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	_, err := temporalEnv.Client().ScheduleClient().Create(ctx, client.ScheduleOptions{
+		ID: assistantRuntimeJanitorScheduleID,
+		Spec: client.ScheduleSpec{
+			Intervals: []client.ScheduleIntervalSpec{{Every: AssistantRuntimeJanitorInterval}},
+		},
+		Action: &client.ScheduleWorkflowAction{
+			ID:                 assistantRuntimeJanitorWorkflowID,
+			Workflow:           AssistantRuntimeJanitorWorkflow,
+			TaskQueue:          string(temporalEnv.Queue()),
+			WorkflowRunTimeout: 15 * time.Minute,
+			Args: []any{AssistantRuntimeJanitorWorkflowParams{
+				InactivityThreshold: 0,
+				BatchSize:           0,
+			}},
+		},
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+	})
+	if err != nil && !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+		return fmt.Errorf("create assistant runtime janitor schedule: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -242,6 +242,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.ProcessAssistantThread)
 	temporalWorker.RegisterActivity(activities.ExpireAssistantThreadRuntime)
 	temporalWorker.RegisterActivity(activities.ReapStuckAssistantRuntimes)
+	temporalWorker.RegisterActivity(activities.ReapInactiveAssistantRuntimes)
 	temporalWorker.RegisterActivity(activities.SignalAssistantCoordinator)
 	temporalWorker.RegisterActivity(activities.SignalAssistantThread)
 
@@ -266,6 +267,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(AssistantCoordinatorWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantThreadWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantReaperWorkflow)
+	temporalWorker.RegisterWorkflow(AssistantRuntimeJanitorWorkflow)
 
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
@@ -281,6 +283,10 @@ func NewTemporalWorker(
 
 	if err := AddAssistantReaperSchedule(context.Background(), env); err != nil {
 		logger.ErrorContext(context.Background(), "failed to add assistant reaper schedule", attr.SlogError(err))
+	}
+
+	if err := AddAssistantRuntimeJanitorSchedule(context.Background(), env); err != nil {
+		logger.ErrorContext(context.Background(), "failed to add assistant runtime janitor schedule", attr.SlogError(err))
 	}
 
 	return temporalWorker


### PR DESCRIPTION
## Summary

- Adds a `Reap` method on the runtime backend interface that tears down per-assistant backend resources (Fly app, IP) and clears persisted metadata. Distinct from `Stop`, which after AGE-2073 may preserve state for warm reuse.
- `DeleteAssistant` reaps inline as a best-effort step. Failures don't roll back the soft-delete; the janitor is the safety net.
- New hourly Temporal workflow `AssistantRuntimeJanitorWorkflow` reaps runtime rows whose owning assistant has had no recorded activity for 7 days (default; configurable via workflow params). `NOT EXISTS` on `max(updated_at)` per assistant keeps normal cold-warm-cold cycles out of the candidate set; active and starting rows are filtered in SQL.

Closes [AGE-2086](https://linear.app/speakeasy/issue/AGE-2086).

✻ Clauded...