### PR TITLE
fix(risk): scope FetchUnanalyzedMessageIDs by project_id

### DIFF
--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -120,8 +120,10 @@ WHERE cm.project_id = @project_id
     SELECT 1
     FROM risk_results rr
     WHERE rr.chat_message_id = cm.id
+      AND rr.project_id = @project_id
       AND rr.risk_policy_id = @risk_policy_id
       AND rr.risk_policy_version = @risk_policy_version
+    LIMIT 1
   )
 LIMIT @batch_limit;
 

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -239,8 +239,10 @@ WHERE cm.project_id = $1
     SELECT 1
     FROM risk_results rr
     WHERE rr.chat_message_id = cm.id
+      AND rr.project_id = $1
       AND rr.risk_policy_id = $2
       AND rr.risk_policy_version = $3
+    LIMIT 1
   )
 LIMIT $4
 `


### PR DESCRIPTION
## Why

DB CPU on `gram-prod-instance` spiked from ~4% baseline to 99% peak (now sustained ~84%) starting around 20:04 UTC today. Datadog monitor `Elevated temporal workflow failures in Gram` (id 274771871) is firing on `drainriskanalysisworkflow`:

- `analyzebatch` activity failing at 511 ops/sec
- `fetchunanalyzedmessages` activity rate climbing 36 → 47 ops/sec

Top hot query by cumulative execution time was `FetchUnanalyzedMessageIDs` at 3s → 8s and rising.

Root cause: the NOT EXISTS subquery filters `risk_results` only by `chat_message_id`, `risk_policy_id`, and `risk_policy_version`. The existing composite index `risk_results_project_policy_version_message_idx (project_id, risk_policy_id, risk_policy_version, chat_message_id)` cannot be used without `project_id` as the leading column, so Postgres falls back to a sequential scan over the entire `risk_results` table for every probe. As `analyzebatch` failures stop new `risk_results` rows from being written, the unanalyzed candidate set grows, the seq scan cost grows, and CPU pegs.

## What changed

### Before

```sql
SELECT cm.id
FROM chat_messages cm
WHERE cm.project_id = @project_id
  AND NOT EXISTS (
    SELECT 1
    FROM risk_results rr
    WHERE rr.chat_message_id = cm.id
      AND rr.risk_policy_id = @risk_policy_id
      AND rr.risk_policy_version = @risk_policy_version
  )
LIMIT @batch_limit;
```

EXPLAIN: `Seq Scan on risk_results` (cost 342, 272 buffers in local).

### After

```sql
SELECT cm.id
FROM chat_messages cm
WHERE cm.project_id = @project_id
  AND NOT EXISTS (
    SELECT 1
    FROM risk_results rr
    WHERE rr.chat_message_id = cm.id
      AND rr.project_id = @project_id
      AND rr.risk_policy_id = @risk_policy_id
      AND rr.risk_policy_version = @risk_policy_version
    LIMIT 1
  )
LIMIT @batch_limit;
```

The added `rr.project_id` filter lets the planner use the existing 4-column composite index. `LIMIT 1` is redundant for NOT EXISTS but makes intent explicit and is cheap. No new index, no migration.

The sqlc-generated query reuses `$1` for both `project_id` references, so the Go signature is unchanged and no callers need updating.

## Test plan

- [ ] CI green
- [ ] Verify EXPLAIN on prod read replica picks `risk_results_project_policy_version_message_idx` after deploy
- [ ] Confirm `gram-prod-instance` CPU returns to baseline after `analyzebatch` failures are also addressed (separate issue: 511 ops/sec failure rate is the driver of the backlog and needs investigation independently)