### PR TITLE
chore: extract Speakeasy IDP client

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -37,6 +37,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
@@ -489,6 +490,17 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to create billing provider: %w", err)
 			}
 
+			speakeasyIDPClient := speakeasyclient.NewClient(
+				logger,
+				tracerProvider,
+				guardianPolicy,
+				c.String("speakeasy-server-address"),
+				c.String("speakeasy-secret-key"),
+				db,
+				conv.Ternary(workosAvailable, workosClient, nil),
+				posthogClient,
+			)
+
 			sessionManager := sessions.NewManager(
 				logger,
 				tracerProvider,
@@ -502,6 +514,7 @@ func newStartCommand() *cli.Command {
 				posthogClient,
 				billingRepo,
 				conv.Ternary(workosAvailable, workosClient, nil),
+				speakeasyIDPClient,
 			)
 
 			chatSessionsManager := chatsessions.NewManager(logger, redisClient, c.String("jwt-signing-key"))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
@@ -529,7 +530,8 @@ func newWorkerCommand() *cli.Command {
 				return fmt.Errorf("failed to create pylon client: %w", err)
 			}
 
-			sessionManager := sessions.NewManager(logger, tracerProvider, guardianPolicy, db, redisClient, cache.SuffixNone, c.String("speakeasy-server-address"), c.String("speakeasy-secret-key"), pylonClient, posthogClient, billingRepo, nil)
+			speakeasyIDPClient := speakeasyclient.NewClient(logger, tracerProvider, guardianPolicy, c.String("speakeasy-server-address"), c.String("speakeasy-secret-key"), db, nil, posthogClient)
+			sessionManager := sessions.NewManager(logger, tracerProvider, guardianPolicy, db, redisClient, cache.SuffixNone, c.String("speakeasy-server-address"), c.String("speakeasy-secret-key"), pylonClient, posthogClient, billingRepo, nil, speakeasyIDPClient)
 
 			chatSessionsManager := chatsessions.NewManager(logger, redisClient, c.String("jwt-signing-key"))
 

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -1,3 +1,16 @@
+// DEPRECATED: this package backs Gram's chat-session authentication path
+// (cookie-based, Speakeasy-IDP-mediated). It is being replaced by the
+// user-session JWT path under `server/internal/usersessions/` (per spike §4.5
+// / RFC "Remote OAuth Clients for Private Repos"). New work belongs in the
+// user-sessions package; do NOT extend this manager.
+//
+// The shared post-IDP user bootstrap (UpsertUser, posthog signup event,
+// WorkOS membership sync) lives in `auth/speakeasyclient` so both this
+// package and the user-session AS path get identical baseline treatment for
+// authenticated users — required for downstream RBAC. This Manager retains
+// only chat-session-specific concerns (sessionCache, userInfoCache, pylon,
+// admin-override, nonFreeOrganizations).
+
 package sessions
 
 import (
@@ -11,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -38,6 +52,11 @@ type Manager struct {
 	posthog                *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
 	billingRepo            billing.Repository
 	workos                 *workos.Client
+	// speakeasyClientFacade owns shared post-IDP bootstrap (UpsertUser,
+	// posthog signup, WorkOS sync) and the validate wire call. Refactor
+	// target: have it own all four IDP wire calls so the manager-side raw
+	// fields above can be removed entirely. See auth/speakeasyclient.
+	speakeasyClientFacade *speakeasyclient.Client
 }
 
 func NewManager(
@@ -53,6 +72,7 @@ func NewManager(
 	posthog *posthog.Posthog,
 	billingRepo billing.Repository,
 	workos *workos.Client,
+	speakeasyClientFacade *speakeasyclient.Client,
 ) *Manager {
 	logger = logger.With(attr.SlogComponent("sessions"))
 	speakeasyClient := guardianPolicy.PooledClient()
@@ -72,6 +92,7 @@ func NewManager(
 		posthog:                posthog,
 		billingRepo:            billingRepo,
 		workos:                 workos,
+		speakeasyClientFacade:  speakeasyClientFacade,
 	}
 }
 

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -1,16 +1,3 @@
-// DEPRECATED: this package backs Gram's chat-session authentication path
-// (cookie-based, Speakeasy-IDP-mediated). It is being replaced by the
-// user-session JWT path under `server/internal/usersessions/` (per spike §4.5
-// / RFC "Remote OAuth Clients for Private Repos"). New work belongs in the
-// user-sessions package; do NOT extend this manager.
-//
-// The shared post-IDP user bootstrap (UpsertUser, posthog signup event,
-// WorkOS membership sync) lives in `auth/speakeasyclient` so both this
-// package and the user-session AS path get identical baseline treatment for
-// authenticated users — required for downstream RBAC. This Manager retains
-// only chat-session-specific concerns (sessionCache, userInfoCache, pylon,
-// admin-override, nonFreeOrganizations).
-
 package sessions
 
 import (
@@ -45,18 +32,14 @@ type Manager struct {
 	userInfoCache          cache.TypedCacheObject[CachedUserInfo]
 	speakeasyServerAddress string
 	speakeasySecretKey     string
-	speakeasyClient        *guardian.HTTPClient
+	httpClient             *guardian.HTTPClient
 	orgRepo                *orgRepo.Queries
 	userRepo               *userRepo.Queries
 	pylon                  *pylon.Pylon
 	posthog                *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
 	billingRepo            billing.Repository
 	workos                 *workos.Client
-	// speakeasyClientFacade owns shared post-IDP bootstrap (UpsertUser,
-	// posthog signup, WorkOS sync) and the validate wire call. Refactor
-	// target: have it own all four IDP wire calls so the manager-side raw
-	// fields above can be removed entirely. See auth/speakeasyclient.
-	speakeasyClientFacade *speakeasyclient.Client
+	speakeasyClient        *speakeasyclient.Client
 }
 
 func NewManager(
@@ -72,11 +55,11 @@ func NewManager(
 	posthog *posthog.Posthog,
 	billingRepo billing.Repository,
 	workos *workos.Client,
-	speakeasyClientFacade *speakeasyclient.Client,
+	speakeasyClient *speakeasyclient.Client,
 ) *Manager {
 	logger = logger.With(attr.SlogComponent("sessions"))
-	speakeasyClient := guardianPolicy.PooledClient()
-	speakeasyClient.Timeout = 10 * time.Second
+	httpClient := guardianPolicy.PooledClient()
+	httpClient.Timeout = 10 * time.Second
 
 	return &Manager{
 		logger:                 logger.With(attr.SlogComponent("sessions")),
@@ -85,14 +68,14 @@ func NewManager(
 		userInfoCache:          cache.NewTypedObjectCache[CachedUserInfo](logger.With(attr.SlogCacheNamespace("user_info")), cache.NewRedisCacheAdapter(redisClient), cache.SuffixNone),
 		speakeasyServerAddress: speakeasyServerAddress,
 		speakeasySecretKey:     speakeasySecretKey,
-		speakeasyClient:        speakeasyClient,
+		httpClient:             httpClient,
 		orgRepo:                orgRepo.New(db),
 		userRepo:               userRepo.New(db),
 		pylon:                  pylon,
 		posthog:                posthog,
 		billingRepo:            billingRepo,
 		workos:                 workos,
-		speakeasyClientFacade:  speakeasyClientFacade,
+		speakeasyClient:        speakeasyClient,
 	}
 }
 

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -77,7 +77,7 @@ func (s *Manager) ExchangeTokenFromSpeakeasy(ctx context.Context, code string) (
 	req.Header.Set("Accept", "application/json")
 
 	// Send the request
-	resp, err := s.speakeasyClient.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to perform token exchange: %w", err)
 	}
@@ -120,7 +120,7 @@ func (s *Manager) RevokeTokenFromSpeakeasy(ctx context.Context, idToken string) 
 	req.Header.Set("speakeasy-auth-provider-id-token", idToken)
 
 	// Send the request
-	resp, err := s.speakeasyClient.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to perform token revocation: %w", err)
 	}
@@ -151,12 +151,12 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 	// (UpsertUser, posthog signup event, WorkOS membership sync) via the
 	// shared client. Side effects identical to the prior inline implementation;
 	// the user-session AS path runs the same pair of calls.
-	validated, err := s.speakeasyClientFacade.ValidateIDToken(ctx, idToken)
+	validated, err := s.speakeasyClient.ValidateIDToken(ctx, idToken)
 	if err != nil {
 		return nil, fmt.Errorf("validate id token: %w", err)
 	}
 
-	user, err := s.speakeasyClientFacade.BootstrapUser(ctx, validated)
+	user, err := s.speakeasyClient.BootstrapUser(ctx, validated)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap user: %w", err)
 	}
@@ -251,7 +251,7 @@ func (s *Manager) CreateOrgFromSpeakeasy(ctx context.Context, idToken string, or
 	req.Header.Set("speakeasy-auth-provider-id-token", idToken)
 	req.Header.Set("speakeasy-auth-provider-key", s.speakeasySecretKey)
 
-	resp, err := s.speakeasyClient.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to make request", attr.SlogError(err))
 		return nil, fmt.Errorf("failed to make request: %w", err)

--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -11,9 +11,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/conv"
-	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
-	userRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"go.opentelemetry.io/otel/codes"
 )
 
@@ -150,67 +147,31 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 		span.End()
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", s.speakeasyServerAddress+"/v1/speakeasy_provider/validate", nil)
+	// Validate the IDP id token + run the shared post-IDP user bootstrap
+	// (UpsertUser, posthog signup event, WorkOS membership sync) via the
+	// shared client. Side effects identical to the prior inline implementation;
+	// the user-session AS path runs the same pair of calls.
+	validated, err := s.speakeasyClientFacade.ValidateIDToken(ctx, idToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("validate id token: %w", err)
 	}
 
-	req.Header.Set("speakeasy-auth-provider-id-token", idToken)
-	req.Header.Set("speakeasy-auth-provider-key", s.speakeasySecretKey)
-
-	resp, err := s.speakeasyClient.Do(req)
+	user, err := s.speakeasyClientFacade.BootstrapUser(ctx, validated)
 	if err != nil {
-		s.logger.ErrorContext(context.Background(), "failed to make request", attr.SlogError(err))
-		return nil, fmt.Errorf("failed to make request: %w", err)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			s.logger.ErrorContext(context.Background(), "failed to close response body", attr.SlogError(err))
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("bootstrap user: %w", err)
 	}
 
-	var validateResp validateTokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&validateResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	user, err := s.userRepo.UpsertUser(ctx, userRepo.UpsertUserParams{
-		ID:          validateResp.User.ID,
-		Email:       validateResp.User.Email,
-		DisplayName: validateResp.User.DisplayName,
-		PhotoUrl:    conv.PtrToPGText(validateResp.User.PhotoURL),
-		Admin:       validateResp.User.Admin,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to upsert user: %w", err)
-	}
-
-	// Check if user was created in this upsert
-	if user.WasCreated {
-		if err := s.posthog.CaptureEvent(ctx, "is_first_time_user_signup", user.Email, map[string]any{
-			"email":        user.Email,
-			"display_name": user.DisplayName,
-		}); err != nil {
-			s.logger.ErrorContext(ctx, "failed to capture is_first_time_user_signup event", attr.SlogError(err))
-		}
-	}
-
-	if err := s.syncWorkOSMemberships(ctx, user, validateResp); err != nil {
-		return nil, fmt.Errorf("sync workos memberships: %w", err)
-	}
-
+	// Chat-session-specific shaping: admin override, non-free org filtering,
+	// pylon signing, then assemble CachedUserInfo. None of this belongs in the
+	// shared client — it's all chat-session-flavored.
 	var adminOverride string
-	if override, _ := contextvalues.GetAdminOverrideFromContext(ctx); override != "" && validateResp.User.Admin {
+	if override, _ := contextvalues.GetAdminOverrideFromContext(ctx); override != "" && validated.Admin {
 		adminOverride = override
 	}
 
-	organizations := make([]Organization, len(validateResp.Organizations))
+	organizations := make([]Organization, len(validated.Organizations))
 	var nonFreeOrganizations []Organization
-	for i, org := range validateResp.Organizations {
+	for i, org := range validated.Organizations {
 		o := Organization{
 			ID:                 org.ID,
 			Name:               org.Name,
@@ -226,7 +187,7 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 		}
 	}
 
-	whitelisted := validateResp.User.Whitelisted
+	whitelisted := validated.Whitelisted
 
 	// If applicable we will only utilize non-free organizations, plus an applied admin override
 	if len(nonFreeOrganizations) > 0 {
@@ -238,19 +199,19 @@ func (s *Manager) GetUserInfoFromSpeakeasy(ctx context.Context, idToken string) 
 	}
 
 	var userPylonSignature *string
-	if pylonSignature, err := s.pylon.Sign(validateResp.User.Email); err != nil {
+	if pylonSignature, err := s.pylon.Sign(validated.Email); err != nil {
 		s.logger.ErrorContext(ctx, "error signing user email", attr.SlogError(err))
 	} else if pylonSignature != "" {
 		userPylonSignature = &pylonSignature
 	}
 
 	return &CachedUserInfo{
-		UserID:             validateResp.User.ID,
+		UserID:             validated.UserID,
 		UserWhitelisted:    whitelisted,
-		Email:              validateResp.User.Email,
-		Admin:              validateResp.User.Admin,
-		DisplayName:        &validateResp.User.DisplayName,
-		PhotoURL:           validateResp.User.PhotoURL,
+		Email:              validated.Email,
+		Admin:              validated.Admin,
+		DisplayName:        &validated.DisplayName,
+		PhotoURL:           validated.PhotoURL,
 		UserPylonSignature: userPylonSignature,
 		Organizations:      organizations,
 	}, nil
@@ -396,64 +357,7 @@ func (p *Manager) BuildAuthorizationURL(ctx context.Context, params AuthURLParam
 	return authURL, nil
 }
 
-// syncWorkOSMemberships reconciles the user's WorkOS identity and membership
-// records against what WorkOS currently reports. Organization metadata upserts
-// are the caller's responsibility and happen at login/switch-scope sites where
-// the active org is known. Failures here are best-effort and logged — they
-// don't block authentication because WorkOS membership data is only used for
-// RBAC features that degrade gracefully without it.
-func (s *Manager) syncWorkOSMemberships(ctx context.Context, user userRepo.UpsertUserRow, validateResp validateTokenResponse) error {
-	if s.workos == nil {
-		return nil
-	}
-
-	var workosUserID string
-
-	if user.WorkosID.Valid && user.WorkosID.String != "" {
-		// Already have the user's WorkOS ID — skip the API lookup
-		workosUserID = user.WorkosID.String
-	} else {
-		workosUser, err := s.workos.GetUserByEmail(ctx, user.Email)
-		if err != nil {
-			s.logger.ErrorContext(ctx, "failed to get workos user by email", attr.SlogError(err))
-			return nil
-		}
-		if workosUser == nil {
-			return nil
-		}
-
-		workosUserID = workosUser.ID
-
-		if err := s.userRepo.SetUserWorkosID(ctx, userRepo.SetUserWorkosIDParams{
-			ID:       user.ID,
-			WorkosID: conv.ToPGText(workosUserID),
-		}); err != nil {
-			s.logger.ErrorContext(ctx, "failed to set user workos ID", attr.SlogError(err))
-		}
-	}
-
-	// Load current org membership state directly from WorkOS so we can populate
-	// the workos membership ID in the org membership records
-	memberships, err := s.workos.ListUserMemberships(ctx, workosUserID)
-	if err != nil {
-		s.logger.ErrorContext(ctx, "failed to list workos user memberships", attr.SlogError(err))
-		return nil
-	}
-
-	workosOrgIDs := make([]string, len(memberships))
-	membershipIDs := make([]string, len(memberships))
-	for i, m := range memberships {
-		workosOrgIDs[i] = m.OrganizationID
-		membershipIDs[i] = m.ID
-	}
-
-	if err := s.orgRepo.SetUserWorkOSMemberships(ctx, orgRepo.SetUserWorkOSMembershipsParams{
-		UserID:              validateResp.User.ID,
-		WorkosOrgIds:        workosOrgIDs,
-		WorkosMembershipIds: membershipIDs,
-	}); err != nil {
-		s.logger.ErrorContext(ctx, "failed to set user workos memberships", attr.SlogError(err))
-	}
-
-	return nil
-}
+// syncWorkOSMemberships moved to auth/speakeasyclient.Client.BootstrapUser as
+// part of the shared post-IDP user bootstrap. Both this manager (via
+// GetUserInfoFromSpeakeasy) and the user-session AS path reach it through the
+// same client.

--- a/server/internal/auth/sessions/speakeasyconnections_test.go
+++ b/server/internal/auth/sessions/speakeasyconnections_test.go
@@ -18,6 +18,7 @@ import (
 
 	mockidp "github.com/speakeasy-api/gram/dev-idp/pkg/testidp"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -176,6 +177,17 @@ func newManagerWithFakeWorkOSConfig(t *testing.T, fake *fakeWorkOSServer, idpCfg
 	fakePosthog := posthog.New(context.Background(), logger, "test-key", "test-host", "")
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
+	speakeasyIDPClient := speakeasyclient.NewClient(
+		logger,
+		tracerProvider,
+		guardianPolicy,
+		idpSrv.URL,
+		mockidp.MockSecretKey,
+		conn,
+		workosClient,
+		fakePosthog,
+	)
+
 	mgr := sessions.NewManager(
 		logger,
 		tracerProvider,
@@ -189,6 +201,7 @@ func newManagerWithFakeWorkOSConfig(t *testing.T, fake *fakeWorkOSServer, idpCfg
 		fakePosthog,
 		billingClient,
 		workosClient,
+		speakeasyIDPClient,
 	)
 
 	// Seed org metadata with workos_id set so the CTE can resolve WorkOS org
@@ -478,6 +491,16 @@ func TestSyncWorkOSIDs_NilWorkOSClient(t *testing.T) {
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
 	// workos = nil simulates OSS mode with no WorkOS configured.
+	speakeasyIDPClient := speakeasyclient.NewClient(
+		logger,
+		tracerProvider,
+		guardianPolicy,
+		idpSrv.URL,
+		mockidp.MockSecretKey,
+		conn,
+		nil,
+		fakePosthog,
+	)
 	mgr := sessions.NewManager(
 		logger,
 		tracerProvider,
@@ -491,6 +514,7 @@ func TestSyncWorkOSIDs_NilWorkOSClient(t *testing.T) {
 		fakePosthog,
 		billingClient,
 		nil,
+		speakeasyIDPClient,
 	)
 
 	ctx := t.Context()

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -302,7 +303,8 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient, nil)
+	speakeasyIDPClient := speakeasyclient.NewClient(logger, testenv.NewTracerProvider(t), guardianPolicy, mockServer.URL, "test-secret-key", conn, nil, posthog)
+	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient, nil, speakeasyIDPClient)
 
 	authConfigs := auth.AuthConfigurations{
 		SpeakeasyServerAddress: mockServer.URL,
@@ -342,7 +344,8 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 
 	billingClient := billing.NewStubClient(logger, tracerProvider)
 
-	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient, nil)
+	speakeasyIDPClient := speakeasyclient.NewClient(logger, testenv.NewTracerProvider(t), guardianPolicy, mockServer.URL, "test-secret-key", conn, nil, posthog)
+	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), guardianPolicy, conn, redisClient, cache.Suffix("gram-test"), mockServer.URL, "test-secret-key", pylon, posthog, billingClient, nil, speakeasyIDPClient)
 
 	authConfigs := auth.AuthConfigurations{
 		SpeakeasyServerAddress: mockServer.URL,

--- a/server/internal/auth/speakeasyclient/client.go
+++ b/server/internal/auth/speakeasyclient/client.go
@@ -1,0 +1,353 @@
+// Package speakeasyclient is a thin HTTP client for the Speakeasy auth
+// provider's IDP wire endpoints (`/v1/speakeasy_provider/{exchange,validate}`)
+// plus the post-IDP user-bootstrap side effects every Speakeasy-authenticated
+// caller should run.
+//
+// It exists SPECIFICALLY AND EXCLUSIVELY to support exchanging tokens with
+// the Speakeasy auth provider in Gram's auth flows. It is NOT a general-
+// purpose IDP integration and should be removed when we replace it with an
+// improved direct OIDC connection.
+//
+// Both `auth/sessions` (chat-session manager) and `mcp/authnchallenge.go`
+// (user-session AS path) depend on this client. Centralising the
+// bootstrap side effects (UpsertUser, posthog "first-time user" signup
+// event, WorkOS membership sync) here means a non-dashboard MCP-only user
+// gets the same baseline treatment as a dashboard user — required for
+// downstream RBAC to work.
+//
+// The chat-session manager keeps its own concerns (sessionCache, userInfoCache,
+// pylon signing, admin-override resolution, non-free org filtering); the
+// user-session path neither needs nor wants those.
+package speakeasyclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	userRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+// Client wraps the IDP wire endpoints and the post-authentication user
+// bootstrap. Constructed once at server boot and shared across goroutines.
+type Client struct {
+	logger        *slog.Logger
+	tracer        trace.Tracer
+	serverAddress string
+	secretKey     string
+	httpClient    *guardian.HTTPClient
+
+	// Bootstrap dependencies — invoked when a user authenticates via the IDP.
+	db      *pgxpool.Pool
+	workos  *workos.Client   // nullable; nil disables WorkOS sync
+	posthog *posthog.Posthog // nullable; nil disables signup events
+}
+
+// NewClient builds the IDP client. The HTTP client is mediated by the
+// supplied Guardian policy with a 10-second timeout — same shape as the
+// chat-session manager used to use, so retry / timeout behaviour stays
+// consistent across both consumers.
+func NewClient(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	guardianPolicy *guardian.Policy,
+	serverAddress string,
+	secretKey string,
+	db *pgxpool.Pool,
+	workos *workos.Client,
+	posthog *posthog.Posthog,
+) *Client {
+	httpClient := guardianPolicy.PooledClient()
+	httpClient.Timeout = 10 * time.Second
+
+	return &Client{
+		logger:        logger.With(attr.SlogComponent("speakeasyclient")),
+		tracer:        tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"),
+		serverAddress: serverAddress,
+		secretKey:     secretKey,
+		httpClient:    httpClient,
+		db:            db,
+		workos:        workos,
+		posthog:       posthog,
+	}
+}
+
+// ValidatedToken is the response shape of the IDP `/validate` endpoint, in
+// the public form callers consume.
+type ValidatedToken struct {
+	UserID        string
+	Email         string
+	DisplayName   string
+	PhotoURL      *string
+	Admin         bool
+	Whitelisted   bool
+	Organizations []ValidatedOrganization
+}
+
+// ValidatedOrganization is one organization record in the IDP /validate
+// response.
+type ValidatedOrganization struct {
+	ID                 string
+	Name               string
+	Slug               string
+	AccountType        string
+	WorkOSID           *string
+	UserWorkspaceSlugs []string
+}
+
+// internal wire shape — the public ValidatedToken is the stable contract.
+type validateResponse struct {
+	User struct {
+		ID          string  `json:"id"`
+		Email       string  `json:"email"`
+		DisplayName string  `json:"display_name"`
+		PhotoURL    *string `json:"photo_url"`
+		Admin       bool    `json:"admin"`
+		Whitelisted bool    `json:"whitelisted"`
+	} `json:"user"`
+	Organizations []struct {
+		ID                 string   `json:"id"`
+		Name               string   `json:"name"`
+		Slug               string   `json:"slug"`
+		AccountType        string   `json:"account_type"`
+		WorkOSID           *string  `json:"workos_id,omitempty"`   //nolint:tagliatelle // workos_id is the canonical key on the wire.
+		UserWorkspaceSlugs []string `json:"user_workspaces_slugs"` //nolint:tagliatelle // user_workspaces_slugs is the canonical key on the wire.
+	} `json:"organizations"`
+}
+
+// ExchangeCode trades a Speakeasy IDP authorization code for an `id_token`.
+// Pure HTTP — no persistence, no telemetry beyond the span.
+func (c *Client) ExchangeCode(ctx context.Context, code string) (idToken string, err error) {
+	ctx, span := c.tracer.Start(ctx, "speakeasyclient.exchangeCode")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	body, err := json.Marshal(struct {
+		Code string `json:"code"`
+	}{Code: code})
+	if err != nil {
+		return "", fmt.Errorf("marshal exchange request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.serverAddress+"/v1/speakeasy_provider/exchange", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create exchange request: %w", err)
+	}
+	c.authHeaders(req, "")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("perform exchange request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("exchange failed with status %s", resp.Status)
+	}
+
+	var out struct {
+		IDToken string `json:"id_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("decode exchange response: %w", err)
+	}
+	return out.IDToken, nil
+}
+
+// ValidateIDToken verifies an `id_token` against the Speakeasy IDP and
+// returns the user + organizations payload. Pure HTTP — does NOT persist
+// anything, populate any cache, or trigger any other side effect. Callers
+// that want bootstrap side effects should call BootstrapUser separately.
+func (c *Client) ValidateIDToken(ctx context.Context, idToken string) (token *ValidatedToken, err error) {
+	ctx, span := c.tracer.Start(ctx, "speakeasyclient.validateIDToken")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.serverAddress+"/v1/speakeasy_provider/validate", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create validate request: %w", err)
+	}
+	c.authHeaders(req, idToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("perform validate request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("validate failed with status %s", resp.Status)
+	}
+
+	var raw validateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode validate response: %w", err)
+	}
+
+	orgs := make([]ValidatedOrganization, len(raw.Organizations))
+	for i, o := range raw.Organizations {
+		orgs[i] = ValidatedOrganization{
+			ID:                 o.ID,
+			Name:               o.Name,
+			Slug:               o.Slug,
+			AccountType:        o.AccountType,
+			WorkOSID:           o.WorkOSID,
+			UserWorkspaceSlugs: o.UserWorkspaceSlugs,
+		}
+	}
+
+	return &ValidatedToken{
+		UserID:        raw.User.ID,
+		Email:         raw.User.Email,
+		DisplayName:   raw.User.DisplayName,
+		PhotoURL:      raw.User.PhotoURL,
+		Admin:         raw.User.Admin,
+		Whitelisted:   raw.User.Whitelisted,
+		Organizations: orgs,
+	}, nil
+}
+
+// BootstrapUser runs the post-IDP user-bootstrap side effects every
+// Speakeasy-authenticated caller should run, in order:
+//
+//  1. UpsertUser — persist a Gram user row keyed on the Speakeasy user id.
+//     Required so we have a stable Gram user_id to put on URNs and audit logs.
+//  2. Posthog "is_first_time_user_signup" event — only fires when the upsert
+//     creates a fresh row. No-ops if posthog is nil.
+//  3. WorkOS membership sync — reconciles the user's WorkOS identity and
+//     organization-membership records. Best-effort; errors are logged and
+//     swallowed (RBAC features degrade gracefully without WorkOS data).
+//     No-ops if workos is nil.
+//
+// Returns the upserted user row so callers don't need to re-query.
+func (c *Client) BootstrapUser(ctx context.Context, token *ValidatedToken) (row userRepo.UpsertUserRow, err error) {
+	ctx, span := c.tracer.Start(ctx, "speakeasyclient.bootstrapUser")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	row, err = userRepo.New(c.db).UpsertUser(ctx, userRepo.UpsertUserParams{
+		ID:          token.UserID,
+		Email:       token.Email,
+		DisplayName: token.DisplayName,
+		PhotoUrl:    conv.PtrToPGText(token.PhotoURL),
+		Admin:       token.Admin,
+	})
+	if err != nil {
+		return userRepo.UpsertUserRow{}, fmt.Errorf("upsert user: %w", err)
+	}
+
+	if row.WasCreated && c.posthog != nil {
+		if err := c.posthog.CaptureEvent(ctx, "is_first_time_user_signup", row.Email, map[string]any{
+			"email":        row.Email,
+			"display_name": row.DisplayName,
+		}); err != nil {
+			c.logger.ErrorContext(ctx, "failed to capture is_first_time_user_signup event", attr.SlogError(err))
+		}
+	}
+
+	if err := c.syncWorkOSMemberships(ctx, row); err != nil {
+		// Per legacy contract: WorkOS sync errors are logged inside the helper
+		// and don't propagate. We only land here on a logic bug in the helper.
+		c.logger.ErrorContext(ctx, "workos membership sync returned error", attr.SlogError(err))
+	}
+
+	return row, nil
+}
+
+// syncWorkOSMemberships reconciles the user's WorkOS identity and membership
+// records against what WorkOS currently reports. Best-effort: failures are
+// logged and swallowed because WorkOS data only feeds RBAC features that
+// degrade gracefully without it. Mirrors the prior implementation in
+// auth/sessions/speakeasyconnections.go.
+func (c *Client) syncWorkOSMemberships(ctx context.Context, user userRepo.UpsertUserRow) error {
+	if c.workos == nil {
+		return nil
+	}
+
+	repos := userRepo.New(c.db)
+	orgs := orgRepo.New(c.db)
+
+	var workosUserID string
+
+	if user.WorkosID.Valid && user.WorkosID.String != "" {
+		workosUserID = user.WorkosID.String
+	} else {
+		workosUser, err := c.workos.GetUserByEmail(ctx, user.Email)
+		if err != nil {
+			c.logger.ErrorContext(ctx, "failed to get workos user by email", attr.SlogError(err))
+			return nil
+		}
+		if workosUser == nil {
+			return nil
+		}
+
+		workosUserID = workosUser.ID
+
+		if err := repos.SetUserWorkosID(ctx, userRepo.SetUserWorkosIDParams{
+			ID:       user.ID,
+			WorkosID: conv.ToPGText(workosUserID),
+		}); err != nil {
+			c.logger.ErrorContext(ctx, "failed to set user workos ID", attr.SlogError(err))
+		}
+	}
+
+	memberships, err := c.workos.ListUserMemberships(ctx, workosUserID)
+	if err != nil {
+		c.logger.ErrorContext(ctx, "failed to list workos user memberships", attr.SlogError(err))
+		return nil
+	}
+
+	workosOrgIDs := make([]string, len(memberships))
+	membershipIDs := make([]string, len(memberships))
+	for i, m := range memberships {
+		workosOrgIDs[i] = m.OrganizationID
+		membershipIDs[i] = m.ID
+	}
+
+	if err := orgs.SetUserWorkOSMemberships(ctx, orgRepo.SetUserWorkOSMembershipsParams{
+		UserID:              user.ID,
+		WorkosOrgIds:        workosOrgIDs,
+		WorkosMembershipIds: membershipIDs,
+	}); err != nil {
+		c.logger.ErrorContext(ctx, "failed to set user workos memberships", attr.SlogError(err))
+	}
+
+	return nil
+}
+
+// authHeaders sets the shared header pair every Speakeasy IDP call sends:
+// the shared-secret authenticating Gram + (optionally) the user's id token.
+func (c *Client) authHeaders(req *http.Request, idToken string) {
+	req.Header.Set("speakeasy-auth-provider-key", c.secretKey)
+	if idToken != "" {
+		req.Header.Set("speakeasy-auth-provider-id-token", idToken)
+	}
+}

--- a/server/internal/auth/speakeasyclient/client.go
+++ b/server/internal/auth/speakeasyclient/client.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
@@ -159,7 +160,7 @@ func (c *Client) ExchangeCode(ctx context.Context, code string) (idToken string,
 	if err != nil {
 		return "", fmt.Errorf("perform exchange request: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer o11y.LogDefer(ctx, c.logger, func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("exchange failed with status %s", resp.Status)
@@ -197,7 +198,7 @@ func (c *Client) ValidateIDToken(ctx context.Context, idToken string) (token *Va
 	if err != nil {
 		return nil, fmt.Errorf("perform validate request: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer o11y.LogDefer(ctx, c.logger, func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("validate failed with status %s", resp.Status)

--- a/server/internal/auth/speakeasyclient/client.go
+++ b/server/internal/auth/speakeasyclient/client.go
@@ -160,7 +160,7 @@ func (c *Client) ExchangeCode(ctx context.Context, code string) (idToken string,
 	if err != nil {
 		return "", fmt.Errorf("perform exchange request: %w", err)
 	}
-	defer o11y.LogDefer(ctx, c.logger, func() error { return resp.Body.Close() })
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("exchange failed with status %s", resp.Status)
@@ -198,7 +198,7 @@ func (c *Client) ValidateIDToken(ctx context.Context, idToken string) (token *Va
 	if err != nil {
 		return nil, fmt.Errorf("perform validate request: %w", err)
 	}
-	defer o11y.LogDefer(ctx, c.logger, func() error { return resp.Body.Close() })
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("validate failed with status %s", resp.Status)

--- a/server/internal/testenv/auth.go
+++ b/server/internal/testenv/auth.go
@@ -16,6 +16,7 @@ import (
 
 	mockidp "github.com/speakeasy-api/gram/dev-idp/pkg/testidp"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -42,6 +43,17 @@ func NewTestManager(t *testing.T, logger *slog.Logger, tracerProvider trace.Trac
 
 	fakePosthog := posthog.New(context.Background(), logger, "test-posthog-key", "test-posthog-host", "")
 
+	speakeasyIDPClient := speakeasyclient.NewClient(
+		logger,
+		tracerProvider,
+		guardianPolicy,
+		srv.URL,
+		mockidp.MockSecretKey,
+		db,
+		nil,
+		fakePosthog,
+	)
+
 	return sessions.NewManager(
 		logger,
 		tracerProvider,
@@ -55,6 +67,7 @@ func NewTestManager(t *testing.T, logger *slog.Logger, tracerProvider trace.Trac
 		fakePosthog,
 		billingRepo,
 		nil,
+		speakeasyIDPClient,
 	)
 }
 


### PR DESCRIPTION
Here we extract the Speakeasy IDP Client from speakeasyconnections.go

The goal here is to remove the User Provisioning side effects from the session establishing side effects of a speakeasy login.

We are adding a new login pathway (MCP) where users will very often _not_ be Dashboard users of Gram and so will not necessarily have had a previous opportunity to have had their user JIT provisioned.

This is an isolated version of this change that allows for relatively clean IDP Client re-use

My aim is to drop speakeasy IDP entirely from the MCP pathway entirely in a follow up and switch to a true OIDC flow, but this change is too high risk to embark on for now