### PR TITLE
fix(dashboard): contain install-dialog content panels within the dialog

### DIFF
--- a/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
+++ b/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
@@ -107,7 +107,7 @@ function ClaudeCodeInstallContent({
     : null;
 
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div>
         <h3 className="mb-2 text-sm font-semibold">
           Install in your Claude Code instance
@@ -257,7 +257,7 @@ function ClaudeCoworkInstallContent({
   const repoSlug = `${repoOwner}/${repoName}`;
 
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div>
         <h3 className="mb-2 text-sm font-semibold">
           Roll out to your organization
@@ -361,7 +361,7 @@ function CursorInstallContent({
   const repoUrl = `https://github.com/${repoOwner}/${repoName}`;
 
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div>
         <h3 className="mb-2 text-sm font-semibold">
           Roll out to your team in Cursor


### PR DESCRIPTION
Dialog.Content uses display: grid, and grid items default to min-width: auto — i.e. their intrinsic content width. The install instructions dialog's per-platform content panels contain code blocks whose long URLs push the panel's intrinsic min-width past the dialog's sm:max-w-lg cap (512px), so on Chrome at typical viewport widths the dialog header + content overflowed the dialog frame.

(Firefox happened to compute min-width: auto more aggressively to 0 for grid items in this scenario; Chrome adheres to the spec literally.)

One min-w-0 on each *InstallContent's top-level div lets the grid item shrink to the dialog's width; the existing break-all / pre-wrap classes inside the gray code panels handle the actual wrapping. No need to widen the dialog or touch the shared Dialog component.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->