### PR TITLE
feat(risk): dedicated Temporal worker for AnalyzeBatch with concurrency cap

### DIFF
--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -46,11 +46,7 @@ type presidioResult struct {
 	Score      float64 `json:"score"`
 }
 
-// perBatchRequestConcurrency caps in-flight Presidio HTTP requests per
-// AnalyzeBatch invocation. NOT fleet-wide — N concurrent batches multiply
-// this. Fleet-wide load = N batches × perBatchRequestConcurrency, so the
-// real ceiling is set on the worker (perPodAnalyzeBatchConcurrency in
-// background/worker.go). Tuned to Presidio capacity as-of 2026-05-01.
+// Tuned to Presidio capacity 2026-05-01. Fleet-wide cap is perPodAnalyzeBatchConcurrency.
 const perBatchRequestConcurrency = 4
 
 // /analyze accepts a string or array; array returns ordered nested list. Bounds blast radius on retry-bisect.

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -46,8 +46,12 @@ type presidioResult struct {
 	Score      float64 `json:"score"`
 }
 
-// Tuned to Presidio capacity as-of 2026-05-01.
-const presidioMaxWorkers = 4
+// perBatchRequestConcurrency caps in-flight Presidio HTTP requests per
+// AnalyzeBatch invocation. NOT fleet-wide — N concurrent batches multiply
+// this. Fleet-wide load = N batches × perBatchRequestConcurrency, so the
+// real ceiling is set on the worker (perPodAnalyzeBatchConcurrency in
+// background/worker.go). Tuned to Presidio capacity as-of 2026-05-01.
+const perBatchRequestConcurrency = 4
 
 // /analyze accepts a string or array; array returns ordered nested list. Bounds blast radius on retry-bisect.
 const presidioHTTPBatchSize = 50
@@ -62,14 +66,14 @@ const presidioRetryBackoffCap = 1 * time.Second
 // unsafe guardian policy with an empty blocklist. The default policy blocks
 // RFC 1918 private ranges (10.0.0.0/8) which Kubernetes ClusterIPs fall into.
 type PresidioClient struct {
-	baseURL         string
-	httpClient      *guardian.HTTPClient
-	tracer          trace.Tracer
-	logger          *slog.Logger
-	maxWorkers      int
-	retryBackoff    time.Duration
-	requestDuration metric.Float64Histogram
-	requestFailures metric.Int64Counter
+	baseURL            string
+	httpClient         *guardian.HTTPClient
+	tracer             trace.Tracer
+	logger             *slog.Logger
+	requestConcurrency int
+	retryBackoff       time.Duration
+	requestDuration    metric.Float64Histogram
+	requestFailures    metric.Int64Counter
 }
 
 // NewPresidioClient creates a client pointing at the given base URL.
@@ -94,23 +98,24 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 	httpClient := unsafePolicy.PooledClient()
 
 	return &PresidioClient{
-		baseURL:         strings.TrimRight(baseURL, "/"),
-		httpClient:      httpClient,
-		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio"),
-		logger:          logger,
-		maxWorkers:      presidioMaxWorkers,
-		retryBackoff:    presidioRetryBackoff,
-		requestDuration: requestDuration,
-		requestFailures: requestFailures,
+		baseURL:            strings.TrimRight(baseURL, "/"),
+		httpClient:         httpClient,
+		tracer:             tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio"),
+		logger:             logger,
+		requestConcurrency: perBatchRequestConcurrency,
+		retryBackoff:       presidioRetryBackoff,
+		requestDuration:    requestDuration,
+		requestFailures:    requestFailures,
 	}
 }
 
