### PR TITLE
mig: usersessions tables

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.761.5
 sources:
     Gram-Internal:
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:cb907678d901c036990ea994a1c2434bd95fce1bbd3c7d7951b8e3002d87e009
-        sourceBlobDigest: sha256:35b27dcb6cc9eb157ca721435a69dc5dac41477edd858e49404211afd5d6398e
+        sourceRevisionDigest: sha256:5f92dc0281be985be115901f758e9472c2ec9e26eb61db6a6e28b79333230e4f
+        sourceBlobDigest: sha256:1e65b3ac119c08b9055315eac3c5f5d3c7c02801097805ae3c4813ad7e7852be
         tags:
             - latest
             - 0.0.1
@@ -11,8 +11,10 @@ targets:
     gram-internal:
         source: Gram-Internal
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:cb907678d901c036990ea994a1c2434bd95fce1bbd3c7d7951b8e3002d87e009
-        sourceBlobDigest: sha256:35b27dcb6cc9eb157ca721435a69dc5dac41477edd858e49404211afd5d6398e
+        sourceRevisionDigest: sha256:5f92dc0281be985be115901f758e9472c2ec9e26eb61db6a6e28b79333230e4f
+        sourceBlobDigest: sha256:1e65b3ac119c08b9055315eac3c5f5d3c7c02801097805ae3c4813ad7e7852be
+        codeSamplesNamespace: gram-api-description-typescript-code-samples
+        codeSamplesRevisionDigest: sha256:8ab8c304671c55f8c5d8327e20c64daeb4e6f8f53930495ef93d998c55dc63ff
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: pinned

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -693,6 +693,119 @@ CREATE UNIQUE INDEX IF NOT EXISTS oauth_proxy_providers_project_slug_key
 ON oauth_proxy_providers (project_id, slug)
 WHERE deleted IS FALSE;
 
