### PR TITLE
fix(server): set pg statement, lock, and idle-in-tx timeouts

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -195,6 +195,15 @@ func newDBClient(ctx context.Context, logger *slog.Logger, meterProvider metric.
 		consoleLogLevel = tracelog.LogLevelDebug
 	}
 
+	statementTimeout := 60 * time.Second
+	poolcfg.ConnConfig.RuntimeParams["statement_timeout"] = fmt.Sprintf("%d", int(statementTimeout.Milliseconds()))
+
+	lockTimeout := 10 * time.Second
+	poolcfg.ConnConfig.RuntimeParams["lock_timeout"] = fmt.Sprintf("%d", int(lockTimeout.Milliseconds()))
+
+	idleInTxSessionTimeout := 60 * time.Second
+	poolcfg.ConnConfig.RuntimeParams["idle_in_transaction_session_timeout"] = fmt.Sprintf("%d", int(idleInTxSessionTimeout.Milliseconds()))
+
 	poolcfg.ConnConfig.Tracer = multitracer.New(
 		&pgxotel.QueryTracer{
 			Name:    "pgx",


### PR DESCRIPTION
Configure postgres runtime params on the pgx pool: 60s statement_timeout, 10s lock_timeout, and 60s idle_in_transaction_session_timeout to prevent runaway queries and held locks/connections.