### PR TITLE
feat(risk): add prompt injection detector (stub) wired end-to-end

### DIFF
--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -99,6 +99,7 @@ function policyToCategories(
   if (sources.includes("gitleaks")) cats.add("secrets");
   if (sources.includes("shadow_mcp")) cats.add("shadow_mcp");
   if (sources.includes("destructive_tool")) cats.add("destructive_tool");
+  if (sources.includes("prompt_injection")) cats.add("prompt_injection");
   for (const cat of PRESIDIO_CATEGORIES) {
     const catEntityIds = DETECTION_RULES[cat].map((r) => r.id);
     if (catEntityIds.some((id) => presidioEntities?.includes(id))) {
@@ -115,6 +116,7 @@ function categoriesToPayload(cats: Set<RuleCategory>) {
   if (cats.has("secrets")) sources.push("gitleaks");
   if (cats.has("shadow_mcp")) sources.push("shadow_mcp");
   if (cats.has("destructive_tool")) sources.push("destructive_tool");
+  if (cats.has("prompt_injection")) sources.push("prompt_injection");
   for (const cat of PRESIDIO_CATEGORIES) {
     if (cats.has(cat)) {
       for (const rule of DETECTION_RULES[cat]) {

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -38,6 +38,7 @@ function getCategoryForFinding(
 ): RuleCategory | null {
   if (source === "destructive_tool") return "destructive_tool";
   if (source === "shadow_mcp") return "shadow_mcp";
+  if (source === "prompt_injection") return "prompt_injection";
   if (!ruleId) return null;
   return RULE_ID_TO_CATEGORY.get(ruleId) ?? null;
 }

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -23,7 +23,7 @@ export type RuleCategory =
 export type DetectionRule = {
   id: string;
   title: string;
-  source: "gitleaks" | "presidio";
+  source: "gitleaks" | "presidio" | "prompt_injection";
 };
 
 export type McpServerScope = {
@@ -1373,28 +1373,7 @@ export const DETECTION_RULES: Record<RuleCategory, DetectionRule[]> = {
       source: "presidio",
     },
   ],
-  prompt_injection: [
-    {
-      id: "indirect-injection",
-      title: "Indirect prompt injection via external content",
-      source: "presidio",
-    },
-    {
-      id: "tool-output-injection",
-      title: "Malicious instructions embedded in tool responses",
-      source: "presidio",
-    },
-    {
-      id: "hidden-instruction",
-      title: "Hidden instructions in user-provided data",
-      source: "presidio",
-    },
-    {
-      id: "encoding-evasion",
-      title: "Encoded or obfuscated injection payloads",
-      source: "presidio",
-    },
-  ],
+  prompt_injection: [],
   off_policy: [
     {
       id: "harmful-content-request",

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -188,6 +188,7 @@ func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages
 	presidioFindings := make([][]Finding, n)
 	shadowMCPFindings := make([][]Finding, n)
 	destructiveToolFindings := make([][]Finding, n)
+	promptInjectionFindings := make([][]Finding, n)
 
 	var wg sync.WaitGroup
 	var gitleaksErr error
@@ -236,12 +237,19 @@ func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages
 		activity.RecordHeartbeat(ctx, "destructive_tool")
 	}
 
+	if slices.Contains(args.Sources, SourcePromptInjection) {
+		for i, content := range contents {
+			promptInjectionFindings[i] = DetectPromptInjection(content)
+		}
+		activity.RecordHeartbeat(ctx, "prompt_injection")
+	}
+
 	merged := make([][]Finding, n)
 	for i := range n {
 		// Gitleaks findings come first so they take priority over presidio
 		// when both scanners match the same text region. Tool-call findings are
 		// non-overlapping with content scanners, so they pass through dedup.
-		combined := slices.Concat(gitleaksFindings[i], presidioFindings[i], shadowMCPFindings[i], destructiveToolFindings[i])
+		combined := slices.Concat(gitleaksFindings[i], presidioFindings[i], shadowMCPFindings[i], destructiveToolFindings[i], promptInjectionFindings[i])
 		merged[i] = dedup(combined)
 	}
 	return merged, nil

--- a/server/internal/background/activities/risk_analysis/prompt_injection.go
+++ b/server/internal/background/activities/risk_analysis/prompt_injection.go
@@ -1,0 +1,51 @@
+package risk_analysis
+
+import "strings"
+
+// SourcePromptInjection is the policy source value that enables prompt
+// injection scanning. Used by both the batch analyzer (writes findings to
+// risk_results) and the realtime risk scanner (hook deny path for
+// action='block' policies).
+const SourcePromptInjection = "prompt_injection"
+
+// promptInjectionStubMarker is the literal substring the stub detector
+// flags. This is intentional placeholder logic so the wiring (policy
+// source -> scanner -> findings -> dashboard) can be exercised
+// end-to-end before a real classifier lands.
+const promptInjectionStubMarker = "__INJECT__"
+
+const (
+	promptInjectionRuleStub = "prompt-injection-stub"
+	promptInjectionDescStub = "Stub prompt injection marker detected"
+)
+
+// DetectPromptInjection scans text for prompt-injection signals and returns
+// one Finding per match. Returns nil when nothing matches.
+func DetectPromptInjection(text string) []Finding {
+	if text == "" {
+		return nil
+	}
+
+	var findings []Finding
+	idx := 0
+	for {
+		rel := strings.Index(text[idx:], promptInjectionStubMarker)
+		if rel < 0 {
+			break
+		}
+		start := idx + rel
+		end := start + len(promptInjectionStubMarker)
+		findings = append(findings, Finding{
+			RuleID:      promptInjectionRuleStub,
+			Description: promptInjectionDescStub,
+			Match:       promptInjectionStubMarker,
+			StartPos:    start,
+			EndPos:      end,
+			Tags:        nil,
+			Source:      SourcePromptInjection,
+			Confidence:  1.0,
+		})
+		idx = end
+	}
+	return findings
+}

--- a/server/internal/background/activities/risk_analysis/prompt_injection_test.go
+++ b/server/internal/background/activities/risk_analysis/prompt_injection_test.go
@@ -1,0 +1,42 @@
+package risk_analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectPromptInjection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, DetectPromptInjection(""))
+	})
+
+	t.Run("no marker returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, DetectPromptInjection("hello world, ignore previous instructions"))
+	})
+
+	t.Run("single match", func(t *testing.T) {
+		t.Parallel()
+		text := "please run __INJECT__ now"
+		findings := DetectPromptInjection(text)
+		require.Len(t, findings, 1)
+		f := findings[0]
+		assert.Equal(t, SourcePromptInjection, f.Source)
+		assert.Equal(t, promptInjectionRuleStub, f.RuleID)
+		assert.Equal(t, promptInjectionStubMarker, f.Match)
+		assert.Equal(t, promptInjectionStubMarker, text[f.StartPos:f.EndPos])
+		assert.InDelta(t, 1.0, f.Confidence, 0.0001)
+	})
+
+	t.Run("multiple non-overlapping matches", func(t *testing.T) {
+		t.Parallel()
+		findings := DetectPromptInjection("__INJECT__ and again __INJECT__")
+		require.Len(t, findings, 2)
+		assert.Less(t, findings[0].StartPos, findings[1].StartPos)
+	})
+}

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background"
+	ra "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -940,7 +941,7 @@ func validateAction(action string) error {
 func validateSources(sources []string) error {
 	for _, src := range sources {
 		switch src {
-		case "gitleaks", "presidio", shadowmcp.SourceShadowMCP, shadowmcp.SourceDestructiveTool:
+		case "gitleaks", "presidio", shadowmcp.SourceShadowMCP, shadowmcp.SourceDestructiveTool, ra.SourcePromptInjection:
 		default:
 			return oops.E(oops.CodeInvalid, nil, "source %q is not a recognized policy source", src)
 		}

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -271,6 +271,18 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, text s
 					Description: f.Description,
 				}, nil
 			}
+		case ra.SourcePromptInjection:
+			findings := ra.DetectPromptInjection(text)
+			if len(findings) > 0 {
+				return &ScanResult{
+					Action:      policy.Action,
+					PolicyID:    policy.ID.String(),
+					PolicyName:  policy.Name,
+					Source:      ra.SourcePromptInjection,
+					RuleID:      findings[0].RuleID,
+					Description: findings[0].Description,
+				}, nil
+			}
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
## Summary

First slice of AGE-1993. Lands the data-path plumbing for a new `prompt_injection` policy source and a stub detector that flags the literal substring `__INJECT__`. The dashboard category stays gated as "Coming Soon" so users don't opt into a half-feature — the gate flips with slice 2 when a real classifier lands.

### Backend
- New `DetectPromptInjection` in `risk_analysis/prompt_injection.go` returning `Finding`s on `__INJECT__` matches.
- Wired into `AnalyzeBatch.scan()` so flag-action policies produce `risk_results` (and surface in the dashboard) via the worker path.
- Wired into `risk.Scanner.scanPolicy` so block-action policies deny in real-time via the hook path.
- `validateSources` accepts the new source string so policy create/update doesn't reject it.

### Dashboard
- `SecurityOverview.tsx` — source-level short-circuit so findings render with the "Prompt Injection" category badge (mirrors `shadow_mcp` / `destructive_tool`).
- `policy-data.ts` — widened `DetectionRule.source` to include `"prompt_injection"`, and **emptied the rule list** under that category. The four rules previously listed (`indirect-injection`, `tool-output-injection`, `hidden-instruction`, `encoding-evasion`) were typed `source: "presidio"` but presidio doesn't detect any of them — they were aspirational placeholders. They get repopulated in slice 2 with rule IDs the real detector actually emits.
- `PolicyCenter.tsx` — `policyToCategories` / `categoriesToPayload` learn the new source↔category mapping, but `AVAILABLE_CATEGORIES` deliberately does **not** include `prompt_injection`. The category remains "Coming Soon" and unselectable until the real detector ships.

### What does NOT ship in this slice
- Any user-facing way to enable a `prompt_injection` policy through the dashboard. The category stays "Coming Soon".
- A real detector. `__INJECT__` is a placeholder for the wiring; nothing else triggers it.

## Verified locally

- Inserted a `prompt_injection` policy via SQL, submitted `__INJECT__` through `mise hooks:test --local` → message persisted to `chat_messages`, batch worker drained, `risk_results` row produced with `source='prompt_injection'`, `rule_id='prompt-injection-stub'`. The "Prompt Injection" category badge renders correctly on the security overview.
- `go build ./...`, `go test ./internal/background/activities/risk_analysis/ -run TestDetectPromptInjection`, and `npx tsc -b --force` in the dashboard all clean.

## Follow-ups (slice 2)

- Replace the `__INJECT__` stub with a real classifier (heuristics + model), mirroring the `ra.PIIScanner` interface pattern.
- Repopulate `DETECTION_RULES.prompt_injection` with the rule IDs the real detector emits.
- Flip the gate so the category becomes selectable — likely via a per-org product feature flag (the `productfeatures` package, mirroring `session_capture`) so rollout is per-customer rather than all-or-nothing at deploy time.

## Test plan

- [x] Insert a `prompt_injection` policy via SQL on a local org, submit `__INJECT__` via Claude Code, confirm a finding row lands and the security overview shows the "Prompt Injection" badge.
- [x] Confirm the Policy Center still shows "Prompt Injection" as "Coming Soon" and the category checkbox is disabled.
- [x] Flip the policy action to `block`, re-submit, confirm Claude is denied with the self-branded reason from the hook path.