### PR TITLE
fix(dashboard): tag assistant chats as 'assistant' source

### DIFF
--- a/.changeset/assistant-source-label.md
+++ b/.changeset/assistant-source-label.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Tag chat sessions started from the Assistants page with `X-Gram-Source: assistant` (was `assistant-onboarding`). Agent session logs now show `assistant` as the source for these sessions instead of conflating ongoing assistant chats with the onboarding flow.

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -190,7 +190,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           api: {
             url: getServerURL(),
             session: getSession,
-            headers: { "X-Gram-Source": "assistant-onboarding" },
+            headers: { "X-Gram-Source": "assistant" },
           },
           history: {
             enabled: true,


### PR DESCRIPTION
## Summary
- The Assistants page was sending `X-Gram-Source: assistant-onboarding` for every chat, including ongoing conversations with an already-onboarded assistant. The agent-session log surfaced this as the chat type, conflating onboarding with regular assistant use.
- Renames the override in `AssistantOnboarding.tsx` to `assistant` so the dashboard's source column reflects the surface the user is actually on.

## Test plan
- [ ] Open an existing assistant in the dashboard, send a message, and confirm the resulting agent session shows `assistant` as the source (not `assistant-onboarding` or `playground`).
- [ ] Create a new assistant via the onboarding flow and confirm the session is also tagged `assistant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)