### PR TITLE
fix(slack-manifest): drop tool-gated bot scope conditioning

### DIFF
--- a/.changeset/age-2182-slack-manifest-superset.md
+++ b/.changeset/age-2182-slack-manifest-superset.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Always grant the full Slack bot-scope superset in the assistant onboarding manifest builder, regardless of which platform tools are attached. Slack manifests are static post-install — adding a scope later forces the user to delete the app and re-OAuth — so per-tool scope gating only locked future capabilities behind a forced re-install.

--- a/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
@@ -118,25 +118,25 @@ export const SLACK_EVENT_BINDINGS: Record<string, SlackEventBinding> = {
   user_change: { bot_events: ["user_change"], scopes: ["users:read"] },
 };
 
-const BASELINE_BOT_SCOPES: readonly string[] = [
-  "chat:write",
-  "im:write",
-  "users:read",
-];
-
-// Slack manifests are static and the user can't easily edit them after
-// install, so subscribe to every event the trigger service supports up
-// front. The trigger config's `event_types` filters at delivery time.
+// Slack manifests are effectively static post-install: adding a scope or
+// event after the user has clicked Create requires deleting the app and
+// going through OAuth again. So we always grant the full bot-token
+// superset — every scope referenced by any platform tool or trigger event
+// — at install time. Per-tool gating saves nothing and locks future
+// capabilities behind a forced re-install. The trigger config's
+// `event_types` still filters delivery, so over-subscribing to events is
+// harmless.
+const ALL_BOT_SCOPES: readonly string[] = Array.from(
+  new Set([
+    ...Object.values(SLACK_TOOL_SCOPES).flatMap((s) => Array.from(s)),
+    ...Object.values(SLACK_EVENT_BINDINGS).flatMap((b) => Array.from(b.scopes)),
+  ]),
+).sort();
 const ALL_EVENT_BOT_EVENTS: readonly string[] = Array.from(
   new Set(
     Object.values(SLACK_EVENT_BINDINGS).flatMap((b) =>
       Array.from(b.bot_events),
     ),
-  ),
-).sort();
-const ALL_EVENT_SCOPES: readonly string[] = Array.from(
-  new Set(
-    Object.values(SLACK_EVENT_BINDINGS).flatMap((b) => Array.from(b.scopes)),
   ),
 ).sort();
 
@@ -157,17 +157,11 @@ export type SlackManifestResult = {
   displayName: string;
   scopes: string[];
   botEvents: string[];
-  unmappedToolUrns: string[];
   searchToolNeedsUserToken: boolean;
 };
 
 function uniqueSorted(values: Iterable<string>): string[] {
   return Array.from(new Set(values)).sort();
-}
-
-function handlerFromUrn(urn: string): string | null {
-  if (!urn.startsWith(SLACK_TOOL_URN_PREFIX)) return null;
-  return urn.slice(SLACK_TOOL_URN_PREFIX.length);
 }
 
 export function buildSlackManifest(
@@ -178,25 +172,10 @@ export function buildSlackManifest(
     SLACK_DISPLAY_NAME_LIMIT,
   );
 
-  const scopes = new Set<string>([...BASELINE_BOT_SCOPES, ...ALL_EVENT_SCOPES]);
+  const scopes = new Set<string>(ALL_BOT_SCOPES);
   const botEvents = new Set<string>(ALL_EVENT_BOT_EVENTS);
-  const unmappedToolUrns: string[] = [];
-  let searchToolNeedsUserToken = false;
-
-  for (const urn of input.toolUrns ?? []) {
-    const handler = handlerFromUrn(urn);
-    if (!handler) continue;
-    const mapped = SLACK_TOOL_SCOPES[handler];
-    if (mapped) {
-      for (const s of mapped) scopes.add(s);
-      continue;
-    }
-    if (handler === "search_messages_and_files") {
-      searchToolNeedsUserToken = true;
-      continue;
-    }
-    unmappedToolUrns.push(urn);
-  }
+  const searchUrn = `${SLACK_TOOL_URN_PREFIX}search_messages_and_files`;
+  const searchToolNeedsUserToken = (input.toolUrns ?? []).includes(searchUrn);
 
   for (const s of input.extraScopes ?? []) scopes.add(s);
   for (const e of input.extraBotEvents ?? []) botEvents.add(e);
@@ -235,7 +214,6 @@ export function buildSlackManifest(
     displayName,
     scopes: sortedScopes,
     botEvents: sortedEvents,
-    unmappedToolUrns,
     searchToolNeedsUserToken,
   };
 }


### PR DESCRIPTION
## Summary

- Slack manifests are effectively static post-install: adding a scope after Create forces the user to delete the app and re-OAuth. Per-tool scope gating in the assistant onboarding manifest builder saved nothing and locked future capabilities behind a forced re-install.
- The builder now emits the full bot-token superset (union of every scope referenced by `SLACK_TOOL_SCOPES` and `SLACK_EVENT_BINDINGS`) regardless of which tools the assistant has attached — same approach we already use for events (`ALL_EVENT_BOT_EVENTS`).
- Dropped the now-vestigial `unmappedToolUrns` reporting and the per-handler scope-mapping loop; `searchToolNeedsUserToken` is preserved as a single-URN check (still surfaced in the UI to flag the `search.all` user-token requirement).
- `search:read` stays out of the bot scopes — Slack only grants it on a user token.

Closes [AGE-2182](https://linear.app/speakeasy/issue/AGE-2182/slack-manifest-drop-tool-gated-scope-conditioning).

✻ Clauded...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->