### PR TITLE
mig: l1 ML prompt-injection classifier (deberta-v3) opt-in

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2399,6 +2399,7 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   name TEXT NOT NULL,
   sources TEXT[] NOT NULL,
   presidio_entities TEXT[],
+  prompt_injection_rules TEXT[],
   action TEXT NOT NULL DEFAULT 'flag',
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,
   user_message TEXT,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1053,21 +1053,22 @@ type RemoteMcpServerHeader struct {
 }
 
 type RiskPolicy struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	OrganizationID   string
-	Enabled          bool
-	Name             string
-	Sources          []string
-	PresidioEntities []string
-	Action           string
-	AutoName         bool
-	UserMessage      pgtype.Text
-	Version          int64
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
-	DeletedAt        pgtype.Timestamptz
-	Deleted          bool
+	ID                   uuid.UUID
+	ProjectID            uuid.UUID
+	OrganizationID       string
+	Enabled              bool
+	Name                 string
+	Sources              []string
+	PresidioEntities     []string
+	PromptInjectionRules []string
+	Action               string
+	AutoName             bool
+	UserMessage          pgtype.Text
+	Version              int64
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	DeletedAt            pgtype.Timestamptz
+	Deleted              bool
 }
 
 type RiskResult struct {

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -10,19 +10,20 @@ import (
 )
 
 type RiskPolicy struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	OrganizationID   string
-	Enabled          bool
-	Name             string
-	Sources          []string
-	PresidioEntities []string
-	Action           string
-	AutoName         bool
-	UserMessage      pgtype.Text
-	Version          int64
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
-	DeletedAt        pgtype.Timestamptz
-	Deleted          bool
+	ID                   uuid.UUID
+	ProjectID            uuid.UUID
+	OrganizationID       string
+	Enabled              bool
+	Name                 string
+	Sources              []string
+	PresidioEntities     []string
+	PromptInjectionRules []string
+	Action               string
+	AutoName             bool
+	UserMessage          pgtype.Text
+	Version              int64
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	DeletedAt            pgtype.Timestamptz
+	Deleted              bool
 }

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -19,7 +19,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -38,6 +38,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PromptInjectionRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -148,7 +149,7 @@ VALUES (
   , $10
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -186,6 +187,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PromptInjectionRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -322,7 +324,7 @@ func (q *Queries) GetMessageContentBatch(ctx context.Context, arg GetMessageCont
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -345,6 +347,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PromptInjectionRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -388,7 +391,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -413,6 +416,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.Name,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PromptInjectionRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -433,7 +437,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -457,6 +461,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.Name,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PromptInjectionRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -477,7 +482,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -503,6 +508,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.Name,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PromptInjectionRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -523,7 +529,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -552,6 +558,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.Name,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PromptInjectionRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -572,7 +579,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -596,6 +603,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.Name,
 			&i.Sources,
 			&i.PresidioEntities,
+			&i.PromptInjectionRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -952,7 +960,7 @@ SET name = $1
 WHERE id = $8
   AND project_id = $9
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -988,6 +996,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.Name,
 		&i.Sources,
 		&i.PresidioEntities,
+		&i.PromptInjectionRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,

--- a/server/migrations/20260512103400_add-prompt-injection-rules.sql
+++ b/server/migrations/20260512103400_add-prompt-injection-rules.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "prompt_injection_rules" text[] NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4y3nmCn6tX7xfg+dzoVk1Ndnatdavn41fvI8Vsa5cAc=
+h1:fSjauz2YONmWdtStM447kPQ745ncmCdwhjeqmXQmXec=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -166,3 +166,4 @@ h1:4y3nmCn6tX7xfg+dzoVk1Ndnatdavn41fvI8Vsa5cAc=
 20260512061053_outbox-public-id.sql h1:+kCMWjjPiWwvaXi+chzNTXTYEtQBo3hbCNI4Lol/0tc=
 20260512092949_add-user-deleted-at-column.sql h1:tjmvmwD0ChThSFMDHnahV0W5dTZpVS/H49x0yh+py88=
 20260512093032_add-org-user-relationship-workos-id-column.sql h1:bfMGYN8vrqG3h3pncuHYh+Efh7Ud4FNhSiH0nswQm0Y=
+20260512103400_add-prompt-injection-rules.sql h1:X5zqk2CoHY9IrOJemHa+UvmRsmrHNcBO01wFfo2+H2U=


### PR DESCRIPTION
## Summary

Migration/schema PR for #2667.

Adds nullable `risk_policies.prompt_injection_rules text[]` so a policy can opt into specific prompt-injection rules, including the L1 classifier rule, separately from the existing `prompt_injection` source.

Regenerated after rebasing on latest `main`:

- `mise db:diff add-prompt-injection-rules`

## Validation

- `mise lint:migrations --no-atlas`

Full `mise lint:migrations` was attempted; migration ordering passed, but Atlas snapshotting could not run because the connected local DB was dirty: `found table "agent_executions" in connected schema`.