### PR TITLE
chore: add workos membership (user) sync flow

### DIFF
--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -74,6 +74,7 @@ type Activities struct {
 	signalAssistantCoordinator      *activities.SignalAssistantCoordinator
 	signalAssistantThread           *activities.SignalAssistantThread
 	processWorkOSOrganizationEvents *activities.ProcessWorkOSOrganizationEvents
+	processWorkOSMembershipEvents   *activities.ProcessWorkOSMembershipEvents
 }
 
 func NewActivities(
@@ -113,8 +114,10 @@ func NewActivities(
 	// configured. Local dev without a key passes nil; the wrapper method below
 	// returns a clear error if the activity is invoked unconfigured.
 	var processWorkOSOrgEvents *activities.ProcessWorkOSOrganizationEvents
+	var processWorkOSMembershipEvents *activities.ProcessWorkOSMembershipEvents
 	if workosEventsClient != nil {
 		processWorkOSOrgEvents = activities.NewProcessWorkOSOrganizationEvents(logger, db, workosEventsClient)
+		processWorkOSMembershipEvents = activities.NewProcessWorkOSMembershipEvents(logger, db, workosEventsClient)
 	}
 
 	return &Activities{
@@ -154,6 +157,7 @@ func NewActivities(
 		signalAssistantCoordinator:      activities.NewSignalAssistantCoordinator(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		signalAssistantThread:           activities.NewSignalAssistantThread(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		processWorkOSOrganizationEvents: processWorkOSOrgEvents,
+		processWorkOSMembershipEvents:   processWorkOSMembershipEvents,
 	}
 }
 
@@ -162,6 +166,13 @@ func (a *Activities) ProcessWorkOSOrganizationEvents(ctx context.Context, params
 		return nil, fmt.Errorf("WorkOS events client is not configured")
 	}
 	return a.processWorkOSOrganizationEvents.Do(ctx, params)
+}
+
+func (a *Activities) ProcessWorkOSMembershipEvents(ctx context.Context, params activities.ProcessWorkOSMembershipEventsParams) (*activities.ProcessWorkOSMembershipEventsResult, error) {
+	if a.processWorkOSMembershipEvents == nil {
+		return nil, fmt.Errorf("WorkOS events client is not configured")
+	}
+	return a.processWorkOSMembershipEvents.Do(ctx, params)
 }
 
 func (a *Activities) TransitionDeployment(ctx context.Context, projectID uuid.UUID, deploymentID uuid.UUID, status string) (*activities.TransitionDeploymentResult, error) {

--- a/server/internal/background/activities/process_workos_membership_events.go
+++ b/server/internal/background/activities/process_workos_membership_events.go
@@ -1,0 +1,335 @@
+package activities
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/workos/workos-go/v6/pkg/events"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/database"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+const workosMembershipEventsPageSize = 100
+
+type ProcessWorkOSMembershipEventsParams struct {
+	// SinceEventID lets a caller override the DB cursor for this run. Workflow
+	// triggers pass nil and let the activity load the singleton cursor from
+	// `workos_user_syncs`.
+	SinceEventID *string `json:"since_event_id,omitempty"`
+}
+
+type ProcessWorkOSMembershipEventsResult struct {
+	SinceEventID string `json:"since_event_id"`
+	LastEventID  string `json:"last_event_id"`
+	HasMore      bool   `json:"has_more"`
+}
+
+// ProcessWorkOSMembershipEvents processes the global organization_membership.*
+// stream. Membership events are not filtered by WorkOS organization because
+// WorkOS users may move across orgs and the cursor is intentionally singleton.
+type ProcessWorkOSMembershipEvents struct {
+	db           *pgxpool.Pool
+	logger       *slog.Logger
+	eventsClient EventsLister
+}
+
+func NewProcessWorkOSMembershipEvents(logger *slog.Logger, db *pgxpool.Pool, eventsClient EventsLister) *ProcessWorkOSMembershipEvents {
+	return &ProcessWorkOSMembershipEvents{
+		db:           db,
+		logger:       logger,
+		eventsClient: eventsClient,
+	}
+}
+
+func (p *ProcessWorkOSMembershipEvents) Do(ctx context.Context, params ProcessWorkOSMembershipEventsParams) (*ProcessWorkOSMembershipEventsResult, error) {
+	logger := p.logger
+
+	sinceEventID := conv.PtrValOr(params.SinceEventID, "")
+	if sinceEventID == "" {
+		cursor, err := workosrepo.New(p.db).GetUserSyncLastEventID(ctx)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			// No cursor yet: full sync from the beginning.
+		case err != nil:
+			return nil, oops.E(oops.CodeUnexpected, err, "failed to get user sync last event ID").Log(ctx, logger)
+		default:
+			sinceEventID = cursor
+		}
+	}
+
+	resp, err := p.eventsClient.ListEvents(ctx, events.ListEventsOpts{
+		Events: []string{
+			string(workos.EventKindOrganizationMembershipCreated),
+			string(workos.EventKindOrganizationMembershipDeleted),
+			string(workos.EventKindOrganizationMembershipUpdated),
+		},
+		Limit:          workosMembershipEventsPageSize,
+		After:          sinceEventID,
+		OrganizationId: "",
+		RangeStart:     "",
+		RangeEnd:       "",
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list WorkOS membership events").Log(ctx, logger)
+	}
+
+	lastEventID, err := p.handlePage(ctx, logger, resp.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProcessWorkOSMembershipEventsResult{
+		SinceEventID: sinceEventID,
+		LastEventID:  lastEventID,
+		HasMore:      len(resp.Data) == workosMembershipEventsPageSize,
+	}, nil
+}
+
+func (p *ProcessWorkOSMembershipEvents) handlePage(ctx context.Context, logger *slog.Logger, page []events.Event) (string, error) {
+	var lastEventID string
+	for _, event := range page {
+		eventLogger := logger.With(
+			attr.SlogWorkOSEventID(event.ID),
+			attr.SlogWorkOSEventType(event.Event),
+		)
+
+		eventID, err := p.handleEvent(ctx, eventLogger, event)
+		if err != nil {
+			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to handle WorkOS membership event").Log(ctx, eventLogger)
+		}
+		if eventID != "" {
+			lastEventID = eventID
+		}
+	}
+
+	return lastEventID, nil
+}
+
+func (p *ProcessWorkOSMembershipEvents) handleEvent(ctx context.Context, logger *slog.Logger, event events.Event) (string, error) {
+	dbtx, err := p.db.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("begin transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	if err := handleMembershipEvent(ctx, logger, dbtx, event); err != nil {
+		return "", err
+	}
+
+	if _, err := workosrepo.New(dbtx).SetUserSyncLastEventID(ctx, event.ID); err != nil {
+		return "", fmt.Errorf("set user sync last event ID: %w", err)
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return event.ID, nil
+}
+
+func handleMembershipEvent(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	switch event.Event {
+	case string(workos.EventKindOrganizationMembershipCreated), string(workos.EventKindOrganizationMembershipUpdated):
+		return handleOrganizationMembershipUpsert(ctx, logger, dbtx, event)
+	case string(workos.EventKindOrganizationMembershipDeleted):
+		return handleOrganizationMembershipDeleted(ctx, logger, dbtx, event)
+	}
+
+	return oops.Permanent(fmt.Errorf("unhandled workos membership event type: %s", event.Event))
+}
+
+type workosMembershipRole struct {
+	Slug string `json:"slug"`
+}
+
+type workosMembershipEventPayload struct {
+	ID             string                 `json:"id"`
+	Object         string                 `json:"object"`
+	OrganizationID string                 `json:"organization_id"`
+	UserID         string                 `json:"user_id"`
+	RoleSlug       string                 `json:"role_slug"`
+	Role           workosMembershipRole   `json:"role"`
+	Roles          []workosMembershipRole `json:"roles"`
+	UpdatedAt      time.Time              `json:"updated_at"`
+}
+
+func handleOrganizationMembershipUpsert(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	payload, err := decodeWorkOSMembershipPayload(event)
+	if err != nil {
+		return err
+	}
+	logger = logger.With(
+		attr.SlogWorkOSOrganizationID(payload.OrganizationID),
+		attr.SlogWorkOSUserID(payload.UserID),
+	)
+
+	org, err := orgrepo.New(dbtx).GetOrganizationByWorkosID(ctx, conv.ToPGText(payload.OrganizationID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		logger.DebugContext(ctx, "skipping membership event for unknown organization")
+		return nil
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", payload.OrganizationID, err)
+	}
+
+	gramUserID, err := usersrepo.New(dbtx).GetUserIDByWorkosID(ctx, conv.ToPGText(payload.UserID))
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get user by workos id %q: %w", payload.UserID, err)
+	}
+
+	if gramUserID != "" {
+		existing, err := orgrepo.New(dbtx).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+			OrganizationID: org.ID,
+			UserID:         gramUserID,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+		case err != nil:
+			return fmt.Errorf("get organization membership %q: %w", payload.ID, err)
+		}
+		var lastEventID *string
+		if existing.WorkosLastEventID.Valid {
+			lastEventID = &existing.WorkosLastEventID.String
+		}
+		var rowUpdatedAt *time.Time
+		if existing.WorkosUpdatedAt.Valid {
+			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+		}
+		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
+			return nil
+		}
+		if err := orgrepo.New(dbtx).UpsertOrganizationUserRelationshipFromWorkOS(ctx, orgrepo.UpsertOrganizationUserRelationshipFromWorkOSParams{
+			OrganizationID:     org.ID,
+			UserID:             gramUserID,
+			WorkosMembershipID: conv.ToPGText(payload.ID),
+			WorkosUpdatedAt:    conv.ToPGTimestamptz(payload.UpdatedAt),
+			WorkosLastEventID:  conv.ToPGText(event.ID),
+		}); err != nil {
+			return fmt.Errorf("upsert organization membership %q: %w", payload.ID, err)
+		}
+	}
+
+	if err := orgrepo.New(dbtx).SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+		OrganizationID:     org.ID,
+		WorkosUserID:       payload.UserID,
+		UserID:             conv.ToPGTextEmpty(gramUserID),
+		WorkosMembershipID: conv.ToPGText(payload.ID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID:  conv.ToPGText(event.ID),
+		WorkosRoleSlugs:    membershipRoleSlugs(payload),
+	}); err != nil {
+		return fmt.Errorf("sync organization role assignments for membership %q: %w", payload.ID, err)
+	}
+
+	return nil
+}
+
+func handleOrganizationMembershipDeleted(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+	payload, err := decodeWorkOSMembershipPayload(event)
+	if err != nil {
+		return err
+	}
+	logger = logger.With(
+		attr.SlogWorkOSOrganizationID(payload.OrganizationID),
+		attr.SlogWorkOSUserID(payload.UserID),
+	)
+
+	org, err := orgrepo.New(dbtx).GetOrganizationByWorkosID(ctx, conv.ToPGText(payload.OrganizationID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		logger.DebugContext(ctx, "skipping membership delete for unknown organization")
+		return nil
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", payload.OrganizationID, err)
+	}
+
+	gramUserID, err := usersrepo.New(dbtx).GetUserIDByWorkosID(ctx, conv.ToPGText(payload.UserID))
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get user by workos id %q: %w", payload.UserID, err)
+	}
+
+	if gramUserID != "" {
+		existing, err := orgrepo.New(dbtx).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+			OrganizationID: org.ID,
+			UserID:         gramUserID,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+		case err != nil:
+			return fmt.Errorf("get organization membership %q: %w", payload.ID, err)
+		}
+		var lastEventID *string
+		if existing.WorkosLastEventID.Valid {
+			lastEventID = &existing.WorkosLastEventID.String
+		}
+		var rowUpdatedAt *time.Time
+		if existing.WorkosUpdatedAt.Valid {
+			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+		}
+		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
+			return nil
+		}
+		if err := orgrepo.New(dbtx).MarkOrganizationUserRelationshipAsDeleted(ctx, orgrepo.MarkOrganizationUserRelationshipAsDeletedParams{
+			OrganizationID:     org.ID,
+			UserID:             gramUserID,
+			WorkosMembershipID: conv.ToPGText(payload.ID),
+			WorkosUpdatedAt:    conv.ToPGTimestamptz(payload.UpdatedAt),
+			WorkosLastEventID:  conv.ToPGText(event.ID),
+		}); err != nil {
+			return fmt.Errorf("mark organization membership %q deleted: %w", payload.ID, err)
+		}
+	}
+
+	if err := orgrepo.New(dbtx).DeleteOrganizationRoleAssignmentsByWorkosUser(ctx, orgrepo.DeleteOrganizationRoleAssignmentsByWorkosUserParams{
+		OrganizationID: org.ID,
+		WorkosUserID:   payload.UserID,
+	}); err != nil {
+		return fmt.Errorf("delete role assignments for workos user %q: %w", payload.UserID, err)
+	}
+
+	return nil
+}
+
+func decodeWorkOSMembershipPayload(event events.Event) (workosMembershipEventPayload, error) {
+	var payload workosMembershipEventPayload
+	if err := json.Unmarshal(event.Data, &payload); err != nil {
+		return payload, oops.Permanent(fmt.Errorf("unmarshal organization membership event payload: %w", err))
+	}
+	if payload.ID == "" || payload.OrganizationID == "" || payload.UserID == "" || payload.UpdatedAt.IsZero() {
+		return payload, oops.Permanent(fmt.Errorf("invalid organization membership event payload"))
+	}
+	return payload, nil
+}
+
+func membershipRoleSlugs(payload workosMembershipEventPayload) []string {
+	roleSlugs := make([]string, 0, len(payload.Roles)+2)
+	for _, role := range payload.Roles {
+		if role.Slug != "" {
+			roleSlugs = append(roleSlugs, role.Slug)
+		}
+	}
+	if payload.Role.Slug != "" {
+		roleSlugs = append(roleSlugs, payload.Role.Slug)
+	}
+	if payload.RoleSlug != "" {
+		roleSlugs = append(roleSlugs, payload.RoleSlug)
+	}
+
+	slices.Sort(roleSlugs)
+	return slices.Compact(roleSlugs)
+}

--- a/server/internal/background/activities/process_workos_membership_events.go
+++ b/server/internal/background/activities/process_workos_membership_events.go
@@ -66,7 +66,7 @@ func (p *ProcessWorkOSMembershipEvents) Do(ctx context.Context, params ProcessWo
 		case errors.Is(err, pgx.ErrNoRows):
 			// No cursor yet: full sync from the beginning.
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get user sync last event ID").Log(ctx, logger)
+			return nil, oops.E(oops.CodeUnexpected, err, "get user sync last event ID").Log(ctx, logger)
 		default:
 			sinceEventID = cursor
 		}
@@ -85,7 +85,7 @@ func (p *ProcessWorkOSMembershipEvents) Do(ctx context.Context, params ProcessWo
 		RangeEnd:       "",
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to list WorkOS membership events").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS membership events").Log(ctx, logger)
 	}
 
 	lastEventID, err := p.handlePage(ctx, logger, resp.Data)
