### PR TITLE
feat(risk): flag destructive CLI commands via cli_destructive source

### DIFF
--- a/.changeset/cli-destructive-source.md
+++ b/.changeset/cli-destructive-source.md
@@ -1,0 +1,23 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Add `cli_destructive` risk-policy source for flagging destructive CLI commands.
+
+Mirrors the existing `destructive_tool` shape (post-hoc batch scan, flag-only,
+no live blocking) but is content-driven instead of annotation-driven. A
+curated regex set covers shell (`rm -rf`, `dd`, `mkfs`, fork-bomb,
+`chmod -R`, `chown -R`, `sudo <arg>`), git (`push --force`, `reset --hard`,
+`clean -f`, `branch -D`), database (`DROP`, `TRUNCATE`, unguarded
+`DELETE FROM`, `dropdb`), and cloud (`aws ec2 terminate-instances`,
+`aws s3 rb`, `gcloud projects delete`, `kubectl delete ns/workloads`).
+
+The scanner walks every recorded tool call's parsed arguments — no MCP
+filter — so native Bash and `run_terminal_cmd` are now in scope alongside
+MCP-routed calls whose arguments happen to carry destructive content.
+First-match-wins iteration over map keys is sorted so rule_ids are
+deterministic across runs.
+
+PolicyCenter exposes the new source as a "Destructive CLI Commands" rule
+category (category-toggle UX matching `destructive_tool`).

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -18,6 +18,7 @@ export type RuleCategory =
   | "off_policy"
   | "shadow_mcp"
   | "destructive_tool"
+  | "cli_destructive"
   | "custom";
 
 export type DetectionRule = {
@@ -105,6 +106,12 @@ export const RULE_CATEGORY_META: Record<
     description:
       "MCP tool calls whose Gram tool definition is annotated as destructive. Requires Speakeasy hooks and Gram-issued MCP tool metadata.",
     icon: "shield-alert",
+  },
+  cli_destructive: {
+    label: "Destructive CLI Commands",
+    description:
+      "Tool calls whose arguments match a curated set of destructive shell, git, database, or cloud CLI patterns (rm -rf, git push --force, DROP TABLE, kubectl delete ns, ...). Applies to native Bash / run_terminal_cmd as well as MCP-routed tools whose arguments carry destructive content.",
+    icon: "terminal",
   },
   custom: {
     label: "Custom Patterns",
@@ -1419,6 +1426,7 @@ export const DETECTION_RULES: Record<RuleCategory, DetectionRule[]> = {
   ],
   shadow_mcp: [],
   destructive_tool: [],
+  cli_destructive: [],
   custom: [],
 };
 

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -171,8 +171,10 @@ func (a *AnalyzeBatch) fetchContent(ctx context.Context, args AnalyzeBatchArgs) 
 
 // scan runs enabled scanners concurrently. Gitleaks is CPU-bound, presidio is
 // IO-bound, so they parallelize well and avoid exceeding the heartbeat timeout.
-// shadow_mcp scanning runs serially after the parallel scans because it makes
-// per-message DB calls.
+// All tool-call scanners (shadow_mcp, destructive_tool, cli_destructive) run
+// serially after the parallel scans — shadow_mcp/destructive_tool make
+// per-message DB calls; cli_destructive is purely in-memory regex but kept
+// in the same lane for consistency.
 func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages []repo.GetMessageContentBatchRow) ([][]Finding, error) {
 	ctx, scanSpan := a.tracer.Start(ctx, "risk.scanMessages")
 	defer scanSpan.End()
@@ -188,6 +190,7 @@ func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages
 	presidioFindings := make([][]Finding, n)
 	shadowMCPFindings := make([][]Finding, n)
 	destructiveToolFindings := make([][]Finding, n)
+	cliDestructiveFindings := make([][]Finding, n)
 
 	var wg sync.WaitGroup
 	var gitleaksErr error
@@ -236,12 +239,17 @@ func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages
 		activity.RecordHeartbeat(ctx, "destructive_tool")
 	}
 
