### PR TITLE
feat(mcp): OAuth discovery + DCR registration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	goa.design/clue v1.2.5
 	goa.design/goa/v3 v3.25.3
+	golang.org/x/crypto v0.50.0
 	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
@@ -321,7 +322,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -171,6 +171,12 @@ const (
 	MimeTypeKey                    = attribute.Key("mime.type")
 	OAuthAuthorizationEndpointKey  = attribute.Key("gram.oauth.authorization_endpoint")
 	OAuthClientIDKey               = attribute.Key("gram.oauth.client_id")
+	OAuthClientNameKey             = attribute.Key("gram.oauth.client_name")
+	// OAuthErrorKey / OAuthErrorDescriptionKey carry the `error` /
+	// `error_description` parameters from RFC 6749 / RFC 7591 error responses
+	// — used across DCR registration, /authorize, /token, and /revoke.
+	OAuthErrorKey                  = attribute.Key("gram.oauth.error")
+	OAuthErrorDescriptionKey       = attribute.Key("gram.oauth.error_description")
 	OAuthGrantKey                  = attribute.Key("gram.oauth.grant")
 	OAuthIssuerKey                 = attribute.Key("gram.oauth.issuer")
 	OAuthProviderKey               = attribute.Key("gram.oauth.provider")
@@ -759,6 +765,19 @@ func SlogOAuthAuthorizationEndpoint(v string) slog.Attr {
 
 func OAuthClientID(v string) attribute.KeyValue { return OAuthClientIDKey.String(v) }
 func SlogOAuthClientID(v string) slog.Attr      { return slog.String(string(OAuthClientIDKey), v) }
+
+func OAuthClientName(v string) attribute.KeyValue { return OAuthClientNameKey.String(v) }
+func SlogOAuthClientName(v string) slog.Attr      { return slog.String(string(OAuthClientNameKey), v) }
+
+func OAuthError(v string) attribute.KeyValue { return OAuthErrorKey.String(v) }
+func SlogOAuthError(v string) slog.Attr      { return slog.String(string(OAuthErrorKey), v) }
+
+func OAuthErrorDescription(v string) attribute.KeyValue {
+	return OAuthErrorDescriptionKey.String(v)
+}
+func SlogOAuthErrorDescription(v string) slog.Attr {
+	return slog.String(string(OAuthErrorDescriptionKey), v)
+}
 
 func OAuthGrant(v string) attribute.KeyValue { return OAuthGrantKey.String(v) }
 func SlogOAuthGrant(v string) slog.Attr      { return slog.String(string(OAuthGrantKey), v) }

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -40,9 +40,10 @@ import (
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
-// supportedGrantTypes / supportedResponseTypes / supportedAuthMethods mirror
-// the values HandleGetAuthorizationServer advertises. Keep in sync — registered
-// clients must request only what the AS metadata claims to support.
+// supportedGrantTypes / supportedResponseTypes / supportedAuthMethods /
+// supportedBearerMethods mirror the values HandleGetAuthorizationServer and
+// HandleGetProtectedResource advertise. Keep in sync — registered clients
+// must request only what the AS metadata claims to support.
 var (
 	supportedGrantTypes    = []string{"authorization_code", "refresh_token"}
 	supportedResponseTypes = []string{"code"}
@@ -50,7 +51,9 @@ var (
 	// MCP clients in the wild use it. PKCE provides per-flow integrity; the
 	// only guard against cross-flow client-id confusion is the consent
 	// prompt itself, which we always render (HandleConsent never skips).
-	supportedAuthMethods = []string{"client_secret_basic", "client_secret_post", "none"}
+	supportedAuthMethods          = []string{"client_secret_basic", "client_secret_post", "none"}
+	supportedBearerMethods        = []string{"header"}
+	supportedCodeChallengeMethods = []string{"S256"}
 )
 
 // dcrMaxBodyBytes caps the RFC 7591 §3.1 client metadata document size on
@@ -253,7 +256,7 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 			Resource:               resource,
 			AuthorizationServers:   []string{resource},
 			ScopesSupported:        nil,
-			BearerMethodsSupported: []string{"header"},
+			BearerMethodsSupported: supportedBearerMethods,
 		})
 	}
 
@@ -318,7 +321,7 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 			ResponseTypesSupported:            supportedResponseTypes,
 			GrantTypesSupported:               supportedGrantTypes,
 			TokenEndpointAuthMethodsSupported: supportedAuthMethods,
-			CodeChallengeMethodsSupported:     []string{"S256"},
+			CodeChallengeMethodsSupported:     supportedCodeChallengeMethods,
 		})
 	}
 

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"slices"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -38,123 +37,32 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
-// supportedGrantTypes / supportedResponseTypes / supportedAuthMethods /
-// supportedBearerMethods mirror the values HandleGetAuthorizationServer and
-// HandleGetProtectedResource advertise. Keep in sync — registered clients
-// must request only what the AS metadata claims to support.
+// supportedBearerMethods / supportedCodeChallengeMethods are the values
+// HandleGetProtectedResource and HandleGetAuthorizationServer advertise.
+// The OAuth grant/response/auth-method sets live in the usersessions
+// package (alongside RegistrationRequest.Validate).
 var (
-	supportedGrantTypes    = []string{"authorization_code", "refresh_token"}
-	supportedResponseTypes = []string{"code"}
-	// `none` covers public PKCE-only clients (mobile, CLI, MCP SDK). Real
-	// MCP clients in the wild use it. PKCE provides per-flow integrity; the
-	// only guard against cross-flow client-id confusion is the consent
-	// prompt itself, which we always render (HandleConsent never skips).
-	supportedAuthMethods          = []string{"client_secret_basic", "client_secret_post", "none"}
 	supportedBearerMethods        = []string{"header"}
 	supportedCodeChallengeMethods = []string{"S256"}
 )
+
 
 // dcrMaxBodyBytes caps the RFC 7591 §3.1 client metadata document size on
 // HandleRegister. The spec doesn't mandate a limit; 64 KiB is well past any
 // real document and defends against memory-exhaustion (gosec G120).
 const dcrMaxBodyBytes int64 = 64 * 1024
-
-// dcrRegistrationRequest is the RFC 7591 §3.1 client metadata document. Only
-// the fields we honour are listed; unknown fields are ignored.
-type dcrRegistrationRequest struct {
-	ClientName              string   `json:"client_name"`
-	RedirectURIs            []string `json:"redirect_uris"`
-	GrantTypes              []string `json:"grant_types,omitempty"`
-	ResponseTypes           []string `json:"response_types,omitempty"`
-	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
-	Scope                   string   `json:"scope,omitempty"`
-}
-
-// dcrError is an RFC 7591 §3.2.2 client registration error in structured
-// form. Carries the wire-protocol error code and human-readable description
-// to the response writer without leaking either into the function signatures
-// of upstream validators.
-type dcrError struct {
-	Code        string
-	Description string
-}
-
-func (e *dcrError) Error() string { return e.Code + ": " + e.Description }
-
-// SetDefaults populates the RFC 7591 §2 defaults for fields the client
-// didn't supply. Must be called before Validate so the §2.1 grant/response
-// correlation check sees materialized values.
-func (r *dcrRegistrationRequest) SetDefaults() {
-	if len(r.GrantTypes) == 0 {
-		r.GrantTypes = []string{"authorization_code"}
-	}
-	if len(r.ResponseTypes) == 0 {
-		r.ResponseTypes = []string{"code"}
-	}
-	if r.TokenEndpointAuthMethod == "" {
-		r.TokenEndpointAuthMethod = "client_secret_basic"
-	}
-}
-
-// Validate checks the (defaulted) fields of an RFC 7591 §3.1 client metadata
-// document. Returns a *dcrError on a spec-defined rejection. Callers must
-// invoke SetDefaults first so grant_types / response_types / auth method
-// are populated.
-func (r *dcrRegistrationRequest) Validate() error {
-	if r.ClientName == "" {
-		return &dcrError{Code: "invalid_client_metadata", Description: "client_name is required"}
-	}
-	if len(r.RedirectURIs) == 0 {
-		return &dcrError{Code: "invalid_redirect_uri", Description: "redirect_uris is required"}
-	}
-	for _, u := range r.RedirectURIs {
-		parsed, parseErr := url.Parse(u)
-		if parseErr != nil || parsed.Scheme == "" || parsed.Host == "" {
-			return &dcrError{Code: "invalid_redirect_uri", Description: "redirect_uri must be an absolute URL"}
-		}
-	}
-	for _, gt := range r.GrantTypes {
-		if !slices.Contains(supportedGrantTypes, gt) {
-			return &dcrError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported grant_type %q", gt)}
-		}
-	}
-	for _, rt := range r.ResponseTypes {
-		if !slices.Contains(supportedResponseTypes, rt) {
-			return &dcrError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported response_type %q", rt)}
-		}
-	}
-	if !slices.Contains(supportedAuthMethods, r.TokenEndpointAuthMethod) {
-		return &dcrError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported token_endpoint_auth_method %q", r.TokenEndpointAuthMethod)}
-	}
-
-	// RFC 7591 §2.1 correlation: response_type "code" requires grant_type
-	// "authorization_code" and vice versa.
-	hasCodeResponse := slices.Contains(r.ResponseTypes, "code")
-	hasAuthCodeGrant := slices.Contains(r.GrantTypes, "authorization_code")
-	if hasCodeResponse && !hasAuthCodeGrant {
-		return &dcrError{Code: "invalid_client_metadata", Description: `response_type "code" requires grant_type "authorization_code"`}
-	}
-	if hasAuthCodeGrant && !hasCodeResponse {
-		return &dcrError{Code: "invalid_client_metadata", Description: `grant_type "authorization_code" requires response_type "code"`}
-	}
-	// refresh_token can only follow an initial authorization_code in our
-	// supported set; a client registering refresh_token alone has no way
-	// to ever obtain one.
-	if slices.Contains(r.GrantTypes, "refresh_token") && !hasAuthCodeGrant {
-		return &dcrError{Code: "invalid_client_metadata", Description: `grant_type "refresh_token" requires grant_type "authorization_code"`}
-	}
-	return nil
-}
-
 // dcrRegistrationResponse is the RFC 7591 §3.2.1 successful registration
 // response. `client_secret` is included exactly once, on this response. Both
 // `client_secret` and `client_secret_expires_at` are omitted entirely for
 // public (`token_endpoint_auth_method=none`) clients per RFC 7591 §3.2.1
 // — emitting an empty string for `client_secret` confuses some MCP SDKs into
 // preferring `client_secret_basic` for the token call.
