### PR TITLE
feat(plugins): allow publish with only the observability plugin

### DIFF
--- a/.changeset/publish-without-custom-plugin.md
+++ b/.changeset/publish-without-custom-plugin.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Allow publishing to GitHub when the org has only the observability plugin (no custom plugins required)

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -196,7 +196,7 @@ export default function Plugins() {
             Code, Cursor, and Codex marketplaces via GitHub.
           </Page.Section.Description>
           <Page.Section.CTA>
-            {hasPlugins && publishStatus?.configured && (
+            {publishStatus?.configured && (
               <Button
                 variant="secondary"
                 onClick={() => setIsPublishDialogOpen(true)}

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1080,10 +1080,6 @@ func (s *Service) PublishPlugins(ctx context.Context, payload *gen.PublishPlugin
 		return nil, err
 	}
 
-	if len(pluginInfos) == 0 {
-		return nil, oops.E(oops.CodeBadRequest, nil, "no plugins with servers to publish")
-	}
-
 	project, err := projectsrepo.New(s.db).GetProjectByID(ctx, *ac.ProjectID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "get project").Log(ctx, s.logger)

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -926,6 +926,43 @@ func TestPluginsService_PublishPlugins_EmitsObservabilityPlugin(t *testing.T) {
 	require.NotNil(t, mock.lastPushedFiles[cursorObservability+"/hook.sh"], "cursor observability hook.sh missing")
 }
 
+// PublishPlugins must succeed when the org has no custom plugins — the
+// observability plugin alone is enough to ship a marketplace, since it's
+// always emitted on publish.
+func TestPluginsService_PublishPlugins_ObservabilityOnly(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+
+	_, err := ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
+	require.NoError(t, err)
+
+	claudeObservability, cursorObservability := orgObservabilitySlugs(t, ctx, ti)
+
+	require.NotNil(t, mock.lastPushedFiles[claudeObservability+"/hook.sh"], "claude observability hook.sh missing")
+	require.NotNil(t, mock.lastPushedFiles[cursorObservability+"/hook.sh"], "cursor observability hook.sh missing")
+
+	for _, p := range []struct {
+		path     string
+		expected string
+	}{
+		{".claude-plugin/marketplace.json", claudeObservability},
+		{".cursor-plugin/marketplace.json", cursorObservability},
+	} {
+		raw := mock.lastPushedFiles[p.path]
+		require.NotNil(t, raw, p.path+" missing")
+		var market struct {
+			Plugins []struct {
+				Name string `json:"name"`
+			} `json:"plugins"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &market))
+		require.Len(t, market.Plugins, 1, "expected only observability plugin in %s", p.path)
+		require.Equal(t, p.expected, market.Plugins[0].Name, "%s", p.path)
+	}
+}
+
 // The observability hook script must contain the freshly-minted hooks-scoped
 // API key (Bearer-token form) so team members can install the plugin without
 // any per-machine credential configuration.

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -444,21 +444,6 @@ func TestPluginsService_GetPublishStatus_Configured(t *testing.T) {
 	require.False(t, result.Connected)
 }
 
-func TestPluginsService_PublishPlugins_NoPlugins(t *testing.T) {
-	t.Parallel()
-
-	mock := &mockGitHubPublisher{}
-	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
-
-	_, err := ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
-	require.Error(t, err)
-
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
-	require.False(t, mock.createRepoCalled)
-}
-
 func TestPluginsService_PublishPlugins_HappyPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Drop the `hasPlugins` guard on the **Publish to GitHub** button in `client/dashboard/src/pages/plugins/Plugins.tsx` — it was hiding the button until a custom plugin existed, which contradicted the observability section's "Connect GitHub publishing to also ship it via the marketplace" copy.
- Drop the matching backend rejection in `server/internal/plugins/impl.go` (`"no plugins with servers to publish"`). `GeneratePluginPackages` always emits the per-org observability plugin and a one-entry marketplace when `HooksAPIKey` is set, which is always true on the publish path.
- Add `TestPluginsService_PublishPlugins_ObservabilityOnly` covering the new "zero custom plugins" publish path.

## Test plan
- [x] `go test ./internal/plugins/...` (5.3s, all green including the new test)
- [x] `npx tsc --noEmit` in `client/dashboard`
- [ ] Manual: in a fresh org with no custom plugins, click **Publish to GitHub**, verify a marketplace repo is created containing only the observability plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)