### PR TITLE
fix(risk): exit AnalyzeBatch early if policy deleted or disabled

### DIFF
--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -3,6 +3,7 @@ package risk_analysis
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -91,6 +93,28 @@ func (a *AnalyzeBatch) Do(ctx context.Context, args AnalyzeBatchArgs) (_ *Analyz
 		}
 		span.End()
 	}()
+
+	policy, err := repo.New(a.db).GetRiskPolicy(ctx, repo.GetRiskPolicyParams{
+		ID:        args.RiskPolicyID,
+		ProjectID: args.ProjectID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		span.SetAttributes(attribute.Bool("risk.policy_deleted", true))
+		a.logger.InfoContext(ctx, "risk policy deleted, skipping batch",
+			attr.SlogRiskPolicyID(args.RiskPolicyID.String()),
+		)
+		return &AnalyzeBatchResult{Processed: 0, Findings: 0}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get risk policy: %w", err)
+	}
+	if !policy.Enabled {
+		span.SetAttributes(attribute.Bool("risk.policy_disabled", true))
+		a.logger.InfoContext(ctx, "risk policy disabled, skipping batch",
+			attr.SlogRiskPolicyID(args.RiskPolicyID.String()),
+		)
+		return &AnalyzeBatchResult{Processed: 0, Findings: 0}, nil
+	}
 
 	messages, err := a.fetchContent(ctx, args)
 	if err != nil {

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -77,8 +77,9 @@ func (a *AnalyzeBatch) Do(ctx context.Context, args AnalyzeBatchArgs) (_ *Analyz
 	}
 
 	start := time.Now()
+	scannedCount := 0
 	defer func() {
-		a.metrics.RecordScan(ctx, args.OrganizationID, o11y.OutcomeFromError(err), len(args.MessageIDs), time.Since(start))
+		a.metrics.RecordScan(ctx, args.OrganizationID, o11y.OutcomeFromError(err), scannedCount, time.Since(start))
 	}()
 
 	ctx, span := a.tracer.Start(ctx, "risk.analyzeBatch", trace.WithAttributes(
@@ -99,6 +100,11 @@ func (a *AnalyzeBatch) Do(ctx context.Context, args AnalyzeBatchArgs) (_ *Analyz
 		ProjectID: args.ProjectID,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
+		// Policy was deleted (soft or hard) between FetchUnanalyzedMessages
+		// returning IDs and this activity running. FetchUnanalyzed errors out
+		// on the next drain cycle, so there is no infinite loop and no need
+		// to write Found=false rows; the FK to risk_policies might also be
+		// gone on hard-delete.
 		span.SetAttributes(attribute.Bool("risk.policy_deleted", true))
 		a.logger.InfoContext(ctx, "risk policy deleted, skipping batch",
 			attr.SlogRiskPolicyID(args.RiskPolicyID.String()),
@@ -109,6 +115,9 @@ func (a *AnalyzeBatch) Do(ctx context.Context, args AnalyzeBatchArgs) (_ *Analyz
 		return nil, fmt.Errorf("get risk policy: %w", err)
 	}
 	if !policy.Enabled {
+		// Policy was disabled mid-flight. FetchUnanalyzed returns no IDs while
+		// disabled (no infinite loop), and a re-enable bumps the policy
+		// version so FetchUnanalyzedMessageIDs picks these messages up again.
 		span.SetAttributes(attribute.Bool("risk.policy_disabled", true))
 		a.logger.InfoContext(ctx, "risk policy disabled, skipping batch",
 			attr.SlogRiskPolicyID(args.RiskPolicyID.String()),
@@ -120,6 +129,7 @@ func (a *AnalyzeBatch) Do(ctx context.Context, args AnalyzeBatchArgs) (_ *Analyz
 	if err != nil {
 		return nil, err
 	}
+	scannedCount = len(messages)
 
 	findings, err := a.scan(ctx, args, messages)
 	if err != nil {

--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -336,3 +336,53 @@ func insertAssistantToolCall(t *testing.T, conn *pgxpool.Pool, td testData, call
 	require.FailNow(t, "inserted tool-call message not found")
 	return uuid.Nil
 }
+
+func TestAnalyzeBatch_SkipsWhenPolicyDisabled(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, false)
+
+	msgID, err := testrepo.New(conn).InsertChatMessage(t.Context(), testrepo.InsertChatMessageParams{
+		ChatID:    td.chatID,
+		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
+		Role:      "user",
+		Content:   "AWS key AKIAIOSFODNN7REALKEY",
+	})
+	require.NoError(t, err)
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{"gitleaks"})
+	assert.Equal(t, 0, result.Processed)
+	assert.Equal(t, 0, result.Findings)
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		Cursor:       uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, rows, "no risk_results should be written for a disabled policy")
+}
+
+func TestAnalyzeBatch_SkipsWhenPolicyDeleted(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	msgID, err := testrepo.New(conn).InsertChatMessage(t.Context(), testrepo.InsertChatMessageParams{
+		ChatID:    td.chatID,
+		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
+		Role:      "user",
+		Content:   "AWS key AKIAIOSFODNN7REALKEY",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, riskrepo.New(conn).DeleteRiskPolicy(t.Context(), riskrepo.DeleteRiskPolicyParams{
+		ID:        td.policyID,
+		ProjectID: td.projectID,
+	}))
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{"gitleaks"})
+	assert.Equal(t, 0, result.Processed)
+	assert.Equal(t, 0, result.Findings)
+}


### PR DESCRIPTION
## Why

`DrainRiskAnalysisWorkflow` fans out `AnalyzeBatch` activities in chunks of 1k messages. If the policy is deleted or disabled while batches are queued, every remaining batch still scans content, writes `risk_results`, and pays the Presidio/gitleaks cost. Those rows are then hidden by every list query (which JOIN `risk_policies` on `deleted IS FALSE AND enabled IS TRUE`), so the work is pure waste.

`FetchUnanalyzed` already short-circuits when the policy is disabled, but the in-flight batches it scheduled before the policy state changed do not.

## What changed

### Before
`AnalyzeBatch.Do` went straight from arg validation into `fetchContent`/`scan`/`writeResults` regardless of current policy state.

### After
`AnalyzeBatch.Do` looks up the policy via `GetRiskPolicy` (which already filters `deleted IS FALSE`) before doing any work:

- `pgx.ErrNoRows` (policy soft-deleted): log + return `Processed=0`.
- `policy.Enabled == false`: log + return `Processed=0`.
- Otherwise: proceed as before.

Span attributes (`risk.policy_deleted` / `risk.policy_disabled`) are set so the skip is visible in traces.

## Test plan

- [x] `go test ./internal/background/activities/risk_analysis/... -run TestAnalyzeBatch_SkipsWhenPolicy` passes (covers both deleted and disabled cases, asserts no `risk_results` rows are written for the disabled case).
- [x] `mise build:server`
- [x] `mise lint:server`