### PR TITLE
fix: allow non-bearer prefixed auth again

### DIFF
--- a/server/internal/mcp/http_headers.go
+++ b/server/internal/mcp/http_headers.go
@@ -7,29 +7,34 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
-// AuthorizationBearerToken returns the Bearer token from the request's
-// Authorization header with the "Bearer " prefix stripped. Prefix matching
-// is case-insensitive per RFC 7235 § 2.1 ("Bearer" / "BEARER" / "bearer").
-// Returns "" when the header is absent or carries a non-Bearer scheme — a
-// non-empty return is always a Bearer token, never the raw header. This
-// matters for callers that synthesise an upstream Authorization header
-// from the result; forwarding a non-Bearer value would produce a malformed
-// "Bearer <other-scheme> ..." upstream.
+// AuthorizationBearerToken returns the token portion of the Authorization
+// header. When the header carries a "Bearer " prefix (case-insensitive per
+// RFC 7235 § 2.1), the prefix is stripped; otherwise the raw header value
+// is returned verbatim.
+//
+// DO NOT make this strict (i.e. return "" for non-Bearer headers). The
+// hosted MCP install page (server/internal/mcpmetadata/hosted_page.html.tmpl)
+// emits "Authorization:${GRAM_KEY}" with no scheme, so users paste their raw
+// Gram API key into the env var and the wire header lands as
+// "Authorization: <key>" with no Bearer prefix. PR #2540 briefly switched
+// this to strict matching and broke every existing private MCP install —
+// don't repeat that. If you ever do tighten this, update the install-page
+// snippets to emit a Bearer prefix in the same change.
 func AuthorizationBearerToken(r *http.Request) string {
 	const bearerPrefix = "Bearer "
 	token := r.Header.Get("Authorization")
 	if len(token) >= len(bearerPrefix) && strings.EqualFold(token[:len(bearerPrefix)], bearerPrefix) {
 		return token[len(bearerPrefix):]
 	}
-	return ""
+	return token
 }
 
 // AuthorizationOrChatSessionToken returns the caller's identity token,
-// drawn from the Authorization Bearer header when present, otherwise the
+// drawn from the Authorization header when present, otherwise the
 // Gram-Chat-Session header. Returns "" when neither carries a value.
