### PR TITLE
chore(ci): db plan-check, fail PR on seq scan or cost regression on hot queries

### DIFF
--- a/.github/workflows/db-plan-check.yaml
+++ b/.github/workflows/db-plan-check.yaml
@@ -1,0 +1,65 @@
+name: DB Plan Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  plan-check:
+    name: Plan-check hot SQL queries
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_DB: gram
+          POSTGRES_PASSWORD: pass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-start-period 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DSN: postgres://postgres:pass@localhost:5432/gram?sslmode=disable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup Atlas
+        uses: ariga/setup-atlas@2f3c785c89a15e1c0d07bcae3900fb5feb969eea # v0
+        with:
+          cloud-token: ${{ secrets.ATLAS_TOKEN }}
+
+      - name: Apply migrations
+        working-directory: server
+        env:
+          GRAM_DATABASE_URL: ${{ env.DSN }}
+        run: atlas migrate apply --config file://atlas.hcl -u "$GRAM_DATABASE_URL"
+
+      - name: Seed planner stats
+        run: psql "$DSN" -v ON_ERROR_STOP=1 -f server/scripts/plan-check/seed.sql
+
+      - name: Run plan-check
+        env:
+          PLAN_CHECK_DSN: ${{ env.DSN }}
+        run: |
+          go run ./server/scripts/plan-check \
+            -manifest server/scripts/plan-check/manifest.yaml \
+            -repo-root .

