### PR TITLE
mig: remove LOCATION from existing risk policies

### DIFF
--- a/server/migrations/20260504160941_remove-location-from-pii-policies.sql
+++ b/server/migrations/20260504160941_remove-location-from-pii-policies.sql
@@ -1,0 +1,11 @@
+-- Remove the LOCATION Presidio entity from existing risk policies. The
+-- geographically defined LOCATION entity is being retired from the Policy
+-- Center because Presidio's NER-backed location detection produces too
+-- many false positives on common nouns to be useful in the runtime hot
+-- path. The selectable rule was removed from the dashboard in a separate
+-- change; this migration cleans up policies that already had it pinned.
+UPDATE risk_policies
+SET presidio_entities = array_remove(presidio_entities, 'LOCATION')
+  , version = version + 1
+WHERE 'LOCATION' = ANY(presidio_entities)
+  AND deleted IS FALSE;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zleYfz3S2cRoqSoJ3IKZKjvsa7ej9M8rmJHZPH68KSk=
+h1:vy6YYmDz/BlT8UPTZKNzqVksS6ZXVfSzlEszmV8cnmo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -151,3 +151,4 @@ h1:zleYfz3S2cRoqSoJ3IKZKjvsa7ej9M8rmJHZPH68KSk=
 20260430111449_add-workos-roles-and-sync-tables.sql h1:tIK7+g0gEt27jixmoso4bHI7GYAtxUzfL8l24k2Os8g=
 20260430201533_risk-policies-action-and-auto-name.sql h1:3tvGuQlzBnUX2gvFtad56YpeX1wpE9asgXh74ywEIhE=
 20260430205315_risk-policies-user-message.sql h1:b3myELZy6W5m08Wz7aqPV6pInYP5SB0KKj5uQ5VYBoQ=
+20260504160941_remove-location-from-pii-policies.sql h1:yCzDGT+8E9xuZpxYwJXpEyHYFW0xNEn9VKe2TchfJgs=


### PR DESCRIPTION
## Why

The geographically defined `LOCATION` Presidio entity is being retired from the Policy Center (frontend change in #2569) because it is noisy and unhelpful: Presidio's NER-backed location detection trips on common capitalized words and ordinary place mentions, producing false positives that drown out the signals that actually matter.

`LOCATION` was backfilled into every existing risk policy by `20260424180559_risk-policies-default-pii.sql`, so customers' policies still reference it even though the rule is no longer selectable in the UI. This migration cleans up the lingering references and bumps `version` so the next analysis cycle rescans without it.

## What changed

### Before

`risk_policies.presidio_entities` could include `LOCATION` for any policy that opted into PII scanning, even though the dashboard no longer offers it.

### After

For every non-deleted `risk_policies` row that pins `LOCATION`:

- `LOCATION` is removed from `presidio_entities` via `array_remove`.
- `version` is bumped by 1.

Migrations ship in their own PR per the project rules; the dashboard change lives in #2569.