### PR TITLE
mig: add mcp_servers FK indexes for remote_mcp_server_id and toolset_id

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2039,6 +2039,14 @@ CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx
 ON mcp_servers (project_id)
 WHERE deleted IS FALSE;
 
+CREATE INDEX IF NOT EXISTS mcp_servers_remote_mcp_server_id_idx
+ON mcp_servers (remote_mcp_server_id)
+WHERE remote_mcp_server_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS mcp_servers_toolset_id_idx
+ON mcp_servers (toolset_id)
+WHERE toolset_id IS NOT NULL;
+
 -- MCP Endpoints: addressable slugs for an MCP server. A NULL custom_domain_id
 -- represents a Gram-hosted endpoint (resolved by slug alone); a non-NULL
 -- custom_domain_id represents a custom-domain endpoint (resolved by the

--- a/server/migrations/20260505150617_mcp-servers-add-fk-indexes.sql
+++ b/server/migrations/20260505150617_mcp-servers-add-fk-indexes.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Create index "mcp_servers_remote_mcp_server_id_idx" to table: "mcp_servers"
+CREATE INDEX CONCURRENTLY "mcp_servers_remote_mcp_server_id_idx" ON "mcp_servers" ("remote_mcp_server_id") WHERE (remote_mcp_server_id IS NOT NULL);
+-- Create index "mcp_servers_toolset_id_idx" to table: "mcp_servers"
+CREATE INDEX CONCURRENTLY "mcp_servers_toolset_id_idx" ON "mcp_servers" ("toolset_id") WHERE (toolset_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lznIRVwDV0TxuEPbLHRS+cznwkOlH1zi6Sq9iiCoFeY=
+h1:TFlFTyaUOfivCkaRtef73QEhZqtTof5t3WkHoPGV8mM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -154,3 +154,4 @@ h1:lznIRVwDV0TxuEPbLHRS+cznwkOlH1zi6Sq9iiCoFeY=
 20260504160941_remove-location-from-pii-policies.sql h1:yCzDGT+8E9xuZpxYwJXpEyHYFW0xNEn9VKe2TchfJgs=
 20260504210916_chat_messages_project_id_id_idx.sql h1:kwShq3wLbk1VNIWRsAWDlqJ2apQ5iDnODP81/Vc6VTY=
 20260505134312_authz-challenge-resolutions.sql h1:t6fg2cQEWZrdYYATaJx+7zfdYvmJCUE3zuKJq4E6Zwo=
+20260505150617_mcp-servers-add-fk-indexes.sql h1:XEvL+LK4Km4lIBK4De3ryBk9ug0dSOBakZVIy9juEco=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2121/add-mcp-servers-fk-indexes-for-remote-mcp-server-id-and-toolset-id

Adds two indexes on `mcp_servers` to support new `remote_mcp_server_id` and `toolset_id` filters for `mcpServers.list` which will be used by [AGE-1719: Initial Remote MCP Source Management UI](https://linear.app/speakeasy/issue/AGE-1719/initial-remote-mcp-source-management-ui).