-// Bearer wins when both are set, matching the priority used by the MCP
-// identity-auth path; non-Bearer Authorization schemes are ignored (see
-// [AuthorizationBearerToken]) and fall through to Gram-Chat-Session.
+// Authorization wins when both are set, matching the priority used by the
+// MCP identity-auth path. See [AuthorizationBearerToken] for the lenient
+// handling of headers that lack a "Bearer " prefix.
 func AuthorizationOrChatSessionToken(r *http.Request) string {
 	if t := AuthorizationBearerToken(r); t != "" {
 		return t

--- a/server/internal/mcp/http_headers.go
+++ b/server/internal/mcp/http_headers.go
@@ -7,37 +7,56 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
-// AuthorizationBearerToken returns the token portion of the Authorization
-// header. When the header carries a "Bearer " prefix (case-insensitive per
-// RFC 7235 § 2.1), the prefix is stripped; otherwise the raw header value
-// is returned verbatim.
+// AuthorizationBearerToken returns the Bearer token from the request's
+// Authorization header with the "Bearer " prefix stripped. Prefix matching
+// is case-insensitive per RFC 7235 § 2.1 ("Bearer" / "BEARER" / "bearer").
+// Returns "" when the header is absent or carries a non-Bearer scheme — a
+// non-empty return is always a Bearer token, never the raw header. This
+// matters for callers that synthesise an upstream Authorization header
+// from the result; forwarding a non-Bearer value would produce a malformed
+// "Bearer <other-scheme> ..." upstream.
 //
-// DO NOT make this strict (i.e. return "" for non-Bearer headers). The
-// hosted MCP install page (server/internal/mcpmetadata/hosted_page.html.tmpl)
-// emits "Authorization:${GRAM_KEY}" with no scheme, so users paste their raw
-// Gram API key into the env var and the wire header lands as
-// "Authorization: <key>" with no Bearer prefix. PR #2540 briefly switched
-// this to strict matching and broke every existing private MCP install —
-// don't repeat that. If you ever do tighten this, update the install-page
-// snippets to emit a Bearer prefix in the same change.
+// Do NOT loosen this for the Gram API key install-snippet case (raw key
+// with no Bearer prefix). The lenient path lives in
+// [AuthorizationOrChatSessionToken], which is the only helper used by the
+// identity-auth path. OAuth-forwarding callers must keep the strict
+// semantics here.
 func AuthorizationBearerToken(r *http.Request) string {
 	const bearerPrefix = "Bearer "
 	token := r.Header.Get("Authorization")
 	if len(token) >= len(bearerPrefix) && strings.EqualFold(token[:len(bearerPrefix)], bearerPrefix) {
 		return token[len(bearerPrefix):]
 	}
-	return token
+	return ""
 }
 
 // AuthorizationOrChatSessionToken returns the caller's identity token,
 // drawn from the Authorization header when present, otherwise the
 // Gram-Chat-Session header. Returns "" when neither carries a value.
-// Authorization wins when both are set, matching the priority used by the
-// MCP identity-auth path. See [AuthorizationBearerToken] for the lenient
-// handling of headers that lack a "Bearer " prefix.
+//
+// Unlike [AuthorizationBearerToken], the Authorization header is read
+// leniently: a "Bearer " prefix is stripped when present, but a header
+// that lacks the prefix is returned verbatim. The hosted MCP install page
+// (server/internal/mcpmetadata/hosted_page.html.tmpl) emits
+// "Authorization:${GRAM_KEY}" with no scheme, so users paste their raw
+// Gram API key directly. PR #2540 briefly required strict Bearer parsing
+// here and broke every existing private MCP install — don't repeat that.
+// If you ever tighten this, update the install-page snippets to emit a
+// Bearer prefix in the same change.
+//
+// Leniency is safe in the identity-auth path because the returned token
+// is only used to look up a Gram API key / chat-session JWT in our own
+// data store; a non-Bearer scheme like "Basic ..." just fails that
+// lookup. It is NOT safe for OAuth upstream-forwarding callers, which is
+// why [AuthorizationBearerToken] stays strict.
 func AuthorizationOrChatSessionToken(r *http.Request) string {
-	if t := AuthorizationBearerToken(r); t != "" {
-		return t
+	const bearerPrefix = "Bearer "
+	raw := r.Header.Get("Authorization")
+	if len(raw) >= len(bearerPrefix) && strings.EqualFold(raw[:len(bearerPrefix)], bearerPrefix) {
+		raw = raw[len(bearerPrefix):]
+	}
+	if raw != "" {
+		return raw
 	}
 	return r.Header.Get(constants.ChatSessionsTokenHeader)
 }

--- a/server/internal/mcp/http_headers_test.go
+++ b/server/internal/mcp/http_headers_test.go
@@ -58,40 +58,48 @@ func TestAuthorizationBearerToken_BearerUppercase(t *testing.T) {
 func TestAuthorizationBearerToken_BearerEmptyToken(t *testing.T) {
 	t.Parallel()
 
-	// "Bearer " with no token after the space is technically a valid prefix
-	// match but yields no token; callers treat empty returns as "no auth".
+	// "Bearer " with no token after the space matches the prefix and strips
+	// to empty; callers treat empty returns as "no auth".
 	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer ")))
 }
 
-// TestAuthorizationBearerToken_BasicScheme is the regression test for the
-// non-Bearer fallthrough: returning the raw header would land "Basic abc123"
-// inside an upstream "Authorization: Bearer Basic abc123" — see the function
-// docstring for the proxy-forwarding rationale.
+// TestAuthorizationBearerToken_RawKeyNoScheme is the regression guard for the
+// hosted install-page snippets, which emit "Authorization:${GRAM_KEY}" with
+// no scheme prefix. The user's raw Gram API key must round-trip through this
+// helper untouched. See the [mcp.AuthorizationBearerToken] docstring.
+func TestAuthorizationBearerToken_RawKeyNoScheme(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "gram_live_abc123", mcp.AuthorizationBearerToken(newAuthRequest(t, "gram_live_abc123")))
+}
+
 func TestAuthorizationBearerToken_BasicScheme(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Basic abc123")))
+	// Non-Bearer schemes are returned verbatim under the lenient policy.
+	require.Equal(t, "Basic abc123", mcp.AuthorizationBearerToken(newAuthRequest(t, "Basic abc123")))
 }
 
 func TestAuthorizationBearerToken_DigestScheme(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, `Digest username="u", realm="r"`)))
+	require.Equal(t, `Digest username="u", realm="r"`, mcp.AuthorizationBearerToken(newAuthRequest(t, `Digest username="u", realm="r"`)))
 }
 
 func TestAuthorizationBearerToken_BareWordBearerNoSpace(t *testing.T) {
 	t.Parallel()
 
-	// "Bearer" alone is shorter than the "Bearer " prefix and must not match.
-	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer")))
+	// "Bearer" alone is shorter than the "Bearer " prefix; it falls through
+	// the prefix check and is returned verbatim.
+	require.Equal(t, "Bearer", mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer")))
 }
 
 func TestAuthorizationBearerToken_BearerLikePrefix(t *testing.T) {
 	t.Parallel()
 
-	// A scheme that starts with the same letters but isn't "Bearer " must not
-	// match — guards against a hypothetical "Bearer-Like xyz" or similar.
-	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer-Like xyz")))
+	// A scheme that starts with the same letters but isn't "Bearer " is
+	// returned verbatim rather than matched as a prefix.
+	require.Equal(t, "Bearer-Like xyz", mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer-Like xyz")))
 }
 
 func TestAuthorizationOrChatSessionToken_BothEmpty(t *testing.T) {
@@ -118,17 +126,26 @@ func TestAuthorizationOrChatSessionToken_BearerWinsWhenBothSet(t *testing.T) {
 	require.Equal(t, "abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Bearer abc123", "session-jwt")))
 }
 
-// TestAuthorizationOrChatSessionToken_BasicSchemeFallsThrough guards the
-// interaction with [mcp.AuthorizationBearerToken]'s non-Bearer drop: a Basic
-// Authorization header must not block the chat-session fallback.
-func TestAuthorizationOrChatSessionToken_BasicSchemeFallsThrough(t *testing.T) {
+// TestAuthorizationOrChatSessionToken_RawKeyWinsOverChatSession asserts the
+// lenient-bearer path: a raw Authorization value (e.g. an unprefixed Gram
+// API key from the install-page snippets) is returned and pre-empts the
+// chat-session fallback.
+func TestAuthorizationOrChatSessionToken_RawKeyWinsOverChatSession(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "session-jwt", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Basic abc123", "session-jwt")))
+	require.Equal(t, "gram_live_abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "gram_live_abc123", "session-jwt")))
+}
+
+func TestAuthorizationOrChatSessionToken_NonBearerSchemePreEmptsChatSession(t *testing.T) {
+	t.Parallel()
+
+	// Non-Bearer schemes are returned verbatim, so they take priority over
+	// the chat-session header just like Bearer and raw values do.
+	require.Equal(t, "Basic abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Basic abc123", "session-jwt")))
 }
 
 func TestAuthorizationOrChatSessionToken_BasicSchemeAlone(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Basic abc123", "")))
+	require.Equal(t, "Basic abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Basic abc123", "")))
 }

