### PR TITLE
fix: continue allowing unauth'd claude hooks traffic

### DIFF
--- a/hooks/plugin-claude/hooks/send_hook.sh
+++ b/hooks/plugin-claude/hooks/send_hook.sh
@@ -17,7 +17,7 @@ response=$(curl -s -w "\n%{http_code}" -X POST \
   -H "Content-Type: application/json" \
   -d @- \
   --max-time 10 \
-  "${server_url}/rpc/hooks.claude")
+  "${server_url}/rpc/hooks.claude") \ 
 
 http_code=$(echo "$response" | tail -1)
 body=$(echo "$response" | sed '$d')

--- a/hooks/plugin-claude/hooks/send_hook.sh
+++ b/hooks/plugin-claude/hooks/send_hook.sh
@@ -17,7 +17,7 @@ response=$(curl -s -w "\n%{http_code}" -X POST \
   -H "Content-Type: application/json" \
   -d @- \
   --max-time 10 \
-  "${server_url}/rpc/hooks.claude") \ 
+  "${server_url}/rpc/hooks.claude")
 
 http_code=$(echo "$response" | tail -1)
 body=$(echo "$response" | sed '$d')

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -198,21 +198,20 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 	)
 
 	if hasOptionalPluginAuth(payload) {
-		var err error
-		ctx, err = s.authorizePluginRequest(ctx, *payload.ApikeyToken, *payload.ProjectSlugInput)
-		if err != nil {
-			// Log the auth failure but do NOT return an error. Returning a 401
-			// here causes the client-side hook script to block ALL tool calls,
-			// creating a deadlock: the user can't run `gram login` because the
-			// hook blocks Bash, but re-auth requires Bash. Instead, fall through
-			// without auth context — the hook still fires, telemetry is buffered,
-			// and policies that need auth context are skipped gracefully.
-			s.logger.WarnContext(ctx, "plugin auth failed on claude hook; continuing without auth context",
+		// Auth is optional. Returning a 401 on failure deadlocks the client:
+		// send_hook.sh maps any non-2xx to "block all tool calls", but
+		// recovering (e.g. `gram login`) requires Bash, which the hook just
+		// blocked. On failure we leave ctx unchanged and fall through to the
+		// same path a no-headers request takes — recordHook buffers the event
+		// in Redis, and the OTEL Logs endpoint flushes it once the session is
+		// validated. Policies that need auth context degrade gracefully.
+		if authedCtx, err := s.authorizePluginRequest(ctx, *payload.ApikeyToken, *payload.ProjectSlugInput); err != nil {
+			s.logger.WarnContext(ctx, "plugin auth failed on claude hook; falling back to OTEL-buffered path",
 				attr.SlogEvent("claude_hook_auth_failed"),
 				attr.SlogError(err),
 			)
-
-			return makeHookResult(payload.HookEventName), nil
+		} else {
+			ctx = authedCtx
 		}
 	}
 

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -77,10 +77,12 @@ func TestClaude_PreToolUse_UsesAuthContextWhenNoCachedMetadata(t *testing.T) {
 // When plugin auth headers are present but the API key is invalid/expired,
 // Claude() must NOT return a 401 error — that causes the client-side hook
 // script to block ALL tool calls, deadlocking the user. Instead it should
-// continue without auth context (same as the OTEL-only path).
+// fall through to the same OTEL-buffered path a no-headers request takes:
+// the event is buffered in Redis so flushPendingHooks can replay it once
+// the session is validated.
 func TestClaude_ContinuesWhenPluginAuthFails(t *testing.T) {
 	t.Parallel()
-	_, ti := newTestHooksService(t)
+	ctx, ti := newTestHooksService(t)
 
 	badKey := "gram_key_expired_or_invalid"
 	projectSlug := "some-project"
@@ -96,6 +98,15 @@ func TestClaude_ContinuesWhenPluginAuthFails(t *testing.T) {
 	})
 	require.NoError(t, err, "expired plugin auth must not return an error")
 	require.NotNil(t, result)
+
+	// The whole point of the fallback is that the event still lands in
+	// the Redis buffer, ready for flushPendingHooks once OTEL Logs seeds
+	// the session metadata. Asserting on the buffer (not just NoError)
+	// is what catches a regression to the early-return shape.
+	var buffered []gen.ClaudePayload
+	require.NoError(t, ti.service.cache.ListRange(ctx, hookPendingCacheKey(sessionID), 0, -1, &buffered))
+	require.Len(t, buffered, 1, "hook should be buffered when plugin auth fails")
+	require.Equal(t, "UserPromptSubmit", buffered[0].HookEventName)
 }
 
 // Sanity check the OTEL fallback path: with no auth context and no Redis


### PR DESCRIPTION
The system is specifically designed to allow unauthenticated traffic to this particular endpoint. Thus we should treat bad auth the same as no auth