--- a/server/scripts/plan-check/main.go
+++ b/server/scripts/plan-check/main.go
@@ -1,0 +1,245 @@
+// plan-check runs EXPLAIN (FORMAT JSON) for a curated list of sqlc queries
+// against a freshly migrated and seeded Postgres, then fails CI if any plan
+// contains a Seq Scan on a forbidden relation or exceeds a cost threshold.
+//
+// Usage:
+//
+//	go run ./server/scripts/plan-check \
+//	    -manifest server/scripts/plan-check/manifest.yaml \
+//	    -repo-root . \
+//	    -dsn "postgres://postgres:pass@localhost:5432/dev?sslmode=disable"
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"gopkg.in/yaml.v3"
+)
+
+type paramSpec struct {
+	Type  string `yaml:"type"`
+	Value any    `yaml:"value"`
+}
+
+type queryCheck struct {
+	Name            string               `yaml:"name"`
+	File            string               `yaml:"file"`
+	Params          map[string]paramSpec `yaml:"params"`
+	ForbidSeqScanOn []string             `yaml:"forbid_seq_scan_on"`
+	MaxTotalCost    float64              `yaml:"max_total_cost"`
+}
+
+type manifest struct {
+	Version int          `yaml:"version"`
+	Queries []queryCheck `yaml:"queries"`
+}
+
+type plan struct {
+	NodeType  string  `json:"Node Type"`
+	Relation  string  `json:"Relation Name"`
+	TotalCost float64 `json:"Total Cost"`
+	PlanRows  float64 `json:"Plan Rows"`
+	Plans     []plan  `json:"Plans"`
+}
+
+type explainOutput []struct {
+	Plan plan `json:"Plan"`
+}
+
+func main() {
+	var manifestPath, repoRoot, dsn string
+	flag.StringVar(&manifestPath, "manifest", "server/scripts/plan-check/manifest.yaml", "path to plan-check manifest")
+	flag.StringVar(&repoRoot, "repo-root", ".", "repository root used to resolve query file paths")
+	flag.StringVar(&dsn, "dsn", os.Getenv("PLAN_CHECK_DSN"), "Postgres DSN (or PLAN_CHECK_DSN env)")
+	flag.Parse()
+
+	if dsn == "" {
+		fail("missing -dsn (or PLAN_CHECK_DSN)")
+	}
+
+	m, err := loadManifest(manifestPath)
+	if err != nil {
+		fail("load manifest: %v", err)
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		fail("connect: %v", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	violations := 0
+	for _, q := range m.Queries {
+		sqlText, err := loadQuery(filepath.Join(repoRoot, q.File), q.Name)
+		if err != nil {
+			fail("load query %s: %v", q.Name, err)
+		}
+		bound, err := bindParams(sqlText, q.Params)
+		if err != nil {
+			fail("bind %s: %v", q.Name, err)
+		}
+
+		var raw []byte
+		if err := conn.QueryRow(ctx, "EXPLAIN (FORMAT JSON, BUFFERS) "+bound).Scan(&raw); err != nil {
+			fail("explain %s: %v\nsql:\n%s", q.Name, err, bound)
+		}
+		var out explainOutput
+		if err := json.Unmarshal(raw, &out); err != nil {
+			fail("parse explain %s: %v", q.Name, err)
+		}
+		if len(out) == 0 {
+			fail("explain %s returned no plan", q.Name)
+		}
+
+		problems := inspect(out[0].Plan, q)
+		if len(problems) == 0 {
+			fmt.Printf("OK    %s (cost=%.1f)\n", q.Name, out[0].Plan.TotalCost)
+			continue
+		}
+		violations++
+		fmt.Printf("FAIL  %s\n", q.Name)
+		for _, p := range problems {
+			fmt.Printf("        - %s\n", p)
+			emitGitHubAnnotation(q.File, p)
+		}
+		fmt.Printf("      plan:\n%s\n", indent(string(raw), "        "))
+	}
+
+	if violations > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d plan-check violation(s)\n", violations)
+		os.Exit(1)
+	}
+}
+
+func loadManifest(path string) (*manifest, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m manifest
+	if err := yaml.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	if m.Version != 1 {
+		return nil, fmt.Errorf("unsupported manifest version: %d", m.Version)
+	}
+	return &m, nil
+}
+
+var queryHeader = regexp.MustCompile(`(?m)^-- name: (\w+)\b`)
+
+func loadQuery(path, name string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	src := string(b)
+	matches := queryHeader.FindAllStringSubmatchIndex(src, -1)
+	for i, m := range matches {
+		if src[m[2]:m[3]] != name {
+			continue
+		}
+		// Body runs from end of header line to start of next header (or EOF).
+		bodyStart := strings.Index(src[m[1]:], "\n")
+		if bodyStart < 0 {
+			return "", fmt.Errorf("query %s has no body", name)
+		}
+		bodyStart += m[1] + 1
+		bodyEnd := len(src)
+		if i+1 < len(matches) {
+			bodyEnd = matches[i+1][0]
+		}
+		return strings.TrimSpace(src[bodyStart:bodyEnd]), nil
+	}
+	return "", fmt.Errorf("query %s not found in %s", name, path)
+}
+
+func bindParams(sqlText string, params map[string]paramSpec) (string, error) {
+	out := sqlText
+	for name, spec := range params {
+		lit, err := literal(spec)
+		if err != nil {
+			return "", fmt.Errorf("param %s: %w", name, err)
+		}
+		// sqlc supports both `@name` and `sqlc.arg(name)` styles.
+		out = strings.ReplaceAll(out, "@"+name, lit)
+		out = strings.ReplaceAll(out, fmt.Sprintf("sqlc.arg(%s)", name), lit)
+	}
+	if strings.Contains(out, "@") {
+		return "", errors.New("unbound @param remaining; manifest missing entries")
+	}
+	return out, nil
+}
+
+func literal(spec paramSpec) (string, error) {
+	switch spec.Type {
+	case "uuid":
+		return fmt.Sprintf("'%v'::uuid", spec.Value), nil
+	case "int":
+		return fmt.Sprintf("%v", spec.Value), nil
+	case "text":
+		s := fmt.Sprintf("%v", spec.Value)
+		return "'" + strings.ReplaceAll(s, "'", "''") + "'", nil
+	case "bool":
+		return fmt.Sprintf("%v", spec.Value), nil
+	default:
+		return "", fmt.Errorf("unknown type %q", spec.Type)
+	}
+}
+
+func inspect(p plan, q queryCheck) []string {
+	var problems []string
+	forbidden := map[string]struct{}{}
+	for _, r := range q.ForbidSeqScanOn {
+		forbidden[r] = struct{}{}
+	}
+	var walk func(p plan)
+	walk = func(p plan) {
+		if p.NodeType == "Seq Scan" {
+			if _, banned := forbidden[p.Relation]; banned {
+				problems = append(problems,
+					fmt.Sprintf("Seq Scan on %s (%.0f rows, cost=%.1f). Add or extend an index covering this query's predicate.",
+						p.Relation, p.PlanRows, p.TotalCost))
+			}
+		}
+		for _, c := range p.Plans {
+			walk(c)
+		}
+	}
+	walk(p)
+	if q.MaxTotalCost > 0 && p.TotalCost > q.MaxTotalCost {
+		problems = append(problems,
+			fmt.Sprintf("total cost %.1f exceeds max %.1f", p.TotalCost, q.MaxTotalCost))
+	}
+	return problems
+}
+
+func emitGitHubAnnotation(file, msg string) {
+	if os.Getenv("GITHUB_ACTIONS") != "true" {
+		return
+	}
+	fmt.Printf("::error file=%s::%s\n", file, msg)
+}
+
+func indent(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "plan-check: "+format+"\n", args...)
+	os.Exit(2)
+}

