### PR TITLE
feat(platformtools): add slack reaction tools

### DIFF
--- a/.changeset/slack-reaction-tools.md
+++ b/.changeset/slack-reaction-tools.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Add Slack reaction platform tools (`platform_slack_add_reaction`, `platform_slack_remove_reaction`, `platform_slack_get_reactions`, `platform_slack_list_reactions`, `platform_slack_list_emoji`) so assistants can react to messages and discover available emoji.

--- a/server/internal/platformtools/registry.go
+++ b/server/internal/platformtools/registry.go
@@ -48,6 +48,21 @@ var registry = []toolFactory{
 	func(deps Dependencies) PlatformToolExecutor {
 		return platformslack.NewSendMessageTool(deps.SlackHTTPClient)
 	},
+	func(deps Dependencies) PlatformToolExecutor {
+		return platformslack.NewAddReactionTool(deps.SlackHTTPClient)
+	},
+	func(deps Dependencies) PlatformToolExecutor {
+		return platformslack.NewRemoveReactionTool(deps.SlackHTTPClient)
+	},
+	func(deps Dependencies) PlatformToolExecutor {
+		return platformslack.NewGetReactionsTool(deps.SlackHTTPClient)
+	},
+	func(deps Dependencies) PlatformToolExecutor {
+		return platformslack.NewListReactionsTool(deps.SlackHTTPClient)
+	},
+	func(deps Dependencies) PlatformToolExecutor {
+		return platformslack.NewListEmojiTool(deps.SlackHTTPClient)
+	},
 }
 
 func BuildExecutors(deps Dependencies) map[string]PlatformToolExecutor {

--- a/server/internal/platformtools/slack/tool_add_reaction.go
+++ b/server/internal/platformtools/slack/tool_add_reaction.go
@@ -1,0 +1,76 @@
+package slack
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+const toolNameAddReaction = "platform_slack_add_reaction"
+
+type addReactionInput struct {
+	ChannelID string `json:"channel_id" jsonschema:"Slack conversation ID containing the message."`
+	Timestamp string `json:"timestamp" jsonschema:"Timestamp of the message to react to (e.g. \"1234567890.123456\")."`
+	Name      string `json:"name" jsonschema:"Reaction (emoji) name without surrounding colons (e.g. \"thumbsup\")."`
+}
+
+func NewAddReactionTool(httpClient *guardian.HTTPClient) core.PlatformToolExecutor {
+	readOnly := false
+	destructive := false
+	idempotent := true
+	openWorld := true
+
+	return &slackTool{
+		descriptor: core.ToolDescriptor{
+			SourceSlug:  sourceSlack,
+			HandlerName: "add_reaction",
+			Name:        toolNameAddReaction,
+			Description: "Add an emoji reaction to a Slack message using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN.",
+			InputSchema: core.BuildInputSchema[addReactionInput](),
+			Variables:   nil,
+			Annotations: slackToolAnnotations(readOnly, destructive, idempotent, openWorld),
+			Managed:     true,
+			OwnerKind:   nil,
+			OwnerID:     nil,
+		},
+		client: newAPIClient(defaultSlackAPIBaseURL, httpClient),
+		callFn: callAddReaction,
+	}
+}
+
+func callAddReaction(ctx context.Context, client *apiClient, env toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	var input addReactionInput
+	if err := decodePayload(payload, &input); err != nil {
+		return err
+	}
+
+	channelID, err := requireString("channel_id", input.ChannelID)
+	if err != nil {
+		return err
+	}
+	timestamp, err := requireString("timestamp", input.Timestamp)
+	if err != nil {
+		return err
+	}
+	name, err := requireString("name", input.Name)
+	if err != nil {
+		return err
+	}
+	name = strings.Trim(name, ":")
+
+	request := map[string]any{
+		"channel":   channelID,
+		"timestamp": timestamp,
+		"name":      name,
+	}
+
+	body, err := client.call(ctx, "reactions.add", request, tokenPreferBot, env)
+	if err != nil {
+		return err
+	}
+	return writeResponse(wr, body)
+}

--- a/server/internal/platformtools/slack/tool_add_reaction_test.go
+++ b/server/internal/platformtools/slack/tool_add_reaction_test.go
@@ -1,0 +1,78 @@
+package slack
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddReactionTool_PostsToReactionsAdd(t *testing.T) {
+	t.Parallel()
+
+	var requestPath string
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewAddReactionTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callAddReaction,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"timestamp":"123.456",
+		"name":":thumbsup:"
+	}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, "/reactions.add", requestPath)
+	require.Equal(t, "C123", requestPayload.Get("channel"))
+	require.Equal(t, "123.456", requestPayload.Get("timestamp"))
+	require.Equal(t, "thumbsup", requestPayload.Get("name"))
+	require.JSONEq(t, `{"ok":true}`, out.String())
+}
+
+func TestAddReactionTool_RequiresFields(t *testing.T) {
+	t.Parallel()
+
+	tool := &slackTool{
+		descriptor: NewAddReactionTool(nil).Descriptor(),
+		client:     newAPIClient("https://slack.test.invalid", nil),
+		callFn:     callAddReaction,
+	}
+
+	cases := []struct {
+		name    string
+		payload string
+		field   string
+	}{
+		{"missing channel", `{"timestamp":"1.2","name":"x"}`, "channel_id"},
+		{"missing timestamp", `{"channel_id":"C","name":"x"}`, "timestamp"},
+		{"missing name", `{"channel_id":"C","timestamp":"1.2"}`, "name"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(tc.payload), &bytes.Buffer{})
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.field)
+		})
+	}
+}

