### PR TITLE
fix(dev-idp): use deterministic UUIDs for user identity

### DIFF
--- a/dev-idp/internal/defaultuser/defaultuser.go
+++ b/dev-idp/internal/defaultuser/defaultuser.go
@@ -33,6 +33,17 @@ const (
 	DefaultOrgSlug = "speakeasy"
 )
 
+// userIDNamespace is a fixed UUID v5 namespace used to derive deterministic
+// user IDs from email addresses. This ensures the same email always maps to
+// the same UUID, surviving dev-idp SQLite resets without colliding with the
+// Gram server's users_email_key unique constraint.
+var userIDNamespace = uuid.MustParse("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
+
+// DeterministicUserID returns a stable UUID v5 derived from the given email.
+func DeterministicUserID(email string) uuid.UUID {
+	return uuid.NewSHA1(userIDNamespace, []byte(email))
+}
+
 // Committer holds the values read from `git config user.{email,name}`.
 type Committer struct {
 	Email string
@@ -76,7 +87,7 @@ func BootstrapLocalUser(ctx context.Context, db *sql.DB, mode string) (uuid.UUID
 	now := time.Now()
 
 	user, err := queries.UpsertUserByEmail(ctx, repo.UpsertUserByEmailParams{
-		ID:          uuid.New(),
+		ID:          DeterministicUserID(committer.Email),
 		Email:       committer.Email,
 		DisplayName: committer.Name,
 	})

--- a/dev-idp/internal/modes/localspeakeasy/workos.go
+++ b/dev-idp/internal/modes/localspeakeasy/workos.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/speakeasy-api/gram/dev-idp/internal/database/repo"
+	"github.com/speakeasy-api/gram/dev-idp/internal/defaultuser"
 )
 
 // invitationLifetime is how long an emulated invitation stays in the
@@ -474,7 +475,7 @@ func (h *Handler) handleWorkosAcceptInvitation(w http.ResponseWriter, r *http.Re
 	// Find or create the user by the invited email; the display_name
 	// defaults to the email local-part since we don't have a name yet.
 	user, err := queries.UpsertUserByEmail(ctx, repo.UpsertUserByEmailParams{
-		ID:          uuid.New(),
+		ID:          defaultuser.DeterministicUserID(inv.Email),
 		Email:       inv.Email,
 		DisplayName: emailLocalPart(inv.Email),
 	})

--- a/dev-idp/internal/modes/workos/handler.go
+++ b/dev-idp/internal/modes/workos/handler.go
@@ -505,6 +505,7 @@ func (h *Handler) resolveShadowUserID(ctx context.Context) (uuid.UUID, error) {
 	}
 
 	shadow, err := queries.UpsertUserByEmail(ctx, repo.UpsertUserByEmailParams{
+		ID:          defaultuser.DeterministicUserID(user.Email),
 		Email:       user.Email,
 		DisplayName: strings.TrimSpace(user.FirstName + " " + user.LastName),
 	})

--- a/dev-idp/internal/modes/workos/handler.go
+++ b/dev-idp/internal/modes/workos/handler.go
@@ -535,6 +535,7 @@ func (h *Handler) bootstrapWorkosCurrentUser(ctx context.Context) (repo.CurrentU
 	row, err := repo.New(h.db).UpsertCurrentUser(ctx, repo.UpsertCurrentUserParams{
 		Mode:       Mode,
 		SubjectRef: user.ID,
+		Ts:         time.Now(),
 	})
 	if err != nil {
 		return repo.CurrentUser{}, fmt.Errorf("persist default workos currentUser: %w", err)

--- a/dev-idp/internal/service/invitations.go
+++ b/dev-idp/internal/service/invitations.go
@@ -17,6 +17,7 @@ import (
 	srv "github.com/speakeasy-api/gram/dev-idp/gen/http/invitations/server"
 	gen "github.com/speakeasy-api/gram/dev-idp/gen/invitations"
 	"github.com/speakeasy-api/gram/dev-idp/internal/database/repo"
+	"github.com/speakeasy-api/gram/dev-idp/internal/defaultuser"
 	"github.com/speakeasy-api/gram/dev-idp/internal/middleware"
 	"github.com/speakeasy-api/gram/dev-idp/internal/oops"
 )
@@ -199,7 +200,7 @@ func (s *InvitationsService) Accept(ctx context.Context, p *gen.AcceptPayload) (
 	}
 
 	user, err := queries.UpsertUserByEmail(ctx, repo.UpsertUserByEmailParams{
-		ID:          uuid.New(),
+		ID:          defaultuser.DeterministicUserID(inv.Email),
 		Email:       inv.Email,
 		DisplayName: emailLocalPart(inv.Email),
 	})


### PR DESCRIPTION
## Summary

- Replaces `uuid.New()` with deterministic UUID v5 (`uuid.NewSHA1`) derived from email in all dev-idp user creation paths
- Fixes `duplicate key value violates unique constraint "users_email_key"` error when switching between dev-idp modes or after SQLite DB reset

## Problem

When the dev-idp SQLite DB is wiped (mode switch, `mise db:reset`, etc.), `uuid.New()` generates a fresh UUID for the same email on next login. The Gram server's `UpsertUser` uses `ON CONFLICT (id)`, so a new ID for an existing email hits the `users_email_key` unique constraint.

## Solution

`uuid.NewSHA1(namespace, email)` always produces the same UUID for a given email, surviving any number of SQLite resets. Applied to all 4 call sites:
- `defaultuser.BootstrapLocalUser` — local mode bootstrap
- `workos.Handler.resolveShadowUserID` — WorkOS shadow user creation
- `localspeakeasy.Handler.handleWorkosAcceptInvitation` — invitation accept
- `service.InvitationsService.Accept` — Goa invitation accept

## Test plan

- [ ] Delete `local/devidp/devidp.db`, restart dev-idp, login — no duplicate key error
- [ ] Switch between mock and WorkOS modes without errors
- [ ] Verify same email always produces same UUID across restarts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->