### PR TITLE
fix(hooks): don't return 401 on expired plugin auth in claude hook

### DIFF
--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -201,7 +201,16 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 		var err error
 		ctx, err = s.authorizePluginRequest(ctx, *payload.ApikeyToken, *payload.ProjectSlugInput)
 		if err != nil {
-			return nil, err
+			// Log the auth failure but do NOT return an error. Returning a 401
+			// here causes the client-side hook script to block ALL tool calls,
+			// creating a deadlock: the user can't run `gram login` because the
+			// hook blocks Bash, but re-auth requires Bash. Instead, fall through
+			// without auth context — the hook still fires, telemetry is buffered,
+			// and policies that need auth context are skipped gracefully.
+			s.logger.WarnContext(ctx, "plugin auth failed on claude hook; continuing without auth context",
+				attr.SlogEvent("claude_hook_auth_failed"),
+				attr.SlogError(err),
+			)
 		}
 	}
 

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -211,6 +211,8 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 				attr.SlogEvent("claude_hook_auth_failed"),
 				attr.SlogError(err),
 			)
+
+			return makeHookResult(payload.HookEventName), nil
 		}
 	}
 

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -74,6 +74,30 @@ func TestClaude_PreToolUse_UsesAuthContextWhenNoCachedMetadata(t *testing.T) {
 		"missing x-gram-toolset-id should be denied once auth-context metadata is in play")
 }
 
+// When plugin auth headers are present but the API key is invalid/expired,
+// Claude() must NOT return a 401 error — that causes the client-side hook
+// script to block ALL tool calls, deadlocking the user. Instead it should
+// continue without auth context (same as the OTEL-only path).
+func TestClaude_ContinuesWhenPluginAuthFails(t *testing.T) {
+	t.Parallel()
+	_, ti := newTestHooksService(t)
+
+	badKey := "gram_key_expired_or_invalid"
+	projectSlug := "some-project"
+	sessionID := uuid.NewString()
+	prompt := "hello"
+
+	result, err := ti.service.Claude(t.Context(), &gen.ClaudePayload{
+		HookEventName:    "UserPromptSubmit",
+		SessionID:        &sessionID,
+		ApikeyToken:      &badKey,
+		ProjectSlugInput: &projectSlug,
+		Prompt:           &prompt,
+	})
+	require.NoError(t, err, "expired plugin auth must not return an error")
+	require.NotNil(t, result)
+}
+
 // Sanity check the OTEL fallback path: with no auth context and no Redis
 // cached metadata, handlePreToolUse should still gracefully allow the call
 // rather than erroring (the buffered hook will be re-persisted later).


### PR DESCRIPTION
## Summary

- When a Claude Code plugin sends an expired/invalid `Gram-Key` header, `authorizePluginRequest` was returning an error that Goa mapped to HTTP 401
- The client-side hook script (`send_hook.sh`) treats any non-2xx as "block all tool calls", creating a **deadlock**: re-authenticating via `gram login` requires running a Bash command, but the hook blocks Bash
- Fix: log the auth failure and continue without auth context instead of returning a 401 — same graceful degradation as the OTEL-only path (no headers at all)
- Risk policies requiring auth context (shadow-MCP blocking) are skipped during expired-auth sessions, which is acceptable since you can't enforce org policies without knowing the org

## Test plan

- [x] Added `TestClaude_ContinuesWhenPluginAuthFails` — sends a bad API key, asserts no error returned
- [x] Full hooks test suite passes (41 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->