### PR TITLE
chore: create audit logger component and refactor

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -39,6 +39,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/access"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -718,4 +719,8 @@ func newTriggersApp(
 		serverURL,
 		bgtriggers.NewNoopDispatcher(logger),
 	)
+}
+
+func newAuditLogger() *audit.Logger {
+	return audit.NewLogger()
 }

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -530,6 +530,8 @@ func newStartCommand() *cli.Command {
 			}
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
+			auditLogger := newAuditLogger()
+
 			productFeatures := productfeatures.NewClient(logger, tracerProvider, db, redisClient)
 
 			var openRouter openrouter.Provisioner
@@ -669,6 +671,7 @@ func newStartCommand() *cli.Command {
 				logger,
 				db,
 				telemSvc,
+				auditLogger,
 				platformtoolsruntime.WithTriggerTools(triggerApp),
 				platformtoolsruntime.WithSlackHTTPClient(guardianPolicy.PooledClient()),
 			)
@@ -698,6 +701,7 @@ func newStartCommand() *cli.Command {
 				authzEngine,
 				assistantTokenManager,
 				shadowMCPClient,
+				auditLogger,
 			)
 
 			chatClient := chat.NewAgenticChatClient(
@@ -713,8 +717,8 @@ func newStartCommand() *cli.Command {
 			assistantsSvc := assistants.NewService(logger, tracerProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv})
 			triggerApp.RegisterDispatcher(assistantsSvc)
 
-			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine)
-			mcpMetadataService := mcpmetadata.NewService(logger, tracerProvider, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient), authzEngine)
+			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
+			mcpMetadataService := mcpmetadata.NewService(logger, tracerProvider, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
 			mux := goahttp.NewMuxer()
 			mux.Use(func(h http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -751,7 +755,7 @@ func newStartCommand() *cli.Command {
 			}
 
 			about.Attach(mux, about.NewService(logger, tracerProvider))
-			access.Attach(mux, access.NewService(logger, tracerProvider, db, sessionManager, roleClient, authzEngine, productFeatures))
+			access.Attach(mux, access.NewService(logger, tracerProvider, db, sessionManager, roleClient, authzEngine, productFeatures, auditLogger))
 			assistants.Attach(mux, assistantsSvc)
 			hooks.Attach(mux, hooks.NewService(logger, db, tracerProvider, telemLogger, sessionManager, hooksCache, chatClient, temporalEnv, authzEngine, productFeatures, &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}, riskScanner, shadowMCPClient, chatWriter))
 			auditapi.Attach(mux, auditapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
@@ -769,7 +773,7 @@ func newStartCommand() *cli.Command {
 				authzEngine,
 			))
 			organizations.Attach(mux, organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, productFeatures, authzEngine))
-			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
+			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			packages.Attach(mux, packages.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 
 			pluginsGitHub, err := plugins.NewGitHubConfig(plugins.GitHubConfigInput{
@@ -787,21 +791,21 @@ func newStartCommand() *cli.Command {
 			} else {
 				logger.InfoContext(ctx, "GitHub publishing for plugins: disabled")
 			}
-			plugins.Attach(mux, plugins.NewService(logger, tracerProvider, db, sessionManager, authzEngine, pluginsGitHub, c.String("environment"), c.String("server-url")))
+			plugins.Attach(mux, plugins.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url")))
 			productfeatures.Attach(mux, productfeatures.NewService(logger, tracerProvider, db, sessionManager, redisClient, authzEngine))
 			toolsets.Attach(mux, toolsetsSvc)
 			integrations.Attach(mux, integrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
-			templates.Attach(mux, templates.NewService(logger, tracerProvider, db, sessionManager, toolsetsSvc, authzEngine))
-			assets.Attach(mux, assets.NewService(logger, tracerProvider, guardianPolicy, db, sessionManager, chatSessionsManager, assetStorage, c.String("jwt-signing-key"), authzEngine))
-			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine))
-			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), authzEngine))
+			templates.Attach(mux, templates.NewService(logger, tracerProvider, db, sessionManager, toolsetsSvc, authzEngine, auditLogger))
+			assets.Attach(mux, assets.NewService(logger, tracerProvider, guardianPolicy, db, sessionManager, chatSessionsManager, assetStorage, c.String("jwt-signing-key"), authzEngine, auditLogger))
+			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger))
+			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), authzEngine, auditLogger))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
-			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine))
-			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
-			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
-			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy))
+			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
+			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
+			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
+			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger))
 			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, billingRepo, billingTracker), mcpService, mcpMetadataService)