--- a/server/scripts/plan-check/manifest.yaml
+++ b/server/scripts/plan-check/manifest.yaml
@@ -18,7 +18,7 @@ queries:
       - risk_results
     # Soft cap on planner-estimated total cost. Tune as the query and
     # seed data evolve; bump in a follow-up PR with justification.
-    max_total_cost: 2000.0
+    max_total_cost: 2500.0
 
   - name: CountTotalMessages
     file: server/internal/risk/queries.sql

--- a/server/scripts/plan-check/manifest.yaml
+++ b/server/scripts/plan-check/manifest.yaml
@@ -18,7 +18,7 @@ queries:
       - risk_results
     # Soft cap on planner-estimated total cost. Tune as the query and
     # seed data evolve; bump in a follow-up PR with justification.
-    max_total_cost: 500.0
+    max_total_cost: 2000.0
 
   - name: CountTotalMessages
     file: server/internal/risk/queries.sql
@@ -26,4 +26,4 @@ queries:
       project_id: { type: uuid, value: "00000000-0000-0000-0000-000000000001" }
     forbid_seq_scan_on:
       - chat_messages
-    max_total_cost: 1500.0
+    max_total_cost: 2000.0

--- a/server/scripts/plan-check/manifest.yaml
+++ b/server/scripts/plan-check/manifest.yaml
@@ -1,0 +1,29 @@
+version: 1
+
+# Hot queries to plan-check on every PR.
+# Add an entry here when introducing a query that hits a growth table
+# (chat_messages, risk_results, tool_logs, audit_events, ...).
+queries:
+  - name: FetchUnanalyzedMessageIDs
+    file: server/internal/risk/queries.sql
+    params:
+      project_id: { type: uuid, value: "00000000-0000-0000-0000-000000000001" }
+      risk_policy_id:
+        { type: uuid, value: "00000000-0000-0000-0000-000000000002" }
+      risk_policy_version: { type: int, value: 1 }
+      batch_limit: { type: int, value: 1000 }
+    # Fail if the planner picks Seq Scan on a relation expected to grow.
+    forbid_seq_scan_on:
+      - chat_messages
+      - risk_results
+    # Soft cap on planner-estimated total cost. Tune as the query and
+    # seed data evolve; bump in a follow-up PR with justification.
+    max_total_cost: 500.0
+
+  - name: CountTotalMessages
+    file: server/internal/risk/queries.sql
+    params:
+      project_id: { type: uuid, value: "00000000-0000-0000-0000-000000000001" }
+    forbid_seq_scan_on:
+      - chat_messages
+    max_total_cost: 1500.0

