### PR TITLE
fix(background): pin chat generation across resolution activities

### DIFF
--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -149,7 +149,7 @@ func NewActivities(
 		segmentChat:                     resolution_activities.NewSegmentChat(logger, db, chatClient),
 		deleteChatResolutions:           resolution_activities.NewDeleteChatResolutions(db),
 		analyzeSegment:                  resolution_activities.NewAnalyzeSegment(logger, db, chatClient, telemetryLogger),
-		getUserFeedbackForChat:          resolution_activities.NewGetUserFeedbackForChat(db),
+		getUserFeedbackForChat:          resolution_activities.NewGetUserFeedbackForChat(logger, db),
 		fetchUnanalyzedMessages:         risk_analysis.NewFetchUnanalyzed(logger, tracerProvider, db),
 		analyzeBatch:                    risk_analysis.NewAnalyzeBatch(logger, tracerProvider, meterProvider, db, piiScanner, shadowMCPClient),
 		admitAssistantThreads:           activities.NewAdmitAssistantThreads(assistantsCore),

--- a/server/internal/background/activities/chat_resolutions/analyze_segment.go
+++ b/server/internal/background/activities/chat_resolutions/analyze_segment.go
@@ -39,10 +39,13 @@ func NewAnalyzeSegment(logger *slog.Logger, db *pgxpool.Pool, chatClient openrou
 }
 
 type AnalyzeSegmentArgs struct {
-	ChatID       uuid.UUID
-	ProjectID    uuid.UUID
-	OrgID        string
-	APIKeyID     string
+	ChatID    uuid.UUID
+	ProjectID uuid.UUID
+	OrgID     string
+	APIKeyID  string
+	// Generation pins the chat snapshot; must match the generation used to
+	// compute StartIndex and EndIndex.
+	Generation   int32
 	StartIndex   int
 	EndIndex     int
 	UserFeedback []UserFeedback
@@ -63,12 +66,9 @@ type segmentAnalysisResult struct {
 }
 
 func (a *AnalyzeSegment) Do(ctx context.Context, args AnalyzeSegmentArgs) error {
-	allMessages, err := a.repo.ListLatestGenerationChatMessages(ctx, repo.ListLatestGenerationChatMessagesParams{
-		ChatID:    args.ChatID,
-		ProjectID: args.ProjectID,
-	})
+	allMessages, err := loadMessagesAtPinnedGeneration(ctx, a.repo, args.ChatID, args.ProjectID, args.Generation)
 	if err != nil {
-		return fmt.Errorf("failed to list chat messages: %w", err)
+		return err
 	}
 
 	// Extract the segment

--- a/server/internal/background/activities/chat_resolutions/errors.go
+++ b/server/internal/background/activities/chat_resolutions/errors.go
@@ -1,0 +1,68 @@
+package resolution_activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+)
+
+// ErrTypeGenerationBumped is the Temporal application error type returned when
+// the chat's generation has advanced past the snapshot the workflow pinned at
+// the start of analysis. The workflow uses this to abandon stale in-flight
+// work and continue-as-new on the new generation.
+const ErrTypeGenerationBumped = "ChatResolutionGenerationBumped"
+
+// ErrGenerationBumped is the underlying sentinel; it is wrapped in a
+// non-retryable Temporal application error before crossing the activity
+// boundary so the workflow can detect and recover.
+var ErrGenerationBumped = errors.New("chat generation bumped during analysis")
+
+func newGenerationBumpedError(pinned, current int32) error {
+	return temporal.NewNonRetryableApplicationError(
+		fmt.Sprintf("chat generation bumped during analysis: pinned=%d current=%d", pinned, current),
+		ErrTypeGenerationBumped,
+		ErrGenerationBumped,
+	)
+}
+
+// IsGenerationBumped reports whether err originated from a generation-bumped
+// activity, including after Temporal has wrapped it as it crossed the activity
+// boundary.
+func IsGenerationBumped(err error) bool {
+	if errors.Is(err, ErrGenerationBumped) {
+		return true
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) {
+		return appErr.Type() == ErrTypeGenerationBumped
+	}
+	return false
+}
+
+// loadMessagesAtPinnedGeneration verifies that the chat's current generation
+// still matches the pinned one and returns the messages at that generation. On
+// mismatch it returns a non-retryable Temporal error so the workflow can
+// continue-as-new on the new generation instead of acting on stale indices.
+func loadMessagesAtPinnedGeneration(ctx context.Context, queries *repo.Queries, chatID, projectID uuid.UUID, expectedGeneration int32) ([]repo.ChatMessage, error) {
+	currentGen, err := queries.GetMaxGenerationForChat(ctx, chatID)
+	if err != nil {
+		return nil, fmt.Errorf("get max generation for chat: %w", err)
+	}
+	if currentGen != expectedGeneration {
+		return nil, newGenerationBumpedError(expectedGeneration, currentGen)
+	}
+	messages, err := queries.ListChatMessagesByGeneration(ctx, repo.ListChatMessagesByGenerationParams{
+		ChatID:     chatID,
+		ProjectID:  projectID,
+		Generation: expectedGeneration,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list chat messages by generation: %w", err)
+	}
+	return messages, nil
+}

--- a/server/internal/background/activities/chat_resolutions/get_user_feedback.go
+++ b/server/internal/background/activities/chat_resolutions/get_user_feedback.go
@@ -4,21 +4,25 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 )
 
 type GetUserFeedbackForChat struct {
-	repo *repo.Queries
+	logger *slog.Logger
+	repo   *repo.Queries
 }
 
-func NewGetUserFeedbackForChat(db *pgxpool.Pool) *GetUserFeedbackForChat {
+func NewGetUserFeedbackForChat(logger *slog.Logger, db *pgxpool.Pool) *GetUserFeedbackForChat {
 	return &GetUserFeedbackForChat{
-		repo: repo.New(db),
+		logger: logger,
+		repo:   repo.New(db),
 	}
 }
 
@@ -36,47 +40,69 @@ type UserFeedback struct {
 }
 
 type GetUserFeedbackForChatResult struct {
+	// Generation is the chat generation pinned for this analysis run. Subsequent
+	// activities in the workflow must pass this value back so every read uses
+	// the same snapshot, otherwise message indices computed here can be
+	// invalidated by a generation bump in flight.
+	Generation   int32
 	UserFeedback []UserFeedback
 }
 
 func (g *GetUserFeedbackForChat) Do(ctx context.Context, args GetUserFeedbackForChatArgs) (*GetUserFeedbackForChatResult, error) {
+	generation, err := g.repo.GetMaxGenerationForChat(ctx, args.ChatID)
+	if err != nil {
+		return nil, fmt.Errorf("get max generation for chat: %w", err)
+	}
+
 	feedback, err := g.repo.ListUserFeedbackForChat(ctx, args.ChatID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			// No user feedback exists
 			return &GetUserFeedbackForChatResult{
+				Generation:   generation,
 				UserFeedback: []UserFeedback{},
 			}, nil
 		}
-		return nil, fmt.Errorf("failed to list user feedback message IDs: %w", err)
+		return nil, fmt.Errorf("list user feedback: %w", err)
 	}
 
-	messages, err := g.repo.ListLatestGenerationChatMessages(ctx, repo.ListLatestGenerationChatMessagesParams{
-		ChatID:    args.ChatID,
-		ProjectID: args.ProjectID,
+	messages, err := g.repo.ListChatMessagesByGeneration(ctx, repo.ListChatMessagesByGenerationParams{
+		ChatID:     args.ChatID,
+		ProjectID:  args.ProjectID,
+		Generation: generation,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list chat messages: %w", err)
+		return nil, fmt.Errorf("list chat messages by generation: %w", err)
 	}
 
-	// Map feedback message IDs to their indices
-	messageIndexMap := make(map[uuid.UUID]int)
+	messageIndexMap := make(map[uuid.UUID]int, len(messages))
 	for i, msg := range messages {
 		messageIndexMap[msg.ID] = i
 	}
 
 	userFeedback := make([]UserFeedback, 0, len(feedback))
 	for _, fb := range feedback {
+		idx, ok := messageIndexMap[fb.MessageID]
+		if !ok {
+			// Feedback references a message from an older generation that has
+			// been replaced; without a stable index we cannot attribute it to a
+			// segment in the pinned snapshot.
+			g.logger.WarnContext(ctx, "skipping user feedback for message outside pinned chat generation",
+				attr.SlogChatID(args.ChatID.String()),
+				attr.SlogMessageID(fb.MessageID.String()),
+			)
+			continue
+		}
 		userFeedback = append(userFeedback, UserFeedback{
 			ID:              fb.ID,
 			MessageID:       fb.MessageID,
-			MessageIndex:    messageIndexMap[fb.MessageID],
+			MessageIndex:    idx,
 			Resolution:      fb.UserResolution,
 			ResolutionNotes: fb.UserResolutionNotes.String,
 		})
 	}
 
 	return &GetUserFeedbackForChatResult{
+		Generation:   generation,
 		UserFeedback: userFeedback,
 	}, nil
 }

--- a/server/internal/background/activities/chat_resolutions/segment_chat.go
+++ b/server/internal/background/activities/chat_resolutions/segment_chat.go
@@ -33,11 +33,14 @@ func NewSegmentChat(logger *slog.Logger, db *pgxpool.Pool, chatClient openrouter
 }
 
 type SegmentChatArgs struct {
-	ChatID       uuid.UUID
-	ProjectID    uuid.UUID
-	OrgID        string
-	APIKeyID     string
-	UserFeedback []UserFeedback // Will be used to inform segmentation
+	ChatID    uuid.UUID
+	ProjectID uuid.UUID
+	OrgID     string
+	APIKeyID  string
+	// Generation pins the chat snapshot; must match the generation used to
+	// compute UserFeedback indices.
+	Generation   int32
+	UserFeedback []UserFeedback
 }
 
 type ChatSegment struct {
@@ -50,12 +53,9 @@ type SegmentChatOutput struct {
 }
 
 func (s *SegmentChat) Do(ctx context.Context, args SegmentChatArgs) (*SegmentChatOutput, error) {
-	messages, err := s.repo.ListLatestGenerationChatMessages(ctx, repo.ListLatestGenerationChatMessagesParams{
-		ChatID:    args.ChatID,
-		ProjectID: args.ProjectID,
-	})
+	messages, err := loadMessagesAtPinnedGeneration(ctx, s.repo, args.ChatID, args.ProjectID, args.Generation)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list chat messages: %w", err)
+		return nil, err
 	}
 
 	if len(messages) == 0 {

--- a/server/internal/background/analyze_chat_resolutions.go
+++ b/server/internal/background/analyze_chat_resolutions.go
@@ -60,7 +60,10 @@ func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatReso
 
 	var a *Activities
 
-	// Phase 0: Get user feedback message ID if it exists
+	// Phase 0: Pin the chat generation and load user feedback against it. The
+	// generation must be reused by every subsequent activity, otherwise a
+	// generation bump mid-workflow can replace the message set and silently
+	// invalidate the indices computed here.
 	var feedbackResult activities.GetUserFeedbackForChatResult
 	err := workflow.ExecuteActivity(
 		ctx,
@@ -71,7 +74,7 @@ func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatReso
 		},
 	).Get(ctx, &feedbackResult)
 	if err != nil {
-		return fmt.Errorf("failed to get user feedback message ID: %w", err)
+		return fmt.Errorf("get user feedback for chat: %w", err)
 	}
 
 	// Phase 1: Segment the chat into logical breakpoints
@@ -85,11 +88,18 @@ func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatReso
 			ProjectID:    params.ProjectID,
 			OrgID:        params.OrgID,
 			APIKeyID:     params.APIKeyID,
+			Generation:   feedbackResult.Generation,
 			UserFeedback: feedbackResult.UserFeedback,
 		},
 	).Get(ctx, &segmentOutput)
 	if err != nil {
-		return fmt.Errorf("failed to segment chat: %w", err)
+		if activities.IsGenerationBumped(err) {
+			workflow.GetLogger(ctx).Info("chat generation bumped during segmentation, restarting analysis on latest generation",
+				"chat_id", params.ChatID.String(),
+			)
+			return workflow.NewContinueAsNewError(ctx, AnalyzeChatResolutionsWorkflow, params)
+		}
+		return fmt.Errorf("segment chat: %w", err)
 	}
 
 	err = workflow.ExecuteActivity(
@@ -100,7 +110,7 @@ func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatReso
 		},
 	).Get(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to delete existing resolutions: %w", err)
+		return fmt.Errorf("delete existing resolutions: %w", err)
 	}
 
 	// Phase 2: Analyze each segment comprehensively
@@ -112,13 +122,22 @@ func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatReso
 				ChatID:       params.ChatID,
 				ProjectID:    params.ProjectID,
 				OrgID:        params.OrgID,
+				APIKeyID:     params.APIKeyID,
+				Generation:   feedbackResult.Generation,
 				StartIndex:   segment.StartIndex,
 				EndIndex:     segment.EndIndex,
-				APIKeyID:     params.APIKeyID,
 				UserFeedback: feedbackResult.UserFeedback,
 			},
 		).Get(ctx, nil)
 		if err != nil {
+			if activities.IsGenerationBumped(err) {
+				workflow.GetLogger(ctx).Info("chat generation bumped during segment analysis, restarting on latest generation",
+					"chat_id", params.ChatID.String(),
+					"start_index", segment.StartIndex,
+					"end_index", segment.EndIndex,
+				)
+				return workflow.NewContinueAsNewError(ctx, AnalyzeChatResolutionsWorkflow, params)
+			}
 			// Log but continue with other segments
 			workflow.GetLogger(ctx).Error("failed to analyze segment",
 				"error", err.Error(),

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -166,6 +166,16 @@ WHERE cm.chat_id = @chat_id
   AND cm.generation = (SELECT MAX(generation) FROM chat_messages WHERE chat_id = @chat_id)
 ORDER BY cm.seq ASC;
 
+-- name: ListChatMessagesByGeneration :many
+-- Returns rows for an explicit generation, used to pin a snapshot across
+-- multiple reads (e.g. across Temporal activities) so indices stay stable
+-- even if a new generation is appended mid-workflow.
+SELECT cm.* FROM chat_messages cm
+WHERE cm.chat_id = @chat_id
+  AND (cm.project_id IS NULL OR cm.project_id = @project_id::uuid)
+  AND cm.generation = @generation::integer
+ORDER BY cm.seq ASC;
+
 -- name: GetMaxGenerationForChat :one
 SELECT COALESCE(MAX(generation), 0)::integer AS generation FROM chat_messages WHERE chat_id = @chat_id;
 

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -811,6 +811,73 @@ func (q *Queries) ListChatMessages(ctx context.Context, arg ListChatMessagesPara
 	return items, nil
 }
 
+const listChatMessagesByGeneration = `-- name: ListChatMessagesByGeneration :many
+SELECT cm.id, cm.seq, cm.chat_id, cm.project_id, cm.role, cm.content, cm.content_raw, cm.content_asset_url, cm.model, cm.message_id, cm.finish_reason, cm.tool_calls, cm.prompt_tokens, cm.completion_tokens, cm.total_tokens, cm.storage_error, cm.user_id, cm.external_user_id, cm.origin, cm.user_agent, cm.ip_address, cm.source, cm.tool_call_id, cm.tool_urn, cm.tool_outcome, cm.tool_outcome_notes, cm.content_hash, cm.generation, cm.created_at FROM chat_messages cm
+WHERE cm.chat_id = $1
+  AND (cm.project_id IS NULL OR cm.project_id = $2::uuid)
+  AND cm.generation = $3::integer
+ORDER BY cm.seq ASC
+`
+
+type ListChatMessagesByGenerationParams struct {
+	ChatID     uuid.UUID
+	ProjectID  uuid.UUID
+	Generation int32
+}
+
+// Returns rows for an explicit generation, used to pin a snapshot across
+// multiple reads (e.g. across Temporal activities) so indices stay stable
+// even if a new generation is appended mid-workflow.
+func (q *Queries) ListChatMessagesByGeneration(ctx context.Context, arg ListChatMessagesByGenerationParams) ([]ChatMessage, error) {
+	rows, err := q.db.Query(ctx, listChatMessagesByGeneration, arg.ChatID, arg.ProjectID, arg.Generation)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ChatMessage
+	for rows.Next() {
+		var i ChatMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.Seq,
+			&i.ChatID,
+			&i.ProjectID,
+			&i.Role,
+			&i.Content,
+			&i.ContentRaw,
+			&i.ContentAssetUrl,
+			&i.Model,
+			&i.MessageID,
+			&i.FinishReason,
+			&i.ToolCalls,
+			&i.PromptTokens,
+			&i.CompletionTokens,
+			&i.TotalTokens,
+			&i.StorageError,
+			&i.UserID,
+			&i.ExternalUserID,
+			&i.Origin,
+			&i.UserAgent,
+			&i.IpAddress,
+			&i.Source,
+			&i.ToolCallID,
+			&i.ToolUrn,
+			&i.ToolOutcome,
+			&i.ToolOutcomeNotes,
+			&i.ContentHash,
+			&i.Generation,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listChatMessagesForMatch = `-- name: ListChatMessagesForMatch :many
 SELECT id, role, content, tool_call_id, tool_calls
 FROM chat_messages


### PR DESCRIPTION
## Summary

- Each chat-resolution activity (`GetUserFeedbackForChat`, `SegmentChat`, `AnalyzeSegment`) was independently calling `ListLatestGenerationChatMessages`. If a new generation was appended mid-workflow, the message set could change between activities and silently invalidate the indices computed earlier — feedback could end up attributed to messages from a different snapshot.
- `GetUserFeedbackForChat` now pins the chat generation, returns it in the activity result, and the workflow threads that generation through `SegmentChat` and `AnalyzeSegment`. Each of those activities re-checks the current generation against the pinned one and bails with a non-retryable Temporal application error (`ChatResolutionGenerationBumped`) if the chat has advanced.
- The workflow detects that error and `ContinueAsNew`s on the new generation rather than acting on stale indices.
- Adds `ListChatMessagesByGeneration` SQL query so reads outside Phase 0 are pinned to an explicit generation rather than implicitly to "latest".
- Drops user feedback whose `MessageID` doesn't exist in the pinned snapshot (with a warn log) instead of silently inserting it at index 0.

✻ Clauded...