### PR TITLE
fix(externalmcp): probe root-level well-known URLs when MCP endpoint has a path

### DIFF
--- a/.changeset/age-2181-oauth-discovery-root-fallback.md
+++ b/.changeset/age-2181-oauth-discovery-root-fallback.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix OAuth discovery for MCP servers that host well-known metadata at the origin root regardless of endpoint path (e.g. Atlassian). When the remote URL has a path and prior discovery strategies find no authorization server metadata, the discovery chain now retries both `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` probes against the origin root with the path stripped.

--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -160,6 +160,36 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 		}
 	}
 
+	// Strategy 4: Some AS servers (e.g. Atlassian) host metadata at the origin
+	// root regardless of the MCP endpoint path. When the remote URL has a path
+	// and prior strategies found nothing, retry both probes with path stripped.
+	if authServerMeta == nil {
+		if u, err := url.Parse(remoteURL); err == nil && u.Path != "" && u.Path != "/" {
+			rootURL := u.Scheme + "://" + u.Host
+
+			prURL := buildWellKnownResourceURL(rootURL)
+			meta, err := fetchJSON[protectedResourceMetadata](ctx, logger, guardianPolicy, prURL)
+			if err == nil && meta != nil {
+				resourceMeta = meta
+				if len(meta.AuthorizationServers) > 0 {
+					asURL := buildWellKnownURL(meta.AuthorizationServers[0])
+					asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
+					if asMeta != nil {
+						authServerMeta = asMeta
+					}
+				}
+			}
+
+			if authServerMeta == nil {
+				asURL := buildWellKnownURL(rootURL)
+				asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
+				if asMeta != nil {
+					authServerMeta = asMeta
+				}
+			}
+		}
+	}
+
 	// Determine the OAuth version based on what we found
 	result := &OAuthDiscoveryResult{
 		Version:               OAuthVersionNone,


### PR DESCRIPTION
## Summary

- Adds Strategy 4 to `DiscoverOAuthMetadata` in `server/internal/externalmcp/oauthdiscovery.go`
- When the remote MCP URL has a path component and Strategies 1–3 all fail to find AS metadata, retries both well-known probes (`oauth-protected-resource` and `oauth-authorization-server`) against the origin root (path stripped)
- Fixes discovery for servers like Atlassian that host `/.well-known/oauth-authorization-server` at the origin regardless of the MCP endpoint path (e.g. `https://mcp.atlassian.com/sse` → probes `https://mcp.atlassian.com/.well-known/oauth-authorization-server`)

## Discovery chain after this change

| Strategy | Mechanism |
|---|---|
| 1 | `WWW-Authenticate: auth_server_metadata=<url>` — fetch AS directly |
| 2 | `WWW-Authenticate: resource_metadata=<url>` — fetch PR → follow to AS |
| 3 | Probe `/.well-known/oauth-protected-resource/<path>` → follow to AS; then probe `/.well-known/oauth-authorization-server/<path>` directly |
| 4 *(new)* | If URL has a path and nothing found yet — strip path, retry both probes at origin root |

## Test plan

- [x] Tested that this successfully found metadata for Atlassian

Closes AGE-2180
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->