### PR TITLE
fix(marketplace): include ref+sha in git-subdir source to fix restart caching

### DIFF
--- a/.changeset/marketplace-plugin-cache-sha.md
+++ b/.changeset/marketplace-plugin-cache-sha.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix private Claude Code plugins showing "not cached at (not recorded)" after restarting Claude Code. The marketplace proxy now fetches the current HEAD commit SHA and embeds it alongside `ref` in each `git-subdir` plugin source, giving Claude Code a stable cache key that survives restarts.

--- a/server/internal/marketplace/handler.go
+++ b/server/internal/marketplace/handler.go
@@ -103,8 +103,10 @@ func tokenFromSlug(slug string) string {
 }
 
 // handleManifest fetches the upstream's published .claude-plugin/marketplace.json
-// via the GitHub Contents API and rewrites each plugin's source to an absolute
-// git URL on this proxy.
+// via the GitHub Contents API, resolves the current HEAD SHA for the published
+// branch, and rewrites each plugin's source to a git-subdir entry pointing at
+// this proxy with an explicit ref and sha so Claude Code can build a stable
+// cache key.
 func (s *Server) handleManifest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	token := r.PathValue("token")
@@ -131,7 +133,14 @@ func (s *Server) handleManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rewritten, err := s.rewriteManifest(raw, token)
+	sha, err := s.fetchRefSHA(ctx, up)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "fetch ref sha", attr.SlogError(err))
+		http.Error(w, "manifest unavailable", http.StatusBadGateway)
+		return
+	}
+
+	rewritten, err := s.rewriteManifest(raw, token, sha)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "rewrite manifest", attr.SlogError(err))
 		http.Error(w, "manifest rewrite failed", http.StatusInternalServerError)
@@ -193,10 +202,57 @@ func (s *Server) fetchPublishedManifest(ctx context.Context, up Upstream) ([]byt
 	return body, nil
 }
 
+// fetchRefSHA returns the commit SHA at the tip of publishedManifestRef via
+// the GitHub Git Refs API. The SHA is embedded in the rewritten manifest so
+// Claude Code can derive a stable on-disk cache path for each plugin version
+// (avoiding the "not cached at (not recorded)" symptom when cache_path is
+// absent from the git-subdir entry).
+func (s *Server) fetchRefSHA(ctx context.Context, up Upstream) (string, error) {
+	refURL := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s/git/ref/heads/%s",
+		url.PathEscape(up.Owner), url.PathEscape(up.Repo), url.QueryEscape(publishedManifestRef),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, refURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build ref request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+up.AccessToken)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("ref api request: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("ref api: status %d: %s", resp.StatusCode, body)
+	}
+
+	var refResp struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&refResp); err != nil {
+		return "", fmt.Errorf("decode ref response: %w", err)
+	}
+	if refResp.Object.SHA == "" {
+		return "", errors.New("ref response missing sha")
+	}
+	return refResp.Object.SHA, nil
+}
+
 // rewriteManifest transforms a git-based manifest (string-typed plugin sources