@@ -110,7 +110,7 @@ func (p *ProcessWorkOSMembershipEvents) handlePage(ctx context.Context, logger *
 
 		eventID, err := p.handleEvent(ctx, eventLogger, event)
 		if err != nil {
-			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to handle WorkOS membership event").Log(ctx, eventLogger)
+			return lastEventID, oops.E(oops.CodeUnexpected, err, "handle WorkOS membership event").Log(ctx, eventLogger)
 		}
 		if eventID != "" {
 			lastEventID = eventID

--- a/server/internal/background/activities/process_workos_membership_events_test.go
+++ b/server/internal/background/activities/process_workos_membership_events_test.go
@@ -1,0 +1,410 @@
+package activities_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/workos/workos-go/v6/pkg/events"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+func newMembershipEventsTestConn(t *testing.T, name string) *pgxpool.Pool {
+	t.Helper()
+
+	conn, err := infra.CloneTestDatabase(t, name)
+	require.NoError(t, err)
+	return conn
+}
+
+func newWorkOSMembershipEvent(t *testing.T, eventType, eventID, membershipID, workosOrgID, workosUserID string, updatedAt time.Time, roleSlugs ...string) events.Event {
+	t.Helper()
+
+	roles := make([]struct {
+		Slug string `json:"slug"`
+	}, 0, len(roleSlugs))
+	for _, slug := range roleSlugs {
+		roles = append(roles, struct {
+			Slug string `json:"slug"`
+		}{Slug: slug})
+	}
+
+	payload := struct {
+		ID             string `json:"id"`
+		Object         string `json:"object"`
+		OrganizationID string `json:"organization_id"`
+		UserID         string `json:"user_id"`
+		Roles          []struct {
+			Slug string `json:"slug"`
+		} `json:"roles"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}{
+		ID:             membershipID,
+		Object:         "organization_membership",
+		OrganizationID: workosOrgID,
+		UserID:         workosUserID,
+		Roles:          roles,
+		UpdatedAt:      updatedAt,
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	return events.Event{
+		ID:        eventID,
+		Event:     eventType,
+		CreatedAt: updatedAt,
+		Data:      data,
+	}
+}
+
+func seedWorkOSOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, workosOrgID string) {
+	t.Helper()
+
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:                organizationID,
+		Name:              "Test Org",
+		Slug:              organizationID,
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)),
+		WorkosLastEventID: conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+}
+
+func seedWorkOSUser(t *testing.T, ctx context.Context, conn *pgxpool.Pool, userID, workosUserID string) {
+	t.Helper()
+
+	_, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       userID + "@example.com",
+		DisplayName: "Test User",
+		PhotoUrl:    conv.ToPGText(""),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	err = usersrepo.New(conn).SetUserWorkosID(ctx, usersrepo.SetUserWorkosIDParams{
+		WorkosID: conv.ToPGText(workosUserID),
+		ID:       userID,
+	})
+	require.NoError(t, err)
+}
+
+func seedOrganizationRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, slug string) accessrepo.OrganizationRole {
+	t.Helper()
+
+	eventTime := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    organizationID,
+		WorkosSlug:        slug,
+		WorkosName:        slug,
+		WorkosDescription: conv.ToPGText(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(eventTime),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(eventTime),
+		WorkosLastEventID: conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+
+	role, err := accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: organizationID,
+		WorkosSlug:     slug,
+	})
+	require.NoError(t, err)
+	return role
+}
+
+func seedGlobalRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, slug string) accessrepo.GlobalRole {
+	t.Helper()
+
+	eventTime := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	err := accessrepo.New(conn).UpsertGlobalRole(ctx, accessrepo.UpsertGlobalRoleParams{
+		WorkosSlug:        slug,
+		WorkosName:        slug,
+		WorkosDescription: conv.ToPGText(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(eventTime),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(eventTime),
+		WorkosLastEventID: conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+
+	role, err := accessrepo.New(conn).GetGlobalRoleBySlug(ctx, slug)
+	require.NoError(t, err)
+	return role
+}
+
+func TestProcessWorkOSMembershipEvents_CursorResumesFromDB(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newMembershipEventsTestConn(t, "workos_membership_events_cursor")
+	logger := testenv.NewLogger(t)
+
+	const storedCursor = "event_01HZCURSOR"
+	_, err := workosrepo.New(conn).SetUserSyncLastEventID(ctx, storedCursor)
+	require.NoError(t, err)
+
+	stub := &stubWorkOSEventsClient{pages: [][]events.Event{nil}}
+	activity := activities.NewProcessWorkOSMembershipEvents(logger, conn, stub)
+
+	res, err := activity.Do(ctx, activities.ProcessWorkOSMembershipEventsParams{})
+	require.NoError(t, err)
+	require.Equal(t, storedCursor, res.SinceEventID)
+	require.Len(t, stub.calls, 1)
+	require.Equal(t, storedCursor, stub.calls[0].After)
+	require.Empty(t, stub.calls[0].OrganizationId)
+	require.ElementsMatch(t, []string{
+		"organization_membership.created",
+		"organization_membership.deleted",
+		"organization_membership.updated",
+	}, stub.calls[0].Events)
+}
+
+func TestProcessWorkOSMembershipEvents_KnownUserSyncsMembershipAndRoles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newMembershipEventsTestConn(t, "workos_membership_events_known_user")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_mem_known"
+	const workosOrgID = "org_01HZMEMKNOWN"
+	const userID = "user_mem_known"
+	const workosUserID = "user_01HZMEMKNOWN"
+
+	updatedAt := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	organizationRole := seedOrganizationRole(t, ctx, conn, organizationID, "member")
+	globalRole := seedGlobalRole(t, ctx, conn, "platform-admin")
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEM1", "mem_01HZKNOWN", workosOrgID, workosUserID, updatedAt, "member", "platform-admin"),
+		}},
+	}
+	activity := activities.NewProcessWorkOSMembershipEvents(logger, conn, stub)
+
+	res, err := activity.Do(ctx, activities.ProcessWorkOSMembershipEventsParams{})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMEM1", res.LastEventID)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         userID,
+	})
+	require.NoError(t, err)
+	require.False(t, relationship.Deleted)
+	require.Equal(t, "mem_01HZKNOWN", relationship.WorkosMembershipID.String)
+	require.Equal(t, "event_01HZMEM1", relationship.WorkosLastEventID.String)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 2)
+	require.ElementsMatch(t, []string{
+		fmt.Sprintf("role:global:%s", globalRole.ID.String()),
+		fmt.Sprintf("role:organization:%s", organizationRole.ID.String()),
+	}, []string{assignments[0].RoleUrn, assignments[1].RoleUrn})
+
+	cursor, err := workosrepo.New(conn).GetUserSyncLastEventID(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMEM1", cursor)
+}
+
+func TestProcessWorkOSMembershipEvents_UnknownUserSyncsRolesAndAdvancesCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newMembershipEventsTestConn(t, "workos_membership_events_unknown_user")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_mem_unknown_user"
+	const workosOrgID = "org_01HZMEMUNKNOWNUSER"
+	const workosUserID = "user_01HZMEMUNKNOWN"
+
+	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	memberRole := seedOrganizationRole(t, ctx, conn, organizationID, "member")
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEMUNK", "mem_01HZUNKNOWN", workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
+		}},
+	}
+	activity := activities.NewProcessWorkOSMembershipEvents(logger, conn, stub)
+
+	res, err := activity.Do(ctx, activities.ProcessWorkOSMembershipEventsParams{})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMEMUNK", res.LastEventID)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	require.Equal(t, fmt.Sprintf("role:organization:%s", memberRole.ID.String()), assignments[0].RoleUrn)
+	require.False(t, assignments[0].UserID.Valid)
+
+	cursor, err := workosrepo.New(conn).GetUserSyncLastEventID(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMEMUNK", cursor)
+}
+
+func TestProcessWorkOSMembershipEvents_StaleUpdateSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newMembershipEventsTestConn(t, "workos_membership_events_stale")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_mem_stale"
+	const workosOrgID = "org_01HZMEMSTALE"
+	const userID = "user_mem_stale"
+	const workosUserID = "user_01HZMEMSTALE"
+
+	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	memberRole := seedOrganizationRole(t, ctx, conn, organizationID, "member")
+	seedOrganizationRole(t, ctx, conn, organizationID, "admin")
+
+	freshTime := time.Date(2026, 5, 6, 13, 0, 0, 0, time.UTC)
+	err := orgrepo.New(conn).UpsertOrganizationUserRelationshipFromWorkOS(ctx, orgrepo.UpsertOrganizationUserRelationshipFromWorkOSParams{
+		OrganizationID:     organizationID,
+		UserID:             userID,
+		WorkosMembershipID: conv.ToPGText("mem_01HZSTALE"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(freshTime),
+		WorkosLastEventID:  conv.ToPGText("event_99FRESH"),
+	})
+	require.NoError(t, err)
+	err = orgrepo.New(conn).SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       workosUserID,
+		WorkosRoleSlugs:    []string{"member"},
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGText("mem_01HZSTALE"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(freshTime),
+		WorkosLastEventID:  conv.ToPGText("event_99FRESH"),
+	})
+	require.NoError(t, err)
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			newWorkOSMembershipEvent(t, "organization_membership.updated", "event_01HZSTALE", "mem_01HZSTALE", workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "admin"),
+		}},
+	}
+	activity := activities.NewProcessWorkOSMembershipEvents(logger, conn, stub)
+
+	_, err = activity.Do(ctx, activities.ProcessWorkOSMembershipEventsParams{})
+	require.NoError(t, err)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         userID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "event_99FRESH", relationship.WorkosLastEventID.String)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	require.Equal(t, fmt.Sprintf("role:organization:%s", memberRole.ID.String()), assignments[0].RoleUrn)
+}
+
+func TestProcessWorkOSMembershipEvents_DeleteSoftDeletesRelationshipAndAssignments(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newMembershipEventsTestConn(t, "workos_membership_events_delete")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_mem_delete"
+	const workosOrgID = "org_01HZMEMDELETE"
+	const userID = "user_mem_delete"
+	const workosUserID = "user_01HZMEMDELETE"
+	const membershipID = "mem_01HZDELETE"
+
+	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	seedOrganizationRole(t, ctx, conn, organizationID, "member")
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZDEL1", membershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
+			newWorkOSMembershipEvent(t, "organization_membership.deleted", "event_01HZDEL2", membershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 13, 0, 0, 0, time.UTC)),
+		}},
+	}
+	activity := activities.NewProcessWorkOSMembershipEvents(logger, conn, stub)
+
+	res, err := activity.Do(ctx, activities.ProcessWorkOSMembershipEventsParams{})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZDEL2", res.LastEventID)
+
+	active, err := orgrepo.New(conn).HasOrganizationUserRelationship(ctx, orgrepo.HasOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         userID,
+	})
+	require.NoError(t, err)
+	require.False(t, active)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         userID,
+	})
+	require.NoError(t, err)
+	require.True(t, relationship.Deleted)
+	require.Equal(t, "event_01HZDEL2", relationship.WorkosLastEventID.String)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, assignments)
+}
+
+func TestProcessWorkOSMembershipEvents_UnknownOrganizationSkips(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newMembershipEventsTestConn(t, "workos_membership_events_unknown_org")
+	logger := testenv.NewLogger(t)
+
+	stub := &stubWorkOSEventsClient{
+		pages: [][]events.Event{{
+			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEMUNKORG", "mem_01HZUNKNOWNORG", "org_01HZUNKNOWN", "user_01HZUNKNOWNORG", time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
+		}},
+	}
+	activity := activities.NewProcessWorkOSMembershipEvents(logger, conn, stub)
+
+	res, err := activity.Do(ctx, activities.ProcessWorkOSMembershipEventsParams{})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMEMUNKORG", res.LastEventID)
+
+	cursor, err := workosrepo.New(conn).GetUserSyncLastEventID(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMEMUNKORG", cursor)
+
+	_, err = orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: "unknown",
+		UserID:         "unknown",
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}

--- a/server/internal/background/activities/process_workos_membership_events_test.go
+++ b/server/internal/background/activities/process_workos_membership_events_test.go
@@ -148,7 +148,7 @@ func seedGlobalRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, slug 
 func TestProcessWorkOSMembershipEvents_CursorResumesFromDB(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn := newMembershipEventsTestConn(t, "workos_membership_events_cursor")
 	logger := testenv.NewLogger(t)
 
@@ -175,7 +175,7 @@ func TestProcessWorkOSMembershipEvents_CursorResumesFromDB(t *testing.T) {
 func TestProcessWorkOSMembershipEvents_KnownUserSyncsMembershipAndRoles(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn := newMembershipEventsTestConn(t, "workos_membership_events_known_user")
 	logger := testenv.NewLogger(t)
 
@@ -229,7 +229,7 @@ func TestProcessWorkOSMembershipEvents_KnownUserSyncsMembershipAndRoles(t *testi
 func TestProcessWorkOSMembershipEvents_UnknownUserSyncsRolesAndAdvancesCursor(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn := newMembershipEventsTestConn(t, "workos_membership_events_unknown_user")
 	logger := testenv.NewLogger(t)
 
@@ -268,7 +268,7 @@ func TestProcessWorkOSMembershipEvents_UnknownUserSyncsRolesAndAdvancesCursor(t 
 func TestProcessWorkOSMembershipEvents_StaleUpdateSkipped(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn := newMembershipEventsTestConn(t, "workos_membership_events_stale")
 	logger := testenv.NewLogger(t)
 
@@ -331,7 +331,7 @@ func TestProcessWorkOSMembershipEvents_StaleUpdateSkipped(t *testing.T) {
 func TestProcessWorkOSMembershipEvents_DeleteSoftDeletesRelationshipAndAssignments(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn := newMembershipEventsTestConn(t, "workos_membership_events_delete")
 	logger := testenv.NewLogger(t)
 
@@ -383,7 +383,7 @@ func TestProcessWorkOSMembershipEvents_DeleteSoftDeletesRelationshipAndAssignmen
 func TestProcessWorkOSMembershipEvents_UnknownOrganizationSkips(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	conn := newMembershipEventsTestConn(t, "workos_membership_events_unknown_org")
 	logger := testenv.NewLogger(t)
 

--- a/server/internal/background/process_workos_membership_events.go
+++ b/server/internal/background/process_workos_membership_events.go
@@ -1,0 +1,92 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	processWorkOSMembershipEventsWorkflowID = "v1:process-workos-membership-events"
+)
+
+type ProcessWorkOSMembershipEventsWorkflowParams struct{}
+
+func processWorkOSMembershipEventsDebounceSignal(ProcessWorkOSMembershipEventsWorkflowParams) string {
+	return processWorkOSMembershipEventsWorkflowID + "/signal"
+}
+
+// ExecuteProcessWorkOSMembershipEventsWorkflowDebounced starts or signals the
+// singleton membership stream workflow. Concurrent triggers collapse onto the
+// active run and HasMore continues as the debounced wrapper.
+func ExecuteProcessWorkOSMembershipEventsWorkflowDebounced(ctx context.Context, temporalEnv *tenv.Environment) (client.WorkflowRun, error) {
+	params := ProcessWorkOSMembershipEventsWorkflowParams{}
+	sig := processWorkOSMembershipEventsDebounceSignal(params)
+
+	run, err := temporalEnv.Client().SignalWithStartWorkflow(
+		ctx,
+		processWorkOSMembershipEventsWorkflowID,
+		sig,
+		"enqueue",
+		client.StartWorkflowOptions{
+			ID:                       processWorkOSMembershipEventsWorkflowID,
+			TaskQueue:                string(temporalEnv.Queue()),
+			WorkflowIDReusePolicy:    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			WorkflowIDConflictPolicy: enums.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+			WorkflowRunTimeout:       30 * time.Minute,
+			StartDelay:               10 * time.Second,
+		},
+		ProcessWorkOSMembershipEventsWorkflowDebounced,
+		params,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("signal with start WorkOS membership workflow: %w", err)
+	}
+	return run, nil
+}
+
+func ProcessWorkOSMembershipEventsWorkflowDebounced(ctx workflow.Context, params ProcessWorkOSMembershipEventsWorkflowParams) (*activities.ProcessWorkOSMembershipEventsResult, error) {
+	return Debounce(
+		ProcessWorkOSMembershipEventsWorkflow,
+		ProcessWorkOSMembershipEventsWorkflowDebounced,
+		processWorkOSMembershipEventsDebounceSignal,
+		func(_ ProcessWorkOSMembershipEventsWorkflowParams, result *activities.ProcessWorkOSMembershipEventsResult) bool {
+			return result.HasMore
+		},
+	)(ctx, params)
+}
+
+func ProcessWorkOSMembershipEventsWorkflow(ctx workflow.Context, _ ProcessWorkOSMembershipEventsWorkflowParams) (*activities.ProcessWorkOSMembershipEventsResult, error) {
+	var a *Activities
+
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			MaximumInterval:    time.Minute,
+			BackoffCoefficient: 2,
+			MaximumAttempts:    5,
+		},
+	})
+
+	var processRes activities.ProcessWorkOSMembershipEventsResult
+	if err := workflow.ExecuteActivity(ctx, a.ProcessWorkOSMembershipEvents, activities.ProcessWorkOSMembershipEventsParams{
+		SinceEventID: nil,
+	}).Get(ctx, &processRes); err != nil {
+		return nil, fmt.Errorf("failed to process WorkOS membership events: %w", err)
+	}
+
+	return &activities.ProcessWorkOSMembershipEventsResult{
+		SinceEventID: processRes.SinceEventID,
+		LastEventID:  processRes.LastEventID,
+		HasMore:      processRes.HasMore,
+	}, nil
+}

--- a/server/internal/background/process_workos_membership_events.go
+++ b/server/internal/background/process_workos_membership_events.go
@@ -81,7 +81,7 @@ func ProcessWorkOSMembershipEventsWorkflow(ctx workflow.Context, _ ProcessWorkOS
 	if err := workflow.ExecuteActivity(ctx, a.ProcessWorkOSMembershipEvents, activities.ProcessWorkOSMembershipEventsParams{
 		SinceEventID: nil,
 	}).Get(ctx, &processRes); err != nil {
-		return nil, fmt.Errorf("failed to process WorkOS membership events: %w", err)
+		return nil, fmt.Errorf("process WorkOS membership events: %w", err)
 	}
 
 	return &activities.ProcessWorkOSMembershipEventsResult{

--- a/server/internal/background/process_workos_membership_events_test.go
+++ b/server/internal/background/process_workos_membership_events_test.go
@@ -1,0 +1,88 @@
+package background
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+)
+
+func TestProcessWorkOSMembershipEventsWorkflowID(t *testing.T) {
+	t.Parallel()
+
+	params := ProcessWorkOSMembershipEventsWorkflowParams{}
+	require.Equal(t, "v1:process-workos-membership-events/signal", processWorkOSMembershipEventsDebounceSignal(params))
+}
+
+func TestProcessWorkOSMembershipEventsWorkflow_CompletesWhenNoMore(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ProcessWorkOSMembershipEventsParams) (*activities.ProcessWorkOSMembershipEventsResult, error) {
+			return &activities.ProcessWorkOSMembershipEventsResult{
+				SinceEventID: "",
+				LastEventID:  "event_01HZA",
+				HasMore:      false,
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ProcessWorkOSMembershipEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessWorkOSMembershipEventsWorkflow, ProcessWorkOSMembershipEventsWorkflowParams{})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result activities.ProcessWorkOSMembershipEventsResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.False(t, result.HasMore)
+}
+
+func TestProcessWorkOSMembershipEventsWorkflowDebounced_ContinuesAsNewOnHasMore(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ProcessWorkOSMembershipEventsParams) (*activities.ProcessWorkOSMembershipEventsResult, error) {
+			return &activities.ProcessWorkOSMembershipEventsResult{HasMore: true}, nil
+		},
+		activity.RegisterOptions{Name: "ProcessWorkOSMembershipEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessWorkOSMembershipEventsWorkflowDebounced, ProcessWorkOSMembershipEventsWorkflowParams{})
+
+	require.True(t, env.IsWorkflowCompleted())
+
+	var canErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
+	require.Equal(t, "ProcessWorkOSMembershipEventsWorkflowDebounced", canErr.WorkflowType.Name)
+}
+
+func TestProcessWorkOSMembershipEventsWorkflowDebounced_CompletesWithoutSignals(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ activities.ProcessWorkOSMembershipEventsParams) (*activities.ProcessWorkOSMembershipEventsResult, error) {
+			return &activities.ProcessWorkOSMembershipEventsResult{HasMore: false}, nil
+		},
+		activity.RegisterOptions{Name: "ProcessWorkOSMembershipEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessWorkOSMembershipEventsWorkflowDebounced, ProcessWorkOSMembershipEventsWorkflowParams{})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -260,6 +260,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.SignalAssistantThread)
 	// WorkOS sync activities
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSOrganizationEvents)
+	temporalWorker.RegisterActivity(activities.ProcessWorkOSMembershipEvents)
 
 	temporalWorker.RegisterWorkflow(ProcessDeploymentWorkflow)
 	temporalWorker.RegisterWorkflow(FunctionsReaperWorkflow)
@@ -286,6 +287,8 @@ func NewTemporalWorker(
 	// WorkOS sync workflows
 	temporalWorker.RegisterWorkflow(ProcessWorkOSOrganizationEventsWorkflow)
 	temporalWorker.RegisterWorkflow(ProcessWorkOSOrganizationEventsWorkflowDebounced)
+	temporalWorker.RegisterWorkflow(ProcessWorkOSMembershipEventsWorkflow)
+	temporalWorker.RegisterWorkflow(ProcessWorkOSMembershipEventsWorkflowDebounced)
 
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -162,6 +162,122 @@ FROM organization_metadata
 WHERE workos_id = @workos_id
 LIMIT 1;
 
+-- name: GetOrganizationRelationshipForUser :one
+SELECT *
+FROM organization_user_relationships
+WHERE organization_id = @organization_id
+  AND user_id = @user_id;
+
+-- name: UpsertOrganizationUserRelationshipFromWorkOS :exec
+-- Upsert a membership row from a WorkOS organization_membership event. Caller
+-- must have already passed the row through ShouldProcessEvent.
+INSERT INTO organization_user_relationships (
+    organization_id,
+    user_id,
+    workos_membership_id,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    @organization_id,
+    @user_id,
+    @workos_membership_id,
+    @workos_updated_at,
+    @workos_last_event_id
+)
+ON CONFLICT (organization_id, user_id) DO UPDATE SET
+    workos_membership_id = EXCLUDED.workos_membership_id,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = NULL,
+    updated_at = clock_timestamp();
+
+-- name: MarkOrganizationUserRelationshipAsDeleted :exec
+-- Record a WorkOS membership delete, inserting a tombstone when the local
+-- relationship did not exist so stale replayed creates cannot resurrect it.
+INSERT INTO organization_user_relationships (
+    organization_id,
+    user_id,
+    workos_membership_id,
+    workos_updated_at,
+    workos_last_event_id,
+    deleted_at
+) VALUES (
+    @organization_id,
+    @user_id,
+    @workos_membership_id,
+    @workos_updated_at,
+    @workos_last_event_id,
+    clock_timestamp()
+)
+ON CONFLICT (organization_id, user_id) DO UPDATE SET
+    workos_membership_id = COALESCE(EXCLUDED.workos_membership_id, organization_user_relationships.workos_membership_id),
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = COALESCE(organization_user_relationships.deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp();
+
+-- name: SyncUserOrganizationRoleAssignments :exec
+-- Declaratively set all WorkOS role assignments for a known Gram user in an
+-- org. Role slugs are resolved from role sync tables and stale assignments for
+-- this WorkOS user are removed.
+WITH input_role_urns AS (
+    SELECT 'role:organization:' || id::text AS role_urn
+    FROM organization_roles
+    WHERE organization_id = @organization_id
+      AND workos_slug = ANY(@workos_role_slugs::text[])
+      AND deleted IS FALSE
+      AND workos_deleted IS FALSE
+    UNION ALL
+    SELECT 'role:global:' || id::text AS role_urn
+    FROM global_roles
+    WHERE workos_slug = ANY(@workos_role_slugs::text[])
+      AND deleted IS FALSE
+      AND workos_deleted IS FALSE
+),
+upserted AS (
+    INSERT INTO organization_role_assignments (
+        organization_id,
+        workos_user_id,
+        user_id,
+        role_urn,
+        workos_membership_id,
+        workos_updated_at,
+        workos_last_event_id
+    )
+    SELECT
+        @organization_id,
+        @workos_user_id,
+        @user_id,
+        input_role_urns.role_urn,
+        @workos_membership_id,
+        @workos_updated_at,
+        @workos_last_event_id
+    FROM input_role_urns
+    ON CONFLICT (organization_id, workos_user_id, role_urn) DO UPDATE SET
+        user_id = EXCLUDED.user_id,
+        workos_membership_id = EXCLUDED.workos_membership_id,
+        workos_updated_at = EXCLUDED.workos_updated_at,
+        workos_last_event_id = EXCLUDED.workos_last_event_id,
+        updated_at = clock_timestamp()
+    RETURNING role_urn
+)
+DELETE FROM organization_role_assignments
+WHERE organization_role_assignments.organization_id = @organization_id
+  AND organization_role_assignments.workos_user_id = @workos_user_id
+  AND organization_role_assignments.role_urn NOT IN (SELECT input_role_urns.role_urn FROM input_role_urns);
+
+-- name: DeleteOrganizationRoleAssignmentsByWorkosUser :exec
+DELETE FROM organization_role_assignments
+WHERE organization_id = @organization_id
+  AND workos_user_id = @workos_user_id;
+
+-- name: ListOrganizationRoleAssignmentsByWorkOSUser :many
+SELECT *
+FROM organization_role_assignments
+WHERE organization_id = @organization_id
+  AND workos_user_id = @workos_user_id
+ORDER BY role_urn;
+
 -- name: UpsertOrganizationMetadataFromWorkOS :one
 -- Upsert an organization row from a WorkOS organization event. Caller must
 -- have already passed the row through ShouldProcessEvent. Sets workos_id and

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -254,7 +254,8 @@ upserted AS (
         @workos_last_event_id
     FROM input_role_urns
     ON CONFLICT (organization_id, workos_user_id, role_urn) DO UPDATE SET
-        user_id = EXCLUDED.user_id,
+        -- COALESCE preserves a backfilled user_id if the sync fires before the Gram user exists.
+        user_id = COALESCE(EXCLUDED.user_id, organization_role_assignments.user_id),
         workos_membership_id = EXCLUDED.workos_membership_id,
         workos_updated_at = EXCLUDED.workos_updated_at,
         workos_last_event_id = EXCLUDED.workos_last_event_id,

--- a/server/internal/organizations/repo/models.go
+++ b/server/internal/organizations/repo/models.go
@@ -5,6 +5,7 @@
 package repo
 
 import (
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -23,6 +24,19 @@ type OrganizationMetadatum struct {
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DisabledAt         pgtype.Timestamptz
+}
+
+type OrganizationRoleAssignment struct {
+	ID                 uuid.UUID
+	OrganizationID     string
+	WorkosUserID       string
+	UserID             pgtype.Text
+	RoleUrn            string
+	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
+	CreatedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
 }
 
 type OrganizationUserRelationship struct {

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -565,7 +565,8 @@ upserted AS (
         $7
     FROM input_role_urns
     ON CONFLICT (organization_id, workos_user_id, role_urn) DO UPDATE SET
-        user_id = EXCLUDED.user_id,
+        -- COALESCE preserves a backfilled user_id if the sync fires before the Gram user exists.
+        user_id = COALESCE(EXCLUDED.user_id, organization_role_assignments.user_id),
         workos_membership_id = EXCLUDED.workos_membership_id,
         workos_updated_at = EXCLUDED.workos_updated_at,
         workos_last_event_id = EXCLUDED.workos_last_event_id,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -67,6 +67,22 @@ func (q *Queries) CreateOrganizationMetadata(ctx context.Context, arg CreateOrga
 	return err
 }
 
+const deleteOrganizationRoleAssignmentsByWorkosUser = `-- name: DeleteOrganizationRoleAssignmentsByWorkosUser :exec
+DELETE FROM organization_role_assignments
+WHERE organization_id = $1
+  AND workos_user_id = $2
+`
+
+type DeleteOrganizationRoleAssignmentsByWorkosUserParams struct {
+	OrganizationID string
+	WorkosUserID   string
+}
+
+func (q *Queries) DeleteOrganizationRoleAssignmentsByWorkosUser(ctx context.Context, arg DeleteOrganizationRoleAssignmentsByWorkosUserParams) error {
+	_, err := q.db.Exec(ctx, deleteOrganizationRoleAssignmentsByWorkosUser, arg.OrganizationID, arg.WorkosUserID)
+	return err
+}
+
 const deleteOrganizationUserRelationship = `-- name: DeleteOrganizationUserRelationship :exec
 UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp()
@@ -179,6 +195,36 @@ func (q *Queries) GetOrganizationNameByWorkosID(ctx context.Context, workosID pg
 	return name, err
 }
 
+const getOrganizationRelationshipForUser = `-- name: GetOrganizationRelationshipForUser :one
+SELECT id, organization_id, user_id, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at, deleted_at, deleted
+FROM organization_user_relationships
+WHERE organization_id = $1
+  AND user_id = $2
+`
+
+type GetOrganizationRelationshipForUserParams struct {
+	OrganizationID string
+	UserID         string
+}
+
+func (q *Queries) GetOrganizationRelationshipForUser(ctx context.Context, arg GetOrganizationRelationshipForUserParams) (OrganizationUserRelationship, error) {
+	row := q.db.QueryRow(ctx, getOrganizationRelationshipForUser, arg.OrganizationID, arg.UserID)
+	var i OrganizationUserRelationship
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.UserID,
+		&i.WorkosMembershipID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getOrganizationUserRelationship = `-- name: GetOrganizationUserRelationship :one
 SELECT id, organization_id, user_id, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at, deleted_at, deleted
 FROM organization_user_relationships
@@ -230,6 +276,50 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err
+}
+
+const listOrganizationRoleAssignmentsByWorkOSUser = `-- name: ListOrganizationRoleAssignmentsByWorkOSUser :many
+SELECT id, organization_id, workos_user_id, user_id, role_urn, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at
+FROM organization_role_assignments
+WHERE organization_id = $1
+  AND workos_user_id = $2
+ORDER BY role_urn
+`
+
+type ListOrganizationRoleAssignmentsByWorkOSUserParams struct {
+	OrganizationID string
+	WorkosUserID   string
+}
+
+func (q *Queries) ListOrganizationRoleAssignmentsByWorkOSUser(ctx context.Context, arg ListOrganizationRoleAssignmentsByWorkOSUserParams) ([]OrganizationRoleAssignment, error) {
+	rows, err := q.db.Query(ctx, listOrganizationRoleAssignmentsByWorkOSUser, arg.OrganizationID, arg.WorkosUserID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OrganizationRoleAssignment
+	for rows.Next() {
+		var i OrganizationRoleAssignment
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.WorkosUserID,
+			&i.UserID,
+			&i.RoleUrn,
+			&i.WorkosMembershipID,
+			&i.WorkosUpdatedAt,
+			&i.WorkosLastEventID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listOrganizationUsers = `-- name: ListOrganizationUsers :many
@@ -292,6 +382,51 @@ func (q *Queries) ListOrganizationUsers(ctx context.Context, organizationID stri
 		return nil, err
 	}
 	return items, nil
+}
+
+const markOrganizationUserRelationshipAsDeleted = `-- name: MarkOrganizationUserRelationshipAsDeleted :exec
+INSERT INTO organization_user_relationships (
+    organization_id,
+    user_id,
+    workos_membership_id,
+    workos_updated_at,
+    workos_last_event_id,
+    deleted_at
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    clock_timestamp()
+)
+ON CONFLICT (organization_id, user_id) DO UPDATE SET
+    workos_membership_id = COALESCE(EXCLUDED.workos_membership_id, organization_user_relationships.workos_membership_id),
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = COALESCE(organization_user_relationships.deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+`
+
+type MarkOrganizationUserRelationshipAsDeletedParams struct {
+	OrganizationID     string
+	UserID             string
+	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
+}
+
+// Record a WorkOS membership delete, inserting a tombstone when the local
+// relationship did not exist so stale replayed creates cannot resurrect it.
+func (q *Queries) MarkOrganizationUserRelationshipAsDeleted(ctx context.Context, arg MarkOrganizationUserRelationshipAsDeletedParams) error {
+	_, err := q.db.Exec(ctx, markOrganizationUserRelationshipAsDeleted,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.WorkosMembershipID,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+	)
+	return err
 }
 
 const setAccountType = `-- name: SetAccountType :exec
@@ -392,6 +527,80 @@ type SetUserWorkOSMembershipsParams struct {
 // workos_id are unaffected. Other users' memberships are never modified.
 func (q *Queries) SetUserWorkOSMemberships(ctx context.Context, arg SetUserWorkOSMembershipsParams) error {
 	_, err := q.db.Exec(ctx, setUserWorkOSMemberships, arg.UserID, arg.WorkosOrgIds, arg.WorkosMembershipIds)
+	return err
+}
+
+const syncUserOrganizationRoleAssignments = `-- name: SyncUserOrganizationRoleAssignments :exec
+WITH input_role_urns AS (
+    SELECT 'role:organization:' || id::text AS role_urn
+    FROM organization_roles
+    WHERE organization_id = $1
+      AND workos_slug = ANY($3::text[])
+      AND deleted IS FALSE
+      AND workos_deleted IS FALSE
+    UNION ALL
+    SELECT 'role:global:' || id::text AS role_urn
+    FROM global_roles
+    WHERE workos_slug = ANY($3::text[])
+      AND deleted IS FALSE
+      AND workos_deleted IS FALSE
+),
+upserted AS (
+    INSERT INTO organization_role_assignments (
+        organization_id,
+        workos_user_id,
+        user_id,
+        role_urn,
+        workos_membership_id,
+        workos_updated_at,
+        workos_last_event_id
+    )
+    SELECT
+        $1,
+        $2,
+        $4,
+        input_role_urns.role_urn,
+        $5,
+        $6,
+        $7
+    FROM input_role_urns
+    ON CONFLICT (organization_id, workos_user_id, role_urn) DO UPDATE SET
+        user_id = EXCLUDED.user_id,
+        workos_membership_id = EXCLUDED.workos_membership_id,
+        workos_updated_at = EXCLUDED.workos_updated_at,
+        workos_last_event_id = EXCLUDED.workos_last_event_id,
+        updated_at = clock_timestamp()
+    RETURNING role_urn
+)
+DELETE FROM organization_role_assignments
+WHERE organization_role_assignments.organization_id = $1
+  AND organization_role_assignments.workos_user_id = $2
+  AND organization_role_assignments.role_urn NOT IN (SELECT input_role_urns.role_urn FROM input_role_urns)
+`
+
+type SyncUserOrganizationRoleAssignmentsParams struct {
+	OrganizationID     string
+	WorkosUserID       string
+	WorkosRoleSlugs    []string
+	UserID             pgtype.Text
+	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
+}
+
+// Declaratively set all WorkOS role assignments for a known Gram user in an
+// org. Role slugs are resolved from role sync tables and stale assignments for
+// this WorkOS user are removed.
+func (q *Queries) SyncUserOrganizationRoleAssignments(ctx context.Context, arg SyncUserOrganizationRoleAssignmentsParams) error {
+	_, err := q.db.Exec(ctx, syncUserOrganizationRoleAssignments,
+		arg.OrganizationID,
+		arg.WorkosUserID,
+		arg.WorkosRoleSlugs,
+		arg.UserID,
+		arg.WorkosMembershipID,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+	)
 	return err
 }
 
@@ -561,4 +770,47 @@ func (q *Queries) UpsertOrganizationUserRelationship(ctx context.Context, arg Up
 		&i.Deleted,
 	)
 	return i, err
+}
+
+const upsertOrganizationUserRelationshipFromWorkOS = `-- name: UpsertOrganizationUserRelationshipFromWorkOS :exec
+INSERT INTO organization_user_relationships (
+    organization_id,
+    user_id,
+    workos_membership_id,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5
+)
+ON CONFLICT (organization_id, user_id) DO UPDATE SET
+    workos_membership_id = EXCLUDED.workos_membership_id,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = NULL,
+    updated_at = clock_timestamp()
+`
+
+type UpsertOrganizationUserRelationshipFromWorkOSParams struct {
+	OrganizationID     string
+	UserID             string
+	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
+}
+
+// Upsert a membership row from a WorkOS organization_membership event. Caller
+// must have already passed the row through ShouldProcessEvent.
+func (q *Queries) UpsertOrganizationUserRelationshipFromWorkOS(ctx context.Context, arg UpsertOrganizationUserRelationshipFromWorkOSParams) error {
+	_, err := q.db.Exec(ctx, upsertOrganizationUserRelationshipFromWorkOS,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.WorkosMembershipID,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+	)
+	return err
 }

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -10,3 +10,16 @@ ON CONFLICT (workos_organization_id) DO UPDATE SET
     last_event_id = EXCLUDED.last_event_id,
     updated_at = clock_timestamp()
 RETURNING id;
+
+-- name: GetUserSyncLastEventID :one
+SELECT last_event_id
+FROM workos_user_syncs
+WHERE id = 1;
+
+-- name: SetUserSyncLastEventID :one
+INSERT INTO workos_user_syncs (id, last_event_id)
+VALUES (1, @last_event_id)
+ON CONFLICT (id) DO UPDATE SET
+    last_event_id = EXCLUDED.last_event_id,
+    updated_at = clock_timestamp()
+RETURNING id;

--- a/server/internal/thirdparty/workos/repo/queries.sql.go
+++ b/server/internal/thirdparty/workos/repo/queries.sql.go
@@ -24,6 +24,19 @@ func (q *Queries) GetOrganizationSyncLastEventID(ctx context.Context, workosOrga
 	return last_event_id, err
 }
 
+const getUserSyncLastEventID = `-- name: GetUserSyncLastEventID :one
+SELECT last_event_id
+FROM workos_user_syncs
+WHERE id = 1
+`
+
+func (q *Queries) GetUserSyncLastEventID(ctx context.Context) (string, error) {
+	row := q.db.QueryRow(ctx, getUserSyncLastEventID)
+	var last_event_id string
+	err := row.Scan(&last_event_id)
+	return last_event_id, err
+}
+
 const setOrganizationSyncLastEventID = `-- name: SetOrganizationSyncLastEventID :one
 INSERT INTO workos_organization_syncs (workos_organization_id, last_event_id)
 VALUES ($1, $2)
@@ -41,6 +54,22 @@ type SetOrganizationSyncLastEventIDParams struct {
 func (q *Queries) SetOrganizationSyncLastEventID(ctx context.Context, arg SetOrganizationSyncLastEventIDParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, setOrganizationSyncLastEventID, arg.WorkosOrganizationID, arg.LastEventID)
 	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const setUserSyncLastEventID = `-- name: SetUserSyncLastEventID :one
+INSERT INTO workos_user_syncs (id, last_event_id)
+VALUES (1, $1)
+ON CONFLICT (id) DO UPDATE SET
+    last_event_id = EXCLUDED.last_event_id,
+    updated_at = clock_timestamp()
+RETURNING id
+`
+
+func (q *Queries) SetUserSyncLastEventID(ctx context.Context, lastEventID string) (int64, error) {
+	row := q.db.QueryRow(ctx, setUserSyncLastEventID, lastEventID)
+	var id int64
 	err := row.Scan(&id)
 	return id, err
 }


### PR DESCRIPTION
Adds the steps to sync Workos memberships (users and user roles) from WorkOS. 

Extracted from the main PR here: https://github.com/speakeasy-api/gram/pull/2093

Note: this is still a no-op (nothing is triggering this activity yet)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->