+//
+// `scope` is intentionally absent (see usersessions.RegistrationRequest comment).
 type dcrRegistrationResponse struct {
 	ClientID                string   `json:"client_id"`
 	ClientSecret            string   `json:"client_secret,omitempty"`
@@ -165,7 +73,6 @@ type dcrRegistrationResponse struct {
 	GrantTypes              []string `json:"grant_types"`
 	ResponseTypes           []string `json:"response_types"`
 	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
-	Scope                   string   `json:"scope,omitempty"`
 }
 
 // WriteAuthenticateChallenge sets the WWW-Authenticate header and returns an
@@ -333,9 +240,9 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 			RegistrationEndpoint:              root + "/register",
 			RevocationEndpoint:                root + "/revoke",
 			ScopesSupported:                   nil,
-			ResponseTypesSupported:            supportedResponseTypes,
-			GrantTypesSupported:               supportedGrantTypes,
-			TokenEndpointAuthMethodsSupported: supportedAuthMethods,
+			ResponseTypesSupported:            usersessions.SupportedResponseTypes,
+			GrantTypesSupported:               usersessions.SupportedGrantTypes,
+			TokenEndpointAuthMethodsSupported: usersessions.SupportedAuthMethods,
 			CodeChallengeMethodsSupported:     supportedCodeChallengeMethods,
 		})
 	}
