### PR TITLE
feat: handle workos organization and role sync events

### DIFF
--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -38,3 +38,91 @@ WHERE id = @id
 DELETE FROM principal_grants
 WHERE organization_id = @organization_id
   AND principal_urn = @principal_urn;
+
+-- name: GetGlobalRoleBySlug :one
+SELECT *
+FROM global_roles
+WHERE workos_slug = @workos_slug;
+
+-- name: UpsertGlobalRole :exec
+-- Upsert an environment-level WorkOS role. Caller must have already passed
+-- the row through ShouldProcessEvent. Resurrects a previously soft-deleted
+-- role on conflict.
+INSERT INTO global_roles (
+    workos_slug,
+    workos_name,
+    workos_description,
+    workos_created_at,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    @workos_slug,
+    @workos_name,
+    @workos_description,
+    @workos_created_at,
+    @workos_updated_at,
+    @workos_last_event_id
+)
+ON CONFLICT (workos_slug) DO UPDATE SET
+    workos_name = EXCLUDED.workos_name,
+    workos_description = EXCLUDED.workos_description,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = NULL,
+    workos_deleted_at = NULL,
+    updated_at = clock_timestamp();
+
+-- name: MarkGlobalRoleDeleted :execrows
+UPDATE global_roles
+SET workos_deleted_at = @workos_deleted_at,
+    workos_last_event_id = @workos_last_event_id,
+    deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE workos_slug = @workos_slug
+  AND deleted_at IS NULL;
+
+-- name: GetOrganizationRoleBySlug :one
+SELECT *
+FROM organization_roles
+WHERE organization_id = @organization_id
+  AND workos_slug = @workos_slug;
+
+-- name: UpsertOrganizationRole :exec
+-- Upsert an org-scoped WorkOS role. Caller must have already passed the row
+-- through ShouldProcessEvent. Resurrects a previously soft-deleted role on
+-- conflict.
+INSERT INTO organization_roles (
+    organization_id,
+    workos_slug,
+    workos_name,
+    workos_description,
+    workos_created_at,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    @organization_id,
+    @workos_slug,
+    @workos_name,
+    @workos_description,
+    @workos_created_at,
+    @workos_updated_at,
+    @workos_last_event_id
+)
+ON CONFLICT (organization_id, workos_slug) DO UPDATE SET
+    workos_name = EXCLUDED.workos_name,
+    workos_description = EXCLUDED.workos_description,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = NULL,
+    workos_deleted_at = NULL,
+    updated_at = clock_timestamp();
+
+-- name: MarkOrganizationRoleDeleted :execrows
+UPDATE organization_roles
+SET workos_deleted_at = @workos_deleted_at,
+    workos_last_event_id = @workos_last_event_id,
+    deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND workos_slug = @workos_slug
+  AND deleted_at IS NULL;

--- a/server/internal/access/repo/models.go
+++ b/server/internal/access/repo/models.go
@@ -3,3 +3,41 @@
 //   sqlc v1.29.0
 
 package repo
