### PR TITLE
chore(dashboard): pre-bundle deps to prevent dev 504s

### DIFF
--- a/.changeset/dull-buckets-rule.md
+++ b/.changeset/dull-buckets-rule.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+resolve intermittent 504 in dev by Vite lazy dep optimization of @assistant-ui packages

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -73,7 +73,11 @@ export default defineConfig(({ command }) => {
       target: "es2022",
     },
     optimizeDeps: {
-      include: ["monaco-editor"],
+      include: [
+        "monaco-editor",
+        "@assistant-ui/react",
+        "@assistant-ui/react-markdown",
+      ],
       esbuildOptions: {
         target: "es2022",
       },


### PR DESCRIPTION
## Summary

Fixes an annoyance I've had for a bit with dev server startup

Adds `@assistant-ui/react` and `@assistant-ui/react-markdown` to
`optimizeDeps.include` in `vite.config.ts`. Vite lazy-discovers these
packages' sub-chunks on first browser request, causing a race with
esbuild that produces 504 Gateway Timeout errors in dev. Explicit
include forces pre-bundling at server startup
