### PR TITLE
fix(ci): retry transient errors on dev fly app creation

### DIFF
--- a/.mise-tasks/fly/init-runner.mts
+++ b/.mise-tasks/fly/init-runner.mts
@@ -6,7 +6,34 @@
 //USAGE flag "--image <image>" required=#false help="The image repository to use e.g. registry.fly.io/my-app"
 //USAGE flag "--force" default="false" help="Exit with success code if app already exists"
 
-import { $, chalk, fs } from "zx";
+import { $, chalk, fs, sleep } from "zx";
+import type { ProcessOutput } from "zx";
+
+const MAX_ATTEMPTS = 5;
+const BASE_DELAY_MS = 2000;
+const MAX_DELAY_MS = 30000;
+
+const TRANSIENT_PATTERNS = [
+  /non-200 status code: 5\d{2}/i,
+  /context deadline exceeded/i,
+  /i\/o timeout/i,
+  /connection (reset|refused|closed)/i,
+  /unexpected EOF/i,
+  /no such host/i,
+  /TLS handshake/i,
+  /temporarily unavailable/i,
+  /gateway/i,
+  /service unavailable/i,
+];
+
+function isTransient(output: string): boolean {
+  return TRANSIENT_PATTERNS.some((p) => p.test(output));
+}
+
+function backoffMs(attempt: number): number {
+  const exp = Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);
+  return exp + Math.floor(Math.random() * 500);
+}
 
 function yn(val: string | undefined) {
   const y = new Set(["1", "t", "T", "true", "TRUE", "True"]);
@@ -60,7 +87,31 @@ async function main() {
   const [, appName] = parseImageName(image);
 
   console.log(`ℹ️ Creating fly app in ${org}: ${appName}`);
-  const proc = await $`fly apps create --org ${org} ${appName}`.nothrow();
+
+  let proc: ProcessOutput | undefined;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    proc = await $`fly apps create --org ${org} ${appName}`.nothrow();
+    if (proc.exitCode === 0) break;
+
+    const combined = `${proc.stderr}\n${proc.stdout}`;
+    if (combined.includes("Name has already been taken")) break;
+
+    if (attempt < MAX_ATTEMPTS && isTransient(combined)) {
+      const delay = backoffMs(attempt);
+      console.warn(
+        chalk.yellow(
+          `⚠️ Attempt ${attempt}/${MAX_ATTEMPTS} failed with transient error; retrying in ${delay}ms.`,
+        ),
+      );
+      await sleep(delay);
+      continue;
+    }
+
+    break;
+  }
+
+  halt(proc, "fly apps create did not run");
+
   const exists = proc.stderr.includes("Name has already been taken");
   const fail = proc.exitCode !== 0;
   switch (true) {

--- a/.mise-tasks/fly/init-runner.mts
+++ b/.mise-tasks/fly/init-runner.mts
@@ -22,7 +22,8 @@ const TRANSIENT_PATTERNS = [
   /no such host/i,
   /TLS handshake/i,
   /temporarily unavailable/i,
-  /gateway/i,
+  /bad gateway/i,
+  /gateway timeout/i,
   /service unavailable/i,
 ];
 
@@ -89,11 +90,11 @@ async function main() {
   console.log(`ℹ️ Creating fly app in ${org}: ${appName}`);
 
   let proc: ProcessOutput | undefined;
+  let combined = "";
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     proc = await $`fly apps create --org ${org} ${appName}`.nothrow();
+    combined = `${proc.stderr}\n${proc.stdout}`;
     if (proc.exitCode === 0) break;
-
-    const combined = `${proc.stderr}\n${proc.stdout}`;
     if (combined.includes("Name has already been taken")) break;
 
     if (attempt < MAX_ATTEMPTS && isTransient(combined)) {
@@ -112,7 +113,7 @@ async function main() {
 
   halt(proc, "fly apps create did not run");
 
-  const exists = proc.stderr.includes("Name has already been taken");
+  const exists = combined.includes("Name has already been taken");
   const fail = proc.exitCode !== 0;
   switch (true) {
     case fail && exists && yn(process.env["usage_force"]):
@@ -122,7 +123,7 @@ async function main() {
       break;
     case fail:
       console.error("❌ Failed to create fly app:");
-      console.error(proc.stderr);
+      console.error(combined);
       return process.exit(1);
     default:
       console.log(`✅ Fly app ${appName} created in ${org}.`);


### PR DESCRIPTION
## Summary

- The `mise run fly:init-runner` task was failing CI when fly.io's GraphQL API returned a transient `5xx` (e.g. `non-200 status code: 503` on the `organizations` query that `flyctl` performs before `apps create`).
- Wrap `fly apps create` in a bounded retry loop (5 attempts, exponential backoff up to 30s, with jitter) that matches common transient error signatures.
- Existing `Name has already been taken` short-circuit (with `--force`) is preserved — the loop also breaks on that signal so we don't waste retries on it.

Closes [AGE-2144](https://linear.app/speakeasy/issue/AGE-2144/bug-add-retries-for-dev-fly-oci-app-creation)

✻ Clauded...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->