--- a/server/internal/platformtools/slack/tool_get_reactions.go
+++ b/server/internal/platformtools/slack/tool_get_reactions.go
@@ -1,0 +1,70 @@
+package slack
+
+import (
+	"context"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+const toolNameGetReactions = "platform_slack_get_reactions"
+
+type getReactionsInput struct {
+	ChannelID string `json:"channel_id" jsonschema:"Slack conversation ID containing the message."`
+	Timestamp string `json:"timestamp" jsonschema:"Timestamp of the message to read reactions from (e.g. \"1234567890.123456\")."`
+	Full      *bool  `json:"full,omitempty" jsonschema:"Return the complete reaction list rather than the truncated default."`
+}
+
+func NewGetReactionsTool(httpClient *guardian.HTTPClient) core.PlatformToolExecutor {
+	readOnly := true
+	destructive := false
+	idempotent := true
+	openWorld := true
+
+	return &slackTool{
+		descriptor: core.ToolDescriptor{
+			SourceSlug:  sourceSlack,
+			HandlerName: "get_reactions",
+			Name:        toolNameGetReactions,
+			Description: "Get the reactions on a Slack message using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN.",
+			InputSchema: core.BuildInputSchema[getReactionsInput](),
+			Variables:   nil,
+			Annotations: slackToolAnnotations(readOnly, destructive, idempotent, openWorld),
+			Managed:     true,
+			OwnerKind:   nil,
+			OwnerID:     nil,
+		},
+		client: newAPIClient(defaultSlackAPIBaseURL, httpClient),
+		callFn: callGetReactions,
+	}
+}
+
+func callGetReactions(ctx context.Context, client *apiClient, env toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	var input getReactionsInput
+	if err := decodePayload(payload, &input); err != nil {
+		return err
+	}
+
+	channelID, err := requireString("channel_id", input.ChannelID)
+	if err != nil {
+		return err
+	}
+	timestamp, err := requireString("timestamp", input.Timestamp)
+	if err != nil {
+		return err
+	}
+
+	request := map[string]any{
+		"channel":   channelID,
+		"timestamp": timestamp,
+	}
+	setOptionalBool(request, "full", input.Full)
+
+	body, err := client.call(ctx, "reactions.get", request, tokenPreferBot, env)
+	if err != nil {
+		return err
+	}
+	return writeResponse(wr, body)
+}

--- a/server/internal/platformtools/slack/tool_get_reactions_test.go
+++ b/server/internal/platformtools/slack/tool_get_reactions_test.go
@@ -1,0 +1,76 @@
+package slack
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetReactionsTool_PostsToReactionsGet(t *testing.T) {
+	t.Parallel()
+
+	var requestPath string
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true,"type":"message","message":{"reactions":[{"name":"thumbsup","users":["U1"],"count":1}]}}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewGetReactionsTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callGetReactions,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"timestamp":"123.456",
+		"full":true
+	}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, "/reactions.get", requestPath)
+	require.Equal(t, "C123", requestPayload.Get("channel"))
+	require.Equal(t, "123.456", requestPayload.Get("timestamp"))
+	require.Equal(t, "true", requestPayload.Get("full"))
+	require.Contains(t, out.String(), "thumbsup")
+}
+
+func TestGetReactionsTool_OmitsFullWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPayload = readForm(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewGetReactionsTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callGetReactions,
+	}
+
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C","timestamp":"1.2"
+	}`), &bytes.Buffer{})
+	require.NoError(t, err)
+	require.Empty(t, requestPayload.Get("full"))
+}

--- a/server/internal/platformtools/slack/tool_list_emoji.go
+++ b/server/internal/platformtools/slack/tool_list_emoji.go
@@ -1,0 +1,56 @@
+package slack
+
+import (
+	"context"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+const toolNameListEmoji = "platform_slack_list_emoji"
+
+type listEmojiInput struct {
+	IncludeCategories *bool `json:"include_categories,omitempty" jsonschema:"Include Unicode emoji categories alongside custom workspace emoji."`
+}
+
+func NewListEmojiTool(httpClient *guardian.HTTPClient) core.PlatformToolExecutor {
+	readOnly := true
+	destructive := false
+	idempotent := true
+	openWorld := true
+
+	return &slackTool{
+		descriptor: core.ToolDescriptor{
+			SourceSlug:  sourceSlack,
+			HandlerName: "list_emoji",
+			Name:        toolNameListEmoji,
+			Description: "List the custom emoji available in the Slack workspace using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN.",
+			InputSchema: core.BuildInputSchema[listEmojiInput](),
+			Variables:   nil,
+			Annotations: slackToolAnnotations(readOnly, destructive, idempotent, openWorld),
+			Managed:     true,
+			OwnerKind:   nil,
+			OwnerID:     nil,
+		},
+		client: newAPIClient(defaultSlackAPIBaseURL, httpClient),
+		callFn: callListEmoji,
+	}
+}
+
+func callListEmoji(ctx context.Context, client *apiClient, env toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	var input listEmojiInput
+	if err := decodePayload(payload, &input); err != nil {
+		return err
+	}
+
+	request := map[string]any{}
+	setOptionalBool(request, "include_categories", input.IncludeCategories)
+
+	body, err := client.call(ctx, "emoji.list", request, tokenPreferBot, env)
+	if err != nil {
+		return err
+	}
+	return writeResponse(wr, body)
+}

--- a/server/internal/platformtools/slack/tool_list_emoji_test.go
+++ b/server/internal/platformtools/slack/tool_list_emoji_test.go
@@ -1,0 +1,68 @@
+package slack
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListEmojiTool_PostsToEmojiList(t *testing.T) {
+	t.Parallel()
+
+	var requestPath string
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true,"emoji":{"shipit":"https://example.com/shipit.png"}}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewListEmojiTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callListEmoji,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{"include_categories":true}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, "/emoji.list", requestPath)
+	require.Equal(t, "true", requestPayload.Get("include_categories"))
+	require.Contains(t, out.String(), "shipit")
+}
+
+func TestListEmojiTool_OmitsUnsetFlag(t *testing.T) {
+	t.Parallel()
+
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPayload = readForm(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true,"emoji":{}}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewListEmojiTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callListEmoji,
+	}
+
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{}`), &bytes.Buffer{})
+	require.NoError(t, err)
+	require.Empty(t, requestPayload.Get("include_categories"))
+}