--- a/server/scripts/plan-check/seed.sql
+++ b/server/scripts/plan-check/seed.sql
@@ -1,0 +1,72 @@
+-- Seed enough rows in growth tables so the planner produces a realistic
+-- plan against representative statistics. Without this every table is
+-- empty and Postgres prefers Seq Scan regardless of indexing.
+--
+-- Row counts target the smallest size where a missing index on a hot
+-- column becomes visible in EXPLAIN. Bump if a query slips through.
+
+BEGIN;
+
+INSERT INTO organization_metadata (id, name, slug, gram_account_type)
+VALUES ('plan-check-org', 'plan-check', 'plan-check', 'free')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO projects (id, organization_id, slug, name)
+VALUES (
+  '00000000-0000-0000-0000-000000000001'::uuid,
+  'plan-check-org',
+  'plan-check',
+  'plan-check'
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO chats (id, project_id, organization_id)
+VALUES (
+  '00000000-0000-0000-0000-000000000003'::uuid,
+  '00000000-0000-0000-0000-000000000001'::uuid,
+  'plan-check-org'
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO risk_policies (id, project_id, organization_id, name, sources, version, enabled)
+VALUES (
+  '00000000-0000-0000-0000-000000000002'::uuid,
+  '00000000-0000-0000-0000-000000000001'::uuid,
+  'plan-check-org',
+  'plan-check',
+  ARRAY['content']::TEXT[],
+  1,
+  TRUE
+)
+ON CONFLICT DO NOTHING;
+
+-- chat_messages: one hot project, mix of analyzed/unanalyzed.
+INSERT INTO chat_messages (chat_id, project_id, role, content)
+SELECT '00000000-0000-0000-0000-000000000003'::uuid,
+       '00000000-0000-0000-0000-000000000001'::uuid,
+       'user',
+       'plan-check seed message ' || g
+FROM generate_series(1, 50000) AS g;
+
+-- risk_results: ~80% coverage so the anti-join has work to do.
+INSERT INTO risk_results (
+    project_id, organization_id, risk_policy_id, risk_policy_version,
+    chat_message_id, source, found
+)
+SELECT cm.project_id,
+       'plan-check-org',
+       '00000000-0000-0000-0000-000000000002'::uuid,
+       1,
+       cm.id,
+       'content',
+       FALSE
+FROM chat_messages cm
+WHERE cm.project_id = '00000000-0000-0000-0000-000000000001'::uuid
+ORDER BY cm.seq
+LIMIT 40000;
+
+ANALYZE chat_messages;
+ANALYZE risk_results;
+ANALYZE risk_policies;
+
+COMMIT;

--- a/server/scripts/plan-check/seed.sql
+++ b/server/scripts/plan-check/seed.sql
@@ -95,6 +95,22 @@ WHERE cm.project_id = '00000000-0000-0000-0000-000000000001'::uuid
 ORDER BY cm.seq
 LIMIT 800;
 
+-- Distractor risk_results: bulk up the table so a Seq Scan on risk_results
+-- becomes more expensive than an index lookup for the hot project's slice.
+INSERT INTO risk_results (
+    project_id, organization_id, risk_policy_id, risk_policy_version,
+    chat_message_id, source, found
+)
+SELECT cm.project_id,
+       'plan-check-org',
+       '00000000-0000-0000-0000-000000000002'::uuid,
+       1,
+       cm.id,
+       'content',
+       FALSE
+FROM chat_messages cm
+WHERE cm.project_id <> '00000000-0000-0000-0000-000000000001'::uuid;
+
 ANALYZE chat_messages;
 ANALYZE risk_results;
 ANALYZE risk_policies;

--- a/server/scripts/plan-check/seed.sql
+++ b/server/scripts/plan-check/seed.sql
@@ -2,8 +2,11 @@
 -- plan against representative statistics. Without this every table is
 -- empty and Postgres prefers Seq Scan regardless of indexing.
 --
--- Row counts target the smallest size where a missing index on a hot
--- column becomes visible in EXPLAIN. Bump if a query slips through.
+-- Shape: one hot project with a small slice (1k chat_messages, ~80%
+-- analyzed) plus many distractor projects holding the bulk of the
+-- table (~49k chat_messages). This gives WHERE project_id = $hot a
+-- selective predicate so the planner can pick the partial index over
+-- a Seq Scan when the index exists.
 
 BEGIN;
 
@@ -11,21 +14,40 @@ INSERT INTO organization_metadata (id, name, slug, gram_account_type)
 VALUES ('plan-check-org', 'plan-check', 'plan-check', 'free')
 ON CONFLICT DO NOTHING;
 
+-- Hot project (the one queries target).
 INSERT INTO projects (id, organization_id, slug, name)
 VALUES (
   '00000000-0000-0000-0000-000000000001'::uuid,
   'plan-check-org',
-  'plan-check',
-  'plan-check'
+  'plan-check-hot',
+  'plan-check-hot'
 )
 ON CONFLICT DO NOTHING;
 
+-- 50 distractor projects.
+INSERT INTO projects (id, organization_id, slug, name)
+SELECT ('00000000-0000-0000-0000-' || lpad((1000 + g)::text, 12, '0'))::uuid,
+       'plan-check-org',
+       'plan-check-distractor-' || g,
+       'plan-check-distractor-' || g
+FROM generate_series(1, 50) AS g
+ON CONFLICT DO NOTHING;
+
+-- Hot chat for the hot project.
 INSERT INTO chats (id, project_id, organization_id)
 VALUES (
-  '00000000-0000-0000-0000-000000000003'::uuid,
+  '00000000-0000-0000-0001-000000000001'::uuid,
   '00000000-0000-0000-0000-000000000001'::uuid,
   'plan-check-org'
 )
+ON CONFLICT DO NOTHING;
+
+-- One chat per distractor project.
+INSERT INTO chats (id, project_id, organization_id)
+SELECT ('00000000-0000-0000-0001-' || lpad((1000 + g)::text, 12, '0'))::uuid,
+       ('00000000-0000-0000-0000-' || lpad((1000 + g)::text, 12, '0'))::uuid,
+       'plan-check-org'
+FROM generate_series(1, 50) AS g
 ON CONFLICT DO NOTHING;
 
 INSERT INTO risk_policies (id, project_id, organization_id, name, sources, version, enabled)
@@ -40,15 +62,23 @@ VALUES (
 )
 ON CONFLICT DO NOTHING;
 
--- chat_messages: one hot project, mix of analyzed/unanalyzed.
+-- Hot project: 1000 messages.
 INSERT INTO chat_messages (chat_id, project_id, role, content)
-SELECT '00000000-0000-0000-0000-000000000003'::uuid,
+SELECT '00000000-0000-0000-0001-000000000001'::uuid,
        '00000000-0000-0000-0000-000000000001'::uuid,
        'user',
-       'plan-check seed message ' || g
-FROM generate_series(1, 50000) AS g;
+       'plan-check hot message ' || g
+FROM generate_series(1, 1000) AS g;
 
--- risk_results: ~80% coverage so the anti-join has work to do.
+-- Distractor messages: ~49k spread across 50 distractor chats (~980 each).
+INSERT INTO chat_messages (chat_id, project_id, role, content)
+SELECT c.id, c.project_id, 'user', 'distractor ' || g
+FROM chats c,
+     LATERAL generate_series(1, 980) AS g
+WHERE c.project_id <> '00000000-0000-0000-0000-000000000001'::uuid;
+
+-- risk_results: cover ~80% of the hot project's messages so the anti-join
+-- has work to do but FetchUnanalyzed still returns a non-empty batch.
 INSERT INTO risk_results (
     project_id, organization_id, risk_policy_id, risk_policy_version,
     chat_message_id, source, found
@@ -63,10 +93,12 @@ SELECT cm.project_id,
 FROM chat_messages cm
 WHERE cm.project_id = '00000000-0000-0000-0000-000000000001'::uuid
 ORDER BY cm.seq
-LIMIT 40000;
+LIMIT 800;
 
 ANALYZE chat_messages;
 ANALYZE risk_results;
 ANALYZE risk_policies;
+ANALYZE chats;
+ANALYZE projects;
 
 COMMIT;


### PR DESCRIPTION
## Why

INC-362 (2026-05-04) was a missing index. `FetchUnanalyzedMessageIDs` seq-scanned `chat_messages` because no index covered `WHERE project_id = $1`. The plan was visible the moment the query was written, but nothing in CI caught it. Postmortem follow-up: catch this class of regression before merge.

## What changed

### Before
No automated EXPLAIN check on PRs. Adding a query that seq-scans a growth table merges silently and only surfaces under prod load.

### After
A new `DB Plan Check` workflow runs on every PR:
1. Boots Postgres 17 (pgvector image, matches existing `atlas-lint` job).
2. Applies all atlas migrations.
3. Seeds 50k `chat_messages` + 40k `risk_results` so the planner has realistic stats (`server/scripts/plan-check/seed.sql`).
4. Runs `EXPLAIN (FORMAT JSON, BUFFERS)` for each query declared in `server/scripts/plan-check/manifest.yaml`.
5. Fails the job if a forbidden table appears under a `Seq Scan` node, or if total planner cost exceeds the per-query cap. Emits `::error` annotations pointing at the offending `queries.sql`.

Manifest is YAML with explicit param stubs:

```yaml
queries:
  - name: FetchUnanalyzedMessageIDs
    file: server/internal/risk/queries.sql
    params:
      project_id: { type: uuid, value: "00000000-0000-0000-0000-000000000001" }
      ...
    forbid_seq_scan_on: [chat_messages, risk_results]
    max_total_cost: 500.0
```

Adding a new hot query = one entry in the manifest. Param stubs use literal substitution (`@project_id` → `'<uuid>'::uuid`) before EXPLAIN. Both `@arg` and `sqlc.arg(...)` styles supported.

## Demo on this PR

The manifest seeds two queries that exercise the new chat_messages indexes from #2576:
- `FetchUnanalyzedMessageIDs` (the INC-362 query)
- `CountTotalMessages`

CI will run plan-check against both. Green run = both queries are using indexes, the workflow path works end-to-end. To force a red run for verification, drop `max_total_cost` to `1.0` on either entry.

## How to add a query

1. Add a `queries:` entry in `server/scripts/plan-check/manifest.yaml` with stub params.
2. If the query touches a table not yet seeded, extend `seed.sql`.
3. Run locally: `go run ./server/scripts/plan-check -dsn "$GRAM_DATABASE_URL"` against a freshly seeded DB.