+-- User Session Issuers house configuration for when Gram acts as an Authorization Server for MCP Clients
+-- See: https://datatracker.ietf.org/doc/html/rfc8414
+CREATE TABLE IF NOT EXISTS user_session_issuers (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 100),
+  authn_challenge_mode TEXT NOT NULL, -- One of ('chain', 'interactive'). chain exists for backwards compatibility and should be phased out. interactive will be the main mode going forward
+  session_duration INTERVAL NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT user_session_issuers_pkey PRIMARY KEY (id),
+  CONSTRAINT user_session_issuers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_session_issuers_project_slug_key
+ON user_session_issuers (project_id, slug)
+WHERE deleted IS FALSE;
+
+-- User Session Clients are MCP Clients that have registered themselves with Gram
+-- See: https://datatracker.ietf.org/doc/html/rfc6749#section-1.1
+CREATE TABLE IF NOT EXISTS user_session_clients (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  user_session_issuer_id uuid NOT NULL,
+
+  client_id TEXT NOT NULL,
+  client_secret_hash TEXT,
+  client_name TEXT NOT NULL,
+  redirect_uris TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+
+  client_id_issued_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  client_secret_expires_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT user_session_clients_pkey PRIMARY KEY (id),
+  CONSTRAINT user_session_clients_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT user_session_clients_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_session_clients_issuer_client_id_key
+ON user_session_clients (user_session_issuer_id, client_id)
+WHERE deleted IS FALSE;
+
+-- User Session Consents track records of consent between Clients and Issuers
+-- Consents are scoped to given sets of underlying credentials so they can be reused between login events
+CREATE TABLE IF NOT EXISTS user_session_consents (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  subject_urn TEXT NOT NULL,
+  user_session_client_id uuid NOT NULL,
+  remote_set_hash TEXT NOT NULL,
+
+  consented_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT user_session_consents_pkey PRIMARY KEY (id),
+  CONSTRAINT user_session_consents_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT user_session_consents_user_session_client_id_fkey FOREIGN KEY (user_session_client_id) REFERENCES user_session_clients (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_session_consents_subject_client_set_key
+ON user_session_consents (subject_urn, user_session_client_id, remote_set_hash)
+WHERE deleted IS FALSE;
+
+-- User Sessions are records representing active Gram sessions for a given Subject
+-- They contain token grant information to allow for validating and exchanging tokens
+CREATE TABLE IF NOT EXISTS user_sessions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  user_session_issuer_id uuid NOT NULL,
+  user_session_client_id uuid,
+  subject_urn TEXT NOT NULL,
+  jti TEXT NOT NULL,
+  refresh_token_hash TEXT NOT NULL,
+  refresh_expires_at timestamptz NOT NULL,
+  expires_at timestamptz NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT user_sessions_pkey PRIMARY KEY (id),
+  CONSTRAINT user_sessions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT user_sessions_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE CASCADE,
+  CONSTRAINT user_sessions_user_session_client_id_fkey FOREIGN KEY (user_session_client_id) REFERENCES user_session_clients (id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS user_sessions_user_session_client_id_idx
+ON user_sessions (user_session_client_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_sessions_refresh_token_hash_key
+ON user_sessions (refresh_token_hash)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS user_sessions_subject_idx
+ON user_sessions (subject_urn, user_session_issuer_id)
+WHERE deleted IS FALSE;
+
 CREATE TABLE IF NOT EXISTS toolsets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1255,6 +1255,63 @@ type UserOauthToken struct {
 	Deleted               bool
 }
 
+type UserSession struct {
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	UserSessionIssuerID uuid.UUID
+	UserSessionClientID uuid.NullUUID
+	SubjectUrn          string
+	Jti                 string
+	RefreshTokenHash    string
+	RefreshExpiresAt    pgtype.Timestamptz
+	ExpiresAt           pgtype.Timestamptz
+	CreatedAt           pgtype.Timestamptz
+	UpdatedAt           pgtype.Timestamptz
+	DeletedAt           pgtype.Timestamptz
+	Deleted             bool
+}
+
+type UserSessionClient struct {
+	ID                    uuid.UUID
+	ProjectID             uuid.UUID
+	UserSessionIssuerID   uuid.UUID
+	ClientID              string
+	ClientSecretHash      pgtype.Text
+	ClientName            string
+	RedirectUris          []string
+	ClientIDIssuedAt      pgtype.Timestamptz
+	ClientSecretExpiresAt pgtype.Timestamptz
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	Deleted               bool
+}
+
+type UserSessionConsent struct {
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	SubjectUrn          string
+	UserSessionClientID uuid.UUID
+	RemoteSetHash       string
+	ConsentedAt         pgtype.Timestamptz
+	CreatedAt           pgtype.Timestamptz
+	UpdatedAt           pgtype.Timestamptz
+	DeletedAt           pgtype.Timestamptz
+	Deleted             bool
+}
+
+type UserSessionIssuer struct {
+	ID                 uuid.UUID
+	ProjectID          uuid.UUID
+	Slug               string
+	AuthnChallengeMode string
+	SessionDuration    pgtype.Interval
+	CreatedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
+	DeletedAt          pgtype.Timestamptz
+	Deleted            bool
+}
+
 type WorkosOrganizationSync struct {
 	ID                   uuid.UUID
 	WorkosOrganizationID string

--- a/server/migrations/20260507160200_usersessions-tables.sql
+++ b/server/migrations/20260507160200_usersessions-tables.sql
@@ -1,0 +1,82 @@
+-- Create "user_session_issuers" table
+CREATE TABLE "user_session_issuers" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "slug" text NOT NULL,
+  "authn_challenge_mode" text NOT NULL,
+  "session_duration" interval NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "user_session_issuers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "user_session_issuers_slug_check" CHECK ((slug <> ''::text) AND (char_length(slug) <= 100))
+);
+-- Create index "user_session_issuers_project_slug_key" to table: "user_session_issuers"
+CREATE UNIQUE INDEX "user_session_issuers_project_slug_key" ON "user_session_issuers" ("project_id", "slug") WHERE (deleted IS FALSE);
+-- Create "user_session_clients" table
+CREATE TABLE "user_session_clients" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "user_session_issuer_id" uuid NOT NULL,
+  "client_id" text NOT NULL,
+  "client_secret_hash" text NULL,
+  "client_name" text NOT NULL,
+  "redirect_uris" text[] NOT NULL DEFAULT ARRAY[]::text[],
+  "client_id_issued_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "client_secret_expires_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "user_session_clients_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "user_session_clients_user_session_issuer_id_fkey" FOREIGN KEY ("user_session_issuer_id") REFERENCES "user_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "user_session_clients_issuer_client_id_key" to table: "user_session_clients"
+CREATE UNIQUE INDEX "user_session_clients_issuer_client_id_key" ON "user_session_clients" ("user_session_issuer_id", "client_id") WHERE (deleted IS FALSE);
+-- Create "user_session_consents" table
+CREATE TABLE "user_session_consents" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "subject_urn" text NOT NULL,
+  "user_session_client_id" uuid NOT NULL,
+  "remote_set_hash" text NOT NULL,
+  "consented_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "user_session_consents_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "user_session_consents_user_session_client_id_fkey" FOREIGN KEY ("user_session_client_id") REFERENCES "user_session_clients" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "user_session_consents_subject_client_set_key" to table: "user_session_consents"
+CREATE UNIQUE INDEX "user_session_consents_subject_client_set_key" ON "user_session_consents" ("subject_urn", "user_session_client_id", "remote_set_hash") WHERE (deleted IS FALSE);
+-- Create "user_sessions" table
+CREATE TABLE "user_sessions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "user_session_issuer_id" uuid NOT NULL,
+  "user_session_client_id" uuid NULL,
+  "subject_urn" text NOT NULL,
+  "jti" text NOT NULL,
+  "refresh_token_hash" text NOT NULL,
+  "refresh_expires_at" timestamptz NOT NULL,
+  "expires_at" timestamptz NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "user_sessions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "user_sessions_user_session_client_id_fkey" FOREIGN KEY ("user_session_client_id") REFERENCES "user_session_clients" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "user_sessions_user_session_issuer_id_fkey" FOREIGN KEY ("user_session_issuer_id") REFERENCES "user_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "user_sessions_refresh_token_hash_key" to table: "user_sessions"
+CREATE UNIQUE INDEX "user_sessions_refresh_token_hash_key" ON "user_sessions" ("refresh_token_hash") WHERE (deleted IS FALSE);
+-- Create index "user_sessions_subject_idx" to table: "user_sessions"
+CREATE INDEX "user_sessions_subject_idx" ON "user_sessions" ("subject_urn", "user_session_issuer_id") WHERE (deleted IS FALSE);
+-- Create index "user_sessions_user_session_client_id_idx" to table: "user_sessions"
+CREATE INDEX "user_sessions_user_session_client_id_idx" ON "user_sessions" ("user_session_client_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:gIxwUvXYX3UbFrgc5luFAvbqvi8c10RLAYx6ZTSPsVw=
+h1:XoemyYloraXZHIMFG2QIhYzvawSwuBful7TtEEMAqp8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -158,3 +158,4 @@ h1:gIxwUvXYX3UbFrgc5luFAvbqvi8c10RLAYx6ZTSPsVw=
 20260506092802_workos-sync-cursor-cols.sql h1:YTWZ24vx+g/exU+1Fs4uCXHrOYpUOYfe7+BxS/6atLo=
 20260506195409_plugin-github-connections-marketplace-token.sql h1:DgB/RCi4aj3HU4fFOlD5Wa5qhRBUK5b9yu49tT0HPEc=
 20260507132747_add-name-and-slug-to-mcp-server-tables.sql h1:COKpEgovsuMJbmjf6ZE5aZcsToJb/m3+jhzQbXZKMeg=
+20260507160200_usersessions-tables.sql h1:FdPdJM8N6wjlfpRof1fcsyS72hBdyHpfIzNbh3qArjM=


### PR DESCRIPTION
## Summary

- Adds the `user_sessions`, `user_session_clients`, `user_session_consents`, and `user_session_issuers` tables that back the upcoming private-OAuth-toolsets feature.
- Migration only — no app code reads these yet. SDL/Atlas-generated.

## Stack

- PR-0: refactor(auth): extract Speakeasy IDP client → main (#2643)
- **PR-1 (this PR)** → PR-0
- PR-2: usersessions management API → PR-1
- PR-3: toolsets.user_session_issuer_id migration → PR-2
- PR-4: MCP OAuth discovery + DCR → PR-3
- PR-5: MCP OAuth authn dance + remote-session foundation → PR-4

## Test plan

- [ ] \`mise lint:migrations\` passes
- [ ] CI green