### PR TITLE
mig: add authz_challenge_resolutions table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2251,3 +2251,38 @@ ON risk_results (project_id, chat_message_id);
 CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
 WHERE found IS TRUE;
+
+CREATE TABLE IF NOT EXISTS authz_challenge_resolutions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  challenge_id TEXT NOT NULL,
+
+  principal_urn TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  resource_kind TEXT NOT NULL DEFAULT '',
+  resource_id TEXT NOT NULL DEFAULT '',
+
+  resolution_type TEXT NOT NULL,
+  role_slug TEXT,
+  notes TEXT,
+
+  resolved_by TEXT NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT authz_challenge_resolutions_pkey PRIMARY KEY (id),
+  CONSTRAINT authz_challenge_resolutions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE authz_challenge_resolutions IS 'Tracks admin resolutions of authz challenge denials. challenge_id references authz_challenges.id in ClickHouse (soft cross-DB reference).';
+COMMENT ON COLUMN authz_challenge_resolutions.challenge_id IS 'UUID of the denied challenge in the ClickHouse authz_challenges table.';
+COMMENT ON COLUMN authz_challenge_resolutions.principal_urn IS 'The principal that was denied, copied from the challenge for query convenience.';
+COMMENT ON COLUMN authz_challenge_resolutions.resolution_type IS 'How the challenge was resolved: role_assigned, dismissed.';
+COMMENT ON COLUMN authz_challenge_resolutions.role_slug IS 'When resolution_type=role_assigned, the role slug that was assigned to the principal.';
+COMMENT ON COLUMN authz_challenge_resolutions.resolved_by IS 'URN of the admin who resolved the challenge.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS authz_challenge_resolutions_org_challenge_key
+ON authz_challenge_resolutions (organization_id, challenge_id);
+
+CREATE INDEX IF NOT EXISTS authz_challenge_resolutions_org_principal_idx
+ON authz_challenge_resolutions (organization_id, principal_urn);

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2264,7 +2264,6 @@ CREATE TABLE IF NOT EXISTS authz_challenge_resolutions (
 
   resolution_type TEXT NOT NULL,
   role_slug TEXT,
-  notes TEXT,
 
   resolved_by TEXT NOT NULL,
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -157,6 +157,26 @@ type AuditLog struct {
 	CreatedAt          pgtype.Timestamptz
 }
 
+// Tracks admin resolutions of authz challenge denials. challenge_id references authz_challenges.id in ClickHouse (soft cross-DB reference).
+type AuthzChallengeResolution struct {
+	ID             uuid.UUID
+	OrganizationID string
+	// UUID of the denied challenge in the ClickHouse authz_challenges table.
+	ChallengeID string
+	// The principal that was denied, copied from the challenge for query convenience.
+	PrincipalUrn string
+	Scope        string
+	ResourceKind string
+	ResourceID   string
+	// How the challenge was resolved: role_assigned, dismissed.
+	ResolutionType string
+	// When resolution_type=role_assigned, the role slug that was assigned to the principal.
+	RoleSlug pgtype.Text
+	// URN of the admin who resolved the challenge.
+	ResolvedBy string
+	CreatedAt  pgtype.Timestamptz
+}
+
 type Chat struct {
 	ID             uuid.UUID
 	ProjectID      uuid.UUID

--- a/server/migrations/20260505133113_authz-challenge-resolutions.sql
+++ b/server/migrations/20260505133113_authz-challenge-resolutions.sql
@@ -1,0 +1,33 @@
+-- Create "authz_challenge_resolutions" table
+CREATE TABLE "authz_challenge_resolutions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "challenge_id" text NOT NULL,
+  "principal_urn" text NOT NULL,
+  "scope" text NOT NULL,
+  "resource_kind" text NOT NULL DEFAULT '',
+  "resource_id" text NOT NULL DEFAULT '',
+  "resolution_type" text NOT NULL,
+  "role_slug" text NULL,
+  "notes" text NULL,
+  "resolved_by" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "authz_challenge_resolutions_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "authz_challenge_resolutions_org_challenge_key" to table: "authz_challenge_resolutions"
+CREATE UNIQUE INDEX "authz_challenge_resolutions_org_challenge_key" ON "authz_challenge_resolutions" ("organization_id", "challenge_id");
+-- Create index "authz_challenge_resolutions_org_principal_idx" to table: "authz_challenge_resolutions"
+CREATE INDEX "authz_challenge_resolutions_org_principal_idx" ON "authz_challenge_resolutions" ("organization_id", "principal_urn");
+-- Set comment to table: "authz_challenge_resolutions"
+COMMENT ON TABLE "authz_challenge_resolutions" IS 'Tracks admin resolutions of authz challenge denials. challenge_id references authz_challenges.id in ClickHouse (soft cross-DB reference).';
+-- Set comment to column: "challenge_id" on table: "authz_challenge_resolutions"
+COMMENT ON COLUMN "authz_challenge_resolutions"."challenge_id" IS 'UUID of the denied challenge in the ClickHouse authz_challenges table.';
+-- Set comment to column: "principal_urn" on table: "authz_challenge_resolutions"
+COMMENT ON COLUMN "authz_challenge_resolutions"."principal_urn" IS 'The principal that was denied, copied from the challenge for query convenience.';
+-- Set comment to column: "resolution_type" on table: "authz_challenge_resolutions"
+COMMENT ON COLUMN "authz_challenge_resolutions"."resolution_type" IS 'How the challenge was resolved: role_assigned, dismissed.';
+-- Set comment to column: "role_slug" on table: "authz_challenge_resolutions"
+COMMENT ON COLUMN "authz_challenge_resolutions"."role_slug" IS 'When resolution_type=role_assigned, the role slug that was assigned to the principal.';
+-- Set comment to column: "resolved_by" on table: "authz_challenge_resolutions"
+COMMENT ON COLUMN "authz_challenge_resolutions"."resolved_by" IS 'URN of the admin who resolved the challenge.';

--- a/server/migrations/20260505134312_authz-challenge-resolutions.sql
+++ b/server/migrations/20260505134312_authz-challenge-resolutions.sql
@@ -9,7 +9,6 @@ CREATE TABLE "authz_challenge_resolutions" (
   "resource_id" text NOT NULL DEFAULT '',
   "resolution_type" text NOT NULL,
   "role_slug" text NULL,
-  "notes" text NULL,
   "resolved_by" text NOT NULL,
   "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
   PRIMARY KEY ("id"),

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:cqPlYrsKL6hBzXezENZP87MOc56DsL6PpZOO8n3FHlU=
+h1:IJGZ8/ipuRqZzeXYAmxFEoNMpqob19PZgbgwkUhA9Hs=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -153,3 +153,4 @@ h1:cqPlYrsKL6hBzXezENZP87MOc56DsL6PpZOO8n3FHlU=
 20260430205315_risk-policies-user-message.sql h1:b3myELZy6W5m08Wz7aqPV6pInYP5SB0KKj5uQ5VYBoQ=
 20260504160941_remove-location-from-pii-policies.sql h1:yCzDGT+8E9xuZpxYwJXpEyHYFW0xNEn9VKe2TchfJgs=
 20260504210916_chat_messages_project_id_id_idx.sql h1:kwShq3wLbk1VNIWRsAWDlqJ2apQ5iDnODP81/Vc6VTY=
+20260505133113_authz-challenge-resolutions.sql h1:jvFEYJNBWBD8EfA4Cp8XeLbZJS8IjJ1LyzbTNBv2lSk=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:IJGZ8/ipuRqZzeXYAmxFEoNMpqob19PZgbgwkUhA9Hs=
+h1:lznIRVwDV0TxuEPbLHRS+cznwkOlH1zi6Sq9iiCoFeY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -153,4 +153,4 @@ h1:IJGZ8/ipuRqZzeXYAmxFEoNMpqob19PZgbgwkUhA9Hs=
 20260430205315_risk-policies-user-message.sql h1:b3myELZy6W5m08Wz7aqPV6pInYP5SB0KKj5uQ5VYBoQ=
 20260504160941_remove-location-from-pii-policies.sql h1:yCzDGT+8E9xuZpxYwJXpEyHYFW0xNEn9VKe2TchfJgs=
 20260504210916_chat_messages_project_id_id_idx.sql h1:kwShq3wLbk1VNIWRsAWDlqJ2apQ5iDnODP81/Vc6VTY=
-20260505133113_authz-challenge-resolutions.sql h1:jvFEYJNBWBD8EfA4Cp8XeLbZJS8IjJ1LyzbTNBv2lSk=
+20260505134312_authz-challenge-resolutions.sql h1:t6fg2cQEWZrdYYATaJx+7zfdYvmJCUE3zuKJq4E6Zwo=


### PR DESCRIPTION
## Summary

- Adds `authz_challenge_resolutions` PostgreSQL table to store admin resolution state for denied authz challenges
- Bridges ClickHouse telemetry (authz_challenges, #2591) with mutable state needed by the challenge UI grant flow (#2542)
- `challenge_id` is a soft cross-DB reference to the ClickHouse `authz_challenges.id` UUID
- Denormalizes `principal_urn` and `scope` from the challenge row for efficient PG-side queries
- Unique index on `(org, challenge_id)` — one resolution per challenge
- Lookup index on `(org, principal_urn)` — list resolutions for a user

## Test plan

- [ ] Migration applies cleanly: `mise db:apply`
- [ ] `mise lint:migrations` passes
- [ ] CI migration check passes