+
+import (
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type GlobalRole struct {
+	ID                uuid.UUID
+	WorkosSlug        string
+	WorkosName        string
+	WorkosDescription pgtype.Text
+	WorkosCreatedAt   pgtype.Timestamptz
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosDeletedAt   pgtype.Timestamptz
+	WorkosDeleted     bool
+	WorkosLastEventID pgtype.Text
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	DeletedAt         pgtype.Timestamptz
+	Deleted           bool
+}
+
+type OrganizationRole struct {
+	ID                uuid.UUID
+	OrganizationID    string
+	WorkosSlug        string
+	WorkosName        string
+	WorkosDescription pgtype.Text
+	WorkosCreatedAt   pgtype.Timestamptz
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosDeletedAt   pgtype.Timestamptz
+	WorkosDeleted     bool
+	WorkosLastEventID pgtype.Text
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	DeletedAt         pgtype.Timestamptz
+	Deleted           bool
+}

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -54,6 +54,67 @@ func (q *Queries) DeletePrincipalGrantsByPrincipal(ctx context.Context, arg Dele
 	return result.RowsAffected(), nil
 }
 
+const getGlobalRoleBySlug = `-- name: GetGlobalRoleBySlug :one
+SELECT id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, workos_deleted_at, workos_deleted, workos_last_event_id, created_at, updated_at, deleted_at, deleted
+FROM global_roles
+WHERE workos_slug = $1
+`
+
+func (q *Queries) GetGlobalRoleBySlug(ctx context.Context, workosSlug string) (GlobalRole, error) {
+	row := q.db.QueryRow(ctx, getGlobalRoleBySlug, workosSlug)
+	var i GlobalRole
+	err := row.Scan(
+		&i.ID,
+		&i.WorkosSlug,
+		&i.WorkosName,
+		&i.WorkosDescription,
+		&i.WorkosCreatedAt,
+		&i.WorkosUpdatedAt,
+		&i.WorkosDeletedAt,
+		&i.WorkosDeleted,
+		&i.WorkosLastEventID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
+const getOrganizationRoleBySlug = `-- name: GetOrganizationRoleBySlug :one
+SELECT id, organization_id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, workos_deleted_at, workos_deleted, workos_last_event_id, created_at, updated_at, deleted_at, deleted
+FROM organization_roles
+WHERE organization_id = $1
+  AND workos_slug = $2
+`
+
+type GetOrganizationRoleBySlugParams struct {
+	OrganizationID string
+	WorkosSlug     string
+}
+
+func (q *Queries) GetOrganizationRoleBySlug(ctx context.Context, arg GetOrganizationRoleBySlugParams) (OrganizationRole, error) {
+	row := q.db.QueryRow(ctx, getOrganizationRoleBySlug, arg.OrganizationID, arg.WorkosSlug)
+	var i OrganizationRole
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.WorkosSlug,
+		&i.WorkosName,
+		&i.WorkosDescription,
+		&i.WorkosCreatedAt,
+		&i.WorkosUpdatedAt,
+		&i.WorkosDeletedAt,
+		&i.WorkosDeleted,
+		&i.WorkosLastEventID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getPrincipalGrants = `-- name: GetPrincipalGrants :many
 SELECT principal_urn, scope, selectors
 FROM principal_grants
@@ -149,6 +210,165 @@ func (q *Queries) ListPrincipalGrantsByOrg(ctx context.Context, arg ListPrincipa
 		return nil, err
 	}
 	return items, nil
+}
+
+const markGlobalRoleDeleted = `-- name: MarkGlobalRoleDeleted :execrows
+UPDATE global_roles
+SET workos_deleted_at = $1,
+    workos_last_event_id = $2,
+    deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE workos_slug = $3
+  AND deleted_at IS NULL
+`
+
+type MarkGlobalRoleDeletedParams struct {
+	WorkosDeletedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+	WorkosSlug        string
+}
+
+func (q *Queries) MarkGlobalRoleDeleted(ctx context.Context, arg MarkGlobalRoleDeletedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markGlobalRoleDeleted, arg.WorkosDeletedAt, arg.WorkosLastEventID, arg.WorkosSlug)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const markOrganizationRoleDeleted = `-- name: MarkOrganizationRoleDeleted :execrows
+UPDATE organization_roles
+SET workos_deleted_at = $1,
+    workos_last_event_id = $2,
+    deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE organization_id = $3
+  AND workos_slug = $4
+  AND deleted_at IS NULL
+`
+
+type MarkOrganizationRoleDeletedParams struct {
+	WorkosDeletedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+	OrganizationID    string
+	WorkosSlug        string
+}
+
+func (q *Queries) MarkOrganizationRoleDeleted(ctx context.Context, arg MarkOrganizationRoleDeletedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markOrganizationRoleDeleted,
+		arg.WorkosDeletedAt,
+		arg.WorkosLastEventID,
+		arg.OrganizationID,
+		arg.WorkosSlug,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const upsertGlobalRole = `-- name: UpsertGlobalRole :exec
+INSERT INTO global_roles (
+    workos_slug,
+    workos_name,
+    workos_description,
+    workos_created_at,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6
+)
+ON CONFLICT (workos_slug) DO UPDATE SET
+    workos_name = EXCLUDED.workos_name,
+    workos_description = EXCLUDED.workos_description,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = NULL,
+    workos_deleted_at = NULL,
+    updated_at = clock_timestamp()
+`
+
+type UpsertGlobalRoleParams struct {
+	WorkosSlug        string
+	WorkosName        string
+	WorkosDescription pgtype.Text
+	WorkosCreatedAt   pgtype.Timestamptz
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+}
+
+// Upsert an environment-level WorkOS role. Caller must have already passed
+// the row through ShouldProcessEvent. Resurrects a previously soft-deleted
+// role on conflict.
+func (q *Queries) UpsertGlobalRole(ctx context.Context, arg UpsertGlobalRoleParams) error {
+	_, err := q.db.Exec(ctx, upsertGlobalRole,
+		arg.WorkosSlug,
+		arg.WorkosName,
+		arg.WorkosDescription,
+		arg.WorkosCreatedAt,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+	)
+	return err
+}
+
+const upsertOrganizationRole = `-- name: UpsertOrganizationRole :exec
+INSERT INTO organization_roles (
+    organization_id,
+    workos_slug,
+    workos_name,
+    workos_description,
+    workos_created_at,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7
+)
+ON CONFLICT (organization_id, workos_slug) DO UPDATE SET
+    workos_name = EXCLUDED.workos_name,
+    workos_description = EXCLUDED.workos_description,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = NULL,
+    workos_deleted_at = NULL,
+    updated_at = clock_timestamp()
+`
+
+type UpsertOrganizationRoleParams struct {
+	OrganizationID    string
+	WorkosSlug        string
+	WorkosName        string
+	WorkosDescription pgtype.Text
+	WorkosCreatedAt   pgtype.Timestamptz
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+}
+
+// Upsert an org-scoped WorkOS role. Caller must have already passed the row
+// through ShouldProcessEvent. Resurrects a previously soft-deleted role on
+// conflict.
+func (q *Queries) UpsertOrganizationRole(ctx context.Context, arg UpsertOrganizationRoleParams) error {
+	_, err := q.db.Exec(ctx, upsertOrganizationRole,
+		arg.OrganizationID,
+		arg.WorkosSlug,
+		arg.WorkosName,
+		arg.WorkosDescription,
+		arg.WorkosCreatedAt,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+	)
+	return err
 }
 
 const upsertPrincipalGrant = `-- name: UpsertPrincipalGrant :one

--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -6,21 +6,28 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/workos/workos-go/v6/pkg/events"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/database"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-const workosOrgEventsPageSize = 100
+const (
+	workosOrgEventsPageSize   = 100
+	workosRoleTypeEnvironment = "EnvironmentRole"
+)
 
 // EventsLister is the subset of the WorkOS events client used by this activity.
 type EventsLister interface {
@@ -136,12 +143,13 @@ func (p *ProcessWorkOSOrganizationEvents) handlePage(ctx context.Context, logger
 			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to unmarshal workos organization event data").Log(ctx, eventLogger)
 		}
 
+		// Resolve the WorkOS organization ID from the payload for logging.
+		// organization.* events carry it on .id; organization_role.* events
+		// carry it on .organization_id (empty for environment-level roles).
 		orgID := conv.Ternary(orgEvent.Object == "organization", orgEvent.ID, orgEvent.OrganizationID)
-		if orgID == "" {
-			return lastEventID, oops.E(oops.CodeUnexpected, nil, "unexpected non-organization event object: %s", orgEvent.Object).Log(ctx, eventLogger)
+		if orgID != "" {
+			eventLogger = eventLogger.With(attr.SlogWorkOSEventOrganizationID(orgID))
 		}
-
-		eventLogger = eventLogger.With(attr.SlogWorkOSEventOrganizationID(orgID))
 
 		eventID, err := p.handleEvent(ctx, eventLogger, workosOrgID, event)
 		if err != nil {
@@ -188,10 +196,340 @@ func (p *ProcessWorkOSOrganizationEvents) handleEvent(ctx context.Context, logge
 	return event.ID, nil
 }
 
-// handleOrganizationEvent applies an organization.* WorkOS event to local
-// state. The implementation lands in a follow-up PR — see [handleEvent] for
-// the consequence of leaving this as a no-op while the workflow is live.
+// handleOrganizationEvent dispatches an organization.* or organization_role.*
+// WorkOS event to its handler. Each handler is responsible for the
+// ShouldProcessEvent guard against duplicate apply.
 func handleOrganizationEvent(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
-	// TODO: implement this method
+	switch event.Event {
+	case string(workos.EventKindOrganizationCreated), string(workos.EventKindOrganizationUpdated):
+		return handleOrganizationUpsert(ctx, logger, dbtx, event)
+	case string(workos.EventKindOrganizationDeleted):
+		return handleOrganizationDeleted(ctx, logger, dbtx, event)
+	case string(workos.EventKindOrganizationRoleCreated), string(workos.EventKindOrganizationRoleUpdated):
+		return handleRoleUpsert(ctx, logger, dbtx, event)
+	case string(workos.EventKindOrganizationRoleDeleted):
+		return handleRoleDeleted(ctx, logger, dbtx, event)
+	}
+
+	return oops.Permanent(fmt.Errorf("unhandled workos organization event type: %s", event.Event))
+}
+
+// workosOrganizationEventPayload is the relevant subset of an
+// organization.{created,updated,deleted} event payload.
+type workosOrganizationEventPayload struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	ExternalID string    `json:"external_id"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// handleOrganizationUpsert applies an organization.created or
+// organization.updated event. Maps the WorkOS organization to a Gram org by
+// looking up workos_id; falls back to the payload's external_id for orgs not
+// yet linked.
+func handleOrganizationUpsert(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	var payload workosOrganizationEventPayload
+	if err := json.Unmarshal(event.Data, &payload); err != nil {
+		return oops.Permanent(fmt.Errorf("unmarshal organization event payload: %w", err))
+	}
+
+	repo := orgrepo.New(dbtx)
+
+	row, err := repo.GetOrganizationByWorkosID(ctx, conv.ToPGText(payload.ID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		if payload.ExternalID == "" {
+			return oops.Permanent(fmt.Errorf("workos organization %q has no external_id and no existing mapping", payload.ID))
+		}
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", payload.ID, err)
+	}
+
+	var lastEventID *string
+	if row.WorkosLastEventID.Valid {
+		lastEventID = &row.WorkosLastEventID.String
+	}
+	var rowUpdatedAt *time.Time
+	if row.WorkosUpdatedAt.Valid {
+		rowUpdatedAt = &row.WorkosUpdatedAt.Time
+	}
+	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
+		return nil
+	}
+
+	organizationID := payload.ExternalID
+	if err == nil {
+		organizationID = row.ID
+	}
+
+	_, err = repo.UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:                organizationID,
+		Name:              payload.Name,
+		Slug:              conv.ToSlug(payload.Name),
+		WorkosID:          conv.ToPGText(payload.ID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID: conv.ToPGText(event.ID),
+	})
+	if err != nil {
+		return fmt.Errorf("upsert organization %q from workos event: %w", payload.ID, err)
+	}
+
 	return nil
+}
+
+func handleOrganizationDeleted(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	var payload workosOrganizationEventPayload
+	if err := json.Unmarshal(event.Data, &payload); err != nil {
+		return oops.Permanent(fmt.Errorf("unmarshal organization delete event payload: %w", err))
+	}
+
+	repo := orgrepo.New(dbtx)
+	row, err := repo.GetOrganizationByWorkosID(ctx, conv.ToPGText(payload.ID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		logger.DebugContext(ctx, "skipping organization delete for unknown org", attr.SlogWorkOSOrganizationID(payload.ID))
+		return nil
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", payload.ID, err)
+	}
+
+	var lastEventID *string
+	if row.WorkosLastEventID.Valid {
+		lastEventID = &row.WorkosLastEventID.String
+	}
+	var rowUpdatedAt *time.Time
+	if row.WorkosUpdatedAt.Valid {
+		rowUpdatedAt = &row.WorkosUpdatedAt.Time
+	}
+	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
+		return nil
+	}
+
+	if _, err := repo.DisableOrganizationByWorkosID(ctx, orgrepo.DisableOrganizationByWorkosIDParams{
+		WorkosID:          conv.ToPGText(payload.ID),
+		WorkosLastEventID: conv.ToPGText(event.ID),
+	}); err != nil {
+		return fmt.Errorf("disable organization %q: %w", payload.ID, err)
+	}
+
+	return nil
+}
+
+// workosRoleEventPayload is the relevant subset of an organization_role.*
+// event payload. OrganizationID is empty for environment-level roles.
+type workosRoleEventPayload struct {
+	OrganizationID string     `json:"organization_id"`
+	Slug           string     `json:"slug"`
+	Name           string     `json:"name"`
+	Description    string     `json:"description"`
+	Type           string     `json:"type"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	DeletedAt      *time.Time `json:"deleted_at"`
+}
+
+// handleRoleUpsert applies an organization_role.created or
+// organization_role.updated event. Routes EnvironmentRole types to
+// global_roles and everything else to organization_roles.
+func handleRoleUpsert(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	var payload workosRoleEventPayload
+	if err := json.Unmarshal(event.Data, &payload); err != nil {
+		return oops.Permanent(fmt.Errorf("unmarshal role event payload: %w", err))
+	}
+
+	if payload.Type == workosRoleTypeEnvironment {
+		return upsertGlobalRole(ctx, dbtx, event, payload)
+	}
+
+	return upsertOrganizationRole(ctx, logger, dbtx, event, payload)
+}
+
+func upsertGlobalRole(ctx context.Context, dbtx database.DBTX, event events.Event, payload workosRoleEventPayload) error {
+	repo := accessrepo.New(dbtx)
+
+	existing, err := repo.GetGlobalRoleBySlug(ctx, payload.Slug)
+	// if the error is due to no rows found, we're ok to proceed (new role)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get global role %q: %w", payload.Slug, err)
+	}
+
+	var lastEventID *string
+	if existing.WorkosLastEventID.Valid {
+		lastEventID = &existing.WorkosLastEventID.String
+	}
+	rowUpdatedAt := existing.WorkosUpdatedAt.Time
+	if !ShouldProcessEvent(lastEventID, &rowUpdatedAt, event.ID, payload.UpdatedAt) {
+		return nil
+	}
+
+	if err := repo.UpsertGlobalRole(ctx, accessrepo.UpsertGlobalRoleParams{
+		WorkosSlug:        payload.Slug,
+		WorkosName:        payload.Name,
+		WorkosDescription: conv.ToPGTextEmpty(payload.Description),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(payload.CreatedAt),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID: conv.ToPGText(event.ID),
+	}); err != nil {
+		return fmt.Errorf("upsert global role %q: %w", payload.Slug, err)
+	}
+
+	return nil
+}
+
+func upsertOrganizationRole(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event, payload workosRoleEventPayload) error {
+	org, err := orgrepo.New(dbtx).GetOrganizationByWorkosID(ctx, conv.ToPGText(payload.OrganizationID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		logger.DebugContext(ctx, "skipping role event for unknown organization", attr.SlogWorkOSOrganizationID(payload.OrganizationID))
+		return nil
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", payload.OrganizationID, err)
+	}
+
+	repo := accessrepo.New(dbtx)
+	existing, err := repo.GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: org.ID,
+		WorkosSlug:     payload.Slug,
+	})
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get organization role %q: %w", payload.Slug, err)
+	}
+
+	var lastEventID *string
+	if existing.WorkosLastEventID.Valid {
+		lastEventID = &existing.WorkosLastEventID.String
+	}
+	rowUpdatedAt := existing.WorkosUpdatedAt.Time
+	if !ShouldProcessEvent(lastEventID, &rowUpdatedAt, event.ID, payload.UpdatedAt) {
+		return nil
+	}
+
+	if err := repo.UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    org.ID,
+		WorkosSlug:        payload.Slug,
+		WorkosName:        payload.Name,
+		WorkosDescription: conv.ToPGTextEmpty(payload.Description),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(payload.CreatedAt),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID: conv.ToPGText(event.ID),
+	}); err != nil {
+		return fmt.Errorf("upsert organization role %q: %w", payload.Slug, err)
+	}
+
+	return nil
+}
+
+func handleRoleDeleted(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	var payload workosRoleEventPayload
+	if err := json.Unmarshal(event.Data, &payload); err != nil {
+		return oops.Permanent(fmt.Errorf("unmarshal role delete event payload: %w", err))
+	}
+
+	deletedAt := payload.DeletedAt
+	if deletedAt == nil || deletedAt.IsZero() {
+		deletedAt = &event.CreatedAt
+	}
+
+	if payload.Type == workosRoleTypeEnvironment {
+		repo := accessrepo.New(dbtx)
+		existing, err := repo.GetGlobalRoleBySlug(ctx, payload.Slug)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			return nil
+		case err != nil:
+			return fmt.Errorf("get global role %q: %w", payload.Slug, err)
+		}
+
+		var lastEventID *string
+		if existing.WorkosLastEventID.Valid {
+			lastEventID = &existing.WorkosLastEventID.String
+		}
+		rowUpdatedAt := existing.WorkosUpdatedAt.Time
+		if !ShouldProcessEvent(lastEventID, &rowUpdatedAt, event.ID, payload.UpdatedAt) {
+			return nil
+		}
+
+		if _, err := repo.MarkGlobalRoleDeleted(ctx, accessrepo.MarkGlobalRoleDeletedParams{
+			WorkosSlug:        payload.Slug,
+			WorkosDeletedAt:   conv.ToPGTimestamptz(*deletedAt),
+			WorkosLastEventID: conv.ToPGText(event.ID),
+		}); err != nil {
+			return fmt.Errorf("mark global role %q deleted: %w", payload.Slug, err)
+		}
+		return nil
+	}
+
+	org, err := orgrepo.New(dbtx).GetOrganizationByWorkosID(ctx, conv.ToPGText(payload.OrganizationID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		logger.DebugContext(ctx, "skipping role delete for unknown organization", attr.SlogWorkOSOrganizationID(payload.OrganizationID))
+		return nil
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", payload.OrganizationID, err)
+	}
+
+	repo := accessrepo.New(dbtx)
+	existing, err := repo.GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: org.ID,
+		WorkosSlug:     payload.Slug,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("get organization role %q: %w", payload.Slug, err)
+	}
+
+	var lastEventID *string
+	if existing.WorkosLastEventID.Valid {
+		lastEventID = &existing.WorkosLastEventID.String
+	}
+	rowUpdatedAt := existing.WorkosUpdatedAt.Time
+	if !ShouldProcessEvent(lastEventID, &rowUpdatedAt, event.ID, payload.UpdatedAt) {
+		return nil
+	}
+
+	if _, err := repo.MarkOrganizationRoleDeleted(ctx, accessrepo.MarkOrganizationRoleDeletedParams{
+		OrganizationID:    org.ID,
+		WorkosSlug:        payload.Slug,
+		WorkosDeletedAt:   conv.ToPGTimestamptz(*deletedAt),
+		WorkosLastEventID: conv.ToPGText(event.ID),
+	}); err != nil {
+		return fmt.Errorf("mark organization role %q deleted: %w", payload.Slug, err)
+	}
+
+	if _, err := repo.DeletePrincipalGrantsByPrincipal(ctx, accessrepo.DeletePrincipalGrantsByPrincipalParams{
+		OrganizationID: org.ID,
+		PrincipalUrn:   urn.NewPrincipal(urn.PrincipalTypeRole, payload.Slug),
+	}); err != nil {
+		return fmt.Errorf("delete grants for role %q: %w", payload.Slug, err)
+	}
+
+	return nil
+}
+
+// ShouldProcessEvent decides whether a WorkOS event should be applied to a
+// row, guarding against duplicate-apply when the sync replays history (e.g.
+// reconcile schedule overlapping with webhook delivery, or a manual
+// backfill).
+//
+// Algorithm:
+//
+//   - If the row has no recorded last_event_id, it has not yet been touched
+//     by an event-driven update. Use the row's workos_updated_at as the
+//     baseline: apply the event only if its payload's updated_at is at least
+//     as recent as the row.
+//   - Otherwise, compare event IDs lexicographically. WorkOS event IDs are
+//     time-ordered (ULIDs), so a strictly greater ID means the event is
+//     newer than the last one we applied.
+//
+// Inputs are nilable to model NULL columns directly.
+func ShouldProcessEvent(rowLastEventID *string, rowWorkOSUpdatedAt *time.Time, eventID string, eventUpdatedAt time.Time) bool {
+	if rowLastEventID == nil || *rowLastEventID == "" {
+		if rowWorkOSUpdatedAt == nil {
+			return true
+		}
+		return !eventUpdatedAt.Before(*rowWorkOSUpdatedAt)
+	}
+	return eventID > *rowLastEventID
 }

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -10,9 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/workos/workos-go/v6/pkg/events"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type stubWorkOSEventsClient struct {
@@ -40,7 +44,9 @@ func newOrgEventsTestConn(t *testing.T, name string) *pgxpool.Pool {
 
 func newOrgEventPayload(t *testing.T, workosOrgID string) []byte {
 	t.Helper()
-	return []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Test","external_id":""}`)
+	// external_id maps to the Speakeasy organization id; the upsert relies on
+	// it for orgs not yet linked via workos_id.
+	return []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Test","external_id":"sb_` + workosOrgID + `","updated_at":"2026-05-06T12:00:00Z"}`)
 }
 
 func TestProcessWorkOSOrganizationEvents_AdvancesCursor(t *testing.T) {
@@ -177,4 +183,327 @@ func TestProcessWorkOSOrganizationEvents_RejectsMalformedEvent(t *testing.T) {
 
 	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
 	require.Error(t, err)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationCreatedAndUpdated(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_create")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZCREATE"
+	const externalID = "sb_01HZCREATE"
+
+	created := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 5, 6, 11, 0, 0, 0, time.UTC)
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			{
+				ID:        "event_01HZA",
+				Event:     "organization.created",
+				CreatedAt: created,
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Acme","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T10:00:00Z"}`),
+			},
+			{
+				ID:        "event_01HZB",
+				Event:     "organization.updated",
+				CreatedAt: updated,
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Acme Inc","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T11:00:00Z"}`),
+			},
+		}},
+	}
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, externalID, row.ID)
+	require.Equal(t, "Acme Inc", row.Name)
+	require.True(t, row.WorkosLastEventID.Valid)
+	require.Equal(t, "event_01HZB", row.WorkosLastEventID.String)
+	require.True(t, row.WorkosUpdatedAt.Valid)
+	require.True(t, row.WorkosUpdatedAt.Time.Equal(updated))
+	require.False(t, row.DisabledAt.Valid)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationUpdateSkippedWhenStale(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_stale")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZSTALE"
+	const externalID = "sb_01HZSTALE"
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			{
+				ID:        "event_01HZ002",
+				Event:     "organization.updated",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Newer","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+			{
+				// Stale replay of an older event — must not overwrite Newer.
+				ID:        "event_01HZ001",
+				Event:     "organization.updated",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Older","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T11:00:00Z"}`),
+			},
+		}},
+	}
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, "Newer", row.Name)
+	require.Equal(t, "event_01HZ002", row.WorkosLastEventID.String)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSetsDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_delete")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZDELETE"
+	const externalID = "sb_01HZDELETE"
+
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:                externalID,
+		Name:              "Doomed",
+		Slug:              "doomed",
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Now()),
+		WorkosLastEventID: conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			{
+				ID:        "event_01HZDEL",
+				Event:     "organization.deleted",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Doomed","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		}},
+	}
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.True(t, row.DisabledAt.Valid)
+	require.Equal(t, "event_01HZDEL", row.WorkosLastEventID.String)
+}
+
+func TestProcessWorkOSOrganizationEvents_GlobalRoleUpsertAndDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_global_role")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZGLOBALROLE"
+	const slug = "platform-admin"
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			{
+				ID:        "event_01HZG1",
+				Event:     "organization_role.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"role_01","object":"role","organization_id":"","slug":"` + slug + `","name":"Platform Admin",` +
+					`"description":"env-level admin","type":"EnvironmentRole",` +
+					`"created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:00:00Z"}`),
+			},
+			{
+				ID:        "event_01HZG2",
+				Event:     "organization_role.deleted",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"role_01","object":"role","organization_id":"","slug":"` + slug + `","name":"Platform Admin",` +
+					`"type":"EnvironmentRole","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T11:00:00Z",` +
+					`"deleted_at":"2026-05-06T11:00:00Z"}`),
+			},
+		}},
+	}
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	role, err := accessrepo.New(conn).GetGlobalRoleBySlug(ctx, slug)
+	require.NoError(t, err)
+	require.Equal(t, "Platform Admin", role.WorkosName)
+	require.True(t, role.Deleted)
+	require.True(t, role.WorkosDeleted)
+	require.Equal(t, "event_01HZG2", role.WorkosLastEventID.String)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationRoleUpsertAndDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_role")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZORGROLE"
+	const externalID = "sb_01HZORGROLE"
+	const slug = "billing-manager"
+
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:                externalID,
+		Name:              "Acme",
+		Slug:              "acme",
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Now()),
+		WorkosLastEventID: conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+
+	rolePrincipal := urn.NewPrincipal(urn.PrincipalTypeRole, slug)
+	_, err = accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		OrganizationID: externalID,
+		PrincipalUrn:   rolePrincipal,
+		Scope:          "billing:read",
+		Selectors:      []byte(`{"resource_kind":"*","resource_id":"*"}`),
+	})
+	require.NoError(t, err)
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			{
+				ID:        "event_01HZR1",
+				Event:     "organization_role.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"role_01","object":"role","organization_id":"` + workosOrgID +
+					`","slug":"` + slug + `","name":"Billing Manager","description":"manages billing",` +
+					`"type":"OrganizationRole","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:00:00Z"}`),
+			},
+			{
+				ID:        "event_01HZR2",
+				Event:     "organization_role.deleted",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"role_01","object":"role","organization_id":"` + workosOrgID +
+					`","slug":"` + slug + `","name":"Billing Manager","type":"OrganizationRole",` +
+					`"created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T11:00:00Z","deleted_at":"2026-05-06T11:00:00Z"}`),
+			},
+		}},
+	}
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	role, err := accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: externalID,
+		WorkosSlug:     slug,
+	})
+	require.NoError(t, err)
+	require.True(t, role.Deleted)
+	require.True(t, role.WorkosDeleted)
+	require.Equal(t, "event_01HZR2", role.WorkosLastEventID.String)
+
+	grants, err := accessrepo.New(conn).GetPrincipalGrants(ctx, accessrepo.GetPrincipalGrantsParams{
+		OrganizationID: externalID,
+		PrincipalUrns:  []string{rolePrincipal.String()},
+	})
+	require.NoError(t, err)
+	require.Empty(t, grants, "principal_grants should be cascade-deleted on role delete")
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSkippedWhenStale(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_delete_stale")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZDELSTALE"
+	const externalID = "sb_01HZDELSTALE"
+
+	// Seed org with cursor advanced past the stale delete event ID.
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:                externalID,
+		Name:              "Live",
+		Slug:              "live",
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Now()),
+		WorkosLastEventID: conv.ToPGText("event_99FRESH"),
+	})
+	require.NoError(t, err)
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			{
+				ID:        "event_01HZSTALEDEL",
+				Event:     "organization.deleted",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Live","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T11:00:00Z"}`),
+			},
+		}},
+	}
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.False(t, row.DisabledAt.Valid, "stale delete event must not disable a fresher org row")
+	require.Equal(t, "event_99FRESH", row.WorkosLastEventID.String)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationRoleSkippedForUnknownOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_role_unknown_org")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZUNKNOWN"
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			{
+				ID:        "event_01HZUR1",
+				Event:     "organization_role.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"role_01","object":"role","organization_id":"` + workosOrgID +
+					`","slug":"phantom","name":"Phantom","type":"OrganizationRole",` +
+					`"created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:00:00Z"}`),
+			},
+		}},
+	}
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	// Cursor still advances — we don't replay events for orgs that don't yet
+	// exist locally, the reconcile/backfill workflow will catch them up.
+	require.Equal(t, "event_01HZUR1", res.LastEventID)
+
+	_, err = accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: "nope",
+		WorkosSlug:     "phantom",
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }

