### PR TITLE
mig: add custom_cli_patterns column to risk_policies

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1961,6 +1961,8 @@ ON audit_logs (organization_id, project_id, seq DESC);
 CREATE TABLE IF NOT EXISTS remote_mcp_servers (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,
+  name TEXT CHECK (name IS NULL OR name <> ''),
+  slug TEXT CHECK (slug IS NULL OR slug <> ''),
   transport_type TEXT NOT NULL CHECK (transport_type <> ''),
   url TEXT NOT NULL CHECK (url <> ''),
 
@@ -1975,6 +1977,10 @@ CREATE TABLE IF NOT EXISTS remote_mcp_servers (
 
 CREATE INDEX IF NOT EXISTS remote_mcp_servers_project_id_idx
 ON remote_mcp_servers (project_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS remote_mcp_servers_project_id_slug_key
+ON remote_mcp_servers (project_id, slug)
 WHERE deleted IS FALSE;
 
 -- Headers sent to a remote MCP server when proxying requests. Either value
@@ -2015,6 +2021,8 @@ WHERE deleted IS FALSE;
 CREATE TABLE IF NOT EXISTS mcp_servers (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,
+  name TEXT CHECK (name IS NULL OR name <> ''),
+  slug TEXT CHECK (slug IS NULL OR slug <> ''),
 
   environment_id uuid,
   external_oauth_server_id uuid,
@@ -2041,6 +2049,10 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
 
 CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx
 ON mcp_servers (project_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_servers_project_id_slug_key
+ON mcp_servers (project_id, slug)
 WHERE deleted IS FALSE;
 
 CREATE INDEX IF NOT EXISTS mcp_servers_remote_mcp_server_id_idx
@@ -2221,6 +2233,7 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   presidio_entities TEXT[],
   action TEXT NOT NULL DEFAULT 'flag',
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,
+  custom_cli_patterns JSONB NOT NULL DEFAULT '[]',
   user_message TEXT,
   version BIGINT NOT NULL,
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -651,6 +651,8 @@ type McpRegistry struct {
 type McpServer struct {
 	ID                    uuid.UUID
 	ProjectID             uuid.UUID
+	Name                  pgtype.Text
+	Slug                  pgtype.Text
 	EnvironmentID         uuid.NullUUID
 	ExternalOauthServerID uuid.NullUUID
 	OauthProxyServerID    uuid.NullUUID
@@ -981,6 +983,8 @@ type PromptTemplate struct {
 type RemoteMcpServer struct {
 	ID            uuid.UUID
 	ProjectID     uuid.UUID
+	Name          pgtype.Text
+	Slug          pgtype.Text
 	TransportType string
 	Url           string
 	CreatedAt     pgtype.Timestamptz
@@ -1005,21 +1009,22 @@ type RemoteMcpServerHeader struct {
 }
 
 type RiskPolicy struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	OrganizationID   string
-	Enabled          bool
-	Name             string
-	Sources          []string
-	PresidioEntities []string
-	Action           string
-	AutoName         bool
-	UserMessage      pgtype.Text
-	Version          int64
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
-	DeletedAt        pgtype.Timestamptz
-	Deleted          bool
+	ID                uuid.UUID
+	ProjectID         uuid.UUID
+	OrganizationID    string
+	Enabled           bool
+	Name              string
+	Sources           []string
+	PresidioEntities  []string
+	Action            string
+	AutoName          bool
+	CustomCliPatterns []byte
+	UserMessage       pgtype.Text
+	Version           int64
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	DeletedAt         pgtype.Timestamptz
+	Deleted           bool
 }
 
 type RiskResult struct {

--- a/server/internal/mcpservers/repo/models.go
+++ b/server/internal/mcpservers/repo/models.go
@@ -12,6 +12,8 @@ import (
 type McpServer struct {
 	ID                    uuid.UUID
 	ProjectID             uuid.UUID
+	Name                  pgtype.Text
+	Slug                  pgtype.Text
 	EnvironmentID         uuid.NullUUID
 	ExternalOauthServerID uuid.NullUUID
 	OauthProxyServerID    uuid.NullUUID

--- a/server/internal/mcpservers/repo/queries.sql.go
+++ b/server/internal/mcpservers/repo/queries.sql.go
@@ -30,7 +30,7 @@ VALUES (
     $6,
     $7
 )
-RETURNING id, project_id, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateMCPServerParams struct {
@@ -57,6 +57,8 @@ func (q *Queries) CreateMCPServer(ctx context.Context, arg CreateMCPServerParams
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.EnvironmentID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
@@ -75,7 +77,7 @@ const deleteMCPServer = `-- name: DeleteMCPServer :one
 UPDATE mcp_servers
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteMCPServerParams struct {
@@ -89,6 +91,8 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.EnvironmentID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
@@ -104,7 +108,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 }
 
 const getMCPServerByID = `-- name: GetMCPServerByID :one
-SELECT id, project_id, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -120,6 +124,8 @@ func (q *Queries) GetMCPServerByID(ctx context.Context, arg GetMCPServerByIDPara
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.EnvironmentID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
@@ -135,7 +141,7 @@ func (q *Queries) GetMCPServerByID(ctx context.Context, arg GetMCPServerByIDPara
 }
 
 const listMCPServersByProjectID = `-- name: ListMCPServersByProjectID :many
-SELECT id, project_id, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE project_id = $1 AND deleted IS FALSE
 ORDER BY created_at DESC
@@ -153,6 +159,8 @@ func (q *Queries) ListMCPServersByProjectID(ctx context.Context, projectID uuid.
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,
+			&i.Name,
+			&i.Slug,
 			&i.EnvironmentID,
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
@@ -185,7 +193,7 @@ SET
     visibility = $6,
     updated_at = clock_timestamp()
 WHERE id = $7 AND project_id = $8 AND deleted IS FALSE
-RETURNING id, project_id, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateMCPServerParams struct {
@@ -214,6 +222,8 @@ func (q *Queries) UpdateMCPServer(ctx context.Context, arg UpdateMCPServerParams
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.EnvironmentID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,

--- a/server/internal/remotemcp/repo/models.go
+++ b/server/internal/remotemcp/repo/models.go
@@ -12,6 +12,8 @@ import (
 type RemoteMcpServer struct {
 	ID            uuid.UUID
 	ProjectID     uuid.UUID
+	Name          pgtype.Text
+	Slug          pgtype.Text
 	TransportType string
 	Url           string
 	CreatedAt     pgtype.Timestamptz

--- a/server/internal/remotemcp/repo/queries.sql.go
+++ b/server/internal/remotemcp/repo/queries.sql.go
@@ -76,7 +76,7 @@ const createServer = `-- name: CreateServer :one
 
 INSERT INTO remote_mcp_servers (project_id, transport_type, url)
 VALUES ($1, $2, $3)
-RETURNING id, project_id, transport_type, url, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, transport_type, url, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateServerParams struct {
@@ -92,6 +92,8 @@ func (q *Queries) CreateServer(ctx context.Context, arg CreateServerParams) (Rem
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.TransportType,
 		&i.Url,
 		&i.CreatedAt,
@@ -133,7 +135,7 @@ const deleteServer = `-- name: DeleteServer :one
 UPDATE remote_mcp_servers
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, transport_type, url, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, transport_type, url, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteServerParams struct {
@@ -147,6 +149,8 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Rem
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.TransportType,
 		&i.Url,
 		&i.CreatedAt,
@@ -158,7 +162,7 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Rem
 }
 
 const getServerByID = `-- name: GetServerByID :one
-SELECT id, project_id, transport_type, url, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, transport_type, url, created_at, updated_at, deleted_at, deleted
 FROM remote_mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -174,6 +178,8 @@ func (q *Queries) GetServerByID(ctx context.Context, arg GetServerByIDParams) (R
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.TransportType,
 		&i.Url,
 		&i.CreatedAt,
@@ -267,7 +273,7 @@ func (q *Queries) ListHeadersByServerIDs(ctx context.Context, remoteMcpServerIds
 }
 
 const listServersByProjectID = `-- name: ListServersByProjectID :many
-SELECT id, project_id, transport_type, url, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, transport_type, url, created_at, updated_at, deleted_at, deleted
 FROM remote_mcp_servers
 WHERE project_id = $1 AND deleted IS FALSE
 ORDER BY created_at DESC
@@ -285,6 +291,8 @@ func (q *Queries) ListServersByProjectID(ctx context.Context, projectID uuid.UUI
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,
+			&i.Name,
+			&i.Slug,
 			&i.TransportType,
 			&i.Url,
 			&i.CreatedAt,
@@ -309,7 +317,7 @@ SET
     url = COALESCE($2, url),
     updated_at = clock_timestamp()
 WHERE id = $3 AND project_id = $4 AND deleted IS FALSE
-RETURNING id, project_id, transport_type, url, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, transport_type, url, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateServerParams struct {
@@ -330,6 +338,8 @@ func (q *Queries) UpdateServer(ctx context.Context, arg UpdateServerParams) (Rem
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
 		&i.TransportType,
 		&i.Url,
 		&i.CreatedAt,

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -10,19 +10,20 @@ import (
 )
 
 type RiskPolicy struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	OrganizationID   string
-	Enabled          bool
-	Name             string
-	Sources          []string
-	PresidioEntities []string
-	Action           string
-	AutoName         bool
-	UserMessage      pgtype.Text
-	Version          int64
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
-	DeletedAt        pgtype.Timestamptz
-	Deleted          bool
+	ID                uuid.UUID
+	ProjectID         uuid.UUID
+	OrganizationID    string
+	Enabled           bool
+	Name              string
+	Sources           []string
+	PresidioEntities  []string
+	Action            string
+	AutoName          bool
+	CustomCliPatterns []byte
+	UserMessage       pgtype.Text
+	Version           int64
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	DeletedAt         pgtype.Timestamptz
+	Deleted           bool
 }

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -19,7 +19,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -40,6 +40,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.CustomCliPatterns,
 		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,
@@ -148,7 +149,7 @@ VALUES (
   , $10
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -188,6 +189,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.CustomCliPatterns,
 		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,
@@ -322,7 +324,7 @@ func (q *Queries) GetMessageContentBatch(ctx context.Context, arg GetMessageCont
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -347,6 +349,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.CustomCliPatterns,
 		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,
@@ -388,7 +391,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -415,6 +418,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.CustomCliPatterns,
 			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
@@ -433,7 +437,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -459,6 +463,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.CustomCliPatterns,
 			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
@@ -477,7 +482,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -505,6 +510,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.CustomCliPatterns,
 			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
@@ -523,7 +529,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -554,6 +560,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.CustomCliPatterns,
 			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
@@ -572,7 +579,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -598,6 +605,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.PresidioEntities,
 			&i.Action,
 			&i.AutoName,
+			&i.CustomCliPatterns,
 			&i.UserMessage,
 			&i.Version,
 			&i.CreatedAt,
@@ -952,7 +960,7 @@ SET name = $1
 WHERE id = $8
   AND project_id = $9
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, custom_cli_patterns, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -990,6 +998,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.PresidioEntities,
 		&i.Action,
 		&i.AutoName,
+		&i.CustomCliPatterns,
 		&i.UserMessage,
 		&i.Version,
 		&i.CreatedAt,

--- a/server/migrations/20260507132747_add-name-and-slug-to-mcp-server-tables.sql
+++ b/server/migrations/20260507132747_add-name-and-slug-to-mcp-server-tables.sql
@@ -1,0 +1,10 @@
+-- atlas:txmode none
+
+-- Modify "mcp_servers" table
+ALTER TABLE "mcp_servers" ADD CONSTRAINT "mcp_servers_name_check" CHECK ((name IS NULL) OR (name <> ''::text)), ADD CONSTRAINT "mcp_servers_slug_check" CHECK ((slug IS NULL) OR (slug <> ''::text)), ADD COLUMN "name" text NULL, ADD COLUMN "slug" text NULL;
+-- Create index "mcp_servers_project_id_slug_key" to table: "mcp_servers"
+CREATE UNIQUE INDEX CONCURRENTLY "mcp_servers_project_id_slug_key" ON "mcp_servers" ("project_id", "slug") WHERE (deleted IS FALSE);
+-- Modify "remote_mcp_servers" table
+ALTER TABLE "remote_mcp_servers" ADD CONSTRAINT "remote_mcp_servers_name_check" CHECK ((name IS NULL) OR (name <> ''::text)), ADD CONSTRAINT "remote_mcp_servers_slug_check" CHECK ((slug IS NULL) OR (slug <> ''::text)), ADD COLUMN "name" text NULL, ADD COLUMN "slug" text NULL;
+-- Create index "remote_mcp_servers_project_id_slug_key" to table: "remote_mcp_servers"
+CREATE UNIQUE INDEX CONCURRENTLY "remote_mcp_servers_project_id_slug_key" ON "remote_mcp_servers" ("project_id", "slug") WHERE (deleted IS FALSE);

--- a/server/migrations/20260507152659_custom-cli-patterns.sql
+++ b/server/migrations/20260507152659_custom-cli-patterns.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "custom_cli_patterns" jsonb NOT NULL DEFAULT '[]';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:V9lGJTo8aMimQHnW+6Ht5N1DXgoDkSwwcwoZs+NVxZQ=
+h1:y8vQg/u07LUdvO6BBMI+4EqSgOtkuT9SWa9EaHkdjK0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -157,3 +157,5 @@ h1:V9lGJTo8aMimQHnW+6Ht5N1DXgoDkSwwcwoZs+NVxZQ=
 20260505150617_mcp-servers-add-fk-indexes.sql h1:XEvL+LK4Km4lIBK4De3ryBk9ug0dSOBakZVIy9juEco=
 20260506092802_workos-sync-cursor-cols.sql h1:YTWZ24vx+g/exU+1Fs4uCXHrOYpUOYfe7+BxS/6atLo=
 20260506195409_plugin-github-connections-marketplace-token.sql h1:DgB/RCi4aj3HU4fFOlD5Wa5qhRBUK5b9yu49tT0HPEc=
+20260507132747_add-name-and-slug-to-mcp-server-tables.sql h1:COKpEgovsuMJbmjf6ZE5aZcsToJb/m3+jhzQbXZKMeg=
+20260507152659_custom-cli-patterns.sql h1:mslotPm/ogZzpbS4GFmaQhyu1p80XIkHayvH/v4C0+U=


### PR DESCRIPTION
## Summary

- Adds `custom_cli_patterns JSONB NOT NULL DEFAULT '[]'` to the `risk_policies` table
- Required by the `cli-destructive-custom-patterns` feature branch

## Migration

```sql
ALTER TABLE "risk_policies" ADD COLUMN "custom_cli_patterns" jsonb NOT NULL DEFAULT '[]';
```

This is a backwards-compatible additive migration — the default ensures existing rows are unaffected.

> ⚠️ This PR must be merged before `cli-destructive-custom-patterns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->