### PR TITLE
fix(dashboard): commit tool log filters on Enter, not on typing pause

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -505,32 +505,26 @@ export function InsightsToolsContent() {
     [setSearchParams],
   );
 
-  useEffect(() => {
-    if (!serverInput.trim()) return;
-
-    const timeoutId = setTimeout(() => {
-      addFilter({
-        display: serverInput,
-        filters: [serverInput],
-        path: "gram.tool_call.source",
-      });
-      setServerInput("");
-    }, 500);
-    return () => clearTimeout(timeoutId);
+  const submitServerFilter = useCallback(() => {
+    const trimmed = serverInput.trim();
+    if (!trimmed) return;
+    addFilter({
+      display: trimmed,
+      filters: [trimmed],
+      path: "gram.tool_call.source",
+    });
+    setServerInput("");
   }, [serverInput, addFilter]);
 
-  useEffect(() => {
-    if (!userEmailInput.trim()) return;
-
-    const timeoutId = setTimeout(() => {
-      addFilter({
-        display: userEmailInput,
-        filters: [userEmailInput],
-        path: "user.email",
-      });
-      setUserEmailInput("");
-    }, 500);
-    return () => clearTimeout(timeoutId);
+  const submitUserEmailFilter = useCallback(() => {
+    const trimmed = userEmailInput.trim();
+    if (!trimmed) return;
+    addFilter({
+      display: trimmed,
+      filters: [trimmed],
+      path: "user.email",
+    });
+    setUserEmailInput("");
   }, [userEmailInput, addFilter]);
 
   const handleHookTypesChange = useCallback(
@@ -604,8 +598,10 @@ export function InsightsToolsContent() {
             groupedTraces={groupedTraces}
             serverInput={serverInput}
             setServerInput={setServerInput}
+            onSubmitServerFilter={submitServerFilter}
             userEmailInput={userEmailInput}
             setUserEmailInput={setUserEmailInput}
+            onSubmitUserEmailFilter={submitUserEmailFilter}
             activeFilters={activeFilters}
             addFilter={addFilter}
             removeFilter={removeFilter}
@@ -637,8 +633,10 @@ function HooksInnerContent({
   groupedTraces,
   serverInput,
   setServerInput,
+  onSubmitServerFilter,
   userEmailInput,
   setUserEmailInput,
+  onSubmitUserEmailFilter,
   activeFilters,
   addFilter,
   removeFilter,
@@ -664,8 +662,10 @@ function HooksInnerContent({
   groupedTraces: HookTrace[];
   serverInput: string;
   setServerInput: (value: string) => void;
+  onSubmitServerFilter: () => void;
   userEmailInput: string;
   setUserEmailInput: (value: string) => void;
+  onSubmitUserEmailFilter: () => void;
   activeFilters: FilterChip[];
   addFilter: (chip: FilterChip) => void;
   removeFilter: (path: string, display?: string) => void;
@@ -721,7 +721,8 @@ function HooksInnerContent({
             <MultiSearch
               value={serverInput}
               onChange={setServerInput}
-              placeholder="Filter by server name"
+              onSubmit={onSubmitServerFilter}
+              placeholder="Filter by server name (press Enter to add)"
               className="min-w-[200px] flex-1"
               chips={activeFilters
                 .filter((f) => f.path === "gram.tool_call.source")
@@ -733,7 +734,8 @@ function HooksInnerContent({
             <MultiSearch
               value={userEmailInput}
               onChange={setUserEmailInput}
-              placeholder="Filter by user email"
+              onSubmit={onSubmitUserEmailFilter}
+              placeholder="Filter by user email (press Enter to add)"
               className="min-w-[200px] flex-1"
               chips={activeFilters
                 .filter((f) => f.path === "user.email")

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -48,7 +48,7 @@ import {
   Chart as ChartJS,
 } from "chart.js";
 import { Settings } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { LogDetailSheet } from "@/pages/logs/LogDetailSheet";
 import { TraceLogsList } from "@/pages/logs/TraceLogsList";
@@ -381,32 +381,26 @@ export function LogsTools() {
     [setSearchParams],
   );
 
-  useEffect(() => {
-    if (!serverInput.trim()) return;
-
-    const timeoutId = setTimeout(() => {
-      addFilter({
-        display: serverInput,
-        filters: [serverInput],
-        path: "gram.tool_call.source",
-      });
-      setServerInput("");
-    }, 500);
-    return () => clearTimeout(timeoutId);
+  const submitServerFilter = useCallback(() => {
+    const trimmed = serverInput.trim();
+    if (!trimmed) return;
+    addFilter({
+      display: trimmed,
+      filters: [trimmed],
+      path: "gram.tool_call.source",
+    });
+    setServerInput("");
   }, [serverInput, addFilter]);
 
-  useEffect(() => {
-    if (!userEmailInput.trim()) return;
-
-    const timeoutId = setTimeout(() => {
-      addFilter({
-        display: userEmailInput,
-        filters: [userEmailInput],
-        path: "user.email",
-      });
-      setUserEmailInput("");
-    }, 500);
-    return () => clearTimeout(timeoutId);
+  const submitUserEmailFilter = useCallback(() => {
+    const trimmed = userEmailInput.trim();
+    if (!trimmed) return;
+    addFilter({
+      display: trimmed,
+      filters: [trimmed],
+      path: "user.email",
+    });
+    setUserEmailInput("");
   }, [userEmailInput, addFilter]);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
@@ -504,8 +498,10 @@ export function LogsTools() {
             groupedTraces={groupedTraces}
             serverInput={serverInput}
             setServerInput={setServerInput}
+            onSubmitServerFilter={submitServerFilter}
             userEmailInput={userEmailInput}
             setUserEmailInput={setUserEmailInput}
+            onSubmitUserEmailFilter={submitUserEmailFilter}
             activeFilters={activeFilters}
             addFilter={addFilter}
             removeFilter={removeFilter}
@@ -542,8 +538,10 @@ function HooksInnerContent({
   groupedTraces,
   serverInput,
   setServerInput,
+  onSubmitServerFilter,
   userEmailInput,
   setUserEmailInput,
+  onSubmitUserEmailFilter,
   activeFilters,
   removeFilter,
   selectedHookTypes,
@@ -573,8 +571,10 @@ function HooksInnerContent({
   groupedTraces: HookTrace[];
   serverInput: string;
   setServerInput: (value: string) => void;
+  onSubmitServerFilter: () => void;
   userEmailInput: string;
   setUserEmailInput: (value: string) => void;
+  onSubmitUserEmailFilter: () => void;
   activeFilters: FilterChip[];
   addFilter: (chip: FilterChip) => void;
   removeFilter: (path: string, display?: string) => void;
@@ -625,7 +625,8 @@ function HooksInnerContent({
             <MultiSearch
               value={serverInput}
               onChange={setServerInput}
-              placeholder="Filter by server name"
+              onSubmit={onSubmitServerFilter}
+              placeholder="Filter by server name (press Enter to add)"
               className="min-w-[200px] flex-1"
               chips={activeFilters
                 .filter((f) => f.path === "gram.tool_call.source")
@@ -637,7 +638,8 @@ function HooksInnerContent({
             <MultiSearch
               value={userEmailInput}
               onChange={setUserEmailInput}
-              placeholder="Filter by user email"
+              onSubmit={onSubmitUserEmailFilter}
+              placeholder="Filter by user email (press Enter to add)"
               className="min-w-[200px] flex-1"
               chips={activeFilters
                 .filter((f) => f.path === "user.email")

--- a/client/dashboard/src/components/ui/multi-search.tsx
+++ b/client/dashboard/src/components/ui/multi-search.tsx
@@ -10,6 +10,7 @@ interface FilterChip {
 export function MultiSearch({
   value,
   onChange,
+  onSubmit,
   placeholder = "Search",
   className,
   disabled,
@@ -18,6 +19,7 @@ export function MultiSearch({
 }: {
   value: string;
   onChange: (value: string) => void;
+  onSubmit?: () => void;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -65,6 +67,12 @@ export function MultiSearch({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && onSubmit && value.trim()) {
+            e.preventDefault();
+            onSubmit();
+          }
+        }}
         disabled={disabled}
         className="min-w-0 flex-1 bg-transparent outline-none disabled:cursor-not-allowed"
       />


### PR DESCRIPTION
## Summary
- The server-name and user-email filter inputs on the Tool Logs and Tools/Insights pages auto-committed your typed text into a chip 500 ms after you stopped typing — it felt like a phantom Enter.
- Removed the debounced \`useEffect\`s in \`LogsTools.tsx\` and \`InsightsTools.tsx\` and replaced them with an explicit \`onSubmit\` callback fired only on Enter.
- Added an \`onSubmit\` prop to the shared \`MultiSearch\` component (with empty-string guard) so future call sites can opt in to the same explicit-commit behaviour.

## Test plan
- [ ] On Tool Logs, type a partial server name and pause — verify the input does NOT auto-convert to a chip.
- [ ] Press Enter while typed text is in the field — verify a chip is added and the input clears.
- [ ] Press Enter on an empty field — verify nothing happens.
- [ ] Same checks for the user-email filter on Tool Logs.
- [ ] Repeat both checks on the Insights/Tools page.
- [ ] Existing chips are still removable via the X button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)