--- a/server/internal/platformtools/slack/tool_list_reactions.go
+++ b/server/internal/platformtools/slack/tool_list_reactions.go
@@ -1,0 +1,62 @@
+package slack
+
+import (
+	"context"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+const toolNameListReactions = "platform_slack_list_reactions"
+
+type listReactionsInput struct {
+	UserID *string `json:"user_id,omitempty" jsonschema:"Slack user ID whose reactions to list. Defaults to the authenticated bot user."`
+	Full   *bool   `json:"full,omitempty" jsonschema:"Return the complete reaction list rather than the truncated default."`
+	Limit  *int    `json:"limit,omitempty" jsonschema:"Maximum number of items to return per page (1-200)."`
+	Cursor *string `json:"cursor,omitempty" jsonschema:"Pagination cursor returned by a previous call as response_metadata.next_cursor."`
+}
+
+func NewListReactionsTool(httpClient *guardian.HTTPClient) core.PlatformToolExecutor {
+	readOnly := true
+	destructive := false
+	idempotent := true
+	openWorld := true
+
+	return &slackTool{
+		descriptor: core.ToolDescriptor{
+			SourceSlug:  sourceSlack,
+			HandlerName: "list_reactions",
+			Name:        toolNameListReactions,
+			Description: "List Slack messages and files that the bot (or a specified user) has reacted to using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN.",
+			InputSchema: core.BuildInputSchema[listReactionsInput](),
+			Variables:   nil,
+			Annotations: slackToolAnnotations(readOnly, destructive, idempotent, openWorld),
+			Managed:     true,
+			OwnerKind:   nil,
+			OwnerID:     nil,
+		},
+		client: newAPIClient(defaultSlackAPIBaseURL, httpClient),
+		callFn: callListReactions,
+	}
+}
+
+func callListReactions(ctx context.Context, client *apiClient, env toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	var input listReactionsInput
+	if err := decodePayload(payload, &input); err != nil {
+		return err
+	}
+
+	request := map[string]any{}
+	setOptionalString(request, "user", input.UserID)
+	setOptionalBool(request, "full", input.Full)
+	setOptionalInt(request, "limit", input.Limit)
+	setOptionalString(request, "cursor", input.Cursor)
+
+	body, err := client.call(ctx, "reactions.list", request, tokenPreferBot, env)
+	if err != nil {
+		return err
+	}
+	return writeResponse(wr, body)
+}

--- a/server/internal/platformtools/slack/tool_list_reactions_test.go
+++ b/server/internal/platformtools/slack/tool_list_reactions_test.go
@@ -1,0 +1,78 @@
+package slack
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListReactionsTool_PassesOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	var requestPath string
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true,"items":[]}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewListReactionsTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callListReactions,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"user_id":"U123",
+		"full":true,
+		"limit":50,
+		"cursor":"abc"
+	}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, "/reactions.list", requestPath)
+	require.Equal(t, "U123", requestPayload.Get("user"))
+	require.Equal(t, "true", requestPayload.Get("full"))
+	require.Equal(t, "50", requestPayload.Get("limit"))
+	require.Equal(t, "abc", requestPayload.Get("cursor"))
+}
+
+func TestListReactionsTool_OmitsUnsetFields(t *testing.T) {
+	t.Parallel()
+
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPayload = readForm(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewListReactionsTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callListReactions,
+	}
+
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{}`), &bytes.Buffer{})
+	require.NoError(t, err)
+	require.Empty(t, requestPayload.Get("user"))
+	require.Empty(t, requestPayload.Get("full"))
+	require.Empty(t, requestPayload.Get("limit"))
+	require.Empty(t, requestPayload.Get("cursor"))
+}

--- a/server/internal/platformtools/slack/tool_remove_reaction.go
+++ b/server/internal/platformtools/slack/tool_remove_reaction.go
@@ -1,0 +1,76 @@
+package slack
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+const toolNameRemoveReaction = "platform_slack_remove_reaction"
+
+type removeReactionInput struct {
+	ChannelID string `json:"channel_id" jsonschema:"Slack conversation ID containing the message."`
+	Timestamp string `json:"timestamp" jsonschema:"Timestamp of the message to remove a reaction from (e.g. \"1234567890.123456\")."`
+	Name      string `json:"name" jsonschema:"Reaction (emoji) name without surrounding colons (e.g. \"thumbsup\")."`
+}
+
+func NewRemoveReactionTool(httpClient *guardian.HTTPClient) core.PlatformToolExecutor {
+	readOnly := false
+	destructive := true
+	idempotent := true
+	openWorld := true
+
+	return &slackTool{
+		descriptor: core.ToolDescriptor{
+			SourceSlug:  sourceSlack,
+			HandlerName: "remove_reaction",
+			Name:        toolNameRemoveReaction,
+			Description: "Remove an emoji reaction previously added by the bot to a Slack message using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN.",
+			InputSchema: core.BuildInputSchema[removeReactionInput](),
+			Variables:   nil,
+			Annotations: slackToolAnnotations(readOnly, destructive, idempotent, openWorld),
+			Managed:     true,
+			OwnerKind:   nil,
+			OwnerID:     nil,
+		},
+		client: newAPIClient(defaultSlackAPIBaseURL, httpClient),
+		callFn: callRemoveReaction,
+	}
+}
+
+func callRemoveReaction(ctx context.Context, client *apiClient, env toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	var input removeReactionInput
+	if err := decodePayload(payload, &input); err != nil {
+		return err
+	}
+
+	channelID, err := requireString("channel_id", input.ChannelID)
+	if err != nil {
+		return err
+	}
+	timestamp, err := requireString("timestamp", input.Timestamp)
+	if err != nil {
+		return err
+	}
+	name, err := requireString("name", input.Name)
+	if err != nil {
+		return err
+	}
+	name = strings.Trim(name, ":")
+
+	request := map[string]any{
+		"channel":   channelID,
+		"timestamp": timestamp,
+		"name":      name,
+	}
+
+	body, err := client.call(ctx, "reactions.remove", request, tokenPreferBot, env)
+	if err != nil {
+		return err
+	}
+	return writeResponse(wr, body)
+}

--- a/server/internal/platformtools/slack/tool_remove_reaction_test.go
+++ b/server/internal/platformtools/slack/tool_remove_reaction_test.go
@@ -1,0 +1,74 @@
+package slack
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveReactionTool_PostsToReactionsRemove(t *testing.T) {
+	t.Parallel()
+
+	var requestPath string
+	var requestPayload url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestPayload = readForm(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":true}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewRemoveReactionTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callRemoveReaction,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"timestamp":"123.456",
+		"name":":thumbsup:"
+	}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, "/reactions.remove", requestPath)
+	require.Equal(t, "C123", requestPayload.Get("channel"))
+	require.Equal(t, "123.456", requestPayload.Get("timestamp"))
+	require.Equal(t, "thumbsup", requestPayload.Get("name"))
+	require.JSONEq(t, `{"ok":true}`, out.String())
+}
+
+func TestRemoveReactionTool_SurfacesNoReaction(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":false,"error":"no_reaction"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewRemoveReactionTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callRemoveReaction,
+	}
+
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C","timestamp":"1.2","name":"x"
+	}`), &bytes.Buffer{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no_reaction")
+}

