### PR TITLE
feat(auth): emit gram_assistants_signup posthog event on auto-provision

### DIFF
--- a/.changeset/age-2166-posthog-assistants-signup.md
+++ b/.changeset/age-2166-posthog-assistants-signup.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Capture a `gram_assistants_signup` PostHog event when the auth callback auto-provisions an org for a user landing with `?disposition=assistants`. The event is keyed on the user's email (matches `is_first_time_user_signup`) and carries `organization_id`, `organization_slug`, `disposition`, and `has_assistants_subscription` so the funnel from signup → benefit attach is observable.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -857,6 +857,7 @@ func newStartCommand() *cli.Command {
 				authzEngine,
 				billingRepo,
 				&background.TemporalAssistantsSubscriptionCancelScheduler{TemporalEnv: temporalEnv},
+				posthogClient,
 			))
 			organizations.Attach(mux, organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, productFeatures, authzEngine))
 			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -33,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 )
 
 const dispositionAssistants = "assistants"
@@ -68,6 +69,7 @@ type Service struct {
 	authz               *authz.Engine
 	billing             billing.Repository
 	cancelSubsScheduler AssistantsSubscriptionCancelScheduler
+	posthog             *posthog.Posthog
 	projectsRepo        *projectsRepo.Queries
 	envRepo             *envRepo.Queries
 	orgRepo             *orgRepo.Queries
@@ -84,6 +86,7 @@ func NewService(
 	authzEngine *authz.Engine,
 	billingRepo billing.Repository,
 	cancelSubsScheduler AssistantsSubscriptionCancelScheduler,
+	posthogClient *posthog.Posthog,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("auth"))
 
@@ -96,6 +99,7 @@ func NewService(
 		authz:               authzEngine,
 		billing:             billingRepo,
 		cancelSubsScheduler: cancelSubsScheduler,
+		posthog:             posthogClient,
 		projectsRepo:        projectsRepo.New(db),
 		envRepo:             envRepo.New(db),
 		orgRepo:             orgRepo.New(db),
@@ -599,6 +603,16 @@ func (s *Service) autoProvisionForAssistants(ctx context.Context, idToken string
 	session.ActiveOrganizationID = org.ID
 	if err := s.sessions.StoreSession(ctx, *session); err != nil {
 		return "", fmt.Errorf("store session: %w", err)
+	}
+
+	if err := s.posthog.CaptureEvent(ctx, "gram_assistants_signup", userInfo.Email, map[string]any{
+		"email":                       userInfo.Email,
+		"organization_id":             org.ID,
+		"organization_slug":           org.Slug,
+		"disposition":                 dispositionAssistants,
+		"has_assistants_subscription": subID != "",
+	}); err != nil {
+		s.logger.ErrorContext(ctx, "failed to capture gram_assistants_signup event", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
 	}
 
 	return fmt.Sprintf("/%s/projects/%s/assistants/new?disposition=%s", org.Slug, projects[0].Slug, dispositionAssistants), nil

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -323,7 +323,7 @@ func newTestAuthService(t *testing.T, userInfo *MockUserInfo) (context.Context, 
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient(), cache.NoopCache)
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, authConfigs, authzEngine, billingClient, noopCancelScheduler{})
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog)
 
 	return ctx, newTestAuthServiceResult(t, svc, conn, sessionManager, mockServer, authConfigs)
 }
@@ -367,7 +367,7 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient(), cache.NoopCache)
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, authConfigs, authzEngine, billingClient, noopCancelScheduler{})
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog)
 
 	return ctx, newTestAuthServiceResult(t, svc, conn, sessionManager, mockServer, authConfigs)
 }


### PR DESCRIPTION
## Summary
- Capture a `gram_assistants_signup` PostHog event at the tail of `autoProvisionForAssistants` (`server/internal/auth/impl.go`) so the disposition=assistants funnel is observable.
- Event is keyed on the user's email (mirroring `is_first_time_user_signup`) and carries `organization_id`, `organization_slug`, `disposition`, and `has_assistants_subscription` (true when `AttachAssistantsBenefit` returned a non-empty subscription ID).
- Threads `*posthog.Posthog` through `auth.NewService` (single new constructor param); no behavior change beyond emission, capture errors are logged and swallowed to match other call sites.
- Follow-up to #2656.

✻ Clauded...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->