### PR TITLE
fix(catalog): wire up NextCursor so infinite scroll fetches all registry entries

### DIFF
--- a/.changeset/catalog-nextcursor-pagination.md
+++ b/.changeset/catalog-nextcursor-pagination.md
@@ -1,0 +1,7 @@
+---
+"server": patch
+---
+
+Fix catalog registry pagination so infinite scroll fetches all entries beyond the first page.
+
+`ListServers` now returns the upstream registry's `nextCursor` alongside the server list. `ListCatalog` passes that cursor through to the API response so the frontend's `getNextPageParam` receives a non-null value and `hasNextPage` becomes `true`. Previously `NextCursor` was always `nil`, causing the intersection observer to never trigger a second fetch and silently dropping any entries past the first 50.

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -170,7 +170,7 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to get registry").Log(ctx, s.logger)
 		}
 
-		servers, err := s.registryClient.ListServers(ctx, Registry{
+		result, err := s.registryClient.ListServers(ctx, Registry{
 			ID:  registry.ID,
 			URL: registry.Url,
 		}, ListServersParams{
@@ -182,8 +182,8 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 		}
 
 		return &gen.ListCatalogResult{
-			Servers:    servers,
-			NextCursor: nil, // Pagination not implemented in v0
+			Servers:    result.Servers,
+			NextCursor: result.NextCursor,
 		}, nil
 	}
 
@@ -195,8 +195,9 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 
 	// Aggregate servers from all registries
 	var allServers []*types.ExternalMCPServer
+	var registryResults []ListServersResult
 	for _, registry := range registries {
-		servers, err := s.registryClient.ListServers(ctx, Registry{
+		result, err := s.registryClient.ListServers(ctx, Registry{
 			ID:  registry.ID,
 			URL: registry.Url,
 		}, ListServersParams{
@@ -211,7 +212,8 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 			)
 			continue
 		}
-		allServers = append(allServers, servers...)
+		allServers = append(allServers, result.Servers...)
+		registryResults = append(registryResults, result)
 	}
 
 	// Cap at 100 servers for v0
@@ -219,9 +221,16 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 		allServers = allServers[:100]
 	}
 
+	// Return the cursor only when there is a single registry —
+	// multi-registry composite cursor support is tracked in AGE-2153.
+	var nextCursor *string
+	if len(registryResults) == 1 {
+		nextCursor = registryResults[0].NextCursor
+	}
+
 	return &gen.ListCatalogResult{
 		Servers:    allServers,
-		NextCursor: nil, // Pagination not implemented in v0
+		NextCursor: nextCursor,
 	}, nil
 }
 

--- a/server/internal/externalmcp/registry_cache.go
+++ b/server/internal/externalmcp/registry_cache.go
@@ -16,8 +16,9 @@ const registryCacheTTL = 24 * time.Hour
 
 // CachedListServersResponse wraps a list of external MCP servers for caching.
 type CachedListServersResponse struct {
-	Key     string
-	Servers []*types.ExternalMCPServer
+	Key        string
+	Servers    []*types.ExternalMCPServer
+	NextCursor *string
 }
 
 var _ cache.CacheableObject[CachedListServersResponse] = (*CachedListServersResponse)(nil)

--- a/server/internal/externalmcp/registryclient.go
+++ b/server/internal/externalmcp/registryclient.go
@@ -79,11 +79,16 @@ type ListServersParams struct {
 	Cursor *string
 }
 
+// ListServersResult is the result of a ListServers call.
+type ListServersResult struct {
+	Servers    []*types.ExternalMCPServer
+	NextCursor *string
+}
+
 // listResponse represents the response from the MCP registry API.
 type listResponse struct {
 	Servers  []serverEntry `json:"servers"`
 	Metadata struct {
-		Count      int     `json:"count"`
 		NextCursor *string `json:"nextCursor"`
 	} `json:"metadata"`
 }
@@ -204,7 +209,7 @@ func toCacheSafeAny(v any) (any, error) {
 }
 
 // ListServers fetches servers from the given registry.
-func (c *RegistryClient) ListServers(ctx context.Context, registry Registry, params ListServersParams) ([]*types.ExternalMCPServer, error) {
+func (c *RegistryClient) ListServers(ctx context.Context, registry Registry, params ListServersParams) (ListServersResult, error) {
 	reqURL := fmt.Sprintf("%s/v0.1/servers?version=latest&limit=50", registry.URL)
 	if params.Search != nil && *params.Search != "" {
 		reqURL += fmt.Sprintf("&search=%s", *params.Search)
@@ -217,12 +222,12 @@ func (c *RegistryClient) ListServers(ctx context.Context, registry Registry, par
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("create list servers request: %w", err)
+		return ListServersResult{}, fmt.Errorf("create list servers request: %w", err)
 	}
 
 	if c.backend.Match(req) {
 		if err := c.backend.Authorize(req); err != nil {
-			return nil, fmt.Errorf("authorize list servers request: %w", err)
+			return ListServersResult{}, fmt.Errorf("authorize list servers request: %w", err)
 		}
 	}
 
@@ -232,30 +237,33 @@ func (c *RegistryClient) ListServers(ctx context.Context, registry Registry, par
 		cached, err := c.listCache.Get(ctx, cacheKey)
 		if err == nil {
 			c.logger.DebugContext(ctx, "registry list cache hit", attr.SlogCacheKey(cacheKey))
-			return cached.Servers, nil
+			return ListServersResult{
+				Servers:    cached.Servers,
+				NextCursor: cached.NextCursor,
+			}, nil
 		}
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch from registry: %w", err)
+		return ListServersResult{}, fmt.Errorf("failed to fetch from registry: %w", err)
 	}
 	defer o11y.LogDefer(ctx, c.logger, func() error {
 		return resp.Body.Close()
 	})
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("registry returned status %d", resp.StatusCode)
+		return ListServersResult{}, fmt.Errorf("registry returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return ListServersResult{}, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	var listResp listResponse
 	if err := json.Unmarshal(body, &listResp); err != nil {
-		return nil, fmt.Errorf("failed to decode registry response: %w", err)
+		return ListServersResult{}, fmt.Errorf("failed to decode registry response: %w", err)
 	}
 
 	registryID := registry.ID.String()
@@ -293,7 +301,7 @@ func (c *RegistryClient) ListServers(ctx context.Context, registry Registry, par
 
 		meta, err := toCacheSafeAny(&s.Meta)
 		if err != nil {
-			return nil, fmt.Errorf("convert meta: %w", err)
+			return ListServersResult{}, fmt.Errorf("convert meta: %w", err)
 		}
 
 		server := &types.ExternalMCPServer{
@@ -313,18 +321,24 @@ func (c *RegistryClient) ListServers(ctx context.Context, registry Registry, par
 		servers = append(servers, server)
 	}
 
+	nextCursor := listResp.Metadata.NextCursor
+
 	// Store in cache on success.
 	if c.listCache != nil {
 		cacheKey := registryCacheKey("list", req)
 		if storeErr := c.listCache.Store(ctx, CachedListServersResponse{
-			Key:     cacheKey,
-			Servers: servers,
+			Key:        cacheKey,
+			Servers:    servers,
+			NextCursor: nextCursor,
 		}); storeErr != nil {
 			c.logger.WarnContext(ctx, "failed to store registry list in cache", attr.SlogError(storeErr))
 		}
 	}
 
-	return servers, nil
+	return ListServersResult{
+		Servers:    servers,
+		NextCursor: nextCursor,
+	}, nil
 }
 
 func toExternalMCPRemoteHeaders(headers []RemoteHeader) []*types.ExternalMCPRemoteHeader {

--- a/server/internal/externalmcp/registryclient_test.go
+++ b/server/internal/externalmcp/registryclient_test.go
@@ -95,9 +95,9 @@ func TestListServers_FiltersDeletedServers(t *testing.T) {
 	result, err := client.ListServers(ctx, registry, ListServersParams{})
 
 	require.NoError(t, err)
-	require.Len(t, result, 2)
-	require.Equal(t, "active-server", result[0].RegistrySpecifier)
-	require.Equal(t, "another-active", result[1].RegistrySpecifier)
+	require.Len(t, result.Servers, 2)
+	require.Equal(t, "active-server", result.Servers[0].RegistrySpecifier)
+	require.Equal(t, "another-active", result.Servers[1].RegistrySpecifier)
 }
 
 func TestListServers_PreservesRemoteHeadersAndVariables(t *testing.T) {
@@ -171,10 +171,10 @@ func TestListServers_PreservesRemoteHeadersAndVariables(t *testing.T) {
 	result, err := client.ListServers(ctx, registry, ListServersParams{})
 
 	require.NoError(t, err)
-	require.Len(t, result, 1)
-	require.Len(t, result[0].Remotes, 1)
+	require.Len(t, result.Servers, 1)
+	require.Len(t, result.Servers[0].Remotes, 1)
 
-	remote := result[0].Remotes[0]
+	remote := result.Servers[0].Remotes[0]
 	require.Equal(t, "https://api.example.com/{region}/mcp", remote.URL)
 	require.Len(t, remote.Headers, 1)
 	require.Equal(t, "Authorization", remote.Headers[0].Name)


### PR DESCRIPTION
## Summary

- `ListServers` now returns the upstream registry's `nextCursor` alongside the server list, storing it in the cache
- `ListCatalog` passes `NextCursor` through to the API response for both single-registry and multi-registry paths
- Frontend `getNextPageParam` now receives a non-null cursor → `hasNextPage` becomes `true` → intersection observer triggers page 2+

Previously `NextCursor` was hardcoded `nil` on both code paths, silently dropping all catalog entries past the first 50 (one page).

Multi-registry composite cursor handling remains out of scope per AGE-2153. For workspaces with a single registry (the common case), pagination is now fully functional.

## Test plan

- [ ] Catalog loads all 52 servers (2 pages: 50 + 2) via infinite scroll
- [ ] Server count updates from 50 → 52 after second page loads
- [ ] Search works across all pages
- [ ] Cache hit path returns `NextCursor` correctly

Closes AGE-2154

🤖 Generated with [Claude Code](https://claude.com/claude-code)