@@ -434,7 +341,7 @@ func (s *Service) HandleRegister(w http.ResponseWriter, r *http.Request) error {
 
 	r.Body = http.MaxBytesReader(w, r.Body, dcrMaxBodyBytes)
 
-	var req dcrRegistrationRequest
+	var req usersessions.RegistrationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
@@ -445,9 +352,9 @@ func (s *Service) HandleRegister(w http.ResponseWriter, r *http.Request) error {
 
 	req.SetDefaults()
 	if err := req.Validate(); err != nil {
-		var dcrErr *dcrError
-		if errors.As(err, &dcrErr) {
-			return writeDCRError(ctx, w, logger, dcrErr.Code, dcrErr.Description)
+		var regErr *usersessions.RegistrationError
+		if errors.As(err, &regErr) {
+			return writeDCRError(ctx, w, logger, regErr.Code, regErr.Description)
 		}
 		return oops.E(oops.CodeUnexpected, err, "validate DCR request").Log(ctx, logger)
 	}
@@ -509,7 +416,6 @@ func (s *Service) HandleRegister(w http.ResponseWriter, r *http.Request) error {
 		GrantTypes:              req.GrantTypes,
 		ResponseTypes:           req.ResponseTypes,
 		TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
-		Scope:                   req.Scope,
 	}
 
 	body, err := json.Marshal(resp)

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -14,23 +14,33 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
 // WriteAuthenticateChallenge sets the WWW-Authenticate header and returns an
-// oops.CodeUnauthorized error. The 401 status and response body still come
-// from the oops error middleware; the helper owns only the header — that
-// behaviour is identical to today's inline writes.
+// oops.CodeUnauthorized error. The 401 status and response body come from
+// the oops error middleware; the helper owns only the header.
 //
 // Header shape (RFC 9728 §5.3):
 //
 //	Bearer resource_metadata="<base>/.well-known/oauth-protected-resource/mcp/<slug>"
 //
-// This is the seam where future user_session_issuer-driven shape extensions
-// (e.g. richer `error=` / `realm=` parameters) will land.
+// The path is the canonical RFC 9728 prefix path — exactly what a
+// spec-compliant client constructs from a resource URL of `<base>/mcp/<slug>`.
 func WriteAuthenticateChallenge(w http.ResponseWriter, baseURL, mcpSlug, message string) error {
 	w.Header().Set(
 		"WWW-Authenticate",
@@ -40,4 +50,192 @@ func WriteAuthenticateChallenge(w http.ResponseWriter, baseURL, mcpSlug, message
 		return oops.C(oops.CodeUnauthorized)
 	}
 	return oops.E(oops.CodeUnauthorized, nil, "%s", message)
+}
+
+// oauthProtectedResourceMetadata mirrors RFC 9728 §2 fields. Distinct from the
+// legacy package's wellknown.OAuthProtectedResourceMetadata so the two paths
+// stay independently editable; the new path may grow fields the legacy path
+// can't.
+type oauthProtectedResourceMetadata struct {
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers"`
+	ScopesSupported        []string `json:"scopes_supported,omitempty"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+}
+
+// oauthAuthorizationServerMetadata mirrors RFC 8414 §2 fields. Distinct from
+// the legacy package's wellknown.OAuthServerMetadata for the same reason as
+// above.
+type oauthAuthorizationServerMetadata struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint"`
+	RevocationEndpoint                string   `json:"revocation_endpoint"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+}
+
+// HandleGetProtectedResource serves RFC 9728 protected-resource metadata at
+// the canonical RFC path `/.well-known/oauth-protected-resource/mcp/{mcpSlug}`
+// — the only path a spec-compliant client constructs from a resource URL of
+// `<base>/mcp/{slug}`. Dispatches internally:
+//
+//   - If toolset.user_session_issuer_id is set: emit the issuer-gated metadata
+//     shape (resource + authorization_servers point at the same /mcp/{slug}
+//     URL the AS metadata is keyed under).
+//   - Else: delegate to wellknown.ResolveOAuthProtectedResourceFromToolset for
+//     legacy toolsets (oauth_proxy_server_id / external_oauth_server_id).
+//   - Else still: 404.
+//
+// Replaces the prior HandleWellKnownOAuthProtectedResourceMetadata in
+// mcp/impl.go (deleted in this commit; route is now registered to this
+// dispatcher).
+func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	mcpSlug := chi.URLParam(r, "mcpSlug")
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+	}
+
+	toolset, customDomainCtx, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
+	switch {
+	case errors.Is(err, errToolsetNotFound):
+		return oops.E(oops.CodeNotFound, err, "mcp server not found")
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
+	}
+
+	baseURL := s.serverURL.String()
+	if customDomainCtx != nil {
+		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
+	}
+
+	if toolset.UserSessionIssuerID.Valid {
+		resource := baseURL + "/mcp/" + mcpSlug
+		return writeJSONMetadata(ctx, w, s.logger, oauthProtectedResourceMetadata{
+			Resource:               resource,
+			AuthorizationServers:   []string{resource},
+			ScopesSupported:        nil,
+			BearerMethodsSupported: []string{"header"},
+		})
+	}
+
+	// Legacy fallback: delegate to the existing wellknown resolver. A nil
+	// result means the toolset has no OAuth configuration at all — 404.
+	legacy, err := wellknown.ResolveOAuthProtectedResourceFromToolset(
+		ctx, s.logger, s.db, &s.toolsetCache, toolset, baseURL+"/mcp/"+mcpSlug,
+	)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, s.logger)
+	}
+	if legacy == nil {
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	}
+	return writeOAuthProtectedResourceMetadataResponse(ctx, s.logger, w, legacy)
+}
+
+// HandleGetAuthorizationServer serves RFC 8414 authorization-server metadata
+// at the canonical RFC path
+// `/.well-known/oauth-authorization-server/mcp/{mcpSlug}` — the only path a
+// spec-compliant client constructs from an issuer URL of `<base>/mcp/{slug}`.
+// Same dispatch model as HandleGetProtectedResource.
+func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	mcpSlug := chi.URLParam(r, "mcpSlug")
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+	}
+
+	toolset, customDomainCtx, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
+	switch {
+	case errors.Is(err, errToolsetNotFound):
+		return oops.E(oops.CodeNotFound, err, "mcp server not found")
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
+	}
+
+	baseURL := s.serverURL.String()
+	if customDomainCtx != nil {
+		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
+	}
+
+	if toolset.UserSessionIssuerID.Valid {
+		if _, err := usersessions_repo.New(s.db).GetUserSessionIssuerByID(ctx, usersessions_repo.GetUserSessionIssuerByIDParams{
+			ID:        toolset.UserSessionIssuerID.UUID,
+			ProjectID: toolset.ProjectID,
+		}); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return oops.E(oops.CodeNotFound, err, "user_session_issuer not found")
+			}
+			return oops.E(oops.CodeUnexpected, err, "load user_session_issuer").Log(ctx, s.logger)
+		}
+
+		root := baseURL + "/mcp/" + mcpSlug
+		return writeJSONMetadata(ctx, w, s.logger, oauthAuthorizationServerMetadata{
+			Issuer:                            root,
+			AuthorizationEndpoint:             root + "/authorize",
+			TokenEndpoint:                     root + "/token",
+			RegistrationEndpoint:              root + "/register",
+			RevocationEndpoint:                root + "/revoke",
+			ScopesSupported:                   nil,
+			ResponseTypesSupported:            []string{"code"},
+			GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+			TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "none"},
+			CodeChallengeMethodsSupported:     []string{"S256"},
+		})
+	}
+
+	// Legacy fallback: delegate to the existing wellknown resolver. A nil
+	// result means the toolset has no OAuth configuration at all — 404.
+	legacy, err := wellknown.ResolveOAuthServerMetadataFromToolset(
+		ctx, s.logger, s.db, s.oauthRepo, &s.toolsetCache, toolset, baseURL, mcpSlug,
+	)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").Log(ctx, s.logger)
+	}
+	if legacy == nil {
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	}
+
+	if legacy.Kind == wellknown.OAuthServerMetadataResultKindProxy {
+		target, parseErr := url.Parse(legacy.ProxyURL)
+		if parseErr != nil {
+			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse well-known URL").Log(ctx, s.logger)
+		}
+		proxy := &httputil.ReverseProxy{
+			Director: nil,
+			Rewrite: func(pr *httputil.ProxyRequest) {
+				pr.SetURL(target)
+			},
+			Transport:      nil,
+			FlushInterval:  0,
+			ErrorLog:       nil,
+			BufferPool:     nil,
+			ModifyResponse: nil,
+			ErrorHandler:   nil,
+		}
+		proxy.ServeHTTP(w, r)
+		return nil
+	}
+
+	return writeOAuthServerMetadataResponse(ctx, s.logger, w, legacy)
+}
+
+// writeJSONMetadata is the shared write path for issuer-gated metadata
+// responses. Marshals the value, sets Content-Type, then commits 200.
+func writeJSONMetadata(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, v any) error {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal metadata").Log(ctx, logger)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+	}
+	return nil
 }

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -37,6 +37,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -215,6 +216,23 @@ type oauthAuthorizationServerMetadata struct {
 	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
 }
 
+// requireUserSessionIssuer verifies the toolset's user_session_issuer_id FK
+// still resolves to a live row. Returns CodeNotFound when the issuer was
+// deleted out from under the toolset, CodeUnexpected on lookup failure.
+// Callers are responsible for first checking toolset.UserSessionIssuerID.Valid.
+func (s *Service) requireUserSessionIssuer(ctx context.Context, toolset *toolsets_repo.Toolset) error {
+	if _, err := usersessions_repo.New(s.db).GetUserSessionIssuerByID(ctx, usersessions_repo.GetUserSessionIssuerByIDParams{
+		ID:        toolset.UserSessionIssuerID.UUID,
+		ProjectID: toolset.ProjectID,
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return oops.E(oops.CodeNotFound, err, "user_session_issuer not found")
+		}
+		return oops.E(oops.CodeUnexpected, err, "load user_session_issuer").Log(ctx, s.logger)
+	}
+	return nil
+}
+
 // HandleGetProtectedResource serves RFC 9728 protected-resource metadata at
 // the canonical RFC path `/.well-known/oauth-protected-resource/mcp/{mcpSlug}`
 // — the only path a spec-compliant client constructs from a resource URL of
@@ -251,6 +269,9 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 	}
 
 	if toolset.UserSessionIssuerID.Valid {
+		if err := s.requireUserSessionIssuer(ctx, toolset); err != nil {
+			return err
+		}
 		resource := baseURL + "/mcp/" + mcpSlug
 		return writeJSONMetadata(ctx, w, s.logger, oauthProtectedResourceMetadata{
 			Resource:               resource,
@@ -300,14 +321,8 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 	}
 
 	if toolset.UserSessionIssuerID.Valid {
-		if _, err := usersessions_repo.New(s.db).GetUserSessionIssuerByID(ctx, usersessions_repo.GetUserSessionIssuerByIDParams{
-			ID:        toolset.UserSessionIssuerID.UUID,
-			ProjectID: toolset.ProjectID,
-		}); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return oops.E(oops.CodeNotFound, err, "user_session_issuer not found")
-			}
-			return oops.E(oops.CodeUnexpected, err, "load user_session_issuer").Log(ctx, s.logger)
+		if err := s.requireUserSessionIssuer(ctx, toolset); err != nil {
+			return err
 		}
 
 		root := baseURL + "/mcp/" + mcpSlug
@@ -400,6 +415,9 @@ func (s *Service) HandleRegister(w http.ResponseWriter, r *http.Request) error {
 
 	if !toolset.UserSessionIssuerID.Valid {
 		return oops.E(oops.CodeNotFound, nil, "not found")
+	}
+	if err := s.requireUserSessionIssuer(ctx, toolset); err != nil {
+		return err
 	}
 
 	logger := s.logger.With(

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -1,0 +1,43 @@
+// OAuth authorization code exchange handlers for MCP clients. Issuer-gated
+// toolsets (toolsets.user_session_issuer_id set) flow through the OAuth 2.1
+// + RFC 7591 / RFC 9728 handlers in this file; toolsets without an issuer
+// fall through to the legacy paths in wellknown.Resolve*.
+//
+// Handlers in this file:
+//
+//   - WriteAuthenticateChallenge — 401 + WWW-Authenticate; points clients
+//     at RFC 9728 discovery.
+//   - HandleGetProtectedResource — GET /.well-known/oauth-protected-resource/mcp/{slug}.
+//   - HandleGetAuthorizationServer — GET /.well-known/oauth-authorization-server/mcp/{slug}.
+//   - HandleRegister — POST /mcp/{slug}/register (RFC 7591 DCR).
+
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// WriteAuthenticateChallenge sets the WWW-Authenticate header and returns an
+// oops.CodeUnauthorized error. The 401 status and response body still come
+// from the oops error middleware; the helper owns only the header — that
+// behaviour is identical to today's inline writes.
+//
+// Header shape (RFC 9728 §5.3):
+//
+//	Bearer resource_metadata="<base>/.well-known/oauth-protected-resource/mcp/<slug>"
+//
+// This is the seam where future user_session_issuer-driven shape extensions
+// (e.g. richer `error=` / `realm=` parameters) will land.
+func WriteAuthenticateChallenge(w http.ResponseWriter, baseURL, mcpSlug, message string) error {
+	w.Header().Set(
+		"WWW-Authenticate",
+		fmt.Sprintf(`Bearer resource_metadata="%s"`, baseURL+"/.well-known/oauth-protected-resource/mcp/"+mcpSlug),
+	)
+	if message == "" {
+		return oops.C(oops.CodeUnauthorized)
+	}
+	return oops.E(oops.CodeUnauthorized, nil, "%s", message)
+}

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -15,21 +15,154 @@ package mcp
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"mime"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"golang.org/x/crypto/bcrypt"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
+
+// supportedGrantTypes / supportedResponseTypes / supportedAuthMethods mirror
+// the values HandleGetAuthorizationServer advertises. Keep in sync — registered
+// clients must request only what the AS metadata claims to support.
+var (
+	supportedGrantTypes    = []string{"authorization_code", "refresh_token"}
+	supportedResponseTypes = []string{"code"}
+	// `none` covers public PKCE-only clients (mobile, CLI, MCP SDK). Real
+	// MCP clients in the wild use it. PKCE provides per-flow integrity; the
+	// only guard against cross-flow client-id confusion is the consent
+	// prompt itself, which we always render (HandleConsent never skips).
+	supportedAuthMethods = []string{"client_secret_basic", "client_secret_post", "none"}
+)
+
+// dcrMaxBodyBytes caps the RFC 7591 §3.1 client metadata document size on
+// HandleRegister. The spec doesn't mandate a limit; 64 KiB is well past any
+// real document and defends against memory-exhaustion (gosec G120).
+const dcrMaxBodyBytes int64 = 64 * 1024
+
+// dcrRegistrationRequest is the RFC 7591 §3.1 client metadata document. Only
+// the fields we honour are listed; unknown fields are ignored.
+type dcrRegistrationRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
+}
+
+// dcrError is an RFC 7591 §3.2.2 client registration error in structured
+// form. Carries the wire-protocol error code and human-readable description
+// to the response writer without leaking either into the function signatures
+// of upstream validators.
+type dcrError struct {
+	Code        string
+	Description string
+}
+
+func (e *dcrError) Error() string { return e.Code + ": " + e.Description }
+
+// SetDefaults populates the RFC 7591 §2 defaults for fields the client
+// didn't supply. Must be called before Validate so the §2.1 grant/response
+// correlation check sees materialized values.
+func (r *dcrRegistrationRequest) SetDefaults() {
+	if len(r.GrantTypes) == 0 {
+		r.GrantTypes = []string{"authorization_code"}
+	}
+	if len(r.ResponseTypes) == 0 {
+		r.ResponseTypes = []string{"code"}
+	}
+	if r.TokenEndpointAuthMethod == "" {
+		r.TokenEndpointAuthMethod = "client_secret_basic"
+	}
+}
+
+// Validate checks the (defaulted) fields of an RFC 7591 §3.1 client metadata
+// document. Returns a *dcrError on a spec-defined rejection. Callers must
+// invoke SetDefaults first so grant_types / response_types / auth method
+// are populated.
+func (r *dcrRegistrationRequest) Validate() error {
+	if r.ClientName == "" {
+		return &dcrError{Code: "invalid_client_metadata", Description: "client_name is required"}
+	}
+	if len(r.RedirectURIs) == 0 {
+		return &dcrError{Code: "invalid_redirect_uri", Description: "redirect_uris is required"}
+	}
+	for _, u := range r.RedirectURIs {
+		parsed, parseErr := url.Parse(u)
+		if parseErr != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return &dcrError{Code: "invalid_redirect_uri", Description: "redirect_uri must be an absolute URL"}
+		}
+	}
+	for _, gt := range r.GrantTypes {
+		if !slices.Contains(supportedGrantTypes, gt) {
+			return &dcrError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported grant_type %q", gt)}
+		}
+	}
+	for _, rt := range r.ResponseTypes {
+		if !slices.Contains(supportedResponseTypes, rt) {
+			return &dcrError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported response_type %q", rt)}
+		}
+	}
+	if !slices.Contains(supportedAuthMethods, r.TokenEndpointAuthMethod) {
+		return &dcrError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported token_endpoint_auth_method %q", r.TokenEndpointAuthMethod)}
+	}
+
+	// RFC 7591 §2.1 correlation: response_type "code" requires grant_type
+	// "authorization_code" and vice versa.
+	hasCodeResponse := slices.Contains(r.ResponseTypes, "code")
+	hasAuthCodeGrant := slices.Contains(r.GrantTypes, "authorization_code")
+	if hasCodeResponse && !hasAuthCodeGrant {
+		return &dcrError{Code: "invalid_client_metadata", Description: `response_type "code" requires grant_type "authorization_code"`}
+	}
+	if hasAuthCodeGrant && !hasCodeResponse {
+		return &dcrError{Code: "invalid_client_metadata", Description: `grant_type "authorization_code" requires response_type "code"`}
+	}
+	// refresh_token can only follow an initial authorization_code in our
+	// supported set; a client registering refresh_token alone has no way
+	// to ever obtain one.
+	if slices.Contains(r.GrantTypes, "refresh_token") && !hasAuthCodeGrant {
+		return &dcrError{Code: "invalid_client_metadata", Description: `grant_type "refresh_token" requires grant_type "authorization_code"`}
+	}
+	return nil
+}
+
+// dcrRegistrationResponse is the RFC 7591 §3.2.1 successful registration
+// response. `client_secret` is included exactly once, on this response. Both
+// `client_secret` and `client_secret_expires_at` are omitted entirely for
+// public (`token_endpoint_auth_method=none`) clients per RFC 7591 §3.2.1
+// — emitting an empty string for `client_secret` confuses some MCP SDKs into
+// preferring `client_secret_basic` for the token call.
+type dcrRegistrationResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientSecret            string   `json:"client_secret,omitempty"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
+	ClientSecretExpiresAt   *int64   `json:"client_secret_expires_at,omitempty"`
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	Scope                   string   `json:"scope,omitempty"`
+}
 
 // WriteAuthenticateChallenge sets the WWW-Authenticate header and returns an
 // oops.CodeUnauthorized error. The 401 status and response body come from
@@ -182,9 +315,9 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 			RegistrationEndpoint:              root + "/register",
 			RevocationEndpoint:                root + "/revoke",
 			ScopesSupported:                   nil,
-			ResponseTypesSupported:            []string{"code"},
-			GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
-			TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "none"},
+			ResponseTypesSupported:            supportedResponseTypes,
+			GrantTypesSupported:               supportedGrantTypes,
+			TokenEndpointAuthMethodsSupported: supportedAuthMethods,
 			CodeChallengeMethodsSupported:     []string{"S256"},
 		})
 	}
