### PR TITLE
chore(ci): Exclude server/database/sqlc.yaml from database migration check

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -48,11 +48,6 @@ migrations:
   - "server/migrations/**"
   - "server/clickhouse/migrations/**"
 
-database-changes:
-  - "server/database/**"
-  - "server/migrations/**"
-  - "server/clickhouse/**"
-
 plog:
   - "go.mod"
   - "go.sum"

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -46,12 +46,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v5.0.0
 
-      - name: Detect changed files
+      - name: Detect database migration changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+        id: filter-database
         with:
-          filters: .github/filters.yaml
+          predicate-quantifier: every
           list-files: json
+          # Excludes SQLc-generated output paths (per `server/database/sqlc.yaml`
+          # `out:` directives) since they legitimately change alongside
+          # schema.sql edits.
+          filters: |
+            database-changes:
+              - "server/database/**"
+              - "!server/database/sqlc.yaml"
+              - "server/migrations/**"
+              - "server/clickhouse/**"
 
       # Run a second paths-filter pass with `predicate-quantifier: every` so
       # the `!` patterns below act as exclusions (every pattern must match,
@@ -75,10 +84,10 @@ jobs:
               - "!server/internal/testenv/testrepo/**"
 
       - name: Validate migration PR does not mix server changes
-        if: ${{ github.event_name != 'merge_group' && steps.filter.outputs.database-changes == 'true' && steps.filter-internal.outputs.server-internal == 'true' }}
+        if: ${{ github.event_name != 'merge_group' && steps.filter-database.outputs.database-changes == 'true' && steps.filter-internal.outputs.server-internal == 'true' }}
         shell: bash
         env:
-          DB_FILES: ${{ steps.filter.outputs.database-changes_files }}
+          DB_FILES: ${{ steps.filter-database.outputs.database-changes_files }}
           INTERNAL_FILES: ${{ steps.filter-internal.outputs.server-internal_files }}
         run: |
           set -e


### PR DESCRIPTION
There can be false positives when there are purely `server/database/sqlc.yaml` changes.