### PR TITLE
feat: backfill user_id on role assignments at login

### DIFF
--- a/server/internal/auth/sessions/speakeasyconnections.go
+++ b/server/internal/auth/sessions/speakeasyconnections.go
@@ -432,6 +432,13 @@ func (s *Manager) syncWorkOSMemberships(ctx context.Context, user userRepo.Upser
 		}
 	}
 
+	if err := s.orgRepo.BackfillRoleAssignmentUserID(ctx, orgRepo.BackfillRoleAssignmentUserIDParams{
+		UserID:       conv.ToPGText(user.ID),
+		WorkosUserID: workosUserID,
+	}); err != nil {
+		s.logger.ErrorContext(ctx, "backfill role assignment user ID", attr.SlogError(err))
+	}
+
 	// Load current org membership state directly from WorkOS so we can populate
 	// the workos membership ID in the org membership records
 	memberships, err := s.workos.ListUserMemberships(ctx, workosUserID)

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -141,6 +141,14 @@ WHERE organization_user_relationships.user_id = @user_id
       SELECT id FROM organization_metadata WHERE workos_id IS NOT NULL
   );
 
+-- name: BackfillRoleAssignmentUserID :exec
+-- Backfill user_id on pending role assignments for a newly-linked WorkOS user.
+UPDATE organization_role_assignments
+SET user_id = @user_id,
+    updated_at = clock_timestamp()
+WHERE workos_user_id = @workos_user_id
+  AND user_id IS NULL;
+
 -- name: SetOrgWorkosID :one
 UPDATE organization_metadata
 SET workos_id = @workos_id,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -42,6 +42,25 @@ func (q *Queries) AttachWorkOSUserToOrg(ctx context.Context, arg AttachWorkOSUse
 	return err
 }
 
+const backfillRoleAssignmentUserID = `-- name: BackfillRoleAssignmentUserID :exec
+UPDATE organization_role_assignments
+SET user_id = $1,
+    updated_at = clock_timestamp()
+WHERE workos_user_id = $2
+  AND user_id IS NULL
+`
+
+type BackfillRoleAssignmentUserIDParams struct {
+	UserID       pgtype.Text
+	WorkosUserID string
+}
+
+// Backfill user_id on pending role assignments for a newly-linked WorkOS user.
+func (q *Queries) BackfillRoleAssignmentUserID(ctx context.Context, arg BackfillRoleAssignmentUserIDParams) error {
+	_, err := q.db.Exec(ctx, backfillRoleAssignmentUserID, arg.UserID, arg.WorkosUserID)
+	return err
+}
+
 const clearOrganizationWorkosID = `-- name: ClearOrganizationWorkosID :exec
 UPDATE organization_metadata SET workos_id = NULL WHERE id = $1
 `


### PR DESCRIPTION
## Summary

- Adds `BackfillRoleAssignmentUserID` SQL query — updates `organization_role_assignments` setting `user_id` for any pending rows where `workos_user_id` matches but `user_id` is NULL
- Wires the backfill into `syncWorkOSMemberships` after the WorkOS user ID is established, covering both first-login and repeat-login paths

## Context

JIT role assignments written by the WorkOS sync workflow store `user_id = NULL` when the Gram user doesn't exist yet. This backfill runs at login to link those assignments once the user is known.

Depends on / pairs with: #2653
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->