### PR TITLE
mig: add workos sync cursor columns

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -53,6 +53,8 @@ CREATE TABLE IF NOT EXISTS organization_metadata (
   gram_account_type TEXT NOT NULL DEFAULT 'free',
   sso_connection_id TEXT, -- links to an organization in the oidc provider to understand if a user is JIT provisioned via SSO. Will be replaced by workos_org_id.
   workos_id TEXT, -- links to an organization in WorkOS to sync metadata like users and groups
+  workos_updated_at timestamptz,
+  workos_last_event_id TEXT,
 
   whitelisted boolean NOT NULL DEFAULT TRUE,
   free_trial_started_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -1428,6 +1430,8 @@ CREATE TABLE IF NOT EXISTS organization_user_relationships (
   organization_id TEXT NOT NULL,
   user_id TEXT NOT NULL,
   workos_membership_id TEXT,
+  workos_updated_at timestamptz,
+  workos_last_event_id TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -776,6 +776,8 @@ type OrganizationMetadatum struct {
 	GramAccountType    string
 	SsoConnectionID    pgtype.Text
 	WorkosID           pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
 	Whitelisted        bool
 	FreeTrialStartedAt pgtype.Timestamptz
 	FreeTrialEndsAt    pgtype.Timestamptz
@@ -819,6 +821,8 @@ type OrganizationUserRelationship struct {
 	OrganizationID     string
 	UserID             string
 	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz

--- a/server/internal/organizations/repo/models.go
+++ b/server/internal/organizations/repo/models.go
@@ -15,6 +15,8 @@ type OrganizationMetadatum struct {
 	GramAccountType    string
 	SsoConnectionID    pgtype.Text
 	WorkosID           pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
 	Whitelisted        bool
 	FreeTrialStartedAt pgtype.Timestamptz
 	FreeTrialEndsAt    pgtype.Timestamptz
@@ -28,6 +30,8 @@ type OrganizationUserRelationship struct {
 	OrganizationID     string
 	UserID             string
 	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -60,7 +60,7 @@ func (q *Queries) DeleteOrganizationUserRelationship(ctx context.Context, arg De
 }
 
 const getOrganizationMetadata = `-- name: GetOrganizationMetadata :one
-SELECT id, name, slug, gram_account_type, sso_connection_id, workos_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+SELECT id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
 FROM organization_metadata
 WHERE id = $1
 `
@@ -75,6 +75,8 @@ func (q *Queries) GetOrganizationMetadata(ctx context.Context, id string) (Organ
 		&i.GramAccountType,
 		&i.SsoConnectionID,
 		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
 		&i.Whitelisted,
 		&i.FreeTrialStartedAt,
 		&i.FreeTrialEndsAt,
@@ -100,7 +102,7 @@ func (q *Queries) GetOrganizationNameByWorkosID(ctx context.Context, workosID pg
 }
 
 const getOrganizationUserRelationship = `-- name: GetOrganizationUserRelationship :one
-SELECT id, organization_id, user_id, workos_membership_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, user_id, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at, deleted_at, deleted
 FROM organization_user_relationships
 WHERE organization_id = $1
   AND user_id = $2
@@ -120,6 +122,8 @@ func (q *Queries) GetOrganizationUserRelationship(ctx context.Context, arg GetOr
 		&i.OrganizationID,
 		&i.UserID,
 		&i.WorkosMembershipID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -152,7 +156,7 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 
 const listOrganizationUsers = `-- name: ListOrganizationUsers :many
 SELECT
-  our.id, our.organization_id, our.user_id, our.workos_membership_id, our.created_at, our.updated_at, our.deleted_at, our.deleted,
+  our.id, our.organization_id, our.user_id, our.workos_membership_id, our.workos_updated_at, our.workos_last_event_id, our.created_at, our.updated_at, our.deleted_at, our.deleted,
   u.email AS user_email,
   u.display_name AS user_display_name,
   u.photo_url AS user_photo_url
@@ -167,6 +171,8 @@ type ListOrganizationUsersRow struct {
 	OrganizationID     string
 	UserID             string
 	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DeletedAt          pgtype.Timestamptz
@@ -190,6 +196,8 @@ func (q *Queries) ListOrganizationUsers(ctx context.Context, organizationID stri
 			&i.OrganizationID,
 			&i.UserID,
 			&i.WorkosMembershipID,
+			&i.WorkosUpdatedAt,
+			&i.WorkosLastEventID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -231,7 +239,7 @@ SET workos_id = $1,
     updated_at = clock_timestamp()
 WHERE id = $2 AND
     workos_id IS NULL
-RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
 `
 
 type SetOrgWorkosIDParams struct {
@@ -249,6 +257,8 @@ func (q *Queries) SetOrgWorkosID(ctx context.Context, arg SetOrgWorkosIDParams) 
 		&i.GramAccountType,
 		&i.SsoConnectionID,
 		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
 		&i.Whitelisted,
 		&i.FreeTrialStartedAt,
 		&i.FreeTrialEndsAt,
@@ -331,7 +341,7 @@ ON CONFLICT (id) DO UPDATE SET
         ELSE organization_metadata.whitelisted
     END,
     updated_at = clock_timestamp()
-RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
 `
 
 type UpsertOrganizationMetadataParams struct {
@@ -358,6 +368,8 @@ func (q *Queries) UpsertOrganizationMetadata(ctx context.Context, arg UpsertOrga
 		&i.GramAccountType,
 		&i.SsoConnectionID,
 		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
 		&i.Whitelisted,
 		&i.FreeTrialStartedAt,
 		&i.FreeTrialEndsAt,
@@ -378,7 +390,7 @@ INSERT INTO organization_user_relationships (
 )
 ON CONFLICT (organization_id, user_id) DO UPDATE SET
     updated_at = clock_timestamp()
-RETURNING id, organization_id, user_id, workos_membership_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, user_id, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpsertOrganizationUserRelationshipParams struct {
@@ -394,6 +406,8 @@ func (q *Queries) UpsertOrganizationUserRelationship(ctx context.Context, arg Up
 		&i.OrganizationID,
 		&i.UserID,
 		&i.WorkosMembershipID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/internal/projects/repo/queries.sql.go
+++ b/server/internal/projects/repo/queries.sql.go
@@ -156,7 +156,7 @@ SELECT
     p.slug as project_slug,
     
     -- Organization metadata fields
-    om.id, om.name, om.slug, om.gram_account_type, om.sso_connection_id, om.workos_id, om.whitelisted, om.free_trial_started_at, om.free_trial_ends_at, om.created_at, om.updated_at, om.disabled_at
+    om.id, om.name, om.slug, om.gram_account_type, om.sso_connection_id, om.workos_id, om.workos_updated_at, om.workos_last_event_id, om.whitelisted, om.free_trial_started_at, om.free_trial_ends_at, om.created_at, om.updated_at, om.disabled_at
     
 FROM projects p
 INNER JOIN organization_metadata om ON p.organization_id = om.id
@@ -174,6 +174,8 @@ type GetProjectWithOrganizationMetadataRow struct {
 	GramAccountType    string
 	SsoConnectionID    pgtype.Text
 	WorkosID           pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
 	Whitelisted        bool
 	FreeTrialStartedAt pgtype.Timestamptz
 	FreeTrialEndsAt    pgtype.Timestamptz
@@ -195,6 +197,8 @@ func (q *Queries) GetProjectWithOrganizationMetadata(ctx context.Context, id uui
 		&i.GramAccountType,
 		&i.SsoConnectionID,
 		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
 		&i.Whitelisted,
 		&i.FreeTrialStartedAt,
 		&i.FreeTrialEndsAt,

--- a/server/migrations/20260506092802_workos-sync-cursor-cols.sql
+++ b/server/migrations/20260506092802_workos-sync-cursor-cols.sql
@@ -1,0 +1,4 @@
+-- Modify "organization_metadata" table
+ALTER TABLE "organization_metadata" ADD COLUMN "workos_updated_at" timestamptz NULL, ADD COLUMN "workos_last_event_id" text NULL;
+-- Modify "organization_user_relationships" table
+ALTER TABLE "organization_user_relationships" ADD COLUMN "workos_updated_at" timestamptz NULL, ADD COLUMN "workos_last_event_id" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TFlFTyaUOfivCkaRtef73QEhZqtTof5t3WkHoPGV8mM=
+h1:SpXqn19ZV5C8F+A9i7PdVzIh0RZ2SYSC+SB57BsNfFY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -155,3 +155,4 @@ h1:TFlFTyaUOfivCkaRtef73QEhZqtTof5t3WkHoPGV8mM=
 20260504210916_chat_messages_project_id_id_idx.sql h1:kwShq3wLbk1VNIWRsAWDlqJ2apQ5iDnODP81/Vc6VTY=
 20260505134312_authz-challenge-resolutions.sql h1:t6fg2cQEWZrdYYATaJx+7zfdYvmJCUE3zuKJq4E6Zwo=
 20260505150617_mcp-servers-add-fk-indexes.sql h1:XEvL+LK4Km4lIBK4De3ryBk9ug0dSOBakZVIy9juEco=
+20260506092802_workos-sync-cursor-cols.sql h1:YTWZ24vx+g/exU+1Fs4uCXHrOYpUOYfe7+BxS/6atLo=


### PR DESCRIPTION
## Summary

Adds nullable `workos_updated_at` + `workos_last_event_id` columns to `organization_metadata` and `organization_user_relationships`. Used by the WorkOS sync handlers (PR follows) for row-level `ShouldProcessEvent` guard against duplicate-apply during webhook + reconcile overlap.

`organization_roles`, `global_roles`, and `organization_role_assignments` already carry these columns from #2515.