### PR TITLE
fix: adjust fly machine soft limit and cpus

### DIFF
--- a/.changeset/flat-loops-wave.md
+++ b/.changeset/flat-loops-wave.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Increase CPUs to 4GiB and lower soft limit to 20% of hard limit.

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -635,7 +635,7 @@ func (f *FlyRunner) reap(ctx context.Context, logger *slog.Logger, appsRepo *rep
 // the hard cap.
 func concurrencyLimits(memoryMB int) (softLimit, hardLimit int) {
 	hardLimit = max(memoryMB/48, 4)
-	softLimit = max(hardLimit*3/4, 2)
+	softLimit = max(hardLimit*1/5, 2)
 	return softLimit, hardLimit
 }
 
@@ -656,7 +656,7 @@ func (f *FlyRunner) newMachineConfig(req RunnerDeployRequest, image string, file
 		},
 		Guest: &fly.MachineGuest{
 			CPUKind:       "shared",
-			CPUs:          2,
+			CPUs:          4,
 			MemoryMB:      mem,
 			GPUs:          0,
 			PersistRootfs: fly.MachinePersistRootfsNever,

--- a/server/internal/functions/deploy_fly_test.go
+++ b/server/internal/functions/deploy_fly_test.go
@@ -45,5 +45,5 @@ func TestConcurrencyLimits_ZeroMemory(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(0)
 	require.Equal(t, 4, hard, "hard limit floors at 4")
-	require.Equal(t, 2, soft, "soft limit floors at 2 but 1/5 of 4 = 3")
+	require.Equal(t, 2, soft, "soft limit floors at 2 because 1/5 of 4 = 0")
 }

--- a/server/internal/functions/deploy_fly_test.go
+++ b/server/internal/functions/deploy_fly_test.go
@@ -10,40 +10,40 @@ func TestConcurrencyLimits_256MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(256)
 	require.Equal(t, 5, hard)
-	require.Equal(t, 3, soft)
+	require.Equal(t, 2, soft)
 }
 
 func TestConcurrencyLimits_512MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(512)
 	require.Equal(t, 10, hard)
-	require.Equal(t, 7, soft)
+	require.Equal(t, 2, soft)
 }
 
 func TestConcurrencyLimits_1024MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(1024)
 	require.Equal(t, 21, hard)
-	require.Equal(t, 15, soft)
+	require.Equal(t, 4, soft)
 }
 
 func TestConcurrencyLimits_2048MB(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(2048)
 	require.Equal(t, 42, hard)
-	require.Equal(t, 31, soft)
+	require.Equal(t, 8, soft)
 }
 
 func TestConcurrencyLimits_TinyMemory(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(64)
 	require.Equal(t, 4, hard, "hard limit floors at 4")
-	require.Equal(t, 3, soft)
+	require.Equal(t, 2, soft)
 }
 
 func TestConcurrencyLimits_ZeroMemory(t *testing.T) {
 	t.Parallel()
 	soft, hard := concurrencyLimits(0)
 	require.Equal(t, 4, hard, "hard limit floors at 4")
-	require.Equal(t, 3, soft, "soft limit floors at 2 but 3/4 of 4 = 3")
+	require.Equal(t, 2, soft, "soft limit floors at 2 but 1/5 of 4 = 3")
 }


### PR DESCRIPTION
Increase CPUs to 4GiB and lower soft limit to 20% of hard limit.