@@ -238,4 +371,173 @@ func writeJSONMetadata(ctx context.Context, w http.ResponseWriter, logger *slog.
 		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
 	}
 	return nil
+}
+
+// HandleRegister implements RFC 7591 Dynamic Client Registration for issuer-
+// gated MCP servers. Mounted at `POST /mcp/{mcpSlug}/register`. Public endpoint
+// (no caller auth); the issuer's metadata document advertises this URL via
+// `registration_endpoint`.
+//
+// Generated client_secret is returned plaintext exactly once; only its bcrypt
+// hash is persisted in user_session_clients.client_secret_hash.
+func (s *Service) HandleRegister(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	mcpSlug := chi.URLParam(r, "mcpSlug")
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
+	}
+
+	toolset, _, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
+	switch {
+	case errors.Is(err, errToolsetNotFound):
+		return oops.E(oops.CodeNotFound, err, "mcp server not found")
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
+	}
+
+	if !toolset.UserSessionIssuerID.Valid {
+		return oops.E(oops.CodeNotFound, nil, "not found")
+	}
+
+	logger := s.logger.With(
+		attr.SlogToolsetID(toolset.ID.String()),
+		attr.SlogProjectID(toolset.ProjectID.String()),
+	)
+
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		mediaType, _, err := mime.ParseMediaType(ct)
+		if err != nil || mediaType != "application/json" {
+			return writeDCRError(ctx, w, logger, "invalid_client_metadata", "Content-Type must be application/json")
+		}
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, dcrMaxBodyBytes)
+
+	var req dcrRegistrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return writeDCRError(ctx, w, logger, "invalid_client_metadata", fmt.Sprintf("request body exceeds %d bytes", dcrMaxBodyBytes))
+		}
+		return writeDCRError(ctx, w, logger, "invalid_client_metadata", "request body is not valid JSON")
+	}
+
+	req.SetDefaults()
+	if err := req.Validate(); err != nil {
+		var dcrErr *dcrError
+		if errors.As(err, &dcrErr) {
+			return writeDCRError(ctx, w, logger, dcrErr.Code, dcrErr.Description)
+		}
+		return oops.E(oops.CodeUnexpected, err, "validate DCR request").Log(ctx, logger)
+	}
+
+	clientID := "client_" + uuid.NewString()
+
+	// Public clients (token_endpoint_auth_method=none) skip secret generation
+	// and store NULL in client_secret_hash. The /token handler treats a NULL
+	// hash as "no secret expected; PKCE is the integrity proof".
+	var clientSecret string
+	var clientSecretHash pgtype.Text
+	if req.TokenEndpointAuthMethod != "none" {
+		var err error
+		clientSecret, err = generateClientSecret()
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to generate client secret").Log(ctx, logger)
+		}
+		hashed, hashErr := bcrypt.GenerateFromPassword([]byte(clientSecret), bcrypt.DefaultCost)
+		if hashErr != nil {
+			return oops.E(oops.CodeUnexpected, hashErr, "failed to hash client secret").Log(ctx, logger)
+		}
+		clientSecretHash = pgtype.Text{String: string(hashed), Valid: true}
+	}
+
+	row, err := usersessions_repo.New(s.db).CreateUserSessionClient(ctx, usersessions_repo.CreateUserSessionClientParams{
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		ClientID:            clientID,
+		ClientSecretHash:    clientSecretHash,
+		ClientName:          req.ClientName,
+		RedirectUris:        req.RedirectURIs,
+		// RFC 7591 §3.2.1 expires_at=0 = non-expiring; we leave the Postgres column NULL.
+		ClientSecretExpiresAt: pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: 0, Valid: false},
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to create user session client").Log(ctx, logger)
+	}
+
+	logger.InfoContext(ctx, "user session client registered",
+		attr.SlogOAuthClientID(clientID),
+		attr.SlogOAuthClientName(req.ClientName),
+	)
+
+	// Confidential clients get client_secret + client_secret_expires_at=0
+	// (non-expiring per RFC 7591 §3.2.1). Public clients (none) get neither
+	// field — emitting them would suggest a secret exists.
+	var clientSecretExpiresAt *int64
+	if req.TokenEndpointAuthMethod != "none" {
+		zero := int64(0)
+		clientSecretExpiresAt = &zero
+	}
+
+	resp := dcrRegistrationResponse{
+		ClientID:                clientID,
+		ClientSecret:            clientSecret,
+		ClientIDIssuedAt:        row.ClientIDIssuedAt.Time.Unix(),
+		ClientSecretExpiresAt:   clientSecretExpiresAt,
+		ClientName:              req.ClientName,
+		RedirectURIs:            req.RedirectURIs,
+		GrantTypes:              req.GrantTypes,
+		ResponseTypes:           req.ResponseTypes,
+		TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
+		Scope:                   req.Scope,
+	}
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal registration response").Log(ctx, logger)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusCreated)
+	if _, err := w.Write(body); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to write response body").Log(ctx, logger)
+	}
+	return nil
+}
+
+// writeDCRError emits an RFC 7591 §3.2.2 client registration error response.
+// Status is 400 with a JSON body { "error": "<code>", "error_description": "..." }.
+func writeDCRError(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, code, description string) error {
+	body, err := json.Marshal(map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to marshal DCR error").Log(ctx, logger)
+	}
+
+	logger.InfoContext(ctx, "DCR registration rejected",
+		attr.SlogOAuthError(code),
+		attr.SlogOAuthErrorDescription(description),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusBadRequest)
+	if _, werr := w.Write(body); werr != nil {
+		return oops.E(oops.CodeUnexpected, werr, "failed to write DCR error body").Log(ctx, logger)
+	}
+	return nil
+}
+
+// generateClientSecret produces 32 bytes of cryptographically random data
+// and base64url-encodes them.
+func generateClientSecret() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("read random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }

--- a/server/internal/mcp/custom_domain_test.go
+++ b/server/internal/mcp/custom_domain_test.go
@@ -196,7 +196,7 @@ func serveWellKnownHTTP(
 	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
 
 	w := httptest.NewRecorder()
-	if err := ti.service.HandleWellKnownOAuthServerMetadata(w, req); err != nil {
+	if err := ti.service.HandleGetAuthorizationServer(w, req); err != nil {
 		return w, fmt.Errorf("well-known oauth: %w", err)
 	}
 	return w, nil

--- a/server/internal/mcp/dcr_request_test.go
+++ b/server/internal/mcp/dcr_request_test.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validateAfterDefaults runs the production order — SetDefaults then
+// Validate — on the supplied request and returns the validation error.
+func validateAfterDefaults(req *dcrRegistrationRequest) error {
+	req.SetDefaults()
+	return req.Validate()
+}
+
+func TestDCRRegistrationRequest_Validate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepts a fully populated request", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:              "Acme MCP Client",
+			RedirectURIs:            []string{"https://app.acme.test/callback"},
+			GrantTypes:              []string{"authorization_code", "refresh_token"},
+			ResponseTypes:           []string{"code"},
+			TokenEndpointAuthMethod: "client_secret_basic",
+			Scope:                   "openid",
+		}
+		require.NoError(t, validateAfterDefaults(req))
+	})
+
+	t.Run("accepts a minimal request with optional fields absent", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:   "minimal",
+			RedirectURIs: []string{"https://app.acme.test/callback"},
+		}
+		require.NoError(t, validateAfterDefaults(req))
+	})
+
+	t.Run("rejects missing client_name", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			RedirectURIs: []string{"https://app.acme.test/callback"},
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", "client_name")
+	})
+
+	t.Run("rejects missing redirect_uris", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{ClientName: "named"}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "redirect_uris")
+	})
+
+	t.Run("rejects empty redirect_uris slice", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{ClientName: "named", RedirectURIs: []string{}}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "redirect_uris")
+	})
+
+	t.Run("rejects relative redirect URI", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:   "named",
+			RedirectURIs: []string{"/callback"},
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
+	})
+
+	t.Run("rejects URI missing scheme", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:   "named",
+			RedirectURIs: []string{"app.acme.test/callback"},
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
+	})
+
+	t.Run("rejects URI missing host", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:   "named",
+			RedirectURIs: []string{"https:///callback"},
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
+	})
+
+	t.Run("rejects unsupported grant_type", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:   "named",
+			RedirectURIs: []string{"https://app.acme.test/callback"},
+			GrantTypes:   []string{"password"},
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported grant_type "password"`)
+	})
+
+	t.Run("rejects unsupported response_type", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:    "named",
+			RedirectURIs:  []string{"https://app.acme.test/callback"},
+			ResponseTypes: []string{"token"},
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported response_type "token"`)
+	})
+
+	t.Run("rejects unsupported token_endpoint_auth_method", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:              "named",
+			RedirectURIs:            []string{"https://app.acme.test/callback"},
+			TokenEndpointAuthMethod: "client_secret_jwt",
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported token_endpoint_auth_method "client_secret_jwt"`)
+	})
+
+	t.Run("accepts public client (none) auth method", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:              "public",
+			RedirectURIs:            []string{"https://app.acme.test/callback"},
+			TokenEndpointAuthMethod: "none",
+		}
+		require.NoError(t, validateAfterDefaults(req))
+	})
+
+	t.Run("rejects refresh_token alone (no authorization_code)", func(t *testing.T) {
+		t.Parallel()
+		// bflad's RFC 7591 §2.1 example
+		req := &dcrRegistrationRequest{
+			ClientName:    "drift",
+			RedirectURIs:  []string{"https://app.acme.test/callback"},
+			GrantTypes:    []string{"refresh_token"},
+			ResponseTypes: []string{"code"},
+		}
+		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `response_type "code" requires grant_type "authorization_code"`)
+	})
+
+	t.Run("accepts authorization_code with refresh_token", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:    "paired",
+			RedirectURIs:  []string{"https://app.acme.test/callback"},
+			GrantTypes:    []string{"authorization_code", "refresh_token"},
+			ResponseTypes: []string{"code"},
+		}
+		require.NoError(t, validateAfterDefaults(req))
+	})
+}
+
+func TestDCRRegistrationRequest_SetDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates all defaults when absent", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:   "named",
+			RedirectURIs: []string{"https://app.acme.test/callback"},
+		}
+		req.SetDefaults()
+		assert.Equal(t, []string{"authorization_code"}, req.GrantTypes)
+		assert.Equal(t, []string{"code"}, req.ResponseTypes)
+		assert.Equal(t, "client_secret_basic", req.TokenEndpointAuthMethod)
+	})
+
+	t.Run("does not overwrite supplied values", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:              "named",
+			RedirectURIs:            []string{"https://app.acme.test/callback"},
+			GrantTypes:              []string{"refresh_token"},
+			ResponseTypes:           []string{"code"},
+			TokenEndpointAuthMethod: "none",
+		}
+		req.SetDefaults()
+		assert.Equal(t, []string{"refresh_token"}, req.GrantTypes)
+		assert.Equal(t, []string{"code"}, req.ResponseTypes)
+		assert.Equal(t, "none", req.TokenEndpointAuthMethod)
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		t.Parallel()
+		req := &dcrRegistrationRequest{
+			ClientName:   "named",
+			RedirectURIs: []string{"https://app.acme.test/callback"},
+		}
+		req.SetDefaults()
+		first := *req
+		req.SetDefaults()
+		assert.Equal(t, first, *req)
+	})
+}
+
+// assertDCRError fails the test unless err unwraps to a *dcrError with the
+// expected code and a description containing the expected substring.
+func assertDCRError(t *testing.T, err error, wantCode, wantDescriptionSubstr string) {
+	t.Helper()
+	require.Error(t, err)
+	var dcrErr *dcrError
+	require.True(t, errors.As(err, &dcrErr), "expected *dcrError, got %T (%v)", err, err)
+	assert.Equal(t, wantCode, dcrErr.Code)
+	assert.Contains(t, dcrErr.Description, wantDescriptionSubstr)
+}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"mime"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"slices"
 	"strings"
@@ -220,9 +219,12 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/install", oops.ErrHandle(service.logger, metadataService.ServeInstallPage).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/install-page-{hash}.js", oops.ErrHandle(service.logger, metadataService.ServeInstallPageScript).ServeHTTP)
 
-	// OAuth 2.1 Authorization Server Metadata
-	o11y.AttachHandler(mux, "GET", wellknown.OAuthAuthorizationServerPath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthServerMetadata).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", wellknown.OAuthProtectedResourcePath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleWellKnownOAuthProtectedResourceMetadata).ServeHTTP)
+	// OAuth metadata at the canonical RFC paths. The handlers in
+	// authnchallenge.go dispatch internally on toolsets.user_session_issuer_id:
+	// issuer-gated toolsets get the new metadata shape; legacy toolsets fall
+	// through to wellknown.Resolve* (preserving the prior behaviour).
+	o11y.AttachHandler(mux, "GET", wellknown.OAuthProtectedResourcePath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleGetProtectedResource).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", wellknown.OAuthAuthorizationServerPath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleGetAuthorizationServer).ServeHTTP)
 }
 
 // HandleGetServer handles GET requests to /mcp/{mcpSlug}, checking for HTML requests
@@ -261,71 +263,6 @@ func (s *Service) HandleGetServer(w http.ResponseWriter, r *http.Request, metada
 	return nil
 }
 
-// handleWellKnownMetadata handles OAuth 2.1 authorization server metadata discovery
-func (s *Service) HandleWellKnownOAuthServerMetadata(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
-	mcpSlug := chi.URLParam(r, "mcpSlug")
-	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
-	}
-
-	toolset, customDomainCtx, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
-	switch {
-	case errors.Is(err, errToolsetNotFound):
-		return oops.E(oops.CodeNotFound, err, "mcp server not found")
-	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
-	}
-
-	baseURL := s.serverURL.String()
-	if customDomainCtx != nil {
-		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
-	}
-
-	result, err := wellknown.ResolveOAuthServerMetadataFromToolset(
-		ctx,
-		s.logger,
-		s.db,
-		s.oauthRepo,
-		&s.toolsetCache,
-		toolset,
-		baseURL,
-		mcpSlug,
-	)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").Log(ctx, s.logger)
-	}
-
-	if result == nil {
-		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
-	}
-
-	// Handle proxy case - reverse proxy to external MCP OAuth server
-	if result.Kind == wellknown.OAuthServerMetadataResultKindProxy {
-		target, parseErr := url.Parse(result.ProxyURL)
-		if parseErr != nil {
-			return oops.E(oops.CodeUnexpected, parseErr, "failed to parse well-known URL").Log(ctx, s.logger)
-		}
-
-		proxy := &httputil.ReverseProxy{
-			Director: nil,
-			Rewrite: func(pr *httputil.ProxyRequest) {
-				pr.SetURL(target)
-			},
-			Transport:      nil,
-			FlushInterval:  0,
-			ErrorLog:       nil,
-			BufferPool:     nil,
-			ModifyResponse: nil,
-			ErrorHandler:   nil,
-		}
-		proxy.ServeHTTP(w, r)
-		return nil
-	}
-
-	return writeOAuthServerMetadataResponse(ctx, s.logger, w, result)
-}
-
 // writeOAuthServerMetadataResponse builds the OAuth server metadata body and
 // only commits the 200 OK status once the body is ready. This ordering matters:
 // if marshaling fails or the result kind is unrecognized, the caller's error
@@ -353,45 +290,6 @@ func writeOAuthServerMetadataResponse(ctx context.Context, logger *slog.Logger, 
 	}
 
 	return nil
-}
-
-func (s *Service) HandleWellKnownOAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
-	mcpSlug := chi.URLParam(r, "mcpSlug")
-	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
-	}
-
-	toolset, customDomainCtx, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
-	switch {
-	case errors.Is(err, errToolsetNotFound):
-		return oops.E(oops.CodeNotFound, err, "mcp server not found")
-	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
-	}
-
-	baseURL := s.serverURL.String()
-	if customDomainCtx != nil {
-		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
-	}
-
-	metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(
-		ctx,
-		s.logger,
-		s.db,
-		&s.toolsetCache,
-		toolset,
-		baseURL+"/mcp/"+mcpSlug,
-	)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth protected resource metadata").Log(ctx, s.logger)
-	}
-
-	if metadata == nil {
-		return oops.E(oops.CodeNotFound, nil, "not found")
-	}
-
-	return writeOAuthProtectedResourceMetadataResponse(ctx, s.logger, w, metadata)
 }
 
 // writeOAuthProtectedResourceMetadataResponse builds the OAuth protected

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -225,6 +225,7 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	// through to wellknown.Resolve* (preserving the prior behaviour).
 	o11y.AttachHandler(mux, "GET", wellknown.OAuthProtectedResourcePath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleGetProtectedResource).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", wellknown.OAuthAuthorizationServerPath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleGetAuthorizationServer).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/register", oops.ErrHandle(service.logger, service.HandleRegister).ServeHTTP)
 }
 
 // HandleGetServer handles GET requests to /mcp/{mcpSlug}, checking for HTML requests

--- a/server/internal/mcp/servepublic_clientdance_test.go
+++ b/server/internal/mcp/servepublic_clientdance_test.go
@@ -28,7 +28,7 @@ import (
 // Well-known OAuth server metadata tests
 // ---------------------------------------------------------------------------
 
-func TestService_HandleWellKnownOAuthServerMetadata(t *testing.T) {
+func TestService_HandleGetAuthorizationServer(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns_error_when_mcp_slug_is_missing", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestService_HandleWellKnownOAuthServerMetadata(t *testing.T) {
 		req = req.WithContext(reqCtx)
 
 		w := httptest.NewRecorder()
-		err := ti.service.HandleWellKnownOAuthServerMetadata(w, req)
+		err := ti.service.HandleGetAuthorizationServer(w, req)
 
 		// Should return an error for missing slug
 		require.Error(t, err)
@@ -65,7 +65,7 @@ func TestService_HandleWellKnownOAuthServerMetadata(t *testing.T) {
 		req = req.WithContext(reqCtx)
 
 		w := httptest.NewRecorder()
-		err := ti.service.HandleWellKnownOAuthServerMetadata(w, req)
+		err := ti.service.HandleGetAuthorizationServer(w, req)
 
 		// Should return a 404 error
 		require.Error(t, err)
@@ -104,7 +104,7 @@ func TestService_HandleWellKnownOAuthServerMetadata(t *testing.T) {
 		req = req.WithContext(reqCtx)
 
 		w := httptest.NewRecorder()
-		err = ti.service.HandleWellKnownOAuthServerMetadata(w, req)
+		err = ti.service.HandleGetAuthorizationServer(w, req)
 
 		// Should return 404 for no OAuth configuration
 		require.Error(t, err)
@@ -175,7 +175,7 @@ func TestService_HandleWellKnownOAuthServerMetadata(t *testing.T) {
 		req = req.WithContext(reqCtx)
 
 		w := httptest.NewRecorder()
-		err = ti.service.HandleWellKnownOAuthServerMetadata(w, req)
+		err = ti.service.HandleGetAuthorizationServer(w, req)
 
 		// Should return successfully with metadata
 		require.NoError(t, err)
@@ -189,7 +189,7 @@ func TestService_HandleWellKnownOAuthServerMetadata(t *testing.T) {
 // Well-known OAuth server metadata — refresh token grant tests
 // ---------------------------------------------------------------------------
 
-func TestService_HandleWellKnownOAuthServerMetadata_RefreshTokenGrant(t *testing.T) {
+func TestService_HandleGetAuthorizationServer_RefreshTokenGrant(t *testing.T) {
 	t.Parallel()
 
 	t.Run("grant_types_supported includes refresh_token", func(t *testing.T) {
@@ -250,7 +250,7 @@ func TestService_HandleWellKnownOAuthServerMetadata_RefreshTokenGrant(t *testing
 		req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
 
 		w := httptest.NewRecorder()
-		err = ti.service.HandleWellKnownOAuthServerMetadata(w, req)
+		err = ti.service.HandleGetAuthorizationServer(w, req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -322,7 +322,7 @@ func TestService_HandleWellKnownOAuthServerMetadata_RefreshTokenGrant(t *testing
 		req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
 
 		w := httptest.NewRecorder()
-		err = ti.service.HandleWellKnownOAuthServerMetadata(w, req)
+		err = ti.service.HandleGetAuthorizationServer(w, req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -394,7 +394,7 @@ func TestService_HandleWellKnownOAuthServerMetadata_RefreshTokenGrant(t *testing
 		req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
 
 		w := httptest.NewRecorder()
-		err = ti.service.HandleWellKnownOAuthServerMetadata(w, req)
+		err = ti.service.HandleGetAuthorizationServer(w, req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, w.Code)
 
@@ -415,7 +415,7 @@ func TestService_HandleWellKnownOAuthServerMetadata_RefreshTokenGrant(t *testing
 // Well-known OAuth protected resource metadata tests
 // ---------------------------------------------------------------------------
 
-func TestService_HandleWellKnownOAuthProtectedResourceMetadata(t *testing.T) {
+func TestService_HandleGetProtectedResource(t *testing.T) {
 	t.Parallel()
 
 	t.Run("returns_error_when_mcp_slug_is_missing", func(t *testing.T) {
@@ -432,7 +432,7 @@ func TestService_HandleWellKnownOAuthProtectedResourceMetadata(t *testing.T) {
 		req = req.WithContext(reqCtx)
 
 		w := httptest.NewRecorder()
-		err := ti.service.HandleWellKnownOAuthProtectedResourceMetadata(w, req)
+		err := ti.service.HandleGetProtectedResource(w, req)
 
 		// Should return an error for missing slug
 		require.Error(t, err)
@@ -452,7 +452,7 @@ func TestService_HandleWellKnownOAuthProtectedResourceMetadata(t *testing.T) {
 		req = req.WithContext(reqCtx)
 
 		w := httptest.NewRecorder()
-		err := ti.service.HandleWellKnownOAuthProtectedResourceMetadata(w, req)
+		err := ti.service.HandleGetProtectedResource(w, req)
 
 		// Should return a 404 error
 		require.Error(t, err)
@@ -523,7 +523,7 @@ func TestService_HandleWellKnownOAuthProtectedResourceMetadata(t *testing.T) {
 		req = req.WithContext(reqCtx)
 
 		w := httptest.NewRecorder()
-		err = ti.service.HandleWellKnownOAuthProtectedResourceMetadata(w, req)
+		err = ti.service.HandleGetProtectedResource(w, req)
 
 		// Should return successfully with metadata
 		require.NoError(t, err)
@@ -573,7 +573,7 @@ func TestClientDance_ExternalOAuth_FullFlow(t *testing.T) {
 	require.NotEmpty(t, wwwAuth, "401 must include WWW-Authenticate header")
 	require.Contains(t, wwwAuth, "Bearer resource_metadata=")
 
-	// 5. Call HandleWellKnownOAuthProtectedResourceMetadata and verify it returns
+	// 5. Call HandleGetProtectedResource and verify it returns
 	//    valid JSON containing the MCP resource URL.
 	prReq := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp/"+mcpSlug, nil)
 	prRctx := chi.NewRouteContext()
@@ -581,7 +581,7 @@ func TestClientDance_ExternalOAuth_FullFlow(t *testing.T) {
 	prReq = prReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, prRctx))
 
 	prW := httptest.NewRecorder()
-	err = ti.service.HandleWellKnownOAuthProtectedResourceMetadata(prW, prReq)
+	err = ti.service.HandleGetProtectedResource(prW, prReq)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, prW.Code)
 
@@ -633,14 +633,14 @@ func TestClientDance_ProxyOAuth_WWWAuthenticateChain(t *testing.T) {
 	require.NotEmpty(t, wwwAuth, "401 must include WWW-Authenticate header")
 	require.Contains(t, wwwAuth, "Bearer resource_metadata=")
 
-	// 4. Call HandleWellKnownOAuthProtectedResourceMetadata — verify valid metadata.
+	// 4. Call HandleGetProtectedResource — verify valid metadata.
 	prReq := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp/"+mcpSlug, nil)
 	prRctx := chi.NewRouteContext()
 	prRctx.URLParams.Add("mcpSlug", mcpSlug)
 	prReq = prReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, prRctx))
 
 	prW := httptest.NewRecorder()
-	err = ti.service.HandleWellKnownOAuthProtectedResourceMetadata(prW, prReq)
+	err = ti.service.HandleGetProtectedResource(prW, prReq)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, prW.Code)
 
@@ -652,7 +652,7 @@ func TestClientDance_ProxyOAuth_WWWAuthenticateChain(t *testing.T) {
 	require.True(t, ok, "resource field must be a string")
 	require.Contains(t, resource, mcpSlug, "resource URL should reference the MCP slug")
 
-	// 5. Call HandleWellKnownOAuthServerMetadata — verify it returns valid metadata
+	// 5. Call HandleGetAuthorizationServer — verify it returns valid metadata
 	//    with authorization_endpoint, token_endpoint, and registration_endpoint.
 	smReq := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/"+mcpSlug, nil)
 	smRctx := chi.NewRouteContext()
@@ -660,7 +660,7 @@ func TestClientDance_ProxyOAuth_WWWAuthenticateChain(t *testing.T) {
 	smReq = smReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, smRctx))
 
 	smW := httptest.NewRecorder()
-	err = ti.service.HandleWellKnownOAuthServerMetadata(smW, smReq)
+	err = ti.service.HandleGetAuthorizationServer(smW, smReq)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, smW.Code)
 

--- a/server/internal/usersessions/clientregistration.go
+++ b/server/internal/usersessions/clientregistration.go
@@ -1,0 +1,122 @@
+// Client registration logic for the user-session OAuth Authorization Server
+// surface. Defines the RFC 7591 §3.1 request shape, RFC 7591 §3.2.2 error
+// shape, and the validate / defaults rules that determine which clients
+// are accepted by /mcp/{slug}/register.
+//
+// The mcp package's HandleRegister handler wraps this with HTTP plumbing
+// (Content-Type sniffing, body cap, response writing). The supported sets
+// declared here are advertised verbatim in the AS metadata document so
+// registered clients can only request what the AS will accept.
+
+package usersessions
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+)
+
+// SupportedGrantTypes / SupportedResponseTypes / SupportedAuthMethods are
+// the OAuth values the user-session AS supports. Mirrored into the RFC 8414
+// metadata document by mcp.HandleGetAuthorizationServer; enforced on the
+// /register handler by RegistrationRequest.Validate.
+var (
+	SupportedGrantTypes    = []string{"authorization_code", "refresh_token"}
+	SupportedResponseTypes = []string{"code"}
+	// `none` covers public PKCE-only clients (mobile, CLI, MCP SDK). Real
+	// MCP clients in the wild use it. PKCE provides per-flow integrity; the
+	// only guard against cross-flow client-id confusion is the consent
+	// prompt itself, which we always render (HandleConsent never skips).
+	SupportedAuthMethods = []string{"client_secret_basic", "client_secret_post", "none"}
+)
+
+// RegistrationRequest is the RFC 7591 §3.1 client metadata document. Only
+// the fields we honour are listed; unknown fields are ignored.
+//
+// `scope` is intentionally absent: RFC 7591 §3.2.1 requires the registration
+// response to reflect actually-registered metadata, and we have no scope
+// enforcement to back it up — echoing a `scope` field would assert server
+// state we don't hold. Add it back when we ship a scope-aware /token.
+type RegistrationRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+}
+
+// RegistrationError is an RFC 7591 §3.2.2 client registration error in
+// structured form. Carries the wire-protocol error code and human-readable
+// description to the response writer without leaking either into the
+// function signatures of upstream validators.
+type RegistrationError struct {
+	Code        string
+	Description string
+}
+
+func (e *RegistrationError) Error() string { return e.Code + ": " + e.Description }
+
+// SetDefaults populates the RFC 7591 §2 defaults for fields the client
+// didn't supply. Must be called before Validate so the §2.1 grant/response
+// correlation check sees materialized values.
+func (r *RegistrationRequest) SetDefaults() {
+	if len(r.GrantTypes) == 0 {
+		r.GrantTypes = []string{"authorization_code"}
+	}
+	if len(r.ResponseTypes) == 0 {
+		r.ResponseTypes = []string{"code"}
+	}
+	if r.TokenEndpointAuthMethod == "" {
+		r.TokenEndpointAuthMethod = "client_secret_basic"
+	}
+}
+
+// Validate checks the (defaulted) fields of an RFC 7591 §3.1 client metadata
+// document. Returns a *RegistrationError on a spec-defined rejection.
+// Callers must invoke SetDefaults first so grant_types / response_types /
+// auth method are populated.
+func (r *RegistrationRequest) Validate() error {
+	if r.ClientName == "" {
+		return &RegistrationError{Code: "invalid_client_metadata", Description: "client_name is required"}
+	}
+	if len(r.RedirectURIs) == 0 {
+		return &RegistrationError{Code: "invalid_redirect_uri", Description: "redirect_uris is required"}
+	}
+	for _, u := range r.RedirectURIs {
+		parsed, parseErr := url.Parse(u)
+		if parseErr != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return &RegistrationError{Code: "invalid_redirect_uri", Description: "redirect_uri must be an absolute URL"}
+		}
+	}
+	for _, gt := range r.GrantTypes {
+		if !slices.Contains(SupportedGrantTypes, gt) {
+			return &RegistrationError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported grant_type %q", gt)}
+		}
+	}
+	for _, rt := range r.ResponseTypes {
+		if !slices.Contains(SupportedResponseTypes, rt) {
+			return &RegistrationError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported response_type %q", rt)}
+		}
+	}
+	if !slices.Contains(SupportedAuthMethods, r.TokenEndpointAuthMethod) {
+		return &RegistrationError{Code: "invalid_client_metadata", Description: fmt.Sprintf("unsupported token_endpoint_auth_method %q", r.TokenEndpointAuthMethod)}
+	}
+
+	// RFC 7591 §2.1 correlation: response_type "code" requires grant_type
+	// "authorization_code" and vice versa.
+	hasCodeResponse := slices.Contains(r.ResponseTypes, "code")
+	hasAuthCodeGrant := slices.Contains(r.GrantTypes, "authorization_code")
+	if hasCodeResponse && !hasAuthCodeGrant {
+		return &RegistrationError{Code: "invalid_client_metadata", Description: `response_type "code" requires grant_type "authorization_code"`}
+	}
+	if hasAuthCodeGrant && !hasCodeResponse {
+		return &RegistrationError{Code: "invalid_client_metadata", Description: `grant_type "authorization_code" requires response_type "code"`}
+	}
+	// refresh_token can only follow an initial authorization_code in our
+	// supported set; a client registering refresh_token alone has no way
+	// to ever obtain one.
+	if slices.Contains(r.GrantTypes, "refresh_token") && !hasAuthCodeGrant {
+		return &RegistrationError{Code: "invalid_client_metadata", Description: `grant_type "refresh_token" requires grant_type "authorization_code"`}
+	}
+	return nil
+}

--- a/server/internal/usersessions/clientregistration_test.go
+++ b/server/internal/usersessions/clientregistration_test.go
@@ -1,7 +1,6 @@
-package mcp
+package usersessions
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,30 +9,29 @@ import (
 
 // validateAfterDefaults runs the production order — SetDefaults then
 // Validate — on the supplied request and returns the validation error.
-func validateAfterDefaults(req *dcrRegistrationRequest) error {
+func validateAfterDefaults(req *RegistrationRequest) error {
 	req.SetDefaults()
 	return req.Validate()
 }
 
-func TestDCRRegistrationRequest_Validate(t *testing.T) {
+func TestRegistrationRequest_Validate(t *testing.T) {
 	t.Parallel()
 
 	t.Run("accepts a fully populated request", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:              "Acme MCP Client",
 			RedirectURIs:            []string{"https://app.acme.test/callback"},
 			GrantTypes:              []string{"authorization_code", "refresh_token"},
 			ResponseTypes:           []string{"code"},
 			TokenEndpointAuthMethod: "client_secret_basic",
-			Scope:                   "openid",
 		}
 		require.NoError(t, validateAfterDefaults(req))
 	})
 
 	t.Run("accepts a minimal request with optional fields absent", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:   "minimal",
 			RedirectURIs: []string{"https://app.acme.test/callback"},
 		}
@@ -42,84 +40,84 @@ func TestDCRRegistrationRequest_Validate(t *testing.T) {
 
 	t.Run("rejects missing client_name", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			RedirectURIs: []string{"https://app.acme.test/callback"},
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", "client_name")
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_client_metadata", "client_name")
 	})
 
 	t.Run("rejects missing redirect_uris", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{ClientName: "named"}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "redirect_uris")
+		req := &RegistrationRequest{ClientName: "named"}
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_redirect_uri", "redirect_uris")
 	})
 
 	t.Run("rejects empty redirect_uris slice", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{ClientName: "named", RedirectURIs: []string{}}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "redirect_uris")
+		req := &RegistrationRequest{ClientName: "named", RedirectURIs: []string{}}
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_redirect_uri", "redirect_uris")
 	})
 
 	t.Run("rejects relative redirect URI", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:   "named",
 			RedirectURIs: []string{"/callback"},
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
 	})
 
 	t.Run("rejects URI missing scheme", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:   "named",
 			RedirectURIs: []string{"app.acme.test/callback"},
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
 	})
 
 	t.Run("rejects URI missing host", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:   "named",
 			RedirectURIs: []string{"https:///callback"},
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_redirect_uri", "absolute URL")
 	})
 
 	t.Run("rejects unsupported grant_type", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:   "named",
 			RedirectURIs: []string{"https://app.acme.test/callback"},
 			GrantTypes:   []string{"password"},
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported grant_type "password"`)
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported grant_type "password"`)
 	})
 
 	t.Run("rejects unsupported response_type", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:    "named",
 			RedirectURIs:  []string{"https://app.acme.test/callback"},
 			ResponseTypes: []string{"token"},
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported response_type "token"`)
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported response_type "token"`)
 	})
 
 	t.Run("rejects unsupported token_endpoint_auth_method", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:              "named",
 			RedirectURIs:            []string{"https://app.acme.test/callback"},
 			TokenEndpointAuthMethod: "client_secret_jwt",
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported token_endpoint_auth_method "client_secret_jwt"`)
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_client_metadata", `unsupported token_endpoint_auth_method "client_secret_jwt"`)
 	})
 
 	t.Run("accepts public client (none) auth method", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:              "public",
 			RedirectURIs:            []string{"https://app.acme.test/callback"},
 			TokenEndpointAuthMethod: "none",
@@ -130,18 +128,18 @@ func TestDCRRegistrationRequest_Validate(t *testing.T) {
 	t.Run("rejects refresh_token alone (no authorization_code)", func(t *testing.T) {
 		t.Parallel()
 		// bflad's RFC 7591 §2.1 example
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:    "drift",
 			RedirectURIs:  []string{"https://app.acme.test/callback"},
 			GrantTypes:    []string{"refresh_token"},
 			ResponseTypes: []string{"code"},
 		}
-		assertDCRError(t, validateAfterDefaults(req), "invalid_client_metadata", `response_type "code" requires grant_type "authorization_code"`)
+		assertRegistrationError(t, validateAfterDefaults(req), "invalid_client_metadata", `response_type "code" requires grant_type "authorization_code"`)
 	})
 
 	t.Run("accepts authorization_code with refresh_token", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:    "paired",
 			RedirectURIs:  []string{"https://app.acme.test/callback"},
 			GrantTypes:    []string{"authorization_code", "refresh_token"},
@@ -151,12 +149,12 @@ func TestDCRRegistrationRequest_Validate(t *testing.T) {
 	})
 }
 
