### PR TITLE
fix(risk): skip empty and oversize texts before sending to Presidio

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -207,6 +207,9 @@ const (
 	ProjectSlugKey                 = attribute.Key("gram.project.slug")
 	RiskPolicyCountKey             = attribute.Key("gram.risk.policy_count")
 	RiskPolicyIDKey                = attribute.Key("gram.risk.policy_id")
+	RiskPresidioMaxBytesKey        = attribute.Key("gram.risk.presidio.max_bytes")
+	RiskPresidioTextBytesKey       = attribute.Key("gram.risk.presidio.text_bytes")
+	RiskPresidioTextIndexKey       = attribute.Key("gram.risk.presidio.text_index")
 	RiskRuleIDKey                  = attribute.Key("gram.risk.rule_id")
 	SecretNameKey                  = attribute.Key("gram.secret.name")
 	SecurityPlacementKey           = attribute.Key("gram.security.placement")
@@ -924,6 +927,15 @@ func SlogRiskPolicyCount(v int) slog.Attr      { return slog.Int(string(RiskPoli
 
 func RiskPolicyID(v string) attribute.KeyValue { return RiskPolicyIDKey.String(v) }
 func SlogRiskPolicyID(v string) slog.Attr      { return slog.String(string(RiskPolicyIDKey), v) }
+
+func RiskPresidioMaxBytes(v int) attribute.KeyValue { return RiskPresidioMaxBytesKey.Int(v) }
+func SlogRiskPresidioMaxBytes(v int) slog.Attr      { return slog.Int(string(RiskPresidioMaxBytesKey), v) }
+
+func RiskPresidioTextBytes(v int) attribute.KeyValue { return RiskPresidioTextBytesKey.Int(v) }
+func SlogRiskPresidioTextBytes(v int) slog.Attr      { return slog.Int(string(RiskPresidioTextBytesKey), v) }
+
+func RiskPresidioTextIndex(v int) attribute.KeyValue { return RiskPresidioTextIndexKey.Int(v) }
+func SlogRiskPresidioTextIndex(v int) slog.Attr      { return slog.Int(string(RiskPresidioTextIndexKey), v) }
 
 func RiskRuleID(v string) attribute.KeyValue { return RiskRuleIDKey.String(v) }
 func SlogRiskRuleID(v string) slog.Attr      { return slog.String(string(RiskRuleIDKey), v) }

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -56,6 +57,14 @@ const presidioHTTPBatchSize = 50
 const presidioRetryBackoff = 100 * time.Millisecond
 
 const presidioRetryBackoffCap = 1 * time.Second
+
+// presidioMaxTextBytes caps per-text size before we skip a message. Presidio's
+// underlying spaCy model defaults to nlp.max_length=1,000,000 chars and OOMs
+// past that (~1GB temp memory per 100k chars). The infra Helm chart gives the
+// analyzer 1.5Gi, so leaving the default in place is what the deployment
+// expects. We measure bytes (not runes) and keep a 10% margin since UTF-8
+// multi-byte chars would let len(text) overshoot the rune count.
+const presidioMaxTextBytes = 900_000
 
 // PresidioClient calls the Presidio Analyzer HTTP API.
 // Presidio is a trusted cluster-internal service, so the client uses an
@@ -160,6 +169,28 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 		return make([][]Finding, n), nil
 	}
 	entities = filtered
+
+	// Skip texts above presidio's max length to avoid OOMing the analyzer.
+	// Replace each oversize entry with an empty string so result indices stay
+	// aligned; the empty slot returns no findings to the caller.
+	var clipped []string
+	for i, t := range texts {
+		if len(t) <= presidioMaxTextBytes {
+			continue
+		}
+		if clipped == nil {
+			clipped = slices.Clone(texts)
+		}
+		clipped[i] = ""
+		p.logger.WarnContext(ctx, "presidio analyze: text exceeds max size, skipping",
+			attr.SlogRiskPresidioTextIndex(i),
+			attr.SlogRiskPresidioTextBytes(len(t)),
+			attr.SlogRiskPresidioMaxBytes(presidioMaxTextBytes),
+		)
+	}
+	if clipped != nil {
+		texts = clipped
+	}
 
 	ctx, span := p.tracer.Start(ctx, "presidio.analyzeBatch", trace.WithAttributes(
 		attribute.Int("presidio.batch_size", n),

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -170,30 +169,36 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	}
 	entities = filtered
 
-	// Skip texts above presidio's max length to avoid OOMing the analyzer.
-	// Replace each oversize entry with an empty string so result indices stay
-	// aligned; the empty slot returns no findings to the caller.
-	var clipped []string
+	// Drop texts that presidio doesn't need to see: empties have nothing to
+	// detect, and oversize texts OOM the spaCy model. Both produce zero
+	// findings, so skipping them gives the same result as sending and saves
+	// the round-trip (and, for oversize, prevents the analyzer crash).
+	results := make([][]Finding, n)
+	sendTexts := make([]string, 0, n)
+	sendOriginalIdx := make([]int, 0, n)
 	for i, t := range texts {
-		if len(t) <= presidioMaxTextBytes {
+		if t == "" {
 			continue
 		}
-		if clipped == nil {
-			clipped = slices.Clone(texts)
+		if len(t) > presidioMaxTextBytes {
+			p.logger.WarnContext(ctx, "presidio analyze: text exceeds max size, skipping",
+				attr.SlogRiskPresidioTextIndex(i),
+				attr.SlogRiskPresidioTextBytes(len(t)),
+				attr.SlogRiskPresidioMaxBytes(presidioMaxTextBytes),
+			)
+			continue
 		}
-		clipped[i] = ""
-		p.logger.WarnContext(ctx, "presidio analyze: text exceeds max size, skipping",
-			attr.SlogRiskPresidioTextIndex(i),
-			attr.SlogRiskPresidioTextBytes(len(t)),
-			attr.SlogRiskPresidioMaxBytes(presidioMaxTextBytes),
-		)
+		sendTexts = append(sendTexts, t)
+		sendOriginalIdx = append(sendOriginalIdx, i)
 	}
-	if clipped != nil {
-		texts = clipped
+
+	if len(sendTexts) == 0 {
+		return results, nil
 	}
 
 	ctx, span := p.tracer.Start(ctx, "presidio.analyzeBatch", trace.WithAttributes(
 		attribute.Int("presidio.batch_size", n),
+		attribute.Int("presidio.send_size", len(sendTexts)),
 		attribute.Int("presidio.http_batch_size", presidioHTTPBatchSize),
 	))
 	defer func() {
@@ -203,8 +208,8 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 		span.End()
 	}()
 
-	results := make([][]Finding, n)
-	batches := chunkTextIndexes(n, presidioHTTPBatchSize)
+	sendResults := make([][]Finding, len(sendTexts))
+	batches := chunkTextIndexes(len(sendTexts), presidioHTTPBatchSize)
 	workers := min(max(1, p.maxWorkers), len(batches))
 
 	ch := make(chan indexRange, len(batches))
@@ -217,12 +222,16 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	for range workers {
 		wg.Go(func() {
 			for batch := range ch {
-				p.analyzeRange(ctx, texts, entities, batch, results, onProgress)
+				p.analyzeRange(ctx, sendTexts, entities, batch, sendResults, onProgress)
 			}
 		})
 	}
 
 	wg.Wait()
+
+	for j, originalIdx := range sendOriginalIdx {
+		results[originalIdx] = sendResults[j]
+	}
 	return results, nil
 }
 

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -253,31 +253,54 @@ func TestPresidioAnalyzeBatchSkipsOversizeText(t *testing.T) {
 	results, err := client.AnalyzeBatch(t.Context(), []string{
 		"contact alice@example.com",
 		oversize,
+		"",
 		"backup alice@example.com",
 	}, nil, nil)
 	require.NoError(t, err)
-	require.Len(t, results, 3)
+	require.Len(t, results, 4)
 
 	require.Len(t, results[0], 1)
 	assert.Equal(t, "alice@example.com", results[0][0].Match)
-	assert.Empty(t, results[1])
-	require.Len(t, results[2], 1)
-	assert.Equal(t, "alice@example.com", results[2][0].Match)
+	assert.Empty(t, results[1], "oversize text should produce no findings")
+	assert.Empty(t, results[2], "empty text should produce no findings")
+	require.Len(t, results[3], 1)
+	assert.Equal(t, "alice@example.com", results[3][0].Match)
 
 	mu.Lock()
 	defer mu.Unlock()
-	require.Len(t, requests, 1)
+	require.Len(t, requests, 1, "single batch with only the eligible texts")
 	assert.Equal(t, []string{
 		"contact alice@example.com",
-		"",
 		"backup alice@example.com",
-	}, requests[0], "oversize text should be replaced with empty string before send")
+	}, requests[0], "oversize and empty texts should not be sent to presidio")
 
 	logMu.Lock()
 	defer logMu.Unlock()
 	logs := logBuf.String()
 	assert.Contains(t, logs, "presidio analyze: text exceeds max size")
-	assert.Contains(t, logs, "text_index=1")
+	assert.Contains(t, logs, "gram.risk.presidio.text_index=1")
+}
+
+func TestPresidioAnalyzeBatchAllEmptyOrOversizeSkipsRequest(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewPresidioClientWithWorkers(srv.URL, otel.GetTracerProvider(), otel.GetMeterProvider(), testLogger(t), 1)
+
+	oversize := strings.Repeat("b", presidioMaxTextBytes+1)
+	results, err := client.AnalyzeBatch(t.Context(), []string{"", oversize, ""}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	for _, r := range results {
+		assert.Empty(t, r)
+	}
+	assert.False(t, called, "presidio should not be called when every text is empty or oversize")
 }
 
 type syncWriter struct {

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -1,7 +1,9 @@
 package risk_analysis
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -200,4 +202,95 @@ func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
 func testLogger(t *testing.T) *slog.Logger {
 	t.Helper()
 	return slog.New(slog.NewTextHandler(t.Output(), nil))
+}
+
+func TestPresidioAnalyzeBatchSkipsOversizeText(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var requests [][]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req presidioRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		mu.Lock()
+		requests = append(requests, slices.Clone(req.Text))
+		mu.Unlock()
+
+		results := make([][]presidioResult, len(req.Text))
+		for i, text := range req.Text {
+			start := strings.Index(text, "alice@example.com")
+			if start < 0 {
+				continue
+			}
+			results[i] = []presidioResult{{
+				EntityType: "EMAIL_ADDRESS",
+				Start:      start,
+				End:        start + len("alice@example.com"),
+				Score:      1,
+			}}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(results); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var logBuf bytes.Buffer
+	var logMu sync.Mutex
+	logger := slog.New(slog.NewTextHandler(&syncWriter{w: &logBuf, mu: &logMu}, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	client := NewPresidioClientWithWorkers(srv.URL, otel.GetTracerProvider(), otel.GetMeterProvider(), logger, 1)
+
+	oversize := strings.Repeat("a", presidioMaxTextBytes+1)
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"contact alice@example.com",
+		oversize,
+		"backup alice@example.com",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	require.Len(t, results[0], 1)
+	assert.Equal(t, "alice@example.com", results[0][0].Match)
+	assert.Empty(t, results[1])
+	require.Len(t, results[2], 1)
+	assert.Equal(t, "alice@example.com", results[2][0].Match)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, requests, 1)
+	assert.Equal(t, []string{
+		"contact alice@example.com",
+		"",
+		"backup alice@example.com",
+	}, requests[0], "oversize text should be replaced with empty string before send")
+
+	logMu.Lock()
+	defer logMu.Unlock()
+	logs := logBuf.String()
+	assert.Contains(t, logs, "presidio analyze: text exceeds max size")
+	assert.Contains(t, logs, "text_index=1")
+}
+
+type syncWriter struct {
+	w  *bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n, err := s.w.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("write log buffer: %w", err)
+	}
+	return n, nil
 }


### PR DESCRIPTION
## Why

Presidio's spaCy model defaults to `nlp.max_length=1,000,000` chars and OOMs above that (~1GB temp memory per 100k chars). The analyzer pod is provisioned with 1.5Gi (per `infra/helm/gram/templates/presidio.yaml`), so a single oversize message can crash the worker mid-batch. Seen in the wild:

```
ERROR - A fatal error occurred during execution of AnalyzerEngine.analyze().
[E088] Text of length 2358595 exceeds maximum of 1000000.
```

The retry-bisect path masks the error but still loses every text in the failed range and burns CPU on hopeless retries.

While we are here, empty strings get filtered in the same pre-flight pass since they have nothing to detect and the round-trip is wasted.

### Why the 128 KiB inline cap does not save us

`chat_messages` has three content-bearing columns and the risk pipeline reads from the one with no size cap:

- `content_raw`: full JSON mirror of the rich message. Gated at 128 KiB (`maxInlineContentSize` in `server/internal/chat/impl.go:1062`); above that, the column is left null and the payload lives only in the asset bucket.
- `content_asset_url`: pointer to the bucket copy. Every message is uploaded regardless of size (`storeMessages` at `server/internal/chat/impl.go:1083-1129`).
- `content`: plain text extracted via `openrouter.GetText(row.content)` at `server/internal/chat/impl.go:1159`. Postgres `TEXT`, unbounded. Whatever text the model emitted lands here verbatim.

`risk/queries.sql` `GetMessageContentBatch` selects `id, content, tool_calls` only, so the analyzer never reads `content_raw` or the bucket. A 2.3 MB assistant turn with a single giant text block writes 2.3 MB into `content` and is handed straight to presidio. The 128 KiB threshold gates a different column and does not bound what the analyzer sees.

## What changed

### Before
`PresidioClient.AnalyzeBatch` forwarded every text regardless of size or content. An oversize entry would 500 from `/analyze`, trigger bisection, and ultimately drop findings for everything that shared its batch. Empty strings were sent and consumed analyzer cycles.

### After
`AnalyzeBatch` filters texts before sending:
- empty strings: dropped silently
- texts whose byte length exceeds `presidioMaxTextBytes` (900_000, a 10% margin under spaCy's char limit since UTF-8 bytes can overshoot rune count): dropped with a warn log carrying the offending size and index

Each skipped slot maps to `nil` findings in the result, which `buildRows` turns into a `Found=false` row exactly as if presidio had been called and returned nothing. Indices stay aligned via a `sendOriginalIdx` mapping.

Added two internal tests:
- mixed batch (valid + oversize + empty + valid): only the two valid texts go on the wire, results map back to original positions, warn fires for the oversize index
- all-empty-or-oversize batch: presidio is never called

## Test plan

- [x] `mise lint:server`
- [x] `go test ./server/internal/background/activities/risk_analysis/ -run "TestPresidio"`