--- a/server/internal/mcp/http_headers_test.go
+++ b/server/internal/mcp/http_headers_test.go
@@ -58,48 +58,50 @@ func TestAuthorizationBearerToken_BearerUppercase(t *testing.T) {
 func TestAuthorizationBearerToken_BearerEmptyToken(t *testing.T) {
 	t.Parallel()
 
-	// "Bearer " with no token after the space matches the prefix and strips
-	// to empty; callers treat empty returns as "no auth".
+	// "Bearer " with no token after the space is technically a valid prefix
+	// match but yields no token; callers treat empty returns as "no auth".
 	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer ")))
 }
 
-// TestAuthorizationBearerToken_RawKeyNoScheme is the regression guard for the
-// hosted install-page snippets, which emit "Authorization:${GRAM_KEY}" with
-// no scheme prefix. The user's raw Gram API key must round-trip through this
-// helper untouched. See the [mcp.AuthorizationBearerToken] docstring.
-func TestAuthorizationBearerToken_RawKeyNoScheme(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "gram_live_abc123", mcp.AuthorizationBearerToken(newAuthRequest(t, "gram_live_abc123")))
-}
-
+// TestAuthorizationBearerToken_BasicScheme is the regression test for the
+// non-Bearer fallthrough: returning the raw header would land "Basic abc123"
+// inside an upstream "Authorization: Bearer Basic abc123" — see the function
+// docstring for the proxy-forwarding rationale.
 func TestAuthorizationBearerToken_BasicScheme(t *testing.T) {
 	t.Parallel()
 
-	// Non-Bearer schemes are returned verbatim under the lenient policy.
-	require.Equal(t, "Basic abc123", mcp.AuthorizationBearerToken(newAuthRequest(t, "Basic abc123")))
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Basic abc123")))
 }
 
 func TestAuthorizationBearerToken_DigestScheme(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, `Digest username="u", realm="r"`, mcp.AuthorizationBearerToken(newAuthRequest(t, `Digest username="u", realm="r"`)))
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, `Digest username="u", realm="r"`)))
 }
 
 func TestAuthorizationBearerToken_BareWordBearerNoSpace(t *testing.T) {
 	t.Parallel()
 
-	// "Bearer" alone is shorter than the "Bearer " prefix; it falls through
-	// the prefix check and is returned verbatim.
-	require.Equal(t, "Bearer", mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer")))
+	// "Bearer" alone is shorter than the "Bearer " prefix and must not match.
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer")))
 }
 
 func TestAuthorizationBearerToken_BearerLikePrefix(t *testing.T) {
 	t.Parallel()
 
-	// A scheme that starts with the same letters but isn't "Bearer " is
-	// returned verbatim rather than matched as a prefix.
-	require.Equal(t, "Bearer-Like xyz", mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer-Like xyz")))
+	// A scheme that starts with the same letters but isn't "Bearer " must not
+	// match — guards against a hypothetical "Bearer-Like xyz" or similar.
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "Bearer-Like xyz")))
+}
+
+// TestAuthorizationBearerToken_RawKeyNoScheme documents that the strict
+// helper does NOT accept a raw token — the lenient path lives in
+// [AuthorizationOrChatSessionToken]. See that helper's tests for the
+// install-page regression guard.
+func TestAuthorizationBearerToken_RawKeyNoScheme(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcp.AuthorizationBearerToken(newAuthRequest(t, "gram_live_abc123")))
 }
 
 func TestAuthorizationOrChatSessionToken_BothEmpty(t *testing.T) {
@@ -126,21 +128,40 @@ func TestAuthorizationOrChatSessionToken_BearerWinsWhenBothSet(t *testing.T) {
 	require.Equal(t, "abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Bearer abc123", "session-jwt")))
 }
 
