### PR TITLE
fix(risk): skip FetchUnanalyzed when policy is deleted instead of erroring

### DIFF
--- a/.changeset/risk-fetch-unanalyzed-skip-deleted-policy.md
+++ b/.changeset/risk-fetch-unanalyzed-skip-deleted-policy.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix(risk): treat missing risk policy as no-op in FetchUnanalyzedMessages instead of activity error

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -101,10 +101,10 @@ func (a *AnalyzeBatch) Do(ctx context.Context, args AnalyzeBatchArgs) (_ *Analyz
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		// Policy was deleted (soft or hard) between FetchUnanalyzedMessages
-		// returning IDs and this activity running. FetchUnanalyzed errors out
-		// on the next drain cycle, so there is no infinite loop and no need
-		// to write Found=false rows; the FK to risk_policies might also be
-		// gone on hard-delete.
+		// returning IDs and this activity running. FetchUnanalyzed also
+		// returns an empty batch on the next drain cycle, so there is no
+		// infinite loop and no need to write Found=false rows; the FK to
+		// risk_policies might also be gone on hard-delete.
 		span.SetAttributes(attribute.Bool("risk.policy_deleted", true))
 		a.logger.InfoContext(ctx, "risk policy deleted, skipping batch",
 			attr.SlogRiskPolicyID(args.RiskPolicyID.String()),

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
@@ -2,15 +2,18 @@ package risk_analysis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
 
@@ -62,6 +65,16 @@ func (a *FetchUnanalyzed) Do(ctx context.Context, args FetchUnanalyzedArgs) (_ *
 		ID:        args.RiskPolicyID,
 		ProjectID: args.ProjectID,
 	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Policy was hard-deleted (or soft-deleted: GetRiskPolicy filters
+		// deleted IS FALSE). Nothing to do, no infinite loop because the
+		// drain workflow stops scheduling activities for a missing policy.
+		span.SetAttributes(attribute.Bool("risk.policy_deleted", true))
+		a.logger.InfoContext(ctx, "risk policy deleted, skipping fetch",
+			attr.SlogRiskPolicyID(args.RiskPolicyID.String()),
+		)
+		return &FetchUnanalyzedResult{}, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("get risk policy: %w", err)
 	}

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
@@ -73,7 +73,13 @@ func (a *FetchUnanalyzed) Do(ctx context.Context, args FetchUnanalyzedArgs) (_ *
 		a.logger.InfoContext(ctx, "risk policy deleted, skipping fetch",
 			attr.SlogRiskPolicyID(args.RiskPolicyID.String()),
 		)
-		return &FetchUnanalyzedResult{}, nil
+		return &FetchUnanalyzedResult{
+			MessageIDs:       nil,
+			OrganizationID:   "",
+			PolicyVersion:    0,
+			Sources:          nil,
+			PresidioEntities: nil,
+		}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get risk policy: %w", err)

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed_test.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed_test.go
@@ -85,6 +85,44 @@ func TestFetchUnanalyzed_DisabledPolicyReturnsEmpty(t *testing.T) {
 	require.Empty(t, result.MessageIDs)
 }
 
+func TestFetchUnanalyzed_DeletedPolicyReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	require.NoError(t, riskrepo.New(conn).DeleteRiskPolicy(t.Context(), riskrepo.DeleteRiskPolicyParams{
+		ID:        td.policyID,
+		ProjectID: td.projectID,
+	}))
+
+	activity := risk_analysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn)
+	result, err := activity.Do(t.Context(), risk_analysis.FetchUnanalyzedArgs{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.MessageIDs)
+}
+
+func TestFetchUnanalyzed_MissingPolicyReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	missingPolicyID, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	activity := risk_analysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn)
+	result, err := activity.Do(t.Context(), risk_analysis.FetchUnanalyzedArgs{
+		ProjectID:    td.projectID,
+		RiskPolicyID: missingPolicyID,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.MessageIDs)
+}
+
 func TestFetchUnanalyzed_RespectsBatchLimit(t *testing.T) {
 	t.Parallel()
 	conn := cloneDB(t)


### PR DESCRIPTION
## Why

`FetchUnanalyzedMessages` activity surfaces \`fetch unanalyzed messages: get risk policy: no rows in result set\` when the risk policy has been hard-deleted (or soft-deleted, since \`GetRiskPolicy\` filters \`deleted IS FALSE\`).

That is not an error condition. The drain workflow has nothing to do; returning an empty batch lets the workflow exit normally instead of marking the activity failed and retrying.

\`AnalyzeBatch\` already handles this case correctly (returns \`Processed=0\` on \`pgx.ErrNoRows\`); \`FetchUnanalyzed\` was inconsistent.

## What changed

### Before
\`\`\`go
policy, err := queries.GetRiskPolicy(ctx, ...)
if err != nil {
    return nil, fmt.Errorf("get risk policy: %w", err)
}
\`\`\`
Activity errors out on missing policy, Temporal retries until backoff, oncall sees noisy errors.

### After
\`\`\`go
policy, err := queries.GetRiskPolicy(ctx, ...)
if errors.Is(err, pgx.ErrNoRows) {
    span.SetAttributes(attribute.Bool("risk.policy_deleted", true))
    a.logger.InfoContext(ctx, "risk policy deleted, skipping fetch", ...)
    return &FetchUnanalyzedResult{}, nil
}
if err != nil {
    return nil, fmt.Errorf("get risk policy: %w", err)
}
\`\`\`
Empty result, span attribute \`risk.policy_deleted=true\`, info log. Mirrors the \`AnalyzeBatch\` pattern so the comment over there is also updated.

## Tests

Two new tests in \`fetch_unanalyzed_test.go\`:
- \`TestFetchUnanalyzed_DeletedPolicyReturnsEmpty\`: soft-delete via \`DeleteRiskPolicy\`, expect no error + empty batch.
- \`TestFetchUnanalyzed_MissingPolicyReturnsEmpty\`: random policy ID never inserted, expect no error + empty batch.

Both pass locally.