--- a/server/internal/background/activities/should_process_test.go
+++ b/server/internal/background/activities/should_process_test.go
@@ -1,0 +1,84 @@
+package activities_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+)
+
+func TestShouldProcessEvent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	earlier := now.Add(-time.Hour)
+	later := now.Add(time.Hour)
+	eventID1 := "event_01HZ001"
+	eventID2 := "event_01HZ002"
+	emptyEventID := ""
+	cases := []struct {
+		name             string
+		rowLastEventID   *string
+		rowWorkOSUpdated *time.Time
+		eventID          string
+		eventUpdated     time.Time
+		want             bool
+	}{
+		{
+			name: "no row state — apply",
+			want: true,
+		},
+		{
+			name:             "no last_event_id, event updated_at == row updated_at — apply",
+			rowWorkOSUpdated: &now,
+			eventUpdated:     now,
+			want:             true,
+		},
+		{
+			name:             "no last_event_id, event newer than row — apply",
+			rowWorkOSUpdated: &now,
+			eventUpdated:     later,
+			want:             true,
+		},
+		{
+			name:             "no last_event_id, event older than row — skip",
+			rowWorkOSUpdated: &now,
+			eventUpdated:     earlier,
+			want:             false,
+		},
+		{
+			name:           "last_event_id set, event ID strictly greater — apply",
+			rowLastEventID: &eventID1,
+			eventID:        "event_01HZ002",
+			want:           true,
+		},
+		{
+			name:           "last_event_id set, event ID equal — skip",
+			rowLastEventID: &eventID1,
+			eventID:        "event_01HZ001",
+			want:           false,
+		},
+		{
+			name:           "last_event_id set, event ID smaller — skip",
+			rowLastEventID: &eventID2,
+			eventID:        "event_01HZ001",
+			want:           false,
+		},
+		{
+			name:           "empty string last_event_id treated as missing",
+			rowLastEventID: &emptyEventID,
+			eventID:        "event_01HZ001",
+			want:           true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := activities.ShouldProcessEvent(tc.rowLastEventID, tc.rowWorkOSUpdated, tc.eventID, tc.eventUpdated)
+			if got != tc.want {
+				t.Fatalf("ShouldProcessEvent() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -155,3 +155,49 @@ UPDATE organization_metadata SET workos_id = NULL WHERE id = @organization_id;
 -- name: CreateOrganizationMetadata :exec
 INSERT INTO organization_metadata (id, name, slug)
 VALUES (@id, @name, @slug);
+
+-- name: GetOrganizationByWorkosID :one
+SELECT *
+FROM organization_metadata
+WHERE workos_id = @workos_id
+LIMIT 1;
+
+-- name: UpsertOrganizationMetadataFromWorkOS :one
+-- Upsert an organization row from a WorkOS organization event. Caller must
+-- have already passed the row through ShouldProcessEvent. Sets workos_id and
+-- the cursor columns; clears disabled_at so a deleted-then-recreated org
+-- comes back online.
+INSERT INTO organization_metadata (
+    id,
+    name,
+    slug,
+    workos_id,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    @id,
+    @name,
+    @slug,
+    @workos_id,
+    @workos_updated_at,
+    @workos_last_event_id
+)
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    slug = EXCLUDED.slug,
+    workos_id = EXCLUDED.workos_id,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    disabled_at = NULL,
+    updated_at = clock_timestamp()
+RETURNING *;
+
+-- name: DisableOrganizationByWorkosID :execrows
+-- Mark a WorkOS-linked organization as disabled. Append-only: keeps
+-- organization_user_relationships intact. Idempotent — disabled_at is only
+-- set on first delete event.
+UPDATE organization_metadata
+SET disabled_at = COALESCE(disabled_at, clock_timestamp()),
+    workos_last_event_id = @workos_last_event_id,
+    updated_at = clock_timestamp()
+WHERE workos_id = @workos_id;

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -84,6 +84,59 @@ func (q *Queries) DeleteOrganizationUserRelationship(ctx context.Context, arg De
 	return err
 }
 
+const disableOrganizationByWorkosID = `-- name: DisableOrganizationByWorkosID :execrows
+UPDATE organization_metadata
+SET disabled_at = COALESCE(disabled_at, clock_timestamp()),
+    workos_last_event_id = $1,
+    updated_at = clock_timestamp()
+WHERE workos_id = $2
+`
+
+type DisableOrganizationByWorkosIDParams struct {
+	WorkosLastEventID pgtype.Text
+	WorkosID          pgtype.Text
+}
+
+// Mark a WorkOS-linked organization as disabled. Append-only: keeps
+// organization_user_relationships intact. Idempotent — disabled_at is only
+// set on first delete event.
+func (q *Queries) DisableOrganizationByWorkosID(ctx context.Context, arg DisableOrganizationByWorkosIDParams) (int64, error) {
+	result, err := q.db.Exec(ctx, disableOrganizationByWorkosID, arg.WorkosLastEventID, arg.WorkosID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const getOrganizationByWorkosID = `-- name: GetOrganizationByWorkosID :one
+SELECT id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+FROM organization_metadata
+WHERE workos_id = $1
+LIMIT 1
+`
+
+func (q *Queries) GetOrganizationByWorkosID(ctx context.Context, workosID pgtype.Text) (OrganizationMetadatum, error) {
+	row := q.db.QueryRow(ctx, getOrganizationByWorkosID, workosID)
+	var i OrganizationMetadatum
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.GramAccountType,
+		&i.SsoConnectionID,
+		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
+		&i.Whitelisted,
+		&i.FreeTrialStartedAt,
+		&i.FreeTrialEndsAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DisabledAt,
+	)
+	return i, err
+}
+
 const getOrganizationMetadata = `-- name: GetOrganizationMetadata :one
 SELECT id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
 FROM organization_metadata
@@ -384,6 +437,75 @@ func (q *Queries) UpsertOrganizationMetadata(ctx context.Context, arg UpsertOrga
 		arg.Slug,
 		arg.WorkosID,
 		arg.Whitelisted,
+	)
+	var i OrganizationMetadatum
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.GramAccountType,
+		&i.SsoConnectionID,
+		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
+		&i.Whitelisted,
+		&i.FreeTrialStartedAt,
+		&i.FreeTrialEndsAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DisabledAt,
+	)
+	return i, err
+}
+
+const upsertOrganizationMetadataFromWorkOS = `-- name: UpsertOrganizationMetadataFromWorkOS :one
+INSERT INTO organization_metadata (
+    id,
+    name,
+    slug,
+    workos_id,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6
+)
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    slug = EXCLUDED.slug,
+    workos_id = EXCLUDED.workos_id,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    disabled_at = NULL,
+    updated_at = clock_timestamp()
+RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+`
+
+type UpsertOrganizationMetadataFromWorkOSParams struct {
+	ID                string
+	Name              string
+	Slug              string
+	WorkosID          pgtype.Text
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+}
+
+// Upsert an organization row from a WorkOS organization event. Caller must
+// have already passed the row through ShouldProcessEvent. Sets workos_id and
+// the cursor columns; clears disabled_at so a deleted-then-recreated org
+// comes back online.
+func (q *Queries) UpsertOrganizationMetadataFromWorkOS(ctx context.Context, arg UpsertOrganizationMetadataFromWorkOSParams) (OrganizationMetadatum, error) {
+	row := q.db.QueryRow(ctx, upsertOrganizationMetadataFromWorkOS,
+		arg.ID,
+		arg.Name,
+		arg.Slug,
+		arg.WorkosID,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
 	)
 	var i OrganizationMetadatum
 	err := row.Scan(


### PR DESCRIPTION
## Summary

Implements `handleOrganizationEvent` in the WorkOS sync activity, replacing the no-op stub introduced in #2525. Each event is gated by a `ShouldProcessEvent` guard against duplicate-apply during webhook + reconcile overlap.

- **organization.created/updated**: upsert `organization_metadata` from payload. Map by `workos_id`; fall back to payload `external_id` for orgs not yet linked.
- **organization.deleted**: load row, gate, then mark `disabled_at`. Append-only — keeps `organization_user_relationships` intact.
- **organization_role.created/updated**: branch on `Type == "EnvironmentRole"` → `global_roles`, else → `organization_roles`. Org-scoped events for unknown orgs are skipped (reconcile catches up).
- **organization_role.deleted**: load row, gate, mark deleted, cascade-delete `principal_grants` for the role principal URN.

`ShouldProcessEvent` lives in the activities package: if a row has no `workos_last_event_id` recorded, gate on `event.updated_at >= row.workos_updated_at`; otherwise gate on lex-greater event ID (WorkOS event IDs are time-ordered).

Adds queries: `GetOrganizationByWorkosID`, `UpsertOrganizationMetadataFromWorkOS`, `DisableOrganizationByWorkosID`, plus role upsert/delete/get queries on `access`. Schema cursor columns landed in #2622.