-func TestDCRRegistrationRequest_SetDefaults(t *testing.T) {
+func TestRegistrationRequest_SetDefaults(t *testing.T) {
 	t.Parallel()
 
 	t.Run("populates all defaults when absent", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:   "named",
 			RedirectURIs: []string{"https://app.acme.test/callback"},
 		}
@@ -168,7 +166,7 @@ func TestDCRRegistrationRequest_SetDefaults(t *testing.T) {
 
 	t.Run("does not overwrite supplied values", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:              "named",
 			RedirectURIs:            []string{"https://app.acme.test/callback"},
 			GrantTypes:              []string{"refresh_token"},
@@ -183,7 +181,7 @@ func TestDCRRegistrationRequest_SetDefaults(t *testing.T) {
 
 	t.Run("is idempotent", func(t *testing.T) {
 		t.Parallel()
-		req := &dcrRegistrationRequest{
+		req := &RegistrationRequest{
 			ClientName:   "named",
 			RedirectURIs: []string{"https://app.acme.test/callback"},
 		}
@@ -194,13 +192,14 @@ func TestDCRRegistrationRequest_SetDefaults(t *testing.T) {
 	})
 }
 
-// assertDCRError fails the test unless err unwraps to a *dcrError with the
-// expected code and a description containing the expected substring.
-func assertDCRError(t *testing.T, err error, wantCode, wantDescriptionSubstr string) {
+// assertRegistrationError fails the test unless err unwraps to a
+// *RegistrationError with the expected code and a description containing
+// the expected substring.
+func assertRegistrationError(t *testing.T, err error, wantCode, wantDescriptionSubstr string) {
 	t.Helper()
 	require.Error(t, err)
-	var dcrErr *dcrError
-	require.True(t, errors.As(err, &dcrErr), "expected *dcrError, got %T (%v)", err, err)
-	assert.Equal(t, wantCode, dcrErr.Code)
-	assert.Contains(t, dcrErr.Description, wantDescriptionSubstr)
+	var regErr *RegistrationError
+	require.ErrorAs(t, err, &regErr, "expected *RegistrationError, got %T (%v)", err, err)
+	assert.Equal(t, wantCode, regErr.Code)
+	assert.Contains(t, regErr.Description, wantDescriptionSubstr)
 }


### PR DESCRIPTION
## Summary

Wires the OAuth 2.1 / RFC 9728 discovery surface for MCP toolsets that are gated by a user-session issuer:

- \`internal/mcp/authnchallenge.go\` — \`WriteAuthenticateChallenge\` helper for emitting WWW-Authenticate
- Well-known handlers (\`/.well-known/oauth-authorization-server\`, \`/.well-known/oauth-protected-resource\`) at the v2 MCP routes
- \`HandleRegister\` — RFC 7591 dynamic client registration

\`token_endpoint_auth_methods_supported\` advertises \`none\` so PKCE-only public clients (which is what real MCP SDKs ship) can register and authenticate end-to-end.

## Stack

- PR-0: refactor(auth): extract Speakeasy IDP client → main (#2643)
- PR-1: usersessions migration → PR-0 (#2644)
- PR-2: usersessions management API → PR-1 (#2645)
- PR-3: toolsets.user_session_issuer_id migration → PR-2 (#2646)
- **PR-4 (this PR)** → PR-3
- PR-5: MCP OAuth authn dance + remote-session foundation → PR-4

## Test plan

- [ ] CI green
- [ ] \`curl /.well-known/oauth-authorization-server\` returns the expected metadata for a private-OAuth toolset
- [ ] DCR registration round-trip with a real MCP SDK client