-// TestAuthorizationOrChatSessionToken_RawKeyWinsOverChatSession asserts the
-// lenient-bearer path: a raw Authorization value (e.g. an unprefixed Gram
-// API key from the install-page snippets) is returned and pre-empts the
-// chat-session fallback.
+// TestAuthorizationOrChatSessionToken_RawKeyWinsOverChatSession is the
+// regression guard for the hosted install-page snippets: a raw Gram API
+// key with no Bearer prefix must round-trip through the identity-auth
+// helper untouched and pre-empt the chat-session fallback. See the
+// [mcp.AuthorizationOrChatSessionToken] docstring.
 func TestAuthorizationOrChatSessionToken_RawKeyWinsOverChatSession(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, "gram_live_abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "gram_live_abc123", "session-jwt")))
 }
 
-func TestAuthorizationOrChatSessionToken_NonBearerSchemePreEmptsChatSession(t *testing.T) {
+func TestAuthorizationOrChatSessionToken_RawKeyAlone(t *testing.T) {
 	t.Parallel()
 
-	// Non-Bearer schemes are returned verbatim, so they take priority over
-	// the chat-session header just like Bearer and raw values do.
+	require.Equal(t, "gram_live_abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "gram_live_abc123", "")))
+}
+
+func TestAuthorizationOrChatSessionToken_BearerEmptyTokenFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	// "Bearer " with no token after the prefix yields an empty Authorization
+	// value, so the chat-session header takes over.
+	require.Equal(t, "session-jwt", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Bearer ", "session-jwt")))
+}
+
+// TestAuthorizationOrChatSessionToken_BasicSchemePreEmptsChatSession
+// documents that under the lenient identity-auth policy a non-Bearer
+// scheme is returned verbatim and pre-empts the chat-session header. The
+// returned value will fail API-key lookup downstream — fine for identity
+// auth but unsafe for OAuth upstream forwarding (which uses the strict
+// [mcp.AuthorizationBearerToken] helper instead).
+func TestAuthorizationOrChatSessionToken_BasicSchemePreEmptsChatSession(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, "Basic abc123", mcp.AuthorizationOrChatSessionToken(newIdentityRequest(t, "Basic abc123", "session-jwt")))
 }
 


### PR DESCRIPTION
This is necessary because our install pages have NEVER shown the Bearer prefix, meaning all existing configs out there don't have it. This was a regression--before yesterday, the code worked as this PR now reflects
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->