### PR TITLE
fix(dashboard): show only denied challenges in org home widget

### DIFF
--- a/.changeset/recent-challenges-denied-only.md
+++ b/.changeset/recent-challenges-denied-only.md
@@ -1,0 +1,8 @@
+---
+"dashboard": patch
+---
+
+Filter the "Recent Challenges" widget on the org home page to only show
+denied, unresolved challenges (previously it listed any challenge in any
+status). When there are no denied challenges, the widget now renders the
+same empty state used on the Denied tab of the Challenges page.

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -94,6 +94,34 @@ function FilterPill({
   );
 }
 
+export function ChallengesEmptyState({
+  outcomeFilter,
+}: {
+  outcomeFilter: OutcomeFilter;
+}) {
+  return (
+    <div className="border-border/50 bg-muted/20 rounded-lg border px-6 py-16 text-center">
+      <div className="bg-primary/10 mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+        <Check className="text-primary h-6 w-6" />
+      </div>
+      <Type variant="body" className="font-medium">
+        {outcomeFilter === "deny"
+          ? "No denied access attempts"
+          : outcomeFilter === "resolved"
+            ? "No resolved challenges yet"
+            : "No challenges found"}
+      </Type>
+      <Type variant="body" className="text-muted-foreground mt-1 text-sm">
+        {outcomeFilter === "deny"
+          ? "All authorization checks are passing. Your team's permissions look good."
+          : outcomeFilter === "resolved"
+            ? "Denied challenges that are resolved by granting access will appear here."
+            : "Authorization challenges will appear here as your team uses the platform."}
+      </Type>
+    </div>
+  );
+}
+
 export function ChallengesTab() {
   const [searchParams] = useSearchParams();
   const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("deny");
@@ -282,25 +310,7 @@ export function ChallengesTab() {
       {isLoading ? (
         <SkeletonTable />
       ) : filtered.length === 0 ? (
-        <div className="border-border/50 bg-muted/20 rounded-lg border px-6 py-16 text-center">
-          <div className="bg-primary/10 mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full">
-            <Check className="text-primary h-6 w-6" />
-          </div>
-          <Type variant="body" className="font-medium">
-            {outcomeFilter === "deny"
-              ? "No denied access attempts"
-              : outcomeFilter === "resolved"
-                ? "No resolved challenges yet"
-                : "No challenges found"}
-          </Type>
-          <Type variant="body" className="text-muted-foreground mt-1 text-sm">
-            {outcomeFilter === "deny"
-              ? "All authorization checks are passing. Your team's permissions look good."
-              : outcomeFilter === "resolved"
-                ? "Denied challenges that are resolved by granting access will appear here."
-                : "Authorization challenges will appear here as your team uses the platform."}
-          </Type>
-        </div>
+        <ChallengesEmptyState outcomeFilter={outcomeFilter} />
       ) : (
         <Table columns={columns} data={filtered} rowKey={(row) => row.id} />
       )}

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -13,6 +13,7 @@ import { useTelemetry } from "@/contexts/Telemetry";
 import { useOrgRoutes } from "@/routes";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useChallenges } from "@gram/client/react-query/challenges.js";
+import { ChallengesEmptyState } from "@/pages/access/ChallengesTab";
 import { useChallengeRowColumns } from "@/pages/access/useChallengeRowColumns";
 import { useGrantFlow } from "@/pages/access/useGrantFlow";
 import { Table } from "@speakeasy-api/moonshine";
@@ -224,7 +225,11 @@ function RecentChallenges() {
   const canAdmin = hasScope("org:admin");
   const { actionsColumn, grantFlowPortals } = useGrantFlow();
   const challengeRowColumns = useChallengeRowColumns();
-  const { data: challengesData } = useChallenges({ limit: 5 });
+  const { data: challengesData, isLoading } = useChallenges({
+    outcome: "deny",
+    resolved: false,
+    limit: 5,
+  });
   const recentChallenges = (challengesData?.challenges ?? []).filter(
     (c) => !!c.scope,
   );
@@ -235,7 +240,7 @@ function RecentChallenges() {
     [canAdmin, challengeRowColumns, actionsColumn],
   );
 
-  if (recentChallenges.length === 0) return null;
+  if (isLoading) return null;
 
   return (
     <div className="mt-12">
@@ -245,11 +250,15 @@ function RecentChallenges() {
           Show more
         </orgRoutes.access.challenges.Link>
       </div>
-      <Table
-        columns={columns}
-        data={recentChallenges}
-        rowKey={(row) => row.id}
-      />
+      {recentChallenges.length === 0 ? (
+        <ChallengesEmptyState outcomeFilter="deny" />
+      ) : (
+        <Table
+          columns={columns}
+          data={recentChallenges}
+          rowKey={(row) => row.id}
+        />
+      )}
       {grantFlowPortals}
     </div>
   );


### PR DESCRIPTION
## Summary

- The org home "Recent Challenges" widget previously listed any challenge regardless of outcome (allow / deny / error / resolved). It now requests only unresolved `deny` outcomes from the API (`useChallenges({ outcome: "deny", resolved: false, limit: 5 })`).
- Extracted the empty state used on the Denied tab in `ChallengesTab` into a reusable `ChallengesEmptyState` component, and reused it from the widget so both surfaces show the same "No denied access attempts" copy when nothing matches.
- Loading no longer flashes the empty state (widget renders nothing until the first fetch completes).

## Test plan

- [ ] Org home page widget shows only denied, unresolved challenges
- [ ] Widget shows the shared empty state (matching the Denied tab) when there are no denied challenges
- [ ] Denied tab on the access challenges page still renders correctly with the same empty state

https://claude.ai/code/session_014ZYarznyjy99eikzxCmbGC

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZYarznyjy99eikzxCmbGC)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->