### PR TITLE
feat: return JSON-RPC error shape for MCP endpoint errors

### DIFF
--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -2,6 +2,7 @@ package contextvalues
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/google/uuid"
 )
@@ -56,6 +57,7 @@ const (
 	AssistantPrincipalKey       contextKey = "assistantPrincipalKey"
 	AdminSessionTokenContextKey contextKey = "adminSessionTokenKey"
 	AdminAuthContextKey         contextKey = "adminAuthKey"
+	MCPIDContextKey             contextKey = "mcpIDContextKey"
 )
 
 func SetSessionTokenInContext(ctx context.Context, value string) context.Context {
@@ -92,6 +94,24 @@ func SetRequestContext(ctx context.Context, value *RequestContext) context.Conte
 func GetRequestContext(ctx context.Context) (*RequestContext, bool) {
 	value, ok := ctx.Value(RequestContextKey).(*RequestContext)
 	return value, ok
+}
+
+func SetMCPIDContext(ctx context.Context, value *json.RawMessage) context.Context {
+	return context.WithValue(ctx, MCPIDContextKey, value)
+}
+
+func SetMCPID(ctx context.Context, value json.RawMessage) {
+	if dst, ok := ctx.Value(MCPIDContextKey).(*json.RawMessage); ok && len(value) > 0 {
+		*dst = value
+	}
+}
+
+func GetMCPID(ctx context.Context) (json.RawMessage, bool) {
+	value, ok := ctx.Value(MCPIDContextKey).(*json.RawMessage)
+	if !ok || value == nil {
+		return nil, false
+	}
+	return *value, len(*value) > 0
 }
 
 func SetRBACScopeOverride(ctx context.Context, value string) context.Context {

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -48,7 +48,7 @@ type AdminAuthContext struct {
 	HD          string
 }
 
-type MCPContext struct {
+type RPCContext struct {
 	ID mcpjsonrpc.ID
 }
 
@@ -61,8 +61,7 @@ const (
 	AssistantPrincipalKey       contextKey = "assistantPrincipalKey"
 	AdminSessionTokenContextKey contextKey = "adminSessionTokenKey"
 	AdminAuthContextKey         contextKey = "adminAuthKey"
-	MCPIDContextKey             contextKey = "mcpIDContextKey"
-	MCPContextKey               contextKey = "mcpContextKey"
+	RPCContextKey               contextKey = "rpcContextKey"
 )
 
 func SetSessionTokenInContext(ctx context.Context, value string) context.Context {
@@ -101,27 +100,13 @@ func GetRequestContext(ctx context.Context) (*RequestContext, bool) {
 	return value, ok
 }
 
-func SetMCPContext(ctx context.Context, value *MCPContext) context.Context {
-	return context.WithValue(ctx, MCPContextKey, value)
+func SetRPCContext(ctx context.Context, value *RPCContext) context.Context {
+	return context.WithValue(ctx, RPCContextKey, value)
 }
 
-func GetMCPContext(ctx context.Context) (*MCPContext, bool) {
-	value, ok := ctx.Value(MCPContextKey).(*MCPContext)
+func GetRPCContext(ctx context.Context) (*RPCContext, bool) {
+	value, ok := ctx.Value(RPCContextKey).(*RPCContext)
 	return value, ok
-}
-
-func SetMCPID(ctx context.Context, value mcpjsonrpc.ID) {
-	if mcpCtx, ok := GetMCPContext(ctx); ok && value.IsSet() {
-		mcpCtx.ID = value
-	}
-}
-
-func GetMCPID(ctx context.Context) (mcpjsonrpc.ID, bool) {
-	mcpCtx, ok := GetMCPContext(ctx)
-	if !ok || !mcpCtx.ID.IsSet() {
-		return mcpjsonrpc.ID{}, false
-	}
-	return mcpCtx.ID, true
 }
 
 func SetRBACScopeOverride(ctx context.Context, value string) context.Context {

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -48,6 +48,10 @@ type AdminAuthContext struct {
 	HD          string
 }
 
+type MCPContext struct {
+	ID json.RawMessage
+}
+
 const (
 	SessionTokenContextKey      contextKey = "sessionTokenKey"
 	SessionValueContextKey      contextKey = "sessionValueKey"
@@ -58,6 +62,7 @@ const (
 	AdminSessionTokenContextKey contextKey = "adminSessionTokenKey"
 	AdminAuthContextKey         contextKey = "adminAuthKey"
 	MCPIDContextKey             contextKey = "mcpIDContextKey"
+	MCPContextKey               contextKey = "mcpContextKey"
 )
 
 func SetSessionTokenInContext(ctx context.Context, value string) context.Context {
@@ -96,22 +101,27 @@ func GetRequestContext(ctx context.Context) (*RequestContext, bool) {
 	return value, ok
 }
 
-func SetMCPIDContext(ctx context.Context, value *json.RawMessage) context.Context {
-	return context.WithValue(ctx, MCPIDContextKey, value)
+func SetMCPContext(ctx context.Context, value *MCPContext) context.Context {
+	return context.WithValue(ctx, MCPContextKey, value)
+}
+
+func GetMCPContext(ctx context.Context) (*MCPContext, bool) {
+	value, ok := ctx.Value(MCPContextKey).(*MCPContext)
+	return value, ok
 }
 
 func SetMCPID(ctx context.Context, value json.RawMessage) {
-	if dst, ok := ctx.Value(MCPIDContextKey).(*json.RawMessage); ok && len(value) > 0 {
-		*dst = value
+	if mcpCtx, ok := GetMCPContext(ctx); ok && len(value) > 0 {
+		mcpCtx.ID = value
 	}
 }
 
 func GetMCPID(ctx context.Context) (json.RawMessage, bool) {
-	value, ok := ctx.Value(MCPIDContextKey).(*json.RawMessage)
-	if !ok || value == nil {
+	mcpCtx, ok := GetMCPContext(ctx)
+	if !ok || len(mcpCtx.ID) == 0 {
 		return nil, false
 	}
-	return *value, len(*value) > 0
+	return mcpCtx.ID, true
 }
 
 func SetRBACScopeOverride(ctx context.Context, value string) context.Context {

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -2,9 +2,9 @@ package contextvalues
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 )
 
 type contextKey string
@@ -49,7 +49,7 @@ type AdminAuthContext struct {
 }
 
 type MCPContext struct {
-	ID json.RawMessage
+	ID mcpjsonrpc.ID
 }
 
 const (
@@ -110,16 +110,16 @@ func GetMCPContext(ctx context.Context) (*MCPContext, bool) {
 	return value, ok
 }
 
-func SetMCPID(ctx context.Context, value json.RawMessage) {
-	if mcpCtx, ok := GetMCPContext(ctx); ok && len(value) > 0 {
+func SetMCPID(ctx context.Context, value mcpjsonrpc.ID) {
+	if mcpCtx, ok := GetMCPContext(ctx); ok && value.IsSet() {
 		mcpCtx.ID = value
 	}
 }
 
-func GetMCPID(ctx context.Context) (json.RawMessage, bool) {
+func GetMCPID(ctx context.Context) (mcpjsonrpc.ID, bool) {
 	mcpCtx, ok := GetMCPContext(ctx)
-	if !ok || len(mcpCtx.ID) == 0 {
-		return nil, false
+	if !ok || !mcpCtx.ID.IsSet() {
+		return mcpjsonrpc.ID{}, false
 	}
 	return mcpCtx.ID, true
 }

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
@@ -151,7 +152,7 @@ type searchToolsArguments struct {
 func handleSearchToolsCall(
 	ctx context.Context,
 	logger *slog.Logger,
-	reqID msgID,
+	reqID mcpjsonrpc.ID,
 	argsRaw json.RawMessage,
 	toolset *types.Toolset,
 	vectorToolStore *rag.ToolsetVectorStore,
@@ -299,7 +300,7 @@ type describeToolsArguments struct {
 func handleDescribeToolsCall(
 	ctx context.Context,
 	logger *slog.Logger,
-	reqID msgID,
+	reqID mcpjsonrpc.ID,
 	argsRaw json.RawMessage,
 	toolset *types.Toolset,
 ) (json.RawMessage, error) {

--- a/server/internal/mcp/dynamic_tool_calling_test.go
+++ b/server/internal/mcp/dynamic_tool_calling_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -171,7 +172,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		}
 
 		argsRaw := json.RawMessage(`{"tool_names": []}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		_, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.Error(t, err)
@@ -190,7 +191,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		}
 
 		argsRaw := json.RawMessage(`{}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		_, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.Error(t, err)
@@ -203,7 +204,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 
 		toolset := &types.Toolset{}
 		argsRaw := json.RawMessage(`{invalid}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		_, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.Error(t, err)
@@ -234,7 +235,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		}
 
 		argsRaw := json.RawMessage(`{"tool_names": ["get-user"]}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		response, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.NoError(t, err)
@@ -257,7 +258,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		}
 
 		argsRaw := json.RawMessage(`{"tool_names": ["nonexistent-tool"]}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		response, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.NoError(t, err)
@@ -279,7 +280,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		}
 
 		argsRaw := json.RawMessage(`{"tool_names": ["proxy-tool"]}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		_, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.Error(t, err)
@@ -300,7 +301,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		}
 
 		argsRaw := json.RawMessage(`{"tool_names": ["tool-a", "tool-c"]}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		response, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.NoError(t, err)
@@ -321,7 +322,7 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		}
 
 		argsRaw := json.RawMessage(`{"tool_names": ["  my-tool  "]}`)
-		reqID := msgID{format: 1, Number: 1}
+		reqID := mcpjsonrpc.NumberID(1)
 
 		response, err := handleDescribeToolsCall(ctx, logger, reqID, argsRaw, toolset)
 		require.NoError(t, err)

--- a/server/internal/mcp/handle_get_server_test.go
+++ b/server/internal/mcp/handle_get_server_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
@@ -85,39 +86,31 @@ func TestHandleGetServer_ContentNegotiation(t *testing.T) {
 			// Create a response recorder
 			rr := httptest.NewRecorder()
 
-			// Call the handler
-			err := testInstance.service.HandleGetServer(rr, req, metadataService)
+			handler := oops.MCPErrHandle(testInstance.logger, func(w http.ResponseWriter, r *http.Request) error {
+				return testInstance.service.HandleGetServer(w, r, metadataService)
+			})
+			handler.ServeHTTP(rr, req)
 
 			if tt.shouldReturnJSON {
-				// For JSON responses, we expect the handler to write the response and return nil (success)
-				require.NoError(t, err, "Expected no error for successful JSON response")
 				assert.Equal(t, tt.expectedStatusCode, rr.Code)
 				assert.Equal(t, tt.expectedContentType, rr.Header().Get("Content-Type"))
 
-				// Verify it's valid JSON with the expected structure
 				var response struct {
-					Error struct {
-						Code    int    `json:"code"`
-						Message string `json:"message"`
+					JSONRPC string `json:"jsonrpc"`
+					Error   struct {
+						Code    oops.MCPCode `json:"code"`
+						Message string       `json:"message"`
 					} `json:"error"`
 				}
 				unmarshalErr := json.Unmarshal(rr.Body.Bytes(), &response)
 				require.NoError(t, unmarshalErr, "Response should be valid JSON")
-				assert.Equal(t, -32000, response.Error.Code)
+				assert.Equal(t, "2.0", response.JSONRPC)
+				assert.Equal(t, oops.MCPCodeServerError, response.Error.Code)
 				assert.NotEmpty(t, response.Error.Message)
 			} else {
 				// For HTML responses, we expect delegation to metadata service
 				// The key test here is content negotiation - we should NOT return JSON
 				assert.NotEqual(t, "application/json", rr.Header().Get("Content-Type"))
-
-				// The metadata service will likely error because "test-slug" doesn't exist in the test DB,
-				// but that's expected - we're testing content negotiation, not data retrieval.
-				// The important thing is that we took the HTML delegation path instead of JSON error path.
-				if err != nil {
-					t.Logf("Expected metadata service error for non-existent slug: %v", err)
-				} else {
-					t.Log("Metadata service successfully handled HTML request")
-				}
 			}
 		})
 	}

--- a/server/internal/mcp/handle_get_server_test.go
+++ b/server/internal/mcp/handle_get_server_test.go
@@ -96,15 +96,15 @@ func TestHandleGetServer_ContentNegotiation(t *testing.T) {
 
 				// Verify it's valid JSON with the expected structure
 				var response struct {
-					ID      any    `json:"id"`
-					Code    int    `json:"code"`
-					Message string `json:"message"`
-					Data    any    `json:"data"`
+					Error struct {
+						Code    int    `json:"code"`
+						Message string `json:"message"`
+					} `json:"error"`
 				}
 				unmarshalErr := json.Unmarshal(rr.Body.Bytes(), &response)
 				require.NoError(t, unmarshalErr, "Response should be valid JSON")
-				assert.Equal(t, -32000, response.Code) // methodNotAllowed errorCode value
-				assert.NotEmpty(t, response.Message)
+				assert.Equal(t, -32000, response.Error.Code)
+				assert.NotEmpty(t, response.Error.Message)
 			} else {
 				// For HTML responses, we expect delegation to metadata service
 				// The key test here is content negotiation - we should NOT return JSON

--- a/server/internal/mcp/helpers_test.go
+++ b/server/internal/mcp/helpers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -54,115 +55,6 @@ func TestIsMCPPassthrough(t *testing.T) {
 			MetaGramKind: 123, // not a string
 		}
 		require.False(t, isMCPPassthrough(meta))
-	})
-}
-
-func TestMsgID_MarshalJSON(t *testing.T) {
-	t.Parallel()
-
-	t.Run("marshals_int64_id", func(t *testing.T) {
-		t.Parallel()
-		id := msgID{format: 1, Number: 42}
-		result, err := json.Marshal(id)
-		require.NoError(t, err)
-		require.Equal(t, "42", string(result))
-	})
-
-	t.Run("marshals_string_id", func(t *testing.T) {
-		t.Parallel()
-		id := msgID{format: 2, String: "test-id"}
-		result, err := json.Marshal(id)
-		require.NoError(t, err)
-		require.Equal(t, `"test-id"`, string(result))
-	})
-}
-
-func TestMsgID_UnmarshalJSON(t *testing.T) {
-	t.Parallel()
-
-	t.Run("unmarshals_int64_id", func(t *testing.T) {
-		t.Parallel()
-		var id msgID
-		err := json.Unmarshal([]byte("42"), &id)
-		require.NoError(t, err)
-		require.Equal(t, byte(1), id.format)
-		require.Equal(t, int64(42), id.Number)
-	})
-
-	t.Run("unmarshals_string_id", func(t *testing.T) {
-		t.Parallel()
-		var id msgID
-		err := json.Unmarshal([]byte(`"test-id"`), &id)
-		require.NoError(t, err)
-		require.Equal(t, byte(2), id.format)
-		require.Equal(t, "test-id", id.String)
-	})
-
-	t.Run("returns_error_for_invalid_json", func(t *testing.T) {
-		t.Parallel()
-		var id msgID
-		err := json.Unmarshal([]byte(`{}`), &id)
-		require.Error(t, err)
-	})
-}
-
-func TestMsgID_Value(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns_int64_as_string", func(t *testing.T) {
-		t.Parallel()
-		id := msgID{format: 1, Number: 123}
-		require.Equal(t, "123", id.Value())
-	})
-
-	t.Run("returns_string_value", func(t *testing.T) {
-		t.Parallel()
-		id := msgID{format: 2, String: "my-id"}
-		require.Equal(t, "my-id", id.Value())
-	})
-}
-
-func TestErrorCode_String(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns_string_representation", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, "-32601", methodNotFound.String())
-		require.Equal(t, "-32700", parseError.String())
-		require.Equal(t, "-32600", invalidRequest.String())
-	})
-}
-
-func TestErrorCode_UserMessage(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns_user_message_for_known_codes", func(t *testing.T) {
-		t.Parallel()
-		require.Equal(t, "method not allowed", methodNotAllowed.UserMessage())
-		require.Equal(t, "invalid json was received by the server", parseError.UserMessage())
-		require.Equal(t, "json sent is not a valid request object", invalidRequest.UserMessage())
-		require.Equal(t, "method does not exist or is not available", methodNotFound.UserMessage())
-		require.Equal(t, "invalid method parameters", invalidParams.UserMessage())
-		require.Equal(t, "internal json-rpc error", internalError.UserMessage())
-	})
-
-	t.Run("returns_default_message_for_unknown_code", func(t *testing.T) {
-		t.Parallel()
-		unknownCode := errorCode(-99999)
-		require.Equal(t, "an unexpected error occurred", unknownCode.UserMessage())
-	})
-}
-
-func TestRpcError_Error(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns_error_string", func(t *testing.T) {
-		t.Parallel()
-		err := &rpcError{
-			Code:    methodNotFound,
-			Message: "test error",
-		}
-		require.Contains(t, err.Error(), "test error")
 	})
 }
 
@@ -290,7 +182,7 @@ func TestResult_MarshalJSON(t *testing.T) {
 	t.Run("marshals_result_with_jsonrpc_version", func(t *testing.T) {
 		t.Parallel()
 		r := result[string]{
-			ID:     msgID{format: 1, Number: 1},
+			ID:     mcpjsonrpc.NumberID(1),
 			Result: "test-result",
 		}
 		data, err := json.Marshal(r)
@@ -331,74 +223,5 @@ func TestResult_UnmarshalJSON(t *testing.T) {
 		var r result[string]
 		err := json.Unmarshal(data, &r)
 		require.Error(t, err)
-	})
-}
-
-func TestRpcError_MarshalJSON(t *testing.T) {
-	t.Parallel()
-
-	t.Run("marshals_error_with_jsonrpc_version", func(t *testing.T) {
-		t.Parallel()
-		rpcErr := &rpcError{
-			ID:      msgID{format: 1, Number: 1},
-			Code:    methodNotFound,
-			Message: "test error message",
-		}
-		data, err := json.Marshal(rpcErr)
-		require.NoError(t, err)
-
-		var parsed map[string]any
-		err = json.Unmarshal(data, &parsed)
-		require.NoError(t, err)
-		require.Equal(t, "2.0", parsed["jsonrpc"])
-		require.NotNil(t, parsed["error"])
-	})
-
-	t.Run("includes_data_when_present", func(t *testing.T) {
-		t.Parallel()
-		rpcErr := &rpcError{
-			ID:      msgID{format: 1, Number: 1},
-			Code:    methodNotFound,
-			Message: "test error",
-			Data:    json.RawMessage(`{"detail": "extra info"}`),
-		}
-		data, err := json.Marshal(rpcErr)
-		require.NoError(t, err)
-		require.Contains(t, string(data), "extra info")
-	})
-}
-
-func TestMsgID_MarshalJSON_ZeroFormat(t *testing.T) {
-	t.Parallel()
-
-	t.Run("marshals_zero_format_as_empty_string", func(t *testing.T) {
-		t.Parallel()
-		// format 0 falls into default case which marshals the String field
-		id := msgID{format: 0, String: ""}
-		result, err := json.Marshal(id)
-		require.NoError(t, err)
-		require.Equal(t, `""`, string(result))
-	})
-
-	t.Run("marshals_zero_format_with_string_value", func(t *testing.T) {
-		t.Parallel()
-		id := msgID{format: 0, String: "custom-id"}
-		result, err := json.Marshal(id)
-		require.NoError(t, err)
-		require.Equal(t, `"custom-id"`, string(result))
-	})
-}
-
-func TestMsgID_UnmarshalJSON_Null(t *testing.T) {
-	t.Parallel()
-
-	t.Run("unmarshals_null_as_zero_int", func(t *testing.T) {
-		t.Parallel()
-		var id msgID
-		err := json.Unmarshal([]byte("null"), &id)
-		require.NoError(t, err)
-		// null unmarshals as 0 for int64, so format becomes 1 (int format)
-		require.Equal(t, byte(1), id.format)
-		require.Equal(t, int64(0), id.Number)
 	})
 }

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -268,7 +268,7 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	o11y.AttachHandler(mux, "POST", PlatformToolsetRoute, oops.ErrHandle(service.logger, service.ServePlatformToolset).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/idp_callback", oops.ErrHandle(service.logger, service.HandleIDPCallback).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/remote_login_callback", oops.ErrHandle(service.logger, service.HandleRemoteLoginCallback).ServeHTTP)
-	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.ServePublic).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, service.ServePublic).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}", oops.ErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
 		return service.HandleGetServer(w, r, metadataService)
 	}).ServeHTTP)
@@ -475,6 +475,17 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
 	}
 
+	// Capture the JSON-RPC id before auth can fail.
+	bodyBytes, bodyReadErr := io.ReadAll(r.Body)
+	if bodyReadErr == nil {
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		if err := json.Unmarshal(bodyBytes, &req); err == nil {
+			contextvalues.SetMCPID(ctx, req.ID)
+		}
+	}
+
 	// Extract tokens from headers separately:
 	// - authToken: from Authorization header (for OAuth flows)
 	// - sessionToken: from Gram-Chat-Session header (for chat session fallback on non-OAuth endpoints)
@@ -671,12 +682,11 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	}
 
 	// Decode the raw body first to check for batch requests
-	bodyBytes, err := io.ReadAll(r.Body)
 	switch {
-	case errors.Is(err, io.EOF) || len(bodyBytes) == 0:
+	case errors.Is(bodyReadErr, io.EOF) || len(bodyBytes) == 0:
 		return nil
-	case err != nil:
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").Log(ctx, s.logger)
+	case bodyReadErr != nil:
+		return oops.E(oops.CodeBadRequest, bodyReadErr, "failed to read request body").Log(ctx, s.logger)
 	}
 
 	// Reject batch (array) requests — batch is deprecated in the MCP spec

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -480,7 +480,9 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			ID mcpjsonrpc.ID `json:"id"`
 		}
 		if err := json.Unmarshal(bodyBytes, &req); err == nil {
-			contextvalues.SetMCPID(ctx, req.ID)
+			if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && req.ID.IsSet() {
+				rpcCtx.ID = req.ID
+			}
 		}
 	}
 
@@ -752,9 +754,9 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	case body == nil && err == nil:
 		return respondWithNoContent(true, w)
 	case err != nil:
-		mcpID, ok := contextvalues.GetMCPID(ctx)
-		if !ok {
-			mcpID = mcpjsonrpc.NullID()
+		mcpID := mcpjsonrpc.NullID()
+		if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && rpcCtx.ID.IsSet() {
+			mcpID = rpcCtx.ID
 		}
 		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(mcpID, err))
 		if merr != nil {
@@ -1005,9 +1007,9 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "resources/read":
 		return handleResourcesRead(ctx, s.logger, s.db, payload, req, s.toolProxy, s.env, s.billingTracker, s.billingRepository, s.telemLogger, s.platformExtras)
 	default:
-		mcpID, ok := contextvalues.GetMCPID(ctx)
-		if !ok {
-			mcpID = mcpjsonrpc.NullID()
+		mcpID := mcpjsonrpc.NullID()
+		if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && rpcCtx.ID.IsSet() {
+			mcpID = rpcCtx.ID
 		}
 		return nil, &oops.MCPError{
 			ID:      mcpID,

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -475,7 +475,6 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
 	}
 
-	// Capture the JSON-RPC id before auth can fail.
 	bodyBytes, bodyReadErr := io.ReadAll(r.Body)
 	if bodyReadErr == nil {
 		var req struct {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -52,6 +52,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -313,11 +314,9 @@ func (s *Service) HandleGetServer(w http.ResponseWriter, r *http.Request, metada
 		}
 	}
 
-	body, err := json.Marshal(rpcError{
-		ID:      msgID{format: 0, String: "", Number: 0},
-		Code:    methodNotAllowed,
+	body, err := json.Marshal(&oops.MCPError{
+		Code:    oops.MCPCodeServerError,
 		Message: "This MCP server uses POST-based Streamable HTTP transport. This GET request is a normal compatibility probe by the MCP client and can be safely ignored. The client will automatically use POST for actual communication.",
-		Data:    nil,
 	})
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "failed to marshal MCP 405 response", attr.SlogError(err))
@@ -478,7 +477,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	bodyBytes, bodyReadErr := io.ReadAll(r.Body)
 	if bodyReadErr == nil {
 		var req struct {
-			ID json.RawMessage `json:"id"`
+			ID mcpjsonrpc.ID `json:"id"`
 		}
 		if err := json.Unmarshal(bodyBytes, &req); err == nil {
 			contextvalues.SetMCPID(ctx, req.ID)
@@ -753,7 +752,11 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	case body == nil && err == nil:
 		return respondWithNoContent(true, w)
 	case err != nil:
-		bs, merr := json.Marshal(NewErrorFromCause(req.ID, err))
+		mcpID, ok := contextvalues.GetMCPID(ctx)
+		if !ok {
+			mcpID = mcpjsonrpc.NullID()
+		}
+		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(mcpID, err))
 		if merr != nil {
 			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").Log(ctx, s.logger)
 		}
@@ -1002,11 +1005,14 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "resources/read":
 		return handleResourcesRead(ctx, s.logger, s.db, payload, req, s.toolProxy, s.env, s.billingTracker, s.billingRepository, s.telemLogger, s.platformExtras)
 	default:
-		return nil, &rpcError{
-			ID:      req.ID,
-			Code:    methodNotFound,
-			Message: fmt.Sprintf("%s: %s", req.Method, methodNotFound.UserMessage()),
-			Data:    nil,
+		mcpID, ok := contextvalues.GetMCPID(ctx)
+		if !ok {
+			mcpID = mcpjsonrpc.NullID()
+		}
+		return nil, &oops.MCPError{
+			ID:      mcpID,
+			Code:    oops.MCPCodeMethodNotFound,
+			Message: fmt.Sprintf("%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message()),
 		}
 	}
 }
@@ -1195,7 +1201,7 @@ func (s *Service) HandleToolsList(
 	// Create a dummy rawRequest for the internal handler
 	req := &rawRequest{
 		JSONRPC: "2.0",
-		ID:      msgID{format: 1, Number: 1, String: ""},
+		ID:      mcpjsonrpc.NumberID(1),
 		Method:  "tools/list",
 		Params:  json.RawMessage("{}"),
 	}
@@ -1266,7 +1272,7 @@ func (s *Service) HandleToolsCall(
 
 	req := &rawRequest{
 		JSONRPC: "2.0",
-		ID:      msgID{format: 1, Number: 1, String: ""},
+		ID:      mcpjsonrpc.NumberID(1),
 		Method:  "tools/call",
 		Params:  params,
 	}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -270,7 +270,7 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	o11y.AttachHandler(mux, "GET", "/mcp/idp_callback", oops.ErrHandle(service.logger, service.HandleIDPCallback).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/remote_login_callback", oops.ErrHandle(service.logger, service.HandleRemoteLoginCallback).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, service.ServePublic).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}", oops.ErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
+	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
 		return service.HandleGetServer(w, r, metadataService)
 	}).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/install", oops.ErrHandle(service.logger, metadataService.ServeInstallPage).ServeHTTP)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -314,10 +314,7 @@ func (s *Service) HandleGetServer(w http.ResponseWriter, r *http.Request, metada
 		}
 	}
 
-	body, err := json.Marshal(&oops.MCPError{
-		Code:    oops.MCPCodeServerError,
-		Message: "This MCP server uses POST-based Streamable HTTP transport. This GET request is a normal compatibility probe by the MCP client and can be safely ignored. The client will automatically use POST for actual communication.",
-	})
+	body, err := json.Marshal(oops.E(oops.CodeUnexpected, nil, "This MCP server uses POST-based Streamable HTTP transport. This GET request is a normal compatibility probe by the MCP client and can be safely ignored. The client will automatically use POST for actual communication."))
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "failed to marshal MCP 405 response", attr.SlogError(err))
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
@@ -1007,15 +1004,7 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "resources/read":
 		return handleResourcesRead(ctx, s.logger, s.db, payload, req, s.toolProxy, s.env, s.billingTracker, s.billingRepository, s.telemLogger, s.platformExtras)
 	default:
-		mcpID := mcpjsonrpc.NullID()
-		if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && rpcCtx.ID.IsSet() {
-			mcpID = rpcCtx.ID
-		}
-		return nil, &oops.MCPError{
-			ID:      mcpID,
-			Code:    oops.MCPCodeMethodNotFound,
-			Message: fmt.Sprintf("%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message()),
-		}
+		return nil, oops.E(oops.CodeNotImplemented, nil, fmt.Sprintf("%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message()))
 	}
 }
 

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1004,7 +1004,7 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "resources/read":
 		return handleResourcesRead(ctx, s.logger, s.db, payload, req, s.toolProxy, s.env, s.billingTracker, s.billingRepository, s.telemLogger, s.platformExtras)
 	default:
-		return nil, oops.E(oops.CodeNotImplemented, nil, fmt.Sprintf("%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message()))
+		return nil, oops.E(oops.CodeNotImplemented, nil, "%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message())
 	}
 }
 

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -456,6 +456,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	bodyBytes, bodyReadErr := io.ReadAll(r.Body)
 	if bodyReadErr == nil {
 		var req struct {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -314,22 +314,7 @@ func (s *Service) HandleGetServer(w http.ResponseWriter, r *http.Request, metada
 		}
 	}
 
-	body, err := json.Marshal(oops.E(oops.CodeUnexpected, nil, "This MCP server uses POST-based Streamable HTTP transport. This GET request is a normal compatibility probe by the MCP client and can be safely ignored. The client will automatically use POST for actual communication."))
-	if err != nil {
-		s.logger.ErrorContext(r.Context(), "failed to marshal MCP 405 response", attr.SlogError(err))
-		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
-		return fmt.Errorf("failed to marshal MCP 405 response: %w", err)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusMethodNotAllowed)
-	_, writeErr := w.Write(body)
-	if writeErr != nil {
-		s.logger.ErrorContext(r.Context(), "failed to write response body", attr.SlogError(writeErr))
-		return fmt.Errorf("failed to write response body: %w", writeErr)
-	}
-
-	return nil
+	return oops.E(oops.CodeMethodNotAllowed, nil, "This MCP server uses POST-based Streamable HTTP transport. This GET request is a normal compatibility probe by the MCP client and can be safely ignored. The client will automatically use POST for actual communication.")
 }
 
 // writeOAuthServerMetadataResponse builds the OAuth server metadata body and

--- a/server/internal/mcp/rpc.go
+++ b/server/internal/mcp/rpc.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 )
 
 const (
@@ -15,104 +15,19 @@ const (
 	MetaGramMimeType = "getgram.ai/mime-type"
 )
 
-type errorCode int
-
-const (
-	methodNotAllowed errorCode = -32000
-	parseError       errorCode = -32700
-	invalidRequest   errorCode = -32600
-	methodNotFound   errorCode = -32601
-	invalidParams    errorCode = -32602
-	internalError    errorCode = -32603
-)
-
-func (e errorCode) UserMessage() string {
-	switch e {
-	case methodNotAllowed:
-		return "method not allowed"
-	case parseError:
-		return "invalid json was received by the server"
-	case invalidRequest:
-		return "json sent is not a valid request object"
-	case methodNotFound:
-		return "method does not exist or is not available"
-	case invalidParams:
-		return "invalid method parameters"
-	case internalError:
-		return "internal json-rpc error"
-	default:
-		return "an unexpected error occurred"
-	}
-}
-
-func (e errorCode) String() string {
-	return fmt.Sprintf("%d", e)
-}
-
 var (
 	errInvalidJSONRPCVersion = errors.New("invalid json-rpc version")
 )
 
-type msgID struct {
-	format byte // 1 for int64. any other values means string.
-	Number int64
-	String string
-}
-
-func (m msgID) Value() string {
-	switch m.format {
-	case 1:
-		return fmt.Sprintf("%d", m.Number)
-	default:
-		return m.String
-	}
-}
-
-func (m msgID) MarshalJSON() ([]byte, error) {
-	var bs []byte
-	var err error
-
-	switch m.format {
-	case 1:
-		bs, err = json.Marshal(m.Number)
-	default:
-		bs, err = json.Marshal(m.String)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("marshal message id: %w", err)
-	}
-
-	return bs, nil
-}
-
-func (m *msgID) UnmarshalJSON(data []byte) error {
-	var intid int64
-	var str string
-
-	if err := json.Unmarshal(data, &intid); err == nil {
-		m.format = 1
-		m.Number = intid
-		return nil
-	}
-
-	if err := json.Unmarshal(data, &str); err == nil {
-		m.format = 2
-		m.String = str
-		return nil
-	}
-
-	return fmt.Errorf("message id must be an integer or string: %s", string(data))
-}
-
 type resultEnvelope[T any] struct {
-	JSONRPC string `json:"jsonrpc"`
-	ID      msgID  `json:"id"`
-	Result  T      `json:"result"`
+	JSONRPC string        `json:"jsonrpc"`
+	ID      mcpjsonrpc.ID `json:"id"`
+	Result  T             `json:"result,omitempty,omitzero"`
 }
 
 type result[T any] struct {
-	ID     msgID `json:"id"`
-	Result T     `json:"result"`
+	ID     mcpjsonrpc.ID `json:"id"`
+	Result T             `json:"result,omitempty,omitzero"`
 }
 
 func (m result[T]) MarshalJSON() ([]byte, error) {
@@ -148,84 +63,9 @@ func (m *result[T]) UnmarshalJSON(data []byte) error {
 
 type rawRequest struct {
 	JSONRPC string          `json:"jsonrpc"`
-	ID      msgID           `json:"id"`
+	ID      mcpjsonrpc.ID   `json:"id"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params"`
-}
-
-type rpcError struct {
-	ID      msgID
-	Code    errorCode
-	Message string
-	Data    any
-}
-
-func NewErrorFromCause(id msgID, source error) *rpcError {
-	var rpce *rpcError
-	var oopse *oops.ShareableError
-
-	switch {
-	case errors.As(source, &rpce):
-		return rpce
-	case errors.As(source, &oopse):
-		var code errorCode
-		switch oopse.Code {
-		case oops.CodeBadRequest:
-			code = parseError
-		case oops.CodeUnauthorized, oops.CodeForbidden, oops.CodeConflict, oops.CodeUnsupportedMedia, oops.CodeNotFound:
-			code = invalidRequest
-		case oops.CodeInvalid:
-			code = invalidParams
-		case oops.CodeUnexpected:
-			code = internalError
-		default:
-			code = internalError
-		}
-
-		return &rpcError{ID: id, Code: code, Message: oopse.Error(), Data: nil}
-	default:
-		return &rpcError{
-			ID:      id,
-			Code:    internalError,
-			Message: internalError.UserMessage(),
-			Data:    nil,
-		}
-	}
-}
-
-func (e *rpcError) Error() string {
-	return fmt.Sprintf("%d: %s", e.Code, e.Message)
-}
-
-func (e *rpcError) MarshalJSON() ([]byte, error) {
-	if e == nil {
-		return nil, nil
-	}
-
-	msg := e.Message
-	if msg == "" {
-		msg = e.Code.UserMessage()
-	}
-
-	payload := map[string]any{
-		"jsonrpc": "2.0",
-		"error": map[string]any{
-			"code":    e.Code,
-			"message": msg,
-			"data":    e.Data,
-		},
-	}
-
-	if (e.ID.format == 1 && e.ID.Number != 0) || (e.ID.format != 1 && e.ID.String != "") {
-		payload["id"] = e.ID
-	}
-
-	bs, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("marshal jsonrpc error: %w", err)
-	}
-
-	return bs, nil
 }
 
 func respondWithNoContent(ack bool, w http.ResponseWriter) error {

--- a/server/internal/mcp/rpc.go
+++ b/server/internal/mcp/rpc.go
@@ -22,12 +22,12 @@ var (
 type resultEnvelope[T any] struct {
 	JSONRPC string        `json:"jsonrpc"`
 	ID      mcpjsonrpc.ID `json:"id"`
-	Result  T             `json:"result,omitempty,omitzero"`
+	Result  T             `json:"result"`
 }
 
 type result[T any] struct {
 	ID     mcpjsonrpc.ID `json:"id"`
-	Result T             `json:"result,omitempty,omitzero"`
+	Result T             `json:"result"`
 }
 
 func (m result[T]) MarshalJSON() ([]byte, error) {

--- a/server/internal/mcp/rpc_ping.go
+++ b/server/internal/mcp/rpc_ping.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"log/slog"
 
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-func handlePing(ctx context.Context, logger *slog.Logger, id msgID) (json.RawMessage, error) {
+func handlePing(ctx context.Context, logger *slog.Logger, id mcpjsonrpc.ID) (json.RawMessage, error) {
 	bs, err := json.Marshal(&result[struct{}]{
 		ID:     id,
 		Result: struct{}{},

--- a/server/internal/mcp/rpc_ping_test.go
+++ b/server/internal/mcp/rpc_ping_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -16,7 +17,7 @@ func TestHandlePing_IncludesEmptyResultObject(t *testing.T) {
 	ctx := context.Background()
 	logger := testenv.NewLogger(t)
 
-	bs, err := handlePing(ctx, logger, msgID{format: 1, Number: 42})
+	bs, err := handlePing(ctx, logger, mcpjsonrpc.StringID("42"))
 	require.NoError(t, err)
 
 	// MCP/JSON-RPC require the result field be present even when empty.

--- a/server/internal/mcp/rpc_ping_test.go
+++ b/server/internal/mcp/rpc_ping_test.go
@@ -17,7 +17,7 @@ func TestHandlePing_IncludesEmptyResultObject(t *testing.T) {
 	ctx := context.Background()
 	logger := testenv.NewLogger(t)
 
-	bs, err := handlePing(ctx, logger, mcpjsonrpc.StringID("42"))
+	bs, err := handlePing(ctx, logger, mcpjsonrpc.NumberID(42))
 	require.NoError(t, err)
 
 	// MCP/JSON-RPC require the result field be present even when empty.

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -91,7 +90,7 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 	case body == nil && err == nil:
 		return respondWithNoContent(true, w)
 	case err != nil:
-		bs, merr := json.Marshal(NewErrorFromCause(req.ID, err))
+		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(req.ID, err))
 		if merr != nil {
 			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").Log(ctx, s.logger)
 		}
@@ -137,12 +136,7 @@ func (s *Service) handlePlatformToolsetRequest(
 	case "tools/call":
 		return s.callPlatformToolsetTool(ctx, authCtx, toolset, req, chatIDHeader)
 	default:
-		return nil, &rpcError{
-			ID:      req.ID,
-			Code:    methodNotFound,
-			Message: fmt.Sprintf("%s: %s", req.Method, methodNotFound.UserMessage()),
-			Data:    nil,
-		}
+		return nil, oops.E(oops.CodeMethodNotAllowed, nil, "%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message())
 	}
 }
 

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -136,7 +136,7 @@ func (s *Service) handlePlatformToolsetRequest(
 	case "tools/call":
 		return s.callPlatformToolsetTool(ctx, authCtx, toolset, req, chatIDHeader)
 	default:
-		return nil, oops.E(oops.CodeMethodNotAllowed, nil, "%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message())
+		return nil, oops.E(oops.CodeNotImplemented, nil, "%s: %s", req.Method, oops.MCPCodeMethodNotFound.Message())
 	}
 }
 

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth"
 	oauth_repo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
@@ -258,6 +260,54 @@ func TestServePublic_PrivateDisabledMCP_Returns404(t *testing.T) {
 	_, err = servePublicHTTP(t, context.Background(), ti, toolset.Slug, makeInitializeBody(), "", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
+}
+
+func TestServePublic_AttachedAuthErrorReturnsMCPError(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Private Auth Error MCP",
+		Slug:                   "private-auth-error-mcp",
+		Description:            conv.ToPGText("A private MCP that rejects unauthenticated requests"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText("private-auth-error-mcp"),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	router := goahttp.NewMuxer()
+	mcp.Attach(router, ti.service, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+toolset.McpSlug.String, bytes.NewReader(makeInitializeBody()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.NotContains(t, w.Body.String(), "<!doctype")
+
+	var response map[string]any
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err, "response body: %s", w.Body.String())
+	require.Equal(t, "2.0", response["jsonrpc"])
+	require.InDelta(t, 1, response["id"], 0)
+
+	errorBody, ok := response["error"].(map[string]any)
+	require.True(t, ok, "expected JSON-RPC error: %v", response)
+	require.InDelta(t, -32600, errorBody["code"], 0)
+	require.Contains(t, errorBody["message"], "expired or invalid access token")
 }
 
 func TestServePublic_ServerInstructionsInInitializeResponse(t *testing.T) {

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -294,7 +294,7 @@ func TestServePublic_AttachedAuthErrorReturnsMCPError(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
 	require.NotContains(t, w.Body.String(), "<!doctype")
 

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -306,7 +306,7 @@ func TestServePublic_AttachedAuthErrorReturnsMCPError(t *testing.T) {
 
 	errorBody, ok := response["error"].(map[string]any)
 	require.True(t, ok, "expected JSON-RPC error: %v", response)
-	require.InDelta(t, -32600, errorBody["code"], 0)
+	require.InDelta(t, -32001, errorBody["code"], 0)
 	require.Contains(t, errorBody["message"], "expired or invalid access token")
 }
 

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -310,6 +310,37 @@ func TestServePublic_AttachedAuthErrorReturnsMCPError(t *testing.T) {
 	require.Contains(t, errorBody["message"], "expired or invalid access token")
 }
 
+func TestServePublic_AttachedNotFoundReturnsMCPErrorWithNullID(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestMCPService(t)
+
+	router := goahttp.NewMuxer()
+	mcp.Attach(router, ti.service, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/bad-slug", bytes.NewReader(makeInitializeBody()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	require.NotContains(t, w.Body.String(), "<!doctype")
+
+	var response map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err, "response body: %s", w.Body.String())
+	require.Equal(t, "2.0", response["jsonrpc"])
+	require.Nil(t, response["id"])
+
+	errorBody, ok := response["error"].(map[string]any)
+	require.True(t, ok, "expected JSON-RPC error: %v", response)
+	require.InDelta(t, -32002, errorBody["code"], 0)
+	require.Equal(t, "mcp server not found", errorBody["message"])
+}
+
 func TestServePublic_ServerInstructionsInInitializeResponse(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcpjsonrpc/id.go
+++ b/server/internal/mcpjsonrpc/id.go
@@ -1,0 +1,98 @@
+package mcpjsonrpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+const (
+	idFormatNumber byte = 1
+	idFormatString byte = 2
+	idFormatNull   byte = 3
+)
+
+type ID struct {
+	format byte // 1 for int64, 3 for null. any other non-zero value means string.
+	Number int64
+	String string
+}
+
+func NullID() ID {
+	return ID{format: idFormatNull}
+}
+
+func NumberID(value int64) ID {
+	return ID{format: idFormatNumber, Number: value}
+}
+
+func StringID(value string) ID {
+	return ID{format: idFormatString, String: value}
+}
+
+func (id ID) IsSet() bool {
+	return id.format != 0
+}
+
+func (id ID) Value() string {
+	switch id.format {
+	case idFormatNumber:
+		return strconv.FormatInt(id.Number, 10)
+	case idFormatNull:
+		return ""
+	default:
+		return id.String
+	}
+}
+
+func (id ID) MarshalJSON() ([]byte, error) {
+	if !id.IsSet() || id.format == idFormatNull {
+		return []byte("null"), nil
+	}
+
+	var bs []byte
+	var err error
+	switch id.format {
+	case idFormatNumber:
+		bs, err = json.Marshal(id.Number)
+	default:
+		bs, err = json.Marshal(id.String)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("marshal json-rpc id: %w", err)
+	}
+
+	return bs, nil
+}
+
+func (id *ID) UnmarshalJSON(data []byte) error {
+	var raw json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("unmarshal json-rpc id: %w", err)
+	}
+
+	if string(raw) == "null" {
+		id.format = idFormatNull
+		id.Number = 0
+		id.String = ""
+		return nil
+	}
+
+	var intID int64
+	if err := json.Unmarshal(raw, &intID); err == nil {
+		id.format = idFormatNumber
+		id.Number = intID
+		id.String = ""
+		return nil
+	}
+
+	var strID string
+	if err := json.Unmarshal(raw, &strID); err == nil {
+		id.format = idFormatString
+		id.Number = 0
+		id.String = strID
+		return nil
+	}
+
+	return fmt.Errorf("json-rpc id must be an integer, string, or null: %s", string(raw))
+}

--- a/server/internal/mcpjsonrpc/id.go
+++ b/server/internal/mcpjsonrpc/id.go
@@ -19,15 +19,15 @@ type ID struct {
 }
 
 func NullID() ID {
-	return ID{format: idFormatNull}
+	return ID{format: idFormatNull, Number: 0, String: ""}
 }
 
 func NumberID(value int64) ID {
-	return ID{format: idFormatNumber, Number: value}
+	return ID{format: idFormatNumber, Number: value, String: ""}
 }
 
 func StringID(value string) ID {
-	return ID{format: idFormatString, String: value}
+	return ID{format: idFormatString, Number: 0, String: value}
 }
 
 func (id ID) IsSet() bool {

--- a/server/internal/mcpjsonrpc/id_test.go
+++ b/server/internal/mcpjsonrpc/id_test.go
@@ -1,0 +1,87 @@
+package mcpjsonrpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestID_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("marshals_int64_id", func(t *testing.T) {
+		t.Parallel()
+		result, err := json.Marshal(NumberID(42))
+		require.NoError(t, err)
+		require.Equal(t, "42", string(result))
+	})
+
+	t.Run("marshals_string_id", func(t *testing.T) {
+		t.Parallel()
+		result, err := json.Marshal(StringID("test-id"))
+		require.NoError(t, err)
+		require.Equal(t, `"test-id"`, string(result))
+	})
+
+	t.Run("marshals_null_id", func(t *testing.T) {
+		t.Parallel()
+		result, err := json.Marshal(NullID())
+		require.NoError(t, err)
+		require.Equal(t, "null", string(result))
+	})
+}
+
+func TestID_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmarshals_int64_id", func(t *testing.T) {
+		t.Parallel()
+		var id ID
+		err := json.Unmarshal([]byte("42"), &id)
+		require.NoError(t, err)
+		require.True(t, id.IsSet())
+		require.Equal(t, idFormatNumber, id.format)
+		require.Equal(t, int64(42), id.Number)
+		require.Equal(t, "42", id.Value())
+	})
+
+	t.Run("unmarshals_string_id", func(t *testing.T) {
+		t.Parallel()
+		var id ID
+		err := json.Unmarshal([]byte(`"test-id"`), &id)
+		require.NoError(t, err)
+		require.True(t, id.IsSet())
+		require.Equal(t, idFormatString, id.format)
+		require.Equal(t, "test-id", id.String)
+		require.Equal(t, "test-id", id.Value())
+	})
+
+	t.Run("unmarshals_null_id", func(t *testing.T) {
+		t.Parallel()
+		var id ID
+		err := json.Unmarshal([]byte("null"), &id)
+		require.NoError(t, err)
+		require.True(t, id.IsSet())
+		require.Equal(t, idFormatNull, id.format)
+
+		result, err := json.Marshal(id)
+		require.NoError(t, err)
+		require.Equal(t, "null", string(result))
+	})
+
+	t.Run("returns_error_for_invalid_json_rpc_id", func(t *testing.T) {
+		t.Parallel()
+		var id ID
+		err := json.Unmarshal([]byte(`{}`), &id)
+		require.Error(t, err)
+	})
+}
+
+func TestID_Value(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "123", NumberID(123).Value())
+	require.Equal(t, "my-id", StringID("my-id").Value())
+	require.Empty(t, NullID().Value())
+}

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -19,6 +19,7 @@ const (
 	CodeNotImplemented      Code = "not_implemented"
 	CodeInsufficientCredits Code = "insufficient_credits"
 	CodeRateLimitExceeded   Code = "rate_limit_exceeded"
+	CodeMethodNotAllowed    Code = "method_not_allowed"
 )
 
 var StatusCodes = map[Code]int{
@@ -36,6 +37,7 @@ var StatusCodes = map[Code]int{
 	CodeNotImplemented:      http.StatusNotImplemented,
 	CodeInsufficientCredits: http.StatusPaymentRequired,
 	CodeRateLimitExceeded:   http.StatusTooManyRequests,
+	CodeMethodNotAllowed:    http.StatusMethodNotAllowed,
 }
 
 func (c Code) UserMessage() string {
@@ -46,6 +48,8 @@ func (c Code) UserMessage() string {
 		return "permission denied"
 	case CodeBadRequest:
 		return "request is invalid"
+	case CodeMethodNotAllowed:
+		return "method not allowed"
 	case CodeNotFound:
 		return "resource not found"
 	case CodeConflict:
@@ -82,6 +86,8 @@ func (c Code) MCPCode() MCPCode {
 		return MCPCodeParseError
 	case CodeUnauthorized, CodeForbidden, CodeConflict, CodeUnsupportedMedia:
 		return MCPCodeInvalidRequest
+	case CodeMethodNotAllowed:
+		return MCPCodeServerError
 	case CodeNotFound:
 		return MCPCodeResourceNotFound
 	case CodeInvalid:

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -11,6 +11,7 @@ const (
 	CodeNotFound            Code = "not_found"
 	CodeConflict            Code = "conflict"
 	CodeUnsupportedMedia    Code = "unsupported_media"
+	CodeMethodNotAllowed    Code = "method_not_allowed"
 	CodeRequestTooLarge     Code = "request_too_large"
 	CodeInvalid             Code = "invalid"
 	CodeUnexpected          Code = "unexpected"
@@ -29,6 +30,7 @@ var StatusCodes = map[Code]int{
 	CodeNotFound:            http.StatusNotFound,
 	CodeConflict:            http.StatusConflict,
 	CodeUnsupportedMedia:    http.StatusUnsupportedMediaType,
+	CodeMethodNotAllowed:    http.StatusMethodNotAllowed,
 	CodeRequestTooLarge:     http.StatusRequestEntityTooLarge,
 	CodeInvalid:             http.StatusUnprocessableEntity,
 	CodeUnexpected:          http.StatusInternalServerError,

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -20,7 +20,6 @@ const (
 	CodeNotImplemented      Code = "not_implemented"
 	CodeInsufficientCredits Code = "insufficient_credits"
 	CodeRateLimitExceeded   Code = "rate_limit_exceeded"
-	CodeMethodNotAllowed    Code = "method_not_allowed"
 )
 
 var StatusCodes = map[Code]int{
@@ -39,7 +38,6 @@ var StatusCodes = map[Code]int{
 	CodeNotImplemented:      http.StatusNotImplemented,
 	CodeInsufficientCredits: http.StatusPaymentRequired,
 	CodeRateLimitExceeded:   http.StatusTooManyRequests,
-	CodeMethodNotAllowed:    http.StatusMethodNotAllowed,
 }
 
 func (c Code) UserMessage() string {

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -82,9 +82,11 @@ func (c Code) IsTemporary() bool {
 
 func (c Code) MCPCode() MCPCode {
 	switch c {
-	case CodeBadRequest:
-		return MCPCodeInvalidRequest
-	case CodeUnauthorized, CodeForbidden, CodeConflict, CodeUnsupportedMedia:
+	case CodeUnauthorized:
+		return MCPCodeUnauthorized
+	case CodeForbidden:
+		return MCPCodeForbidden
+	case CodeBadRequest, CodeConflict, CodeUnsupportedMedia:
 		return MCPCodeInvalidRequest
 	case CodeMethodNotAllowed:
 		return MCPCodeServerError

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -83,7 +83,7 @@ func (c Code) IsTemporary() bool {
 func (c Code) MCPCode() MCPCode {
 	switch c {
 	case CodeBadRequest:
-		return MCPCodeParseError
+		return MCPCodeInvalidRequest
 	case CodeUnauthorized, CodeForbidden, CodeConflict, CodeUnsupportedMedia:
 		return MCPCodeInvalidRequest
 	case CodeMethodNotAllowed:

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -75,3 +75,20 @@ func (c Code) IsTemporary() bool {
 		return false
 	}
 }
+
+func (c Code) MCPCode() MCPCode {
+	switch c {
+	case CodeBadRequest:
+		return MCPCodeParseError
+	case CodeUnauthorized, CodeForbidden, CodeConflict, CodeUnsupportedMedia:
+		return MCPCodeInvalidRequest
+	case CodeNotFound:
+		return MCPCodeResourceNotFound
+	case CodeInvalid:
+		return MCPCodeInvalidParams
+	case CodeNotImplemented:
+		return MCPCodeMethodNotFound
+	default:
+		return MCPCodeInternalError
+	}
+}

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -25,20 +25,29 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 			return
 		}
 
-		code := http.StatusInternalServerError
-
-		var shareableErr *ShareableError
-		if !errors.As(err, &shareableErr) {
-			code = shareableErr.HTTPStatus()
-			stack := string(debug.Stack())
-			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogError(err), attr.SlogErrorStack(stack))
-		}
-
 		mcpID := mcpjsonrpc.NullID()
 		if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok && rpcCtx.ID.IsSet() {
 			mcpID = rpcCtx.ID
 		}
-		payload := NewMCPErrorFromCause(mcpID, err)
+
+		code := http.StatusInternalServerError
+
+		payload := &MCPError{
+			ID:      mcpID,
+			Code:    MCPCodeInternalError,
+			Message: MCPCodeInternalError.Message(),
+		}
+
+		var shareableErr *ShareableError
+		switch {
+		case errors.As(err, &shareableErr):
+			code = shareableErr.HTTPStatus()
+			payload.Code = shareableErr.Code.MCPCode()
+			payload.Message = shareableErr.Error()
+		default:
+			stack := string(debug.Stack())
+			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogError(err), attr.SlogErrorStack(stack))
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(code)

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -25,8 +25,11 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 			return
 		}
 
+		code := http.StatusInternalServerError
+
 		var shareableErr *ShareableError
 		if !errors.As(err, &shareableErr) {
+			code = shareableErr.HTTPStatus()
 			stack := string(debug.Stack())
 			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogError(err), attr.SlogErrorStack(stack))
 		}
@@ -38,7 +41,7 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 		payload := NewMCPErrorFromCause(mcpID, err)
 
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(shareableErr.HTTPStatus())
+		w.WriteHeader(code)
 		err = json.NewEncoder(w).Encode(payload)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "failed to encode MCP error response", attr.SlogError(err))

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -77,19 +77,6 @@ func (c MCPCode) Message() string {
 	}
 }
 
-func (c MCPCode) HTTPStatus() int {
-	switch c {
-	case MCPCodeParseError, MCPCodeInvalidRequest, MCPCodeInvalidParams:
-		return http.StatusBadRequest
-	case MCPCodeMethodNotFound, MCPCodeResourceNotFound:
-		return http.StatusNotFound
-	case MCPCodeInternalError, MCPCodeServerError:
-		return http.StatusInternalServerError
-	default:
-		return http.StatusInternalServerError
-	}
-}
-
 type MCPError struct {
 	ID      mcpjsonrpc.ID
 	Code    MCPCode
@@ -119,13 +106,6 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
 			Message: MCPCodeInternalError.Message(),
 		}
 	}
-}
-
-func (e *MCPError) HTTPStatusCode() int {
-	if e == nil {
-		return MCPCodeInternalError.HTTPStatus()
-	}
-	return e.Code.HTTPStatus()
 }
 
 func (e *MCPError) Error() string {

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -15,8 +15,8 @@ import (
 // errors as JSON-RPC error responses instead of the generic HTTP error shape.
 func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.Request) error) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id := new(json.RawMessage)
-		r = r.WithContext(contextvalues.SetMCPIDContext(r.Context(), id))
+		mcpCtx := &contextvalues.MCPContext{ID: json.RawMessage("null")}
+		r = r.WithContext(contextvalues.SetMCPContext(r.Context(), mcpCtx))
 
 		err := handler(w, r)
 		if err == nil {

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -38,7 +38,7 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 		payload := NewMCPErrorFromCause(mcpID, err)
 
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(payload.HTTPStatusCode())
+		w.WriteHeader(shareableErr.HTTPStatus())
 		err = json.NewEncoder(w).Encode(payload)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "failed to encode MCP error response", attr.SlogError(err))

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -1,0 +1,120 @@
+package oops
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+)
+
+// MCPErrHandle wraps an MCP/JSON-RPC HTTP handler and serializes returned
+// errors as JSON-RPC error responses instead of the generic HTTP error shape.
+func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.Request) error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := new(json.RawMessage)
+		r = r.WithContext(contextvalues.SetMCPIDContext(r.Context(), id))
+
+		err := handler(w, r)
+		if err == nil {
+			return
+		}
+
+		code := MCPCodeInternalError
+		httpCode := code.HTTPStatus()
+		message := code.Message()
+
+		var se *ShareableError
+		switch {
+		case errors.As(err, &se):
+			code = se.Code.MCPCode()
+			httpCode = se.HTTPStatus()
+			message = se.Error()
+		default:
+			stack := string(debug.Stack())
+			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogError(err), attr.SlogErrorStack(stack))
+		}
+
+		mcpID, ok := contextvalues.GetMCPID(r.Context())
+		if !ok {
+			mcpID = json.RawMessage("null")
+		}
+		payload := mcpErrorPayload(mcpID, code, message)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(httpCode)
+		err = json.NewEncoder(w).Encode(payload)
+		if err != nil {
+			logger.ErrorContext(r.Context(), "failed to encode MCP error response", attr.SlogError(err))
+		}
+	})
+}
+
+type MCPCode int
+
+const (
+	MCPCodeParseError       MCPCode = -32700
+	MCPCodeInvalidRequest   MCPCode = -32600
+	MCPCodeMethodNotFound   MCPCode = -32601
+	MCPCodeInvalidParams    MCPCode = -32602
+	MCPCodeInternalError    MCPCode = -32603
+	MCPCodeServerError      MCPCode = -32000
+	MCPCodeResourceNotFound MCPCode = -32002
+)
+
+func (c MCPCode) Message() string {
+	switch c {
+	case MCPCodeParseError:
+		return "Parse error"
+	case MCPCodeInvalidRequest:
+		return "Invalid Request"
+	case MCPCodeMethodNotFound:
+		return "Method not found"
+	case MCPCodeInvalidParams:
+		return "Invalid params"
+	case MCPCodeServerError:
+		return "Server error"
+	case MCPCodeResourceNotFound:
+		return "Resource not found"
+	default:
+		return "Internal error"
+	}
+}
+
+func (c MCPCode) HTTPStatus() int {
+	switch c {
+	case MCPCodeParseError, MCPCodeInvalidRequest, MCPCodeInvalidParams:
+		return http.StatusBadRequest
+	case MCPCodeMethodNotFound, MCPCodeResourceNotFound:
+		return http.StatusNotFound
+	case MCPCodeInternalError, MCPCodeServerError:
+		return http.StatusInternalServerError
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+type mcpErrorResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Error   mcpError        `json:"error"`
+}
+
+type mcpError struct {
+	Code    MCPCode `json:"code"`
+	Message string  `json:"message"`
+}
+
+func mcpErrorPayload(id json.RawMessage, code MCPCode, message string) mcpErrorResponse {
+	return mcpErrorResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: mcpError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -17,8 +17,8 @@ import (
 // errors as JSON-RPC error responses instead of the generic HTTP error shape.
 func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.Request) error) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mcpCtx := &contextvalues.MCPContext{ID: mcpjsonrpc.NullID()}
-		r = r.WithContext(contextvalues.SetMCPContext(r.Context(), mcpCtx))
+		rpcCtx := &contextvalues.RPCContext{ID: mcpjsonrpc.NullID()}
+		r = r.WithContext(contextvalues.SetRPCContext(r.Context(), rpcCtx))
 
 		err := handler(w, r)
 		if err == nil {
@@ -31,9 +31,9 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogError(err), attr.SlogErrorStack(stack))
 		}
 
-		mcpID, ok := contextvalues.GetMCPID(r.Context())
-		if !ok {
-			mcpID = mcpjsonrpc.NullID()
+		mcpID := mcpjsonrpc.NullID()
+		if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok && rpcCtx.ID.IsSet() {
+			mcpID = rpcCtx.ID
 		}
 		payload := NewMCPErrorFromCause(mcpID, err)
 

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -94,9 +94,6 @@ type MCPError struct {
 	ID      mcpjsonrpc.ID
 	Code    MCPCode
 	Message string
-	Data    any
-
-	HTTPStatus int
 }
 
 func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
@@ -111,10 +108,9 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
 		return mcpErr
 	case errors.As(source, &shareableErr):
 		return &MCPError{
-			ID:         id,
-			Code:       shareableErr.Code.MCPCode(),
-			Message:    shareableErr.Error(),
-			HTTPStatus: shareableErr.HTTPStatus(),
+			ID:      id,
+			Code:    shareableErr.Code.MCPCode(),
+			Message: shareableErr.Error(),
 		}
 	default:
 		return &MCPError{
@@ -128,9 +124,6 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
 func (e *MCPError) HTTPStatusCode() int {
 	if e == nil {
 		return MCPCodeInternalError.HTTPStatus()
-	}
-	if e.HTTPStatus != 0 {
-		return e.HTTPStatus
 	}
 	return e.Code.HTTPStatus()
 }
@@ -150,9 +143,6 @@ func (e *MCPError) MarshalJSON() ([]byte, error) {
 	errorBody := map[string]any{
 		"code":    e.Code,
 		"message": e.message(),
-	}
-	if e.Data != nil {
-		errorBody["data"] = e.Data
 	}
 
 	payload := map[string]any{

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -3,19 +3,21 @@ package oops
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"runtime/debug"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 )
 
 // MCPErrHandle wraps an MCP/JSON-RPC HTTP handler and serializes returned
 // errors as JSON-RPC error responses instead of the generic HTTP error shape.
 func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.Request) error) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mcpCtx := &contextvalues.MCPContext{ID: json.RawMessage("null")}
+		mcpCtx := &contextvalues.MCPContext{ID: mcpjsonrpc.NullID()}
 		r = r.WithContext(contextvalues.SetMCPContext(r.Context(), mcpCtx))
 
 		err := handler(w, r)
@@ -23,29 +25,20 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 			return
 		}
 
-		code := MCPCodeInternalError
-		httpCode := code.HTTPStatus()
-		message := code.Message()
-
-		var se *ShareableError
-		switch {
-		case errors.As(err, &se):
-			code = se.Code.MCPCode()
-			httpCode = se.HTTPStatus()
-			message = se.Error()
-		default:
+		var shareableErr *ShareableError
+		if !errors.As(err, &shareableErr) {
 			stack := string(debug.Stack())
 			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogError(err), attr.SlogErrorStack(stack))
 		}
 
 		mcpID, ok := contextvalues.GetMCPID(r.Context())
 		if !ok {
-			mcpID = json.RawMessage("null")
+			mcpID = mcpjsonrpc.NullID()
 		}
-		payload := mcpErrorPayload(mcpID, code, message)
+		payload := NewMCPErrorFromCause(mcpID, err)
 
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(httpCode)
+		w.WriteHeader(payload.HTTPStatusCode())
 		err = json.NewEncoder(w).Encode(payload)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "failed to encode MCP error response", attr.SlogError(err))
@@ -97,24 +90,90 @@ func (c MCPCode) HTTPStatus() int {
 	}
 }
 
-type mcpErrorResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id,omitempty"`
-	Error   mcpError        `json:"error"`
+type MCPError struct {
+	ID      mcpjsonrpc.ID
+	Code    MCPCode
+	Message string
+	Data    any
+
+	HTTPStatus int
 }
 
-type mcpError struct {
-	Code    MCPCode `json:"code"`
-	Message string  `json:"message"`
-}
+func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
+	var mcpErr *MCPError
+	var shareableErr *ShareableError
 
-func mcpErrorPayload(id json.RawMessage, code MCPCode, message string) mcpErrorResponse {
-	return mcpErrorResponse{
-		JSONRPC: "2.0",
-		ID:      id,
-		Error: mcpError{
-			Code:    code,
-			Message: message,
-		},
+	switch {
+	case errors.As(source, &mcpErr):
+		if !mcpErr.ID.IsSet() {
+			mcpErr.ID = id
+		}
+		return mcpErr
+	case errors.As(source, &shareableErr):
+		return &MCPError{
+			ID:         id,
+			Code:       shareableErr.Code.MCPCode(),
+			Message:    shareableErr.Error(),
+			HTTPStatus: shareableErr.HTTPStatus(),
+		}
+	default:
+		return &MCPError{
+			ID:      id,
+			Code:    MCPCodeInternalError,
+			Message: MCPCodeInternalError.Message(),
+		}
 	}
+}
+
+func (e *MCPError) HTTPStatusCode() int {
+	if e == nil {
+		return MCPCodeInternalError.HTTPStatus()
+	}
+	if e.HTTPStatus != 0 {
+		return e.HTTPStatus
+	}
+	return e.Code.HTTPStatus()
+}
+
+func (e *MCPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d: %s", e.Code, e.message())
+}
+
+func (e *MCPError) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return nil, nil
+	}
+
+	errorBody := map[string]any{
+		"code":    e.Code,
+		"message": e.message(),
+	}
+	if e.Data != nil {
+		errorBody["data"] = e.Data
+	}
+
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"error":   errorBody,
+	}
+	if e.ID.IsSet() {
+		payload["id"] = e.ID
+	}
+
+	bs, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal mcp error: %w", err)
+	}
+
+	return bs, nil
+}
+
+func (e *MCPError) message() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return e.Code.Message()
 }

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -61,13 +61,18 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 type MCPCode int
 
 const (
-	MCPCodeParseError       MCPCode = -32700
-	MCPCodeInvalidRequest   MCPCode = -32600
-	MCPCodeMethodNotFound   MCPCode = -32601
-	MCPCodeInvalidParams    MCPCode = -32602
-	MCPCodeInternalError    MCPCode = -32603
+	MCPCodeParseError     MCPCode = -32700
+	MCPCodeInvalidRequest MCPCode = -32600
+	MCPCodeMethodNotFound MCPCode = -32601
+	MCPCodeInvalidParams  MCPCode = -32602
+	MCPCodeInternalError  MCPCode = -32603
+
+	// Server-defined codes occupy the JSON-RPC 2.0 reserved range -32000 to
+	// -32099 and are used for application-level errors.
 	MCPCodeServerError      MCPCode = -32000
+	MCPCodeUnauthorized     MCPCode = -32001
 	MCPCodeResourceNotFound MCPCode = -32002
+	MCPCodeForbidden        MCPCode = -32003
 )
 
 func (c MCPCode) Message() string {
@@ -82,8 +87,12 @@ func (c MCPCode) Message() string {
 		return "Invalid params"
 	case MCPCodeServerError:
 		return "Server error"
+	case MCPCodeUnauthorized:
+		return "Unauthorized"
 	case MCPCodeResourceNotFound:
 		return "Resource not found"
+	case MCPCodeForbidden:
+		return "Forbidden"
 	default:
 		return "Internal error"
 	}

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -139,9 +139,9 @@ func (e *MCPError) MarshalJSON() ([]byte, error) {
 
 	payload := map[string]any{
 		"jsonrpc": "2.0",
+		"id":      e.ID,
 		"error":   errorBody,
 	}
-	payload["id"] = e.ID
 
 	bs, err := json.Marshal(payload)
 	if err != nil {

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -141,9 +141,7 @@ func (e *MCPError) MarshalJSON() ([]byte, error) {
 		"jsonrpc": "2.0",
 		"error":   errorBody,
 	}
-	if e.ID.IsSet() {
-		payload["id"] = e.ID
-	}
+	payload["id"] = e.ID
 
 	bs, err := json.Marshal(payload)
 	if err != nil {

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -18,7 +18,9 @@ func TestMCPErrHandle_IncludesMCPID(t *testing.T) {
 
 	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
 		rpcCtx, ok := contextvalues.GetRPCContext(r.Context())
-		require.True(t, ok)
+		if !ok {
+			return E(CodeUnexpected, nil, "unexpected error")
+		}
 		rpcCtx.ID = mcpjsonrpc.StringID("req-1")
 		return E(CodeUnauthorized, nil, "unauthorized")
 	})

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -2,11 +2,13 @@ package oops
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +17,7 @@ func TestMCPErrHandle_IncludesMCPID(t *testing.T) {
 	logger, logBuf := captureLogger()
 
 	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
-		contextvalues.SetMCPID(r.Context(), json.RawMessage(`"req-1"`))
+		contextvalues.SetMCPID(r.Context(), mcpjsonrpc.StringID("req-1"))
 		return E(CodeUnauthorized, nil, "unauthorized")
 	})
 
@@ -81,4 +83,66 @@ func TestMCPCode_HTTPStatusAndMessage(t *testing.T) {
 		require.Equal(t, tt.status, tt.code.HTTPStatus())
 		require.Equal(t, tt.message, tt.code.Message())
 	}
+}
+
+func TestMCPError_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	err := &MCPError{
+		ID:      mcpjsonrpc.NumberID(1),
+		Code:    MCPCodeMethodNotFound,
+		Message: "tools/unknown: Method not found",
+		Data:    json.RawMessage(`{"detail":"extra info"}`),
+	}
+
+	data, marshalErr := json.Marshal(err)
+	require.NoError(t, marshalErr)
+
+	var response map[string]any
+	unmarshalErr := json.Unmarshal(data, &response)
+	require.NoError(t, unmarshalErr)
+	require.Equal(t, "2.0", response["jsonrpc"])
+	require.InDelta(t, 1, response["id"], 0)
+
+	errorBody, ok := response["error"].(map[string]any)
+	require.True(t, ok)
+	require.InDelta(t, -32601, errorBody["code"], 0)
+	require.Equal(t, "tools/unknown: Method not found", errorBody["message"])
+	require.NotNil(t, errorBody["data"])
+}
+
+func TestNewMCPErrorFromCause(t *testing.T) {
+	t.Parallel()
+
+	id := mcpjsonrpc.StringID("req-1")
+
+	t.Run("returns_existing_mcp_error", func(t *testing.T) {
+		t.Parallel()
+
+		existing := &MCPError{Code: MCPCodeMethodNotFound, Message: "missing"}
+		err := NewMCPErrorFromCause(id, existing)
+
+		require.Same(t, existing, err)
+		require.Equal(t, id, err.ID)
+	})
+
+	t.Run("maps_shareable_error_code", func(t *testing.T) {
+		t.Parallel()
+
+		err := NewMCPErrorFromCause(id, E(CodeNotFound, nil, "mcp server not found"))
+
+		require.Equal(t, id, err.ID)
+		require.Equal(t, MCPCodeResourceNotFound, err.Code)
+		require.Equal(t, "mcp server not found", err.Message)
+	})
+
+	t.Run("defaults_unknown_error_to_internal", func(t *testing.T) {
+		t.Parallel()
+
+		err := NewMCPErrorFromCause(id, errors.New("boom"))
+
+		require.Equal(t, id, err.ID)
+		require.Equal(t, MCPCodeInternalError, err.Code)
+		require.Equal(t, "Internal error", err.Message)
+	})
 }

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -17,7 +17,9 @@ func TestMCPErrHandle_IncludesMCPID(t *testing.T) {
 	logger, logBuf := captureLogger()
 
 	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
-		contextvalues.SetMCPID(r.Context(), mcpjsonrpc.StringID("req-1"))
+		rpcCtx, ok := contextvalues.GetRPCContext(r.Context())
+		require.True(t, ok)
+		rpcCtx.ID = mcpjsonrpc.StringID("req-1")
 		return E(CodeUnauthorized, nil, "unauthorized")
 	})
 

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -30,7 +30,7 @@ func TestMCPErrHandle_IncludesMCPID(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
 	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 
 	var response map[string]any
@@ -55,7 +55,7 @@ func TestMCPErrHandle_UsesNullMCPIDWhenMissing(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
 
 	var response map[string]any
 	err := json.Unmarshal(rec.Body.Bytes(), &response)

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -65,30 +65,6 @@ func TestMCPErrHandle_UsesNullMCPIDWhenMissing(t *testing.T) {
 	require.Empty(t, logBuf.String())
 }
 
-func TestMCPCode_HTTPStatusAndMessage(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		code    MCPCode
-		status  int
-		message string
-	}{
-		{MCPCodeParseError, http.StatusBadRequest, "Parse error"},
-		{MCPCodeInvalidRequest, http.StatusBadRequest, "Invalid Request"},
-		{MCPCodeMethodNotFound, http.StatusNotFound, "Method not found"},
-		{MCPCodeInvalidParams, http.StatusBadRequest, "Invalid params"},
-		{MCPCodeInternalError, http.StatusInternalServerError, "Internal error"},
-		{MCPCodeServerError, http.StatusInternalServerError, "Server error"},
-		{MCPCodeResourceNotFound, http.StatusNotFound, "Resource not found"},
-		{MCPCode(-1), http.StatusInternalServerError, "Internal error"},
-	}
-
-	for _, tt := range tests {
-		require.Equal(t, tt.status, tt.code.HTTPStatus())
-		require.Equal(t, tt.message, tt.code.Message())
-	}
-}
-
 func TestMCPError_MarshalJSON(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -1,0 +1,84 @@
+package oops
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPErrHandle_IncludesMCPID(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		contextvalues.SetMCPID(r.Context(), json.RawMessage(`"req-1"`))
+		return E(CodeUnauthorized, nil, "unauthorized")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var response map[string]any
+	err := json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Equal(t, "2.0", response["jsonrpc"])
+	require.Equal(t, "req-1", response["id"])
+	require.NotNil(t, response["error"])
+	require.Empty(t, logBuf.String())
+}
+
+func TestMCPErrHandle_UsesNullMCPIDWhenMissing(t *testing.T) {
+	t.Parallel()
+	logger, logBuf := captureLogger()
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		return E(CodeUnauthorized, nil, "unauthorized")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	var response map[string]any
+	err := json.Unmarshal(rec.Body.Bytes(), &response)
+	require.NoError(t, err)
+	require.Contains(t, response, "id")
+	require.Nil(t, response["id"])
+	require.Empty(t, logBuf.String())
+}
+
+func TestMCPCode_HTTPStatusAndMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		code    MCPCode
+		status  int
+		message string
+	}{
+		{MCPCodeParseError, http.StatusBadRequest, "Parse error"},
+		{MCPCodeInvalidRequest, http.StatusBadRequest, "Invalid Request"},
+		{MCPCodeMethodNotFound, http.StatusNotFound, "Method not found"},
+		{MCPCodeInvalidParams, http.StatusBadRequest, "Invalid params"},
+		{MCPCodeInternalError, http.StatusInternalServerError, "Internal error"},
+		{MCPCodeServerError, http.StatusInternalServerError, "Server error"},
+		{MCPCodeResourceNotFound, http.StatusNotFound, "Resource not found"},
+		{MCPCode(-1), http.StatusInternalServerError, "Internal error"},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.status, tt.code.HTTPStatus())
+		require.Equal(t, tt.message, tt.code.Message())
+	}
+}

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -28,7 +28,7 @@ func TestMCPErrHandle_IncludesMCPID(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 
 	var response map[string]any
@@ -53,7 +53,7 @@ func TestMCPErrHandle_UsesNullMCPIDWhenMissing(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 
 	var response map[string]any
 	err := json.Unmarshal(rec.Body.Bytes(), &response)
@@ -94,7 +94,6 @@ func TestMCPError_MarshalJSON(t *testing.T) {
 		ID:      mcpjsonrpc.NumberID(1),
 		Code:    MCPCodeMethodNotFound,
 		Message: "tools/unknown: Method not found",
-		Data:    json.RawMessage(`{"detail":"extra info"}`),
 	}
 
 	data, marshalErr := json.Marshal(err)
@@ -110,7 +109,7 @@ func TestMCPError_MarshalJSON(t *testing.T) {
 	require.True(t, ok)
 	require.InDelta(t, -32601, errorBody["code"], 0)
 	require.Equal(t, "tools/unknown: Method not found", errorBody["message"])
-	require.NotNil(t, errorBody["data"])
+	require.NotContains(t, errorBody, "data")
 }
 
 func TestNewMCPErrorFromCause(t *testing.T) {

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -90,6 +90,44 @@ func TestMCPError_MarshalJSON(t *testing.T) {
 	require.NotContains(t, errorBody, "data")
 }
 
+func TestCodeMCPCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code Code
+		want MCPCode
+	}{
+		{"unauthorized_uses_server_defined_code", CodeUnauthorized, MCPCodeUnauthorized},
+		{"forbidden_uses_server_defined_code", CodeForbidden, MCPCodeForbidden},
+		{"bad_request_is_invalid_request", CodeBadRequest, MCPCodeInvalidRequest},
+		{"conflict_is_invalid_request", CodeConflict, MCPCodeInvalidRequest},
+		{"unsupported_media_is_invalid_request", CodeUnsupportedMedia, MCPCodeInvalidRequest},
+		{"method_not_allowed_is_server_error", CodeMethodNotAllowed, MCPCodeServerError},
+		{"not_found_is_resource_not_found", CodeNotFound, MCPCodeResourceNotFound},
+		{"invalid_is_invalid_params", CodeInvalid, MCPCodeInvalidParams},
+		{"not_implemented_is_method_not_found", CodeNotImplemented, MCPCodeMethodNotFound},
+		{"unexpected_defaults_to_internal", CodeUnexpected, MCPCodeInternalError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, tt.code.MCPCode())
+		})
+	}
+
+	t.Run("auth_codes_are_in_server_defined_range", func(t *testing.T) {
+		t.Parallel()
+
+		for _, c := range []MCPCode{MCPCodeUnauthorized, MCPCodeForbidden} {
+			require.GreaterOrEqual(t, int(c), -32099, "server-defined codes must be >= -32099")
+			require.LessOrEqual(t, int(c), -32000, "server-defined codes must be <= -32000")
+		}
+	})
+}
+
 func TestNewMCPErrorFromCause(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/xmcp/service.go
+++ b/server/internal/xmcp/service.go
@@ -68,7 +68,7 @@ func NewService(
 // for parity with /mcp; the .well-known routes are owned by xmcp directly
 // so they can dispatch per-backend (see [Service.HandleWellKnownOAuthServerMetadata]).
 func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Service) {
-	handler := oops.ErrHandle(service.logger, service.ServeMCP).ServeHTTP
+	handler := oops.MCPErrHandle(service.logger, service.ServeMCP).ServeHTTP
 	o11y.AttachHandler(mux, http.MethodDelete, RuntimePath, handler)
 	o11y.AttachHandler(mux, http.MethodGet, RuntimePath, handler)
 	o11y.AttachHandler(mux, http.MethodPost, RuntimePath, handler)


### PR DESCRIPTION
## Summary

MCP clients expect errors in JSON-RPC 2.0 format, but the `POST /mcp/{mcpSlug}` endpoint was returning generic HTTP error responses. This PR fixes that.

- Adds `mcpjsonrpc` package with an `ID` type that handles JSON-RPC `id` marshaling (number, string, or null)
- Adds `RPCContext` to the context value system to carry the JSON-RPC request ID through the request lifecycle; body reading is moved earlier in `ServeToolsetResolved` (before auth) so the ID is captured even when auth fails
- Adds `MCPErrHandle` in `oops/mcp.go` — a handler wrapper that catches errors and serializes them as proper JSON-RPC 2.0 error objects (`jsonrpc`, `id`, `error.code`, `error.message`) with oops error code → JSON-RPC code mapping and corresponding HTTP statuses
- Switches `POST /mcp/{mcpSlug}` from `ErrHandle` → `MCPErrHandle`

## Tests

- `TestServePublic_AttachedAuthErrorReturnsMCPError` — verifies auth failures return 401 with JSON-RPC error shape and the request `id` echoed back
- `TestServePublic_AttachedNotFoundReturnsMCPErrorWithNullID` — verifies not-found errors return 404 with JSON-RPC error shape and null id when no body was parseable

Resolves [AGE-2147](https://linear.app/speakeasy/issue/AGE-2147/bug-improve-mcp-route-auth-error-response)

<img width="1511" height="963" alt="Screenshot 2026-05-06 at 8 35 00 PM" src="https://github.com/user-attachments/assets/acfd148b-8806-4073-94fc-b02515300704" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->