### PR TITLE
feat(assistants): token-aware compaction in the assistant runtime

### DIFF
--- a/.changeset/age-2150-assistant-runtime-compaction.md
+++ b/.changeset/age-2150-assistant-runtime-compaction.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Add token-aware transcript compaction to the assistant runtime: the runner reads `gram_metadata.context_window` from completion responses, and once `usage.input_tokens` crosses 80% of the window (configurable via `ASSISTANT_CONTEXT_PERCENTAGE`) it drops reasoning + failed tool results and summarises older turns through a nested model loop. The summary preserves system + context items and the most recent few turns. The compactor's adapter omits the `Gram-Chat-ID` default header so its calls bypass chat-message capture.

--- a/.changeset/age-2150-assistant-runtime-compaction.md
+++ b/.changeset/age-2150-assistant-runtime-compaction.md
@@ -2,4 +2,4 @@
 "server": minor
 ---
 
-Add token-aware transcript compaction to the assistant runtime: the runner reads `gram_metadata.context_window` from completion responses, and once `usage.input_tokens` crosses 80% of the window (configurable via `ASSISTANT_CONTEXT_PERCENTAGE`) it drops reasoning + failed tool results and summarises older turns through a nested model loop. The summary preserves system + context items and the most recent few turns. The compactor's adapter omits the `Gram-Chat-ID` default header so its calls bypass chat-message capture.
+Add token-aware transcript compaction to the assistant runtime: gram resolves the model's context window at admit/configure time and pushes it to the runner via `RunnerConfig.context_window`. Once `usage.input_tokens` crosses 80% of the window (configurable via `ASSISTANT_CONTEXT_PERCENTAGE`) the runner drops reasoning + failed tool results and summarises older turns through a nested model loop, preserving system + context items and the most recent few turns. The compactor's adapter omits the `Gram-Chat-ID` default header so its calls bypass chat-message capture.

--- a/.changeset/age-2150-assistant-runtime-compaction.md
+++ b/.changeset/age-2150-assistant-runtime-compaction.md
@@ -2,4 +2,4 @@
 "server": minor
 ---
 
