### PR TITLE
mig: add marketplace_token to plugin_github_connections

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2176,6 +2176,12 @@ CREATE TABLE IF NOT EXISTS plugin_github_connections (
   installation_id BIGINT NOT NULL,
   repo_owner TEXT NOT NULL CHECK (repo_owner <> ''),
   repo_name TEXT NOT NULL CHECK (repo_name <> ''),
+  -- Opaque URL token issued at marketplace setup. The marketplace proxy uses
+  -- it to resolve a Claude Code install URL back to this connection, whose
+  -- installation_id + owner/repo locate the upstream content. Nullable so
+  -- existing connections (and any future connection without the marketplace
+  -- surface enabled) are unconstrained.
+  marketplace_token TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -2194,6 +2200,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS plugin_github_connections_project_id_key
 -- "Octocat/Hello-World" and "octocat/hello-world" collide as expected.
 CREATE UNIQUE INDEX IF NOT EXISTS plugin_github_connections_installation_repo_key
   ON plugin_github_connections (installation_id, LOWER(repo_owner), LOWER(repo_name));
+
+-- Lookup index for the marketplace proxy. Partial so existing rows without a
+-- token (and any future rows where the marketplace surface isn't enabled)
+-- aren't constrained against each other.
+CREATE UNIQUE INDEX IF NOT EXISTS plugin_github_connections_marketplace_token_key
+  ON plugin_github_connections (marketplace_token)
+  WHERE marketplace_token IS NOT NULL;
 
 -- Risk analysis policies for scanning chat messages against configurable rules.
 -- One workflow per policy drains unanalyzed messages and produces risk_results.

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -886,13 +886,14 @@ type PluginAssignment struct {
 }
 
 type PluginGithubConnection struct {
-	ID             uuid.UUID
-	ProjectID      uuid.UUID
-	InstallationID int64
-	RepoOwner      string
-	RepoName       string
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
+	ID               uuid.UUID
+	ProjectID        uuid.UUID
+	InstallationID   int64
+	RepoOwner        string
+	RepoName         string
+	MarketplaceToken pgtype.Text
+	CreatedAt        pgtype.Timestamptz
+	UpdatedAt        pgtype.Timestamptz
 }
 
 type PluginServer struct {

--- a/server/internal/plugins/repo/models.go
+++ b/server/internal/plugins/repo/models.go
@@ -32,13 +32,14 @@ type PluginAssignment struct {
 }
 
 type PluginGithubConnection struct {
-	ID             uuid.UUID
-	ProjectID      uuid.UUID
-	InstallationID int64
-	RepoOwner      string
-	RepoName       string
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
+	ID               uuid.UUID
+	ProjectID        uuid.UUID
+	InstallationID   int64
+	RepoOwner        string
+	RepoName         string
+	MarketplaceToken pgtype.Text
+	CreatedAt        pgtype.Timestamptz
+	UpdatedAt        pgtype.Timestamptz
 }
 
 type PluginServer struct {

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -147,7 +147,7 @@ func (q *Queries) DeletePlugin(ctx context.Context, arg DeletePluginParams) erro
 }
 
 const getGitHubConnection = `-- name: GetGitHubConnection :one
-SELECT id, project_id, installation_id, repo_owner, repo_name, created_at, updated_at
+SELECT id, project_id, installation_id, repo_owner, repo_name, marketplace_token, created_at, updated_at
 FROM plugin_github_connections
 WHERE project_id = $1
 `
@@ -161,6 +161,7 @@ func (q *Queries) GetGitHubConnection(ctx context.Context, projectID uuid.UUID) 
 		&i.InstallationID,
 		&i.RepoOwner,
 		&i.RepoName,
+		&i.MarketplaceToken,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -562,7 +563,7 @@ ON CONFLICT (project_id) DO UPDATE
       repo_owner = EXCLUDED.repo_owner,
       repo_name = EXCLUDED.repo_name,
       updated_at = clock_timestamp()
-RETURNING id, project_id, installation_id, repo_owner, repo_name, created_at, updated_at
+RETURNING id, project_id, installation_id, repo_owner, repo_name, marketplace_token, created_at, updated_at
 `
 
 type UpsertGitHubConnectionParams struct {
@@ -586,6 +587,7 @@ func (q *Queries) UpsertGitHubConnection(ctx context.Context, arg UpsertGitHubCo
 		&i.InstallationID,
 		&i.RepoOwner,
 		&i.RepoName,
+		&i.MarketplaceToken,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/migrations/20260506195409_plugin-github-connections-marketplace-token.sql
+++ b/server/migrations/20260506195409_plugin-github-connections-marketplace-token.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "plugin_github_connections" table
+ALTER TABLE "plugin_github_connections" ADD COLUMN "marketplace_token" text NULL;
+-- Create index "plugin_github_connections_marketplace_token_key" to table: "plugin_github_connections"
+CREATE UNIQUE INDEX CONCURRENTLY "plugin_github_connections_marketplace_token_key" ON "plugin_github_connections" ("marketplace_token") WHERE (marketplace_token IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:SpXqn19ZV5C8F+A9i7PdVzIh0RZ2SYSC+SB57BsNfFY=
+h1:V9lGJTo8aMimQHnW+6Ht5N1DXgoDkSwwcwoZs+NVxZQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -156,3 +156,4 @@ h1:SpXqn19ZV5C8F+A9i7PdVzIh0RZ2SYSC+SB57BsNfFY=
 20260505134312_authz-challenge-resolutions.sql h1:t6fg2cQEWZrdYYATaJx+7zfdYvmJCUE3zuKJq4E6Zwo=
 20260505150617_mcp-servers-add-fk-indexes.sql h1:XEvL+LK4Km4lIBK4De3ryBk9ug0dSOBakZVIy9juEco=
 20260506092802_workos-sync-cursor-cols.sql h1:YTWZ24vx+g/exU+1Fs4uCXHrOYpUOYfe7+BxS/6atLo=
+20260506195409_plugin-github-connections-marketplace-token.sql h1:DgB/RCi4aj3HU4fFOlD5Wa5qhRBUK5b9yu49tT0HPEc=


### PR DESCRIPTION
Nullable opaque token column with a partial unique index, used by the upcoming marketplace proxy to resolve a Claude Code install URL back to the connection's installation_id + repo. Nullable so existing rows are unconstrained until a token is minted at first publish.