### PR TITLE
feat(dev-idp): add admin toggle for workos mode in dev-idp dashboard

### DIFF
--- a/dev-idp-dashboard/src/components/providers/WorkosModePane.tsx
+++ b/dev-idp-dashboard/src/components/providers/WorkosModePane.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,6 +15,7 @@ import {
   useClearCurrentUser,
   useCurrentUser,
   useSetCurrentUser,
+  useUpdateUser,
 } from "@/hooks/use-devidp";
 
 const WORKOS_USERS_DASHBOARD_URL =
@@ -28,6 +29,12 @@ interface WorkosUser {
   profile_picture_url?: string;
 }
 
+interface WorkosCurrentUser extends WorkosUser {
+  workos_sub: string;
+  shadow_id?: string;
+  shadow_admin: boolean;
+}
+
 async function fetchWorkos(suffix: string): Promise<unknown> {
   const res = await fetch(`/devidp/workos/${suffix}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
@@ -38,6 +45,8 @@ export function WorkosModePane() {
   const cur = useCurrentUser("workos");
   const set = useSetCurrentUser();
   const clear = useClearCurrentUser();
+  const updateUser = useUpdateUser();
+  const qc = useQueryClient();
   const [input, setInput] = useState("");
 
   const preview = useQuery({
@@ -60,6 +69,14 @@ export function WorkosModePane() {
     enabled: !!sub,
   });
 
+  // Fetch the workos currentUser from the mode handler — this enriches the
+  // Goa response with shadow_id and shadow_admin so we can toggle admin here.
+  const shadowQ = useQuery<WorkosCurrentUser>({
+    queryKey: ["workos", "shadow", sub],
+    queryFn: () => fetchWorkos("currentUser") as Promise<WorkosCurrentUser>,
+    enabled: !!sub,
+  });
+
   const merged: WorkosUser & { workos_sub?: string } = {
     workos_sub: sub,
     first_name: lookupQ.data?.first_name ?? current?.first_name,
@@ -71,6 +88,9 @@ export function WorkosModePane() {
   const fullName = [merged.first_name, merged.last_name]
     .filter(Boolean)
     .join(" ");
+
+  const shadowId = shadowQ.data?.shadow_id;
+  const isAdmin = shadowQ.data?.shadow_admin ?? false;
 
   return (
     <div className="space-y-6">
@@ -111,6 +131,39 @@ export function WorkosModePane() {
                 <div className="text-xs text-destructive">
                   Couldn't resolve full profile:{" "}
                   {(lookupQ.error as Error).message}
+                </div>
+              )}
+              {shadowId && (
+                <div className="flex items-center gap-2 pt-1">
+                  <span className="text-xs text-muted-foreground">Admin:</span>
+                  <span
+                    className={`text-xs font-medium ${isAdmin ? "text-green-600" : "text-muted-foreground"}`}
+                  >
+                    {isAdmin ? "Yes" : "No"}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    disabled={updateUser.isPending}
+                    onClick={() =>
+                      updateUser.mutate(
+                        { id: shadowId, admin: !isAdmin },
+                        {
+                          onSuccess: () =>
+                            qc.invalidateQueries({
+                              queryKey: ["workos", "shadow", sub],
+                            }),
+                        },
+                      )
+                    }
+                  >
+                    {updateUser.isPending
+                      ? "…"
+                      : isAdmin
+                        ? "Revoke admin"
+                        : "Make admin"}
+                  </Button>
                 </div>
               )}
             </div>

--- a/dev-idp/internal/modes/workos/handler.go
+++ b/dev-idp/internal/modes/workos/handler.go
@@ -388,6 +388,12 @@ type currentUserJSON struct {
 	FirstName         *string `json:"first_name,omitempty"`
 	LastName          *string `json:"last_name,omitempty"`
 	ProfilePictureURL *string `json:"profile_picture_url,omitempty"`
+	// ShadowID is the local users.id of the shadow row that backs this workos
+	// identity. Present whenever the shadow has been created (first login or
+	// first /currentUser fetch). The dashboard uses it to call users.update
+	// for admin/whitelisted toggles.
+	ShadowID    *string `json:"shadow_id,omitempty"`
+	ShadowAdmin bool    `json:"shadow_admin"`
 }
 
 func (h *Handler) handleGetUser(w http.ResponseWriter, r *http.Request) {
@@ -465,6 +471,42 @@ func (h *Handler) handleGetCurrentUser(w http.ResponseWriter, r *http.Request) {
 		resp.FirstName = strPtr(user.FirstName)
 		resp.LastName = strPtr(user.LastName)
 		resp.ProfilePictureURL = strPtr(user.ProfilePictureURL)
+
+		// Resolve the local shadow user for admin toggling. Look up by
+		// email first to avoid the SQLite ON CONFLICT RETURNING nil-UUID
+		// bug. Only call UpsertUserByEmail when no row exists yet (fresh
+		// insert path has no conflict, so RETURNING is safe).
+		q := repo.New(h.db)
+		shadows, serr := q.ListUsersFiltered(ctx, repo.ListUsersFilteredParams{
+			After:          uuid.Nil,
+			Email:          user.Email,
+			OrganizationID: nil,
+			MaxRows:        1,
+		})
+		var shadow *repo.User
+		if serr == nil && len(shadows) > 0 && shadows[0].ID != uuid.Nil {
+			shadow = &shadows[0]
+		} else {
+			displayName := strings.TrimSpace(user.FirstName + " " + user.LastName)
+			if displayName == "" {
+				displayName = user.Email
+			}
+			created, cerr := q.UpsertUserByEmail(ctx, repo.UpsertUserByEmailParams{
+				ID:          uuid.New(),
+				Email:       user.Email,
+				DisplayName: displayName,
+			})
+			if cerr != nil {
+				h.logger.WarnContext(ctx, "create shadow for currentUser", slog.Any("error", cerr))
+			} else if created.ID != uuid.Nil {
+				shadow = &created
+			}
+		}
+		if shadow != nil {
+			sid := shadow.ID.String()
+			resp.ShadowID = &sid
+			resp.ShadowAdmin = shadow.Admin
+		}
 	}
 	writeJSON(w, http.StatusOK, resp)
 }


### PR DESCRIPTION
## Summary

- Exposes `shadow_id` and `shadow_admin` on `GET /workos/currentUser` in the workos mode handler
- Adds an **Admin toggle** to the WorkOS pane in the dev-idp dashboard — shows current admin status and a "Make admin" / "Revoke admin" button
- Shadow user lookup uses `ListUsersFiltered` (read-only by email) before falling back to `UpsertUserByEmail` on first use, avoiding the SQLite `ON CONFLICT RETURNING` nil-UUID bug

## Why

In workos mode, the `admin` flag on the IDP response comes from the local shadow user's `admin` column — but there was no way to set it from the dashboard. Developers had to either use a raw SQL update or log in as a different user.

## How it works

1. `GET /devidp/workos/currentUser` now returns `shadow_id` + `shadow_admin`
2. The dashboard fetches this and renders the toggle below the user's name
3. Toggle calls `rpc/users.update` on the shadow ID — takes effect on next login (Gram re-validates the session token against the dev-idp)

## Test plan

- [ ] In workos mode with a current user set, Admin toggle appears below `workos_sub`
- [ ] "Make admin" sets admin=true, button changes to "Revoke admin"
- [ ] Log out and back in → super admin nav appears in Gram
- [ ] "Revoke admin" sets admin=false, log out/in → super admin nav gone
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->