+	if slices.Contains(args.Sources, SourceCLIDestructive) {
+		cliDestructiveFindings = a.scanDestructiveCLICommands(ctx, messages)
+		activity.RecordHeartbeat(ctx, "cli_destructive")
+	}
+
 	merged := make([][]Finding, n)
 	for i := range n {
 		// Gitleaks findings come first so they take priority over presidio
 		// when both scanners match the same text region. Tool-call findings are
 		// non-overlapping with content scanners, so they pass through dedup.
-		combined := slices.Concat(gitleaksFindings[i], presidioFindings[i], shadowMCPFindings[i], destructiveToolFindings[i])
+		combined := slices.Concat(gitleaksFindings[i], presidioFindings[i], shadowMCPFindings[i], destructiveToolFindings[i], cliDestructiveFindings[i])
 		merged[i] = dedup(combined)
 	}
 	return merged, nil
@@ -372,6 +380,61 @@ func (a *AnalyzeBatch) scanMessageDestructiveToolCalls(ctx context.Context, orgI
 			RuleID:      "destructive_tool.annotation",
 			Description: "Tool is annotated as destructive",
 			Match:       resolved.ToolName,
+			StartPos:    0,
+			EndPos:      0,
+			Tags:        nil,
+			Confidence:  1.0,
+		})
+	}
+	return findings
+}
+
+// scanDestructiveCLICommands flags recorded tool calls whose arguments contain
+// a curated destructive CLI pattern (rm -rf, git push --force, DROP TABLE,
+// ...). Unlike scanDestructiveToolAnnotations the trigger is content-driven,
+// so it applies to **every** tool call — native Bash / run_terminal_cmd as
+// well as MCP-routed calls whose args carry destructive content. The MCP
+// path can overlap with destructive_tool annotations; rule_id distinguishes
+// them and the dedup pass at the merge boundary is non-overlapping (start/end
+// positions are zero on tool-call findings).
+func (a *AnalyzeBatch) scanDestructiveCLICommands(ctx context.Context, messages []repo.GetMessageContentBatchRow) [][]Finding {
+	out := make([][]Finding, len(messages))
+	for i, msg := range messages {
+		if len(msg.ToolCalls) == 0 {
+			continue
+		}
+		out[i] = a.scanMessageDestructiveCLICalls(ctx, msg.ToolCalls)
+	}
+	return out
+}
+
+func (a *AnalyzeBatch) scanMessageDestructiveCLICalls(ctx context.Context, raw []byte) []Finding {
+	calls := a.parseRecordedToolCalls(ctx, SourceCLIDestructive, raw)
+
+	var findings []Finding
+	for _, call := range calls {
+		toolName := call.Function.Name
+		if toolName == "" {
+			continue
+		}
+
+		var toolInput any
+		if call.Function.Arguments != "" {
+			if err := json.Unmarshal([]byte(call.Function.Arguments), &toolInput); err != nil {
+				continue
+			}
+		}
+
+		matched, ok := scanForCLIDestructive(toolInput)
+		if !ok {
+			continue
+		}
+
+		findings = append(findings, Finding{
+			Source:      SourceCLIDestructive,
+			RuleID:      "cli_destructive." + matched.FullName(),
+			Description: "Tool input matched a destructive CLI pattern",
+			Match:       toolName,
 			StartPos:    0,
 			EndPos:      0,
 			Tags:        nil,

--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -132,6 +132,231 @@ func TestAnalyzeBatch_DestructiveToolAnnotationSkipsFalseHint(t *testing.T) {
 	require.Equal(t, 0, result.Findings)
 }
 
+// TestAnalyzeBatch_CLIDestructive_BashRmRf seeds a native Bash tool call
+// with `rm -rf *` and asserts the cli_destructive scanner emits a finding
+// keyed by the matched pattern. Native tools were previously skipped by the
+// MCP-only filter in scanDestructiveToolAnnotations — proving they are now
+// in scope is the core of this scenario.
+func TestAnalyzeBatch_CLIDestructive_BashRmRf(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "Bash", map[string]any{"command": "rm -rf *"})
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{risk_analysis.SourceCLIDestructive})
+	require.Equal(t, 1, result.Processed)
+	require.Equal(t, 1, result.Findings)
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		Cursor:       uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.True(t, rows[0].Found)
+	assert.Equal(t, risk_analysis.SourceCLIDestructive, rows[0].Source)
+	assert.Equal(t, "cli_destructive.shell/rm-rf", rows[0].RuleID.String)
+	assert.Equal(t, "Bash", rows[0].Match.String)
+}
+
+func TestAnalyzeBatch_CLIDestructive_GitForcePush(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "run_terminal_cmd", map[string]any{"command": "git push --force origin main"})
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{risk_analysis.SourceCLIDestructive})
+	require.Equal(t, 1, result.Processed)
+	require.Equal(t, 1, result.Findings)
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		Cursor:       uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "cli_destructive.git/push-force", rows[0].RuleID.String)
+}
+
+// TestAnalyzeBatch_CLIDestructive_MCPArgsDropTable proves the cli_destructive
+// scanner is genuinely tool-name-agnostic: an MCP-routed tool whose
+// `arguments` carry a destructive SQL fragment also flags. This is the
+// "scan all tool calls" semantics the planner asked for.
+func TestAnalyzeBatch_CLIDestructive_MCPArgsDropTable(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "mcp__db__run_query", map[string]any{"query": "DROP TABLE users"})
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{risk_analysis.SourceCLIDestructive})
+	require.Equal(t, 1, result.Processed)
+	require.Equal(t, 1, result.Findings)
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		Cursor:       uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "cli_destructive.database/drop", rows[0].RuleID.String)
+}
+
+// TestAnalyzeBatch_CLIDestructive_StableRuleIDAcrossKeys exercises the
+// deterministic-iteration guarantee of flattenCLIStrings: a tool call whose
+// arguments carry destructive content under multiple keys must report the
+// same rule_id every run. Without sorted map iteration the rule_id flaps
+// between matches because the first-match-wins inner loop sees keys in a
+// random order.
+func TestAnalyzeBatch_CLIDestructive_StableRuleIDAcrossKeys(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "Bash", map[string]any{
+		"command": "rm -rf *",                     // shell/rm-rf
+		"context": "DROP TABLE x",                 // database/drop
+		"alt":     "git push --force origin main", // git/push-force
+	})
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{risk_analysis.SourceCLIDestructive})
+	require.Equal(t, 1, result.Findings)
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		Cursor:       uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	// Sorted-key iteration walks "alt" → "command" → "context", so the
+	// first match is git/push-force from the "alt" key. Locking this in
+	// a test catches accidental reintroduction of random map ordering.
+	assert.Equal(t, "cli_destructive.git/push-force", rows[0].RuleID.String)
+}
+
+// TestAnalyzeBatch_BothSources_OnSameMCPCall asserts that destructive_tool
+// (annotation) and cli_destructive (content) emit two distinct findings on
+// a single MCP tool call when both sources are enabled. Proves the dedup
+// pass at the merge boundary lets non-overlapping findings through and
+// neither rule_id collides.
+func TestAnalyzeBatch_BothSources_OnSameMCPCall(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	destructive := true
+	toolsetID := seedHTTPToolset(t, conn, td, "run_query", &destructive)
+
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "mcp__gram__run_query", map[string]any{
+		shadowmcp.XGramToolsetIDField: toolsetID.String(),
+		"query":                       "DROP TABLE users",
+	})
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{shadowmcp.SourceDestructiveTool, risk_analysis.SourceCLIDestructive})
+	require.Equal(t, 1, result.Processed)
+	require.Equal(t, 2, result.Findings, "destructive_tool + cli_destructive must both fire")
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		Cursor:       uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	ruleIDs := []string{rows[0].RuleID.String, rows[1].RuleID.String}
+	assert.Contains(t, ruleIDs, "destructive_tool.annotation")
+	assert.Contains(t, ruleIDs, "cli_destructive.database/drop")
+}
+
+func TestAnalyzeBatch_CLIDestructive_BenignBash(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "Bash", map[string]any{"command": "ls -la"})
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{risk_analysis.SourceCLIDestructive})
+	require.Equal(t, 1, result.Processed)
+	require.Equal(t, 0, result.Findings)
+}
+
+// insertAssistantToolCallWithArgs is a sibling of insertAssistantToolCall for
+// CLI scenarios where the recorded arguments don't carry a Gram toolset id —
+// the cli_destructive scanner is content-driven, so the args field is the
+// thing under test.
+func insertAssistantToolCallWithArgs(t *testing.T, conn *pgxpool.Pool, td testData, callName string, argsMap map[string]any) uuid.UUID {
+	t.Helper()
+
+	args, err := json.Marshal(argsMap)
+	require.NoError(t, err)
+
+	toolCalls, err := json.Marshal([]map[string]any{
+		{
+			"id":   "call_1",
+			"type": "function",
+			"function": map[string]any{
+				"name":      callName,
+				"arguments": string(args),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	messageID := "msg-" + uuid.NewString()
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, nil)
+	t.Cleanup(func() { _ = shutdown(t.Context()) })
+	_, err = writer.Write(t.Context(), td.projectID, []chatrepo.CreateChatMessageParams{{
+		ChatID:           td.chatID,
+		Role:             "assistant",
+		ProjectID:        td.projectID,
+		Content:          "",
+		ContentRaw:       nil,
+		ContentAssetUrl:  pgtype.Text{},
+		StorageError:     pgtype.Text{},
+		Model:            pgtype.Text{},
+		MessageID:        pgtype.Text{String: messageID, Valid: true},
+		ToolCallID:       pgtype.Text{},
+		UserID:           pgtype.Text{},
+		ExternalUserID:   pgtype.Text{},
+		FinishReason:     pgtype.Text{String: "tool_calls", Valid: true},
+		ToolCalls:        toolCalls,
+		PromptTokens:     0,
+		CompletionTokens: 0,
+		TotalTokens:      0,
+		Origin:           pgtype.Text{},
+		UserAgent:        pgtype.Text{},
+		IpAddress:        pgtype.Text{},
+		Source:           pgtype.Text{},
+		ContentHash:      nil,
+		Generation:       0,
+	}})
+	require.NoError(t, err)
+
+	messages, err := chatrepo.New(conn).ListChatMessages(t.Context(), chatrepo.ListChatMessagesParams{
+		ChatID:    td.chatID,
+		ProjectID: td.projectID,
+	})
+	require.NoError(t, err)
+	for _, msg := range messages {
+		if msg.MessageID.String == messageID {
+			return msg.ID
+		}
+	}
+	require.FailNow(t, "inserted tool-call message not found")
+	return uuid.Nil
+}
+
 func executeAnalyzeBatch(t *testing.T, conn *pgxpool.Pool, td testData, messageIDs []uuid.UUID, sources []string) risk_analysis.AnalyzeBatchResult {
 	t.Helper()
 

--- a/server/internal/background/activities/risk_analysis/cli_destructive.go
+++ b/server/internal/background/activities/risk_analysis/cli_destructive.go
@@ -1,0 +1,194 @@
+package risk_analysis
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// SourceCLIDestructive is the policy source value that flags tool calls whose
+// arguments contain a curated destructive CLI command pattern (rm -rf, git
+// push --force, DROP TABLE, ...). Mirrors SourceDestructiveTool but is
+// content-driven instead of annotation-driven and applies to native tools
+// (Bash, run_terminal_cmd) as well as MCP-routed calls whose arguments
+// happen to carry a destructive payload.
+const SourceCLIDestructive = "cli_destructive"
+
+// cliDestructivePattern is one curated rule for matching destructive command
+// content inside a recorded tool call's arguments JSON. Patterns are
+// tool-name-agnostic — they run against every string value reachable from
+// the parsed arguments so a destructive shell snippet trips regardless of
+// whether it lives in a Bash tool's "command" field or an MCP query tool's
+// "query" / "args" field.
+//
+// Guard, when non-nil, is an "innocence" regex: a candidate string only
+// counts as destructive when Regex matches AND Guard does NOT. Used to
+// express rules like "DELETE FROM is destructive only if there's no WHERE
+// clause" without negative lookahead (which Go's RE2 doesn't support).
+type cliDestructivePattern struct {
+	Category string
+	Name     string
+	Regex    *regexp.Regexp
+	Guard    *regexp.Regexp
+}
+
+// FullName returns "category/name" for use in rule_ids and finding metadata.
+func (p cliDestructivePattern) FullName() string {
+	if p.Category == "" && p.Name == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(p.Category)
+	b.WriteByte('/')
+	b.WriteString(p.Name)
+	return b.String()
+}
+
+type cliDestructiveSpec struct {
+	Category string
+	Name     string
+	Pattern  string
+	Guard    string
+}
+
+// cliDestructivePatterns is the curated v1 set covering shell, git, database,
+// and cloud CLI commands. Kept in-code rather than per-policy because the
+// trade-off here is "first-line guardrail, not full sandbox" — see PR
+// description for the rationale. Adding a new pattern is a code change so
+// reviewers see every addition.
+//
+// Order matters: matchCLIDestructiveString returns the first match, so
+// **specific** patterns must come before broader catch-alls in the same
+// category. Within "shell", e.g., chmod-recursive precedes the bare-`sudo`
+// catch-all so `sudo chmod -R 777 /` reports as shell/chmod-recursive
+// rather than shell/sudo.
+var cliDestructivePatterns = compileCLIDestructivePatterns([]cliDestructiveSpec{
+	// Shell.
+	{Category: "shell", Name: "rm-rf", Pattern: `(?i)\brm\s+(?:-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r|--recursive\s+--force|--force\s+--recursive)\b`, Guard: ""},
+	{Category: "shell", Name: "dd", Pattern: `(?i)\bdd\b\s+(?:[a-z]+=)`, Guard: ""},
+	{Category: "shell", Name: "mkfs", Pattern: `(?i)\bmkfs(?:\.\w+)?\b`, Guard: ""},
+	{Category: "shell", Name: "fork-bomb", Pattern: `:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:`, Guard: ""},
+	{Category: "shell", Name: "chmod-recursive", Pattern: `(?i)\bchmod\s+(?:-[a-z]*R[a-z]*|--recursive)\b`, Guard: ""},
+	{Category: "shell", Name: "chown-recursive", Pattern: `(?i)\bchown\s+(?:-[a-z]*R[a-z]*|--recursive)\b`, Guard: ""},
+	// `sudo` requires a following token, so a bare-`sudo` mention won't trip
+	// — but prose like "sudo grants" will. Acceptable because we only scan
+	// tool-call argument values, not free chat text. Declared after the more
+	// specific shell patterns above so `sudo chmod -R 777 /` reports as
+	// chmod-recursive, not as sudo.
+	{Category: "shell", Name: "sudo", Pattern: `(?i)\bsudo\s+\S+`, Guard: ""},
+
+	// Git.
+	{Category: "git", Name: "push-force", Pattern: `(?i)\bgit\s+push\b[^\n]*(?:--force\b|--force-with-lease\b|\s-f\b)`, Guard: ""},
+	{Category: "git", Name: "reset-hard", Pattern: `(?i)\bgit\s+reset\s+--hard\b`, Guard: ""},
+	{Category: "git", Name: "clean-force", Pattern: `(?i)\bgit\s+clean\s+(?:-[a-z]*f[a-z]*|--force)\b`, Guard: ""},
+	{Category: "git", Name: "branch-delete-force", Pattern: `(?i)\bgit\s+branch\s+-D\b`, Guard: ""},
+
+	// Database.
+	{Category: "database", Name: "drop", Pattern: `(?i)\bDROP\s+(?:TABLE|DATABASE|SCHEMA|INDEX)\b`, Guard: ""},
+	{Category: "database", Name: "truncate", Pattern: `(?i)\bTRUNCATE\b`, Guard: ""},
+	// Unguarded DELETE: matches DELETE FROM only when the same string has no
+	// WHERE clause. Go's RE2 has no negative lookahead, so the absence check
+	// is expressed via Guard. Note: the guard is whole-string, so a
+	// concatenation like "DELETE FROM a; DELETE FROM b WHERE id=1" suppresses
+	// the unguarded first statement. Acceptable for v1.
+	{Category: "database", Name: "delete-without-where", Pattern: `(?i)\bDELETE\s+FROM\b`, Guard: `(?i)\bWHERE\b`},
+	{Category: "database", Name: "dropdb", Pattern: `(?i)\bdropdb\b`, Guard: ""},
+
+	// Cloud.
+	{Category: "cloud", Name: "aws-ec2-terminate", Pattern: `(?i)\baws\s+ec2\s+terminate-instances\b`, Guard: ""},
+	{Category: "cloud", Name: "aws-s3-rb", Pattern: `(?i)\baws\s+s3\s+rb\b`, Guard: ""},
+	{Category: "cloud", Name: "gcloud-projects-delete", Pattern: `(?i)\bgcloud\s+projects\s+delete\b`, Guard: ""},
+	{Category: "cloud", Name: "kubectl-delete-namespace", Pattern: `(?i)\bkubectl\s+delete\s+(?:ns|namespace)\b`, Guard: ""},
+	{Category: "cloud", Name: "kubectl-delete-workload", Pattern: `(?i)\bkubectl\s+delete\s+(?:deployment|sts|statefulset|daemonset|pv|pvc)\b`, Guard: ""},
+})
+
+func compileCLIDestructivePatterns(specs []cliDestructiveSpec) []cliDestructivePattern {
+	out := make([]cliDestructivePattern, 0, len(specs))
+	for _, spec := range specs {
+		p := cliDestructivePattern{
+			Category: spec.Category,
+			Name:     spec.Name,
+			Regex:    regexp.MustCompile(spec.Pattern),
+			Guard:    nil,
+		}
+		if spec.Guard != "" {
+			p.Guard = regexp.MustCompile(spec.Guard)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// flattenCLIStrings walks a parsed-JSON value and returns every string value
+// reachable via map values or slice elements. Map keys are not included — the
+// threat model is the values (a key like "DROP TABLE" would be strange but
+// not actually destructive). Numbers, bools, and nil are ignored.
+//
+// Map iteration is keyed-sorted so the first-match-wins ordering downstream
+// produces the same rule_id every run. Otherwise an input like
+// {"shell": "rm -rf *", "query": "DROP TABLE"} would flap between
+// shell/rm-rf and database/drop on alert dashboards.
+func flattenCLIStrings(input any) []string {
+	if input == nil {
+		return nil
+	}
+	var out []string
+	var walk func(v any)
+	walk = func(v any) {
+		switch t := v.(type) {
+		case string:
+			if t != "" {
+				out = append(out, t)
+			}
+		case map[string]any:
+			keys := make([]string, 0, len(t))
+			for k := range t {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				walk(t[k])
+			}
+		case []any:
+			for _, val := range t {
+				walk(val)
+			}
+		}
+	}
+	walk(input)
+	return out
+}
+
+// scanForCLIDestructive returns the first matching destructive pattern found
+// in any string value reachable from input, or zero value + false when nothing
+// matches. The first-match-wins ordering keeps the hot path predictable.
+func scanForCLIDestructive(input any) (cliDestructivePattern, bool) {
+	for _, str := range flattenCLIStrings(input) {
+		if matched, ok := matchCLIDestructiveString(str); ok {
+			return matched, true
+		}
+	}
+	return cliDestructivePattern{Category: "", Name: "", Regex: nil, Guard: nil}, false
+}
+
+// matchCLIDestructiveString applies the curated pattern set to a single
+// string. Exposed for tests; not exported.
+func matchCLIDestructiveString(s string) (cliDestructivePattern, bool) {
+	if s == "" {
+		return cliDestructivePattern{Category: "", Name: "", Regex: nil, Guard: nil}, false
+	}
+	for _, p := range cliDestructivePatterns {
+		if !p.Regex.MatchString(s) {
+			continue
+		}
+		// Guard expresses an "innocence" check — when present and matched,
+		// the candidate string is treated as non-destructive (e.g. a DELETE
+		// with a WHERE clause). Lets us encode the "unguarded DELETE" rule
+		// without negative lookahead.
+		if p.Guard != nil && p.Guard.MatchString(s) {
+			continue
+		}
+		return p, true
+	}
+	return cliDestructivePattern{Category: "", Name: "", Regex: nil, Guard: nil}, false
+}

--- a/server/internal/background/activities/risk_analysis/cli_destructive_test.go
+++ b/server/internal/background/activities/risk_analysis/cli_destructive_test.go
@@ -1,0 +1,143 @@
+package risk_analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMatchCLIDestructiveString_CuratedPatterns exercises one representative
+// example per curated pattern. Each case is named after the FullName the
+// matcher is expected to return.
+func TestMatchCLIDestructiveString_CuratedPatterns(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		fullName string
+	}{
+		{name: "shell/rm-rf", input: "rm -rf /tmp/work", fullName: "shell/rm-rf"},
+		{name: "shell/rm-rf-glob", input: "sudo rm -rf *", fullName: "shell/rm-rf"}, // rm-rf precedes sudo in declaration order
+		{name: "shell/dd", input: "dd if=/dev/zero of=/dev/sda bs=1M", fullName: "shell/dd"},
+		{name: "shell/mkfs", input: "mkfs.ext4 /dev/sdb1", fullName: "shell/mkfs"},
+		{name: "shell/fork-bomb", input: ":(){ :|: & };:", fullName: "shell/fork-bomb"},
+		{name: "shell/chmod-recursive", input: "chmod -R 777 /etc", fullName: "shell/chmod-recursive"},
+		{name: "shell/chown-recursive", input: "chown --recursive root:root /home", fullName: "shell/chown-recursive"},
+		{name: "shell/sudo", input: "sudo cat /etc/shadow", fullName: "shell/sudo"},
+		{name: "git/push-force", input: "git push --force origin main", fullName: "git/push-force"},
+		{name: "git/push-force-shorthand", input: "git push -f origin main", fullName: "git/push-force"},
+		{name: "git/push-force-with-lease", input: "git push --force-with-lease origin main", fullName: "git/push-force"},
+		{name: "git/reset-hard", input: "git reset --hard HEAD~3", fullName: "git/reset-hard"},
+		{name: "git/clean-force", input: "git clean -fd", fullName: "git/clean-force"},
+		{name: "git/branch-delete-force", input: "git branch -D feature/x", fullName: "git/branch-delete-force"},
+		{name: "database/drop-table", input: "DROP TABLE users", fullName: "database/drop"},
+		{name: "database/drop-database", input: "DROP DATABASE prod", fullName: "database/drop"},
+		{name: "database/truncate", input: "TRUNCATE accounts", fullName: "database/truncate"},
+		{name: "database/dropdb", input: "dropdb prod", fullName: "database/dropdb"},
+		{name: "cloud/aws-ec2-terminate", input: "aws ec2 terminate-instances --instance-ids i-1234", fullName: "cloud/aws-ec2-terminate"},
+		{name: "cloud/aws-s3-rb", input: "aws s3 rb s3://my-bucket --force", fullName: "cloud/aws-s3-rb"},
+		{name: "cloud/gcloud-projects-delete", input: "gcloud projects delete my-project", fullName: "cloud/gcloud-projects-delete"},
+		{name: "cloud/kubectl-delete-namespace", input: "kubectl delete ns production", fullName: "cloud/kubectl-delete-namespace"},
+		{name: "cloud/kubectl-delete-deployment", input: "kubectl delete deployment api", fullName: "cloud/kubectl-delete-workload"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			matched, ok := matchCLIDestructiveString(tc.input)
+			if assert.True(t, ok, "expected pattern match for %q", tc.input) {
+				assert.Equal(t, tc.fullName, matched.FullName())
+			}
+		})
+	}
+}
+
+// TestMatchCLIDestructiveString_DeleteWhereGuard exercises the Guard:
+// DELETE FROM ... WHERE is benign, DELETE FROM without WHERE flags.
+func TestMatchCLIDestructiveString_DeleteWhereGuard(t *testing.T) {
+	t.Parallel()
+
+	guarded, ok := matchCLIDestructiveString("DELETE FROM users WHERE id = 7")
+	assert.False(t, ok, "DELETE with WHERE clause must not flag, got %q", guarded.FullName())
+
+	unguarded, ok := matchCLIDestructiveString("DELETE FROM users")
+	if assert.True(t, ok, "DELETE without WHERE must flag") {
+		assert.Equal(t, "database/delete-without-where", unguarded.FullName())
+	}
+}
+
+func TestMatchCLIDestructiveString_BenignInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"ls -la",
+		"cat README.md",
+		"git status",
+		"git push origin main", // no force flag
+		"echo hello world",
+		"npm run test",
+		"SELECT * FROM users WHERE id = 7",
+		"",
+		// Bare-`sudo` mentions in prose must not flag — the curated pattern
+		// requires at least one argument.
+		"run with sudo",
+		"sudo",
+	}
+	for _, in := range cases {
+		matched, ok := matchCLIDestructiveString(in)
+		assert.False(t, ok, "expected no match for %q, got %q", in, matched.FullName())
+	}
+}
+
+// TestScanForCLIDestructive_NestedStructures verifies the matcher walks into
+// maps and slices to find destructive content nested anywhere in tool args.
+func TestScanForCLIDestructive_NestedStructures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("map value", func(t *testing.T) {
+		t.Parallel()
+		input := map[string]any{"command": "rm -rf /tmp/x"}
+		matched, ok := scanForCLIDestructive(input)
+		if assert.True(t, ok) {
+			assert.Equal(t, "shell/rm-rf", matched.FullName())
+		}
+	})
+
+	t.Run("nested map", func(t *testing.T) {
+		t.Parallel()
+		input := map[string]any{
+			"args": map[string]any{
+				"shell": "DROP TABLE users",
+			},
+		}
+		matched, ok := scanForCLIDestructive(input)
+		if assert.True(t, ok) {
+			assert.Equal(t, "database/drop", matched.FullName())
+		}
+	})
+
+	t.Run("slice element", func(t *testing.T) {
+		t.Parallel()
+		input := map[string]any{
+			"command": []any{"git", "push", "--force"},
+		}
+		// Each slice element is scanned individually — "git push --force" only
+		// matches when assembled. So this doesn't trip git/push-force, which
+		// is the documented behavior (we don't reconstruct shell argv).
+		_, ok := scanForCLIDestructive(input)
+		assert.False(t, ok, "argv slice elements are scanned individually")
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		t.Parallel()
+		_, ok := scanForCLIDestructive(nil)
+		assert.False(t, ok)
+	})
+
+	t.Run("benign nested", func(t *testing.T) {
+		t.Parallel()
+		input := map[string]any{"command": "ls -la"}
+		_, ok := scanForCLIDestructive(input)
+		assert.False(t, ok)
+	})
+}

--- a/server/internal/risk/createpolicy_test.go
+++ b/server/internal/risk/createpolicy_test.go
@@ -83,6 +83,37 @@ func TestCreateRiskPolicy_DestructiveToolRejectsBlock(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCreateRiskPolicy_CLIDestructiveSource(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)})
+
+	result, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{
+		Sources: []string{"cli_destructive"},
+		Action:  "flag",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cli_destructive"}, result.Sources)
+	require.Equal(t, "Destructive CLI Command Scanner", result.Name)
+}
+
+func TestCreateRiskPolicy_CLIDestructiveRejectsBlock(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn, authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)})
+
+	_, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{
+		Sources: []string{"cli_destructive"},
+		Action:  "block",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cli_destructive")
+}
+
 func TestCreateRiskPolicy_EmptyName(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -914,6 +915,8 @@ func (s *Service) fallbackPolicyName(sources []string, action string) string {
 			parts = append(parts, "Shadow MCP")
 		case shadowmcp.SourceDestructiveTool:
 			parts = append(parts, "Destructive Tool")
+		case risk_analysis.SourceCLIDestructive:
+			parts = append(parts, "Destructive CLI Command")
 		}
 	}
 	if len(parts) == 0 {
@@ -940,7 +943,7 @@ func validateAction(action string) error {
 func validateSources(sources []string) error {
 	for _, src := range sources {
 		switch src {
-		case "gitleaks", "presidio", shadowmcp.SourceShadowMCP, shadowmcp.SourceDestructiveTool:
+		case "gitleaks", "presidio", shadowmcp.SourceShadowMCP, shadowmcp.SourceDestructiveTool, risk_analysis.SourceCLIDestructive:
 		default:
 			return oops.E(oops.CodeInvalid, nil, "source %q is not a recognized policy source", src)
 		}
@@ -949,8 +952,13 @@ func validateSources(sources []string) error {
 }
 
 func validateSourceAction(sources []string, action string) error {
-	if action == "block" && slices.Contains(sources, shadowmcp.SourceDestructiveTool) {
-		return oops.E(oops.CodeInvalid, nil, "source %q supports flagging only", shadowmcp.SourceDestructiveTool)
+	if action != "block" {
+		return nil
+	}
+	for _, src := range []string{shadowmcp.SourceDestructiveTool, risk_analysis.SourceCLIDestructive} {
+		if slices.Contains(sources, src) {
+			return oops.E(oops.CodeInvalid, nil, "source %q supports flagging only", src)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Adds a new risk-policy source `cli_destructive` that mirrors the existing `destructive_tool` shape — post-hoc batch scan, flag-only, no live blocking. Where `destructive_tool` is annotation-driven (MCP tool definition's DestructiveHint), `cli_destructive` is content-driven: a curated regex set covering shell (rm -rf, dd, mkfs, fork-bomb, chmod/chown -R, sudo with arg), git (push --force, reset --hard, clean -f, branch -D), database (DROP, TRUNCATE, unguarded DELETE FROM, dropdb), and cloud (aws ec2 terminate-instances, aws s3 rb, gcloud projects delete, kubectl delete ns/workloads).

The scanner walks every recorded tool call's parsed arguments — no MCP filter — so native Bash and run_terminal_cmd land alongside MCP-routed calls whose arguments happen to carry destructive content. Map iteration is sorted-key so the first-match-wins rule_id is deterministic across runs.

The new source is registered in validateSources / fallbackPolicyName, and block-action is rejected (flag-only, matches destructive_tool). The ListEnabledToolIdentityPoliciesByProject query is intentionally NOT extended — cli_destructive doesn't need x-gram-toolset-id schema injection since it's content-driven.

Dashboard PolicyCenter exposes it as a new "Destructive CLI Commands" rule category (empty rules list, category-toggle UX matching destructive_tool).