### PR TITLE
chore(ci): remove server/database from migration checking

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -49,7 +49,6 @@ migrations:
   - "server/clickhouse/migrations/**"
 
 database-changes:
-  - "server/database/**"
   - "server/migrations/**"
   - "server/clickhouse/**"
 


### PR DESCRIPTION
Updates to pure sqlc changes can cause false positives. We don't need schema.sql / stub.sql detection as that is caught in other checks.