### PR TITLE
fix: return proper response shape from stop hook

### DIFF
--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -138,3 +138,48 @@ func TestClaude_PreToolUse_AllowsWhenNoAuthAndNoCachedMetadata(t *testing.T) {
 	assert.Equal(t, "allow", *output.PermissionDecision,
 		"OTEL path with no metadata should default to allow so first call isn't blocked")
 }
+
+// Claude Code's hook output schema only permits hookSpecificOutput for
+// PreToolUse, PostToolUse, UserPromptSubmit, and PostToolBatch — and even
+// those variants need their own required fields. For Stop, SessionStart,
+// SessionEnd, Notification, and PostToolUseFailure, including any
+// hookSpecificOutput object causes Claude Code to reject the response with
+// "Hook JSON output validation failed — (root): Invalid input", which the
+// user sees as a Stop hook error. Make sure makeHookResult omits it for those.
+func TestClaude_OmitsHookSpecificOutputForNonPreToolUseEvents(t *testing.T) {
+	t.Parallel()
+	_, ti := newTestHooksService(t)
+
+	sessionID := uuid.NewString()
+	for _, event := range []string{"Stop", "SessionEnd", "Notification", "PostToolUse", "PostToolUseFailure", "UserPromptSubmit"} {
+		t.Run(event, func(t *testing.T) {
+			t.Parallel()
+			result, err := ti.service.Claude(t.Context(), &gen.ClaudePayload{
+				HookEventName: event,
+				SessionID:     &sessionID,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Nil(t, result.HookSpecificOutput,
+				"%s response must not include hookSpecificOutput — Claude Code rejects unknown variants", event)
+		})
+	}
+}
+
+// SessionStart is the one non-PreToolUse event that has a meaningful response
+// shape (Continue), but it still must NOT carry hookSpecificOutput.
+func TestClaude_SessionStart_OmitsHookSpecificOutput(t *testing.T) {
+	t.Parallel()
+	_, ti := newTestHooksService(t)
+
+	sessionID := uuid.NewString()
+	result, err := ti.service.Claude(t.Context(), &gen.ClaudePayload{
+		HookEventName: "SessionStart",
+		SessionID:     &sessionID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Nil(t, result.HookSpecificOutput)
+	require.NotNil(t, result.Continue)
+	assert.True(t, *result.Continue, "SessionStart should always allow the session to continue")
+}

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -64,20 +64,27 @@ func sessionIDToUUID(sessionID string) uuid.UUID {
 	return uuid.NewSHA1(claudeSessionNamespace, []byte(sessionID))
 }
 
-// makeHookResult creates a ClaudeHookResult with the HookSpecificOutput populated.
+// makeHookResult creates a ClaudeHookResult, attaching HookSpecificOutput only
+// for hook events whose Claude Code response schema permits it. Stop, SessionStart,
+// SessionEnd, Notification, and PostToolUseFailure must NOT carry hookSpecificOutput
+// — Claude Code rejects unknown variants with "Hook JSON output validation failed".
 func makeHookResult(hookEventName string) *gen.ClaudeHookResult {
-	return &gen.ClaudeHookResult{
-		HookSpecificOutput: &HookSpecificOutput{
+	result := &gen.ClaudeHookResult{
+		HookSpecificOutput: nil,
+		Continue:           nil,
+		StopReason:         nil,
+		SuppressOutput:     nil,
+		SystemMessage:      nil,
+	}
+	if hookEventName == "PreToolUse" {
+		result.HookSpecificOutput = &HookSpecificOutput{
 			HookEventName:            &hookEventName,
 			AdditionalContext:        nil,
 			PermissionDecision:       nil,
 			PermissionDecisionReason: nil,
-		},
-		Continue:       nil,
-		StopReason:     nil,
-		SuppressOutput: nil,
-		SystemMessage:  nil,
+		}
 	}
+	return result
 }
 
 // handleUserPromptSubmit captures the user's prompt text as a chat message.

--- a/server/internal/productfeatures/setup_test.go
+++ b/server/internal/productfeatures/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -70,6 +72,20 @@ func newTestProductFeaturesService(t *testing.T) (context.Context, *testInstance
 	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, guardianPolicy, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
+
+	// The mock IDP returns the same organization for every test, so parallel
+	// subtests would otherwise share the cache key feature:<orgID>:<feature>
+	// in the shared redis db. One test enabling and another disabling the
+	// same feature races on that key and produces flaky failures (e.g.
+	// "returns true for enabled feature" reading a `false` written by
+	// "returns false after feature is disabled"). Override the org ID with
+	// a fresh UUID per test so cache keys are unique. organization_features
+	// has no FK on organization_id, and ShouldEnforce skips RBAC for the
+	// non-enterprise account type used in tests, so this needs no extra setup.
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok, "auth context not found")
+	authCtx.ActiveOrganizationID = uuid.NewString()
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)


### PR DESCRIPTION
Claude only expects the hook name in the response for the various tool use hooks, resulting in this error from the stop hook

<img width="1772" height="1392" alt="CleanShot 2026-05-06 at 17 06 58@2x" src="https://github.com/user-attachments/assets/5f5e3f6c-dcc2-4539-81b7-d388a86da0b4" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->