### PR TITLE
feat(observe): unify filter bar for tools, insights and logs

### DIFF
--- a/.changeset/shaky-states-pick.md
+++ b/.changeset/shaky-states-pick.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Unified the Observe filter bar for Insights Tools and Logs Tools views; server, email, and type filters are now multi-select dropdowns with OR semantics.

--- a/client/dashboard/src/components/observe/InsightsMCP.tsx
+++ b/client/dashboard/src/components/observe/InsightsMCP.tsx
@@ -53,6 +53,7 @@ import { cn } from "@/lib/utils";
 import { Dialog } from "@/components/ui/dialog";
 import { Button } from "@speakeasy-api/moonshine";
 import { MCPServerFilter } from "@/components/observe/ObserveFilterBar";
+import { isValidPreset } from "@/components/observe/observeFilterUtils";
 
 function hasTimeSeriesData(
   timeSeries: Array<{
@@ -363,23 +364,6 @@ function FilterBar({
       </div>
     </div>
   );
-}
-
-const validPresets: DateRangePreset[] = [
-  "15m",
-  "1h",
-  "4h",
-  "1d",
-  "2d",
-  "3d",
-  "7d",
-  "15d",
-  "30d",
-  "90d",
-];
-
-function isValidPreset(value: string | null): value is DateRangePreset {
-  return value !== null && validPresets.includes(value as DateRangePreset);
 }
 
 function toLocalISOString(date: Date): string {

--- a/client/dashboard/src/components/observe/InsightsMCP.tsx
+++ b/client/dashboard/src/components/observe/InsightsMCP.tsx
@@ -35,8 +35,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Check, ChevronDown } from "lucide-react";
-import { McpIcon } from "@/components/ui/mcp-icon";
+import { Check, ChevronRight, ChevronDown } from "lucide-react";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -49,11 +48,11 @@ import {
   type TooltipItem,
 } from "chart.js";
 import { Line } from "react-chartjs-2";
-import { ChevronRight } from "lucide-react";
 import { useRoutes } from "@/routes";
 import { cn } from "@/lib/utils";
 import { Dialog } from "@/components/ui/dialog";
 import { Button } from "@speakeasy-api/moonshine";
+import { MCPServerFilter } from "@/components/observe/ObserveFilterBar";
 
 function hasTimeSeriesData(
   timeSeries: Array<{
@@ -354,98 +353,6 @@ function FilterBar({
                           {option.count.toLocaleString()}
                         </span>
                       </div>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      </div>
-    </div>
-  );
-}
-
-function MCPServerFilter({
-  selectedServer,
-  onServerChange,
-  toolsets,
-  isLoading,
-  disabled,
-}: {
-  selectedServer: string | null;
-  onServerChange: (serverId: string | null) => void;
-  toolsets: Array<{ slug: string; name: string }>;
-  isLoading?: boolean;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-
-  const selectedToolset = toolsets.find((t) => t.slug === selectedServer);
-  const displayLabel = selectedToolset?.name ?? "All Servers";
-
-  return (
-    <div
-      className={`flex items-center gap-2 ${disabled ? "pointer-events-none opacity-50" : ""}`}
-    >
-      <span className="text-muted-foreground hidden text-sm font-medium 2xl:inline">
-        Filter by
-      </span>
-      <div className="border-border flex h-[42px] items-center rounded-md border p-1">
-        <div className="flex h-8 items-center gap-1.5 px-3">
-          <McpIcon className="text-muted-foreground size-3.5" />
-          <span className="text-foreground text-sm font-medium">Server</span>
-        </div>
-        <div className="bg-border/50 mx-1 h-6 w-px" />
-        <Popover open={!disabled && open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild>
-            <button
-              disabled={disabled || isLoading}
-              className={`flex h-8 min-w-[140px] items-center justify-between gap-2 rounded px-2 text-sm transition-colors ${
-                disabled || isLoading
-                  ? "cursor-not-allowed opacity-40"
-                  : "hover:bg-muted/50"
-              }`}
-            >
-              <span className="max-w-[120px] truncate">
-                {isLoading ? "Loading..." : displayLabel}
-              </span>
-              <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[220px] p-0" align="end">
-            <Command>
-              <CommandInput placeholder="Search servers..." className="h-9" />
-              <CommandList>
-                <CommandEmpty>No servers found.</CommandEmpty>
-                <CommandGroup>
-                  <CommandItem
-                    value="__all__"
-                    onSelect={() => {
-                      onServerChange(null);
-                      setOpen(false);
-                    }}
-                    className="cursor-pointer"
-                  >
-                    <Check
-                      className={`mr-2 size-4 ${selectedServer === null ? "opacity-100" : "opacity-0"}`}
-                    />
-                    <span>All Servers</span>
-                  </CommandItem>
-                  {toolsets.map((toolset) => (
-                    <CommandItem
-                      key={toolset.slug}
-                      value={toolset.name}
-                      onSelect={() => {
-                        onServerChange(toolset.slug);
-                        setOpen(false);
-                      }}
-                      className="cursor-pointer"
-                    >
-                      <Check
-                        className={`mr-2 size-4 ${selectedServer === toolset.slug ? "opacity-100" : "opacity-0"}`}
-                      />
-                      <span className="truncate">{toolset.name}</span>
                     </CommandItem>
                   ))}
                 </CommandGroup>

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -6,24 +6,17 @@ import { ErrorAlert } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { Checkbox } from "@/components/ui/checkbox";
-import { MultiSearch } from "@/components/ui/multi-search";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  FilterChip,
+  ObserveFilterBar,
+} from "@/components/observe/ObserveFilterBar";
 import { useSlugs } from "@/contexts/Sdk";
 import { useLogsEnabledErrorCheck } from "@/hooks/useLogsEnabled";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { useServerNameMappings } from "@/hooks/useServerNameMappings";
 import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
-import {
-  getPresetRange,
-  TimeRangePicker,
-  type DateRangePreset,
-} from "@gram-ai/elements";
+import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
 import { telemetryGetHooksSummary } from "@gram/client/funcs/telemetryGetHooksSummary";
 import { telemetryListHooksTraces } from "@gram/client/funcs/telemetryListHooksTraces";
 import type {
@@ -185,12 +178,6 @@ const validPresets: DateRangePreset[] = [
 
 function isValidPreset(value: string | null): value is DateRangePreset {
   return value !== null && validPresets.includes(value as DateRangePreset);
-}
-
-interface FilterChip {
-  display: string;
-  filters: string[];
-  path: string;
 }
 
 function safeBase64Encode(str: string): string {
@@ -717,47 +704,25 @@ function HooksInnerContent({
             </div>
           </div>
 
-          <div className="flex shrink-0 flex-wrap items-center gap-2">
-            <MultiSearch
-              value={serverInput}
-              onChange={setServerInput}
-              onSubmit={onSubmitServerFilter}
-              placeholder="Filter by server name (press Enter to add)"
-              className="min-w-[200px] flex-1"
-              chips={activeFilters
-                .filter((f) => f.path === "gram.tool_call.source")
-                .map((f) => ({ display: f.display, value: f.display }))}
-              onRemoveChip={(display) =>
-                removeFilter("gram.tool_call.source", display)
-              }
-            />
-            <MultiSearch
-              value={userEmailInput}
-              onChange={setUserEmailInput}
-              onSubmit={onSubmitUserEmailFilter}
-              placeholder="Filter by user email (press Enter to add)"
-              className="min-w-[200px] flex-1"
-              chips={activeFilters
-                .filter((f) => f.path === "user.email")
-                .map((f) => ({ display: f.display, value: f.display }))}
-              onRemoveChip={(display) => removeFilter("user.email", display)}
-            />
-            <HookTypeFilter
-              selectedHookTypes={selectedHookTypes}
-              onHookTypesChange={onHookTypesChange}
-            />
-            <div className="ml-auto">
-              <TimeRangePicker
-                preset={customRange ? null : dateRange}
-                customRange={customRange}
-                customRangeLabel={customRangeLabel}
-                onPresetChange={onDateRangeChange}
-                onCustomRangeChange={onCustomRangeChange}
-                onClearCustomRange={onClearCustomRange}
-                projectSlug={projectSlug}
-              />
-            </div>
-          </div>
+          <ObserveFilterBar
+            serverInput={serverInput}
+            setServerInput={setServerInput}
+            onSubmitServerFilter={onSubmitServerFilter}
+            userEmailInput={userEmailInput}
+            setUserEmailInput={setUserEmailInput}
+            onSubmitUserEmailFilter={onSubmitUserEmailFilter}
+            activeFilters={activeFilters}
+            removeFilter={removeFilter}
+            selectedTypes={selectedHookTypes}
+            onTypesChange={onHookTypesChange}
+            dateRange={dateRange}
+            customRange={customRange}
+            customRangeLabel={customRangeLabel}
+            onDateRangeChange={onDateRangeChange}
+            onCustomRangeChange={onCustomRangeChange}
+            onClearCustomRange={onClearCustomRange}
+            projectSlug={projectSlug}
+          />
 
           <div className="flex min-h-0 flex-1 overflow-hidden">
             <div className="min-h-0 flex-1 overflow-y-auto pb-4">
@@ -817,92 +782,6 @@ function HooksInnerContent({
         onOpenChange={(open) => !open && setSelectedLog(null)}
       />
     </>
-  );
-}
-
-const HOOK_TYPE_OPTIONS = [
-  {
-    label: "MCP Servers",
-    labelShort: "Servers",
-    value: "mcp" as TypesToInclude,
-  },
-  {
-    label: "Local Tools",
-    labelShort: "Local",
-    value: "local" as TypesToInclude,
-  },
-  { label: "Skills", labelShort: "Skills", value: "skill" as TypesToInclude },
-];
-
-function HookTypeFilter({
-  selectedHookTypes,
-  onHookTypesChange,
-}: {
-  selectedHookTypes: TypesToInclude[];
-  onHookTypesChange: (types: TypesToInclude[]) => void;
-}) {
-  const getButtonText = () => {
-    if (selectedHookTypes.length === 3) {
-      return "Showing all types";
-    }
-
-    if (selectedHookTypes.length === 0) {
-      return "No types selected";
-    }
-
-    if (selectedHookTypes.length === 1) {
-      const selected = HOOK_TYPE_OPTIONS.find(
-        (opt) => opt.value === selectedHookTypes[0],
-      );
-      return `Showing ${selected?.labelShort || selectedHookTypes[0]}`;
-    }
-
-    const labels = HOOK_TYPE_OPTIONS.filter((opt) =>
-      selectedHookTypes.includes(opt.value),
-    ).map((opt) => opt.labelShort);
-    return `Showing ${labels.join(" & ")}`;
-  };
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-[42px] w-[200px] shrink-0 justify-between"
-        >
-          <span className="text-sm">{getButtonText()}</span>
-          <Icon name="chevron-down" className="ml-2 size-4" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-3" align="start">
-        <div className="space-y-2">
-          {HOOK_TYPE_OPTIONS.map((option) => (
-            <div key={option.value} className="flex items-center space-x-2">
-              <Checkbox
-                id={`hook-type-${option.value}`}
-                checked={selectedHookTypes.includes(option.value)}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    onHookTypesChange([...selectedHookTypes, option.value]);
-                  } else {
-                    onHookTypesChange(
-                      selectedHookTypes.filter((t) => t !== option.value),
-                    );
-                  }
-                }}
-              />
-              <label
-                htmlFor={`hook-type-${option.value}`}
-                className="cursor-pointer text-sm leading-none font-medium"
-              >
-                {option.label}
-              </label>
-            </div>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
   );
 }
 

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -261,7 +261,6 @@ export function InsightsToolsContent() {
     return filters;
   });
 
-  const [serverInput, setServerInput] = useState("");
   const [userEmailInput, setUserEmailInput] = useState("");
   const [selectedHookTypes, setSelectedHookTypes] =
     useState<TypesToInclude[]>(parsedHookTypes);
@@ -417,6 +416,54 @@ export function InsightsToolsContent() {
     throwOnError: false,
   });
 
+  const [knownServers, setKnownServers] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!summaryData) return;
+    const names = summaryData.breakdown.map((r) => r.serverName);
+    setKnownServers((prev) => {
+      const merged = [...new Set([...prev, ...names])];
+      return merged.length === prev.length ? prev : merged;
+    });
+  }, [summaryData]);
+
+  const serverOptions = useMemo(() => {
+    const selected = activeFilters
+      .filter((f) => f.path === "gram.tool_call.source")
+      .map((f) => f.filters[0])
+      .filter((v): v is string => Boolean(v));
+    return [...new Set([...knownServers, ...selected])];
+  }, [knownServers, activeFilters]);
+
+  const handleServerSelectionChange = useCallback(
+    (values: string[]) => {
+      setActiveFilters((prev) => {
+        const nonServer = prev.filter(
+          (f) => f.path !== "gram.tool_call.source",
+        );
+        const serverFilters: FilterChip[] = values.map((v) => ({
+          display: v,
+          filters: [v],
+          path: "gram.tool_call.source",
+        }));
+        return [...nonServer, ...serverFilters];
+      });
+      setSearchParams(
+        (urlPrev) => {
+          const next = new URLSearchParams(urlPrev);
+          if (values.length > 0) {
+            next.set("server", values.join(","));
+          } else {
+            next.delete("server");
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
   const addFilter = useCallback(
     (chip: FilterChip) => {
       setActiveFilters((prev) => {
@@ -491,17 +538,6 @@ export function InsightsToolsContent() {
     },
     [setSearchParams],
   );
-
-  const submitServerFilter = useCallback(() => {
-    const trimmed = serverInput.trim();
-    if (!trimmed) return;
-    addFilter({
-      display: trimmed,
-      filters: [trimmed],
-      path: "gram.tool_call.source",
-    });
-    setServerInput("");
-  }, [serverInput, addFilter]);
 
   const submitUserEmailFilter = useCallback(() => {
     const trimmed = userEmailInput.trim();
@@ -583,9 +619,8 @@ export function InsightsToolsContent() {
             isLoading={isLoading}
             error={error}
             groupedTraces={groupedTraces}
-            serverInput={serverInput}
-            setServerInput={setServerInput}
-            onSubmitServerFilter={submitServerFilter}
+            serverOptions={serverOptions}
+            onServerSelectionChange={handleServerSelectionChange}
             userEmailInput={userEmailInput}
             setUserEmailInput={setUserEmailInput}
             onSubmitUserEmailFilter={submitUserEmailFilter}
@@ -618,9 +653,8 @@ function HooksInnerContent({
   isLoading,
   error,
   groupedTraces,
-  serverInput,
-  setServerInput,
-  onSubmitServerFilter,
+  serverOptions,
+  onServerSelectionChange,
   userEmailInput,
   setUserEmailInput,
   onSubmitUserEmailFilter,
@@ -647,9 +681,8 @@ function HooksInnerContent({
   isLoading: boolean;
   error: Error | null;
   groupedTraces: HookTrace[];
-  serverInput: string;
-  setServerInput: (value: string) => void;
-  onSubmitServerFilter: () => void;
+  serverOptions: string[];
+  onServerSelectionChange: (values: string[]) => void;
   userEmailInput: string;
   setUserEmailInput: (value: string) => void;
   onSubmitUserEmailFilter: () => void;
@@ -705,9 +738,8 @@ function HooksInnerContent({
           </div>
 
           <ObserveFilterBar
-            serverInput={serverInput}
-            setServerInput={setServerInput}
-            onSubmitServerFilter={onSubmitServerFilter}
+            serverOptions={serverOptions}
+            onServerSelectionChange={onServerSelectionChange}
             userEmailInput={userEmailInput}
             setUserEmailInput={setUserEmailInput}
             onSubmitUserEmailFilter={onSubmitUserEmailFilter}

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -26,7 +26,6 @@ import type {
   SkillBreakdownRow,
   SkillTimeSeriesPoint,
   HookTraceSummary as HookTrace,
-  LogFilter,
   TelemetryLogRecord,
   TypesToInclude,
 } from "@gram/client/models/components";
@@ -56,7 +55,9 @@ import {
 import { Bar, Line } from "react-chartjs-2";
 import { Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { Link } from "react-router";
+import { useObserveFilters } from "@/components/observe/useObserveFilters";
+import { perPage } from "@/components/observe/observeFilterUtils";
 import { LogDetailSheet } from "@/pages/logs/LogDetailSheet";
 import { HooksEmptyState } from "@/pages/hooks/HooksEmptyState";
 import { HooksSetupButton } from "@/pages/hooks/HooksSetupDialog";
@@ -163,48 +164,7 @@ const SHARED_BAR_SCALES = {
   },
 } satisfies _BarScales;
 
-const validPresets: DateRangePreset[] = [
-  "15m",
-  "1h",
-  "4h",
-  "1d",
-  "2d",
-  "3d",
-  "7d",
-  "15d",
-  "30d",
-  "90d",
-];
-
-function isValidPreset(value: string | null): value is DateRangePreset {
-  return value !== null && validPresets.includes(value as DateRangePreset);
-}
-
-function safeBase64Encode(str: string): string {
-  try {
-    return btoa(str);
-  } catch {
-    return btoa(encodeURIComponent(str));
-  }
-}
-
-function safeBase64Decode(str: string): string | null {
-  try {
-    const decoded = atob(str);
-    try {
-      return decodeURIComponent(decoded);
-    } catch {
-      return decoded;
-    }
-  } catch {
-    return null;
-  }
-}
-
-const perPage = 100;
-
 export function InsightsToolsContent() {
-  const [searchParams, setSearchParams] = useSearchParams();
   const { projectSlug } = useSlugs();
 
   const mcpConfig = useObservabilityMcpConfig({
@@ -214,140 +174,34 @@ export function InsightsToolsContent() {
 
   const serverNameMappings = useServerNameMappings();
 
-  const initialServer = searchParams.get("server");
-  const initialUserEmail = searchParams.get("user");
+  const {
+    from,
+    to,
+    logFilters,
+    selectedHookTypes,
+    activeFilters,
+    addKnownServers,
+    serverOptions,
+    handleServerSelectionChange,
+    userEmailInput,
+    setUserEmailInput,
+    submitUserEmailFilter,
+    addFilter,
+    removeFilter,
+    handleHookTypesChange,
+    dateRange,
+    customRange,
+    customRangeLabel,
+    setDateRangeParam,
+    setCustomRangeParam,
+    clearCustomRange,
+  } = useObserveFilters();
 
-  const initialHookTypes = searchParams.get("hookTypes");
-  const defaultHookTypes: TypesToInclude[] = ["mcp", "skill"];
-  const parsedHookTypes: TypesToInclude[] = initialHookTypes
-    ? (initialHookTypes
-        .split(",")
-        .filter((t) =>
-          ["mcp", "local", "skill"].includes(t),
-        ) as TypesToInclude[])
-    : defaultHookTypes;
-
-  const [activeFilters, setActiveFilters] = useState<FilterChip[]>(() => {
-    const filters: FilterChip[] = [];
-
-    if (initialServer) {
-      const serverValues = initialServer
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      serverValues.forEach((value) => {
-        filters.push({
-          display: value,
-          filters: [value],
-          path: "gram.tool_call.source",
-        });
-      });
-    }
-
-    if (initialUserEmail) {
-      const userValues = initialUserEmail
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      userValues.forEach((value) => {
-        filters.push({
-          display: value,
-          filters: [value],
-          path: "user.email",
-        });
-      });
-    }
-
-    return filters;
-  });
-
-  const [userEmailInput, setUserEmailInput] = useState("");
-  const [selectedHookTypes, setSelectedHookTypes] =
-    useState<TypesToInclude[]>(parsedHookTypes);
   const [selectedLog, setSelectedLog] = useState<TelemetryLogRecord | null>(
     null,
   );
 
   const client = useGramContext();
-
-  const urlRange = searchParams.get("range");
-  const urlFrom = searchParams.get("from");
-  const urlTo = searchParams.get("to");
-  const urlLabelEncoded = searchParams.get("label");
-  const urlLabel = useMemo(() => {
-    if (!urlLabelEncoded) return null;
-    return safeBase64Decode(urlLabelEncoded);
-  }, [urlLabelEncoded]);
-
-  const dateRange: DateRangePreset = isValidPreset(urlRange) ? urlRange : "7d";
-
-  const customRange = useMemo(() => {
-    if (urlFrom && urlTo) {
-      const from = new Date(urlFrom);
-      const to = new Date(urlTo);
-      if (!isNaN(from.getTime()) && !isNaN(to.getTime())) {
-        return { from, to };
-      }
-    }
-    return null;
-  }, [urlFrom, urlTo]);
-
-  const updateSearchParams = useCallback(
-    (updates: Record<string, string | null>) => {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        for (const [key, value] of Object.entries(updates)) {
-          if (value === null) {
-            next.delete(key);
-          } else {
-            next.set(key, value);
-          }
-        }
-        return next;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const setDateRangeParam = useCallback(
-    (preset: DateRangePreset) => {
-      updateSearchParams({ range: preset, from: null, to: null, label: null });
-    },
-    [updateSearchParams],
-  );
-
-  const setCustomRangeParam = useCallback(
-    (from: Date, to: Date, label?: string) => {
-      updateSearchParams({
-        range: null,
-        from: from.toISOString(),
-        to: to.toISOString(),
-        label: label ? safeBase64Encode(label) : null,
-      });
-    },
-    [updateSearchParams],
-  );
-
-  const clearCustomRange = useCallback(() => {
-    updateSearchParams({ from: null, to: null, label: null });
-  }, [updateSearchParams]);
-
-  const { from, to } = useMemo(
-    () => customRange ?? getPresetRange(dateRange),
-    [customRange, dateRange],
-  );
-
-  const logFilters = useMemo(() => {
-    const filters: LogFilter[] = [];
-    for (const chip of activeFilters) {
-      filters.push({
-        path: chip.path,
-        operator: chip.filters.length > 1 ? "in" : "contains",
-        values: chip.filters,
-      });
-    }
-    return filters.length > 0 ? filters : undefined;
-  }, [activeFilters]);
 
   const {
     data: tracesData,
@@ -416,165 +270,10 @@ export function InsightsToolsContent() {
     throwOnError: false,
   });
 
-  const [knownServers, setKnownServers] = useState<string[]>([]);
-
   useEffect(() => {
     if (!summaryData) return;
-    const names = summaryData.breakdown.map((r) => r.serverName);
-    setKnownServers((prev) => {
-      const merged = [...new Set([...prev, ...names])];
-      return merged.length === prev.length ? prev : merged;
-    });
-  }, [summaryData]);
-
-  const serverOptions = useMemo(() => {
-    const selected = activeFilters
-      .filter((f) => f.path === "gram.tool_call.source")
-      .map((f) => f.filters[0])
-      .filter((v): v is string => Boolean(v));
-    return [...new Set([...knownServers, ...selected])];
-  }, [knownServers, activeFilters]);
-
-  const handleServerSelectionChange = useCallback(
-    (values: string[]) => {
-      setActiveFilters((prev) => {
-        const nonServer = prev.filter(
-          (f) => f.path !== "gram.tool_call.source",
-        );
-        const serverFilters: FilterChip[] = values.map((v) => ({
-          display: v,
-          filters: [v],
-          path: "gram.tool_call.source",
-        }));
-        return [...nonServer, ...serverFilters];
-      });
-      setSearchParams(
-        (urlPrev) => {
-          const next = new URLSearchParams(urlPrev);
-          if (values.length > 0) {
-            next.set("server", values.join(","));
-          } else {
-            next.delete("server");
-          }
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  const addFilter = useCallback(
-    (chip: FilterChip) => {
-      setActiveFilters((prev) => {
-        const exists = prev.some(
-          (f) => f.path === chip.path && f.display === chip.display,
-        );
-        if (exists) return prev;
-
-        const newFilters = [...prev, chip];
-
-        setSearchParams(
-          (urlPrev) => {
-            const next = new URLSearchParams(urlPrev);
-            if (chip.path === "gram.tool_call.source") {
-              const serverFilters = newFilters
-                .filter((f) => f.path === "gram.tool_call.source")
-                .map((f) => f.display);
-              next.set("server", serverFilters.join(","));
-            } else if (chip.path === "user.email") {
-              const userFilters = newFilters
-                .filter((f) => f.path === "user.email")
-                .map((f) => f.display);
-              next.set("user", userFilters.join(","));
-            }
-            return next;
-          },
-          { replace: true },
-        );
-
-        return newFilters;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const removeFilter = useCallback(
-    (path: string, display?: string) => {
-      setActiveFilters((prev) => {
-        const newFilters = display
-          ? prev.filter((f) => !(f.path === path && f.display === display))
-          : prev.filter((f) => f.path !== path);
-
-        setSearchParams(
-          (urlPrev) => {
-            const next = new URLSearchParams(urlPrev);
-            if (path === "gram.tool_call.source") {
-              const serverFilters = newFilters
-                .filter((f) => f.path === "gram.tool_call.source")
-                .map((f) => f.display);
-              if (serverFilters.length > 0) {
-                next.set("server", serverFilters.join(","));
-              } else {
-                next.delete("server");
-              }
-            } else if (path === "user.email") {
-              const userFilters = newFilters
-                .filter((f) => f.path === "user.email")
-                .map((f) => f.display);
-              if (userFilters.length > 0) {
-                next.set("user", userFilters.join(","));
-              } else {
-                next.delete("user");
-              }
-            }
-            return next;
-          },
-          { replace: true },
-        );
-
-        return newFilters;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const submitUserEmailFilter = useCallback(() => {
-    const trimmed = userEmailInput.trim();
-    if (!trimmed) return;
-    addFilter({
-      display: trimmed,
-      filters: [trimmed],
-      path: "user.email",
-    });
-    setUserEmailInput("");
-  }, [userEmailInput, addFilter]);
-
-  const handleHookTypesChange = useCallback(
-    (types: TypesToInclude[]) => {
-      setSelectedHookTypes(types);
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          const isDefault =
-            types.length === 2 &&
-            types.includes("mcp") &&
-            types.includes("skill") &&
-            !types.includes("local");
-          if (isDefault) {
-            next.delete("hookTypes");
-          } else if (types.length > 0) {
-            next.set("hookTypes", types.join(","));
-          } else {
-            next.set("hookTypes", "");
-          }
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
+    addKnownServers(summaryData.breakdown.map((r) => r.serverName));
+  }, [summaryData, addKnownServers]);
 
   const refetch = useCallback(() => {
     refetchLogs();
@@ -633,7 +332,7 @@ export function InsightsToolsContent() {
             setSelectedLog={setSelectedLog}
             dateRange={dateRange}
             customRange={customRange}
-            customRangeLabel={urlLabel}
+            customRangeLabel={customRangeLabel}
             onDateRangeChange={setDateRangeParam}
             onCustomRangeChange={setCustomRangeParam}
             onClearCustomRange={clearCustomRange}

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -183,11 +183,10 @@ export function InsightsToolsContent() {
     addKnownServers,
     serverOptions,
     handleServerSelectionChange,
-    userEmailInput,
-    setUserEmailInput,
-    submitUserEmailFilter,
+    userEmailOptions,
+    addKnownUserEmails,
+    handleUserEmailSelectionChange,
     addFilter,
-    removeFilter,
     handleHookTypesChange,
     dateRange,
     customRange,
@@ -275,6 +274,14 @@ export function InsightsToolsContent() {
     addKnownServers(summaryData.breakdown.map((r) => r.serverName));
   }, [summaryData, addKnownServers]);
 
+  useEffect(() => {
+    addKnownUserEmails(
+      groupedTraces
+        .map((t) => t.userEmail)
+        .filter((e): e is string => Boolean(e)),
+    );
+  }, [groupedTraces, addKnownUserEmails]);
+
   const refetch = useCallback(() => {
     refetchLogs();
   }, [refetchLogs]);
@@ -320,12 +327,10 @@ export function InsightsToolsContent() {
             groupedTraces={groupedTraces}
             serverOptions={serverOptions}
             onServerSelectionChange={handleServerSelectionChange}
-            userEmailInput={userEmailInput}
-            setUserEmailInput={setUserEmailInput}
-            onSubmitUserEmailFilter={submitUserEmailFilter}
+            userEmailOptions={userEmailOptions}
+            onUserEmailSelectionChange={handleUserEmailSelectionChange}
             activeFilters={activeFilters}
             addFilter={addFilter}
-            removeFilter={removeFilter}
             selectedHookTypes={selectedHookTypes}
             onHookTypesChange={handleHookTypesChange}
             selectedLog={selectedLog}
@@ -354,12 +359,10 @@ function HooksInnerContent({
   groupedTraces,
   serverOptions,
   onServerSelectionChange,
-  userEmailInput,
-  setUserEmailInput,
-  onSubmitUserEmailFilter,
+  userEmailOptions,
+  onUserEmailSelectionChange,
   activeFilters,
   addFilter,
-  removeFilter,
   selectedHookTypes,
   onHookTypesChange,
   selectedLog,
@@ -382,12 +385,10 @@ function HooksInnerContent({
   groupedTraces: HookTrace[];
   serverOptions: string[];
   onServerSelectionChange: (values: string[]) => void;
-  userEmailInput: string;
-  setUserEmailInput: (value: string) => void;
-  onSubmitUserEmailFilter: () => void;
+  userEmailOptions: string[];
+  onUserEmailSelectionChange: (values: string[]) => void;
   activeFilters: FilterChip[];
   addFilter: (chip: FilterChip) => void;
-  removeFilter: (path: string, display?: string) => void;
   selectedHookTypes: TypesToInclude[];
   onHookTypesChange: (types: TypesToInclude[]) => void;
   selectedLog: TelemetryLogRecord | null;
@@ -439,11 +440,9 @@ function HooksInnerContent({
           <ObserveFilterBar
             serverOptions={serverOptions}
             onServerSelectionChange={onServerSelectionChange}
-            userEmailInput={userEmailInput}
-            setUserEmailInput={setUserEmailInput}
-            onSubmitUserEmailFilter={onSubmitUserEmailFilter}
+            userEmailOptions={userEmailOptions}
+            onUserEmailSelectionChange={onUserEmailSelectionChange}
             activeFilters={activeFilters}
-            removeFilter={removeFilter}
             selectedTypes={selectedHookTypes}
             onTypesChange={onHookTypesChange}
             dateRange={dateRange}

--- a/client/dashboard/src/components/observe/LogsAgents.tsx
+++ b/client/dashboard/src/components/observe/LogsAgents.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/select";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { ArrowUpIcon, ArrowDownIcon } from "lucide-react";
+import { isValidPreset } from "@/components/observe/observeFilterUtils";
 
 type SortField = "chronological" | "messageCount" | "score";
 type SortOrder = "asc" | "desc";
@@ -98,23 +99,6 @@ function ScoreLegend() {
       </div>
     </div>
   );
-}
-
-const validPresets: DateRangePreset[] = [
-  "15m",
-  "1h",
-  "4h",
-  "1d",
-  "2d",
-  "3d",
-  "7d",
-  "15d",
-  "30d",
-  "90d",
-];
-
-function isValidPreset(value: string | null): value is DateRangePreset {
-  return value !== null && validPresets.includes(value as DateRangePreset);
 }
 
 export function LogsAgentsContent() {

--- a/client/dashboard/src/components/observe/LogsMCP.tsx
+++ b/client/dashboard/src/components/observe/LogsMCP.tsx
@@ -2,20 +2,7 @@ import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { InsightsConfig } from "@/components/insights-sidebar";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import { McpIcon } from "@/components/ui/mcp-icon";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { MCPServerFilter } from "@/components/observe/ObserveFilterBar";
 import { useSlugs } from "@/contexts/Sdk";
 import { cn } from "@/lib/utils";
 import { useLogsEnabledErrorCheck } from "@/hooks/useLogsEnabled";
@@ -39,14 +26,7 @@ import {
 import { unwrapAsync } from "@gram/client/types/fp";
 import { Icon } from "@speakeasy-api/moonshine";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  Check,
-  ChevronDown,
-  Loader2,
-  RefreshCw,
-  Settings,
-  XIcon,
-} from "lucide-react";
+import { Loader2, RefreshCw, Settings, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOrgRoutes } from "@/routes";
 import { Link, useSearchParams } from "react-router";
@@ -103,95 +83,6 @@ function safeBase64Decode(str: string): string | null {
 }
 
 const perPage = 100;
-
-function MCPServerFilter({
-  selectedServer,
-  onServerChange,
-  toolsets,
-  isLoading,
-  disabled,
-}: {
-  selectedServer: string | null;
-  onServerChange: (serverId: string | null) => void;
-  toolsets: Array<{ slug: string; name: string }>;
-  isLoading?: boolean;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-
-  const selectedToolset = toolsets.find((t) => t.slug === selectedServer);
-  const displayLabel = selectedToolset?.name ?? "All Servers";
-
-  return (
-    <div
-      className={`flex items-center gap-2 ${disabled ? "pointer-events-none opacity-50" : ""}`}
-    >
-      <div className="border-border flex h-[42px] items-center rounded-md border p-1">
-        <div className="flex h-8 items-center gap-1.5 px-3">
-          <McpIcon className="text-muted-foreground size-3.5" />
-          <span className="text-foreground text-sm font-medium">Server</span>
-        </div>
-        <div className="bg-border/50 mx-1 h-6 w-px" />
-        <Popover open={!disabled && open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild>
-            <button
-              disabled={disabled || isLoading}
-              className={`flex h-8 min-w-[140px] items-center justify-between gap-2 rounded px-2 text-sm transition-colors ${
-                disabled || isLoading
-                  ? "cursor-not-allowed opacity-40"
-                  : "hover:bg-muted/50"
-              }`}
-            >
-              <span className="max-w-[120px] truncate">
-                {isLoading ? "Loading..." : displayLabel}
-              </span>
-              <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[220px] p-0" align="end">
-            <Command>
-              <CommandInput placeholder="Search servers..." className="h-9" />
-              <CommandList>
-                <CommandEmpty>No servers found.</CommandEmpty>
-                <CommandGroup>
-                  <CommandItem
-                    value="__all__"
-                    onSelect={() => {
-                      onServerChange(null);
-                      setOpen(false);
-                    }}
-                    className="cursor-pointer"
-                  >
-                    <Check
-                      className={`mr-2 size-4 ${selectedServer === null ? "opacity-100" : "opacity-0"}`}
-                    />
-                    <span>All Servers</span>
-                  </CommandItem>
-                  {toolsets.map((toolset) => (
-                    <CommandItem
-                      key={toolset.slug}
-                      value={toolset.name}
-                      onSelect={() => {
-                        onServerChange(toolset.slug);
-                        setOpen(false);
-                      }}
-                      className="cursor-pointer"
-                    >
-                      <Check
-                        className={`mr-2 size-4 ${selectedServer === toolset.slug ? "opacity-100" : "opacity-0"}`}
-                      />
-                      <span className="truncate">{toolset.name}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      </div>
-    </div>
-  );
-}
 
 export function LogsMCPContent() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/client/dashboard/src/components/observe/LogsMCP.tsx
+++ b/client/dashboard/src/components/observe/LogsMCP.tsx
@@ -43,46 +43,12 @@ import {
   useAttributeLogsQuery,
   type TraceSummary,
 } from "@/pages/logs/use-attribute-logs-query";
-
-const validPresets: DateRangePreset[] = [
-  "15m",
-  "1h",
-  "4h",
-  "1d",
-  "2d",
-  "3d",
-  "7d",
-  "15d",
-  "30d",
-  "90d",
-];
-
-function isValidPreset(value: string | null): value is DateRangePreset {
-  return value !== null && validPresets.includes(value as DateRangePreset);
-}
-
-function safeBase64Encode(str: string): string {
-  try {
-    return btoa(str);
-  } catch {
-    return btoa(encodeURIComponent(str));
-  }
-}
-
-function safeBase64Decode(str: string): string | null {
-  try {
-    const decoded = atob(str);
-    try {
-      return decodeURIComponent(decoded);
-    } catch {
-      return decoded;
-    }
-  } catch {
-    return null;
-  }
-}
-
-const perPage = 100;
+import {
+  isValidPreset,
+  safeBase64Encode,
+  safeBase64Decode,
+  perPage,
+} from "@/components/observe/observeFilterUtils";
 
 export function LogsMCPContent() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -81,11 +81,10 @@ export function LogsTools() {
     addKnownServers,
     serverOptions,
     handleServerSelectionChange,
-    userEmailInput,
-    setUserEmailInput,
-    submitUserEmailFilter,
+    userEmailOptions,
+    addKnownUserEmails,
+    handleUserEmailSelectionChange,
     addFilter,
-    removeFilter,
     handleHookTypesChange,
     dateRange,
     customRange,
@@ -153,6 +152,14 @@ export function LogsTools() {
         .filter((s): s is string => Boolean(s)),
     );
   }, [groupedTraces, addKnownServers]);
+
+  useEffect(() => {
+    addKnownUserEmails(
+      groupedTraces
+        .map((t) => t.userEmail)
+        .filter((e): e is string => Boolean(e)),
+    );
+  }, [groupedTraces, addKnownUserEmails]);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const container = e.currentTarget;
@@ -223,12 +230,10 @@ export function LogsTools() {
             groupedTraces={groupedTraces}
             serverOptions={serverOptions}
             onServerSelectionChange={handleServerSelectionChange}
-            userEmailInput={userEmailInput}
-            setUserEmailInput={setUserEmailInput}
-            onSubmitUserEmailFilter={submitUserEmailFilter}
+            userEmailOptions={userEmailOptions}
+            onUserEmailSelectionChange={handleUserEmailSelectionChange}
             activeFilters={activeFilters}
             addFilter={addFilter}
-            removeFilter={removeFilter}
             selectedHookTypes={selectedHookTypes}
             onHookTypesChange={handleHookTypesChange}
             expandedTraceId={expandedTraceId}
@@ -262,11 +267,9 @@ function HooksInnerContent({
   groupedTraces,
   serverOptions,
   onServerSelectionChange,
-  userEmailInput,
-  setUserEmailInput,
-  onSubmitUserEmailFilter,
+  userEmailOptions,
+  onUserEmailSelectionChange,
   activeFilters,
-  removeFilter,
   selectedHookTypes,
   onHookTypesChange,
   expandedTraceId,
@@ -294,12 +297,10 @@ function HooksInnerContent({
   groupedTraces: HookTrace[];
   serverOptions: string[];
   onServerSelectionChange: (values: string[]) => void;
-  userEmailInput: string;
-  setUserEmailInput: (value: string) => void;
-  onSubmitUserEmailFilter: () => void;
+  userEmailOptions: string[];
+  onUserEmailSelectionChange: (values: string[]) => void;
   activeFilters: FilterChip[];
   addFilter: (chip: FilterChip) => void;
-  removeFilter: (path: string, display?: string) => void;
   selectedHookTypes: TypesToInclude[];
   onHookTypesChange: (types: TypesToInclude[]) => void;
   expandedTraceId: string | null;
@@ -346,11 +347,9 @@ function HooksInnerContent({
           <ObserveFilterBar
             serverOptions={serverOptions}
             onServerSelectionChange={onServerSelectionChange}
-            userEmailInput={userEmailInput}
-            setUserEmailInput={setUserEmailInput}
-            onSubmitUserEmailFilter={onSubmitUserEmailFilter}
+            userEmailOptions={userEmailOptions}
+            onUserEmailSelectionChange={onUserEmailSelectionChange}
             activeFilters={activeFilters}
-            removeFilter={removeFilter}
             selectedTypes={selectedHookTypes}
             onTypesChange={onHookTypesChange}
             dateRange={dateRange}

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -16,11 +16,10 @@ import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { useServerNameMappings } from "@/hooks/useServerNameMappings";
 import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
-import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
+import { type DateRangePreset } from "@gram-ai/elements";
 import { telemetryListHooksTraces } from "@gram/client/funcs/telemetryListHooksTraces";
 import type {
   HookTraceSummary as HookTrace,
-  LogFilter,
   TelemetryLogRecord,
   TypesToInclude,
 } from "@gram/client/models/components";
@@ -42,7 +41,9 @@ import {
 } from "chart.js";
 import { Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Link, useSearchParams } from "react-router";
+import { Link } from "react-router";
+import { useObserveFilters } from "@/components/observe/useObserveFilters";
+import { perPage } from "@/components/observe/observeFilterUtils";
 import { LogDetailSheet } from "@/pages/logs/LogDetailSheet";
 import { TraceLogsList } from "@/pages/logs/TraceLogsList";
 import { HooksEmptyState } from "@/pages/hooks/HooksEmptyState";
@@ -61,48 +62,7 @@ ChartJS.register(
   Legend,
 );
 
-const validPresets: DateRangePreset[] = [
-  "15m",
-  "1h",
-  "4h",
-  "1d",
-  "2d",
-  "3d",
-  "7d",
-  "15d",
-  "30d",
-  "90d",
-];
-
-function isValidPreset(value: string | null): value is DateRangePreset {
-  return value !== null && validPresets.includes(value as DateRangePreset);
-}
-
-function safeBase64Encode(str: string): string {
-  try {
-    return btoa(str);
-  } catch {
-    return btoa(encodeURIComponent(str));
-  }
-}
-
-function safeBase64Decode(str: string): string | null {
-  try {
-    const decoded = atob(str);
-    try {
-      return decodeURIComponent(decoded);
-    } catch {
-      return decoded;
-    }
-  } catch {
-    return null;
-  }
-}
-
-const perPage = 100;
-
 export function LogsTools() {
-  const [searchParams, setSearchParams] = useSearchParams();
   const { projectSlug } = useSlugs();
 
   const mcpConfig = useObservabilityMcpConfig({
@@ -112,56 +72,29 @@ export function LogsTools() {
 
   const serverNameMappings = useServerNameMappings();
 
-  const initialServer = searchParams.get("server");
-  const initialUserEmail = searchParams.get("user");
+  const {
+    from,
+    to,
+    logFilters,
+    selectedHookTypes,
+    activeFilters,
+    addKnownServers,
+    serverOptions,
+    handleServerSelectionChange,
+    userEmailInput,
+    setUserEmailInput,
+    submitUserEmailFilter,
+    addFilter,
+    removeFilter,
+    handleHookTypesChange,
+    dateRange,
+    customRange,
+    customRangeLabel,
+    setDateRangeParam,
+    setCustomRangeParam,
+    clearCustomRange,
+  } = useObserveFilters();
 
-  const initialHookTypes = searchParams.get("hookTypes");
-  const defaultHookTypes: TypesToInclude[] = ["mcp", "skill"];
-  const parsedHookTypes: TypesToInclude[] = initialHookTypes
-    ? (initialHookTypes
-        .split(",")
-        .filter((t) =>
-          ["mcp", "local", "skill"].includes(t),
-        ) as TypesToInclude[])
-    : defaultHookTypes;
-
-  const [activeFilters, setActiveFilters] = useState<FilterChip[]>(() => {
-    const filters: FilterChip[] = [];
-
-    if (initialServer) {
-      const serverValues = initialServer
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      serverValues.forEach((value) => {
-        filters.push({
-          display: value,
-          filters: [value],
-          path: "gram.tool_call.source",
-        });
-      });
-    }
-
-    if (initialUserEmail) {
-      const userValues = initialUserEmail
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      userValues.forEach((value) => {
-        filters.push({
-          display: value,
-          filters: [value],
-          path: "user.email",
-        });
-      });
-    }
-
-    return filters;
-  });
-
-  const [userEmailInput, setUserEmailInput] = useState("");
-  const [selectedHookTypes, setSelectedHookTypes] =
-    useState<TypesToInclude[]>(parsedHookTypes);
   const [expandedTraceId, setExpandedTraceId] = useState<string | null>(null);
   const [selectedLog, setSelectedLog] = useState<TelemetryLogRecord | null>(
     null,
@@ -169,85 +102,6 @@ export function LogsTools() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const client = useGramContext();
-
-  const urlRange = searchParams.get("range");
-  const urlFrom = searchParams.get("from");
-  const urlTo = searchParams.get("to");
-  const urlLabelEncoded = searchParams.get("label");
-  const urlLabel = useMemo(() => {
-    if (!urlLabelEncoded) return null;
-    return safeBase64Decode(urlLabelEncoded);
-  }, [urlLabelEncoded]);
-
-  const dateRange: DateRangePreset = isValidPreset(urlRange) ? urlRange : "7d";
-
-  const customRange = useMemo(() => {
-    if (urlFrom && urlTo) {
-      const from = new Date(urlFrom);
-      const to = new Date(urlTo);
-      if (!isNaN(from.getTime()) && !isNaN(to.getTime())) {
-        return { from, to };
-      }
-    }
-    return null;
-  }, [urlFrom, urlTo]);
-
-  const updateSearchParams = useCallback(
-    (updates: Record<string, string | null>) => {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev);
-        for (const [key, value] of Object.entries(updates)) {
-          if (value === null) {
-            next.delete(key);
-          } else {
-            next.set(key, value);
-          }
-        }
-        return next;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const setDateRangeParam = useCallback(
-    (preset: DateRangePreset) => {
-      updateSearchParams({ range: preset, from: null, to: null, label: null });
-    },
-    [updateSearchParams],
-  );
-
-  const setCustomRangeParam = useCallback(
-    (from: Date, to: Date, label?: string) => {
-      updateSearchParams({
-        range: null,
-        from: from.toISOString(),
-        to: to.toISOString(),
-        label: label ? safeBase64Encode(label) : null,
-      });
-    },
-    [updateSearchParams],
-  );
-
-  const clearCustomRange = useCallback(() => {
-    updateSearchParams({ from: null, to: null, label: null });
-  }, [updateSearchParams]);
-
-  const { from, to } = useMemo(
-    () => customRange ?? getPresetRange(dateRange),
-    [customRange, dateRange],
-  );
-
-  const logFilters = useMemo(() => {
-    const filters: LogFilter[] = [];
-    for (const chip of activeFilters) {
-      filters.push({
-        path: chip.path,
-        operator: chip.filters.length > 1 ? "in" : "contains",
-        values: chip.filters,
-      });
-    }
-    return filters.length > 0 ? filters : undefined;
-  }, [activeFilters]);
 
   const {
     data: tracesData,
@@ -292,141 +146,13 @@ export function LogsTools() {
     return tracesData?.pages.flatMap((page) => page.traces) ?? [];
   }, [tracesData]);
 
-  const [knownServers, setKnownServers] = useState<string[]>([]);
-
   useEffect(() => {
-    const names = groupedTraces
-      .map((t) => t.toolSource)
-      .filter((s): s is string => Boolean(s));
-    if (names.length === 0) return;
-    setKnownServers((prev) => {
-      const merged = [...new Set([...prev, ...names])];
-      return merged.length === prev.length ? prev : merged;
-    });
-  }, [groupedTraces]);
-
-  const serverOptions = useMemo(() => {
-    const selected = activeFilters
-      .filter((f) => f.path === "gram.tool_call.source")
-      .map((f) => f.filters[0])
-      .filter((v): v is string => Boolean(v));
-    return [...new Set([...knownServers, ...selected])];
-  }, [knownServers, activeFilters]);
-
-  const handleServerSelectionChange = useCallback(
-    (values: string[]) => {
-      setActiveFilters((prev) => {
-        const nonServer = prev.filter(
-          (f) => f.path !== "gram.tool_call.source",
-        );
-        const serverFilters: FilterChip[] = values.map((v) => ({
-          display: v,
-          filters: [v],
-          path: "gram.tool_call.source",
-        }));
-        return [...nonServer, ...serverFilters];
-      });
-      setSearchParams(
-        (urlPrev) => {
-          const next = new URLSearchParams(urlPrev);
-          if (values.length > 0) {
-            next.set("server", values.join(","));
-          } else {
-            next.delete("server");
-          }
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  const addFilter = useCallback(
-    (chip: FilterChip) => {
-      setActiveFilters((prev) => {
-        const exists = prev.some(
-          (f) => f.path === chip.path && f.display === chip.display,
-        );
-        if (exists) return prev;
-
-        const newFilters = [...prev, chip];
-
-        setSearchParams(
-          (urlPrev) => {
-            const next = new URLSearchParams(urlPrev);
-            if (chip.path === "gram.tool_call.source") {
-              const serverFilters = newFilters
-                .filter((f) => f.path === "gram.tool_call.source")
-                .map((f) => f.display);
-              next.set("server", serverFilters.join(","));
-            } else if (chip.path === "user.email") {
-              const userFilters = newFilters
-                .filter((f) => f.path === "user.email")
-                .map((f) => f.display);
-              next.set("user", userFilters.join(","));
-            }
-            return next;
-          },
-          { replace: true },
-        );
-
-        return newFilters;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const removeFilter = useCallback(
-    (path: string, display?: string) => {
-      setActiveFilters((prev) => {
-        const newFilters = display
-          ? prev.filter((f) => !(f.path === path && f.display === display))
-          : prev.filter((f) => f.path !== path);
-
-        setSearchParams(
-          (urlPrev) => {
-            const next = new URLSearchParams(urlPrev);
-            if (path === "gram.tool_call.source") {
-              const serverFilters = newFilters
-                .filter((f) => f.path === "gram.tool_call.source")
-                .map((f) => f.display);
-              if (serverFilters.length > 0) {
-                next.set("server", serverFilters.join(","));
-              } else {
-                next.delete("server");
-              }
-            } else if (path === "user.email") {
-              const userFilters = newFilters
-                .filter((f) => f.path === "user.email")
-                .map((f) => f.display);
-              if (userFilters.length > 0) {
-                next.set("user", userFilters.join(","));
-              } else {
-                next.delete("user");
-              }
-            }
-            return next;
-          },
-          { replace: true },
-        );
-
-        return newFilters;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const submitUserEmailFilter = useCallback(() => {
-    const trimmed = userEmailInput.trim();
-    if (!trimmed) return;
-    addFilter({
-      display: trimmed,
-      filters: [trimmed],
-      path: "user.email",
-    });
-    setUserEmailInput("");
-  }, [userEmailInput, addFilter]);
+    addKnownServers(
+      groupedTraces
+        .map((t) => t.toolSource)
+        .filter((s): s is string => Boolean(s)),
+    );
+  }, [groupedTraces, addKnownServers]);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const container = e.currentTarget;
@@ -450,32 +176,6 @@ export function LogsTools() {
   const toggleExpand = (traceId: string) => {
     setExpandedTraceId((prev) => (prev === traceId ? null : traceId));
   };
-
-  const handleHookTypesChange = useCallback(
-    (types: TypesToInclude[]) => {
-      setSelectedHookTypes(types);
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          const isDefault =
-            types.length === 2 &&
-            types.includes("mcp") &&
-            types.includes("skill") &&
-            !types.includes("local");
-          if (isDefault) {
-            next.delete("hookTypes");
-          } else if (types.length > 0) {
-            next.set("hookTypes", types.join(","));
-          } else {
-            next.set("hookTypes", "");
-          }
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
 
   const refetch = useCallback(() => {
     refetchLogs();
@@ -542,7 +242,7 @@ export function LogsTools() {
             isFetchingNextPage={isFetchingNextPage}
             dateRange={dateRange}
             customRange={customRange}
-            customRangeLabel={urlLabel}
+            customRangeLabel={customRangeLabel}
             onDateRangeChange={setDateRangeParam}
             onCustomRangeChange={setCustomRangeParam}
             onClearCustomRange={clearCustomRange}

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -41,7 +41,7 @@ import {
   Chart as ChartJS,
 } from "chart.js";
 import { Settings } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { LogDetailSheet } from "@/pages/logs/LogDetailSheet";
 import { TraceLogsList } from "@/pages/logs/TraceLogsList";
@@ -159,7 +159,6 @@ export function LogsTools() {
     return filters;
   });
 
-  const [serverInput, setServerInput] = useState("");
   const [userEmailInput, setUserEmailInput] = useState("");
   const [selectedHookTypes, setSelectedHookTypes] =
     useState<TypesToInclude[]>(parsedHookTypes);
@@ -293,6 +292,56 @@ export function LogsTools() {
     return tracesData?.pages.flatMap((page) => page.traces) ?? [];
   }, [tracesData]);
 
+  const [knownServers, setKnownServers] = useState<string[]>([]);
+
+  useEffect(() => {
+    const names = groupedTraces
+      .map((t) => t.toolSource)
+      .filter((s): s is string => Boolean(s));
+    if (names.length === 0) return;
+    setKnownServers((prev) => {
+      const merged = [...new Set([...prev, ...names])];
+      return merged.length === prev.length ? prev : merged;
+    });
+  }, [groupedTraces]);
+
+  const serverOptions = useMemo(() => {
+    const selected = activeFilters
+      .filter((f) => f.path === "gram.tool_call.source")
+      .map((f) => f.filters[0])
+      .filter((v): v is string => Boolean(v));
+    return [...new Set([...knownServers, ...selected])];
+  }, [knownServers, activeFilters]);
+
+  const handleServerSelectionChange = useCallback(
+    (values: string[]) => {
+      setActiveFilters((prev) => {
+        const nonServer = prev.filter(
+          (f) => f.path !== "gram.tool_call.source",
+        );
+        const serverFilters: FilterChip[] = values.map((v) => ({
+          display: v,
+          filters: [v],
+          path: "gram.tool_call.source",
+        }));
+        return [...nonServer, ...serverFilters];
+      });
+      setSearchParams(
+        (urlPrev) => {
+          const next = new URLSearchParams(urlPrev);
+          if (values.length > 0) {
+            next.set("server", values.join(","));
+          } else {
+            next.delete("server");
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
   const addFilter = useCallback(
     (chip: FilterChip) => {
       setActiveFilters((prev) => {
@@ -367,17 +416,6 @@ export function LogsTools() {
     },
     [setSearchParams],
   );
-
-  const submitServerFilter = useCallback(() => {
-    const trimmed = serverInput.trim();
-    if (!trimmed) return;
-    addFilter({
-      display: trimmed,
-      filters: [trimmed],
-      path: "gram.tool_call.source",
-    });
-    setServerInput("");
-  }, [serverInput, addFilter]);
 
   const submitUserEmailFilter = useCallback(() => {
     const trimmed = userEmailInput.trim();
@@ -483,9 +521,8 @@ export function LogsTools() {
             isFetching={isFetching}
             error={error}
             groupedTraces={groupedTraces}
-            serverInput={serverInput}
-            setServerInput={setServerInput}
-            onSubmitServerFilter={submitServerFilter}
+            serverOptions={serverOptions}
+            onServerSelectionChange={handleServerSelectionChange}
             userEmailInput={userEmailInput}
             setUserEmailInput={setUserEmailInput}
             onSubmitUserEmailFilter={submitUserEmailFilter}
@@ -523,9 +560,8 @@ function HooksInnerContent({
   isFetching,
   error,
   groupedTraces,
-  serverInput,
-  setServerInput,
-  onSubmitServerFilter,
+  serverOptions,
+  onServerSelectionChange,
   userEmailInput,
   setUserEmailInput,
   onSubmitUserEmailFilter,
@@ -556,9 +592,8 @@ function HooksInnerContent({
   isFetching: boolean;
   error: Error | null;
   groupedTraces: HookTrace[];
-  serverInput: string;
-  setServerInput: (value: string) => void;
-  onSubmitServerFilter: () => void;
+  serverOptions: string[];
+  onServerSelectionChange: (values: string[]) => void;
   userEmailInput: string;
   setUserEmailInput: (value: string) => void;
   onSubmitUserEmailFilter: () => void;
@@ -609,9 +644,8 @@ function HooksInnerContent({
           </div>
 
           <ObserveFilterBar
-            serverInput={serverInput}
-            setServerInput={setServerInput}
-            onSubmitServerFilter={onSubmitServerFilter}
+            serverOptions={serverOptions}
+            onServerSelectionChange={onServerSelectionChange}
             userEmailInput={userEmailInput}
             setUserEmailInput={setUserEmailInput}
             onSubmitUserEmailFilter={onSubmitUserEmailFilter}

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -6,24 +6,17 @@ import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
-import { Checkbox } from "@/components/ui/checkbox";
-import { MultiSearch } from "@/components/ui/multi-search";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  FilterChip,
+  ObserveFilterBar,
+} from "@/components/observe/ObserveFilterBar";
 import { useSlugs } from "@/contexts/Sdk";
 import { useLogsEnabledErrorCheck } from "@/hooks/useLogsEnabled";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { useServerNameMappings } from "@/hooks/useServerNameMappings";
 import { cn } from "@/lib/utils";
 import { useOrgRoutes } from "@/routes";
-import {
-  getPresetRange,
-  TimeRangePicker,
-  type DateRangePreset,
-} from "@gram-ai/elements";
+import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
 import { telemetryListHooksTraces } from "@gram/client/funcs/telemetryListHooksTraces";
 import type {
   HookTraceSummary as HookTrace,
@@ -83,12 +76,6 @@ const validPresets: DateRangePreset[] = [
 
 function isValidPreset(value: string | null): value is DateRangePreset {
   return value !== null && validPresets.includes(value as DateRangePreset);
-}
-
-interface FilterChip {
-  display: string;
-  filters: string[];
-  path: string;
 }
 
 function safeBase64Encode(str: string): string {
@@ -621,47 +608,25 @@ function HooksInnerContent({
             </div>
           </div>
 
-          <div className="flex shrink-0 flex-wrap items-center gap-2">
-            <MultiSearch
-              value={serverInput}
-              onChange={setServerInput}
-              onSubmit={onSubmitServerFilter}
-              placeholder="Filter by server name (press Enter to add)"
-              className="min-w-[200px] flex-1"
-              chips={activeFilters
-                .filter((f) => f.path === "gram.tool_call.source")
-                .map((f) => ({ display: f.display, value: f.display }))}
-              onRemoveChip={(display) =>
-                removeFilter("gram.tool_call.source", display)
-              }
-            />
-            <MultiSearch
-              value={userEmailInput}
-              onChange={setUserEmailInput}
-              onSubmit={onSubmitUserEmailFilter}
-              placeholder="Filter by user email (press Enter to add)"
-              className="min-w-[200px] flex-1"
-              chips={activeFilters
-                .filter((f) => f.path === "user.email")
-                .map((f) => ({ display: f.display, value: f.display }))}
-              onRemoveChip={(display) => removeFilter("user.email", display)}
-            />
-            <HookTypeFilter
-              selectedHookTypes={selectedHookTypes}
-              onHookTypesChange={onHookTypesChange}
-            />
-            <div className="ml-auto">
-              <TimeRangePicker
-                preset={customRange ? null : dateRange}
-                customRange={customRange}
-                customRangeLabel={customRangeLabel}
-                onPresetChange={onDateRangeChange}
-                onCustomRangeChange={onCustomRangeChange}
-                onClearCustomRange={onClearCustomRange}
-                projectSlug={projectSlug}
-              />
-            </div>
-          </div>
+          <ObserveFilterBar
+            serverInput={serverInput}
+            setServerInput={setServerInput}
+            onSubmitServerFilter={onSubmitServerFilter}
+            userEmailInput={userEmailInput}
+            setUserEmailInput={setUserEmailInput}
+            onSubmitUserEmailFilter={onSubmitUserEmailFilter}
+            activeFilters={activeFilters}
+            removeFilter={removeFilter}
+            selectedTypes={selectedHookTypes}
+            onTypesChange={onHookTypesChange}
+            dateRange={dateRange}
+            customRange={customRange}
+            customRangeLabel={customRangeLabel}
+            onDateRangeChange={onDateRangeChange}
+            onCustomRangeChange={onCustomRangeChange}
+            onClearCustomRange={onClearCustomRange}
+            projectSlug={projectSlug}
+          />
 
           <div className="flex min-h-0 flex-1 overflow-hidden">
             <div className="min-h-0 flex-1 overflow-y-auto border">
@@ -720,92 +685,6 @@ function HooksInnerContent({
         onOpenChange={(open) => !open && setSelectedLog(null)}
       />
     </>
-  );
-}
-
-const HOOK_TYPE_OPTIONS = [
-  {
-    label: "MCP Servers",
-    labelShort: "Servers",
-    value: "mcp" as TypesToInclude,
-  },
-  {
-    label: "Local Tools",
-    labelShort: "Local",
-    value: "local" as TypesToInclude,
-  },
-  { label: "Skills", labelShort: "Skills", value: "skill" as TypesToInclude },
-];
-
-function HookTypeFilter({
-  selectedHookTypes,
-  onHookTypesChange,
-}: {
-  selectedHookTypes: TypesToInclude[];
-  onHookTypesChange: (types: TypesToInclude[]) => void;
-}) {
-  const getButtonText = () => {
-    if (selectedHookTypes.length === 3) {
-      return "Showing all types";
-    }
-
-    if (selectedHookTypes.length === 0) {
-      return "No types selected";
-    }
-
-    if (selectedHookTypes.length === 1) {
-      const selected = HOOK_TYPE_OPTIONS.find(
-        (opt) => opt.value === selectedHookTypes[0],
-      );
-      return `Showing ${selected?.labelShort || selectedHookTypes[0]}`;
-    }
-
-    const labels = HOOK_TYPE_OPTIONS.filter((opt) =>
-      selectedHookTypes.includes(opt.value),
-    ).map((opt) => opt.labelShort);
-    return `Showing ${labels.join(" & ")}`;
-  };
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-[42px] w-[200px] shrink-0 justify-between"
-        >
-          <span className="text-sm">{getButtonText()}</span>
-          <Icon name="chevron-down" className="ml-2 size-4" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-3" align="start">
-        <div className="space-y-2">
-          {HOOK_TYPE_OPTIONS.map((option) => (
-            <div key={option.value} className="flex items-center space-x-2">
-              <Checkbox
-                id={`hook-type-${option.value}`}
-                checked={selectedHookTypes.includes(option.value)}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    onHookTypesChange([...selectedHookTypes, option.value]);
-                  } else {
-                    onHookTypesChange(
-                      selectedHookTypes.filter((t) => t !== option.value),
-                    );
-                  }
-                }}
-              />
-              <label
-                htmlFor={`hook-type-${option.value}`}
-                className="cursor-pointer text-sm leading-none font-medium"
-              >
-                {option.label}
-              </label>
-            </div>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
   );
 }
 

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -14,7 +14,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { McpIcon } from "@/components/ui/mcp-icon";
-import { MultiSearch } from "@/components/ui/multi-search";
 import { MultiSelect } from "@/components/ui/multi-select";
 import {
   Popover,
@@ -122,11 +121,9 @@ export function ObserveTypeFilter({
 export function ObserveFilterBar({
   serverOptions,
   onServerSelectionChange,
-  userEmailInput,
-  setUserEmailInput,
-  onSubmitUserEmailFilter,
+  userEmailOptions,
+  onUserEmailSelectionChange,
   activeFilters,
-  removeFilter,
   selectedTypes,
   onTypesChange,
   dateRange,
@@ -140,11 +137,9 @@ export function ObserveFilterBar({
 }: {
   serverOptions: string[];
   onServerSelectionChange: (values: string[]) => void;
-  userEmailInput: string;
-  setUserEmailInput: (value: string) => void;
-  onSubmitUserEmailFilter: () => void;
+  userEmailOptions: string[];
+  onUserEmailSelectionChange: (values: string[]) => void;
   activeFilters: FilterChip[];
-  removeFilter: (path: string, display?: string) => void;
   selectedTypes: TypesToInclude[];
   onTypesChange: (types: TypesToInclude[]) => void;
   dateRange: DateRangePreset;
@@ -165,6 +160,15 @@ export function ObserveFilterBar({
     [activeFilters],
   );
 
+  const selectedEmails = useMemo(
+    () =>
+      activeFilters
+        .filter((f) => f.path === "user.email")
+        .map((f) => f.filters[0])
+        .filter((v): v is string => Boolean(v)),
+    [activeFilters],
+  );
+
   return (
     <div
       className={cn("flex shrink-0 flex-wrap items-center gap-2", className)}
@@ -174,19 +178,18 @@ export function ObserveFilterBar({
         defaultValue={selectedServers}
         onValueChange={onServerSelectionChange}
         placeholder="Filter by server name"
+        className="min-w-[200px] flex-1"
         hideSelectAll
-        className="min-w-[200px] flex-1"
+        singleLine
       />
-      <MultiSearch
-        value={userEmailInput}
-        onChange={setUserEmailInput}
-        onSubmit={onSubmitUserEmailFilter}
-        placeholder="Filter by user email (press Enter to add)"
+      <MultiSelect
+        options={userEmailOptions.map((e) => ({ label: e, value: e }))}
+        defaultValue={selectedEmails}
+        onValueChange={onUserEmailSelectionChange}
+        placeholder="Filter by user email"
         className="min-w-[200px] flex-1"
-        chips={activeFilters
-          .filter((f) => f.path === "user.email")
-          .map((f) => ({ display: f.display, value: f.display }))}
-        onRemoveChip={(display) => removeFilter("user.email", display)}
+        hideSelectAll
+        singleLine
       />
       <ObserveTypeFilter
         selectedTypes={selectedTypes}

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -68,7 +68,7 @@ export function ObserveFilterBar({
     () =>
       activeFilters
         .filter((f) => f.path === "gram.tool_call.source")
-        .map((f) => f.display)
+        .flatMap((f) => f.filters)
         .filter(Boolean),
     [activeFilters],
   );
@@ -77,8 +77,8 @@ export function ObserveFilterBar({
     () =>
       activeFilters
         .filter((f) => f.path === "user.email")
-        .map((f) => f.filters[0])
-        .filter((v): v is string => Boolean(v)),
+        .flatMap((f) => f.filters)
+        .filter(Boolean),
     [activeFilters],
   );
 

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -1,15 +1,26 @@
+import { TimeRangePicker, type DateRangePreset } from "@gram-ai/elements";
+import type { TypesToInclude } from "@gram/client/models/components";
+import { useState } from "react";
+import { ChevronDown, Check } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Icon,
+} from "@speakeasy-api/moonshine";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { McpIcon } from "@/components/ui/mcp-icon";
 import { MultiSearch } from "@/components/ui/multi-search";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { TimeRangePicker, type DateRangePreset } from "@gram-ai/elements";
 import { cn } from "@/lib/utils";
-import type { TypesToInclude } from "@gram/client/models/components";
-import { Icon } from "@speakeasy-api/moonshine";
 
 export interface FilterChip {
   display: string;
@@ -188,6 +199,98 @@ export function ObserveFilterBar({
         projectSlug={projectSlug}
         className="ml-auto"
       />
+    </div>
+  );
+}
+
+export function MCPServerFilter({
+  selectedServer,
+  onServerChange,
+  toolsets,
+  isLoading,
+  disabled,
+}: {
+  selectedServer: string | null;
+  onServerChange: (serverId: string | null) => void;
+  toolsets: Array<{ slug: string; name: string }>;
+  isLoading?: boolean;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const selectedToolset = toolsets.find((t) => t.slug === selectedServer);
+  const displayLabel = selectedToolset?.name ?? "All Servers";
+
+  return (
+    <div
+      className={`flex items-center gap-2 ${disabled ? "pointer-events-none opacity-50" : ""}`}
+    >
+      <span className="text-muted-foreground hidden text-sm font-medium 2xl:inline">
+        Filter by
+      </span>
+      <div className="border-border flex h-[42px] items-center rounded-md border p-1">
+        <div className="flex h-8 items-center gap-1.5 px-3">
+          <McpIcon className="text-muted-foreground size-3.5" />
+          <span className="text-foreground text-sm font-medium">Server</span>
+        </div>
+        <div className="bg-border/50 mx-1 h-6 w-px" />
+        <Popover open={!disabled && open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              disabled={disabled || isLoading}
+              className={`flex h-8 min-w-[140px] items-center justify-between gap-2 rounded px-2 text-sm transition-colors ${
+                disabled || isLoading
+                  ? "cursor-not-allowed opacity-40"
+                  : "hover:bg-muted/50"
+              }`}
+            >
+              <span className="max-w-[120px] truncate">
+                {isLoading ? "Loading..." : displayLabel}
+              </span>
+              <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[220px] p-0" align="end">
+            <Command>
+              <CommandInput placeholder="Search servers..." className="h-9" />
+              <CommandList>
+                <CommandEmpty>No servers found.</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value="__all__"
+                    onSelect={() => {
+                      onServerChange(null);
+                      setOpen(false);
+                    }}
+                    className="cursor-pointer"
+                  >
+                    <Check
+                      className={`mr-2 size-4 ${selectedServer === null ? "opacity-100" : "opacity-0"}`}
+                    />
+                    <span>All Servers</span>
+                  </CommandItem>
+                  {toolsets.map((toolset) => (
+                    <CommandItem
+                      key={toolset.slug}
+                      value={toolset.name}
+                      onSelect={() => {
+                        onServerChange(toolset.slug);
+                        setOpen(false);
+                      }}
+                      className="cursor-pointer"
+                    >
+                      <Check
+                        className={`mr-2 size-4 ${selectedServer === toolset.slug ? "opacity-100" : "opacity-0"}`}
+                      />
+                      <span className="truncate">{toolset.name}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
     </div>
   );
 }

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -9,10 +9,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  Icon,
 } from "@speakeasy-api/moonshine";
-import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { McpIcon } from "@/components/ui/mcp-icon";
 import { MultiSelect } from "@/components/ui/multi-select";
 import {
@@ -28,105 +25,11 @@ export interface FilterChip {
   path: string;
 }
 
-const SERVER_TYPES: Array<{
-  label: string;
-  labelShort: string;
-  value: TypesToInclude;
-}> = [
-  {
-    label: "MCP Servers",
-    labelShort: "Servers",
-    value: "mcp",
-  },
-  {
-    label: "Local Tools",
-    labelShort: "Local",
-    value: "local",
-  },
-  { label: "Skills", labelShort: "Skills", value: "skill" },
+const SERVER_TYPES: Array<{ label: string; value: TypesToInclude }> = [
+  { label: "MCP Servers", value: "mcp" },
+  { label: "Local Tools", value: "local" },
+  { label: "Skills", value: "skill" },
 ];
-
-export function ObserveTypeFilter({
-  selectedTypes,
-  onTypesChange,
-}: {
-  selectedTypes: TypesToInclude[];
-  onTypesChange: (types: TypesToInclude[]) => void;
-}) {
-  const getButtonText = () => {
-    if (selectedTypes.length === 3) {
-      return "Showing all types";
-    }
-
-    if (selectedTypes.length === 0) {
-      return "No types selected";
-    }
-
-    if (selectedTypes.length === 1) {
-      const selected = SERVER_TYPES.find(
-        (opt) => opt.value === selectedTypes[0],
-      );
-      return `Showing ${selected?.labelShort || selectedTypes[0]}`;
-    }
-
-    const labels = SERVER_TYPES.filter((opt) =>
-      selectedTypes.includes(opt.value),
-    ).map((opt) => opt.labelShort);
-    return `Showing ${labels.join(" & ")}`;
-  };
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-[42px] w-[200px] shrink-0 justify-between"
-        >
-          <span className="text-sm">{getButtonText()}</span>
-          <Icon name="chevron-down" className="ml-2 size-4" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-3" align="start">
-        <div className="space-y-2">
-          {SERVER_TYPES.map((option) => {
-            const isSelected = selectedTypes.includes(option.value);
-            const isLastSelected = isSelected && selectedTypes.length === 1;
-            return (
-              <div key={option.value} className="flex items-center space-x-2">
-                <Checkbox
-                  id={`observe-type-${option.value}`}
-                  checked={isSelected}
-                  disabled={isLastSelected}
-                  onCheckedChange={(checked) => {
-                    if (checked) {
-                      if (!isSelected) {
-                        onTypesChange([...selectedTypes, option.value]);
-                      }
-                    } else {
-                      const nextTypes = selectedTypes.filter(
-                        (t) => t !== option.value,
-                      );
-                      if (nextTypes.length > 0) {
-                        onTypesChange(nextTypes);
-                      }
-                    }
-                  }}
-                />
-                <label
-                  htmlFor={`observe-type-${option.value}`}
-                  className="cursor-pointer text-sm leading-none font-medium"
-                >
-                  {option.label}
-                </label>
-              </div>
-            );
-          })}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
 
 export function ObserveFilterBar({
   serverOptions,
@@ -201,9 +104,16 @@ export function ObserveFilterBar({
         hideSelectAll
         singleLine
       />
-      <ObserveTypeFilter
-        selectedTypes={selectedTypes}
-        onTypesChange={onTypesChange}
+      <MultiSelect
+        options={SERVER_TYPES}
+        defaultValue={selectedTypes}
+        onValueChange={(values) => onTypesChange(values as TypesToInclude[])}
+        placeholder="Filter by type"
+        className="min-w-[96px]"
+        searchable={false}
+        autoSize
+        hideSelectAll
+        singleLine
       />
       <TimeRangePicker
         preset={customRange ? null : dateRange}

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -89,29 +89,39 @@ export function ObserveTypeFilter({
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-3" align="start">
         <div className="space-y-2">
-          {SERVER_TYPES.map((option) => (
-            <div key={option.value} className="flex items-center space-x-2">
-              <Checkbox
-                id={`observe-type-${option.value}`}
-                checked={selectedTypes.includes(option.value)}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    onTypesChange([...selectedTypes, option.value]);
-                  } else {
-                    onTypesChange(
-                      selectedTypes.filter((t) => t !== option.value),
-                    );
-                  }
-                }}
-              />
-              <label
-                htmlFor={`observe-type-${option.value}`}
-                className="cursor-pointer text-sm leading-none font-medium"
-              >
-                {option.label}
-              </label>
-            </div>
-          ))}
+          {SERVER_TYPES.map((option) => {
+            const isSelected = selectedTypes.includes(option.value);
+            const isLastSelected = isSelected && selectedTypes.length === 1;
+            return (
+              <div key={option.value} className="flex items-center space-x-2">
+                <Checkbox
+                  id={`observe-type-${option.value}`}
+                  checked={isSelected}
+                  disabled={isLastSelected}
+                  onCheckedChange={(checked) => {
+                    if (checked) {
+                      if (!isSelected) {
+                        onTypesChange([...selectedTypes, option.value]);
+                      }
+                    } else {
+                      const nextTypes = selectedTypes.filter(
+                        (t) => t !== option.value,
+                      );
+                      if (nextTypes.length > 0) {
+                        onTypesChange(nextTypes);
+                      }
+                    }
+                  }}
+                />
+                <label
+                  htmlFor={`observe-type-${option.value}`}
+                  className="cursor-pointer text-sm leading-none font-medium"
+                >
+                  {option.label}
+                </label>
+              </div>
+            );
+          })}
         </div>
       </PopoverContent>
     </Popover>
@@ -155,8 +165,8 @@ export function ObserveFilterBar({
     () =>
       activeFilters
         .filter((f) => f.path === "gram.tool_call.source")
-        .map((f) => f.filters[0])
-        .filter((v): v is string => Boolean(v)),
+        .map((f) => f.display)
+        .filter(Boolean),
     [activeFilters],
   );
 

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -1,0 +1,193 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { MultiSearch } from "@/components/ui/multi-search";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { TimeRangePicker, type DateRangePreset } from "@gram-ai/elements";
+import { cn } from "@/lib/utils";
+import type { TypesToInclude } from "@gram/client/models/components";
+import { Icon } from "@speakeasy-api/moonshine";
+
+export interface FilterChip {
+  display: string;
+  filters: string[];
+  path: string;
+}
+
+const SERVER_TYPES: Array<{
+  label: string;
+  labelShort: string;
+  value: TypesToInclude;
+}> = [
+  {
+    label: "MCP Servers",
+    labelShort: "Servers",
+    value: "mcp",
+  },
+  {
+    label: "Local Tools",
+    labelShort: "Local",
+    value: "local",
+  },
+  { label: "Skills", labelShort: "Skills", value: "skill" },
+];
+
+export function ObserveTypeFilter({
+  selectedTypes,
+  onTypesChange,
+}: {
+  selectedTypes: TypesToInclude[];
+  onTypesChange: (types: TypesToInclude[]) => void;
+}) {
+  const getButtonText = () => {
+    if (selectedTypes.length === 3) {
+      return "Showing all types";
+    }
+
+    if (selectedTypes.length === 0) {
+      return "No types selected";
+    }
+
+    if (selectedTypes.length === 1) {
+      const selected = SERVER_TYPES.find(
+        (opt) => opt.value === selectedTypes[0],
+      );
+      return `Showing ${selected?.labelShort || selectedTypes[0]}`;
+    }
+
+    const labels = SERVER_TYPES.filter((opt) =>
+      selectedTypes.includes(opt.value),
+    ).map((opt) => opt.labelShort);
+    return `Showing ${labels.join(" & ")}`;
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-[42px] w-[200px] shrink-0 justify-between"
+        >
+          <span className="text-sm">{getButtonText()}</span>
+          <Icon name="chevron-down" className="ml-2 size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-3" align="start">
+        <div className="space-y-2">
+          {SERVER_TYPES.map((option) => (
+            <div key={option.value} className="flex items-center space-x-2">
+              <Checkbox
+                id={`observe-type-${option.value}`}
+                checked={selectedTypes.includes(option.value)}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    onTypesChange([...selectedTypes, option.value]);
+                  } else {
+                    onTypesChange(
+                      selectedTypes.filter((t) => t !== option.value),
+                    );
+                  }
+                }}
+              />
+              <label
+                htmlFor={`observe-type-${option.value}`}
+                className="cursor-pointer text-sm leading-none font-medium"
+              >
+                {option.label}
+              </label>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function ObserveFilterBar({
+  serverInput,
+  setServerInput,
+  onSubmitServerFilter,
+  userEmailInput,
+  setUserEmailInput,
+  onSubmitUserEmailFilter,
+  activeFilters,
+  removeFilter,
+  selectedTypes,
+  onTypesChange,
+  dateRange,
+  customRange,
+  customRangeLabel,
+  onDateRangeChange,
+  onCustomRangeChange,
+  onClearCustomRange,
+  projectSlug,
+  className,
+}: {
+  serverInput: string;
+  setServerInput: (value: string) => void;
+  onSubmitServerFilter: () => void;
+  userEmailInput: string;
+  setUserEmailInput: (value: string) => void;
+  onSubmitUserEmailFilter: () => void;
+  activeFilters: FilterChip[];
+  removeFilter: (path: string, display?: string) => void;
+  selectedTypes: TypesToInclude[];
+  onTypesChange: (types: TypesToInclude[]) => void;
+  dateRange: DateRangePreset;
+  customRange: { from: Date; to: Date } | null;
+  customRangeLabel: string | null;
+  onDateRangeChange: (preset: DateRangePreset) => void;
+  onCustomRangeChange: (from: Date, to: Date, label?: string) => void;
+  onClearCustomRange: () => void;
+  projectSlug?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("flex shrink-0 flex-wrap items-center gap-2", className)}
+    >
+      <MultiSearch
+        value={serverInput}
+        onChange={setServerInput}
+        onSubmit={onSubmitServerFilter}
+        placeholder="Filter by server name (press Enter to add)"
+        className="min-w-[200px] flex-1"
+        chips={activeFilters
+          .filter((f) => f.path === "gram.tool_call.source")
+          .map((f) => ({ display: f.display, value: f.display }))}
+        onRemoveChip={(display) =>
+          removeFilter("gram.tool_call.source", display)
+        }
+      />
+      <MultiSearch
+        value={userEmailInput}
+        onChange={setUserEmailInput}
+        onSubmit={onSubmitUserEmailFilter}
+        placeholder="Filter by user email (press Enter to add)"
+        className="min-w-[200px] flex-1"
+        chips={activeFilters
+          .filter((f) => f.path === "user.email")
+          .map((f) => ({ display: f.display, value: f.display }))}
+        onRemoveChip={(display) => removeFilter("user.email", display)}
+      />
+      <ObserveTypeFilter
+        selectedTypes={selectedTypes}
+        onTypesChange={onTypesChange}
+      />
+      <TimeRangePicker
+        preset={customRange ? null : dateRange}
+        customRange={customRange}
+        customRangeLabel={customRangeLabel}
+        onPresetChange={onDateRangeChange}
+        onCustomRangeChange={onCustomRangeChange}
+        onClearCustomRange={onClearCustomRange}
+        projectSlug={projectSlug}
+        className="ml-auto"
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -1,6 +1,6 @@
 import { TimeRangePicker, type DateRangePreset } from "@gram-ai/elements";
 import type { TypesToInclude } from "@gram/client/models/components";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ChevronDown, Check } from "lucide-react";
 import {
   Command,
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { McpIcon } from "@/components/ui/mcp-icon";
 import { MultiSearch } from "@/components/ui/multi-search";
+import { MultiSelect } from "@/components/ui/multi-select";
 import {
   Popover,
   PopoverContent,
@@ -119,9 +120,8 @@ export function ObserveTypeFilter({
 }
 
 export function ObserveFilterBar({
-  serverInput,
-  setServerInput,
-  onSubmitServerFilter,
+  serverOptions,
+  onServerSelectionChange,
   userEmailInput,
   setUserEmailInput,
   onSubmitUserEmailFilter,
@@ -138,9 +138,8 @@ export function ObserveFilterBar({
   projectSlug,
   className,
 }: {
-  serverInput: string;
-  setServerInput: (value: string) => void;
-  onSubmitServerFilter: () => void;
+  serverOptions: string[];
+  onServerSelectionChange: (values: string[]) => void;
   userEmailInput: string;
   setUserEmailInput: (value: string) => void;
   onSubmitUserEmailFilter: () => void;
@@ -157,22 +156,26 @@ export function ObserveFilterBar({
   projectSlug?: string;
   className?: string;
 }) {
+  const selectedServers = useMemo(
+    () =>
+      activeFilters
+        .filter((f) => f.path === "gram.tool_call.source")
+        .map((f) => f.filters[0])
+        .filter((v): v is string => Boolean(v)),
+    [activeFilters],
+  );
+
   return (
     <div
       className={cn("flex shrink-0 flex-wrap items-center gap-2", className)}
     >
-      <MultiSearch
-        value={serverInput}
-        onChange={setServerInput}
-        onSubmit={onSubmitServerFilter}
-        placeholder="Filter by server name (press Enter to add)"
+      <MultiSelect
+        options={serverOptions.map((s) => ({ label: s, value: s }))}
+        defaultValue={selectedServers}
+        onValueChange={onServerSelectionChange}
+        placeholder="Filter by server name"
+        hideSelectAll
         className="min-w-[200px] flex-1"
-        chips={activeFilters
-          .filter((f) => f.path === "gram.tool_call.source")
-          .map((f) => ({ display: f.display, value: f.display }))}
-        onRemoveChip={(display) =>
-          removeFilter("gram.tool_call.source", display)
-        }
       />
       <MultiSearch
         value={userEmailInput}

--- a/client/dashboard/src/components/observe/observeFilterConstants.ts
+++ b/client/dashboard/src/components/observe/observeFilterConstants.ts
@@ -1,0 +1,4 @@
+import type { TypesToInclude } from "@gram/client/models/components";
+
+export const DEFAULT_HOOK_TYPES: TypesToInclude[] = ["mcp", "skill"];
+export const VALID_HOOK_TYPES: TypesToInclude[] = ["mcp", "local", "skill"];

--- a/client/dashboard/src/components/observe/observeFilterUtils.test.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Operator } from "@gram/client/models/components";
-import { buildLogFilters } from "./observeFilterUtils";
+import { buildLogFilters, mergeFilterChip } from "./observeFilterUtils";
 
 describe("buildLogFilters", () => {
   it("uses exact in matching for a single curated filter value", () => {
@@ -56,5 +56,57 @@ describe("buildLogFilters", () => {
 
   it("returns undefined when no filters are active", () => {
     expect(buildLogFilters([])).toBeUndefined();
+  });
+});
+
+describe("mergeFilterChip", () => {
+  it("merges a partially overlapping chip for the same path", () => {
+    const result = mergeFilterChip(
+      [
+        {
+          display: "api",
+          filters: ["api"],
+          path: "gram.tool_call.source",
+        },
+      ],
+      {
+        display: "API group",
+        filters: ["api", "api-v2"],
+        path: "gram.tool_call.source",
+      },
+    );
+
+    expect(result).toEqual({
+      filters: [
+        {
+          display: "api, api-v2",
+          filters: ["api", "api-v2"],
+          path: "gram.tool_call.source",
+        },
+      ],
+      merged: {
+        display: "api, api-v2",
+        filters: ["api", "api-v2"],
+        path: "gram.tool_call.source",
+      },
+    });
+  });
+
+  it("skips only when the incoming chip is fully subsumed", () => {
+    const activeFilters = [
+      {
+        display: "api, api-v2",
+        filters: ["api", "api-v2"],
+        path: "gram.tool_call.source",
+      },
+    ];
+
+    expect(
+      mergeFilterChip(activeFilters, {
+        display: "api",
+        filters: ["api"],
+        path: "gram.tool_call.source",
+      }),
+    ).toEqual({ filters: activeFilters, merged: null });
   });
 });

--- a/client/dashboard/src/components/observe/observeFilterUtils.test.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { Operator } from "@gram/client/models/components";
+import { buildLogFilters } from "./observeFilterUtils";
+
+describe("buildLogFilters", () => {
+  it("uses exact in matching for a single curated filter value", () => {
+    const result = buildLogFilters([
+      {
+        display: "api",
+        filters: ["api"],
+        path: "gram.tool_call.source",
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        path: "gram.tool_call.source",
+        operator: Operator.In,
+        values: ["api"],
+      },
+    ]);
+  });
+
+  it("groups multiple curated filter values by path with in matching", () => {
+    const result = buildLogFilters([
+      {
+        display: "api",
+        filters: ["api"],
+        path: "gram.tool_call.source",
+      },
+      {
+        display: "staging",
+        filters: ["api-staging"],
+        path: "gram.tool_call.source",
+      },
+      {
+        display: "alex@example.com",
+        filters: ["alex@example.com"],
+        path: "user.email",
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        path: "gram.tool_call.source",
+        operator: Operator.In,
+        values: ["api", "api-staging"],
+      },
+      {
+        path: "user.email",
+        operator: Operator.In,
+        values: ["alex@example.com"],
+      },
+    ]);
+  });
+
+  it("returns undefined when no filters are active", () => {
+    expect(buildLogFilters([])).toBeUndefined();
+  });
+});

--- a/client/dashboard/src/components/observe/observeFilterUtils.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.ts
@@ -59,3 +59,29 @@ export function buildLogFilters(
   }
   return filters.length > 0 ? filters : undefined;
 }
+
+export function mergeFilterChip(
+  activeFilters: FilterChip[],
+  chip: FilterChip,
+): { filters: FilterChip[]; merged: FilterChip | null } {
+  const existing = activeFilters.find((f) => f.path === chip.path);
+  const alreadyPresent = existing
+    ? chip.filters.every((v) => existing.filters.includes(v))
+    : false;
+  if (alreadyPresent) return { filters: activeFilters, merged: null };
+
+  const merged: FilterChip = existing
+    ? {
+        path: chip.path,
+        filters: [...new Set([...existing.filters, ...chip.filters])],
+        display: [...new Set([...existing.filters, ...chip.filters])].join(
+          ", ",
+        ),
+      }
+    : chip;
+
+  return {
+    filters: [...activeFilters.filter((f) => f.path !== chip.path), merged],
+    merged,
+  };
+}

--- a/client/dashboard/src/components/observe/observeFilterUtils.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.ts
@@ -45,10 +45,17 @@ export function safeBase64Decode(str: string): string | null {
 export function buildLogFilters(
   activeFilters: FilterChip[],
 ): LogFilter[] | undefined {
-  const filters: LogFilter[] = activeFilters.map((chip) => ({
-    path: chip.path,
-    operator: chip.filters.length > 1 ? Operator.In : Operator.Contains,
-    values: chip.filters,
-  }));
+  const byPath = new Map<string, string[]>();
+  for (const chip of activeFilters) {
+    byPath.set(chip.path, [...(byPath.get(chip.path) ?? []), ...chip.filters]);
+  }
+  const filters: LogFilter[] = [];
+  for (const [path, values] of byPath) {
+    filters.push({
+      path,
+      operator: values.length > 1 ? Operator.In : Operator.Contains,
+      values,
+    });
+  }
   return filters.length > 0 ? filters : undefined;
 }

--- a/client/dashboard/src/components/observe/observeFilterUtils.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.ts
@@ -53,7 +53,7 @@ export function buildLogFilters(
   for (const [path, values] of byPath) {
     filters.push({
       path,
-      operator: values.length > 1 ? Operator.In : Operator.Contains,
+      operator: Operator.In,
       values,
     });
   }

--- a/client/dashboard/src/components/observe/observeFilterUtils.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.ts
@@ -1,0 +1,54 @@
+import type { DateRangePreset } from "@gram-ai/elements";
+import { Operator, type LogFilter } from "@gram/client/models/components";
+import type { FilterChip } from "@/components/observe/ObserveFilterBar";
+
+export const validPresets: DateRangePreset[] = [
+  "15m",
+  "1h",
+  "4h",
+  "1d",
+  "2d",
+  "3d",
+  "7d",
+  "15d",
+  "30d",
+  "90d",
+];
+
+export const perPage = 100;
+
+export function isValidPreset(value: string | null): value is DateRangePreset {
+  return value !== null && validPresets.includes(value as DateRangePreset);
+}
+
+export function safeBase64Encode(str: string): string {
+  try {
+    return btoa(str);
+  } catch {
+    return btoa(encodeURIComponent(str));
+  }
+}
+
+export function safeBase64Decode(str: string): string | null {
+  try {
+    const decoded = atob(str);
+    try {
+      return decodeURIComponent(decoded);
+    } catch {
+      return decoded;
+    }
+  } catch {
+    return null;
+  }
+}
+
+export function buildLogFilters(
+  activeFilters: FilterChip[],
+): LogFilter[] | undefined {
+  const filters: LogFilter[] = activeFilters.map((chip) => ({
+    path: chip.path,
+    operator: chip.filters.length > 1 ? Operator.In : Operator.Contains,
+    values: chip.filters,
+  }));
+  return filters.length > 0 ? filters : undefined;
+}

--- a/client/dashboard/src/components/observe/useObserveFilters.test.tsx
+++ b/client/dashboard/src/components/observe/useObserveFilters.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MemoryRouter, useNavigate } from "react-router";
+import { DEFAULT_HOOK_TYPES } from "./observeFilterConstants";
+import { useObserveFilters } from "./useObserveFilters";
+
+function useObserveFiltersWithNavigation() {
+  const filters = useObserveFilters();
+  const navigate = useNavigate();
+  return { filters, navigate };
+}
+
+describe("useObserveFilters", () => {
+  it("derives chips and hook types from browser navigation", () => {
+    function RouterWrapper({ children }: { children: ReactNode }) {
+      return (
+        <MemoryRouter
+          initialEntries={[
+            "/?server=api&user=alex@example.com&hookTypes=mcp",
+            "/?server=api-v2&user=becca@example.com&hookTypes=local,skill",
+          ]}
+          initialIndex={1}
+        >
+          {children}
+        </MemoryRouter>
+      );
+    }
+
+    const { result } = renderHook(() => useObserveFiltersWithNavigation(), {
+      wrapper: RouterWrapper,
+    });
+
+    expect(result.current.filters.activeFilters).toEqual([
+      {
+        display: "api-v2",
+        filters: ["api-v2"],
+        path: "gram.tool_call.source",
+      },
+      {
+        display: "becca@example.com",
+        filters: ["becca@example.com"],
+        path: "user.email",
+      },
+    ]);
+    expect(result.current.filters.selectedHookTypes).toEqual([
+      "local",
+      "skill",
+    ]);
+
+    act(() => result.current.navigate(-1));
+
+    expect(result.current.filters.activeFilters).toEqual([
+      {
+        display: "api",
+        filters: ["api"],
+        path: "gram.tool_call.source",
+      },
+      {
+        display: "alex@example.com",
+        filters: ["alex@example.com"],
+        path: "user.email",
+      },
+    ]);
+    expect(result.current.filters.selectedHookTypes).toEqual(["mcp"]);
+  });
+
+  it("falls back to default hook types when the URL param is cleared", () => {
+    function RouterWrapper({ children }: { children: ReactNode }) {
+      return (
+        <MemoryRouter initialEntries={["/?hookTypes=local"]}>
+          {children}
+        </MemoryRouter>
+      );
+    }
+
+    const { result } = renderHook(() => useObserveFiltersWithNavigation(), {
+      wrapper: RouterWrapper,
+    });
+
+    expect(result.current.filters.selectedHookTypes).toEqual(["local"]);
+
+    act(() => result.current.navigate("/"));
+
+    expect(result.current.filters.selectedHookTypes).toEqual(
+      DEFAULT_HOOK_TYPES,
+    );
+  });
+});

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -11,6 +11,21 @@ import {
 } from "./observeFilterUtils";
 
 const DEFAULT_HOOK_TYPES: TypesToInclude[] = ["mcp", "skill"];
+const VALID_HOOK_TYPES: TypesToInclude[] = ["mcp", "local", "skill"];
+const SERVER_FILTER_PATH = "gram.tool_call.source";
+const USER_EMAIL_FILTER_PATH = "user.email";
+
+function parseHookTypesParam(raw: string | null): TypesToInclude[] {
+  if (!raw) return [...DEFAULT_HOOK_TYPES];
+
+  const parsed = raw
+    .split(",")
+    .filter((t): t is TypesToInclude =>
+      VALID_HOOK_TYPES.includes(t as TypesToInclude),
+    );
+  const unique = [...new Set(parsed)];
+  return unique.length > 0 ? unique : [...DEFAULT_HOOK_TYPES];
+}
 
 export function useObserveFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -28,7 +43,7 @@ export function useObserveFilters() {
           filters.push({
             display: value,
             filters: [value],
-            path: "gram.tool_call.source",
+            path: SERVER_FILTER_PATH,
           });
         });
     }
@@ -43,7 +58,7 @@ export function useObserveFilters() {
           filters.push({
             display: value,
             filters: [value],
-            path: "user.email",
+            path: USER_EMAIL_FILTER_PATH,
           });
         });
     }
@@ -52,15 +67,7 @@ export function useObserveFilters() {
   });
 
   const [selectedHookTypes, setSelectedHookTypes] = useState<TypesToInclude[]>(
-    () => {
-      const raw = searchParams.get("hookTypes");
-      if (!raw) return DEFAULT_HOOK_TYPES;
-      return raw
-        .split(",")
-        .filter((t) =>
-          ["mcp", "local", "skill"].includes(t),
-        ) as TypesToInclude[];
-    },
+    () => parseHookTypesParam(searchParams.get("hookTypes")),
   );
   const [knownServers, setKnownServers] = useState<string[]>([]);
   const [knownUserEmails, setKnownUserEmails] = useState<string[]>([]);
@@ -157,15 +164,15 @@ export function useObserveFilters() {
 
   const serverOptions = useMemo(() => {
     const selected = activeFilters
-      .filter((f) => f.path === "gram.tool_call.source")
-      .map((f) => f.filters[0])
-      .filter((v): v is string => Boolean(v));
+      .filter((f) => f.path === SERVER_FILTER_PATH)
+      .map((f) => f.display)
+      .filter(Boolean);
     return [...new Set([...knownServers, ...selected])];
   }, [knownServers, activeFilters]);
 
   const userEmailOptions = useMemo(() => {
     const selected = activeFilters
-      .filter((f) => f.path === "user.email")
+      .filter((f) => f.path === USER_EMAIL_FILTER_PATH)
       .map((f) => f.filters[0])
       .filter((v): v is string => Boolean(v));
     return [...new Set([...knownUserEmails, ...selected])];
@@ -174,11 +181,11 @@ export function useObserveFilters() {
   const handleUserEmailSelectionChange = useCallback(
     (values: string[]) => {
       setActiveFilters((prev) => {
-        const nonEmail = prev.filter((f) => f.path !== "user.email");
+        const nonEmail = prev.filter((f) => f.path !== USER_EMAIL_FILTER_PATH);
         const emailFilters: FilterChip[] = values.map((v) => ({
           display: v,
           filters: [v],
-          path: "user.email",
+          path: USER_EMAIL_FILTER_PATH,
         }));
         return [...nonEmail, ...emailFilters];
       });
@@ -201,14 +208,20 @@ export function useObserveFilters() {
   const handleServerSelectionChange = useCallback(
     (values: string[]) => {
       setActiveFilters((prev) => {
-        const nonServer = prev.filter(
-          (f) => f.path !== "gram.tool_call.source",
+        const nonServer = prev.filter((f) => f.path !== SERVER_FILTER_PATH);
+        const existingServers = new Map(
+          prev
+            .filter((f) => f.path === SERVER_FILTER_PATH)
+            .map((filter) => [filter.display, filter]),
         );
-        const serverFilters: FilterChip[] = values.map((v) => ({
-          display: v,
-          filters: [v],
-          path: "gram.tool_call.source",
-        }));
+        const serverFilters: FilterChip[] = values.map(
+          (v) =>
+            existingServers.get(v) ?? {
+              display: v,
+              filters: [v],
+              path: SERVER_FILTER_PATH,
+            },
+        );
         return [...nonServer, ...serverFilters];
       });
       setSearchParams(
@@ -240,14 +253,14 @@ export function useObserveFilters() {
         setSearchParams(
           (urlPrev) => {
             const next = new URLSearchParams(urlPrev);
-            if (chip.path === "gram.tool_call.source") {
+            if (chip.path === SERVER_FILTER_PATH) {
               const serverFilters = newFilters
-                .filter((f) => f.path === "gram.tool_call.source")
+                .filter((f) => f.path === SERVER_FILTER_PATH)
                 .map((f) => f.display);
               next.set("server", serverFilters.join(","));
-            } else if (chip.path === "user.email") {
+            } else if (chip.path === USER_EMAIL_FILTER_PATH) {
               const userFilters = newFilters
-                .filter((f) => f.path === "user.email")
+                .filter((f) => f.path === USER_EMAIL_FILTER_PATH)
                 .map((f) => f.display);
               next.set("user", userFilters.join(","));
             }
@@ -272,18 +285,18 @@ export function useObserveFilters() {
         setSearchParams(
           (urlPrev) => {
             const next = new URLSearchParams(urlPrev);
-            if (path === "gram.tool_call.source") {
+            if (path === SERVER_FILTER_PATH) {
               const serverFilters = newFilters
-                .filter((f) => f.path === "gram.tool_call.source")
+                .filter((f) => f.path === SERVER_FILTER_PATH)
                 .map((f) => f.display);
               if (serverFilters.length > 0) {
                 next.set("server", serverFilters.join(","));
               } else {
                 next.delete("server");
               }
-            } else if (path === "user.email") {
+            } else if (path === USER_EMAIL_FILTER_PATH) {
               const userFilters = newFilters
-                .filter((f) => f.path === "user.email")
+                .filter((f) => f.path === USER_EMAIL_FILTER_PATH)
                 .map((f) => f.display);
               if (userFilters.length > 0) {
                 next.set("user", userFilters.join(","));
@@ -304,21 +317,28 @@ export function useObserveFilters() {
 
   const handleHookTypesChange = useCallback(
     (types: TypesToInclude[]) => {
-      setSelectedHookTypes(types);
+      const nextTypes = [
+        ...new Set(
+          types.filter((t): t is TypesToInclude =>
+            VALID_HOOK_TYPES.includes(t as TypesToInclude),
+          ),
+        ),
+      ];
+      if (nextTypes.length === 0) return;
+
+      setSelectedHookTypes(nextTypes);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
           const isDefault =
-            types.length === 2 &&
-            types.includes("mcp") &&
-            types.includes("skill") &&
-            !types.includes("local");
+            nextTypes.length === 2 &&
+            nextTypes.includes("mcp") &&
+            nextTypes.includes("skill") &&
+            !nextTypes.includes("local");
           if (isDefault) {
             next.delete("hookTypes");
-          } else if (types.length > 0) {
-            next.set("hookTypes", types.join(","));
           } else {
-            next.delete("hookTypes");
+            next.set("hookTypes", nextTypes.join(","));
           }
           return next;
         },

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -27,47 +27,40 @@ function parseHookTypesParam(raw: string | null): TypesToInclude[] {
   return unique.length > 0 ? unique : [...DEFAULT_HOOK_TYPES];
 }
 
+function parseFilterParam(raw: string | null, path: string): FilterChip | null {
+  if (!raw) return null;
+
+  const values = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (values.length === 0) return null;
+
+  return {
+    display: values.join(", "),
+    filters: values,
+    path,
+  };
+}
+
+function buildActiveFilters(searchParams: URLSearchParams): FilterChip[] {
+  return [
+    parseFilterParam(searchParams.get("server"), SERVER_FILTER_PATH),
+    parseFilterParam(searchParams.get("user"), USER_EMAIL_FILTER_PATH),
+  ].filter((filter): filter is FilterChip => filter !== null);
+}
+
 export function useObserveFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const [activeFilters, setActiveFilters] = useState<FilterChip[]>(() => {
-    const filters: FilterChip[] = [];
-
-    const initialServer = searchParams.get("server");
-    if (initialServer) {
-      const values = initialServer
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      if (values.length > 0) {
-        filters.push({
-          display: values.join(", "),
-          filters: values,
-          path: SERVER_FILTER_PATH,
-        });
-      }
-    }
-
-    const initialUserEmail = searchParams.get("user");
-    if (initialUserEmail) {
-      const values = initialUserEmail
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-      if (values.length > 0) {
-        filters.push({
-          display: values.join(", "),
-          filters: values,
-          path: USER_EMAIL_FILTER_PATH,
-        });
-      }
-    }
-
-    return filters;
-  });
-
-  const [selectedHookTypes, setSelectedHookTypes] = useState<TypesToInclude[]>(
+  const activeFilters = useMemo(
+    () => buildActiveFilters(searchParams),
+    [searchParams],
+  );
+  const selectedHookTypes = useMemo(
     () => parseHookTypesParam(searchParams.get("hookTypes")),
+    [searchParams],
   );
   const [knownServers, setKnownServers] = useState<string[]>([]);
   const [knownUserEmails, setKnownUserEmails] = useState<string[]>([]);
@@ -180,20 +173,6 @@ export function useObserveFilters() {
 
   const handleUserEmailSelectionChange = useCallback(
     (values: string[]) => {
-      setActiveFilters((prev) => {
-        const nonEmail = prev.filter((f) => f.path !== USER_EMAIL_FILTER_PATH);
-        const emailFilters: FilterChip[] =
-          values.length > 0
-            ? [
-                {
-                  display: values.join(", "),
-                  filters: values,
-                  path: USER_EMAIL_FILTER_PATH,
-                },
-              ]
-            : [];
-        return [...nonEmail, ...emailFilters];
-      });
       setSearchParams(
         (urlPrev) => {
           const next = new URLSearchParams(urlPrev);
@@ -212,20 +191,6 @@ export function useObserveFilters() {
 
   const handleServerSelectionChange = useCallback(
     (values: string[]) => {
-      setActiveFilters((prev) => {
-        const nonServer = prev.filter((f) => f.path !== SERVER_FILTER_PATH);
-        const serverFilters: FilterChip[] =
-          values.length > 0
-            ? [
-                {
-                  display: values.join(", "),
-                  filters: values,
-                  path: SERVER_FILTER_PATH,
-                },
-              ]
-            : [];
-        return [...nonServer, ...serverFilters];
-      });
       setSearchParams(
         (urlPrev) => {
           const next = new URLSearchParams(urlPrev);
@@ -244,25 +209,21 @@ export function useObserveFilters() {
 
   const addFilter = useCallback(
     (chip: FilterChip) => {
-      setActiveFilters((prev) => {
-        const { filters: newFilters, merged } = mergeFilterChip(prev, chip);
-        if (!merged) return prev;
+      setSearchParams(
+        (urlPrev) => {
+          const { merged } = mergeFilterChip(buildActiveFilters(urlPrev), chip);
+          if (!merged) return urlPrev;
 
-        setSearchParams(
-          (urlPrev) => {
-            const next = new URLSearchParams(urlPrev);
-            if (chip.path === SERVER_FILTER_PATH) {
-              next.set("server", merged.filters.join(","));
-            } else if (chip.path === USER_EMAIL_FILTER_PATH) {
-              next.set("user", merged.filters.join(","));
-            }
-            return next;
-          },
-          { replace: true },
-        );
-
-        return newFilters;
-      });
+          const next = new URLSearchParams(urlPrev);
+          if (chip.path === SERVER_FILTER_PATH) {
+            next.set("server", merged.filters.join(","));
+          } else if (chip.path === USER_EMAIL_FILTER_PATH) {
+            next.set("user", merged.filters.join(","));
+          }
+          return next;
+        },
+        { replace: true },
+      );
     },
     [setSearchParams],
   );
@@ -283,7 +244,6 @@ export function useObserveFilters() {
         resolved.length === DEFAULT_HOOK_TYPES.length &&
         DEFAULT_HOOK_TYPES.every((t) => resolved.includes(t));
 
-      setSelectedHookTypes(resolved);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -10,6 +10,7 @@ import {
   safeBase64Encode,
 } from "./observeFilterUtils";
 import { DEFAULT_HOOK_TYPES, VALID_HOOK_TYPES } from "./observeFilterConstants";
+
 const SERVER_FILTER_PATH = "gram.tool_call.source";
 const USER_EMAIL_FILTER_PATH = "user.email";
 
@@ -33,32 +34,32 @@ export function useObserveFilters() {
 
     const initialServer = searchParams.get("server");
     if (initialServer) {
-      initialServer
+      const values = initialServer
         .split(",")
         .map((s) => s.trim())
-        .filter(Boolean)
-        .forEach((value) => {
-          filters.push({
-            display: value,
-            filters: [value],
-            path: SERVER_FILTER_PATH,
-          });
+        .filter(Boolean);
+      if (values.length > 0) {
+        filters.push({
+          display: values.join(", "),
+          filters: values,
+          path: SERVER_FILTER_PATH,
         });
+      }
     }
 
     const initialUserEmail = searchParams.get("user");
     if (initialUserEmail) {
-      initialUserEmail
+      const values = initialUserEmail
         .split(",")
         .map((s) => s.trim())
-        .filter(Boolean)
-        .forEach((value) => {
-          filters.push({
-            display: value,
-            filters: [value],
-            path: USER_EMAIL_FILTER_PATH,
-          });
+        .filter(Boolean);
+      if (values.length > 0) {
+        filters.push({
+          display: values.join(", "),
+          filters: values,
+          path: USER_EMAIL_FILTER_PATH,
         });
+      }
     }
 
     return filters;
@@ -163,7 +164,7 @@ export function useObserveFilters() {
   const serverOptions = useMemo(() => {
     const selected = activeFilters
       .filter((f) => f.path === SERVER_FILTER_PATH)
-      .map((f) => f.display)
+      .flatMap((f) => f.filters)
       .filter(Boolean);
     return [...new Set([...knownServers, ...selected])];
   }, [knownServers, activeFilters]);
@@ -171,8 +172,8 @@ export function useObserveFilters() {
   const userEmailOptions = useMemo(() => {
     const selected = activeFilters
       .filter((f) => f.path === USER_EMAIL_FILTER_PATH)
-      .map((f) => f.filters[0])
-      .filter((v): v is string => Boolean(v));
+      .flatMap((f) => f.filters)
+      .filter(Boolean);
     return [...new Set([...knownUserEmails, ...selected])];
   }, [knownUserEmails, activeFilters]);
 
@@ -180,11 +181,16 @@ export function useObserveFilters() {
     (values: string[]) => {
       setActiveFilters((prev) => {
         const nonEmail = prev.filter((f) => f.path !== USER_EMAIL_FILTER_PATH);
-        const emailFilters: FilterChip[] = values.map((v) => ({
-          display: v,
-          filters: [v],
-          path: USER_EMAIL_FILTER_PATH,
-        }));
+        const emailFilters: FilterChip[] =
+          values.length > 0
+            ? [
+                {
+                  display: values.join(", "),
+                  filters: values,
+                  path: USER_EMAIL_FILTER_PATH,
+                },
+              ]
+            : [];
         return [...nonEmail, ...emailFilters];
       });
       setSearchParams(
@@ -207,19 +213,16 @@ export function useObserveFilters() {
     (values: string[]) => {
       setActiveFilters((prev) => {
         const nonServer = prev.filter((f) => f.path !== SERVER_FILTER_PATH);
-        const existingServers = new Map(
-          prev
-            .filter((f) => f.path === SERVER_FILTER_PATH)
-            .map((filter) => [filter.display, filter]),
-        );
-        const serverFilters: FilterChip[] = values.map(
-          (v) =>
-            existingServers.get(v) ?? {
-              display: v,
-              filters: [v],
-              path: SERVER_FILTER_PATH,
-            },
-        );
+        const serverFilters: FilterChip[] =
+          values.length > 0
+            ? [
+                {
+                  display: values.join(", "),
+                  filters: values,
+                  path: SERVER_FILTER_PATH,
+                },
+              ]
+            : [];
         return [...nonServer, ...serverFilters];
       });
       setSearchParams(
@@ -241,66 +244,34 @@ export function useObserveFilters() {
   const addFilter = useCallback(
     (chip: FilterChip) => {
       setActiveFilters((prev) => {
-        const exists = prev.some(
-          (f) => f.path === chip.path && f.display === chip.display,
+        const existing = prev.find((f) => f.path === chip.path);
+        const alreadyPresent = existing?.filters.some((v) =>
+          chip.filters.includes(v),
         );
-        if (exists) return prev;
+        if (alreadyPresent) return prev;
 
-        const newFilters = [...prev, chip];
+        const merged: FilterChip = existing
+          ? {
+              path: chip.path,
+              filters: [...new Set([...existing.filters, ...chip.filters])],
+              display: [
+                ...new Set([...existing.filters, ...chip.filters]),
+              ].join(", "),
+            }
+          : chip;
+
+        const newFilters = [
+          ...prev.filter((f) => f.path !== chip.path),
+          merged,
+        ];
 
         setSearchParams(
           (urlPrev) => {
             const next = new URLSearchParams(urlPrev);
             if (chip.path === SERVER_FILTER_PATH) {
-              const serverFilters = newFilters
-                .filter((f) => f.path === SERVER_FILTER_PATH)
-                .map((f) => f.display);
-              next.set("server", serverFilters.join(","));
+              next.set("server", merged.filters.join(","));
             } else if (chip.path === USER_EMAIL_FILTER_PATH) {
-              const userFilters = newFilters
-                .filter((f) => f.path === USER_EMAIL_FILTER_PATH)
-                .map((f) => f.display);
-              next.set("user", userFilters.join(","));
-            }
-            return next;
-          },
-          { replace: true },
-        );
-
-        return newFilters;
-      });
-    },
-    [setSearchParams],
-  );
-
-  const removeFilter = useCallback(
-    (path: string, display?: string) => {
-      setActiveFilters((prev) => {
-        const newFilters = display
-          ? prev.filter((f) => !(f.path === path && f.display === display))
-          : prev.filter((f) => f.path !== path);
-
-        setSearchParams(
-          (urlPrev) => {
-            const next = new URLSearchParams(urlPrev);
-            if (path === SERVER_FILTER_PATH) {
-              const serverFilters = newFilters
-                .filter((f) => f.path === SERVER_FILTER_PATH)
-                .map((f) => f.display);
-              if (serverFilters.length > 0) {
-                next.set("server", serverFilters.join(","));
-              } else {
-                next.delete("server");
-              }
-            } else if (path === USER_EMAIL_FILTER_PATH) {
-              const userFilters = newFilters
-                .filter((f) => f.path === USER_EMAIL_FILTER_PATH)
-                .map((f) => f.display);
-              if (userFilters.length > 0) {
-                next.set("user", userFilters.join(","));
-              } else {
-                next.delete("user");
-              }
+              next.set("user", merged.filters.join(","));
             }
             return next;
           },
@@ -362,7 +333,6 @@ export function useObserveFilters() {
     addKnownUserEmails,
     handleUserEmailSelectionChange,
     addFilter,
-    removeFilter,
     handleHookTypesChange,
     setDateRangeParam,
     setCustomRangeParam,

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -1,0 +1,316 @@
+import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
+import type { TypesToInclude } from "@gram/client/models/components";
+import { useCallback, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
+import type { FilterChip } from "@/components/observe/ObserveFilterBar";
+import {
+  buildLogFilters,
+  isValidPreset,
+  safeBase64Decode,
+  safeBase64Encode,
+} from "./observeFilterUtils";
+
+const DEFAULT_HOOK_TYPES: TypesToInclude[] = ["mcp", "skill"];
+
+export function useObserveFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [activeFilters, setActiveFilters] = useState<FilterChip[]>(() => {
+    const filters: FilterChip[] = [];
+
+    const initialServer = searchParams.get("server");
+    if (initialServer) {
+      initialServer
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .forEach((value) => {
+          filters.push({
+            display: value,
+            filters: [value],
+            path: "gram.tool_call.source",
+          });
+        });
+    }
+
+    const initialUserEmail = searchParams.get("user");
+    if (initialUserEmail) {
+      initialUserEmail
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .forEach((value) => {
+          filters.push({
+            display: value,
+            filters: [value],
+            path: "user.email",
+          });
+        });
+    }
+
+    return filters;
+  });
+
+  const [userEmailInput, setUserEmailInput] = useState("");
+  const [selectedHookTypes, setSelectedHookTypes] = useState<TypesToInclude[]>(
+    () => {
+      const raw = searchParams.get("hookTypes");
+      if (!raw) return DEFAULT_HOOK_TYPES;
+      return raw
+        .split(",")
+        .filter((t) =>
+          ["mcp", "local", "skill"].includes(t),
+        ) as TypesToInclude[];
+    },
+  );
+  const [knownServers, setKnownServers] = useState<string[]>([]);
+
+  const urlRange = searchParams.get("range");
+  const urlFrom = searchParams.get("from");
+  const urlTo = searchParams.get("to");
+  const urlLabelEncoded = searchParams.get("label");
+  const urlLabel = urlLabelEncoded ? safeBase64Decode(urlLabelEncoded) : null;
+
+  const dateRange: DateRangePreset = isValidPreset(urlRange) ? urlRange : "7d";
+
+  const customRange = useMemo(() => {
+    if (urlFrom && urlTo) {
+      const from = new Date(urlFrom);
+      const to = new Date(urlTo);
+      if (!isNaN(from.getTime()) && !isNaN(to.getTime())) {
+        return { from, to };
+      }
+    }
+    return null;
+  }, [urlFrom, urlTo]);
+
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null) {
+            next.delete(key);
+          } else {
+            next.set(key, value);
+          }
+        }
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setDateRangeParam = useCallback(
+    (preset: DateRangePreset) => {
+      updateSearchParams({ range: preset, from: null, to: null, label: null });
+    },
+    [updateSearchParams],
+  );
+
+  const setCustomRangeParam = useCallback(
+    (from: Date, to: Date, label?: string) => {
+      updateSearchParams({
+        range: null,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        label: label ? safeBase64Encode(label) : null,
+      });
+    },
+    [updateSearchParams],
+  );
+
+  const clearCustomRange = useCallback(() => {
+    updateSearchParams({ from: null, to: null, label: null });
+  }, [updateSearchParams]);
+
+  const { from, to } = useMemo(
+    () => customRange ?? getPresetRange(dateRange),
+    [customRange, dateRange],
+  );
+
+  const logFilters = useMemo(
+    () => buildLogFilters(activeFilters),
+    [activeFilters],
+  );
+
+  const addKnownServers = useCallback((names: string[]) => {
+    if (names.length === 0) return;
+    setKnownServers((prev) => {
+      const merged = [...new Set([...prev, ...names])];
+      return merged.length === prev.length ? prev : merged;
+    });
+  }, []);
+
+  const serverOptions = useMemo(() => {
+    const selected = activeFilters
+      .filter((f) => f.path === "gram.tool_call.source")
+      .map((f) => f.filters[0])
+      .filter((v): v is string => Boolean(v));
+    return [...new Set([...knownServers, ...selected])];
+  }, [knownServers, activeFilters]);
+
+  const handleServerSelectionChange = useCallback(
+    (values: string[]) => {
+      setActiveFilters((prev) => {
+        const nonServer = prev.filter(
+          (f) => f.path !== "gram.tool_call.source",
+        );
+        const serverFilters: FilterChip[] = values.map((v) => ({
+          display: v,
+          filters: [v],
+          path: "gram.tool_call.source",
+        }));
+        return [...nonServer, ...serverFilters];
+      });
+      setSearchParams(
+        (urlPrev) => {
+          const next = new URLSearchParams(urlPrev);
+          if (values.length > 0) {
+            next.set("server", values.join(","));
+          } else {
+            next.delete("server");
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const addFilter = useCallback(
+    (chip: FilterChip) => {
+      setActiveFilters((prev) => {
+        const exists = prev.some(
+          (f) => f.path === chip.path && f.display === chip.display,
+        );
+        if (exists) return prev;
+
+        const newFilters = [...prev, chip];
+
+        setSearchParams(
+          (urlPrev) => {
+            const next = new URLSearchParams(urlPrev);
+            if (chip.path === "gram.tool_call.source") {
+              const serverFilters = newFilters
+                .filter((f) => f.path === "gram.tool_call.source")
+                .map((f) => f.display);
+              next.set("server", serverFilters.join(","));
+            } else if (chip.path === "user.email") {
+              const userFilters = newFilters
+                .filter((f) => f.path === "user.email")
+                .map((f) => f.display);
+              next.set("user", userFilters.join(","));
+            }
+            return next;
+          },
+          { replace: true },
+        );
+
+        return newFilters;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const removeFilter = useCallback(
+    (path: string, display?: string) => {
+      setActiveFilters((prev) => {
+        const newFilters = display
+          ? prev.filter((f) => !(f.path === path && f.display === display))
+          : prev.filter((f) => f.path !== path);
+
+        setSearchParams(
+          (urlPrev) => {
+            const next = new URLSearchParams(urlPrev);
+            if (path === "gram.tool_call.source") {
+              const serverFilters = newFilters
+                .filter((f) => f.path === "gram.tool_call.source")
+                .map((f) => f.display);
+              if (serverFilters.length > 0) {
+                next.set("server", serverFilters.join(","));
+              } else {
+                next.delete("server");
+              }
+            } else if (path === "user.email") {
+              const userFilters = newFilters
+                .filter((f) => f.path === "user.email")
+                .map((f) => f.display);
+              if (userFilters.length > 0) {
+                next.set("user", userFilters.join(","));
+              } else {
+                next.delete("user");
+              }
+            }
+            return next;
+          },
+          { replace: true },
+        );
+
+        return newFilters;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const submitUserEmailFilter = useCallback(() => {
+    const trimmed = userEmailInput.trim();
+    if (!trimmed) return;
+    addFilter({
+      display: trimmed,
+      filters: [trimmed],
+      path: "user.email",
+    });
+    setUserEmailInput("");
+  }, [userEmailInput, addFilter]);
+
+  const handleHookTypesChange = useCallback(
+    (types: TypesToInclude[]) => {
+      setSelectedHookTypes(types);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const isDefault =
+            types.length === 2 &&
+            types.includes("mcp") &&
+            types.includes("skill") &&
+            !types.includes("local");
+          if (isDefault) {
+            next.delete("hookTypes");
+          } else if (types.length > 0) {
+            next.set("hookTypes", types.join(","));
+          } else {
+            next.delete("hookTypes");
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return {
+    activeFilters,
+    userEmailInput,
+    setUserEmailInput,
+    selectedHookTypes,
+    dateRange,
+    customRange,
+    customRangeLabel: urlLabel,
+    from,
+    to,
+    logFilters,
+    serverOptions,
+    addKnownServers,
+    handleServerSelectionChange,
+    addFilter,
+    removeFilter,
+    submitUserEmailFilter,
+    handleHookTypesChange,
+    setDateRangeParam,
+    setCustomRangeParam,
+    clearCustomRange,
+  };
+}

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -9,9 +9,7 @@ import {
   safeBase64Decode,
   safeBase64Encode,
 } from "./observeFilterUtils";
-
-const DEFAULT_HOOK_TYPES: TypesToInclude[] = ["mcp", "skill"];
-const VALID_HOOK_TYPES: TypesToInclude[] = ["mcp", "local", "skill"];
+import { DEFAULT_HOOK_TYPES, VALID_HOOK_TYPES } from "./observeFilterConstants";
 const SERVER_FILTER_PATH = "gram.tool_call.source";
 const USER_EMAIL_FILTER_PATH = "user.email";
 
@@ -315,6 +313,7 @@ export function useObserveFilters() {
     [setSearchParams],
   );
 
+  // Passing an empty array resets to DEFAULT_HOOK_TYPES and clears the URL param.
   const handleHookTypesChange = useCallback(
     (types: TypesToInclude[]) => {
       const nextTypes = [
@@ -324,21 +323,20 @@ export function useObserveFilters() {
           ),
         ),
       ];
-      if (nextTypes.length === 0) return;
+      const resolved =
+        nextTypes.length === 0 ? [...DEFAULT_HOOK_TYPES] : nextTypes;
+      const isDefault =
+        resolved.length === DEFAULT_HOOK_TYPES.length &&
+        DEFAULT_HOOK_TYPES.every((t) => resolved.includes(t));
 
-      setSelectedHookTypes(nextTypes);
+      setSelectedHookTypes(resolved);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
-          const isDefault =
-            nextTypes.length === 2 &&
-            nextTypes.includes("mcp") &&
-            nextTypes.includes("skill") &&
-            !nextTypes.includes("local");
           if (isDefault) {
             next.delete("hookTypes");
           } else {
-            next.set("hookTypes", nextTypes.join(","));
+            next.set("hookTypes", resolved.join(","));
           }
           return next;
         },

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -6,6 +6,7 @@ import type { FilterChip } from "@/components/observe/ObserveFilterBar";
 import {
   buildLogFilters,
   isValidPreset,
+  mergeFilterChip,
   safeBase64Decode,
   safeBase64Encode,
 } from "./observeFilterUtils";
@@ -244,26 +245,8 @@ export function useObserveFilters() {
   const addFilter = useCallback(
     (chip: FilterChip) => {
       setActiveFilters((prev) => {
-        const existing = prev.find((f) => f.path === chip.path);
-        const alreadyPresent = existing?.filters.some((v) =>
-          chip.filters.includes(v),
-        );
-        if (alreadyPresent) return prev;
-
-        const merged: FilterChip = existing
-          ? {
-              path: chip.path,
-              filters: [...new Set([...existing.filters, ...chip.filters])],
-              display: [
-                ...new Set([...existing.filters, ...chip.filters]),
-              ].join(", "),
-            }
-          : chip;
-
-        const newFilters = [
-          ...prev.filter((f) => f.path !== chip.path),
-          merged,
-        ];
+        const { filters: newFilters, merged } = mergeFilterChip(prev, chip);
+        if (!merged) return prev;
 
         setSearchParams(
           (urlPrev) => {

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -1,6 +1,6 @@
 import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
 import type { TypesToInclude } from "@gram/client/models/components";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import type { FilterChip } from "@/components/observe/ObserveFilterBar";
 import {
@@ -51,7 +51,6 @@ export function useObserveFilters() {
     return filters;
   });
 
-  const [userEmailInput, setUserEmailInput] = useState("");
   const [selectedHookTypes, setSelectedHookTypes] = useState<TypesToInclude[]>(
     () => {
       const raw = searchParams.get("hookTypes");
@@ -64,6 +63,7 @@ export function useObserveFilters() {
     },
   );
   const [knownServers, setKnownServers] = useState<string[]>([]);
+  const [knownUserEmails, setKnownUserEmails] = useState<string[]>([]);
 
   const urlRange = searchParams.get("range");
   const urlFrom = searchParams.get("from");
@@ -129,6 +129,11 @@ export function useObserveFilters() {
     [customRange, dateRange],
   );
 
+  useEffect(() => {
+    setKnownServers([]);
+    setKnownUserEmails([]);
+  }, [from, to]);
+
   const logFilters = useMemo(
     () => buildLogFilters(activeFilters),
     [activeFilters],
@@ -142,6 +147,14 @@ export function useObserveFilters() {
     });
   }, []);
 
+  const addKnownUserEmails = useCallback((emails: string[]) => {
+    if (emails.length === 0) return;
+    setKnownUserEmails((prev) => {
+      const merged = [...new Set([...prev, ...emails])];
+      return merged.length === prev.length ? prev : merged;
+    });
+  }, []);
+
   const serverOptions = useMemo(() => {
     const selected = activeFilters
       .filter((f) => f.path === "gram.tool_call.source")
@@ -149,6 +162,41 @@ export function useObserveFilters() {
       .filter((v): v is string => Boolean(v));
     return [...new Set([...knownServers, ...selected])];
   }, [knownServers, activeFilters]);
+
+  const userEmailOptions = useMemo(() => {
+    const selected = activeFilters
+      .filter((f) => f.path === "user.email")
+      .map((f) => f.filters[0])
+      .filter((v): v is string => Boolean(v));
+    return [...new Set([...knownUserEmails, ...selected])];
+  }, [knownUserEmails, activeFilters]);
+
+  const handleUserEmailSelectionChange = useCallback(
+    (values: string[]) => {
+      setActiveFilters((prev) => {
+        const nonEmail = prev.filter((f) => f.path !== "user.email");
+        const emailFilters: FilterChip[] = values.map((v) => ({
+          display: v,
+          filters: [v],
+          path: "user.email",
+        }));
+        return [...nonEmail, ...emailFilters];
+      });
+      setSearchParams(
+        (urlPrev) => {
+          const next = new URLSearchParams(urlPrev);
+          if (values.length > 0) {
+            next.set("user", values.join(","));
+          } else {
+            next.delete("user");
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const handleServerSelectionChange = useCallback(
     (values: string[]) => {
@@ -254,17 +302,6 @@ export function useObserveFilters() {
     [setSearchParams],
   );
 
-  const submitUserEmailFilter = useCallback(() => {
-    const trimmed = userEmailInput.trim();
-    if (!trimmed) return;
-    addFilter({
-      display: trimmed,
-      filters: [trimmed],
-      path: "user.email",
-    });
-    setUserEmailInput("");
-  }, [userEmailInput, addFilter]);
-
   const handleHookTypesChange = useCallback(
     (types: TypesToInclude[]) => {
       setSelectedHookTypes(types);
@@ -293,8 +330,6 @@ export function useObserveFilters() {
 
   return {
     activeFilters,
-    userEmailInput,
-    setUserEmailInput,
     selectedHookTypes,
     dateRange,
     customRange,
@@ -305,9 +340,11 @@ export function useObserveFilters() {
     serverOptions,
     addKnownServers,
     handleServerSelectionChange,
+    userEmailOptions,
+    addKnownUserEmails,
+    handleUserEmailSelectionChange,
     addFilter,
     removeFilter,
-    submitUserEmailFilter,
     handleHookTypesChange,
     setDateRangeParam,
     setCustomRangeParam,


### PR DESCRIPTION
### Summary

Replaces the duplicated per-page filter implementations across ToolsInsights  and LogsInsights with a shared `ObserveFilterBar` component and `useObserveFilters` hook.

- Server name and email filters migrated from freetext `MultiSearch` to `MultiSelect` dropdowns
- Type filter (tools/hooks/etc.) migrated to `MultiSelect`
- All filters use OR semantics — selecting multiple values shows rows matching any of them
- Hook filter state preserved correctly across navigation
- ~1,200 lines of duplicated filter code removed

### Related PRs
- https://github.com/speakeasy-api/gram/pull/2615
