### PR TITLE
feat(dashboard): default-attach slack reaction tools in onboarding

### DIFF
--- a/.changeset/slack-reaction-onboarding.md
+++ b/.changeset/slack-reaction-onboarding.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Default-attach Slack reaction tools during assistant onboarding and inject reaction etiquette guidance into the assistant's `# Behavior` section. Slack manifest builder now maps the reaction tool handlers to the `reactions:write`, `reactions:read`, and `emoji:read` bot scopes.

--- a/client/dashboard/src/pages/assistants/onboarding/behaviors.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/behaviors.ts
@@ -3,12 +3,29 @@ type BehaviorRule = {
   bullets: string[];
 };
 
+const REACTION_TOOL_URNS = new Set([
+  "tools:platform:slack:add_reaction",
+  "tools:platform:slack:remove_reaction",
+  "tools:platform:slack:get_reactions",
+  "tools:platform:slack:list_reactions",
+  "tools:platform:slack:list_emoji",
+]);
+
 const RULES: BehaviorRule[] = [
   {
     matches: (urn) => urn === "tools:platform:slack:send_message",
     bullets: [
       "Keep the user informed during long-running work by posting status messages.",
       "When referring to a Slack user, look up their profile by ID — never infer a name from the user ID itself.",
+    ],
+  },
+  {
+    matches: (urn) => REACTION_TOOL_URNS.has(urn),
+    bullets: [
+      "Reactions carry meaning — don't decorate, don't spam.",
+      "Use reactions as lightweight checkpoints (received, working, done) and as look-back markers in long threads.",
+      "Prefer a reaction over a message for well-known statuses (e.g. acknowledging a request you're now processing).",
+      "Don't duplicate a reaction with a message saying the same thing.",
     ],
   },
 ];

--- a/client/dashboard/src/pages/assistants/onboarding/docs/slack.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/docs/slack.ts
@@ -15,7 +15,7 @@ The assistant owns one shared environment. Extend it with \`add_environment_keys
 
 ## Recommended flow (pre-filled webhook)
 
-1. **Attach a Slack toolset.** \`list_integrations\` (\`"slack"\`) → \`create_toolset\` if needed → \`attach_toolset\`. Required so the bot's tools are callable in step 7.
+1. **Attach a Slack toolset.** \`list_integrations\` (\`"slack"\`) → \`create_toolset\` if needed → \`attach_toolset\`. Required so the bot's tools are callable in step 7. After attach, default-add the reaction platform tools (\`tools:platform:slack:add_reaction\`, \`tools:platform:slack:remove_reaction\`, \`tools:platform:slack:get_reactions\`, \`tools:platform:slack:list_reactions\`, \`tools:platform:slack:list_emoji\`) via \`add_tools_to_toolset\` — skip only if the user has explicitly said they don't want reaction tooling.
 2. **Declare keys.** \`add_environment_keys({ keys: ["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"] })\`.
 3. **Create the trigger.** \`create_trigger\` with \`definition_slug: "slack"\` and the relevant \`event_types\`. The response includes a \`webhook_url\` that already responds to Slack's \`url_verification\` challenge. Remember the trigger \`id\` for step 7d.
 4. **Show the app guide — only if the bot doesn't exist.** Check \`list_environments\` → \`populated_entry_names\`; skip if \`SLACK_BOT_TOKEN\` is already set. Otherwise \`show_slack_app_guide\` with the \`webhook_url\`. The component derives bot scopes and \`bot_events\` from the attached toolset and trigger; do not pass overrides unless adding a scope the catalog lacks.

--- a/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
@@ -18,6 +18,11 @@ export const SLACK_TOOL_SCOPES: Record<string, readonly string[]> = {
   search_channels: ["channels:read", "groups:read", "im:read", "mpim:read"],
   read_user_profile: ["users:read", "users:read.email"],
   search_users: ["users:read", "users:read.email"],
+  add_reaction: ["reactions:write"],
+  remove_reaction: ["reactions:write"],
+  get_reactions: ["reactions:read"],
+  list_reactions: ["reactions:read"],
+  list_emoji: ["emoji:read"],
   // search_messages_and_files (search.all) requires a USER token scope
   // (search:read) that Slack will not grant on a bot token, so it is omitted
   // from the bot-scope manifest deliberately.


### PR DESCRIPTION
## Summary

- Slack assistant onboarding now default-adds the five reaction platform tools (`platform_slack_add_reaction`, `..._remove_reaction`, `..._get_reactions`, `..._list_reactions`, `..._list_emoji`) after the slack toolset is attached, with an explicit opt-out path in the onboarding doc.
- Reaction etiquette guidance is injected into the assistant's `# Behavior` section whenever any reaction tool is attached: reactions carry meaning, use them as lightweight checkpoints, prefer them over duplicate status messages.
- Slack manifest builder maps the new handlers to `reactions:write`, `reactions:read`, and `emoji:read` bot scopes so the manifest produced for app install grants what the tools call.

Closes [AGE-2142](https://linear.app/speakeasy/issue/AGE-2142/update-slack-assistant-onboarding-prompt-default-attach-reaction-tools).

✻ Clauded...