-			triggers.Attach(mux, triggers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, triggerApp))
+			triggers.Attach(mux, triggers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, triggerApp, auditLogger))
 			tools.Attach(mux, tools.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			resources.Attach(mux, resources.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			oauth.AttachExternalOAuth(mux, externalOAuthService)
@@ -812,7 +816,7 @@ func newStartCommand() *cli.Command {
 			collections.Attach(mux, collections.NewService(logger, tracerProvider, db, sessionManager, authzEngine, serverURL))
 			mcp.Attach(mux, mcpService, mcpMetadataService)
 			chat.Attach(mux, chatService)
-			variations.Attach(mux, variations.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
+			variations.Attach(mux, variations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			customdomains.Attach(mux, customdomains.NewService(logger, tracerProvider, db, sessionManager, &background.CustomDomainRegistrationClient{TemporalEnv: temporalEnv}, authzEngine))
 			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, posthogClient, openRouter, authzEngine))
 			tm.Attach(mux, telemSvc)
@@ -824,7 +828,7 @@ func newStartCommand() *cli.Command {
 				logger,
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
-			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, authzEngine, riskSignaler, completionsClient, shadowMCPClient)
+			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, authzEngine, riskSignaler, completionsClient, shadowMCPClient, auditLogger)
 			chatWriter.AddObserver(riskService)
 			risk.Attach(mux, riskService)
 
@@ -886,6 +890,7 @@ func newStartCommand() *cli.Command {
 						TemporalEnv:         temporalEnv,
 						PIIScanner:          piiScanner,
 						ShadowMCPClient:     shadowMCPClient,
+						AuditLogger:         auditLogger,
 					})
 					if err := temporalWorker.Run(workerInterruptCh); err != nil {
 						logger.ErrorContext(ctx, "temporal worker failed", attr.SlogError(err))

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -817,7 +817,7 @@ func newStartCommand() *cli.Command {
 			mcp.Attach(mux, mcpService, mcpMetadataService)
 			chat.Attach(mux, chatService)
 			variations.Attach(mux, variations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
-			customdomains.Attach(mux, customdomains.NewService(logger, tracerProvider, db, sessionManager, &background.CustomDomainRegistrationClient{TemporalEnv: temporalEnv}, authzEngine))
+			customdomains.Attach(mux, customdomains.NewService(logger, tracerProvider, db, sessionManager, &background.CustomDomainRegistrationClient{TemporalEnv: temporalEnv}, authzEngine, auditLogger))
 			usage.Attach(mux, usage.NewService(logger, tracerProvider, db, sessionManager, billingRepo, serverURL, posthogClient, openRouter, authzEngine))
 			tm.Attach(mux, telemSvc)
 			functions.Attach(mux, functions.NewService(logger, tracerProvider, db, encryptionClient, tigrisStore))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -362,6 +362,8 @@ func newWorkerCommand() *cli.Command {
 				return fmt.Errorf("failed to create encryption client: %w", err)
 			}
 
+			auditLogger := newAuditLogger()
+
 			mcpMetadataRepo := mcpmetadata_repo.New(db)
 			env := environments.NewEnvironmentEntries(logger, db, encryptionClient, mcpMetadataRepo)
 
@@ -478,7 +480,7 @@ func newWorkerCommand() *cli.Command {
 				logger,
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
-			chatWriter.AddObserver(risk.NewObserver(logger, tracerProvider, db, riskSignaler))
+			chatWriter.AddObserver(risk.NewObserver(logger, tracerProvider, db, riskSignaler, auditLogger))
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,
@@ -547,6 +549,7 @@ func newWorkerCommand() *cli.Command {
 				authzEngine,
 				assistantTokenManager,
 				shadowMCPClient,
+				auditLogger,
 			)
 
 			chatClient := chat.NewAgenticChatClient(
@@ -602,6 +605,7 @@ func newWorkerCommand() *cli.Command {
 				TemporalEnv:         temporalEnv,
 				PIIScanner:          piiScanner,
 				ShadowMCPClient:     shadowMCPClient,
+				AuditLogger:         auditLogger,
 			})
 
 			return temporalWorker.Run(worker.InterruptCh())

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -70,12 +70,22 @@ type Service struct {
 	authz        *authz.Engine
 	roles        RoleProvider
 	featureCache FeatureCacheWriter
+	audit        *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, roles RoleProvider, authz *authz.Engine, featureCache FeatureCacheWriter) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	roles RoleProvider,
+	authz *authz.Engine,
+	featureCache FeatureCacheWriter,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("access"))
 
 	return &Service{
@@ -86,6 +96,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		authz:        authz,
 		roles:        roles,
 		featureCache: featureCache,
+		audit:        auditLogger,
 	}
 }
 
@@ -311,7 +322,7 @@ func (s *Service) CreateRole(ctx context.Context, payload *gen.CreateRolePayload
 		return nil, err
 	}
 
-	if err := audit.LogAccessRoleCreate(ctx, s.db, audit.LogAccessRoleCreateEvent{
+	if err := s.audit.LogAccessRoleCreate(ctx, s.db, audit.LogAccessRoleCreateEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
 		ActorDisplayName: ac.Email,
@@ -449,7 +460,7 @@ func (s *Service) UpdateRole(ctx context.Context, payload *gen.UpdateRolePayload
 		return nil, err
 	}
 
-	if err := audit.LogAccessRoleUpdate(ctx, s.db, audit.LogAccessRoleUpdateEvent{
+	if err := s.audit.LogAccessRoleUpdate(ctx, s.db, audit.LogAccessRoleUpdateEvent{
 		OrganizationID:     ac.ActiveOrganizationID,
 		Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
 		ActorDisplayName:   ac.Email,
@@ -540,7 +551,7 @@ func (s *Service) DeleteRole(ctx context.Context, payload *gen.DeleteRolePayload
 		return oops.E(oops.CodeUnexpected, err, "delete role in workos").Log(ctx, logger)
 	}
 
-	if err := audit.LogAccessRoleDelete(ctx, s.db, audit.LogAccessRoleDeleteEvent{
+	if err := s.audit.LogAccessRoleDelete(ctx, s.db, audit.LogAccessRoleDeleteEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
 		ActorDisplayName: ac.Email,
@@ -846,7 +857,7 @@ func (s *Service) UpdateMemberRole(ctx context.Context, payload *gen.UpdateMembe
 		JoinedAt: conv.Default(updatedMember.CreatedAt, time.Time{}.UTC().Format(time.RFC3339)),
 	}
 
-	if err := audit.LogAccessMemberRoleUpdate(ctx, s.db, audit.LogAccessMemberRoleUpdateEvent{
+	if err := s.audit.LogAccessMemberRoleUpdate(ctx, s.db, audit.LogAccessMemberRoleUpdateEvent{
 		OrganizationID:       ac.ActiveOrganizationID,
 		Actor:                urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
 		ActorDisplayName:     ac.Email,

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -89,7 +90,9 @@ func newTestAccessService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := NewService(logger, tracerProvider, conn, sessionManager, roles, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), noopFeatureCacheWriter{})
+	auditLogger := audit.NewLogger()
+
+	svc := NewService(logger, tracerProvider, conn, sessionManager, roles, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), noopFeatureCacheWriter{}, auditLogger)
 
 	return ctx, &testInstance{
 		service: svc,

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -64,12 +64,24 @@ type Service struct {
 	chatSessions *chatsessions.Manager
 	projects     *projectsRepo.Queries
 	repo         *repo.Queries
+	audit        *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, db *pgxpool.Pool, sessions *sessions.Manager, chatSessions *chatsessions.Manager, storage BlobStore, jwtSecret string, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	guardianPolicy *guardian.Policy,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	chatSessions *chatsessions.Manager,
+	storage BlobStore,
+	jwtSecret string,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("assets"))
 
 	return &Service{
@@ -83,6 +95,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, guardi
 		chatSessions:   chatSessions,
 		projects:       projectsRepo.New(db),
 		repo:           repo.New(db),
+		audit:          auditLogger,
 	}
 }
 
@@ -256,7 +269,7 @@ func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm,
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
 	}
 
-	if err := audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
+	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 
@@ -373,7 +386,7 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
 	}
 
-	if err := audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
+	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 
@@ -486,7 +499,7 @@ func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAP
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
 	}
 
-	if err := audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
+	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 
@@ -946,7 +959,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("create asset in database: %w", err), "error saving document info").Log(ctx, logger)
 	}
 
-	if err := audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
+	if err := s.audit.LogAssetCreate(ctx, dbtx, audit.LogAssetCreateEvent{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 

--- a/server/internal/assets/setup_test.go
+++ b/server/internal/assets/setup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
 	"github.com/speakeasy-api/gram/server/internal/assets/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -84,7 +85,25 @@ func newTestAssetsService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, storage, "test-jwt-secret", authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache))
+	auditLogger := audit.NewLogger()
+
+	svc := assets.NewService(logger,
+		tracerProvider,
+		guardianPolicy,
+		conn,
+		sessionManager,
+		chatSessionsManager,
+		storage,
+		"test-jwt-secret",
+		authz.NewEngine(logger,
+			conn,
+			chConn,
+			authztest.RBACAlwaysEnabled,
+			workos.NewStubClient(),
+			cache.NoopCache,
+		),
+		auditLogger,
+	)
 	repository := repo.New(conn)
 
 	return ctx, &testInstance{

--- a/server/internal/audit/access.go
+++ b/server/internal/audit/access.go
@@ -31,7 +31,7 @@ type LogAccessRoleCreateEvent struct {
 	RoleSlug string
 }
 
-func LogAccessRoleCreate(ctx context.Context, dbtx repo.DBTX, event LogAccessRoleCreateEvent) error {
+func (l *Logger) LogAccessRoleCreate(ctx context.Context, dbtx repo.DBTX, event LogAccessRoleCreateEvent) error {
 	action := ActionAccessRoleCreate
 
 	entry := repo.InsertAuditLogParams{
@@ -77,7 +77,7 @@ type LogAccessRoleUpdateEvent struct {
 	RoleSnapshotAfter  *accessgen.Role
 }
 
-func LogAccessRoleUpdate(ctx context.Context, dbtx repo.DBTX, event LogAccessRoleUpdateEvent) error {
+func (l *Logger) LogAccessRoleUpdate(ctx context.Context, dbtx repo.DBTX, event LogAccessRoleUpdateEvent) error {
 	action := ActionAccessRoleUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.RoleSnapshotBefore)
@@ -130,7 +130,7 @@ type LogAccessRoleDeleteEvent struct {
 	RoleSlug string
 }
 
-func LogAccessRoleDelete(ctx context.Context, dbtx repo.DBTX, event LogAccessRoleDeleteEvent) error {
+func (l *Logger) LogAccessRoleDelete(ctx context.Context, dbtx repo.DBTX, event LogAccessRoleDeleteEvent) error {
 	action := ActionAccessRoleDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -175,7 +175,7 @@ type LogAccessMemberRoleUpdateEvent struct {
 	MemberSnapshotAfter  *accessgen.AccessMember
 }
 
-func LogAccessMemberRoleUpdate(ctx context.Context, dbtx repo.DBTX, event LogAccessMemberRoleUpdateEvent) error {
+func (l *Logger) LogAccessMemberRoleUpdate(ctx context.Context, dbtx repo.DBTX, event LogAccessMemberRoleUpdateEvent) error {
 	action := ActionAccessMemberRoleUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.MemberSnapshotBefore)

--- a/server/internal/audit/assets.go
+++ b/server/internal/audit/assets.go
@@ -27,7 +27,7 @@ type LogAssetCreateEvent struct {
 	AssetName string
 }
 
-func LogAssetCreate(ctx context.Context, dbtx repo.DBTX, event LogAssetCreateEvent) error {
+func (l *Logger) LogAssetCreate(ctx context.Context, dbtx repo.DBTX, event LogAssetCreateEvent) error {
 	action := ActionAssetCreate
 
 	metadata, err := marshalAuditPayload(map[string]any{

--- a/server/internal/audit/customdomains.go
+++ b/server/internal/audit/customdomains.go
@@ -69,7 +69,7 @@ type LogCustomDomainDeleteEvent struct {
 	DomainName      string
 }
 
-func LogCustomDomainDelete(ctx context.Context, dbtx repo.DBTX, event LogCustomDomainDeleteEvent) error {
+func (l *Logger) LogCustomDomainDelete(ctx context.Context, dbtx repo.DBTX, event LogCustomDomainDeleteEvent) error {
 	action := ActionCustomDomainsDelete
 
 	entry := repo.InsertAuditLogParams{

--- a/server/internal/audit/customdomains.go
+++ b/server/internal/audit/customdomains.go
@@ -27,7 +27,7 @@ type LogCustomDomainCreateEvent struct {
 	DomainName      string
 }
 
-func LogCustomDomainCreate(ctx context.Context, dbtx repo.DBTX, event LogCustomDomainCreateEvent) error {
+func (l *Logger) LogCustomDomainCreate(ctx context.Context, dbtx repo.DBTX, event LogCustomDomainCreateEvent) error {
 	action := ActionCustomDomainsCreate
 
 	entry := repo.InsertAuditLogParams{

--- a/server/internal/audit/deployments.go
+++ b/server/internal/audit/deployments.go
@@ -29,7 +29,7 @@ type LogDeploymentCreateEvent struct {
 	DeploymentURN urn.Deployment
 }
 
-func LogDeploymentCreate(ctx context.Context, dbtx repo.DBTX, event LogDeploymentCreateEvent) error {
+func (l *Logger) LogDeploymentCreate(ctx context.Context, dbtx repo.DBTX, event LogDeploymentCreateEvent) error {
 	action := ActionDeploymentsCreate
 
 	entry := repo.InsertAuditLogParams{
@@ -74,7 +74,7 @@ type LogDeploymentEvolveEvent struct {
 	Current  *types.Deployment
 }
 
-func LogDeploymentEvolve(ctx context.Context, dbtx repo.DBTX, event LogDeploymentEvolveEvent) error {
+func (l *Logger) LogDeploymentEvolve(ctx context.Context, dbtx repo.DBTX, event LogDeploymentEvolveEvent) error {
 	action := ActionDeploymentsEvolve
 
 	var beforePayload any
@@ -132,7 +132,7 @@ type LogDeploymentRedeployEvent struct {
 	SourceDeploymentURN urn.Deployment
 }
 
-func LogDeploymentRedeploy(ctx context.Context, dbtx repo.DBTX, event LogDeploymentRedeployEvent) error {
+func (l *Logger) LogDeploymentRedeploy(ctx context.Context, dbtx repo.DBTX, event LogDeploymentRedeployEvent) error {
 	action := ActionDeploymentsRedeploy
 
 	metadata, err := marshalAuditPayload(map[string]any{

--- a/server/internal/audit/environments.go
+++ b/server/internal/audit/environments.go
@@ -31,7 +31,7 @@ type LogEnvironmentCreateEvent struct {
 	EnvironmentSlug string
 }
 
-func LogEnvironmentCreate(ctx context.Context, dbtx repo.DBTX, event LogEnvironmentCreateEvent) error {
+func (l *Logger) LogEnvironmentCreate(ctx context.Context, dbtx repo.DBTX, event LogEnvironmentCreateEvent) error {
 	action := ActionEnvironmentCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -76,7 +76,7 @@ type LogEnvironmentUpdateEvent struct {
 	EnvironmentSnapshotAfter  *types.Environment
 }
 
-func LogEnvironmentUpdate(ctx context.Context, dbtx repo.DBTX, event LogEnvironmentUpdateEvent) error {
+func (l *Logger) LogEnvironmentUpdate(ctx context.Context, dbtx repo.DBTX, event LogEnvironmentUpdateEvent) error {
 	action := ActionEnvironmentUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.EnvironmentSnapshotBefore)
@@ -130,7 +130,7 @@ type LogEnvironmentDeleteEvent struct {
 	EnvironmentSlug string
 }
 
-func LogEnvironmentDelete(ctx context.Context, dbtx repo.DBTX, event LogEnvironmentDeleteEvent) error {
+func (l *Logger) LogEnvironmentDelete(ctx context.Context, dbtx repo.DBTX, event LogEnvironmentDeleteEvent) error {
 	action := ActionEnvironmentDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,

--- a/server/internal/audit/keys.go
+++ b/server/internal/audit/keys.go
@@ -30,7 +30,7 @@ type LogKeyCreateEvent struct {
 	Scopes []string
 }
 
-func LogKeyCreate(ctx context.Context, dbtx repo.DBTX, event LogKeyCreateEvent) error {
+func (l *Logger) LogKeyCreate(ctx context.Context, dbtx repo.DBTX, event LogKeyCreateEvent) error {
 	action := ActionKeyCreate
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -81,7 +81,7 @@ type LogKeyRevokeEvent struct {
 	Scopes []string
 }
 
-func LogKeyRevoke(ctx context.Context, dbtx repo.DBTX, event LogKeyRevokeEvent) error {
+func (l *Logger) LogKeyRevoke(ctx context.Context, dbtx repo.DBTX, event LogKeyRevokeEvent) error {
 	action := ActionKeyRevoke
 
 	metadata, err := marshalAuditPayload(map[string]any{

--- a/server/internal/audit/logger.go
+++ b/server/internal/audit/logger.go
@@ -1,0 +1,8 @@
+package audit
+
+type Logger struct {
+}
+
+func NewLogger() *Logger {
+	return &Logger{}
+}

--- a/server/internal/audit/mcpendpoints.go
+++ b/server/internal/audit/mcpendpoints.go
@@ -30,7 +30,7 @@ type LogMcpEndpointCreateEvent struct {
 	Slug           string
 }
 
-func LogMcpEndpointCreate(ctx context.Context, dbtx repo.DBTX, event LogMcpEndpointCreateEvent) error {
+func (l *Logger) LogMcpEndpointCreate(ctx context.Context, dbtx repo.DBTX, event LogMcpEndpointCreateEvent) error {
 	action := ActionMcpEndpointCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -74,7 +74,7 @@ type LogMcpEndpointUpdateEvent struct {
 	McpEndpointSnapshotAfter  *types.McpEndpoint
 }
 
-func LogMcpEndpointUpdate(ctx context.Context, dbtx repo.DBTX, event LogMcpEndpointUpdateEvent) error {
+func (l *Logger) LogMcpEndpointUpdate(ctx context.Context, dbtx repo.DBTX, event LogMcpEndpointUpdateEvent) error {
 	action := ActionMcpEndpointUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.McpEndpointSnapshotBefore)
@@ -127,7 +127,7 @@ type LogMcpEndpointDeleteEvent struct {
 	Slug           string
 }
 
-func LogMcpEndpointDelete(ctx context.Context, dbtx repo.DBTX, event LogMcpEndpointDeleteEvent) error {
+func (l *Logger) LogMcpEndpointDelete(ctx context.Context, dbtx repo.DBTX, event LogMcpEndpointDeleteEvent) error {
 	action := ActionMcpEndpointDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,

--- a/server/internal/audit/mcpmetadata.go
+++ b/server/internal/audit/mcpmetadata.go
@@ -32,7 +32,7 @@ type LogMCPMetadataUpdateEvent struct {
 	MCPMetadataSnapshotAfter  *types.McpMetadata
 }
 
-func LogMCPMetadataUpdate(ctx context.Context, dbtx repo.DBTX, event LogMCPMetadataUpdateEvent) error {
+func (l *Logger) LogMCPMetadataUpdate(ctx context.Context, dbtx repo.DBTX, event LogMCPMetadataUpdateEvent) error {
 	action := ActionMCPMetadataUpdate
 
 	var beforePayload any

--- a/server/internal/audit/mcpservers.go
+++ b/server/internal/audit/mcpservers.go
@@ -29,7 +29,7 @@ type LogMcpServerCreateEvent struct {
 	McpServerURN urn.McpServer
 }
 
-func LogMcpServerCreate(ctx context.Context, dbtx repo.DBTX, event LogMcpServerCreateEvent) error {
+func (l *Logger) LogMcpServerCreate(ctx context.Context, dbtx repo.DBTX, event LogMcpServerCreateEvent) error {
 	action := ActionMcpServerCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -72,7 +72,7 @@ type LogMcpServerUpdateEvent struct {
 	McpServerSnapshotAfter  *types.McpServer
 }
 
-func LogMcpServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogMcpServerUpdateEvent) error {
+func (l *Logger) LogMcpServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogMcpServerUpdateEvent) error {
 	action := ActionMcpServerUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.McpServerSnapshotBefore)
@@ -124,7 +124,7 @@ type LogMcpServerDeleteEvent struct {
 	McpServerURN urn.McpServer
 }
 
-func LogMcpServerDelete(ctx context.Context, dbtx repo.DBTX, event LogMcpServerDeleteEvent) error {
+func (l *Logger) LogMcpServerDelete(ctx context.Context, dbtx repo.DBTX, event LogMcpServerDeleteEvent) error {
 	action := ActionMcpServerDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,

--- a/server/internal/audit/plugins.go
+++ b/server/internal/audit/plugins.go
@@ -43,7 +43,7 @@ type LogPluginCreateEvent struct {
 	PluginSlug string
 }
 
-func LogPluginCreate(ctx context.Context, dbtx repo.DBTX, event LogPluginCreateEvent) error {
+func (l *Logger) LogPluginCreate(ctx context.Context, dbtx repo.DBTX, event LogPluginCreateEvent) error {
 	action := ActionPluginCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -88,7 +88,7 @@ type LogPluginUpdateEvent struct {
 	SnapshotAfter  *PluginSnapshot
 }
 
-func LogPluginUpdate(ctx context.Context, dbtx repo.DBTX, event LogPluginUpdateEvent) error {
+func (l *Logger) LogPluginUpdate(ctx context.Context, dbtx repo.DBTX, event LogPluginUpdateEvent) error {
 	action := ActionPluginUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.SnapshotBefore)
@@ -142,7 +142,7 @@ type LogPluginDeleteEvent struct {
 	PluginSlug string
 }
 
-func LogPluginDelete(ctx context.Context, dbtx repo.DBTX, event LogPluginDeleteEvent) error {
+func (l *Logger) LogPluginDelete(ctx context.Context, dbtx repo.DBTX, event LogPluginDeleteEvent) error {
 	action := ActionPluginDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -191,7 +191,7 @@ type LogPluginServerAddEvent struct {
 	ToolsetURN        urn.Toolset
 }
 
-func LogPluginServerAdd(ctx context.Context, dbtx repo.DBTX, event LogPluginServerAddEvent) error {
+func (l *Logger) LogPluginServerAdd(ctx context.Context, dbtx repo.DBTX, event LogPluginServerAddEvent) error {
 	action := ActionPluginServerAdd
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -251,7 +251,7 @@ type LogPluginServerUpdateEvent struct {
 	ServerSortOrder   int32
 }
 
-func LogPluginServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogPluginServerUpdateEvent) error {
+func (l *Logger) LogPluginServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogPluginServerUpdateEvent) error {
 	action := ActionPluginServerUpdate
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -307,7 +307,7 @@ type LogPluginServerRemoveEvent struct {
 	ServerID uuid.UUID //nolint:glint // TODO(AGE-1954): introduce urn.PluginServer and migrate to ServerURN; pending team discussion
 }
 
-func LogPluginServerRemove(ctx context.Context, dbtx repo.DBTX, event LogPluginServerRemoveEvent) error {
+func (l *Logger) LogPluginServerRemove(ctx context.Context, dbtx repo.DBTX, event LogPluginServerRemoveEvent) error {
 	action := ActionPluginServerRemove
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -360,7 +360,7 @@ type LogPluginAssignmentsSetEvent struct {
 	PrincipalURNs []string
 }
 
-func LogPluginAssignmentsSet(ctx context.Context, dbtx repo.DBTX, event LogPluginAssignmentsSetEvent) error {
+func (l *Logger) LogPluginAssignmentsSet(ctx context.Context, dbtx repo.DBTX, event LogPluginAssignmentsSetEvent) error {
 	action := ActionPluginAssignmentsSet
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -417,7 +417,7 @@ type LogPluginPublishEvent struct {
 	RepoName    string
 }
 
-func LogPluginPublish(ctx context.Context, dbtx repo.DBTX, event LogPluginPublishEvent) error {
+func (l *Logger) LogPluginPublish(ctx context.Context, dbtx repo.DBTX, event LogPluginPublishEvent) error {
 	action := ActionPluginPublish
 
 	metadata, err := marshalAuditPayload(map[string]any{

--- a/server/internal/audit/projects.go
+++ b/server/internal/audit/projects.go
@@ -30,7 +30,7 @@ type LogProjectCreateEvent struct {
 	ProjectSlug string
 }
 
-func LogProjectCreate(ctx context.Context, dbtx repo.DBTX, event LogProjectCreateEvent) error {
+func (l *Logger) LogProjectCreate(ctx context.Context, dbtx repo.DBTX, event LogProjectCreateEvent) error {
 	action := ActionProjectCreate
 
 	entry := repo.InsertAuditLogParams{
@@ -75,7 +75,7 @@ type LogProjectUpdateEvent struct {
 	ProjectSnapshotAfter  *gen.Project
 }
 
-func LogProjectUpdate(ctx context.Context, dbtx repo.DBTX, event LogProjectUpdateEvent) error {
+func (l *Logger) LogProjectUpdate(ctx context.Context, dbtx repo.DBTX, event LogProjectUpdateEvent) error {
 	action := ActionProjectUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.ProjectSnapshotBefore)
@@ -127,7 +127,7 @@ type LogProjectDeleteEvent struct {
 	ProjectSlug string
 }
 
-func LogProjectDelete(ctx context.Context, dbtx repo.DBTX, event LogProjectDeleteEvent) error {
+func (l *Logger) LogProjectDelete(ctx context.Context, dbtx repo.DBTX, event LogProjectDeleteEvent) error {
 	action := ActionProjectDelete
 
 	entry := repo.InsertAuditLogParams{

--- a/server/internal/audit/remotemcpservers.go
+++ b/server/internal/audit/remotemcpservers.go
@@ -30,7 +30,7 @@ type LogRemoteMcpServerCreateEvent struct {
 	RemoteMcpServerURL string
 }
 
-func LogRemoteMcpServerCreate(ctx context.Context, dbtx repo.DBTX, event LogRemoteMcpServerCreateEvent) error {
+func (l *Logger) LogRemoteMcpServerCreate(ctx context.Context, dbtx repo.DBTX, event LogRemoteMcpServerCreateEvent) error {
 	action := ActionRemoteMcpServerCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -74,7 +74,7 @@ type LogRemoteMcpServerUpdateEvent struct {
 	SnapshotAfter      *types.RemoteMcpServer
 }
 
-func LogRemoteMcpServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogRemoteMcpServerUpdateEvent) error {
+func (l *Logger) LogRemoteMcpServerUpdate(ctx context.Context, dbtx repo.DBTX, event LogRemoteMcpServerUpdateEvent) error {
 	action := ActionRemoteMcpServerUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.SnapshotBefore)
@@ -127,7 +127,7 @@ type LogRemoteMcpServerDeleteEvent struct {
 	RemoteMcpServerURL string
 }
 
-func LogRemoteMcpServerDelete(ctx context.Context, dbtx repo.DBTX, event LogRemoteMcpServerDeleteEvent) error {
+func (l *Logger) LogRemoteMcpServerDelete(ctx context.Context, dbtx repo.DBTX, event LogRemoteMcpServerDeleteEvent) error {
 	action := ActionRemoteMcpServerDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,

--- a/server/internal/audit/risk.go
+++ b/server/internal/audit/risk.go
@@ -31,7 +31,7 @@ type LogRiskPolicyCreateEvent struct {
 	RiskPolicyName string
 }
 
-func LogRiskPolicyCreate(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyCreateEvent) error {
+func (l *Logger) LogRiskPolicyCreate(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyCreateEvent) error {
 	action := ActionRiskPolicyCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -76,7 +76,7 @@ type LogRiskPolicyUpdateEvent struct {
 	SnapshotAfter  *types.RiskPolicy
 }
 
-func LogRiskPolicyUpdate(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyUpdateEvent) error {
+func (l *Logger) LogRiskPolicyUpdate(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyUpdateEvent) error {
 	action := ActionRiskPolicyUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.SnapshotBefore)
@@ -129,7 +129,7 @@ type LogRiskPolicyDeleteEvent struct {
 	RiskPolicyName string
 }
 
-func LogRiskPolicyDelete(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyDeleteEvent) error {
+func (l *Logger) LogRiskPolicyDelete(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyDeleteEvent) error {
 	action := ActionRiskPolicyDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -171,7 +171,7 @@ type LogRiskPolicyTriggerEvent struct {
 	RiskPolicyName string
 }
 
-func LogRiskPolicyTrigger(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyTriggerEvent) error {
+func (l *Logger) LogRiskPolicyTrigger(ctx context.Context, dbtx repo.DBTX, event LogRiskPolicyTriggerEvent) error {
 	action := ActionRiskPolicyTrigger
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,

--- a/server/internal/audit/templates.go
+++ b/server/internal/audit/templates.go
@@ -29,7 +29,7 @@ type LogTemplateCreateEvent struct {
 	TemplateName string
 }
 
-func LogTemplateCreate(ctx context.Context, dbtx repo.DBTX, event LogTemplateCreateEvent) error {
+func (l *Logger) LogTemplateCreate(ctx context.Context, dbtx repo.DBTX, event LogTemplateCreateEvent) error {
 	action := ActionTemplateCreate
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -79,7 +79,7 @@ type LogTemplateUpdateEvent struct {
 	TemplateName string
 }
 
-func LogTemplateUpdate(ctx context.Context, dbtx repo.DBTX, event LogTemplateUpdateEvent) error {
+func (l *Logger) LogTemplateUpdate(ctx context.Context, dbtx repo.DBTX, event LogTemplateUpdateEvent) error {
 	action := ActionTemplateUpdate
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -129,7 +129,7 @@ type LogTemplateDeleteEvent struct {
 	TemplateName string
 }
 
-func LogTemplateDelete(ctx context.Context, dbtx repo.DBTX, event LogTemplateDeleteEvent) error {
+func (l *Logger) LogTemplateDelete(ctx context.Context, dbtx repo.DBTX, event LogTemplateDeleteEvent) error {
 	action := ActionTemplateDelete
 
 	metadata, err := marshalAuditPayload(map[string]any{

--- a/server/internal/audit/toolsets.go
+++ b/server/internal/audit/toolsets.go
@@ -36,7 +36,7 @@ type LogToolsetCreateEvent struct {
 	ToolsetSlug string
 }
 
-func LogToolsetCreate(ctx context.Context, dbtx repo.DBTX, event LogToolsetCreateEvent) error {
+func (l *Logger) LogToolsetCreate(ctx context.Context, dbtx repo.DBTX, event LogToolsetCreateEvent) error {
 	action := ActionToolsetCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -82,7 +82,7 @@ type LogToolsetUpdateEvent struct {
 	ToolsetSnapshotAfter  *types.Toolset
 }
 
-func LogToolsetUpdate(ctx context.Context, dbtx repo.DBTX, event LogToolsetUpdateEvent) error {
+func (l *Logger) LogToolsetUpdate(ctx context.Context, dbtx repo.DBTX, event LogToolsetUpdateEvent) error {
 	action := ActionToolsetUpdate
 
 	// Clone snapshots and strip the Tools field to avoid serializing a potentially massive list of tools into the audit log.
@@ -156,7 +156,7 @@ type LogToolsetDeleteEvent struct {
 	ToolsetSlug string
 }
 
-func LogToolsetDelete(ctx context.Context, dbtx repo.DBTX, event LogToolsetDeleteEvent) error {
+func (l *Logger) LogToolsetDelete(ctx context.Context, dbtx repo.DBTX, event LogToolsetDeleteEvent) error {
 	action := ActionToolsetDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -203,7 +203,7 @@ type LogToolsetAttachExternalOAuthEvent struct {
 	ExternalOAuthServerSlug string
 }
 
-func LogToolsetAttachExternalOAuth(ctx context.Context, dbtx repo.DBTX, event LogToolsetAttachExternalOAuthEvent) error {
+func (l *Logger) LogToolsetAttachExternalOAuth(ctx context.Context, dbtx repo.DBTX, event LogToolsetAttachExternalOAuthEvent) error {
 	action := ActionToolsetAttachExternalOAuth
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -260,7 +260,7 @@ type LogToolsetDetachExternalOAuthEvent struct {
 	ExternalOAuthServerSlug *string
 }
 
-func LogToolsetDetachExternalOAuth(ctx context.Context, dbtx repo.DBTX, event LogToolsetDetachExternalOAuthEvent) error {
+func (l *Logger) LogToolsetDetachExternalOAuth(ctx context.Context, dbtx repo.DBTX, event LogToolsetDetachExternalOAuthEvent) error {
 	action := ActionToolsetDetachExternalOAuth
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -317,7 +317,7 @@ type LogToolsetAttachOAuthProxyEvent struct {
 	OAuthProxyServerSlug string
 }
 
-func LogToolsetAttachOAuthProxy(ctx context.Context, dbtx repo.DBTX, event LogToolsetAttachOAuthProxyEvent) error {
+func (l *Logger) LogToolsetAttachOAuthProxy(ctx context.Context, dbtx repo.DBTX, event LogToolsetAttachOAuthProxyEvent) error {
 	action := ActionToolsetAttachOAuthProxy
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -374,7 +374,7 @@ type LogToolsetDetachOAuthProxyEvent struct {
 	OAuthProxyServerSlug *string
 }
 
-func LogToolsetDetachOAuthProxy(ctx context.Context, dbtx repo.DBTX, event LogToolsetDetachOAuthProxyEvent) error {
+func (l *Logger) LogToolsetDetachOAuthProxy(ctx context.Context, dbtx repo.DBTX, event LogToolsetDetachOAuthProxyEvent) error {
 	action := ActionToolsetDetachOAuthProxy
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -434,7 +434,7 @@ type LogToolsetUpdateOAuthProxyEvent struct {
 	ToolsetSnapshotAfter  *types.Toolset
 }
 
-func LogToolsetUpdateOAuthProxy(ctx context.Context, dbtx repo.DBTX, event LogToolsetUpdateOAuthProxyEvent) error {
+func (l *Logger) LogToolsetUpdateOAuthProxy(ctx context.Context, dbtx repo.DBTX, event LogToolsetUpdateOAuthProxyEvent) error {
 	action := ActionToolsetUpdateOAuthProxy
 
 	// Clone snapshots and strip the Tools field to avoid serializing a potentially massive list of tools into the audit log.

--- a/server/internal/audit/triggerinstances.go
+++ b/server/internal/audit/triggerinstances.go
@@ -33,7 +33,7 @@ type LogTriggerInstanceCreateEvent struct {
 	DefinitionSlug     string
 }
 
-func LogTriggerInstanceCreate(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceCreateEvent) error {
+func (l *Logger) LogTriggerInstanceCreate(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceCreateEvent) error {
 	action := ActionTriggerInstanceCreate
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -78,7 +78,7 @@ type LogTriggerInstanceUpdateEvent struct {
 	TriggerInstanceSnapshotAfter  *types.TriggerInstance
 }
 
-func LogTriggerInstanceUpdate(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceUpdateEvent) error {
+func (l *Logger) LogTriggerInstanceUpdate(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceUpdateEvent) error {
 	action := ActionTriggerInstanceUpdate
 
 	beforeSnapshot, err := marshalAuditPayload(event.TriggerInstanceSnapshotBefore)
@@ -132,7 +132,7 @@ type LogTriggerInstanceDeleteEvent struct {
 	DefinitionSlug     string
 }
 
-func LogTriggerInstanceDelete(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceDeleteEvent) error {
+func (l *Logger) LogTriggerInstanceDelete(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceDeleteEvent) error {
 	action := ActionTriggerInstanceDelete
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -175,7 +175,7 @@ type LogTriggerInstancePauseEvent struct {
 	DefinitionSlug     string
 }
 
-func LogTriggerInstancePause(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstancePauseEvent) error {
+func (l *Logger) LogTriggerInstancePause(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstancePauseEvent) error {
 	action := ActionTriggerInstancePause
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,
@@ -218,7 +218,7 @@ type LogTriggerInstanceResumeEvent struct {
 	DefinitionSlug     string
 }
 
-func LogTriggerInstanceResume(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceResumeEvent) error {
+func (l *Logger) LogTriggerInstanceResume(ctx context.Context, dbtx repo.DBTX, event LogTriggerInstanceResumeEvent) error {
 	action := ActionTriggerInstanceResume
 	entry := repo.InsertAuditLogParams{
 		OrganizationID: event.OrganizationID,

--- a/server/internal/audit/variations.go
+++ b/server/internal/audit/variations.go
@@ -32,7 +32,7 @@ type LogVariationUpdateGlobalEvent struct {
 	VariationSnapshotAfter  *types.ToolVariation
 }
 
-func LogVariationUpdateGlobal(ctx context.Context, dbtx repo.DBTX, event LogVariationUpdateGlobalEvent) error {
+func (l *Logger) LogVariationUpdateGlobal(ctx context.Context, dbtx repo.DBTX, event LogVariationUpdateGlobalEvent) error {
 	action := ActionVariationUpdateGlobal
 
 	metadata, err := marshalAuditPayload(map[string]any{
@@ -91,7 +91,7 @@ type LogVariationDeleteGlobalEvent struct {
 	SourceToolURN urn.Tool
 }
 
-func LogVariationDeleteGlobal(ctx context.Context, dbtx repo.DBTX, event LogVariationDeleteGlobalEvent) error {
+func (l *Logger) LogVariationDeleteGlobal(ctx context.Context, dbtx repo.DBTX, event LogVariationDeleteGlobalEvent) error {
 	action := ActionVariationDeleteGlobal
 
 	metadata, err := marshalAuditPayload(map[string]any{

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assistants"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	resolution_activities "github.com/speakeasy-api/gram/server/internal/background/activities/chat_resolutions"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
@@ -101,6 +102,7 @@ func NewActivities(
 	assistantsCore *assistants.ServiceCore,
 	piiScanner risk_analysis.PIIScanner,
 	shadowMCPClient *shadowmcp.Client,
+	auditLogger *audit.Logger,
 ) *Activities {
 	usageTrackingStrategy := chat.NewDefaultUsageTrackingStrategy(db, logger, openrouterProvisioner, billingTracker, nil)
 
@@ -123,7 +125,7 @@ func NewActivities(
 		slackChatCompletion:           activities.NewSlackChatCompletionActivity(logger, slackClient, chatClient),
 		transitionDeployment:          activities.NewTransitionDeployment(logger, db),
 		validateDeployment:            activities.NewValidateDeployment(logger, db, billingRepo),
-		verifyCustomDomain:            activities.NewVerifyCustomDomain(logger, db, expectedTargetCNAME),
+		verifyCustomDomain:            activities.NewVerifyCustomDomain(logger, db, auditLogger, expectedTargetCNAME),
 		generateToolsetEmbeddings:     activities.NewGenerateToolsetEmbeddingsActivity(tracerProvider, db, ragService, logger),
 		dispatchTrigger:               activities.NewDispatchTrigger(triggerApp),
 		processScheduledTrigger:       activities.NewProcessScheduledTrigger(triggerApp),

--- a/server/internal/background/activities/verify_custom_domain.go
+++ b/server/internal/background/activities/verify_custom_domain.go
@@ -26,15 +26,17 @@ type VerifyCustomDomain struct {
 	db                  *pgxpool.Pool
 	logger              *slog.Logger
 	expectedTargetCNAME string
+	audit               *audit.Logger
 	resolver            dns.Resolver
 }
 
-func NewVerifyCustomDomain(logger *slog.Logger, db *pgxpool.Pool, expectedTargetCNAME string) *VerifyCustomDomain {
+func NewVerifyCustomDomain(logger *slog.Logger, db *pgxpool.Pool, auditLogger *audit.Logger, expectedTargetCNAME string) *VerifyCustomDomain {
 	return &VerifyCustomDomain{
 		db:                  db,
 		logger:              logger,
 		expectedTargetCNAME: expectedTargetCNAME,
 		resolver:            dns.NewNetResolver(),
+		audit:               auditLogger,
 	}
 }
 
@@ -89,7 +91,7 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 			return oops.E(oops.CodeUnexpected, err, "error creating custom domain").Log(ctx, d.logger)
 		}
 
-		if err := audit.LogCustomDomainCreate(ctx, dbtx, audit.LogCustomDomainCreateEvent{
+		if err := d.audit.LogCustomDomainCreate(ctx, dbtx, audit.LogCustomDomainCreateEvent{
 			OrganizationID:   args.OrgID,
 			Actor:            args.CreatedBy,
 			ActorDisplayName: args.CreatedByName,

--- a/server/internal/background/activities/verify_custom_domain_test.go
+++ b/server/internal/background/activities/verify_custom_domain_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	customdomainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/dns"
@@ -53,7 +54,7 @@ func newActivity(t *testing.T, ti *testInstance) *activities.VerifyCustomDomain 
 	t.Helper()
 
 	logger := testenv.NewLogger(t)
-	activity := activities.NewVerifyCustomDomain(logger, ti.conn, testTargetCNAME)
+	activity := activities.NewVerifyCustomDomain(logger, ti.conn, audit.NewLogger(), testTargetCNAME)
 	activity.SetResolver(ti.resolver)
 
 	return activity

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assistants"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/background/interceptors"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
@@ -64,6 +65,7 @@ type WorkerOptions struct {
 	TemporalEnv         *tenv.Environment
 	PIIScanner          risk_analysis.PIIScanner
 	ShadowMCPClient     *shadowmcp.Client
+	AuditLogger         *audit.Logger
 }
 
 func ForDeploymentProcessing(
@@ -74,6 +76,7 @@ func ForDeploymentProcessing(
 	enc *encryption.Client,
 	deployer functions.Deployer,
 	mcpRegistryClient *externalmcp.RegistryClient,
+	auditLogger *audit.Logger,
 ) *WorkerOptions {
 	return &WorkerOptions{
 		DB:                  db,
@@ -84,6 +87,7 @@ func ForDeploymentProcessing(
 		FunctionsDeployer:   deployer,
 		FunctionsVersion:    "local", // Test deployers don't use baked versions
 		MCPRegistryClient:   mcpRegistryClient,
+		AuditLogger:         auditLogger,
 		SlackClient:         nil,
 		ChatClient:          nil,
 		OpenRouter:          nil,
@@ -137,6 +141,7 @@ func NewTemporalWorker(
 		TemporalEnv:         env,
 		PIIScanner:          nil,
 		ShadowMCPClient:     nil,
+		AuditLogger:         nil,
 	}
 
 	for _, o := range options {
@@ -166,6 +171,7 @@ func NewTemporalWorker(
 			TemporalEnv:         conv.Default(o.TemporalEnv, opts.TemporalEnv),
 			PIIScanner:          conv.Default(o.PIIScanner, opts.PIIScanner),
 			ShadowMCPClient:     conv.Default(o.ShadowMCPClient, opts.ShadowMCPClient),
+			AuditLogger:         conv.Default(o.AuditLogger, opts.AuditLogger),
 		}
 	}
 
@@ -205,6 +211,7 @@ func NewTemporalWorker(
 		opts.AssistantsCore,
 		opts.PIIScanner,
 		opts.ShadowMCPClient,
+		opts.AuditLogger,
 	)
 
 	temporalWorker.RegisterActivity(activities.ProcessDeployment)

--- a/server/internal/collections/setup_test.go
+++ b/server/internal/collections/setup_test.go
@@ -12,6 +12,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/collections"
 	tgen "github.com/speakeasy-api/gram/server/gen/toolsets"
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -80,9 +81,10 @@ func newTestCollectionsService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
+	auditLogger := audit.NewLogger()
 
 	svc := collections.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, testenv.DefaultSiteURL(t))
-	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine)
+	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/customdomains/impl.go
+++ b/server/internal/customdomains/impl.go
@@ -35,6 +35,7 @@ type Service struct {
 	auth           *auth.Auth
 	authz          *authz.Engine
 	temporalClient TemporalClient
+	audit          *audit.Logger
 }
 
 type TemporalClient interface {
@@ -45,7 +46,15 @@ type TemporalClient interface {
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, temporal TemporalClient, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	temporal TemporalClient,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("custom_domains"))
 
 	return &Service{
@@ -55,6 +64,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		auth:           auth.New(logger, db, sessions, authzEngine),
 		authz:          authzEngine,
 		temporalClient: temporal,
+		audit:          auditLogger,
 	}
 }
 
@@ -168,7 +178,7 @@ func (s *Service) DeleteDomain(ctx context.Context, _ *gen.DeleteDomainPayload) 
 		return oops.E(oops.CodeUnexpected, err, "failed to delete custom domain").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogCustomDomainDelete(ctx, dbtx, audit.LogCustomDomainDeleteEvent{
+	if err := s.audit.LogCustomDomainDelete(ctx, dbtx, audit.LogCustomDomainDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
 		ActorDisplayName: authCtx.Email,

--- a/server/internal/customdomains/setup_test.go
+++ b/server/internal/customdomains/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -84,7 +85,8 @@ func newTestCustomDomainsService(t *testing.T) (context.Context, *serviceTestIns
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := customdomains.NewService(logger, tracerProvider, conn, sessionManager, temporal, authzEngine)
+	auditLogger := audit.NewLogger()
+	svc := customdomains.NewService(logger, tracerProvider, conn, sessionManager, temporal, authzEngine, auditLogger)
 
 	return ctx, &serviceTestInstance{service: svc, conn: conn, sessionManager: sessionManager, temporal: temporal, repo: cdrepo.New(conn)}
 }

--- a/server/internal/deployments/impl.go
+++ b/server/internal/deployments/impl.go
@@ -62,6 +62,7 @@ type Service struct {
 	temporalEnv    *temporal.Environment
 	posthog        *posthog.Posthog
 	siteURL        *url.URL
+	audit          *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -78,6 +79,7 @@ func NewService(
 	siteURL *url.URL,
 	mcpRegistryClient *externalmcp.RegistryClient,
 	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("deployments"))
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/deployments")
@@ -97,6 +99,7 @@ func NewService(
 		posthog:        posthog,
 		siteURL:        siteURL,
 		registryClient: mcpRegistryClient,
+		audit:          auditLogger,
 		Service:        annotations.Service[gen.Service, gen.Auther]{},
 	}
 }
@@ -519,7 +522,7 @@ func (s *Service) CreateDeployment(ctx context.Context, form *gen.CreateDeployme
 		return nil, err
 	}
 
-	if err := audit.LogDeploymentCreate(ctx, dbtx, audit.LogDeploymentCreateEvent{
+	if err := s.audit.LogDeploymentCreate(ctx, dbtx, audit.LogDeploymentCreateEvent{
 		OrganizationID:   organizationID,
 		ProjectID:        projectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -782,7 +785,7 @@ func (s *Service) Evolve(ctx context.Context, form *gen.EvolvePayload) (*gen.Evo
 		return nil, err
 	}
 
-	if err := audit.LogDeploymentEvolve(ctx, dbtx, audit.LogDeploymentEvolveEvent{
+	if err := s.audit.LogDeploymentEvolve(ctx, dbtx, audit.LogDeploymentEvolveEvent{
 		OrganizationID: organizationID,
 		ProjectID:      projectID,
 
@@ -893,7 +896,7 @@ func (s *Service) Redeploy(ctx context.Context, payload *gen.RedeployPayload) (*
 		return nil, err
 	}
 
-	if err := audit.LogDeploymentRedeploy(ctx, dbtx, audit.LogDeploymentRedeployEvent{
+	if err := s.audit.LogDeploymentRedeploy(ctx, dbtx, audit.LogDeploymentRedeployEvent{
 		OrganizationID: organizationID,
 		ProjectID:      projectID,
 

--- a/server/internal/deployments/setup_test.go
+++ b/server/internal/deployments/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/assets"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -79,11 +80,11 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	enc := testenv.NewEncryptionClient(t)
 	funcs := functionstest.NewOrchestrator(t, assetStorage)
 	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
-
+	temporalEnv, _ := infra.NewTemporalEnv(t)
+	auditLogger := audit.NewLogger()
 	f := &feature.InMemory{}
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient, auditLogger))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -106,8 +107,8 @@ func newTestDeploymentService(t *testing.T, assetStorage assets.BlobStore) (cont
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine)
-	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine)
+	svc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine, auditLogger)
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine, auditLogger)
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, authzEngine)
 
 	return ctx, &testInstance{

--- a/server/internal/environments/impl.go
+++ b/server/internal/environments/impl.go
@@ -43,11 +43,19 @@ type Service struct {
 	auth    *auth.Auth
 	authz   *authz.Engine
 	entries *EnvironmentEntries
+	audit   *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, enc *encryption.Client, authz *authz.Engine) *Service {
+func NewService(logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	enc *encryption.Client,
+	authz *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("environments"))
 	envRepo := repo.New(db)
 	mcpMetadataRepo := mcpmetadata_repo.New(db)
@@ -60,6 +68,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		auth:    auth.New(logger, db, sessions, authz),
 		authz:   authz,
 		entries: NewEnvironmentEntries(logger, db, enc, mcpMetadataRepo),
+		audit:   auditLogger,
 	}
 }
 
@@ -134,7 +143,7 @@ func (s *Service) CreateEnvironment(ctx context.Context, payload *gen.CreateEnvi
 
 	environmentView := buildEnvironmentView(environment, rows)
 
-	if err := audit.LogEnvironmentCreate(ctx, dbtx, audit.LogEnvironmentCreateEvent{
+	if err := s.audit.LogEnvironmentCreate(ctx, dbtx, audit.LogEnvironmentCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -297,7 +306,7 @@ func (s *Service) UpdateEnvironment(ctx context.Context, payload *gen.UpdateEnvi
 
 	afterView := buildEnvironmentView(environment, entries)
 
-	if err := audit.LogEnvironmentUpdate(ctx, dbtx, audit.LogEnvironmentUpdateEvent{
+	if err := s.audit.LogEnvironmentUpdate(ctx, dbtx, audit.LogEnvironmentUpdateEvent{
 		OrganizationID:            authCtx.ActiveOrganizationID,
 		ProjectID:                 *authCtx.ProjectID,
 		Actor:                     urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -350,7 +359,7 @@ func (s *Service) DeleteEnvironment(ctx context.Context, payload *gen.DeleteEnvi
 		return oops.E(oops.CodeUnexpected, err, "failed to delete environment").Log(ctx, logger)
 	}
 
-	if err := audit.LogEnvironmentDelete(ctx, dbtx, audit.LogEnvironmentDeleteEvent{
+	if err := s.audit.LogEnvironmentDelete(ctx, dbtx, audit.LogEnvironmentDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/environments/setup_test.go
+++ b/server/internal/environments/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -75,9 +76,10 @@ func newTestEnvironmentService(t *testing.T) (context.Context, *testInstance) {
 
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
+	auditLogger := audit.NewLogger()
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := environments.NewService(logger, tracerProvider, conn, sessionManager, enc, authzEngine)
+	svc := environments.NewService(logger, tracerProvider, conn, sessionManager, enc, authzEngine, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/functions/setup_test.go
+++ b/server/internal/functions/setup_test.go
@@ -15,6 +15,7 @@ import (
 	dgen "github.com/speakeasy-api/gram/server/gen/deployments"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -90,9 +91,10 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 	funcs := functionstest.NewOrchestrator(t, assetStorage)
 	tigrisStore := assets.NewTigrisStore(assetStorage)
 	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
-
 	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	auditLogger := audit.NewLogger()
+
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient, auditLogger))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -116,8 +118,8 @@ func newTestFunctionsService(t *testing.T) (context.Context, *testInstance) {
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 	svc := functions.NewService(logger, tracerProvider, conn, enc, tigrisStore)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, ph, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine)
-	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine)
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, ph, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine, auditLogger)
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -72,7 +72,7 @@ func NewService(
 		authz:       authzEngine,
 		projectRepo: project_repo.New(db),
 		orgsRepo:    organizations_repo.New(db),
-		audit:       audit.NewLogger(),
+		audit:       auditLogger,
 		keyPrefix:   fullKeyPrefix,
 	}
 }

--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -45,12 +45,21 @@ type Service struct {
 	authz       *authz.Engine
 	projectRepo *project_repo.Queries
 	orgsRepo    *organizations_repo.Queries
+	audit       *audit.Logger
 	keyPrefix   string
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, env string, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	env string,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("keys"))
 
 	fullKeyPrefix := auth.APIKeyPrefix(env)
@@ -63,6 +72,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		authz:       authzEngine,
 		projectRepo: project_repo.New(db),
 		orgsRepo:    organizations_repo.New(db),
+		audit:       audit.NewLogger(),
 		keyPrefix:   fullKeyPrefix,
 	}
 }
@@ -148,7 +158,7 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 		return nil, oops.E(oops.CodeUnexpected, err, "error creating api key").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogKeyCreate(ctx, dbtx, audit.LogKeyCreateEvent{
+	if err := s.audit.LogKeyCreate(ctx, dbtx, audit.LogKeyCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        projectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -253,7 +263,7 @@ func (s *Service) RevokeKey(ctx context.Context, payload *gen.RevokeKeyPayload) 
 		return oops.E(oops.CodeUnexpected, err, "error revoking api key").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogKeyRevoke(ctx, dbtx, audit.LogKeyRevokeEvent{
+	if err := s.audit.LogKeyRevoke(ctx, dbtx, audit.LogKeyRevokeEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        deleted.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/keys/setup_test.go
+++ b/server/internal/keys/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -82,7 +83,8 @@ func newTestKeysService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := keys.NewService(logger, tracerProvider, conn, sessionManager, "local", authzEngine)
+	auditLogger := audit.NewLogger()
+	svc := keys.NewService(logger, tracerProvider, conn, sessionManager, "local", authzEngine, auditLogger)
 	keyAuth := auth.NewKeyAuth(conn, logger, billingClient)
 
 	return ctx, &testInstance{

--- a/server/internal/mcp/handle_get_server_test.go
+++ b/server/internal/mcp/handle_get_server_test.go
@@ -34,6 +34,7 @@ func TestHandleGetServer_ContentNegotiation(t *testing.T) {
 		testInstance.siteURL,
 		testInstance.cacheAdapter,
 		authz.NewEngine(testInstance.logger, testInstance.conn, chConn, nil, workos.NewStubClient(), cache.NoopCache),
+		testInstance.audit,
 	)
 
 	tests := []struct {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
@@ -145,6 +146,7 @@ func NewService(
 	authzEngine *authz.Engine,
 	assistantTokens *assistanttokens.Manager,
 	shadowMCPClient *shadowmcp.Client,
+	auditLogger *audit.Logger,
 ) *Service {
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcp")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcp")
@@ -154,6 +156,7 @@ func NewService(
 		logger,
 		db,
 		telemSvc,
+		auditLogger,
 		platformtoolsruntime.WithTriggerTools(triggerApp),
 		platformtoolsruntime.WithSlackHTTPClient(guardianPolicy.PooledClient()),
 	)

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
@@ -75,6 +76,7 @@ type testInstance struct {
 	cacheAdapter   cache.Cache
 	enc            *encryption.Client
 	authzEngine    *authz.Engine
+	audit          *audit.Logger
 }
 
 func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
@@ -148,7 +150,8 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	assistantTokens := assistanttokens.New("test-jwt-secret", conn, authzEngine)
 	_ = featClient
 	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter)
-	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient)
+	auditLogger := audit.NewLogger()
+	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,
@@ -161,13 +164,14 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 		cacheAdapter:   cacheAdapter,
 		enc:            enc,
 		authzEngine:    authzEngine,
+		audit:          auditLogger,
 	}
 }
 
 // createTestAPIKey creates an API key for the test context project
 func (ti *testInstance) createTestAPIKey(ctx context.Context, t *testing.T) string {
 	t.Helper()
-	keysService := keys.NewService(ti.logger, ti.tracerProvider, ti.conn, ti.sessionManager, "local", ti.authzEngine)
+	keysService := keys.NewService(ti.logger, ti.tracerProvider, ti.conn, ti.sessionManager, "local", ti.authzEngine, ti.audit)
 
 	key, err := keysService.CreateKey(ctx, &keys_gen.CreateKeyPayload{
 		Name:   "test-key",

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -42,12 +42,20 @@ type Service struct {
 	db     *pgxpool.Pool
 	auth   *auth.Auth
 	authz  *authz.Engine
+	audit  *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("mcpendpoints"))
 
 	return &Service{
@@ -56,6 +64,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		db:     db,
 		auth:   auth.New(logger, db, sessions, authzEngine),
 		authz:  authzEngine,
+		audit:  auditLogger,
 	}
 }
 
@@ -126,7 +135,7 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 		return nil, oops.E(oops.CodeUnexpected, err, "create mcp endpoint").Log(ctx, logger)
 	}
 
-	if err := audit.LogMcpEndpointCreate(ctx, dbtx, audit.LogMcpEndpointCreateEvent{
+	if err := s.audit.LogMcpEndpointCreate(ctx, dbtx, audit.LogMcpEndpointCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -322,7 +331,7 @@ func (s *Service) UpdateMcpEndpoint(ctx context.Context, payload *gen.UpdateMcpE
 
 	afterView := mv.BuildMcpEndpointView(updated)
 
-	if err := audit.LogMcpEndpointUpdate(ctx, dbtx, audit.LogMcpEndpointUpdateEvent{
+	if err := s.audit.LogMcpEndpointUpdate(ctx, dbtx, audit.LogMcpEndpointUpdateEvent{
 		OrganizationID:            authCtx.ActiveOrganizationID,
 		ProjectID:                 *authCtx.ProjectID,
 		Actor:                     urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -379,7 +388,7 @@ func (s *Service) DeleteMcpEndpoint(ctx context.Context, payload *gen.DeleteMcpE
 		return oops.E(oops.CodeUnexpected, err, "delete mcp endpoint").Log(ctx, logger)
 	}
 
-	if err := audit.LogMcpEndpointDelete(ctx, dbtx, audit.LogMcpEndpointDeleteEvent{
+	if err := s.audit.LogMcpEndpointDelete(ctx, dbtx, audit.LogMcpEndpointDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/mcpendpoints/setup_test.go
+++ b/server/internal/mcpendpoints/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -79,7 +80,9 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := mcpendpoints.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache))
+	auditLogger := audit.NewLogger()
+
+	svc := mcpendpoints.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -159,6 +159,7 @@ type Service struct {
 	serverURL    *url.URL
 	siteURL      *url.URL
 	toolsetCache cache.TypedCacheObject[mv.ToolsetBaseContents]
+	audit        *audit.Logger
 
 	// Hosted install page script (embedded and served with cache-busting hash)
 	installPageScriptHash string
@@ -168,7 +169,17 @@ type Service struct {
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, serverURL *url.URL, siteURL *url.URL, cacheAdapter cache.Cache, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	serverURL *url.URL,
+	siteURL *url.URL,
+	cacheAdapter cache.Cache,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("mcp_metadata"))
 
 	// Calculate content hash for install page script (for cache busting)
@@ -187,6 +198,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		serverURL:    serverURL,
 		siteURL:      siteURL,
 		toolsetCache: cache.NewTypedObjectCache[mv.ToolsetBaseContents](logger.With(attr.SlogCacheNamespace("toolset")), cacheAdapter, cache.SuffixNone),
+		audit:        auditLogger,
 
 		installPageScriptHash: scriptHashStr,
 		installPageScriptData: hostedPageScriptData,
@@ -388,7 +400,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 		return nil, err
 	}
 
-	if err := audit.LogMCPMetadataUpdate(ctx, dbtx, audit.LogMCPMetadataUpdateEvent{
+	if err := s.audit.LogMCPMetadataUpdate(ctx, dbtx, audit.LogMCPMetadataUpdateEvent{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
 

--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -90,7 +91,9 @@ func newTestMCPMetadataService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := mcpmetadata.NewService(logger, tracerProvider, conn, sessionManager, serverURL, siteURL, cacheAdapter, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache))
+	auditLogger := audit.NewLogger()
+
+	svc := mcpmetadata.NewService(logger, tracerProvider, conn, sessionManager, serverURL, siteURL, cacheAdapter, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -42,12 +42,20 @@ type Service struct {
 	db     *pgxpool.Pool
 	auth   *auth.Auth
 	authz  *authz.Engine
+	audit  *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("mcpservers"))
 
 	return &Service{
@@ -56,6 +64,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		db:     db,
 		auth:   auth.New(logger, db, sessions, authzEngine),
 		authz:  authzEngine,
+		audit:  auditLogger,
 	}
 }
 
@@ -127,7 +136,7 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 		return nil, oops.E(oops.CodeUnexpected, err, "create mcp server").Log(ctx, logger)
 	}
 
-	if err := audit.LogMcpServerCreate(ctx, dbtx, audit.LogMcpServerCreateEvent{
+	if err := s.audit.LogMcpServerCreate(ctx, dbtx, audit.LogMcpServerCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -270,7 +279,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 
 	afterView := mv.BuildMcpServerView(updated)
 
-	if err := audit.LogMcpServerUpdate(ctx, dbtx, audit.LogMcpServerUpdateEvent{
+	if err := s.audit.LogMcpServerUpdate(ctx, dbtx, audit.LogMcpServerUpdateEvent{
 		OrganizationID:          authCtx.ActiveOrganizationID,
 		ProjectID:               *authCtx.ProjectID,
 		Actor:                   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -338,7 +347,7 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 	}
 
 	for _, endpoint := range deletedEndpoints {
-		if err := audit.LogMcpEndpointDelete(ctx, dbtx, audit.LogMcpEndpointDeleteEvent{
+		if err := s.audit.LogMcpEndpointDelete(ctx, dbtx, audit.LogMcpEndpointDeleteEvent{
 			OrganizationID:   authCtx.ActiveOrganizationID,
 			ProjectID:        *authCtx.ProjectID,
 			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -351,7 +360,7 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 		}
 	}
 
-	if err := audit.LogMcpServerDelete(ctx, dbtx, audit.LogMcpServerDeleteEvent{
+	if err := s.audit.LogMcpServerDelete(ctx, dbtx, audit.LogMcpServerDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/mcpservers/setup_test.go
+++ b/server/internal/mcpservers/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -77,7 +78,9 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := mcpservers.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache))
+	auditLogger := audit.NewLogger()
+
+	svc := mcpservers.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/platformtools/registry.go
+++ b/server/internal/platformtools/registry.go
@@ -22,7 +22,7 @@ var registry = []toolFactory{
 		return platformtriggers.NewListTriggersTool(deps.DB, deps.TriggerApp)
 	},
 	func(deps Dependencies) PlatformToolExecutor {
-		return platformtriggers.NewConfigureTriggerTool(deps.DB, deps.TriggerApp)
+		return platformtriggers.NewConfigureTriggerTool(deps.DB, deps.TriggerApp, deps.Audit)
 	},
 	func(deps Dependencies) PlatformToolExecutor {
 		return platformslack.NewReadChannelMessagesTool(deps.SlackHTTPClient)
@@ -67,6 +67,7 @@ func ListPlatformTools() []ToolDescriptor {
 		TelemetryService: nil,
 		TriggerApp:       nil,
 		SlackHTTPClient:  nil,
+		Audit:            nil,
 	}
 	for _, factory := range registry {
 		tools = append(tools, factory(deps).Descriptor())

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
@@ -44,12 +45,14 @@ func NewService(
 	logger *slog.Logger,
 	db *pgxpool.Pool,
 	telemetrySvc platformtools.TelemetryService,
+	auditLogger *audit.Logger,
 	options ...Option,
 ) *Service {
 	deps := platformtools.Dependencies{
 		Logger:           logger,
 		DB:               db,
 		TelemetryService: telemetrySvc,
+		Audit:            auditLogger,
 		TriggerApp:       nil,
 		SlackHTTPClient:  nil,
 	}

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -17,7 +18,7 @@ import (
 func TestService_ExecuteTool_RequiresProjectAuthContext(t *testing.T) {
 	t.Parallel()
 
-	svc := NewService(testenv.NewLogger(t), nil, nil)
+	svc := NewService(testenv.NewLogger(t), nil, nil, audit.NewLogger())
 	projectID := uuid.New()
 
 	_, err := svc.ExecuteTool(context.Background(), &gateway.ToolCallPlan{
@@ -39,7 +40,7 @@ func TestService_ExecuteTool_RequiresProjectAuthContext(t *testing.T) {
 func TestService_ExecuteTool_RejectsMismatchedProjectAuthContext(t *testing.T) {
 	t.Parallel()
 
-	svc := NewService(testenv.NewLogger(t), nil, nil)
+	svc := NewService(testenv.NewLogger(t), nil, nil, audit.NewLogger())
 	descriptorProjectID := uuid.New()
 	authProjectID := uuid.New()
 	ctx := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{

--- a/server/internal/platformtools/triggers/tools.go
+++ b/server/internal/platformtools/triggers/tools.go
@@ -96,6 +96,7 @@ type ConfigureTrigger struct {
 	db          *pgxpool.Pool
 	app         *bgtriggers.App
 	inputSchema []byte
+	audit       *audit.Logger
 }
 
 func NewListTriggersTool(db *pgxpool.Pool, app *bgtriggers.App) *ListTriggers {
@@ -105,11 +106,12 @@ func NewListTriggersTool(db *pgxpool.Pool, app *bgtriggers.App) *ListTriggers {
 	}
 }
 
-func NewConfigureTriggerTool(db *pgxpool.Pool, app *bgtriggers.App) *ConfigureTrigger {
+func NewConfigureTriggerTool(db *pgxpool.Pool, app *bgtriggers.App, audit *audit.Logger) *ConfigureTrigger {
 	return &ConfigureTrigger{
 		db:          db,
 		app:         app,
 		inputSchema: buildConfigureTriggerInputSchema(),
+		audit:       audit,
 	}
 }
 
@@ -413,7 +415,7 @@ func (t *ConfigureTrigger) upsertTrigger(
 			Config:         params.Config,
 			Status:         status,
 		}, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
-			return audit.LogTriggerInstanceCreate(ctx, dbtx, audit.LogTriggerInstanceCreateEvent{
+			return t.audit.LogTriggerInstanceCreate(ctx, dbtx, audit.LogTriggerInstanceCreateEvent{
 				OrganizationID:     authCtx.ActiveOrganizationID,
 				ProjectID:          *authCtx.ProjectID,
 				Actor:              actorPrincipal,
@@ -463,7 +465,7 @@ func (t *ConfigureTrigger) upsertTrigger(
 			if err != nil {
 				return fmt.Errorf("build trigger instance after-snapshot: %w", err)
 			}
-			return audit.LogTriggerInstanceUpdate(ctx, dbtx, audit.LogTriggerInstanceUpdateEvent{
+			return t.audit.LogTriggerInstanceUpdate(ctx, dbtx, audit.LogTriggerInstanceUpdateEvent{
 				OrganizationID:                authCtx.ActiveOrganizationID,
 				ProjectID:                     *authCtx.ProjectID,
 				Actor:                         actorPrincipal,

--- a/server/internal/platformtools/triggers/tools_test.go
+++ b/server/internal/platformtools/triggers/tools_test.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfigureTriggerToolDescriptor(t *testing.T) {
 	t.Parallel()
 
-	descriptor := NewConfigureTriggerTool(nil, nil).Descriptor()
+	descriptor := NewConfigureTriggerTool(nil, nil, audit.NewLogger()).Descriptor()
 
 	require.Equal(t, toolNameConfigure, descriptor.Name)
 	require.Equal(t, sourceTriggers, descriptor.SourceSlug)

--- a/server/internal/platformtools/types.go
+++ b/server/internal/platformtools/types.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
@@ -33,6 +34,7 @@ type Dependencies struct {
 	TelemetryService TelemetryService
 	TriggerApp       *bgtriggers.App
 	SlackHTTPClient  *guardian.HTTPClient
+	Audit            *audit.Logger
 }
 
 type ToolDescriptor = core.ToolDescriptor

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -137,6 +137,7 @@ type Service struct {
 	repo      *repo.Queries
 	auth      *auth.Auth
 	authz     *authz.Engine
+	audit     *audit.Logger
 	github    *GitHubConfig
 	serverURL string
 	keyPrefix string
@@ -151,6 +152,7 @@ func NewService(
 	db *pgxpool.Pool,
 	sessions *sessions.Manager,
 	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
 	github *GitHubConfig,
 	env string,
 	serverURL string,
@@ -164,6 +166,7 @@ func NewService(
 		repo:      repo.New(db),
 		auth:      auth.New(logger, db, sessions, authzEngine),
 		authz:     authzEngine,
+		audit:     auditLogger,
 		github:    github,
 		serverURL: serverURL,
 		keyPrefix: auth.APIKeyPrefix(env),
@@ -307,7 +310,7 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 		return nil, oops.E(oops.CodeUnexpected, err, "create plugin").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogPluginCreate(ctx, tx, audit.LogPluginCreateEvent{
+	if err := s.audit.LogPluginCreate(ctx, tx, audit.LogPluginCreateEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -386,7 +389,7 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 		return nil, oops.E(oops.CodeUnexpected, err, "update plugin").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogPluginUpdate(ctx, tx, audit.LogPluginUpdateEvent{
+	if err := s.audit.LogPluginUpdate(ctx, tx, audit.LogPluginUpdateEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -474,7 +477,7 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 		return oops.E(oops.CodeUnexpected, err, "delete plugin").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogPluginDelete(ctx, tx, audit.LogPluginDeleteEvent{
+	if err := s.audit.LogPluginDelete(ctx, tx, audit.LogPluginDeleteEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -560,7 +563,7 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 		return nil, oops.E(oops.CodeUnexpected, err, "add plugin server").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogPluginServerAdd(ctx, tx, audit.LogPluginServerAddEvent{
+	if err := s.audit.LogPluginServerAdd(ctx, tx, audit.LogPluginServerAddEvent{
 		OrganizationID:    ac.ActiveOrganizationID,
 		ProjectID:         *ac.ProjectID,
 		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -633,7 +636,7 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 		return nil, oops.E(oops.CodeUnexpected, err, "update plugin server").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogPluginServerUpdate(ctx, tx, audit.LogPluginServerUpdateEvent{
+	if err := s.audit.LogPluginServerUpdate(ctx, tx, audit.LogPluginServerUpdateEvent{
 		OrganizationID:    ac.ActiveOrganizationID,
 		ProjectID:         *ac.ProjectID,
 		Actor:             urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -698,7 +701,7 @@ func (s *Service) RemovePluginServer(ctx context.Context, payload *gen.RemovePlu
 		return oops.E(oops.CodeUnexpected, err, "remove plugin server").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogPluginServerRemove(ctx, tx, audit.LogPluginServerRemoveEvent{
+	if err := s.audit.LogPluginServerRemove(ctx, tx, audit.LogPluginServerRemoveEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -775,7 +778,7 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 		assignments = append(assignments, pluginAssignmentToGen(row))
 	}
 
-	if err := audit.LogPluginAssignmentsSet(ctx, tx, audit.LogPluginAssignmentsSetEvent{
+	if err := s.audit.LogPluginAssignmentsSet(ctx, tx, audit.LogPluginAssignmentsSetEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -1002,7 +1005,7 @@ func (s *Service) persistDownloadAPIKey(ctx context.Context, ac *contextvalues.A
 		return fmt.Errorf("create api key: %w", err)
 	}
 
-	if err := audit.LogKeyCreate(ctx, tx, audit.LogKeyCreateEvent{
+	if err := s.audit.LogKeyCreate(ctx, tx, audit.LogKeyCreateEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        projectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -1238,7 +1241,7 @@ func (s *Service) persistPluginAPIKeys(
 			return fmt.Errorf("create api key %s: %w", candidate.keyName, err)
 		}
 
-		if err := audit.LogKeyCreate(ctx, tx, audit.LogKeyCreateEvent{
+		if err := s.audit.LogKeyCreate(ctx, tx, audit.LogKeyCreateEvent{
 			OrganizationID:   ac.ActiveOrganizationID,
 			ProjectID:        projectID,
 			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
@@ -1265,7 +1268,7 @@ func (s *Service) persistPluginAPIKeys(
 	if ac.ProjectSlug != nil {
 		projectSlug = *ac.ProjectSlug
 	}
-	if err := audit.LogPluginPublish(ctx, tx, audit.LogPluginPublishEvent{
+	if err := s.audit.LogPluginPublish(ctx, tx, audit.LogPluginPublishEvent{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
 		ProjectName:      projectName,

--- a/server/internal/plugins/setup_test.go
+++ b/server/internal/plugins/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -94,7 +95,9 @@ func newTestPluginsService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := plugins.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), nil, "local", "https://app.getgram.ai")
+	auditLogger := audit.NewLogger()
+
+	svc := plugins.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), auditLogger, nil, "local", "https://app.getgram.ai")
 
 	return ctx, &testInstance{
 		service:        svc,
@@ -144,10 +147,18 @@ func newTestPluginsServiceWithGitHub(t *testing.T, ghClient plugins.GitHubPublis
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
+	auditLogger := audit.NewLogger()
+
 	svc := plugins.NewService(
-		logger, tracerProvider, conn, sessionManager,
+		logger,
+		tracerProvider,
+		conn,
+		sessionManager,
 		authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache),
-		ghConfig, "local", "https://app.getgram.ai",
+		auditLogger,
+		ghConfig,
+		"local",
+		"https://app.getgram.ai",
 	)
 
 	return ctx, &testInstance{

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -44,11 +44,19 @@ type Service struct {
 	sessions *sessions.Manager
 	auth     *auth.Auth
 	authz    *authz.Engine
+	audit    *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("projects"))
 
 	return &Service{
@@ -60,6 +68,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		sessions: sessions,
 		auth:     auth.New(logger, db, sessions, authzEngine),
 		authz:    authzEngine,
+		audit:    auditLogger,
 	}
 }
 
@@ -177,7 +186,7 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 		return nil, oops.E(oops.CodeUnexpected, err, "error creating default environment").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogProjectCreate(ctx, dbtx, audit.LogProjectCreateEvent{
+	if err := s.audit.LogProjectCreate(ctx, dbtx, audit.LogProjectCreateEvent{
 		OrganizationID: payload.OrganizationID,
 		ProjectID:      prj.ID,
 
@@ -317,7 +326,7 @@ func (s *Service) SetLogo(ctx context.Context, payload *gen.SetLogoPayload) (res
 
 	projectResponse := toProject(updatedProject)
 
-	if err := audit.LogProjectUpdate(ctx, dbtx, audit.LogProjectUpdateEvent{
+	if err := s.audit.LogProjectUpdate(ctx, dbtx, audit.LogProjectUpdateEvent{
 		OrganizationID: updatedProject.OrganizationID,
 		ProjectID:      updatedProject.ID,
 
@@ -461,7 +470,7 @@ func (s *Service) DeleteProject(ctx context.Context, payload *gen.DeleteProjectP
 		return oops.E(oops.CodeUnexpected, err, "error deleting project").Log(ctx, s.logger, attr.SlogProjectID(payload.ID))
 	}
 
-	if err := audit.LogProjectDelete(ctx, dbtx, audit.LogProjectDeleteEvent{
+	if err := s.audit.LogProjectDelete(ctx, dbtx, audit.LogProjectDeleteEvent{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      projectID,
 

--- a/server/internal/projects/setup_test.go
+++ b/server/internal/projects/setup_test.go
@@ -12,6 +12,7 @@ import (
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -92,9 +93,25 @@ func newTestProjectsService(t *testing.T, enableRBAC bool) (context.Context, *te
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := projects.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, func(context.Context, string) (bool, error) {
-		return enableRBAC, nil
-	}, workos.NewStubClient(), cache.NoopCache))
+	auditLogger := audit.NewLogger()
+
+	svc := projects.NewService(
+		logger,
+		tracerProvider,
+		conn,
+		sessionManager,
+		authz.NewEngine(
+			logger,
+			conn,
+			chConn,
+			func(context.Context, string) (bool, error) {
+				return enableRBAC, nil
+			},
+			workos.NewStubClient(),
+			cache.NoopCache,
+		),
+		auditLogger,
+	)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/remotemcp/impl.go
+++ b/server/internal/remotemcp/impl.go
@@ -42,12 +42,22 @@ type Service struct {
 	authz   *authz.Engine
 	headers *Headers
 	policy  *guardian.Policy
+	audit   *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, enc *encryption.Client, authzEngine *authz.Engine, policy *guardian.Policy) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	enc *encryption.Client,
+	authzEngine *authz.Engine,
+	policy *guardian.Policy,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("remotemcp"))
 
 	return &Service{
@@ -58,6 +68,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		authz:   authzEngine,
 		headers: NewHeaders(logger, db, enc),
 		policy:  policy,
+		audit:   auditLogger,
 	}
 }
 
@@ -130,7 +141,7 @@ func (s *Service) CreateServer(ctx context.Context, payload *gen.CreateServerPay
 		headerRows = append(headerRows, row)
 	}
 
-	if err := audit.LogRemoteMcpServerCreate(ctx, dbtx, audit.LogRemoteMcpServerCreateEvent{
+	if err := s.audit.LogRemoteMcpServerCreate(ctx, dbtx, audit.LogRemoteMcpServerCreateEvent{
 		OrganizationID:     authCtx.ActiveOrganizationID,
 		ProjectID:          *authCtx.ProjectID,
 		Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -385,7 +396,7 @@ func (s *Service) UpdateServer(ctx context.Context, payload *gen.UpdateServerPay
 
 	afterView := mv.BuildRemoteMcpServerView(updatedServer, afterHeaders)
 
-	if err := audit.LogRemoteMcpServerUpdate(ctx, dbtx, audit.LogRemoteMcpServerUpdateEvent{
+	if err := s.audit.LogRemoteMcpServerUpdate(ctx, dbtx, audit.LogRemoteMcpServerUpdateEvent{
 		OrganizationID:     authCtx.ActiveOrganizationID,
 		ProjectID:          *authCtx.ProjectID,
 		Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -447,7 +458,7 @@ func (s *Service) DeleteServer(ctx context.Context, payload *gen.DeleteServerPay
 		return oops.E(oops.CodeUnexpected, err, "delete remote mcp server").Log(ctx, logger)
 	}
 
-	if err := audit.LogRemoteMcpServerDelete(ctx, dbtx, audit.LogRemoteMcpServerDeleteEvent{
+	if err := s.audit.LogRemoteMcpServerDelete(ctx, dbtx, audit.LogRemoteMcpServerDeleteEvent{
 		OrganizationID:     authCtx.ActiveOrganizationID,
 		ProjectID:          *authCtx.ProjectID,
 		Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/remotemcp/setup_test.go
+++ b/server/internal/remotemcp/setup_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -104,7 +105,9 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	svc := remotemcp.NewService(logger, tracerProvider, conn, sessionManager, enc, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), servicePolicy)
+	auditLogger := audit.NewLogger()
+
+	svc := remotemcp.NewService(logger, tracerProvider, conn, sessionManager, enc, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache), servicePolicy, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -56,6 +56,7 @@ type Service struct {
 	signaler         RiskAnalysisSignaler
 	completionClient openrouter.CompletionClient
 	shadowMCPClient  *shadowmcp.Client
+	audit            *audit.Logger
 }
 
 var _ chat.MessageObserver = (*Service)(nil)
@@ -63,9 +64,16 @@ var _ chat.MessageObserver = (*Service)(nil)
 // NewObserver creates a lightweight chat.MessageObserver that signals the risk
 // drain workflow when new messages are stored. Use this in contexts (e.g. the
 // worker process) where the full risk Service is not needed.
-func NewObserver(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, signaler RiskAnalysisSignaler) chat.MessageObserver {
+func NewObserver(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	signaler RiskAnalysisSignaler,
+	auditLogger *audit.Logger,
+) chat.MessageObserver {
 	return &Service{
-		tracer:           tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
+		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
+
 		logger:           logger.With(attr.SlogComponent("risk")),
 		db:               db,
 		repo:             repo.New(db),
@@ -74,6 +82,7 @@ func NewObserver(logger *slog.Logger, tracerProvider trace.TracerProvider, db *p
 		signaler:         signaler,
 		completionClient: nil,
 		shadowMCPClient:  nil,
+		audit:            auditLogger,
 	}
 }
 
@@ -86,6 +95,7 @@ func NewService(
 	signaler RiskAnalysisSignaler,
 	completionClient openrouter.CompletionClient,
 	shadowMCPClient *shadowmcp.Client,
+	auditLogger *audit.Logger,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("risk"))
 
@@ -99,6 +109,7 @@ func NewService(
 		signaler:         signaler,
 		completionClient: completionClient,
 		shadowMCPClient:  shadowMCPClient,
+		audit:            auditLogger,
 	}
 }
 
@@ -234,7 +245,7 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogRiskPolicyCreate(ctx, dbtx, audit.LogRiskPolicyCreateEvent{
+	if err := s.audit.LogRiskPolicyCreate(ctx, dbtx, audit.LogRiskPolicyCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -421,7 +432,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		return nil, oops.E(oops.CodeUnexpected, err, "update risk policy").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogRiskPolicyUpdate(ctx, dbtx, audit.LogRiskPolicyUpdateEvent{
+	if err := s.audit.LogRiskPolicyUpdate(ctx, dbtx, audit.LogRiskPolicyUpdateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -492,7 +503,7 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 		return oops.E(oops.CodeUnexpected, err, "delete risk policy").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogRiskPolicyDelete(ctx, dbtx, audit.LogRiskPolicyDeleteEvent{
+	if err := s.audit.LogRiskPolicyDelete(ctx, dbtx, audit.LogRiskPolicyDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -764,7 +775,7 @@ func (s *Service) TriggerRiskAnalysis(ctx context.Context, payload *gen.TriggerR
 		return oops.E(oops.CodeUnexpected, err, "bump policy version").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogRiskPolicyTrigger(ctx, s.db, audit.LogRiskPolicyTriggerEvent{
+	if err := s.audit.LogRiskPolicyTrigger(ctx, s.db, audit.LogRiskPolicyTriggerEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -95,8 +96,9 @@ func newTestRiskService(t *testing.T) (context.Context, *testInstance) {
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 
 	shadowMCPClient := shadowmcp.NewClient(logger, conn, cache.NewRedisCacheAdapter(redisClient))
+	auditLogger := audit.NewLogger()
 
-	svc := risk.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, sig, nil, shadowMCPClient)
+	svc := risk.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, sig, nil, shadowMCPClient, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/templates/impl.go
+++ b/server/internal/templates/impl.go
@@ -52,12 +52,21 @@ type Service struct {
 	variations *variations.Service
 	toolsets   ToolsetsService
 	authz      *authz.Engine
+	audit      *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, toolsets ToolsetsService, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	toolsets ToolsetsService,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("templates"))
 
 	return &Service{
@@ -66,9 +75,10 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		db:         db,
 		auth:       auth.New(logger, db, sessions, authzEngine),
 		repo:       repo.New(db),
-		variations: variations.NewService(logger, tracerProvider, db, sessions, authzEngine),
+		variations: variations.NewService(logger, tracerProvider, db, sessions, authzEngine, auditLogger),
 		toolsets:   toolsets,
 		authz:      authzEngine,
+		audit:      auditLogger,
 	}
 }
 
@@ -149,7 +159,7 @@ func (s *Service) CreateTemplate(ctx context.Context, payload *gen.CreateTemplat
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to create template").Log(ctx, logger)
 	}
 
-	if err := audit.LogTemplateCreate(ctx, dbtx, audit.LogTemplateCreateEvent{
+	if err := s.audit.LogTemplateCreate(ctx, dbtx, audit.LogTemplateCreateEvent{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      uuid.NullUUID{UUID: projectID, Valid: true},
 
@@ -287,7 +297,7 @@ func (s *Service) UpdateTemplate(ctx context.Context, payload *gen.UpdateTemplat
 	}
 
 	if updated {
-		if err := audit.LogTemplateUpdate(ctx, dbtx, audit.LogTemplateUpdateEvent{
+		if err := s.audit.LogTemplateUpdate(ctx, dbtx, audit.LogTemplateUpdateEvent{
 			OrganizationID: authCtx.ActiveOrganizationID,
 			ProjectID:      uuid.NullUUID{UUID: projectID, Valid: true},
 
@@ -402,7 +412,7 @@ func (s *Service) DeleteTemplate(ctx context.Context, payload *gen.DeleteTemplat
 	}
 
 	if auditEntry.id != uuid.Nil {
-		if err := audit.LogTemplateDelete(ctx, dbtx, audit.LogTemplateDeleteEvent{
+		if err := s.audit.LogTemplateDelete(ctx, dbtx, audit.LogTemplateDeleteEvent{
 			OrganizationID: authCtx.ActiveOrganizationID,
 			ProjectID:      uuid.NullUUID{UUID: projectID, Valid: true},
 

--- a/server/internal/templates/setup_test.go
+++ b/server/internal/templates/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -84,7 +85,8 @@ func newTestTemplateService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := templates.NewService(logger, tracerProvider, conn, sessionManager, toolsetsSvc, authzEngine)
+	auditLogger := audit.NewLogger()
+	svc := templates.NewService(logger, tracerProvider, conn, sessionManager, toolsetsSvc, authzEngine, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -16,6 +16,7 @@ import (
 
 	agen "github.com/speakeasy-api/gram/server/gen/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -101,11 +102,11 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 	enc := testenv.NewEncryptionClient(t)
 	funcs := functionstest.NewOrchestrator(t, assetStorage)
 	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
-
+	temporalEnv, _ := infra.NewTemporalEnv(t)
+	auditLogger := audit.NewLogger()
 	f := &feature.InMemory{}
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient, auditLogger))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -116,11 +117,11 @@ func newTestToolsService(t *testing.T, assetStorage assets.BlobStore) (context.C
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
 	toolsSvc := tools.NewService(logger, tracerProvider, conn, sessionManager, authzEngine)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine)
-	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine)
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine, auditLogger)
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine, auditLogger)
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, authzEngine)
-	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine)
-	templatesSvc := templates.NewService(logger, tracerProvider, conn, sessionManager, toolsetsSvc, authzEngine)
+	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
+	templatesSvc := templates.NewService(logger, tracerProvider, conn, sessionManager, toolsetsSvc, authzEngine, auditLogger)
 
 	return ctx, &testInstance{
 		service:        toolsSvc,

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -70,11 +70,20 @@ type Service struct {
 	oauthRepo       *oauthRepo.Queries
 	mcpmetadataRepo *mcpmetadataRepo.Queries
 	toolsetCache    cache.TypedCacheObject[mv.ToolsetBaseContents]
+	audit           *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, cacheAdapter cache.Cache, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	cacheAdapter cache.Cache,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("toolsets"))
 
 	return &Service{
@@ -91,6 +100,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		oauthRepo:       oauthRepo.New(db),
 		mcpmetadataRepo: mcpmetadataRepo.New(db),
 		toolsetCache:    cache.NewTypedObjectCache[mv.ToolsetBaseContents](logger.With(attr.SlogCacheNamespace("toolset")), cacheAdapter, cache.SuffixNone),
+		audit:           auditLogger,
 	}
 }
 
@@ -201,7 +211,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 		return nil, err
 	}
 
-	if err := audit.LogToolsetCreate(ctx, dbtx, audit.LogToolsetCreateEvent{
+	if err := s.audit.LogToolsetCreate(ctx, dbtx, audit.LogToolsetCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -471,7 +481,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		if existingView.ExternalOauthServer != nil {
 			extoauthslug = new(string(existingView.ExternalOauthServer.Slug))
 		}
-		if err := audit.LogToolsetDetachExternalOAuth(ctx, dbtx, audit.LogToolsetDetachExternalOAuthEvent{
+		if err := s.audit.LogToolsetDetachExternalOAuth(ctx, dbtx, audit.LogToolsetDetachExternalOAuthEvent{
 			OrganizationID:          authCtx.ActiveOrganizationID,
 			ProjectID:               *authCtx.ProjectID,
 			Actor:                   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -493,7 +503,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		if existingView.OauthProxyServer != nil {
 			oauthProxySlug = new(string(existingView.OauthProxyServer.Slug))
 		}
-		if err := audit.LogToolsetDetachOAuthProxy(ctx, dbtx, audit.LogToolsetDetachOAuthProxyEvent{
+		if err := s.audit.LogToolsetDetachOAuthProxy(ctx, dbtx, audit.LogToolsetDetachOAuthProxyEvent{
 			OrganizationID:       authCtx.ActiveOrganizationID,
 			ProjectID:            *authCtx.ProjectID,
 			Actor:                urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -510,7 +520,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		}
 	}
 
-	if err := audit.LogToolsetUpdate(ctx, dbtx, audit.LogToolsetUpdateEvent{
+	if err := s.audit.LogToolsetUpdate(ctx, dbtx, audit.LogToolsetUpdateEvent{
 		OrganizationID:        authCtx.ActiveOrganizationID,
 		ProjectID:             *authCtx.ProjectID,
 		Actor:                 urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -575,7 +585,7 @@ func (s *Service) DeleteToolset(ctx context.Context, payload *gen.DeleteToolsetP
 		return oops.E(oops.CodeUnexpected, err, "failed to delete toolset").Log(ctx, logger)
 	}
 
-	if err := audit.LogToolsetDelete(ctx, dbtx, audit.LogToolsetDeleteEvent{
+	if err := s.audit.LogToolsetDelete(ctx, dbtx, audit.LogToolsetDeleteEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -710,7 +720,7 @@ func (s *Service) CloneToolset(ctx context.Context, payload *gen.CloneToolsetPay
 		return nil, oops.E(oops.CodeConflict, nil, "could not create unique toolset name").Log(ctx, logger)
 	}
 
-	if err := audit.LogToolsetCreate(ctx, dbtx, audit.LogToolsetCreateEvent{
+	if err := s.audit.LogToolsetCreate(ctx, dbtx, audit.LogToolsetCreateEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -869,7 +879,7 @@ func (s *Service) AddExternalOAuthServer(ctx context.Context, payload *gen.AddEx
 		return nil, err
 	}
 
-	if err := audit.LogToolsetAttachExternalOAuth(ctx, dbtx, audit.LogToolsetAttachExternalOAuthEvent{
+	if err := s.audit.LogToolsetAttachExternalOAuth(ctx, dbtx, audit.LogToolsetAttachExternalOAuthEvent{
 		OrganizationID:          authCtx.ActiveOrganizationID,
 		ProjectID:               *authCtx.ProjectID,
 		Actor:                   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -981,7 +991,7 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 	}
 
 	if externalServerID != nil {
-		if err := audit.LogToolsetDetachExternalOAuth(ctx, dbtx, audit.LogToolsetDetachExternalOAuthEvent{
+		if err := s.audit.LogToolsetDetachExternalOAuth(ctx, dbtx, audit.LogToolsetDetachExternalOAuthEvent{
 			OrganizationID:          authCtx.ActiveOrganizationID,
 			ProjectID:               *authCtx.ProjectID,
 			Actor:                   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -999,7 +1009,7 @@ func (s *Service) RemoveOAuthServer(ctx context.Context, payload *gen.RemoveOAut
 	}
 
 	if oauthProxyID != nil {
-		if err := audit.LogToolsetDetachOAuthProxy(ctx, dbtx, audit.LogToolsetDetachOAuthProxyEvent{
+		if err := s.audit.LogToolsetDetachOAuthProxy(ctx, dbtx, audit.LogToolsetDetachOAuthProxyEvent{
 			OrganizationID:       authCtx.ActiveOrganizationID,
 			ProjectID:            *authCtx.ProjectID,
 			Actor:                urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -1182,7 +1192,7 @@ func (s *Service) AddOAuthProxyServer(ctx context.Context, payload *gen.AddOAuth
 		return nil, err
 	}
 
-	if err := audit.LogToolsetAttachOAuthProxy(ctx, dbtx, audit.LogToolsetAttachOAuthProxyEvent{
+	if err := s.audit.LogToolsetAttachOAuthProxy(ctx, dbtx, audit.LogToolsetAttachOAuthProxyEvent{
 		OrganizationID:       authCtx.ActiveOrganizationID,
 		ProjectID:            *authCtx.ProjectID,
 		Actor:                urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -97,11 +98,11 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	enc := testenv.NewEncryptionClient(t)
 	funcs := functionstest.NewOrchestrator(t, assetStorage)
 	mcpRegistryClient := externalmcptest.NewRegistryClient(t, logger, tracerProvider)
-
+	temporalEnv, _ := infra.NewTemporalEnv(t)
+	auditLogger := audit.NewLogger()
 	f := &feature.InMemory{}
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
-	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient))
+	worker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, background.ForDeploymentProcessing(guardianPolicy, conn, f, assetStorage, enc, funcs, mcpRegistryClient, auditLogger))
 	t.Cleanup(func() {
 		worker.Stop()
 	})
@@ -124,9 +125,9 @@ func newTestToolsetsService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine)
-	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine)
-	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine)
+	svc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger)
+	deploymentsSvc := deployments.NewService(logger, tracerProvider, conn, temporalEnv, sessionManager, assetStorage, posthog, testenv.DefaultSiteURL(t), mcpRegistryClient, authzEngine, auditLogger)
+	assetsSvc := assets.NewService(logger, tracerProvider, guardianPolicy, conn, sessionManager, chatSessionsManager, assetStorage, "test-jwt-secret", authzEngine, auditLogger)
 	packagesSvc := packages.NewService(logger, tracerProvider, conn, sessionManager, authzEngine)
 
 	return ctx, &testInstance{

--- a/server/internal/toolsets/updateoauthproxyserver.go
+++ b/server/internal/toolsets/updateoauthproxyserver.go
@@ -215,7 +215,7 @@ func (s *Service) UpdateOAuthProxyServer(ctx context.Context, payload *gen.Updat
 	// Emit audit event inside the transaction (before commit). Pass before/after
 	// toolset snapshots so the audit log captures what actually changed, not just
 	// that an update occurred. Mirrors LogToolsetUpdate's snapshot pattern.
-	if err := audit.LogToolsetUpdateOAuthProxy(ctx, dbtx, audit.LogToolsetUpdateOAuthProxyEvent{
+	if err := s.audit.LogToolsetUpdateOAuthProxy(ctx, dbtx, audit.LogToolsetUpdateOAuthProxyEvent{
 		OrganizationID:        authCtx.ActiveOrganizationID,
 		ProjectID:             *authCtx.ProjectID,
 		Actor:                 urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/triggers/impl.go
+++ b/server/internal/triggers/impl.go
@@ -41,6 +41,7 @@ type Service struct {
 	logger *slog.Logger
 	auth   *auth.Auth
 	app    *bgtriggers.App
+	audit  *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -53,6 +54,7 @@ func NewService(
 	sessions *sessions.Manager,
 	authzEngine *authz.Engine,
 	app *bgtriggers.App,
+	auditLogger *audit.Logger,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("triggers"))
 	return &Service{
@@ -60,6 +62,7 @@ func NewService(
 		logger: logger,
 		auth:   auth.New(logger, db, sessions, authzEngine),
 		app:    app,
+		audit:  auditLogger,
 	}
 }
 
@@ -163,7 +166,7 @@ func (s *Service) CreateTriggerInstance(ctx context.Context, payload *gen.Create
 		Config:         payload.Config,
 		Status:         normalizeTriggerStatus(payload.Status),
 	}, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
-		return audit.LogTriggerInstanceCreate(ctx, dbtx, audit.LogTriggerInstanceCreateEvent{
+		return s.audit.LogTriggerInstanceCreate(ctx, dbtx, audit.LogTriggerInstanceCreateEvent{
 			OrganizationID:     authCtx.ActiveOrganizationID,
 			ProjectID:          *authCtx.ProjectID,
 			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -238,7 +241,7 @@ func (s *Service) UpdateTriggerInstance(ctx context.Context, payload *gen.Update
 		if err != nil {
 			return fmt.Errorf("build trigger instance after-snapshot: %w", err)
 		}
-		return audit.LogTriggerInstanceUpdate(ctx, dbtx, audit.LogTriggerInstanceUpdateEvent{
+		return s.audit.LogTriggerInstanceUpdate(ctx, dbtx, audit.LogTriggerInstanceUpdateEvent{
 			OrganizationID:                authCtx.ActiveOrganizationID,
 			ProjectID:                     *authCtx.ProjectID,
 			Actor:                         urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -274,7 +277,7 @@ func (s *Service) DeleteTriggerInstance(ctx context.Context, payload *gen.Delete
 	}
 
 	if err := s.app.Delete(ctx, *authCtx.ProjectID, triggerID, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
-		return audit.LogTriggerInstanceDelete(ctx, dbtx, audit.LogTriggerInstanceDeleteEvent{
+		return s.audit.LogTriggerInstanceDelete(ctx, dbtx, audit.LogTriggerInstanceDeleteEvent{
 			OrganizationID:     authCtx.ActiveOrganizationID,
 			ProjectID:          *authCtx.ProjectID,
 			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -298,7 +301,7 @@ func (s *Service) PauseTriggerInstance(ctx context.Context, payload *gen.PauseTr
 	}
 
 	return s.setTriggerStatus(ctx, authCtx, payload.ID, bgtriggers.StatusPaused, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
-		return audit.LogTriggerInstancePause(ctx, dbtx, audit.LogTriggerInstancePauseEvent{
+		return s.audit.LogTriggerInstancePause(ctx, dbtx, audit.LogTriggerInstancePauseEvent{
 			OrganizationID:     authCtx.ActiveOrganizationID,
 			ProjectID:          *authCtx.ProjectID,
 			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -318,7 +321,7 @@ func (s *Service) ResumeTriggerInstance(ctx context.Context, payload *gen.Resume
 	}
 
 	return s.setTriggerStatus(ctx, authCtx, payload.ID, bgtriggers.StatusActive, func(ctx context.Context, dbtx pgx.Tx, instance triggerrepo.TriggerInstance) error {
-		return audit.LogTriggerInstanceResume(ctx, dbtx, audit.LogTriggerInstanceResumeEvent{
+		return s.audit.LogTriggerInstanceResume(ctx, dbtx, audit.LogTriggerInstanceResumeEvent{
 			OrganizationID:     authCtx.ActiveOrganizationID,
 			ProjectID:          *authCtx.ProjectID,
 			Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/triggers/setup_test.go
+++ b/server/internal/triggers/setup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
@@ -112,6 +113,8 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
+	auditLogger := audit.NewLogger()
+
 	svc := triggers.NewService(
 		logger,
 		tracerProvider,
@@ -119,6 +122,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		sessionManager,
 		authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache),
 		app,
+		auditLogger,
 	)
 
 	return ctx, &testInstance{

--- a/server/internal/variations/impl.go
+++ b/server/internal/variations/impl.go
@@ -37,11 +37,19 @@ type Service struct {
 	repo   *repo.Queries
 	auth   *auth.Auth
 	authz  *authz.Engine
+	audit  *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, authzEngine *authz.Engine) *Service {
+func NewService(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	sessions *sessions.Manager,
+	authzEngine *authz.Engine,
+	auditLogger *audit.Logger,
+) *Service {
 	logger = logger.With(attr.SlogComponent("variations"))
 
 	return &Service{
@@ -51,6 +59,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		repo:   repo.New(db),
 		auth:   auth.New(logger, db, sessions, authzEngine),
 		authz:  authzEngine,
+		audit:  auditLogger,
 	}
 }
 
@@ -203,7 +212,7 @@ func (s *Service) UpsertGlobal(ctx context.Context, payload *gen.UpsertGlobalPay
 
 	result := toVariation(row)
 
-	if err := audit.LogVariationUpdateGlobal(ctx, dbtx, audit.LogVariationUpdateGlobalEvent{
+	if err := s.audit.LogVariationUpdateGlobal(ctx, dbtx, audit.LogVariationUpdateGlobalEvent{
 		OrganizationID:          authCtx.ActiveOrganizationID,
 		ProjectID:               uuid.NullUUID{UUID: projectID, Valid: true},
 		Actor:                   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
@@ -258,7 +267,7 @@ func (s *Service) DeleteGlobal(ctx context.Context, payload *gen.DeleteGlobalPay
 		return nil, oops.E(oops.CodeUnexpected, err, "error deleting global tool variation").Log(ctx, s.logger)
 	}
 
-	if err := audit.LogVariationDeleteGlobal(ctx, dbtx, audit.LogVariationDeleteGlobalEvent{
+	if err := s.audit.LogVariationDeleteGlobal(ctx, dbtx, audit.LogVariationDeleteGlobalEvent{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),

--- a/server/internal/variations/setup_test.go
+++ b/server/internal/variations/setup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -74,7 +75,9 @@ func newTestVariationsService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, workos.NewStubClient(), cache.NoopCache)
-	svc := variations.NewService(logger, tracerProvider, conn, sessionManager, authzEngine)
+	auditLogger := audit.NewLogger()
+
+	svc := variations.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,


### PR DESCRIPTION
This change introduces an audit logger that holds all audit logging logic in place of the the package-level functions. This in preparation for work to emit outbox entries alongside audit logs.