--- a/server/internal/platformtools/types.go
+++ b/server/internal/platformtools/types.go
@@ -26,6 +26,11 @@ const (
 	ToolNameSearchUsers            = "platform_slack_search_users"
 	ToolNameScheduleMessage        = "platform_slack_schedule_message"
 	ToolNameSendMessage            = "platform_slack_send_message"
+	ToolNameAddReaction            = "platform_slack_add_reaction"
+	ToolNameRemoveReaction         = "platform_slack_remove_reaction"
+	ToolNameGetReactions           = "platform_slack_get_reactions"
+	ToolNameListReactions          = "platform_slack_list_reactions"
+	ToolNameListEmoji              = "platform_slack_list_emoji"
 )
 
 type Dependencies struct {


### PR DESCRIPTION
## Summary

Adds five Slack platform tools so assistants can react to messages and discover available reactions/emoji:

- `platform_slack_add_reaction` → `reactions.add`
- `platform_slack_remove_reaction` → `reactions.remove`
- `platform_slack_get_reactions` → `reactions.get` (reactions on a specific message)
- `platform_slack_list_reactions` → `reactions.list` (items the user has reacted to)
- `platform_slack_list_emoji` → `emoji.list` (workspace emoji catalog)

Slack errors (`already_reacted`, `no_reaction`, etc.) are passed through as tool errors, matching the convention used by sibling Slack tools (`send_message`, `schedule_message`, …).

Closes [AGE-2141](https://linear.app/speakeasy/issue/AGE-2141/add-slack-reaction-platform-tool).

✻ Clauded...