-// NewPresidioClientWithWorkers is like NewPresidioClient but allows overriding
-// the concurrency limit. Used for benchmarking and tests; the retry backoff is
-// disabled so test sweeps don't pay 500ms per bisect step.
-func NewPresidioClientWithWorkers(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, maxWorkers int) *PresidioClient {
+// NewPresidioClientWithConcurrency is like NewPresidioClient but allows
+// overriding the per-batch HTTP request concurrency. Used for benchmarking
+// and tests; the retry backoff is disabled so test sweeps don't pay 500ms
+// per bisect step.
+func NewPresidioClientWithConcurrency(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, requestConcurrency int) *PresidioClient {
 	c := NewPresidioClient(baseURL, tracerProvider, meterProvider, logger)
-	c.maxWorkers = maxWorkers
+	c.requestConcurrency = requestConcurrency
 	c.retryBackoff = 0
 	return c
 }
@@ -174,7 +179,7 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 
 	results := make([][]Finding, n)
 	batches := chunkTextIndexes(n, presidioHTTPBatchSize)
-	workers := min(max(1, p.maxWorkers), len(batches))
+	workers := min(max(1, p.requestConcurrency), len(batches))
 
 	ch := make(chan indexRange, len(batches))
 	for _, batch := range batches {

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -107,7 +107,7 @@ func TestPresidioAnalyzeBatchSplitsPoisonedBatch(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	client := NewPresidioClientWithWorkers(
+	client := NewPresidioClientWithConcurrency(
 		srv.URL,
 		otel.GetTracerProvider(),
 		otel.GetMeterProvider(),
@@ -164,7 +164,7 @@ func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	client := NewPresidioClientWithWorkers(
+	client := NewPresidioClientWithConcurrency(
 		srv.URL,
 		otel.GetTracerProvider(),
 		otel.GetMeterProvider(),

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -29,11 +29,7 @@ const (
 	// drainBatchSize is how many messages each AnalyzeBatch activity processes.
 	drainBatchSize = 1_000
 
-	// Per-drain (per-policy) cap on AnalyzeBatch activities in flight. NOT
-	// fleet-wide — N drain workflows can each have this many in flight, so
-	// fleet load = N × perDrainBatchConcurrency × perBatchRequestConcurrency.
-	// The fleet-wide ceiling lives on the risk-analysis worker
-	// (perPodAnalyzeBatchConcurrency in worker.go). Tuned to demand 2026-05-01.
+	// Tuned 2026-05-01. Fleet-wide cap is perPodAnalyzeBatchConcurrency.
 	perDrainBatchConcurrency = 1
 )
 
@@ -64,10 +60,8 @@ func DrainRiskAnalysisWorkflow(ctx workflow.Context, params DrainRiskAnalysisPar
 	}
 	ctx = workflow.WithActivityOptions(ctx, activityOpts)
 
-	// AnalyzeBatch is dispatched to a dedicated worker pool so its concurrency
-	// against external scanners can be capped independently. The queue name is
-	// derived from the workflow's own task queue so every environment stays
-	// isolated.
+	// AnalyzeBatch runs on a dedicated, capped queue derived from the
+	// workflow's own queue so each environment stays isolated.
 	analyzeBatchOpts := activityOpts
 	analyzeBatchOpts.TaskQueue = RiskAnalysisTaskQueue(tenv.TaskQueueName(workflow.GetInfo(ctx).TaskQueueName))
 	analyzeBatchCtx := workflow.WithActivityOptions(ctx, analyzeBatchOpts)

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -60,6 +60,14 @@ func DrainRiskAnalysisWorkflow(ctx workflow.Context, params DrainRiskAnalysisPar
 	}
 	ctx = workflow.WithActivityOptions(ctx, activityOpts)
 
+	// AnalyzeBatch is dispatched to a dedicated worker pool so its concurrency
+	// against external scanners can be capped independently. The queue name is
+	// derived from the workflow's own task queue so every environment stays
+	// isolated.
+	analyzeBatchOpts := activityOpts
+	analyzeBatchOpts.TaskQueue = RiskAnalysisTaskQueue(tenv.TaskQueueName(workflow.GetInfo(ctx).TaskQueueName))
+	analyzeBatchCtx := workflow.WithActivityOptions(ctx, analyzeBatchOpts)
+
 	var a *Activities
 
 	// ── Fetch unanalyzed messages ──────────────────────────────────────
@@ -89,7 +97,7 @@ func DrainRiskAnalysisWorkflow(ctx workflow.Context, params DrainRiskAnalysisPar
 				pending = pending[1:]
 			}
 
-			f := workflow.ExecuteActivity(ctx, a.AnalyzeBatch, risk_analysis.AnalyzeBatchArgs{
+			f := workflow.ExecuteActivity(analyzeBatchCtx, a.AnalyzeBatch, risk_analysis.AnalyzeBatchArgs{
 				ProjectID:        params.ProjectID,
 				OrganizationID:   fetchResult.OrganizationID,
 				RiskPolicyID:     params.RiskPolicyID,

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -29,8 +29,12 @@ const (
 	// drainBatchSize is how many messages each AnalyzeBatch activity processes.
 	drainBatchSize = 1_000
 
-	// Tuned to demand as-of 2026-05-01.
-	drainMaxConcurrency = 1
+	// Per-drain (per-policy) cap on AnalyzeBatch activities in flight. NOT
+	// fleet-wide — N drain workflows can each have this many in flight, so
+	// fleet load = N × perDrainBatchConcurrency × perBatchRequestConcurrency.
+	// The fleet-wide ceiling lives on the risk-analysis worker
+	// (perPodAnalyzeBatchConcurrency in worker.go). Tuned to demand 2026-05-01.
+	perDrainBatchConcurrency = 1
 )
 
 // DrainRiskAnalysisParams identifies the policy this workflow drains.
@@ -87,10 +91,10 @@ func DrainRiskAnalysisWorkflow(ctx workflow.Context, params DrainRiskAnalysisPar
 	// ── Analyze batches ────────────────────────────────────────────────
 	if len(fetchResult.MessageIDs) > 0 {
 		batches := chunkUUIDs(fetchResult.MessageIDs, drainBatchSize)
-		pending := make([]workflow.Future, 0, min(len(batches), drainMaxConcurrency))
+		pending := make([]workflow.Future, 0, min(len(batches), perDrainBatchConcurrency))
 
 		for _, batch := range batches {
-			if len(pending) >= drainMaxConcurrency {
+			if len(pending) >= perDrainBatchConcurrency {
 				if err := pending[0].Get(ctx, nil); err != nil {
 					logger.Error("analyze batch failed", "error", err.Error())
 				}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -185,7 +185,7 @@ func NewTemporalWorker(
 	// providers that we must not overwhelm.
 	riskWorker := worker.New(env.Client(), RiskAnalysisTaskQueue(env.Queue()), worker.Options{
 		Interceptors:                       workerInterceptors,
-		MaxConcurrentActivityExecutionSize: riskAnalysisMaxConcurrentActivities,
+		MaxConcurrentActivityExecutionSize: perPodAnalyzeBatchConcurrency,
 	})
 
 	activities := NewActivities(
@@ -305,11 +305,13 @@ func NewTemporalWorker(
 	return &Workers{main: temporalWorker, riskAnalysis: riskWorker}
 }
 
-// riskAnalysisMaxConcurrentActivities caps how many AnalyzeBatch activities
-// the dedicated risk-analysis worker will run concurrently. Bound to protect
-// downstream scanners (Presidio, LLM providers) from overload. Per-process —
-// scaling the worker horizontally multiplies the effective cap.
-const riskAnalysisMaxConcurrentActivities = 20
+// perPodAnalyzeBatchConcurrency caps in-flight AnalyzeBatch activities per
+// worker pod. The only fleet-wide ceiling in the chain — perDrainBatchConcurrency
+// (drain_risk_analysis.go) and perBatchRequestConcurrency (presidio.go) are
+// scope-local and multiply with N policies / N batches, so they cannot bound
+// fleet load. Fleet ceiling = pod_count × perPodAnalyzeBatchConcurrency.
+// Bound to protect downstream scanners (Presidio, LLM providers) from overload.
+const perPodAnalyzeBatchConcurrency = 20
 
 // RiskAnalysisTaskQueue returns the dedicated task queue for risk analysis
 // activities, derived from the main worker's queue so each environment

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -3,6 +3,7 @@ package background
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -110,7 +111,7 @@ func NewTemporalWorker(
 	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
 	options ...*WorkerOptions,
-) worker.Worker {
+) *Workers {
 	opts := &WorkerOptions{
 		GuardianPolicy:      nil,
 		DB:                  nil,
@@ -169,12 +170,22 @@ func NewTemporalWorker(
 		}
 	}
 
+	workerInterceptors := []interceptor.WorkerInterceptor{
+		&interceptors.Recovery{WorkerInterceptorBase: interceptor.WorkerInterceptorBase{}},
+		&interceptors.InjectExecutionInfo{WorkerInterceptorBase: interceptor.WorkerInterceptorBase{}},
+		&interceptors.Logging{WorkerInterceptorBase: interceptor.WorkerInterceptorBase{}},
+	}
+
 	temporalWorker := worker.New(env.Client(), string(env.Queue()), worker.Options{
-		Interceptors: []interceptor.WorkerInterceptor{
-			&interceptors.Recovery{WorkerInterceptorBase: interceptor.WorkerInterceptorBase{}},
-			&interceptors.InjectExecutionInfo{WorkerInterceptorBase: interceptor.WorkerInterceptorBase{}},
-			&interceptors.Logging{WorkerInterceptorBase: interceptor.WorkerInterceptorBase{}},
-		},
+		Interceptors: workerInterceptors,
+	})
+
+	// Risk analysis runs on its own task queue so we can bound concurrency
+	// independently of the main worker — AnalyzeBatch hits Presidio + LLM
+	// providers that we must not overwhelm.
+	riskWorker := worker.New(env.Client(), RiskAnalysisTaskQueue(env.Queue()), worker.Options{
+		Interceptors:                       workerInterceptors,
+		MaxConcurrentActivityExecutionSize: riskAnalysisMaxConcurrentActivities,
 	})
 
 	activities := NewActivities(
@@ -234,9 +245,11 @@ func NewTemporalWorker(
 	// Trigger related activities
 	temporalWorker.RegisterActivity(activities.DispatchTrigger)
 	temporalWorker.RegisterActivity(activities.ProcessScheduledTrigger)
-	// Risk analysis activities
+	// Risk analysis activities. AnalyzeBatch runs on a dedicated worker so
+	// concurrency against external scanners (Presidio, LLM providers) is
+	// capped independently of the main worker.
 	temporalWorker.RegisterActivity(activities.FetchUnanalyzedMessages)
-	temporalWorker.RegisterActivity(activities.AnalyzeBatch)
+	riskWorker.RegisterActivity(activities.AnalyzeBatch)
 	// Assistant activities
 	temporalWorker.RegisterActivity(activities.AdmitAssistantThreads)
 	temporalWorker.RegisterActivity(activities.ProcessAssistantThread)
@@ -289,5 +302,59 @@ func NewTemporalWorker(
 		logger.ErrorContext(context.Background(), "failed to add assistant runtime janitor schedule", attr.SlogError(err))
 	}
 
-	return temporalWorker
+	return &Workers{main: temporalWorker, riskAnalysis: riskWorker}
+}
+
+// riskAnalysisMaxConcurrentActivities caps how many AnalyzeBatch activities
+// the dedicated risk-analysis worker will run concurrently. Bound to protect
+// downstream scanners (Presidio, LLM providers) from overload. Per-process —
+// scaling the worker horizontally multiplies the effective cap.
+const riskAnalysisMaxConcurrentActivities = 20
+
+// RiskAnalysisTaskQueue returns the dedicated task queue for risk analysis
+// activities, derived from the main worker's queue so each environment
+// (test, dev, prod) stays isolated.
+func RiskAnalysisTaskQueue(mainQueue tenv.TaskQueueName) string {
+	return string(mainQueue) + "-risk-analysis"
+}
+
+// Workers bundles the Temporal workers managed by the background package.
+// Risk analysis runs on its own queue + worker so its concurrency can be
+// capped without throttling the rest of the system.
+type Workers struct {
+	main         worker.Worker
+	riskAnalysis worker.Worker
+}
+
+// Run starts the auxiliary risk-analysis worker, then runs the main worker,
+// blocking until interruptCh receives. Returns the first error encountered.
+func (w *Workers) Run(interruptCh <-chan any) error {
+	if err := w.riskAnalysis.Start(); err != nil {
+		return fmt.Errorf("start risk analysis worker: %w", err)
+	}
+	defer w.riskAnalysis.Stop()
+
+	if err := w.main.Run(interruptCh); err != nil {
+		return fmt.Errorf("run main worker: %w", err)
+	}
+	return nil
+}
+
+// Start starts both workers without blocking. Pair with Stop. Used by tests
+// that drive workflows directly rather than waiting on an interrupt signal.
+func (w *Workers) Start() error {
+	if err := w.main.Start(); err != nil {
+		return fmt.Errorf("start main worker: %w", err)
+	}
+	if err := w.riskAnalysis.Start(); err != nil {
+		w.main.Stop()
+		return fmt.Errorf("start risk analysis worker: %w", err)
+	}
+	return nil
+}
+
+// Stop stops both workers. Safe to call after a partial Start failure.
+func (w *Workers) Stop() {
+	w.riskAnalysis.Stop()
+	w.main.Stop()
 }

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -180,9 +180,6 @@ func NewTemporalWorker(
 		Interceptors: workerInterceptors,
 	})
 
-	// Risk analysis runs on its own task queue so we can bound concurrency
-	// independently of the main worker — AnalyzeBatch hits Presidio + LLM
-	// providers that we must not overwhelm.
 	riskWorker := worker.New(env.Client(), RiskAnalysisTaskQueue(env.Queue()), worker.Options{
 		Interceptors:                       workerInterceptors,
 		MaxConcurrentActivityExecutionSize: perPodAnalyzeBatchConcurrency,
@@ -245,9 +242,7 @@ func NewTemporalWorker(
 	// Trigger related activities
 	temporalWorker.RegisterActivity(activities.DispatchTrigger)
 	temporalWorker.RegisterActivity(activities.ProcessScheduledTrigger)
-	// Risk analysis activities. AnalyzeBatch runs on a dedicated worker so
-	// concurrency against external scanners (Presidio, LLM providers) is
-	// capped independently of the main worker.
+	// Risk analysis activities — AnalyzeBatch on the dedicated worker.
 	temporalWorker.RegisterActivity(activities.FetchUnanalyzedMessages)
 	riskWorker.RegisterActivity(activities.AnalyzeBatch)
 	// Assistant activities
@@ -305,31 +300,22 @@ func NewTemporalWorker(
 	return &Workers{main: temporalWorker, riskAnalysis: riskWorker}
 }
 
-// perPodAnalyzeBatchConcurrency caps in-flight AnalyzeBatch activities per
-// worker pod. The only fleet-wide ceiling in the chain — perDrainBatchConcurrency
-// (drain_risk_analysis.go) and perBatchRequestConcurrency (presidio.go) are
-// scope-local and multiply with N policies / N batches, so they cannot bound
-// fleet load. Fleet ceiling = pod_count × perPodAnalyzeBatchConcurrency.
-// Bound to protect downstream scanners (Presidio, LLM providers) from overload.
+// Fleet-wide cap on in-flight AnalyzeBatch per worker pod — the only knob
+// in the chain that doesn't multiply with N policies or N batches.
 const perPodAnalyzeBatchConcurrency = 20
 
-// RiskAnalysisTaskQueue returns the dedicated task queue for risk analysis
-// activities, derived from the main worker's queue so each environment
-// (test, dev, prod) stays isolated.
 func RiskAnalysisTaskQueue(mainQueue tenv.TaskQueueName) string {
 	return string(mainQueue) + "-risk-analysis"
 }
 
-// Workers bundles the Temporal workers managed by the background package.
-// Risk analysis runs on its own queue + worker so its concurrency can be
-// capped without throttling the rest of the system.
+// Workers bundles the main and risk-analysis Temporal workers.
 type Workers struct {
 	main         worker.Worker
 	riskAnalysis worker.Worker
 }
 
-// Run starts the auxiliary risk-analysis worker, then runs the main worker,
-// blocking until interruptCh receives. Returns the first error encountered.
+// Run starts the risk-analysis worker, then blocks running the main worker
+// until interruptCh receives.
 func (w *Workers) Run(interruptCh <-chan any) error {
 	if err := w.riskAnalysis.Start(); err != nil {
 		return fmt.Errorf("start risk analysis worker: %w", err)
@@ -342,8 +328,7 @@ func (w *Workers) Run(interruptCh <-chan any) error {
 	return nil
 }
 
-// Start starts both workers without blocking. Pair with Stop. Used by tests
-// that drive workflows directly rather than waiting on an interrupt signal.
+// Start starts both workers without blocking. Pair with Stop (used by tests).
 func (w *Workers) Start() error {
 	if err := w.main.Start(); err != nil {
 		return fmt.Errorf("start main worker: %w", err)
@@ -355,7 +340,6 @@ func (w *Workers) Start() error {
 	return nil
 }
 
-// Stop stops both workers. Safe to call after a partial Start failure.
 func (w *Workers) Stop() {
 	w.riskAnalysis.Stop()
 	w.main.Stop()


### PR DESCRIPTION
## Why

Risk analysis took Presidio down on May 1. The hotfix (#2550) cut two constants — `drainMaxConcurrency: 20→1`, `presidioMaxWorkers: 100→4` — which stopped the bleeding, but **both knobs are scope-local**: one is per drain workflow, the other per `AnalyzeBatch` activity. Fleet load is still:

```
fleet HTTP = N policies × perDrainBatchConcurrency × perBatchRequestConcurrency
```

So the hotfix tuned values *inside the patch and inside the policy*. Neither knob can ever cap fleet load — they're factors that multiply with N. As policies grow, the same overload shape returns at a smaller multiplier.

```
incident:        500 × 20 × 100 = 1,000,000   ← Presidio fell over
hotfix (#2550):  500 ×  1 ×   4 =     2,000   ← scope-local, still grows with N
this PR:          40 ×   ⋯ ×  4 =       160   ← fleet-wide, bounded by pod count
```

## What this PR does

**Adds the missing fleet-wide limiter.** `AnalyzeBatch` runs on a dedicated Temporal task queue + worker, capped at `perPodAnalyzeBatchConcurrency = 20` per pod. With 2 worker pods in prod, fleet ceiling = 40 × 4 = **~160 concurrent Presidio HTTP, regardless of N policies**. Excess batches sit on the Temporal queue (durable backpressure).

**Renames the scope-local limiters** so the hierarchy is obvious in code:

| Scope | Was | Now | Bounds fleet load? |
|---|---|---|---|
| Per drain workflow | `drainMaxConcurrency` | `perDrainBatchConcurrency` | No — × N policies |
| Per `AnalyzeBatch` | `presidioMaxWorkers` | `perBatchRequestConcurrency` | No — × N batches |
| **Per worker pod (new)** | — | `perPodAnalyzeBatchConcurrency` | **Yes** — bounded by pod count |

Also `PresidioClient.maxWorkers` → `requestConcurrency` and `NewPresidioClientWithWorkers` → `NewPresidioClientWithConcurrency` (the field shadowed gunicorn workers in Presidio's helm config).

## Notes

- `NewTemporalWorker` now returns `*Workers` (wrapper exposing `Run`/`Start`/`Stop`); existing callers already use those methods.
- **No `gram-infra` change needed.** Datadog dashboard `aaj-2rm-zb3` uses a `$task_queue` wildcard and the failures monitor is namespace-scoped — both pick up the new queue automatically.
- Optional follow-up: alert on `temporal_worker_task_slots_used{task_queue:main-risk-analysis}` ≈ 20 to detect sustained saturation.

## Test plan

- [x] `go build`, `go vet`, `mise lint:server`, `go test ./internal/background/...` all clean
- [ ] Verify in dev that drain dispatches `AnalyzeBatch` to `dev-risk-analysis` (and not the main worker)
- [ ] Confirm new queue appears in Temporal UI and on the Temporal Workers dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)