### PR TITLE
mig: add chat_messages (project_id, id) index

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1048,6 +1048,7 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_idx ON chat_messages (chat_id);
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_generation_seq_idx ON chat_messages (chat_id, generation, seq);
+CREATE INDEX IF NOT EXISTS chat_messages_project_id_id_idx ON chat_messages (project_id, id);
 
 CREATE TABLE IF NOT EXISTS chat_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1048,7 +1048,9 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_idx ON chat_messages (chat_id);
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_generation_seq_idx ON chat_messages (chat_id, generation, seq);
-CREATE INDEX IF NOT EXISTS chat_messages_project_id_id_idx ON chat_messages (project_id, id);
+CREATE INDEX IF NOT EXISTS chat_messages_project_id_id_idx
+ON chat_messages (project_id, id)
+WHERE project_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS chat_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/20260504210453_chat_messages_project_id_id_idx.sql
+++ b/server/migrations/20260504210453_chat_messages_project_id_id_idx.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "chat_messages_project_id_id_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_project_id_id_idx" ON "chat_messages" ("project_id", "id");

--- a/server/migrations/20260504210453_chat_messages_project_id_id_idx.sql
+++ b/server/migrations/20260504210453_chat_messages_project_id_id_idx.sql
@@ -1,4 +1,0 @@
--- atlas:txmode none
-
--- Create index "chat_messages_project_id_id_idx" to table: "chat_messages"
-CREATE INDEX CONCURRENTLY "chat_messages_project_id_id_idx" ON "chat_messages" ("project_id", "id");

--- a/server/migrations/20260504210916_chat_messages_project_id_id_idx.sql
+++ b/server/migrations/20260504210916_chat_messages_project_id_id_idx.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "chat_messages_project_id_id_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_project_id_id_idx" ON "chat_messages" ("project_id", "id") WHERE (project_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:2zXnuF+XSCXPbxB37avSedGjvCwDEjZaaj9Bp6Lb/0Y=
+h1:cqPlYrsKL6hBzXezENZP87MOc56DsL6PpZOO8n3FHlU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -152,4 +152,4 @@ h1:2zXnuF+XSCXPbxB37avSedGjvCwDEjZaaj9Bp6Lb/0Y=
 20260430201533_risk-policies-action-and-auto-name.sql h1:3tvGuQlzBnUX2gvFtad56YpeX1wpE9asgXh74ywEIhE=
 20260430205315_risk-policies-user-message.sql h1:b3myELZy6W5m08Wz7aqPV6pInYP5SB0KKj5uQ5VYBoQ=
 20260504160941_remove-location-from-pii-policies.sql h1:yCzDGT+8E9xuZpxYwJXpEyHYFW0xNEn9VKe2TchfJgs=
-20260504210453_chat_messages_project_id_id_idx.sql h1:kA80ryvWcv9w1nyV4u32Iox+0il4Y4FjZvl1LlZN2lk=
+20260504210916_chat_messages_project_id_id_idx.sql h1:kwShq3wLbk1VNIWRsAWDlqJ2apQ5iDnODP81/Vc6VTY=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vy6YYmDz/BlT8UPTZKNzqVksS6ZXVfSzlEszmV8cnmo=
+h1:2zXnuF+XSCXPbxB37avSedGjvCwDEjZaaj9Bp6Lb/0Y=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -152,3 +152,4 @@ h1:vy6YYmDz/BlT8UPTZKNzqVksS6ZXVfSzlEszmV8cnmo=
 20260430201533_risk-policies-action-and-auto-name.sql h1:3tvGuQlzBnUX2gvFtad56YpeX1wpE9asgXh74ywEIhE=
 20260430205315_risk-policies-user-message.sql h1:b3myELZy6W5m08Wz7aqPV6pInYP5SB0KKj5uQ5VYBoQ=
 20260504160941_remove-location-from-pii-policies.sql h1:yCzDGT+8E9xuZpxYwJXpEyHYFW0xNEn9VKe2TchfJgs=
+20260504210453_chat_messages_project_id_id_idx.sql h1:kA80ryvWcv9w1nyV4u32Iox+0il4Y4FjZvl1LlZN2lk=


### PR DESCRIPTION
## Summary

- Adds `chat_messages_project_id_id_idx` on `(project_id, id)` to back the risk-analysis drain workflow.
- `FetchUnanalyzedMessageIDs` (server/internal/risk/queries.sql:115) filters `chat_messages` by `project_id` with no index covering the predicate; every call seq-scanned the heap.
- One hot project with ~10 risk policies fires drains every ~3s (per-policy 30s cooldown). Activity duration ranges 240ms typical, 150–280s tail. Index makes the project-scoped slice an index scan; PK lookup feeds the existing risk_results anti-join index.

## Notes

- Migration-only PR per repo convention.
- `CREATE INDEX CONCURRENTLY` with `atlas:txmode none`.
- Expand-only; no rewrites, no app-code changes.
- Index includes `id` so the anti-join's outer loop can use an index-only scan.

✻ Clauded...