-// like "./foo") into a URL-based one (object-typed sources pointing at the
-// proxy). Object sources are passed through unmodified.
-func (s *Server) rewriteManifest(raw []byte, token string) ([]byte, error) {
+// like "./foo") into git-subdir entries pointing at the proxy with an explicit
+// ref and sha. Object sources are passed through unmodified.
+//
+// Including sha lets Claude Code build a deterministic on-disk cache path for
+// each plugin version, fixing the "not cached at (not recorded)" restart bug
+// that occurs when the git-subdir entry carries no sha.
+func (s *Server) rewriteManifest(raw []byte, token, sha string) ([]byte, error) {
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return nil, fmt.Errorf("unmarshal manifest: %w", err)
@@ -205,7 +261,6 @@ func (s *Server) rewriteManifest(raw []byte, token string) ([]byte, error) {
 	if !ok {
 		return nil, errors.New("manifest missing plugins array")
 	}
-	gitURL := fmt.Sprintf("%s%sp/%s.git", s.publicBaseURL, RoutePrefix, token)
 	for _, p := range pluginsRaw {
 		entry, ok := p.(map[string]any)
 		if !ok {
@@ -217,14 +272,18 @@ func (s *Server) rewriteManifest(raw []byte, token string) ([]byte, error) {
 		}
 		if pathStr, isString := src.(string); isString {
 			// Per the official Claude Code marketplace schema (schemastore.org/
-			// claude-code-marketplace.json), `git-subdir` is the source type for
-			// "clone this URL, the plugin lives at the given subdirectory". The
-			// plain "git" source type doesn't exist; the four supported types
-			// are npm | url | github | git-subdir.
+			// claude-code-marketplace.json), git-subdir accepts url, path, ref,
+			// and sha. Supplying sha gives Claude Code a stable cache key so the
+			// plugin survives restarts without showing "not cached at (not
+			// recorded)".
+			slug := trimRelPrefix(pathStr)
+			gitURL := fmt.Sprintf("%s%sp/%s.git", s.publicBaseURL, RoutePrefix, token)
 			entry["source"] = map[string]any{
 				"source": "git-subdir",
 				"url":    gitURL,
-				"path":   trimRelPrefix(pathStr),
+				"path":   slug,
+				"ref":    publishedManifestRef,
+				"sha":    sha,
 			}
 		}
 	}

--- a/server/internal/marketplace/handler_test.go
+++ b/server/internal/marketplace/handler_test.go
@@ -15,9 +15,10 @@ import (
 // rewriteManifest is the only place we encode the Claude Code marketplace
 // schema, so its output shape is the load-bearing contract. The schema
 // (https://www.schemastore.org/claude-code-marketplace.json) defines exactly
-// four plugin source types: npm, url, github, and git-subdir. There is no
-// plain "git" type — installs fail with "source type your version does not
-// support" if you use one. These tests pin the discriminator and field names.
+// four plugin source types: npm, url, github, and git-subdir.
+//
+// We use git-subdir with an explicit sha so Claude Code has a stable cache
+// key and survives restarts without "not cached at (not recorded)".
 func TestRewriteManifest(t *testing.T) {
 	t.Parallel()
 
@@ -26,7 +27,9 @@ func TestRewriteManifest(t *testing.T) {
 		logger:        testenv.NewLogger(t),
 	}
 
-	t.Run("relative path source becomes git-subdir", func(t *testing.T) {
+	const testSHA = "abc123def456abc123def456abc123def456abc123"
+
+	t.Run("relative path source becomes git-subdir with ref and sha", func(t *testing.T) {
 		t.Parallel()
 		in := []byte(`{
 			"name": "m",
@@ -36,7 +39,7 @@ func TestRewriteManifest(t *testing.T) {
 			]
 		}`)
 
-		out, err := s.rewriteManifest(in, "TOK")
+		out, err := s.rewriteManifest(in, "TOK", testSHA)
 		require.NoError(t, err)
 
 		var got struct {
@@ -46,15 +49,18 @@ func TestRewriteManifest(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(out, &got))
 		require.Len(t, got.Plugins, 1)
-		require.Equal(t, "git-subdir", got.Plugins[0].Source["source"])
-		require.Equal(t, "https://gram.test/marketplace/p/TOK.git", got.Plugins[0].Source["url"])
-		require.Equal(t, "foo", got.Plugins[0].Source["path"])
+		src := got.Plugins[0].Source
+		require.Equal(t, "git-subdir", src["source"])
+		require.Equal(t, "https://gram.test/marketplace/p/TOK.git", src["url"])
+		require.Equal(t, "foo", src["path"])
+		require.Equal(t, "main", src["ref"])
+		require.Equal(t, testSHA, src["sha"])
 	})
 
-	t.Run("leading slash on path is trimmed", func(t *testing.T) {
+	t.Run("leading slash on path is trimmed in git-subdir path", func(t *testing.T) {
 		t.Parallel()
 		in := []byte(`{"plugins": [{"name": "x", "source": "/x"}]}`)
-		out, err := s.rewriteManifest(in, "TOK")
+		out, err := s.rewriteManifest(in, "TOK", testSHA)
 		require.NoError(t, err)
 
 		var got struct {
@@ -72,7 +78,7 @@ func TestRewriteManifest(t *testing.T) {
 		// (e.g. github source for a public dep), the proxy should leave them
 		// alone — only string sources need rewriting.
 		in := []byte(`{"plugins": [{"name": "y", "source": {"source": "github", "repo": "anthropics/example"}}]}`)
-		out, err := s.rewriteManifest(in, "TOK")
+		out, err := s.rewriteManifest(in, "TOK", testSHA)
 		require.NoError(t, err)
 
 		var got struct {
@@ -91,7 +97,7 @@ func TestRewriteManifest(t *testing.T) {
 			{"name": "a", "source": "./a"},
 			{"name": "b", "source": "./b"}
 		]}`)
-		out, err := s.rewriteManifest(in, "TOK")
+		out, err := s.rewriteManifest(in, "TOK", testSHA)
 		require.NoError(t, err)
 
 		var got struct {
@@ -104,17 +110,19 @@ func TestRewriteManifest(t *testing.T) {
 		require.Len(t, got.Plugins, 2)
 		require.Equal(t, "a", got.Plugins[0].Source["path"])
 		require.Equal(t, "b", got.Plugins[1].Source["path"])
+		require.Equal(t, testSHA, got.Plugins[0].Source["sha"])
+		require.Equal(t, testSHA, got.Plugins[1].Source["sha"])
 	})
 
 	t.Run("missing plugins array errors", func(t *testing.T) {
 		t.Parallel()
-		_, err := s.rewriteManifest([]byte(`{"name": "no-plugins"}`), "TOK")
+		_, err := s.rewriteManifest([]byte(`{"name": "no-plugins"}`), "TOK", testSHA)
 		require.Error(t, err)
 	})
 
 	t.Run("malformed JSON errors", func(t *testing.T) {
 		t.Parallel()
-		_, err := s.rewriteManifest([]byte(`{not json`), "TOK")
+		_, err := s.rewriteManifest([]byte(`{not json`), "TOK", testSHA)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes the "not cached at (not recorded)" error that appears after restarting Claude Code with a private plugin installed via the Gram marketplace proxy
- The root cause: Claude Code's `git-subdir` source type uses the `sha` field to build its on-disk cache path; without it the cache path is `(not recorded)` and the plugin appears missing on every restart
- The proxy now calls the GitHub Git Refs API (`GET /repos/{owner}/{repo}/git/ref/heads/main`) when serving `marketplace.json` and embeds the current HEAD commit SHA alongside `ref: "main"` in every rewritten `git-subdir` source entry

## Test plan

- [ ] Install a private plugin via a Gram marketplace URL
- [ ] Quit and reopen Claude Code — plugin should load without `/plugins` refresh
- [ ] Verify `marketplace.json` response includes `ref` and `sha` fields in each plugin source
- [ ] Unit tests: `go test ./server/internal/marketplace/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->