### PR TITLE
feat(dashboard): drop LOCATION from selectable Presidio entities

### DIFF
--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -25,30 +25,16 @@ import {
 import { ChatDetailPanel } from "@/pages/chatLogs/ChatDetailPanel";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
 
-// Rules that are no longer selectable in the Policy Center but may still
-// surface in historical findings or in policies whose presidio_entities
-// haven't been cleaned up yet. Without this fallback, getCategoryForRule
-// would default these to "secrets" and the UI would render the wrong
-// category badge.
-const RETIRED_RULE_TO_CATEGORY: Record<string, RuleCategory> = {
-  LOCATION: "pii",
-  PERSON: "pii",
-};
-
-// Build a ruleId -> category lookup from the detection rules registry.
 const RULE_ID_TO_CATEGORY = new Map<string, RuleCategory>();
 for (const [category, rules] of Object.entries(DETECTION_RULES)) {
   for (const rule of rules) {
     RULE_ID_TO_CATEGORY.set(rule.id, category as RuleCategory);
   }
 }
-for (const [ruleId, category] of Object.entries(RETIRED_RULE_TO_CATEGORY)) {
-  RULE_ID_TO_CATEGORY.set(ruleId, category);
-}
 
-function getCategoryForRule(ruleId: string | undefined): RuleCategory {
-  if (!ruleId) return "secrets";
-  return RULE_ID_TO_CATEGORY.get(ruleId) ?? "secrets";
+function getCategoryForRule(ruleId: string | undefined): RuleCategory | null {
+  if (!ruleId) return null;
+  return RULE_ID_TO_CATEGORY.get(ruleId) ?? null;
 }
 
 export default function SecurityOverview() {
@@ -328,13 +314,17 @@ function SecurityOverviewContent() {
                           }}
                         >
                           <TableCell>
-                            <Badge variant="secondary">
-                              {
-                                RULE_CATEGORY_META[
-                                  getCategoryForRule(result.ruleId)
-                                ].label
-                              }
-                            </Badge>
+                            {(() => {
+                              const category = getCategoryForRule(
+                                result.ruleId,
+                              );
+                              if (!category) return null;
+                              return (
+                                <Badge variant="secondary">
+                                  {RULE_CATEGORY_META[category].label}
+                                </Badge>
+                              );
+                            })()}
                           </TableCell>
                           <TableCell className="font-mono text-xs">
                             {result.ruleId ?? "-"}

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -25,12 +25,25 @@ import {
 import { ChatDetailPanel } from "@/pages/chatLogs/ChatDetailPanel";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
 
+// Rules that are no longer selectable in the Policy Center but may still
+// surface in historical findings or in policies whose presidio_entities
+// haven't been cleaned up yet. Without this fallback, getCategoryForRule
+// would default these to "secrets" and the UI would render the wrong
+// category badge.
+const RETIRED_RULE_TO_CATEGORY: Record<string, RuleCategory> = {
+  LOCATION: "pii",
+  PERSON: "pii",
+};
+
 // Build a ruleId -> category lookup from the detection rules registry.
 const RULE_ID_TO_CATEGORY = new Map<string, RuleCategory>();
 for (const [category, rules] of Object.entries(DETECTION_RULES)) {
   for (const rule of rules) {
     RULE_ID_TO_CATEGORY.set(rule.id, category as RuleCategory);
   }
+}
+for (const [ruleId, category] of Object.entries(RETIRED_RULE_TO_CATEGORY)) {
+  RULE_ID_TO_CATEGORY.set(ruleId, category);
 }
 
 function getCategoryForRule(ruleId: string | undefined): RuleCategory {

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -37,6 +37,14 @@ function getCategoryForRule(ruleId: string | undefined): RuleCategory | null {
   return RULE_ID_TO_CATEGORY.get(ruleId) ?? null;
 }
 
+function CategoryBadge({ ruleId }: { ruleId: string | undefined }) {
+  const category = getCategoryForRule(ruleId);
+  if (!category) return null;
+  return (
+    <Badge variant="secondary">{RULE_CATEGORY_META[category].label}</Badge>
+  );
+}
+
 export default function SecurityOverview() {
   return (
     <RequireScope scope="org:admin" level="page">
@@ -314,17 +322,7 @@ function SecurityOverviewContent() {
                           }}
                         >
                           <TableCell>
-                            {(() => {
-                              const category = getCategoryForRule(
-                                result.ruleId,
-                              );
-                              if (!category) return null;
-                              return (
-                                <Badge variant="secondary">
-                                  {RULE_CATEGORY_META[category].label}
-                                </Badge>
-                              );
-                            })()}
+                            <CategoryBadge ruleId={result.ruleId} />
                           </TableCell>
                           <TableCell className="font-mono text-xs">
                             {result.ruleId ?? "-"}

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -64,7 +64,7 @@ export const RULE_CATEGORY_META: Record<
   },
   pii: {
     label: "Personal Identifiable Information",
-    description: "Names, addresses, phone numbers, email addresses",
+    description: "Phone numbers, email addresses, IP and MAC addresses",
     icon: "user",
   },
   government_ids: {
@@ -1219,11 +1219,6 @@ export const DETECTION_RULES: Record<RuleCategory, DetectionRule[]> = {
     // a scoped allow-list.
     { id: "EMAIL_ADDRESS", title: "Email address", source: "presidio" },
     { id: "PHONE_NUMBER", title: "Telephone number", source: "presidio" },
-    {
-      id: "LOCATION",
-      title: "Geographically defined location",
-      source: "presidio",
-    },
     {
       id: "IP_ADDRESS",
       title: "IPv4 or IPv6 address",


### PR DESCRIPTION
## Why

The geographically defined `LOCATION` Presidio entity is being retired from the Policy Center because it is noisy and unhelpful: Presidio's NER-backed location detection trips on common capitalized words and ordinary place mentions, producing false positives that drown out the signals that actually matter. Removing it from the selectable rule list also forces us to keep the PII category subtitle honest, since names and addresses are no longer in the list either (PERSON was already disabled in code).

A companion mig: PR strips `LOCATION` from any existing risk policies that reference it.

## What changed

### Before

- Policy Center > Personal Identifiable Information offered `LOCATION` ("Geographically defined location") as a selectable rule.
- The PII category subtitle read: "Names, addresses, phone numbers, email addresses".

### After

- `LOCATION` is removed from `DETECTION_RULES.pii` in `client/dashboard/src/pages/security/policy-data.ts`.
- The PII subtitle reads: "Phone numbers, email addresses, IP and MAC addresses", matching the rules actually offered.