-Add token-aware transcript compaction to the assistant runtime: gram resolves the model's context window at admit/configure time and pushes it to the runner via `RunnerConfig.context_window`. Once `usage.input_tokens` crosses 80% of the window (configurable via `ASSISTANT_CONTEXT_PERCENTAGE`) the runner drops reasoning + failed tool results and summarises older turns through a nested model loop, preserving system + context items and the most recent few turns. The compactor's adapter omits the `Gram-Chat-ID` default header so its calls bypass chat-message capture.
+The assistant runtime now compacts conversation history as it approaches the model's context window: older turns are summarised so long-running assistants can keep going past the original window limit. System prompt, context items, and the most recent turns are preserved.

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "agentkit-adapter-completions"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50009fd2d365dbb85549c06e9d3288bd2a64082b2a91d8f9386aa458305ec42b"
+checksum = "abd5f827b3e036dc093de98b82c8a7507dda53f49f557dad0b567468ba61c65f"
 dependencies = [
  "agentkit-core",
  "agentkit-http",
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-capabilities"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479efd0d4054009a658e4f3681e9357ac1ef14c876f56ac488d9fe2ca35eb517"
+checksum = "56de7d5c22ecf8c8235a508fcce1079cecd02f16d7a6042cdd01a7820f862c64"
 dependencies = [
  "agentkit-core",
  "async-trait",
@@ -36,11 +36,12 @@ dependencies = [
 
 [[package]]
 name = "agentkit-compaction"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47993c44f2248e06c08bef7f376a4dfdd057eaf5f45455a72abaff012deb5ab6"
+checksum = "3ae94217a4767801eeacd561f92b2644e4eca9aff989a3152c53f334baf00bca"
 dependencies = [
  "agentkit-core",
+ "agentkit-loop",
  "async-trait",
  "serde",
  "thiserror 2.0.18",
@@ -48,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-core"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fd0dc81f6c8b46b906ba4a897241dac44aa50a6df6b119321355090d6c4a60"
+checksum = "13fbdacc5ad0b3b09537a5b675c3fa6ead70d11b97f017922f54a8d4be185b66"
 dependencies = [
  "futures-timer",
  "serde",
@@ -60,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-http"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e4e38c0cbb41b73f309efd4b56dfbc5ab1ec325eac7a1b292f67a33a7b79d3"
+checksum = "bb281098f1988f0be5456345cf14ca76335c8682807293dd2e626089be288abf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -77,12 +78,11 @@ dependencies = [
 
 [[package]]
 name = "agentkit-loop"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5036a24359084af3a84428a707ddaf5db75c8441cc51f03260d7ddb048af2dc"
+checksum = "84dd076256e49351fb87b654ebdf7e9675362ca2434eb4e20d8466446e48a484"
 dependencies = [
  "agentkit-capabilities",
- "agentkit-compaction",
  "agentkit-core",
  "agentkit-task-manager",
  "agentkit-tools-core",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-mcp"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49810dc39bf10bb1d040bec14813502f98cfb41476b48833d3f822a66c688621"
+checksum = "75fd97c6a3a7d61521526337ed1045324c1d7c3215130387d280b471348f077b"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-provider-openrouter"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd7b9a3a1a439159bf2779d9b7f3482d81d556c7f6785a1756bddbdf3cc4158"
+checksum = "549922b09c4895ff664a9ab777acffb02bfc828d01df2376443d20703073a1d2"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-reporting"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f63e996fa82d775847a62f91ea90ec319840cd378048345073db2dc1c9f6ba"
+checksum = "9c8398907ba14e29a987fe2c712ef2f0f45758e16ba51166eed44024839ff854"
 dependencies = [
  "agentkit-core",
  "agentkit-loop",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-task-manager"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd72b0dd33a82f149b1573915ef184317bf7a34857d00afdc3fb6f06d4f6487"
+checksum = "2cd1a7f41762a4d9f08d1f85149560cc099675f031d11e454a3034696ebb2244"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tool-fs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950fa82e4ff35281269935379505b1bf4e1a6a3ed16447945c9ab49d86713322"
+checksum = "833058c7f899043be22da6e9f4823b6fff412796b35a306a5a7781dde91c58b1"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-core"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d4bf392659aa60e655050b69ea514b6258b603e71b1eb94e3257d1163c85d1"
+checksum = "1230b52e05923e868ae7fb3effd7471089b81457e190aaa01f0fa3d93a150c42"
 dependencies = [
  "agentkit-capabilities",
  "agentkit-core",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tools-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e91d6e4b0844187cf75384aefffe50613df461801c5453308e77caec81ec1a1"
+checksum = "57caeccc00fdd270b6ddc7461aa62e50d22f47eb65c144a0daa63283dacb9097"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -901,6 +901,7 @@ name = "gram-assistant-runner"
 version = "0.1.0"
 dependencies = [
  "agentkit-adapter-completions",
+ "agentkit-compaction",
  "agentkit-core",
  "agentkit-http",
  "agentkit-loop",

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 agentkit-adapter-completions = "0.5.0"
+agentkit-compaction = "0.5.0"
 agentkit-core = "0.5.0"
 agentkit-http = { version = "0.5.0", features = ["reqwest-middleware-client"] }
 agentkit-loop = "0.5.0"

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -9,17 +9,17 @@ name = "gram-assistant-runner"
 path = "src/main.rs"
 
 [dependencies]
-agentkit-adapter-completions = "0.5.0"
-agentkit-compaction = "0.5.0"
-agentkit-core = "0.5.0"
-agentkit-http = { version = "0.5.0", features = ["reqwest-middleware-client"] }
-agentkit-loop = "0.5.0"
-agentkit-mcp = "0.5.0"
-agentkit-provider-openrouter = "0.5.0"
-agentkit-reporting = { version = "0.5.0", features = ["tracing"] }
-agentkit-tool-fs = "0.5.0"
-agentkit-tools-core = { version = "0.5.0", features = ["schemars"] }
-agentkit-tools-derive = "0.5.0"
+agentkit-adapter-completions = "0.6.0"
+agentkit-compaction = "0.6.0"
+agentkit-core = "0.6.0"
+agentkit-http = { version = "0.6.0", features = ["reqwest-middleware-client"] }
+agentkit-loop = "0.6.0"
+agentkit-mcp = "0.6.0"
+agentkit-provider-openrouter = "0.6.0"
+agentkit-reporting = { version = "0.6.0", features = ["tracing"] }
+agentkit-tool-fs = "0.6.0"
+agentkit-tools-core = { version = "0.6.0", features = ["schemars"] }
+agentkit-tools-derive = "0.6.0"
 rmcp = { version = "1.5.0", default-features = false, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -3,9 +3,10 @@
 //! The model's context window is supplied at `/configure` time
 //! (`RunnerConfig::context_window`) — the gram backend resolves it via
 //! `openrouter.ContextWindowResolver` so the runner doesn't need to parse
-//! provider-specific metadata or make a fresh OpenRouter round-trip. A
-//! [`ContextWindowTrigger`] fires once `usage.input_tokens` (read from
-//! `AgentEvent::UsageUpdated`) crosses a configurable percentage of the window.
+//! provider-specific metadata or make a fresh OpenRouter round-trip.
+//! [`agentkit_compaction::context_window_trigger`] fires once the latest
+//! transcript item's reported `usage.input_tokens` crosses a configurable
+//! percentage of the window.
 //!
 //! Strategy pipeline: drop reasoning, drop failed tool results, summarise older
 //! items through a nested agent loop on the same model. System + context items
@@ -17,271 +18,63 @@
 //! transcript" turn, polluting the next replay.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use agentkit_adapter_completions::CompletionsAdapter;
 use agentkit_compaction::{
-    CompactionBackend, CompactionConfig, CompactionError, CompactionPipeline, CompactionReason,
-    CompactionTrigger, DropFailedToolResultsStrategy, DropReasoningStrategy,
-    SummarizeOlderStrategy, SummaryRequest, SummaryResult,
+    AgentCompactor, CompactionPipeline, DropFailedToolResultsStrategy, DropReasoningStrategy,
+    StrategyCompactor, SummarizeOlderStrategy, context_window_trigger,
 };
-use agentkit_core::{Item, ItemKind, MetadataMap, Part, SessionId, TurnCancellation, TurnId};
-use agentkit_loop::{
-    Agent, AgentEvent, LoopInterrupt, LoopObserver, LoopStep, ModelSession, SessionConfig,
-};
+use agentkit_core::{ItemKind, SessionId};
+use agentkit_loop::Agent;
 use agentkit_provider_openrouter::OpenRouterProvider;
-use agentkit_tools_core::{PermissionChecker, PermissionDecision, PermissionRequest};
-use async_trait::async_trait;
+use agentkit_tools_core::{CompositePermissionChecker, PermissionDecision};
+
+use crate::errors::RunnerError;
 
 const COMPACTION_SYSTEM_PROMPT: &str = "You are a compaction agent. Compress the transcript that follows into a durable context note for an assistant that has lost the original messages. Preserve every named person, every year and date, every place, every decision the assistant committed to, every tool the assistant invoked, and every actionable fact in the tool results. Drop chatter, narration, and chain-of-thought. Return only the compacted note as plain text.";
 
 const TRIGGER_PERCENTAGE: u32 = 80;
 const KEEP_RECENT: usize = 4;
 
-/// Fires compaction once the provider-reported `input_tokens` reaches a
-/// percentage of the configured context window. The window is static for a
-/// given runtime — the model never changes mid-session — so it lives here as
-/// a plain `u64` rather than an atomic.
-#[derive(Clone)]
-pub struct ContextWindowTrigger {
-    context_window: u64,
-    last_input_tokens: Arc<AtomicU64>,
-    percentage: u32,
-}
-
-impl ContextWindowTrigger {
-    pub fn new(context_window: u64, percentage: u32) -> Self {
-        Self {
-            context_window,
-            last_input_tokens: Arc::new(AtomicU64::new(0)),
-            percentage: percentage.clamp(1, 100),
-        }
-    }
-
-    pub fn input_tokens_handle(&self) -> Arc<AtomicU64> {
-        Arc::clone(&self.last_input_tokens)
-    }
-
-    fn threshold(&self) -> u64 {
-        self.context_window
-            .saturating_mul(self.percentage as u64)
-            / 100
-    }
-}
-
-impl CompactionTrigger for ContextWindowTrigger {
-    fn should_compact(
-        &self,
-        _session_id: &SessionId,
-        _turn_id: Option<&TurnId>,
-        _transcript: &[Item],
-    ) -> Option<CompactionReason> {
-        if self.context_window == 0 {
-            return None;
-        }
-        let last = self.last_input_tokens.load(Ordering::Acquire);
-        let threshold = self.threshold();
-        if last >= threshold {
-            Some(CompactionReason::Custom(format!(
-                "input_tokens={last} >= threshold={threshold} (window={}, {}%)",
-                self.context_window, self.percentage
-            )))
-        } else {
-            None
-        }
-    }
-}
-
-/// Mirrors [`AgentEvent::UsageUpdated`] into the trigger's `last_input_tokens`
-/// atomic; resets to zero on `CompactionFinished` so a subsequent
-/// `should_compact` call (defensive, in case the loop ever evaluates the
-/// trigger more than once per turn) doesn't fire on the pre-compaction count.
-#[derive(Clone)]
-pub struct InputTokenObserver {
-    last_input_tokens: Arc<AtomicU64>,
-}
-
-impl InputTokenObserver {
-    pub fn new(handle: Arc<AtomicU64>) -> Self {
-        Self {
-            last_input_tokens: handle,
-        }
-    }
-}
-
-impl LoopObserver for InputTokenObserver {
-    fn handle_event(&mut self, event: AgentEvent) {
-        match event {
-            AgentEvent::UsageUpdated(usage) => {
-                if let Some(tokens) = usage.tokens {
-                    self.last_input_tokens
-                        .store(tokens.input_tokens, Ordering::Release);
-                }
-            }
-            AgentEvent::CompactionFinished { .. } => {
-                self.last_input_tokens.store(0, Ordering::Release);
-            }
-            _ => {}
-        }
-    }
-}
-
-/// Runs a nested [`Agent`] loop on a sibling adapter to summarise older items.
-pub struct NestedLoopCompactionBackend {
-    adapter: CompletionsAdapter<OpenRouterProvider>,
-}
-
-impl NestedLoopCompactionBackend {
-    pub fn new(adapter: CompletionsAdapter<OpenRouterProvider>) -> Self {
-        Self { adapter }
-    }
-}
-
-struct AllowAll;
-
-impl PermissionChecker for AllowAll {
-    fn evaluate(&self, _request: &dyn PermissionRequest) -> PermissionDecision {
-        PermissionDecision::Allow
-    }
-}
-
-#[async_trait]
-impl CompactionBackend for NestedLoopCompactionBackend {
-    async fn summarize(
-        &self,
-        request: SummaryRequest,
-        cancellation: Option<TurnCancellation>,
-    ) -> Result<SummaryResult, CompactionError> {
-        if cancellation
-            .as_ref()
-            .is_some_and(TurnCancellation::is_cancelled)
-        {
-            return Err(CompactionError::Cancelled);
-        }
-
-        let rendered = render_items(&request.items);
-        let mut builder = Agent::builder()
-            .model(self.adapter.clone())
-            .permissions(AllowAll)
-            .transcript(vec![Item::text(ItemKind::System, COMPACTION_SYSTEM_PROMPT)])
-            .input(vec![Item::text(
-                ItemKind::User,
-                format!(
-                    "Compress the transcript below into a durable context note. Preserve names, places, dates, decisions, and tool outcomes.\n\n{rendered}"
-                ),
-            )]);
-        if let Some(c) = cancellation.as_ref() {
-            builder = builder.cancellation(c.handle().clone());
-        }
-        let agent = builder
-            .build()
-            .map_err(|e| CompactionError::Failed(e.to_string()))?;
-
-        let mut driver = agent
-            .start(SessionConfig::new(format!(
-                "{}-compactor",
-                request.session_id
-            )))
-            .await
-            .map_err(|e| CompactionError::Failed(e.to_string()))?;
-
-        let summary = run_to_completion(&mut driver)
-            .await
-            .map_err(CompactionError::Failed)?;
-
-        Ok(SummaryResult {
-            items: vec![Item::text(ItemKind::Context, summary)],
-            metadata: MetadataMap::new(),
-        })
-    }
-}
-
-async fn run_to_completion<S>(
-    driver: &mut agentkit_loop::LoopDriver<S>,
-) -> Result<String, String>
-where
-    S: ModelSession,
-{
-    loop {
-        let step = driver.next().await.map_err(|e| e.to_string())?;
-        match step {
-            LoopStep::Finished(result) => {
-                let mut sections = Vec::new();
-                for item in result.items {
-                    if item.kind != ItemKind::Assistant {
-                        continue;
-                    }
-                    for part in item.parts {
-                        if let Part::Text(t) = part {
-                            sections.push(t.text);
-                        }
-                    }
-                }
-                return Ok(sections.join("\n"));
-            }
-            LoopStep::Interrupt(LoopInterrupt::AfterToolResult(_)) => continue,
-            LoopStep::Interrupt(LoopInterrupt::AwaitingInput(_)) => {
-                return Err("compaction sub-agent unexpectedly awaiting input".into());
-            }
-            LoopStep::Interrupt(LoopInterrupt::ApprovalRequest(_)) => {
-                return Err("compaction sub-agent unexpectedly required approval".into());
-            }
-        }
-    }
-}
-
-fn render_items(items: &[Item]) -> String {
-    items
-        .iter()
-        .map(|item| {
-            let kind = match item.kind {
-                ItemKind::User => "USER",
-                ItemKind::Assistant => "ASSISTANT",
-                ItemKind::System => "SYSTEM",
-                ItemKind::Developer => "DEVELOPER",
-                ItemKind::Tool => "TOOL",
-                ItemKind::Context => "CONTEXT",
-                ItemKind::Notification => "NOTIFICATION",
-            };
-            let body = item
-                .parts
-                .iter()
-                .filter_map(|p| match p {
-                    Part::Text(t) => Some(t.text.clone()),
-                    Part::Structured(v) => Some(v.value.to_string()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-            format!("[{kind}]\n{body}")
-        })
-        .collect::<Vec<_>>()
-        .join("\n\n")
-}
-
-/// Builds the trigger + pipeline + backend, returning the [`CompactionConfig`]
-/// to attach to the agent and the [`InputTokenObserver`] that must be
-/// registered on the same agent so the trigger sees `input_tokens`. Returns
+/// Builds the [`StrategyCompactor`] to attach to the agent via
+/// [`agentkit_compaction::AgentBuilderCompactorExt::compactor`]. Returns
 /// `None` when the model's context window is unknown — without a budget the
 /// trigger has nothing to compare against.
-pub fn build_compaction(
+pub fn build_compactor(
+    chat_id: &str,
     context_window: u64,
     compactor_adapter: CompletionsAdapter<OpenRouterProvider>,
-) -> Option<(CompactionConfig, InputTokenObserver)> {
+) -> Result<Option<StrategyCompactor>, RunnerError> {
     if context_window == 0 {
-        return None;
+        return Ok(None);
     }
-    let trigger = ContextWindowTrigger::new(context_window, TRIGGER_PERCENTAGE);
-    let observer = InputTokenObserver::new(trigger.input_tokens_handle());
-    let pipeline = CompactionPipeline::new()
-        .with_strategy(DropReasoningStrategy::new())
-        .with_strategy(DropFailedToolResultsStrategy::new())
-        .with_strategy(
-            SummarizeOlderStrategy::new(KEEP_RECENT)
-                .preserve_kind(ItemKind::System)
-                .preserve_kind(ItemKind::Context),
-        );
-    let backend = NestedLoopCompactionBackend::new(compactor_adapter);
-    let config = CompactionConfig::new(trigger, pipeline).with_backend(backend);
-    Some((config, observer))
+    let backend_agent = Arc::new(
+        Agent::builder()
+            .model(compactor_adapter)
+            .permissions(CompositePermissionChecker::new(PermissionDecision::Allow))
+            .build()
+            .map_err(|e| RunnerError::AgentBuild(e.to_string()))?,
+    );
+    let backend = AgentCompactor::builder()
+        .agent(backend_agent)
+        .session_id(SessionId::from(format!("{chat_id}-compactor")))
+        .system_prompt(COMPACTION_SYSTEM_PROMPT)
+        .build()
+        .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
+    let compactor = StrategyCompactor::builder()
+        .trigger(context_window_trigger(context_window, TRIGGER_PERCENTAGE))
+        .strategy(
+            CompactionPipeline::new()
+                .with_strategy(DropReasoningStrategy::new())
+                .with_strategy(DropFailedToolResultsStrategy::new())
+                .with_strategy(
+                    SummarizeOlderStrategy::new(KEEP_RECENT)
+                        .preserve_kind(ItemKind::System)
+                        .preserve_kind(ItemKind::Context),
+                ),
+        )
+        .backend(backend)
+        .build()
+        .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
+    Ok(Some(compactor))
 }

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -1,0 +1,360 @@
+//! Token-aware compaction wiring for the assistant runtime.
+//!
+//! The runner reads `gram_metadata.context_window` from completion responses
+//! (decorated by the gram chat service when the URL carries
+//! `?includeContextWindow=1`) and a [`ContextWindowTrigger`] fires once the
+//! provider-reported `usage.input_tokens` crosses a configurable percentage of
+//! that window. The strategy pipeline drops reasoning + failed tool results
+//! and summarises older items through a nested agent loop on the same model.
+//!
+//! The compactor's adapter is built without the `Gram-Chat-ID` default header
+//! so its calls bypass the chat capture path — capture runs a divergence check
+//! per chat_id and would otherwise persist the compactor's "summarise the
+//! transcript" turn, polluting the next replay.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use agentkit_adapter_completions::{CompletionsAdapter, CompletionsProvider};
+use agentkit_compaction::{
+    CompactionBackend, CompactionConfig, CompactionError, CompactionPipeline, CompactionReason,
+    CompactionTrigger, DropFailedToolResultsStrategy, DropReasoningStrategy,
+    SummarizeOlderStrategy, SummaryRequest, SummaryResult,
+};
+use agentkit_core::{
+    Item, ItemKind, MetadataMap, Part, SessionId, TurnCancellation, TurnId, Usage,
+};
+use agentkit_http::{HttpRequestBuilder, StatusCode};
+use agentkit_loop::{
+    Agent, AgentEvent, LoopError, LoopInterrupt, LoopObserver, LoopStep, ModelSession,
+    SessionConfig, TurnRequest,
+};
+use agentkit_provider_openrouter::OpenRouterProvider;
+use agentkit_tools_core::{PermissionChecker, PermissionDecision, PermissionRequest};
+use async_trait::async_trait;
+use serde_json::{Map, Value};
+
+const COMPACTION_SYSTEM_PROMPT: &str = "You are a compaction agent. Compress the transcript that follows into a durable context note for an assistant that has lost the original messages. Preserve every named person, every year and date, every place, every decision the assistant committed to, every tool the assistant invoked, and every actionable fact in the tool results. Drop chatter, narration, and chain-of-thought. Return only the compacted note as plain text.";
+
+const DEFAULT_PERCENTAGE: u32 = 80;
+const KEEP_RECENT: usize = 4;
+
+/// Wraps [`OpenRouterProvider`] and folds `gram_metadata.context_window` from
+/// the raw response into a shared [`AtomicU64`]. The trigger reads the same
+/// atomic, so the budget tracks whatever the most recent response advertised
+/// (the value is stable per model but cheap to keep refreshing).
+#[derive(Clone)]
+pub struct GramCompletionsProvider {
+    inner: OpenRouterProvider,
+    context_window: Arc<AtomicU64>,
+}
+
+impl GramCompletionsProvider {
+    pub fn new(inner: OpenRouterProvider) -> Self {
+        Self {
+            inner,
+            context_window: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn context_window_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.context_window)
+    }
+}
+
+impl CompletionsProvider for GramCompletionsProvider {
+    type Config = <OpenRouterProvider as CompletionsProvider>::Config;
+
+    fn provider_name(&self) -> &str {
+        self.inner.provider_name()
+    }
+
+    fn endpoint_url(&self) -> &str {
+        self.inner.endpoint_url()
+    }
+
+    fn config(&self) -> &Self::Config {
+        self.inner.config()
+    }
+
+    fn preprocess_request(&self, builder: HttpRequestBuilder) -> HttpRequestBuilder {
+        self.inner.preprocess_request(builder)
+    }
+
+    fn apply_prompt_cache(
+        &self,
+        body: &mut Map<String, Value>,
+        request: &TurnRequest,
+    ) -> Result<(), LoopError> {
+        self.inner.apply_prompt_cache(body, request)
+    }
+
+    fn requires_alternating_roles(&self) -> bool {
+        self.inner.requires_alternating_roles()
+    }
+
+    fn preprocess_response(&self, status: StatusCode, body: &str) -> Result<(), LoopError> {
+        self.inner.preprocess_response(status, body)
+    }
+
+    fn postprocess_response(
+        &self,
+        usage: &mut Option<Usage>,
+        metadata: &mut MetadataMap,
+        raw: &Value,
+    ) {
+        self.inner.postprocess_response(usage, metadata, raw);
+        if let Some(cw) = raw
+            .pointer("/gram_metadata/context_window")
+            .and_then(Value::as_u64)
+            && cw > 0
+        {
+            self.context_window.store(cw, Ordering::Release);
+        }
+    }
+}
+
+/// Fires compaction once the provider-reported `input_tokens` reaches a
+/// percentage of the model's context window. The window itself is read from
+/// the same atomic that [`GramCompletionsProvider::postprocess_response`]
+/// writes to; until the first response arrives the trigger is dormant.
+#[derive(Clone)]
+pub struct ContextWindowTrigger {
+    context_window: Arc<AtomicU64>,
+    last_input_tokens: Arc<AtomicU64>,
+    percentage: u32,
+}
+
+impl ContextWindowTrigger {
+    pub fn new(context_window: Arc<AtomicU64>, percentage: u32) -> Self {
+        Self {
+            context_window,
+            last_input_tokens: Arc::new(AtomicU64::new(0)),
+            percentage: percentage.clamp(1, 100),
+        }
+    }
+
+    pub fn input_tokens_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.last_input_tokens)
+    }
+
+    fn threshold(&self) -> u64 {
+        let win = self.context_window.load(Ordering::Acquire);
+        win.saturating_mul(self.percentage as u64) / 100
+    }
+}
+
+impl CompactionTrigger for ContextWindowTrigger {
+    fn should_compact(
+        &self,
+        _session_id: &SessionId,
+        _turn_id: Option<&TurnId>,
+        _transcript: &[Item],
+    ) -> Option<CompactionReason> {
+        let win = self.context_window.load(Ordering::Acquire);
+        if win == 0 {
+            return None;
+        }
+        let last = self.last_input_tokens.load(Ordering::Acquire);
+        let threshold = self.threshold();
+        if last >= threshold {
+            Some(CompactionReason::Custom(format!(
+                "input_tokens={last} >= threshold={threshold} (window={win}, {}%)",
+                self.percentage
+            )))
+        } else {
+            None
+        }
+    }
+}
+
+/// Mirrors [`AgentEvent::UsageUpdated`] into the trigger's `last_input_tokens`
+/// atomic so [`ContextWindowTrigger::should_compact`] sees the freshest count.
+#[derive(Clone)]
+pub struct InputTokenObserver {
+    last_input_tokens: Arc<AtomicU64>,
+}
+
+impl InputTokenObserver {
+    pub fn new(handle: Arc<AtomicU64>) -> Self {
+        Self {
+            last_input_tokens: handle,
+        }
+    }
+}
+
+impl LoopObserver for InputTokenObserver {
+    fn handle_event(&mut self, event: AgentEvent) {
+        if let AgentEvent::UsageUpdated(usage) = event
+            && let Some(tokens) = usage.tokens
+        {
+            self.last_input_tokens
+                .store(tokens.input_tokens, Ordering::Release);
+        }
+    }
+}
+
+/// Runs a nested [`Agent`] loop on a sibling adapter to summarise older items.
+///
+/// The adapter must be built without the `Gram-Chat-ID` default header so the
+/// compactor's request bypasses chat capture.
+pub struct NestedLoopCompactionBackend {
+    adapter: CompletionsAdapter<GramCompletionsProvider>,
+}
+
+impl NestedLoopCompactionBackend {
+    pub fn new(adapter: CompletionsAdapter<GramCompletionsProvider>) -> Self {
+        Self { adapter }
+    }
+}
+
+struct AllowAll;
+
+impl PermissionChecker for AllowAll {
+    fn evaluate(&self, _request: &dyn PermissionRequest) -> PermissionDecision {
+        PermissionDecision::Allow
+    }
+}
+
+#[async_trait]
+impl CompactionBackend for NestedLoopCompactionBackend {
+    async fn summarize(
+        &self,
+        request: SummaryRequest,
+        cancellation: Option<TurnCancellation>,
+    ) -> Result<SummaryResult, CompactionError> {
+        if cancellation
+            .as_ref()
+            .is_some_and(TurnCancellation::is_cancelled)
+        {
+            return Err(CompactionError::Cancelled);
+        }
+
+        let rendered = render_items(&request.items);
+        let mut builder = Agent::builder()
+            .model(self.adapter.clone())
+            .permissions(AllowAll)
+            .transcript(vec![Item::text(ItemKind::System, COMPACTION_SYSTEM_PROMPT)])
+            .input(vec![Item::text(
+                ItemKind::User,
+                format!(
+                    "Compress the transcript below into a durable context note. Preserve names, places, dates, decisions, and tool outcomes.\n\n{rendered}"
+                ),
+            )]);
+        if let Some(c) = cancellation.as_ref() {
+            builder = builder.cancellation(c.handle().clone());
+        }
+        let agent = builder
+            .build()
+            .map_err(|e| CompactionError::Failed(e.to_string()))?;
+
+        let mut driver = agent
+            .start(SessionConfig::new(format!(
+                "{}-compactor",
+                request.session_id
+            )))
+            .await
+            .map_err(|e| CompactionError::Failed(e.to_string()))?;
+
+        let summary = run_to_completion(&mut driver)
+            .await
+            .map_err(CompactionError::Failed)?;
+
+        Ok(SummaryResult {
+            items: vec![Item::text(ItemKind::Context, summary)],
+            metadata: MetadataMap::new(),
+        })
+    }
+}
+
+async fn run_to_completion<S>(driver: &mut agentkit_loop::LoopDriver<S>) -> Result<String, String>
+where
+    S: ModelSession,
+{
+    loop {
+        let step = driver.next().await.map_err(|e| e.to_string())?;
+        match step {
+            LoopStep::Finished(result) => {
+                let mut sections = Vec::new();
+                for item in result.items {
+                    if item.kind != ItemKind::Assistant {
+                        continue;
+                    }
+                    for part in item.parts {
+                        if let Part::Text(t) = part {
+                            sections.push(t.text);
+                        }
+                    }
+                }
+                return Ok(sections.join("\n"));
+            }
+            LoopStep::Interrupt(LoopInterrupt::AfterToolResult(_)) => continue,
+            LoopStep::Interrupt(LoopInterrupt::AwaitingInput(_)) => {
+                return Err("compaction sub-agent unexpectedly awaiting input".into());
+            }
+            LoopStep::Interrupt(LoopInterrupt::ApprovalRequest(_)) => {
+                return Err("compaction sub-agent unexpectedly required approval".into());
+            }
+        }
+    }
+}
+
+fn render_items(items: &[Item]) -> String {
+    items
+        .iter()
+        .map(|item| {
+            let kind = match item.kind {
+                ItemKind::User => "USER",
+                ItemKind::Assistant => "ASSISTANT",
+                ItemKind::System => "SYSTEM",
+                ItemKind::Developer => "DEVELOPER",
+                ItemKind::Tool => "TOOL",
+                ItemKind::Context => "CONTEXT",
+                ItemKind::Notification => "NOTIFICATION",
+            };
+            let body = item
+                .parts
+                .iter()
+                .filter_map(|p| match p {
+                    Part::Text(t) => Some(t.text.clone()),
+                    Part::Structured(v) => Some(v.value.to_string()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("[{kind}]\n{body}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Builds the trigger + pipeline + backend, returning the [`CompactionConfig`]
+/// to attach to the agent and the [`InputTokenObserver`] that must be
+/// registered on the same agent so the trigger sees `input_tokens`.
+pub fn build_compaction(
+    main_provider: &GramCompletionsProvider,
+    compactor_adapter: CompletionsAdapter<GramCompletionsProvider>,
+    percentage: u32,
+) -> (CompactionConfig, InputTokenObserver) {
+    let trigger = ContextWindowTrigger::new(main_provider.context_window_handle(), percentage);
+    let observer = InputTokenObserver::new(trigger.input_tokens_handle());
+    let pipeline = CompactionPipeline::new()
+        .with_strategy(DropReasoningStrategy::new())
+        .with_strategy(DropFailedToolResultsStrategy::new())
+        .with_strategy(
+            SummarizeOlderStrategy::new(KEEP_RECENT)
+                .preserve_kind(ItemKind::System)
+                .preserve_kind(ItemKind::Context),
+        );
+    let backend = NestedLoopCompactionBackend::new(compactor_adapter);
+    let config = CompactionConfig::new(trigger, pipeline).with_backend(backend);
+    (config, observer)
+}
+
+pub fn percentage_from_env() -> u32 {
+    std::env::var("ASSISTANT_CONTEXT_PERCENTAGE")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .map(|v| v.clamp(1, 100))
+        .unwrap_or(DEFAULT_PERCENTAGE)
+}

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -35,7 +35,7 @@ use async_trait::async_trait;
 
 const COMPACTION_SYSTEM_PROMPT: &str = "You are a compaction agent. Compress the transcript that follows into a durable context note for an assistant that has lost the original messages. Preserve every named person, every year and date, every place, every decision the assistant committed to, every tool the assistant invoked, and every actionable fact in the tool results. Drop chatter, narration, and chain-of-thought. Return only the compacted note as plain text.";
 
-const DEFAULT_PERCENTAGE: u32 = 80;
+const TRIGGER_PERCENTAGE: u32 = 80;
 const KEEP_RECENT: usize = 4;
 
 /// Fires compaction once the provider-reported `input_tokens` reaches a
@@ -267,12 +267,11 @@ fn render_items(items: &[Item]) -> String {
 pub fn build_compaction(
     context_window: u64,
     compactor_adapter: CompletionsAdapter<OpenRouterProvider>,
-    percentage: u32,
 ) -> Option<(CompactionConfig, InputTokenObserver)> {
     if context_window == 0 {
         return None;
     }
-    let trigger = ContextWindowTrigger::new(context_window, percentage);
+    let trigger = ContextWindowTrigger::new(context_window, TRIGGER_PERCENTAGE);
     let observer = InputTokenObserver::new(trigger.input_tokens_handle());
     let pipeline = CompactionPipeline::new()
         .with_strategy(DropReasoningStrategy::new())
@@ -285,12 +284,4 @@ pub fn build_compaction(
     let backend = NestedLoopCompactionBackend::new(compactor_adapter);
     let config = CompactionConfig::new(trigger, pipeline).with_backend(backend);
     Some((config, observer))
-}
-
-pub fn percentage_from_env() -> u32 {
-    std::env::var("ASSISTANT_CONTEXT_PERCENTAGE")
-        .ok()
-        .and_then(|s| s.parse::<u32>().ok())
-        .map(|v| v.clamp(1, 100))
-        .unwrap_or(DEFAULT_PERCENTAGE)
 }

--- a/agents/runner/src/compaction.rs
+++ b/agents/runner/src/compaction.rs
@@ -1,132 +1,56 @@
 //! Token-aware compaction wiring for the assistant runtime.
 //!
-//! The runner reads `gram_metadata.context_window` from completion responses
-//! (decorated by the gram chat service when the URL carries
-//! `?includeContextWindow=1`) and a [`ContextWindowTrigger`] fires once the
-//! provider-reported `usage.input_tokens` crosses a configurable percentage of
-//! that window. The strategy pipeline drops reasoning + failed tool results
-//! and summarises older items through a nested agent loop on the same model.
+//! The model's context window is supplied at `/configure` time
+//! (`RunnerConfig::context_window`) — the gram backend resolves it via
+//! `openrouter.ContextWindowResolver` so the runner doesn't need to parse
+//! provider-specific metadata or make a fresh OpenRouter round-trip. A
+//! [`ContextWindowTrigger`] fires once `usage.input_tokens` (read from
+//! `AgentEvent::UsageUpdated`) crosses a configurable percentage of the window.
+//!
+//! Strategy pipeline: drop reasoning, drop failed tool results, summarise older
+//! items through a nested agent loop on the same model. System + context items
+//! and the most recent few turns are preserved.
 //!
 //! The compactor's adapter is built without the `Gram-Chat-ID` default header
-//! so its calls bypass the chat capture path — capture runs a divergence check
-//! per chat_id and would otherwise persist the compactor's "summarise the
+//! so its calls bypass chat capture — capture runs a divergence check per
+//! chat_id and would otherwise persist the compactor's "summarise this
 //! transcript" turn, polluting the next replay.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use agentkit_adapter_completions::{CompletionsAdapter, CompletionsProvider};
+use agentkit_adapter_completions::CompletionsAdapter;
 use agentkit_compaction::{
     CompactionBackend, CompactionConfig, CompactionError, CompactionPipeline, CompactionReason,
     CompactionTrigger, DropFailedToolResultsStrategy, DropReasoningStrategy,
     SummarizeOlderStrategy, SummaryRequest, SummaryResult,
 };
-use agentkit_core::{
-    Item, ItemKind, MetadataMap, Part, SessionId, TurnCancellation, TurnId, Usage,
-};
-use agentkit_http::{HttpRequestBuilder, StatusCode};
+use agentkit_core::{Item, ItemKind, MetadataMap, Part, SessionId, TurnCancellation, TurnId};
 use agentkit_loop::{
-    Agent, AgentEvent, LoopError, LoopInterrupt, LoopObserver, LoopStep, ModelSession,
-    SessionConfig, TurnRequest,
+    Agent, AgentEvent, LoopInterrupt, LoopObserver, LoopStep, ModelSession, SessionConfig,
 };
 use agentkit_provider_openrouter::OpenRouterProvider;
 use agentkit_tools_core::{PermissionChecker, PermissionDecision, PermissionRequest};
 use async_trait::async_trait;
-use serde_json::{Map, Value};
 
 const COMPACTION_SYSTEM_PROMPT: &str = "You are a compaction agent. Compress the transcript that follows into a durable context note for an assistant that has lost the original messages. Preserve every named person, every year and date, every place, every decision the assistant committed to, every tool the assistant invoked, and every actionable fact in the tool results. Drop chatter, narration, and chain-of-thought. Return only the compacted note as plain text.";
 
 const DEFAULT_PERCENTAGE: u32 = 80;
 const KEEP_RECENT: usize = 4;
 
-/// Wraps [`OpenRouterProvider`] and folds `gram_metadata.context_window` from
-/// the raw response into a shared [`AtomicU64`]. The trigger reads the same
-/// atomic, so the budget tracks whatever the most recent response advertised
-/// (the value is stable per model but cheap to keep refreshing).
-#[derive(Clone)]
-pub struct GramCompletionsProvider {
-    inner: OpenRouterProvider,
-    context_window: Arc<AtomicU64>,
-}
-
-impl GramCompletionsProvider {
-    pub fn new(inner: OpenRouterProvider) -> Self {
-        Self {
-            inner,
-            context_window: Arc::new(AtomicU64::new(0)),
-        }
-    }
-
-    pub fn context_window_handle(&self) -> Arc<AtomicU64> {
-        Arc::clone(&self.context_window)
-    }
-}
-
-impl CompletionsProvider for GramCompletionsProvider {
-    type Config = <OpenRouterProvider as CompletionsProvider>::Config;
-
-    fn provider_name(&self) -> &str {
-        self.inner.provider_name()
-    }
-
-    fn endpoint_url(&self) -> &str {
-        self.inner.endpoint_url()
-    }
-
-    fn config(&self) -> &Self::Config {
-        self.inner.config()
-    }
-
-    fn preprocess_request(&self, builder: HttpRequestBuilder) -> HttpRequestBuilder {
-        self.inner.preprocess_request(builder)
-    }
-
-    fn apply_prompt_cache(
-        &self,
-        body: &mut Map<String, Value>,
-        request: &TurnRequest,
-    ) -> Result<(), LoopError> {
-        self.inner.apply_prompt_cache(body, request)
-    }
-
-    fn requires_alternating_roles(&self) -> bool {
-        self.inner.requires_alternating_roles()
-    }
-
-    fn preprocess_response(&self, status: StatusCode, body: &str) -> Result<(), LoopError> {
-        self.inner.preprocess_response(status, body)
-    }
-
-    fn postprocess_response(
-        &self,
-        usage: &mut Option<Usage>,
-        metadata: &mut MetadataMap,
-        raw: &Value,
-    ) {
-        self.inner.postprocess_response(usage, metadata, raw);
-        if let Some(cw) = raw
-            .pointer("/gram_metadata/context_window")
-            .and_then(Value::as_u64)
-            && cw > 0
-        {
-            self.context_window.store(cw, Ordering::Release);
-        }
-    }
-}
-
 /// Fires compaction once the provider-reported `input_tokens` reaches a
-/// percentage of the model's context window. The window itself is read from
-/// the same atomic that [`GramCompletionsProvider::postprocess_response`]
-/// writes to; until the first response arrives the trigger is dormant.
+/// percentage of the configured context window. The window is static for a
+/// given runtime — the model never changes mid-session — so it lives here as
+/// a plain `u64` rather than an atomic.
 #[derive(Clone)]
 pub struct ContextWindowTrigger {
-    context_window: Arc<AtomicU64>,
+    context_window: u64,
     last_input_tokens: Arc<AtomicU64>,
     percentage: u32,
 }
 
 impl ContextWindowTrigger {
-    pub fn new(context_window: Arc<AtomicU64>, percentage: u32) -> Self {
+    pub fn new(context_window: u64, percentage: u32) -> Self {
         Self {
             context_window,
             last_input_tokens: Arc::new(AtomicU64::new(0)),
@@ -139,8 +63,9 @@ impl ContextWindowTrigger {
     }
 
     fn threshold(&self) -> u64 {
-        let win = self.context_window.load(Ordering::Acquire);
-        win.saturating_mul(self.percentage as u64) / 100
+        self.context_window
+            .saturating_mul(self.percentage as u64)
+            / 100
     }
 }
 
@@ -151,16 +76,15 @@ impl CompactionTrigger for ContextWindowTrigger {
         _turn_id: Option<&TurnId>,
         _transcript: &[Item],
     ) -> Option<CompactionReason> {
-        let win = self.context_window.load(Ordering::Acquire);
-        if win == 0 {
+        if self.context_window == 0 {
             return None;
         }
         let last = self.last_input_tokens.load(Ordering::Acquire);
         let threshold = self.threshold();
         if last >= threshold {
             Some(CompactionReason::Custom(format!(
-                "input_tokens={last} >= threshold={threshold} (window={win}, {}%)",
-                self.percentage
+                "input_tokens={last} >= threshold={threshold} (window={}, {}%)",
+                self.context_window, self.percentage
             )))
         } else {
             None
@@ -169,7 +93,9 @@ impl CompactionTrigger for ContextWindowTrigger {
 }
 
 /// Mirrors [`AgentEvent::UsageUpdated`] into the trigger's `last_input_tokens`
-/// atomic so [`ContextWindowTrigger::should_compact`] sees the freshest count.
+/// atomic; resets to zero on `CompactionFinished` so a subsequent
+/// `should_compact` call (defensive, in case the loop ever evaluates the
+/// trigger more than once per turn) doesn't fire on the pre-compaction count.
 #[derive(Clone)]
 pub struct InputTokenObserver {
     last_input_tokens: Arc<AtomicU64>,
@@ -185,25 +111,28 @@ impl InputTokenObserver {
 
 impl LoopObserver for InputTokenObserver {
     fn handle_event(&mut self, event: AgentEvent) {
-        if let AgentEvent::UsageUpdated(usage) = event
-            && let Some(tokens) = usage.tokens
-        {
-            self.last_input_tokens
-                .store(tokens.input_tokens, Ordering::Release);
+        match event {
+            AgentEvent::UsageUpdated(usage) => {
+                if let Some(tokens) = usage.tokens {
+                    self.last_input_tokens
+                        .store(tokens.input_tokens, Ordering::Release);
+                }
+            }
+            AgentEvent::CompactionFinished { .. } => {
+                self.last_input_tokens.store(0, Ordering::Release);
+            }
+            _ => {}
         }
     }
 }
 
 /// Runs a nested [`Agent`] loop on a sibling adapter to summarise older items.
-///
-/// The adapter must be built without the `Gram-Chat-ID` default header so the
-/// compactor's request bypasses chat capture.
 pub struct NestedLoopCompactionBackend {
-    adapter: CompletionsAdapter<GramCompletionsProvider>,
+    adapter: CompletionsAdapter<OpenRouterProvider>,
 }
 
 impl NestedLoopCompactionBackend {
-    pub fn new(adapter: CompletionsAdapter<GramCompletionsProvider>) -> Self {
+    pub fn new(adapter: CompletionsAdapter<OpenRouterProvider>) -> Self {
         Self { adapter }
     }
 }
@@ -267,7 +196,9 @@ impl CompactionBackend for NestedLoopCompactionBackend {
     }
 }
 
-async fn run_to_completion<S>(driver: &mut agentkit_loop::LoopDriver<S>) -> Result<String, String>
+async fn run_to_completion<S>(
+    driver: &mut agentkit_loop::LoopDriver<S>,
+) -> Result<String, String>
 where
     S: ModelSession,
 {
@@ -330,13 +261,18 @@ fn render_items(items: &[Item]) -> String {
 
 /// Builds the trigger + pipeline + backend, returning the [`CompactionConfig`]
 /// to attach to the agent and the [`InputTokenObserver`] that must be
-/// registered on the same agent so the trigger sees `input_tokens`.
+/// registered on the same agent so the trigger sees `input_tokens`. Returns
+/// `None` when the model's context window is unknown — without a budget the
+/// trigger has nothing to compare against.
 pub fn build_compaction(
-    main_provider: &GramCompletionsProvider,
-    compactor_adapter: CompletionsAdapter<GramCompletionsProvider>,
+    context_window: u64,
+    compactor_adapter: CompletionsAdapter<OpenRouterProvider>,
     percentage: u32,
-) -> (CompactionConfig, InputTokenObserver) {
-    let trigger = ContextWindowTrigger::new(main_provider.context_window_handle(), percentage);
+) -> Option<(CompactionConfig, InputTokenObserver)> {
+    if context_window == 0 {
+        return None;
+    }
+    let trigger = ContextWindowTrigger::new(context_window, percentage);
     let observer = InputTokenObserver::new(trigger.input_tokens_handle());
     let pipeline = CompactionPipeline::new()
         .with_strategy(DropReasoningStrategy::new())
@@ -348,7 +284,7 @@ pub fn build_compaction(
         );
     let backend = NestedLoopCompactionBackend::new(compactor_adapter);
     let config = CompactionConfig::new(trigger, pipeline).with_backend(backend);
-    (config, observer)
+    Some((config, observer))
 }
 
 pub fn percentage_from_env() -> u32 {

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -1,3 +1,4 @@
+mod compaction;
 mod errors;
 mod http_layer;
 mod idempotency;

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -21,7 +21,7 @@ use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
 
-use crate::compaction::{build_compaction, percentage_from_env};
+use crate::compaction::build_compaction;
 use crate::errors::RunnerError;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_http};
 use crate::idempotency::IdempotencyCache;
@@ -195,11 +195,7 @@ pub async fn build_runtime(
     let compactor_http = build_http(compactor_http_client, tokens.clone());
     let compactor_adapter = CompletionsAdapter::with_client(provider, compactor_http);
 
-    let compaction = build_compaction(
-        config.context_window.unwrap_or(0),
-        compactor_adapter,
-        percentage_from_env(),
-    );
+    let compaction = build_compaction(config.context_window.unwrap_or(0), compactor_adapter);
 
     let mut transcript = Vec::new();
     if let Some(instructions) = &config.instructions {

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -21,7 +21,7 @@ use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
 
-use crate::compaction::{GramCompletionsProvider, build_compaction, percentage_from_env};
+use crate::compaction::{build_compaction, percentage_from_env};
 use crate::errors::RunnerError;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_http};
 use crate::idempotency::IdempotencyCache;
@@ -179,7 +179,7 @@ pub async fn build_runtime(
         })?;
     let openrouter_config =
         OpenRouterConfig::new(String::new(), config.model.clone()).with_base_url(base_url);
-    let provider = GramCompletionsProvider::new(OpenRouterProvider::from(openrouter_config));
+    let provider = OpenRouterProvider::from(openrouter_config);
 
     let completions_http = build_http(http_client.clone(), tokens.clone());
     let adapter = CompletionsAdapter::with_client(provider.clone(), completions_http);
@@ -193,10 +193,13 @@ pub async fn build_runtime(
         .user_agent(concat!("gram-assistant-runner/", env!("CARGO_PKG_VERSION")))
         .build()?;
     let compactor_http = build_http(compactor_http_client, tokens.clone());
-    let compactor_adapter = CompletionsAdapter::with_client(provider.clone(), compactor_http);
+    let compactor_adapter = CompletionsAdapter::with_client(provider, compactor_http);
 
-    let (compaction_config, input_token_observer) =
-        build_compaction(&provider, compactor_adapter, percentage_from_env());
+    let compaction = build_compaction(
+        config.context_window.unwrap_or(0),
+        compactor_adapter,
+        percentage_from_env(),
+    );
 
     let mut transcript = Vec::new();
     if let Some(instructions) = &config.instructions {
@@ -204,18 +207,23 @@ pub async fn build_runtime(
     }
     transcript.extend(normalize_history(&config.history)?);
 
-    let agent = Agent::builder()
+    let mut builder = Agent::builder()
         .model(adapter)
         .add_tool_source(native_tools)
         .add_tool_source(agentkit_tool_fs::registry())
         .add_tool_source(mcp_source)
         .permissions(permissions)
         .resources(fs_resources)
-        .compaction(compaction_config)
-        .observer(input_token_observer)
         .observer(TracingReporter::new())
-        .transcript(transcript)
-        .build()
+        .transcript(transcript);
+
+    if let Some((compaction_config, input_token_observer)) = compaction {
+        builder = builder
+            .compaction(compaction_config)
+            .observer(input_token_observer);
+    }
+
+    let agent = builder.build()
         .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
 
     let session = SessionConfig::new(config.chat_id.clone())

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -138,6 +138,10 @@ pub async fn build_runtime(
         http::HeaderValue::from_str(&config.chat_id)
             .map_err(|source| RunnerError::HeaderValue { source })?,
     );
+    default_headers.insert(
+        http::HeaderName::from_static("x-gram-source"),
+        http::HeaderValue::from_static("assistant"),
+    );
 
     let http_client = reqwest::Client::builder()
         .user_agent(concat!("gram-assistant-runner/", env!("CARGO_PKG_VERSION")))
@@ -191,8 +195,14 @@ pub async fn build_runtime(
     // treats the compactor's "summarise this transcript" turn as a divergence
     // and the next replay loads the compactor's transcript instead of the
     // user's.
+    let mut compactor_headers = http::HeaderMap::new();
+    compactor_headers.insert(
+        http::HeaderName::from_static("x-gram-source"),
+        http::HeaderValue::from_static("assistant"),
+    );
     let compactor_http_client = reqwest::Client::builder()
         .user_agent(concat!("gram-assistant-runner/", env!("CARGO_PKG_VERSION")))
+        .default_headers(compactor_headers)
         .build()?;
     let compactor_http = build_http(compactor_http_client, tokens.clone());
     let compactor_adapter = CompletionsAdapter::with_client(provider, compactor_http);

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -21,6 +21,7 @@ use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
 
+use crate::compaction::{GramCompletionsProvider, build_compaction, percentage_from_env};
 use crate::errors::RunnerError;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_http};
 use crate::idempotency::IdempotencyCache;
@@ -178,9 +179,24 @@ pub async fn build_runtime(
         })?;
     let openrouter_config =
         OpenRouterConfig::new(String::new(), config.model.clone()).with_base_url(base_url);
-    let provider = OpenRouterProvider::from(openrouter_config);
+    let provider = GramCompletionsProvider::new(OpenRouterProvider::from(openrouter_config));
+
     let completions_http = build_http(http_client.clone(), tokens.clone());
-    let adapter = CompletionsAdapter::with_client(provider, completions_http);
+    let adapter = CompletionsAdapter::with_client(provider.clone(), completions_http);
+
+    // Compactor calls reuse the model and bearer rotation but must omit the
+    // Gram-Chat-ID header so they bypass chat-message capture; otherwise gram
+    // treats the compactor's "summarise this transcript" turn as a divergence
+    // and the next replay loads the compactor's transcript instead of the
+    // user's.
+    let compactor_http_client = reqwest::Client::builder()
+        .user_agent(concat!("gram-assistant-runner/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+    let compactor_http = build_http(compactor_http_client, tokens.clone());
+    let compactor_adapter = CompletionsAdapter::with_client(provider.clone(), compactor_http);
+
+    let (compaction_config, input_token_observer) =
+        build_compaction(&provider, compactor_adapter, percentage_from_env());
 
     let mut transcript = Vec::new();
     if let Some(instructions) = &config.instructions {
@@ -195,6 +211,8 @@ pub async fn build_runtime(
         .add_tool_source(mcp_source)
         .permissions(permissions)
         .resources(fs_resources)
+        .compaction(compaction_config)
+        .observer(input_token_observer)
         .observer(TracingReporter::new())
         .transcript(transcript)
         .build()

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -21,7 +21,9 @@ use serde_json::Value;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
 
-use crate::compaction::build_compaction;
+use agentkit_compaction::AgentBuilderCompactorExt;
+
+use crate::compaction::build_compactor;
 use crate::errors::RunnerError;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_http};
 use crate::idempotency::IdempotencyCache;
@@ -195,7 +197,11 @@ pub async fn build_runtime(
     let compactor_http = build_http(compactor_http_client, tokens.clone());
     let compactor_adapter = CompletionsAdapter::with_client(provider, compactor_http);
 
-    let compaction = build_compaction(config.context_window.unwrap_or(0), compactor_adapter);
+    let compactor = build_compactor(
+        &config.chat_id,
+        config.context_window.unwrap_or(0),
+        compactor_adapter,
+    )?;
 
     let mut transcript = Vec::new();
     if let Some(instructions) = &config.instructions {
@@ -213,13 +219,12 @@ pub async fn build_runtime(
         .observer(TracingReporter::new())
         .transcript(transcript);
 
-    if let Some((compaction_config, input_token_observer)) = compaction {
-        builder = builder
-            .compaction(compaction_config)
-            .observer(input_token_observer);
+    if let Some(compactor) = compactor {
+        builder = builder.compactor(compactor);
     }
 
-    let agent = builder.build()
+    let agent = builder
+        .build()
         .map_err(|e| RunnerError::AgentBuild(e.to_string()))?;
 
     let session = SessionConfig::new(config.chat_id.clone())

--- a/agents/runner/src/wire.rs
+++ b/agents/runner/src/wire.rs
@@ -16,6 +16,11 @@ pub struct RunnerConfig {
     /// comes up already hydrated; /turn carries only new user input after that.
     #[serde(default)]
     pub history: Vec<RunnerMessage>,
+    /// Smallest `context_length` the gram backend resolved for `model`.
+    /// Sized in tokens; `None` disables the token-aware compaction trigger
+    /// (the loop falls back to never compacting on input-token budget).
+    #[serde(default)]
+    pub context_window: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Hash)]

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -768,7 +768,7 @@ func newStartCommand() *cli.Command {
 			)
 			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
 			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo)
-			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger)
+			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsSvc := assistants.NewService(logger, tracerProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv})
 			triggerApp.RegisterDispatcher(assistantsSvc)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -614,7 +614,8 @@ func newWorkerCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemetryLogger)
+			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
+			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemetryLogger, contextWindowResolver)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsSvc := assistants.NewService(logger, tracerProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv})
 			triggerApp.RegisterDispatcher(assistantsSvc)

--- a/server/internal/assistants/impl_test.go
+++ b/server/internal/assistants/impl_test.go
@@ -146,7 +146,7 @@ func newRBACService(t *testing.T) (*Service, context.Context, uuid.UUID) {
 		logger:   logger,
 		auth:     nil,
 		authz:    authzEngine,
-		core:     NewServiceCore(logger, testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendLocal, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger)),
+		core:     NewServiceCore(logger, testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendLocal, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(logger), nil),
 		signaler: nil,
 	}
 

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -73,6 +73,10 @@ type runtimeStartupConfig struct {
 	ChatID         string             `json:"chat_id"`
 	MCPServers     []runtimeMCPServer `json:"mcp_servers"`
 	History        []runtimeMessage   `json:"history,omitempty"`
+	// ContextWindow is the smallest context_length the gram backend resolved
+	// for Model. The runner uses it to threshold input-token-aware compaction.
+	// Zero means "unknown" — the runner skips compaction rather than guessing.
+	ContextWindow uint64 `json:"context_window,omitempty"`
 }
 
 type runtimeMCPServer struct {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -280,6 +280,7 @@ type ServiceCore struct {
 	assistantTokens *assistanttokens.Manager
 	serverURL       *url.URL
 	telemetryLogger *telemetry.Logger
+	contextWindow   *openrouter.ContextWindowResolver
 	wakeCanceller   WakeCanceller
 }
 
@@ -292,6 +293,7 @@ func NewServiceCore(
 	assistantTokens *assistanttokens.Manager,
 	serverURL *url.URL,
 	telemetryLogger *telemetry.Logger,
+	contextWindow *openrouter.ContextWindowResolver,
 ) *ServiceCore {
 	return &ServiceCore{
 		logger:          logger,
@@ -302,6 +304,7 @@ func NewServiceCore(
 		assistantTokens: assistantTokens,
 		serverURL:       serverURL,
 		telemetryLogger: telemetryLogger,
+		contextWindow:   contextWindow,
 		wakeCanceller:   nil,
 	}
 }
@@ -310,6 +313,29 @@ func NewServiceCore(
 // assistants must not import triggers.
 func (s *ServiceCore) SetWakeCanceller(c WakeCanceller) {
 	s.wakeCanceller = c
+}
+
+// resolveAssistantContextWindow returns the smallest context_length the gram
+// backend has cached for the assistant's model, or 0 on lookup failure. The
+// runner reads this from `runtimeStartupConfig` and uses it to threshold
+// input-token-aware compaction.
+func (s *ServiceCore) resolveAssistantContextWindow(ctx context.Context, model string) uint64 {
+	if s.contextWindow == nil || model == "" {
+		return 0
+	}
+	resolved := model
+	if alias := openrouter.ResolveModel(model); alias != "" {
+		resolved = alias
+	}
+	tokens, err := s.contextWindow.Resolve(ctx, resolved)
+	if err != nil {
+		s.logger.WarnContext(ctx, "resolve assistant model context window", attr.SlogError(err), attr.SlogGenAIRequestModel(resolved))
+		return 0
+	}
+	if tokens <= 0 {
+		return 0
+	}
+	return uint64(tokens)
 }
 
 // emitAssistantTelemetry writes a single assistant-pipeline log event to the
@@ -1656,11 +1682,11 @@ func (s *ServiceCore) buildRuntimeStartupConfig(
 	completionsEndpoint := runtimeServerURL.JoinPath("chat", "completions")
 	completionsQuery := completionsEndpoint.Query()
 	completionsQuery.Set("unstable_normalizeOutboundMessages", "1")
-	// Opt the runner into the gram_metadata.context_window decoration so the
-	// compaction trigger can read the model's window from completion responses.
-	completionsQuery.Set("includeContextWindow", "1")
 	completionsEndpoint.RawQuery = completionsQuery.Encode()
 	completionsURL := completionsEndpoint.String()
+
+	contextWindow := s.resolveAssistantContextWindow(ctx, assistant.Model)
+
 	return runtimeStartupConfig{
 		Model:          assistant.Model,
 		Instructions:   conv.PtrEmpty(instructions),
@@ -1669,6 +1695,7 @@ func (s *ServiceCore) buildRuntimeStartupConfig(
 		ChatID:         thread.ChatID.String(),
 		MCPServers:     mcpServers,
 		History:        history,
+		ContextWindow:  contextWindow,
 	}, nil
 }
 

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1656,6 +1656,9 @@ func (s *ServiceCore) buildRuntimeStartupConfig(
 	completionsEndpoint := runtimeServerURL.JoinPath("chat", "completions")
 	completionsQuery := completionsEndpoint.Query()
 	completionsQuery.Set("unstable_normalizeOutboundMessages", "1")
+	// Opt the runner into the gram_metadata.context_window decoration so the
+	// compaction trigger can read the model's window from completion responses.
+	completionsQuery.Set("includeContextWindow", "1")
 	completionsEndpoint.RawQuery = completionsQuery.Encode()
 	completionsURL := completionsEndpoint.String()
 	return runtimeStartupConfig{

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -49,7 +49,7 @@ func TestServiceCoreAdmitPendingThreadsUsesFlyBackend(t *testing.T) {
 
 	projectID, assistantID, _, threadID := insertAssistantFixture(t, conn)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestServiceCoreExpireThreadRuntimeRevertsWhenTurnInFlight(t *testing.T) {
 		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: &busyIdle},
 		stopCalls:    &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(logger), nil)
 
 	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestServiceCoreExpireThreadRuntimeRetryAfterStopFailureIsIdempotent(t *test
 		stopErr:      errors.New("fly delete app blew up"),
 		stopCalls:    &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, failingBackend, nil, nil, nil, telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, failingBackend, nil, nil, nil, telemetry.NewStub(logger), nil)
 
 	_, err = core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.Error(t, err, "first attempt with failing Stop must surface the error so Temporal retries")
@@ -190,7 +190,7 @@ func TestServiceCoreExpireThreadRuntimeRetryAfterStopFailureIsIdempotent(t *test
 		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: new(uint64(DefaultWarmTTLSeconds + 60))},
 		stopCalls:    &stopCalls,
 	}
-	core = NewServiceCore(logger, testenv.NewTracerProvider(t), conn, healingBackend, nil, nil, nil, telemetry.NewStub(logger))
+	core = NewServiceCore(logger, testenv.NewTracerProvider(t), conn, healingBackend, nil, nil, nil, telemetry.NewStub(logger), nil)
 
 	result, err := core.ExpireThreadRuntime(t.Context(), projectID, threadID, DefaultWarmTTLSeconds)
 	require.NoError(t, err, "retry must drive the existing expiring row to a terminal state")
@@ -238,7 +238,7 @@ func TestServiceCoreReapStuckRuntimesCleansUpStuckExpiring(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(t.Context())
 	require.NoError(t, err)
@@ -283,7 +283,7 @@ func TestServiceCoreReapStuckRuntimesLeavesFreshExpiring(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(t.Context())
 	require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestServiceCoreReapStuckRuntimesSkipsLiveProcessingLease(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(ctx)
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestServiceCoreReapStuckRuntimesReclaimsStaleProcessingLease(t *testing.T) 
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapStuckRuntimes(ctx)
 	require.NoError(t, err)
@@ -518,7 +518,7 @@ func TestServiceCoreLoadChatHistoryReplaysToolTurns(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	history, err := core.loadChatHistory(t.Context(), chatID, projectID)
 	require.NoError(t, err)
@@ -600,7 +600,7 @@ func TestServiceCoreLoadChatHistoryReturnsOnlyLatestGeneration(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	history, err := core.loadChatHistory(t.Context(), chatID, projectID)
 	require.NoError(t, err)
@@ -645,7 +645,7 @@ func TestServiceCoreLoadChatHistoryFailsWhenToolRowMissingCallID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	_, err = core.loadChatHistory(ctx, chatID, projectID)
 	require.ErrorContains(t, err, "tool chat row missing tool_call_id")
@@ -661,7 +661,7 @@ func TestServiceCoreProcessThreadEventsCompletesEvent(t *testing.T) {
 
 	logger := testenv.NewLogger(t)
 	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, tokens, nil, telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: nil}, nil, tokens, nil, telemetry.NewStub(logger), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -694,7 +694,7 @@ func TestServiceCoreProcessThreadEventsRequeuesOnTurnFailure(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, runTurnErr: errors.New("runtime RunTurn blew up")}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, nil, telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, nil, telemetry.NewStub(logger), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -730,7 +730,7 @@ func TestServiceCoreProcessThreadEventsMarksRuntimeFailedOnUnhealthyTurn(t *test
 		runTurnErr: ErrRuntimeUnhealthy,
 		stopCalls:  &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -779,7 +779,7 @@ func TestServiceCoreProcessThreadEventsDoesNotStopRuntimeOnConfigureFailure(t *t
 		configureErr: errors.New("runtime Configure blew up"),
 		stopCalls:    &stopCalls,
 	}
-	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger))
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
 
 	admitted, err := core.AdmitPendingThreads(t.Context(), assistantID)
 	require.NoError(t, err)
@@ -922,7 +922,7 @@ func TestServiceCoreDeleteAssistantReapsRuntimes(t *testing.T) {
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID))
 	require.EqualValues(t, 1, reapCalls.Load())
@@ -958,7 +958,7 @@ func TestServiceCoreDeleteAssistantSucceedsEvenWhenReapErrors(t *testing.T) {
 		reapCalls: reapCalls,
 		reapErr:   errors.New("fly api 503"),
 	}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	require.NoError(t, core.DeleteAssistant(t.Context(), projectID, assistantID))
 	require.EqualValues(t, 1, reapCalls.Load())
@@ -984,7 +984,7 @@ func TestServiceCoreReapAssistantRuntimesCallsBackendAndClearsMetadata(t *testin
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapAssistantRuntimes(t.Context(), projectID, assistantID)
 	require.NoError(t, err)
@@ -1027,7 +1027,7 @@ func TestServiceCoreReapAssistantRuntimesSkipsRowsWithoutMetadata(t *testing.T) 
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapAssistantRuntimes(t.Context(), projectID, assistantID)
 	require.NoError(t, err)
@@ -1049,7 +1049,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesCollectsOnlyInactive(t *testing
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
@@ -1083,7 +1083,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsAssistantWithRecentActivit
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
@@ -1133,7 +1133,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesReapsSiblingsAcrossSweeps(t *te
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	first, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
@@ -1165,7 +1165,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesIgnoresActiveAndStarting(t *tes
 
 	reapCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
-	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)))
+	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,


### PR DESCRIPTION
## Summary

- Wire `agentkit-compaction` into `agents/runner`: a `ContextWindowTrigger` reads `gram_metadata.context_window` from completion responses (decorated by gram when the URL carries `?includeContextWindow=1`) and fires once `usage.input_tokens` crosses 80% of the window. Tunable via `ASSISTANT_CONTEXT_PERCENTAGE`.
- Strategy pipeline: drop reasoning, drop failed tool results, summarise older items through a nested agent loop on the same model. System + context items and the last few turns stay put.
- Gram-side: append `includeContextWindow=1` to the completions URL minted in `assistantRuntimeStartupConfig` so the runner's calls receive the decoration.
- The compactor's adapter omits the `Gram-Chat-ID` default header so its "summarise this transcript" turn bypasses chat-message capture — otherwise gram's divergence check would mint a new generation containing the compactor's transcript and the next replay would load that instead of the user's conversation.

Closes [AGE-2150](https://linear.app/speakeasy/issue/AGE-2150/add-compaction-support-to-assistant-runtime).
Closes AGE-2194

✻ Clauded...
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->