### PR TITLE
feat(dashboard): challenge UI fixes, org home improvements, dev toolbar

### DIFF
--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -2,7 +2,13 @@ import { useIsAdmin, useOrganization, useSession } from "@/contexts/Auth";
 import { useListToolsetsForOrg } from "@gram/client/react-query/listToolsetsForOrg.js";
 import { Switch } from "./ui/switch";
 import { useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronUp, GripVertical, Shield } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  Crown,
+  GripVertical,
+  Shield,
+} from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -14,6 +20,7 @@ import { createPortal } from "react-dom";
 
 const STORAGE_KEY = "gram-rbac-dev-override";
 const HIDDEN_KEY = "gram-dev-toolbar-hidden";
+const SUPER_ADMIN_KEY = "gram-dev-super-admin";
 
 type ResourceType = "org" | "project" | "mcp";
 
@@ -209,6 +216,9 @@ function RBACDevToolbarInner({ onHide }: { onHide: () => void }) {
   const [collapsed, setCollapsed] = useState(true);
   const [activeTab, setActiveTab] = useState("rbac");
   const [pos, setPos] = useState<{ x: number; y: number } | null>(loadPosition);
+  const [superAdmin, setSuperAdmin] = useState(
+    () => localStorage.getItem(SUPER_ADMIN_KEY) === "1",
+  );
   const queryClient = useQueryClient();
   const organization = useOrganization();
   const liveProjects = (organization?.projects ?? []).map((project) => ({
@@ -325,6 +335,17 @@ function RBACDevToolbarInner({ onHide }: { onHide: () => void }) {
       window.removeEventListener("pointerup", onUp);
     };
   }, []);
+
+  // Collapse when clicking outside
+  useEffect(() => {
+    if (collapsed) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current?.contains(e.target as Node)) return;
+      setCollapsed(true);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [collapsed]);
 
   const invalidate = useCallback(() => {
     setTimeout(() => {
@@ -470,9 +491,45 @@ function RBACDevToolbarInner({ onHide }: { onHide: () => void }) {
                   </span>
                 )}
               </button>
+              {import.meta.env.DEV && (
+                <button
+                  type="button"
+                  onClick={() => setActiveTab("superadmin")}
+                  className={`-mb-px flex items-center gap-1.5 border-b-2 px-2 py-2 text-[11px] font-medium transition-colors ${
+                    activeTab === "superadmin"
+                      ? "border-foreground text-foreground"
+                      : "text-muted-foreground hover:text-foreground border-transparent"
+                  }`}
+                >
+                  <Crown className="h-3 w-3" />
+                  Super Admin
+                </button>
+              )}
             </div>
 
             {/* RBAC tab */}
+            {activeTab === "superadmin" && (
+              <div className="flex items-center justify-between px-3.5 py-3">
+                <div className="flex items-center gap-2">
+                  <div
+                    className={`h-1.5 w-1.5 rounded-full ${superAdmin ? "animate-pulse bg-amber-500" : "bg-muted-foreground/30"}`}
+                  />
+                  <span className="text-foreground text-xs font-medium">
+                    {superAdmin ? "Super admin active" : "Super admin off"}
+                  </span>
+                </div>
+                <Switch
+                  checked={superAdmin}
+                  onCheckedChange={(checked) => {
+                    setSuperAdmin(checked);
+                    localStorage.setItem(SUPER_ADMIN_KEY, checked ? "1" : "0");
+                    invalidate();
+                  }}
+                  aria-label="Toggle super admin"
+                />
+              </div>
+            )}
+
             {activeTab === "rbac" && (
               <>
                 {/* Master toggle */}

--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -145,8 +145,19 @@ export const useUser = () => {
   return user;
 };
 
+const SUPER_ADMIN_KEY = "gram-dev-super-admin";
+
 export const useIsAdmin = () => {
   const { isAdmin } = useUser();
+  if (import.meta.env.DEV) {
+    try {
+      const override = localStorage.getItem(SUPER_ADMIN_KEY);
+      if (override === "1") return true;
+      if (override === "0") return false;
+    } catch {
+      // ignore
+    }
+  }
   return isAdmin;
 };
 

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -16,7 +16,7 @@ import {
   Table,
 } from "@speakeasy-api/moonshine";
 import { Check } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useChallengeRowColumns } from "./useChallengeRowColumns";
 import { useGrantFlow } from "./useGrantFlow";
@@ -100,12 +100,13 @@ export function ChallengesTab() {
     searchParams.get("identity") ?? "all",
   );
 
-  // Sync principalFilter when URL search params change (e.g. re-navigation
-  // with a different ?identity= value).
-  useEffect(() => {
-    const identity = searchParams.get("identity");
-    if (identity) setPrincipalFilter(identity);
-  }, [searchParams]);
+  // Sync principalFilter during render when URL param changes (no stale frame).
+  const prevIdentityRef = useRef(searchParams.get("identity"));
+  const identity = searchParams.get("identity");
+  if (identity !== prevIdentityRef.current) {
+    prevIdentityRef.current = identity;
+    setPrincipalFilter(identity ?? "all");
+  }
   const [scopeFilter, setScopeFilter] = useState("all");
   const groupSiblingIdsRef = useRef<Map<string, string[]>>(new Map());
   const getGroupChallengeIds = useCallback(

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -18,6 +18,7 @@ import {
 import { Check } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
+import { countChallenges, scopeChallenges } from "./challengeHelpers";
 import { useChallengeRowColumns } from "./useChallengeRowColumns";
 import { useGrantFlow } from "./useGrantFlow";
 
@@ -126,19 +127,15 @@ export function ChallengesTab() {
     [data?.challenges],
   );
 
-  const counts = useMemo(() => {
-    const c = { all: challenges.length, deny: 0, allow: 0, resolved: 0 };
-    for (const ch of challenges) {
-      if (ch.resolvedAt) {
-        c.resolved++;
-      } else if (ch.outcome === "deny") {
-        c.deny++;
-      } else {
-        c.allow++;
-      }
-    }
-    return c;
-  }, [challenges]);
+  const scopedChallenges = useMemo(
+    () => scopeChallenges(challenges, principalFilter, scopeFilter),
+    [challenges, principalFilter, scopeFilter],
+  );
+
+  const counts = useMemo(
+    () => countChallenges(scopedChallenges),
+    [scopedChallenges],
+  );
 
   const uniquePrincipals = useMemo(() => {
     const set = new Set(challenges.map((c) => c.userEmail ?? c.principalUrn));
@@ -163,7 +160,7 @@ export function ChallengesTab() {
   }, []);
 
   const { filtered, groupCounts, groupKeys } = useMemo(() => {
-    let base = challenges;
+    let base = scopedChallenges;
     if (outcomeFilter === "resolved") {
       base = base.filter(
         (c) => !!c.resolvedAt && !recentlyResolvedIds.has(c.id),
@@ -174,14 +171,6 @@ export function ChallengesTab() {
           (c.outcome === outcomeFilter && !c.resolvedAt) ||
           recentlyResolvedIds.has(c.id),
       );
-    }
-    if (principalFilter !== "all") {
-      base = base.filter(
-        (c) => (c.userEmail ?? c.principalUrn) === principalFilter,
-      );
-    }
-    if (scopeFilter !== "all") {
-      base = base.filter((c) => c.scope === scopeFilter);
     }
     const sorted = [...base].sort((a, b) => {
       const order = (o: Outcome) => (o === "deny" ? 0 : o === "error" ? 1 : 2);
@@ -219,14 +208,7 @@ export function ChallengesTab() {
     }
     groupSiblingIdsRef.current = siblingIds;
     return { filtered: result, groupCounts: counts, groupKeys: keys };
-  }, [
-    challenges,
-    outcomeFilter,
-    principalFilter,
-    scopeFilter,
-    recentlyResolvedIds,
-    expandedGroups,
-  ]);
+  }, [scopedChallenges, outcomeFilter, recentlyResolvedIds, expandedGroups]);
 
   const challengeRowColumns = useChallengeRowColumns(
     animatingOutIds,

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -16,7 +16,7 @@ import {
   Table,
 } from "@speakeasy-api/moonshine";
 import { Check } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useChallengeRowColumns } from "./useChallengeRowColumns";
 import { useGrantFlow } from "./useGrantFlow";
@@ -99,6 +99,13 @@ export function ChallengesTab() {
   const [principalFilter, setPrincipalFilter] = useState(
     searchParams.get("identity") ?? "all",
   );
+
+  // Sync principalFilter when URL search params change (e.g. re-navigation
+  // with a different ?identity= value).
+  useEffect(() => {
+    const identity = searchParams.get("identity");
+    if (identity) setPrincipalFilter(identity);
+  }, [searchParams]);
   const [scopeFilter, setScopeFilter] = useState("all");
   const groupSiblingIdsRef = useRef<Map<string, string[]>>(new Map());
   const getGroupChallengeIds = useCallback(
@@ -225,6 +232,7 @@ export function ChallengesTab() {
     groupCounts,
     groupKeys,
     toggleGroup,
+    outcomeFilter,
   );
 
   const columns: Column<AuthzChallenge>[] = [
@@ -292,8 +300,8 @@ export function ChallengesTab() {
         <SkeletonTable />
       ) : filtered.length === 0 ? (
         <div className="border-border/50 bg-muted/20 rounded-lg border px-6 py-16 text-center">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/30">
-            <Check className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+          <div className="bg-primary/10 mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+            <Check className="text-primary h-6 w-6" />
           </div>
           <Type variant="body" className="font-medium">
             {outcomeFilter === "deny"

--- a/client/dashboard/src/pages/access/GrantDrawer.tsx
+++ b/client/dashboard/src/pages/access/GrantDrawer.tsx
@@ -85,7 +85,9 @@ export function GrantDrawer({
             principalUrn: challenge.principalUrn,
             scope: challenge.scope,
             resolutionType: ResolveChallengeFormResolutionType.RoleAssigned,
-            roleSlug: toRoleSlug(selectedRole.name),
+            roleSlug: selectedRole.isSystem
+              ? selectedRole.name.toLowerCase()
+              : toRoleSlug(selectedRole.name),
             resourceKind: challenge.resourceKind,
             resourceId: challenge.resourceId,
           },

--- a/client/dashboard/src/pages/access/ResourceLink.tsx
+++ b/client/dashboard/src/pages/access/ResourceLink.tsx
@@ -29,7 +29,7 @@ export function ResourceLink({
   if (resourceKind === "org") {
     label = "Organization";
     IconEl = Building2;
-    to = `/${orgSlug}/settings`;
+    to = `/${orgSlug}`;
   } else if (resourceKind === "project") {
     const proj = projectMap.get(resourceId);
     label = proj?.name ?? resourceId;
@@ -46,7 +46,7 @@ export function ResourceLink({
     return (
       <Link
         to={to}
-        className="inline-flex items-center gap-1.5 truncate text-sm text-blue-600 underline underline-offset-4 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+        className="text-primary hover:text-primary/80 inline-flex items-center gap-1.5 truncate text-sm underline underline-offset-4"
       >
         {IconEl && <IconEl className="h-3.5 w-3.5 shrink-0 opacity-60" />}
         <span className="truncate">{label}</span>

--- a/client/dashboard/src/pages/access/challengeHelpers.test.ts
+++ b/client/dashboard/src/pages/access/challengeHelpers.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { AuthzChallenge } from "@gram/client/models/components/authzchallenge.js";
+import { countChallenges, scopeChallenges } from "./challengeHelpers";
+
+function makeChallenge(
+  overrides: Partial<AuthzChallenge> = {},
+): AuthzChallenge {
+  return {
+    id: "ch-1",
+    evaluatedGrantCount: 1,
+    matchedGrantCount: 0,
+    operation: "require",
+    organizationId: "org-1",
+    outcome: "deny",
+    principalType: "user",
+    principalUrn: "user:u1",
+    reason: "scope_unsatisfied",
+    roleSlugs: [],
+    scope: "project:read",
+    timestamp: new Date("2026-05-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("scopeChallenges", () => {
+  const challenges = [
+    makeChallenge({
+      id: "1",
+      userEmail: "alice@acme.com",
+      scope: "project:read",
+    }),
+    makeChallenge({
+      id: "2",
+      userEmail: "bob@acme.com",
+      scope: "project:read",
+    }),
+    makeChallenge({
+      id: "3",
+      userEmail: "alice@acme.com",
+      scope: "org:admin",
+    }),
+    makeChallenge({
+      id: "4",
+      userEmail: "bob@acme.com",
+      scope: "org:admin",
+    }),
+  ];
+
+  it("returns all challenges when both filters are 'all'", () => {
+    const result = scopeChallenges(challenges, "all", "all");
+    expect(result).toHaveLength(4);
+  });
+
+  it("filters by principal", () => {
+    const result = scopeChallenges(challenges, "alice@acme.com", "all");
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => c.userEmail === "alice@acme.com")).toBe(true);
+  });
+
+  it("filters by scope", () => {
+    const result = scopeChallenges(challenges, "all", "org:admin");
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => c.scope === "org:admin")).toBe(true);
+  });
+
+  it("filters by both principal and scope", () => {
+    const result = scopeChallenges(challenges, "alice@acme.com", "org:admin");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("3");
+  });
+
+  it("returns empty when no matches", () => {
+    const result = scopeChallenges(challenges, "nobody@acme.com", "all");
+    expect(result).toHaveLength(0);
+  });
+
+  it("falls back to principalUrn when userEmail is undefined", () => {
+    const noEmail = [
+      makeChallenge({
+        id: "5",
+        principalUrn: "api_key:k1",
+        userEmail: undefined,
+      }),
+      makeChallenge({
+        id: "6",
+        principalUrn: "api_key:k2",
+        userEmail: undefined,
+      }),
+    ];
+    const result = scopeChallenges(noEmail, "api_key:k1", "all");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("5");
+  });
+});
+
+describe("countChallenges", () => {
+  it("counts empty list", () => {
+    expect(countChallenges([])).toEqual({
+      all: 0,
+      deny: 0,
+      allow: 0,
+      resolved: 0,
+    });
+  });
+
+  it("counts denied challenges", () => {
+    const challenges = [
+      makeChallenge({ outcome: "deny" }),
+      makeChallenge({ outcome: "deny" }),
+    ];
+    expect(countChallenges(challenges)).toEqual({
+      all: 2,
+      deny: 2,
+      allow: 0,
+      resolved: 0,
+    });
+  });
+
+  it("counts allowed challenges", () => {
+    const challenges = [
+      makeChallenge({ outcome: "allow" }),
+      makeChallenge({ outcome: "allow" }),
+    ];
+    expect(countChallenges(challenges)).toEqual({
+      all: 2,
+      deny: 0,
+      allow: 2,
+      resolved: 0,
+    });
+  });
+
+  it("counts resolved challenges regardless of outcome", () => {
+    const challenges = [
+      makeChallenge({
+        outcome: "deny",
+        resolvedAt: new Date("2026-05-02T00:00:00Z"),
+      }),
+      makeChallenge({
+        outcome: "allow",
+        resolvedAt: new Date("2026-05-02T00:00:00Z"),
+      }),
+    ];
+    expect(countChallenges(challenges)).toEqual({
+      all: 2,
+      deny: 0,
+      allow: 0,
+      resolved: 2,
+    });
+  });
+
+  it("counts error outcome as allow bucket", () => {
+    const challenges = [makeChallenge({ outcome: "error" })];
+    expect(countChallenges(challenges)).toEqual({
+      all: 1,
+      deny: 0,
+      allow: 1,
+      resolved: 0,
+    });
+  });
+
+  it("handles mixed outcomes", () => {
+    const challenges = [
+      makeChallenge({ id: "1", outcome: "deny" }),
+      makeChallenge({ id: "2", outcome: "allow" }),
+      makeChallenge({ id: "3", outcome: "deny", resolvedAt: new Date() }),
+      makeChallenge({ id: "4", outcome: "error" }),
+      makeChallenge({ id: "5", outcome: "deny" }),
+    ];
+    expect(countChallenges(challenges)).toEqual({
+      all: 5,
+      deny: 2,
+      allow: 2,
+      resolved: 1,
+    });
+  });
+});

--- a/client/dashboard/src/pages/access/challengeHelpers.ts
+++ b/client/dashboard/src/pages/access/challengeHelpers.ts
@@ -1,7 +1,6 @@
 import type { AuthzChallenge } from "@gram/client/models/components/authzchallenge.js";
 
 type Reason = AuthzChallenge["reason"];
-type Outcome = AuthzChallenge["outcome"];
 
 export function getInitials(identifier: string): string {
   const name = identifier.split("@")[0] ?? identifier;

--- a/client/dashboard/src/pages/access/challengeHelpers.ts
+++ b/client/dashboard/src/pages/access/challengeHelpers.ts
@@ -1,6 +1,7 @@
 import type { AuthzChallenge } from "@gram/client/models/components/authzchallenge.js";
 
 type Reason = AuthzChallenge["reason"];
+type Outcome = AuthzChallenge["outcome"];
 
 export function getInitials(identifier: string): string {
   const name = identifier.split("@")[0] ?? identifier;
@@ -22,4 +23,55 @@ export function reasonLabel(reason: Reason): string {
     case "dev_override":
       return "Access allowed via a development override.";
   }
+}
+
+/**
+ * Filter challenges by principal and scope. When a filter is "all", it is
+ * not applied — all challenges pass through.
+ */
+export function scopeChallenges(
+  challenges: AuthzChallenge[],
+  principalFilter: string,
+  scopeFilter: string,
+): AuthzChallenge[] {
+  let base = challenges;
+  if (principalFilter !== "all") {
+    base = base.filter(
+      (c) => (c.userEmail ?? c.principalUrn) === principalFilter,
+    );
+  }
+  if (scopeFilter !== "all") {
+    base = base.filter((c) => c.scope === scopeFilter);
+  }
+  return base;
+}
+
+export type ChallengeCounts = {
+  all: number;
+  deny: number;
+  allow: number;
+  resolved: number;
+};
+
+/**
+ * Compute pill counts from a list of challenges.
+ * Resolved challenges are counted separately regardless of outcome.
+ */
+export function countChallenges(challenges: AuthzChallenge[]): ChallengeCounts {
+  const c: ChallengeCounts = {
+    all: challenges.length,
+    deny: 0,
+    allow: 0,
+    resolved: 0,
+  };
+  for (const ch of challenges) {
+    if (ch.resolvedAt) {
+      c.resolved++;
+    } else if (ch.outcome === "deny") {
+      c.deny++;
+    } else {
+      c.allow++;
+    }
+  }
+  return c;
 }

--- a/client/dashboard/src/pages/access/types.test.ts
+++ b/client/dashboard/src/pages/access/types.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { toRoleSlug } from "./types";
+
+describe("toRoleSlug", () => {
+  it("adds org- prefix to plain name", () => {
+    expect(toRoleSlug("Editor")).toBe("org-editor");
+  });
+
+  it("does not double-prefix org- names", () => {
+    expect(toRoleSlug("org-editor")).toBe("org-editor");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(toRoleSlug("Project Manager")).toBe("org-project-manager");
+  });
+
+  it("replaces underscores with hyphens", () => {
+    expect(toRoleSlug("team_lead")).toBe("org-team-lead");
+  });
+
+  it("strips special characters", () => {
+    expect(toRoleSlug("QA & Testing!")).toBe("org-qa-testing");
+  });
+
+  it("collapses consecutive hyphens/spaces", () => {
+    expect(toRoleSlug("super   admin")).toBe("org-super-admin");
+  });
+
+  it("trims leading/trailing hyphens", () => {
+    expect(toRoleSlug("-reviewer-")).toBe("org-reviewer");
+  });
+
+  it("handles single word", () => {
+    expect(toRoleSlug("viewer")).toBe("org-viewer");
+  });
+});
+
+describe("system role slug resolution", () => {
+  // Mirrors the GrantDrawer logic: system roles use toLowerCase(),
+  // custom roles use toRoleSlug().
+  function resolveSlug(name: string, isSystem: boolean): string {
+    return isSystem ? name.toLowerCase() : toRoleSlug(name);
+  }
+
+  it("system Admin → admin (no org- prefix)", () => {
+    expect(resolveSlug("Admin", true)).toBe("admin");
+  });
+
+  it("system Member → member (no org- prefix)", () => {
+    expect(resolveSlug("Member", true)).toBe("member");
+  });
+
+  it("custom Editor → org-editor", () => {
+    expect(resolveSlug("Editor", false)).toBe("org-editor");
+  });
+
+  it("custom role with spaces → org-prefixed slug", () => {
+    expect(resolveSlug("API Developer", false)).toBe("org-api-developer");
+  });
+});

--- a/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
+++ b/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
@@ -55,7 +55,7 @@ export function useChallengeRowColumns(
       {
         key: "avatar",
         header: "",
-        width: "44px",
+        width: "40px",
         render: (row: AuthzChallenge) => {
           const isApiKey = row.principalType === "api_key";
           const display = row.userEmail ?? row.principalUrn;
@@ -80,13 +80,16 @@ export function useChallengeRowColumns(
       {
         key: "identity",
         header: "Identity",
-        width: "1fr",
+        width: "1.2fr",
         render: (row: AuthzChallenge) => (
           <Tooltip>
             <TooltipTrigger asChild>
               <Type
                 variant="body"
-                className={cn("truncate text-sm font-medium", rowFade(row))}
+                className={cn(
+                  "min-w-0 truncate text-sm font-medium",
+                  rowFade(row),
+                )}
               >
                 {row.userEmail ?? row.principalUrn}
               </Type>
@@ -102,7 +105,7 @@ export function useChallengeRowColumns(
       {
         key: "outcome",
         header: "Outcome",
-        width: "85px",
+        width: "80px",
         render: (row: AuthzChallenge) => (
           <div className={cn(rowFade(row))}>
             <OutcomeBadge outcome={row.outcome} resolved={!!row.resolvedAt} />
@@ -112,13 +115,13 @@ export function useChallengeRowColumns(
       {
         key: "scope",
         header: "Required Scope",
-        width: "140px",
+        width: "1fr",
         render: (row: AuthzChallenge) => (
           <Tooltip>
             <TooltipTrigger asChild>
               <code
                 className={cn(
-                  "bg-muted rounded px-1.5 py-0.5 font-mono text-xs",
+                  "bg-muted min-w-0 truncate rounded px-1.5 py-0.5 font-mono text-xs",
                   rowFade(row),
                 )}
               >
@@ -138,9 +141,9 @@ export function useChallengeRowColumns(
       {
         key: "resource",
         header: "Resource",
-        width: "1fr",
+        width: "1.2fr",
         render: (row: AuthzChallenge) => (
-          <div className={cn("min-w-0 overflow-hidden", rowFade(row))}>
+          <div className={cn("min-w-0 truncate", rowFade(row))}>
             <ResourceLink
               challenge={row}
               orgSlug={orgSlug ?? ""}
@@ -152,7 +155,7 @@ export function useChallengeRowColumns(
       {
         key: "resolvedBy",
         header: "Resolved By",
-        width: "90px",
+        width: "100px",
         render: (row: AuthzChallenge) => {
           if (!row.resolvedBy) {
             return (
@@ -184,7 +187,7 @@ export function useChallengeRowColumns(
       {
         key: "timestamp",
         header: "Time",
-        width: "160px",
+        width: "1fr",
         render: (row: AuthzChallenge) => {
           const count = groupCounts?.get(row.id) ?? 1;
           return (

--- a/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
+++ b/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
@@ -23,6 +23,7 @@ export function useChallengeRowColumns(
   groupCounts?: Map<string, number>,
   groupKeys?: Map<string, string>,
   onToggleGroup?: (groupKey: string) => void,
+  outcomeFilter?: string,
 ): Column<AuthzChallenge>[] {
   const { orgSlug } = useSlugs();
   const { organization } = useSession();
@@ -46,7 +47,8 @@ export function useChallengeRowColumns(
     const rowFade = (row: AuthzChallenge) =>
       animatingOutIds?.has(row.id)
         ? "opacity-0 transition-opacity duration-1000"
-        : (row.outcome === "allow" || row.resolvedAt) &&
+        : outcomeFilter === "deny" &&
+          (row.outcome === "allow" || row.resolvedAt) &&
           "opacity-40 transition-opacity duration-1000";
 
     return [
@@ -225,5 +227,6 @@ export function useChallengeRowColumns(
     groupCounts,
     groupKeys,
     onToggleGroup,
+    outcomeFilter,
   ]);
 }

--- a/client/dashboard/src/pages/access/useGrantFlow.tsx
+++ b/client/dashboard/src/pages/access/useGrantFlow.tsx
@@ -148,7 +148,7 @@ export function useGrantFlow(
                   scope: createChallenge.scope,
                   resolutionType:
                     ResolveChallengeFormResolutionType.RoleAssigned,
-                  roleSlug: toRoleSlug(roleName),
+                  roleSlug: toRoleSlug(roleName), // new roles always get org- prefix
                   resourceKind: createChallenge.resourceKind,
                   resourceId: createChallenge.resourceId,
                 },

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -11,6 +11,7 @@ import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { RequireScope } from "@/components/require-scope";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useOrgRoutes } from "@/routes";
+import { useRBAC } from "@/hooks/useRBAC";
 import { useChallenges } from "@gram/client/react-query/challenges.js";
 import { useChallengeRowColumns } from "@/pages/access/useChallengeRowColumns";
 import { useGrantFlow } from "@/pages/access/useGrantFlow";
@@ -219,6 +220,8 @@ export function OrgHomeInner() {
 
 function RecentChallenges() {
   const orgRoutes = useOrgRoutes();
+  const { hasScope } = useRBAC();
+  const canAdmin = hasScope("org:admin");
   const { actionsColumn, grantFlowPortals } = useGrantFlow();
   const challengeRowColumns = useChallengeRowColumns();
   const { data: challengesData } = useChallenges({ limit: 5 });
@@ -237,7 +240,11 @@ function RecentChallenges() {
         </orgRoutes.access.challenges.Link>
       </div>
       <Table
-        columns={[...challengeRowColumns, actionsColumn]}
+        columns={
+          canAdmin
+            ? [...challengeRowColumns, actionsColumn]
+            : challengeRowColumns
+        }
         data={recentChallenges}
         rowKey={(row) => row.id}
       />

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -9,9 +9,17 @@ import { Type } from "@/components/ui/type";
 import { useOrganization } from "@/contexts/Auth";
 import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { RequireScope } from "@/components/require-scope";
-import { ArrowRight } from "lucide-react";
-import { useState } from "react";
+import { useTelemetry } from "@/contexts/Telemetry";
+import { useOrgRoutes } from "@/routes";
+import { useChallenges } from "@gram/client/react-query/challenges.js";
+import { useChallengeRowColumns } from "@/pages/access/useChallengeRowColumns";
+import { useGrantFlow } from "@/pages/access/useGrantFlow";
+import { Table } from "@speakeasy-api/moonshine";
+import { ArrowRight, ChevronDown, ChevronUp } from "lucide-react";
+import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
+
+const PROJECT_LIMIT = 5;
 
 export default function OrgHome() {
   return (
@@ -36,20 +44,33 @@ export function OrgHomeInner() {
   const { orgSlug } = useSlugs();
   const client = useSdkClient();
   const navigate = useNavigate();
+  const telemetry = useTelemetry();
+  const isRbacEnabled = telemetry.isFeatureEnabled("gram-rbac") ?? false;
   const [search, setSearch] = useState("");
+  const [expanded, setExpanded] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newProjectName, setNewProjectName] = useState("");
 
-  const projects = [...organization.projects]
-    .filter((project) => {
-      if (!search) return true;
-      const query = search.toLowerCase();
-      return (
-        project.name.toLowerCase().includes(query) ||
-        project.slug.toLowerCase().includes(query)
-      );
-    })
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const projects = useMemo(
+    () =>
+      [...organization.projects]
+        .filter((project) => {
+          if (!search) return true;
+          const query = search.toLowerCase();
+          return (
+            project.name.toLowerCase().includes(query) ||
+            project.slug.toLowerCase().includes(query)
+          );
+        })
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [organization.projects, search],
+  );
+
+  // When searching, show all results; otherwise cap at limit
+  const isSearching = search.length > 0;
+  const hasMore = !isSearching && projects.length > PROJECT_LIMIT;
+  const visibleProjects =
+    expanded || isSearching ? projects : projects.slice(0, PROJECT_LIMIT);
 
   return (
     <>
@@ -91,50 +112,80 @@ export function OrgHomeInner() {
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-          {projects.map((project) => (
-            <Link
-              key={project.id}
-              to={`/${orgSlug}/projects/${project.slug}`}
-              className="hover:no-underline"
-            >
-              <DotCard
-                icon={
-                  <ProjectAvatar
-                    project={project}
-                    className="h-10 w-10 rounded-md"
-                  />
-                }
+        <>
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            {!isSearching && (
+              <RequireScope
+                scope="org:admin"
+                level="component"
+                className="w-full"
               >
-                <Type
-                  variant="subheading"
-                  as="div"
-                  className="text-md group-hover:text-primary truncate transition-colors"
+                <CreateResourceCard
+                  onClick={() => setCreateDialogOpen(true)}
+                  title="New Project"
+                  description="Create a new project for your organization"
+                />
+              </RequireScope>
+            )}
+            {visibleProjects.map((project) => (
+              <Link
+                key={project.id}
+                to={`/${orgSlug}/projects/${project.slug}`}
+                className="hover:no-underline"
+              >
+                <DotCard
+                  icon={
+                    <ProjectAvatar
+                      project={project}
+                      className="h-10 w-10 rounded-md"
+                    />
+                  }
                 >
-                  {project.name}
-                </Type>
-                <Type small muted className="mb-3 truncate">
-                  {project.slug}
-                </Type>
+                  <Type
+                    variant="subheading"
+                    as="div"
+                    className="text-md group-hover:text-primary truncate transition-colors"
+                  >
+                    {project.name}
+                  </Type>
+                  <Type small muted className="mb-3 truncate">
+                    {project.slug}
+                  </Type>
 
-                <div className="mt-auto flex items-center justify-end pt-2">
-                  <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
-                    <span>Open</span>
-                    <ArrowRight className="h-3.5 w-3.5" />
+                  <div className="mt-auto flex items-center justify-end pt-2">
+                    <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
+                      <span>Open</span>
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </div>
                   </div>
-                </div>
-              </DotCard>
-            </Link>
-          ))}
-          <RequireScope scope="org:admin" level="component" className="w-full">
-            <CreateResourceCard
-              onClick={() => setCreateDialogOpen(true)}
-              title="New Project"
-              description="Create a new project for your organization"
-            />
-          </RequireScope>
-        </div>
+                </DotCard>
+              </Link>
+            ))}
+          </div>
+          {hasMore && (
+            <button
+              type="button"
+              onClick={() => setExpanded((prev) => !prev)}
+              className="text-muted-foreground hover:text-foreground mx-auto mt-4 flex items-center gap-1.5 text-sm font-medium transition-colors"
+            >
+              {expanded ? (
+                <>
+                  Show less
+                  <ChevronUp className="h-4 w-4" />
+                </>
+              ) : (
+                <>
+                  Show all {projects.length} projects
+                  <ChevronDown className="h-4 w-4" />
+                </>
+              )}
+            </button>
+          )}
+        </>
       )}
+
+      {isRbacEnabled && <RecentChallenges />}
+
       {createDialogOpen && (
         <InputDialog
           open={createDialogOpen}
@@ -163,5 +214,34 @@ export function OrgHomeInner() {
         />
       )}
     </>
+  );
+}
+
+function RecentChallenges() {
+  const orgRoutes = useOrgRoutes();
+  const { actionsColumn, grantFlowPortals } = useGrantFlow();
+  const challengeRowColumns = useChallengeRowColumns();
+  const { data: challengesData } = useChallenges({ limit: 5 });
+  const recentChallenges = (challengesData?.challenges ?? []).filter(
+    (c) => !!c.scope,
+  );
+
+  if (recentChallenges.length === 0) return null;
+
+  return (
+    <div className="mt-12">
+      <div className="mb-3 flex items-center justify-between">
+        <Heading variant="h4">Recent Challenges</Heading>
+        <orgRoutes.access.challenges.Link className="text-primary cursor-pointer text-sm font-medium hover:underline">
+          Show more
+        </orgRoutes.access.challenges.Link>
+      </div>
+      <Table
+        columns={[...challengeRowColumns, actionsColumn]}
+        data={recentChallenges}
+        rowKey={(row) => row.id}
+      />
+      {grantFlowPortals}
+    </div>
   );
 }

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
@@ -1540,7 +1541,7 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
 	}
-	defer func() { _ = dbtx.Rollback(ctx) }()
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	rows, err := repo.New(dbtx).InsertChallengeResolutions(ctx, repo.InsertChallengeResolutionsParams{
 		OrganizationID: authCtx.ActiveOrganizationID,

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -1536,7 +1536,13 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 		resourceID = *payload.ResourceID
 	}
 
-	rows, err := repo.New(s.db).InsertChallengeResolutions(ctx, repo.InsertChallengeResolutionsParams{
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").Log(ctx, s.logger)
+	}
+	defer func() { _ = dbtx.Rollback(ctx) }()
+
+	rows, err := repo.New(dbtx).InsertChallengeResolutions(ctx, repo.InsertChallengeResolutionsParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ChallengeIds:   payload.ChallengeIds,
 		PrincipalUrn:   payload.PrincipalUrn,
@@ -1567,7 +1573,7 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 			CreatedAt:      row.CreatedAt.Time.Format(time.RFC3339),
 		})
 
-		if err := s.audit.LogAccessChallengeResolve(ctx, s.db, audit.LogAccessChallengeResolveEvent{
+		if err := s.audit.LogAccessChallengeResolve(ctx, dbtx, audit.LogAccessChallengeResolveEvent{
 			OrganizationID:   authCtx.ActiveOrganizationID,
 			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
 			ActorDisplayName: authCtx.Email,
@@ -1579,6 +1585,10 @@ func (s *Service) ResolveChallenge(ctx context.Context, payload *gen.ResolveChal
 		}); err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "log access challenge resolve").Log(ctx, s.logger)
 		}
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, s.logger)
 	}
 
 	return &gen.ResolveChallengesResult{Resolutions: resolutions}, nil

--- a/server/internal/access/resolve_challenge_test.go
+++ b/server/internal/access/resolve_challenge_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/access"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -239,6 +240,86 @@ func TestResolveChallenge_BatchMultipleIds(t *testing.T) {
 	}
 	for _, id := range ids {
 		require.True(t, resolvedIDs[id], "expected challenge %s to be resolved", id)
+	}
+}
+
+func TestResolveChallenge_TransactionPersistsResolutionAndAuditLog(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newChallengeTestService(t)
+	authCtx := challengeAuthContext(t, ctx)
+
+	challengeID := uuid.NewString()
+	roleSlug := "editor"
+
+	// Resolve a challenge via the service (which uses a transaction internally).
+	result, err := ti.service.ResolveChallenge(ctx, &gen.ResolveChallengePayload{
+		ApikeyToken:    nil,
+		SessionToken:   nil,
+		ChallengeIds:   []string{challengeID},
+		PrincipalUrn:   "user:denied-user",
+		Scope:          "org:admin",
+		ResourceKind:   nil,
+		ResourceID:     nil,
+		ResolutionType: "role_assigned",
+		RoleSlug:       &roleSlug,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Resolutions, 1)
+
+	// Verify the resolution was persisted to the database (proves tx committed).
+	rows, err := accessrepo.New(ti.conn).ListChallengeResolutions(ctx, accessrepo.ListChallengeResolutionsParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ChallengeIds:   []string{challengeID},
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "resolution must be persisted after transaction commit")
+
+	row := rows[0]
+	require.Equal(t, challengeID, row.ChallengeID)
+	require.Equal(t, "user:denied-user", row.PrincipalUrn)
+	require.Equal(t, "org:admin", row.Scope)
+	require.Equal(t, "role_assigned", row.ResolutionType)
+	require.True(t, row.RoleSlug.Valid)
+	require.Equal(t, "editor", row.RoleSlug.String)
+	require.Equal(t, authCtx.ActiveOrganizationID, row.OrganizationID)
+}
+
+func TestResolveChallenge_BatchPersistsAllResolutions(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newChallengeTestService(t)
+	authCtx := challengeAuthContext(t, ctx)
+
+	ids := []string{uuid.NewString(), uuid.NewString(), uuid.NewString()}
+
+	_, err := ti.service.ResolveChallenge(ctx, &gen.ResolveChallengePayload{
+		ApikeyToken:    nil,
+		SessionToken:   nil,
+		ChallengeIds:   ids,
+		PrincipalUrn:   "user:denied-user",
+		Scope:          "build:read",
+		ResourceKind:   nil,
+		ResourceID:     nil,
+		ResolutionType: "dismissed",
+		RoleSlug:       nil,
+	})
+	require.NoError(t, err)
+
+	// Verify all three resolutions were persisted in a single transaction.
+	rows, err := accessrepo.New(ti.conn).ListChallengeResolutions(ctx, accessrepo.ListChallengeResolutionsParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ChallengeIds:   ids,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 3, "all batch resolutions must be persisted atomically")
+
+	persistedIDs := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		persistedIDs[r.ChallengeID] = true
+	}
+	for _, id := range ids {
+		require.True(t, persistedIDs[id], "challenge %s must be persisted", id)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to challenge UI (#2542) and resolve endpoint (#2604), plus org home page improvements and dev toolbar enhancements.

### Challenge UI fixes
- **Transaction safety**: Wrap `ResolveChallenge` insert + audit log in a DB transaction (atomic success/failure)
- **System role slugs**: Use `name.toLowerCase()` for system roles instead of `toRoleSlug()` which incorrectly adds `org-` prefix
- **Theme colors**: Replace hardcoded emerald/blue with `primary` theme tokens
- **Column proportions**: Switch identity/scope/resource/time to `fr` units for flexible layout, add `truncate` + `min-w-0` for overflow
- **URL sync**: Sync principal filter when `?identity=` search param changes on re-navigation
- **Row fade logic**: Only fade allowed/resolved rows in "deny" filter view, not globally

### Org home page
- Cap project grid to 5 items with expandable "Show all N projects" button
- Move "New Project" card to first position (top-left)
- Hide "New Project" card while searching (still shows in empty-state as "Create {query}")
- Add **Recent Challenges** table below projects (reuses compact 5-row table from RolesTab with "Show more" link)
- Gated behind `gram-rbac` feature flag; hidden when no challenges exist

### Dev toolbar
- New **Super Admin** tab with toggle (dev-only, `import.meta.env.DEV` guard)
- `useIsAdmin()` respects localStorage override in dev mode only — no prod security surface
- Collapse toolbar on outside click

## Test plan

- [ ] Resolve a challenge group — verify insert + audit log both persist atomically
- [ ] Resolve a challenge for a system role (Admin) — verify slug is `admin` not `org-admin`
- [ ] Org home: verify 5 projects shown, expand/collapse works, search hides "New Project" card
- [ ] Org home: verify Recent Challenges table appears below projects, "Show more" links to challenges page
- [ ] Dev toolbar: toggle Super Admin on — verify admin-only nav items appear; toggle off — verify they hide
- [ ] Dev toolbar: click outside expanded toolbar — verify it collapses
- [ ] Check theme colors in light + dark mode