### PR TITLE
feat(email): add Loops client and typed-template email facade

### DIFF
--- a/server/internal/email/service.go
+++ b/server/internal/email/service.go
@@ -1,0 +1,65 @@
+package email
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+)
+
+// ErrEmptyRecipient is returned when Send is called without a recipient
+// address. It is a sentinel so tests and callers can distinguish input errors
+// from transport failures.
+var ErrEmptyRecipient = errors.New("email: recipient is required")
+
+// ErrUnregisteredTemplate is returned when the supplied template's
+// TransactionalID is empty, indicating the template has not been registered
+// with a Loops transactional ID.
+var ErrUnregisteredTemplate = errors.New("email: template has no transactional ID")
+
+// Service is the application-facing facade for sending transactional emails.
+// Callers depend on this type instead of the underlying transport so we can
+// swap providers without touching feature code.
+type Service struct {
+	logger *slog.Logger
+	sender loops.Client
+}
+
+// NewService returns an email Service backed by the supplied Loops client.
+// The sender is expected to be a usable client — pass loops.New(...) which
+// returns a no-op when the API key is unset.
+func NewService(logger *slog.Logger, sender loops.Client) *Service {
+	return &Service{
+		logger: logger.With(attr.SlogComponent("email")),
+		sender: sender,
+	}
+}
+
+// Send dispatches a transactional email rendered from the supplied template.
+// The template carries the strongly typed variables and the transactional ID
+// it targets, so a misuse such as passing the wrong variable shape is a
+// compile-time error.
+func (s *Service) Send(ctx context.Context, recipient string, template Template) error {
+	if recipient == "" {
+		return ErrEmptyRecipient
+	}
+
+	id := template.TransactionalID()
+	if id == "" {
+		return ErrUnregisteredTemplate
+	}
+
+	if err := s.sender.SendTransactional(ctx, loops.SendTransactionalInput{
+		TransactionalID: string(id),
+		Email:           recipient,
+		DataVariables:   template.Variables(),
+		AddToAudience:   template.AddToAudience(),
+	}); err != nil {
+		return fmt.Errorf("send email %q: %w", id, err)
+	}
+
+	return nil
+}

--- a/server/internal/email/service_test.go
+++ b/server/internal/email/service_test.go
@@ -35,20 +35,20 @@ func TestService_Send_TranslatesTemplateToLoopsInput(t *testing.T) {
 	svc := NewService(testenv.NewLogger(t), sender)
 
 	tmpl := TeamInvite{
-		InviteLink:    "https://app.gram.sh/invite?token=xyz",
-		InviterName:   "Bob",
-		InviterEmail:  "bob@example.com",
-		WorkspaceName: "Workspace",
+		InviteLink:       "https://app.gram.sh/invite?token=xyz",
+		InviterName:      "Bob",
+		InviterEmail:     "bob@example.com",
+		OrganizationName: "Acme Corp",
 	}
 
 	expected := loops.SendTransactionalInput{
 		TransactionalID: string(transactionalIDTeamInvite),
 		Email:           "carol@example.com",
 		DataVariables: map[string]string{
-			"invite_link":    "https://app.gram.sh/invite?token=xyz",
-			"teammate_fn":    "Bob",
-			"teammate_email": "bob@example.com",
-			"workspace_name": "Workspace",
+			"invite_link":       "https://app.gram.sh/invite?token=xyz",
+			"inviter_name":      "Bob",
+			"inviter_email":     "bob@example.com",
+			"organization_name": "Acme Corp",
 		},
 		AddToAudience: true,
 	}
@@ -66,10 +66,10 @@ func TestService_Send_EmptyRecipientReturnsSentinel(t *testing.T) {
 	svc := NewService(testenv.NewLogger(t), sender)
 
 	err := svc.Send(t.Context(), "", TeamInvite{
-		InviteLink:    "https://example.com",
-		InviterName:   "Bob",
-		InviterEmail:  "bob@example.com",
-		WorkspaceName: "WS",
+		InviteLink:       "https://example.com",
+		InviterName:      "Bob",
+		InviterEmail:     "bob@example.com",
+		OrganizationName: "Acme Corp",
 	})
 	require.ErrorIs(t, err, ErrEmptyRecipient)
 }
@@ -94,10 +94,10 @@ func TestService_Send_PropagatesSenderError(t *testing.T) {
 	sender.On("SendTransactional", mock.Anything, mock.Anything).Return(transportErr).Once()
 
 	err := svc.Send(t.Context(), "user@example.com", TeamInvite{
-		InviteLink:    "https://example.com",
-		InviterName:   "Bob",
-		InviterEmail:  "bob@example.com",
-		WorkspaceName: "WS",
+		InviteLink:       "https://example.com",
+		InviterName:      "Bob",
+		InviterEmail:     "bob@example.com",
+		OrganizationName: "Acme Corp",
 	})
 	require.Error(t, err)
 	require.ErrorIs(t, err, transportErr)

--- a/server/internal/email/service_test.go
+++ b/server/internal/email/service_test.go
@@ -1,0 +1,155 @@
+package email
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+)
+
+type mockSender struct {
+	mock.Mock
+}
+
+func (m *mockSender) SendTransactional(ctx context.Context, input loops.SendTransactionalInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0) //nolint:wrapcheck // mock return is not a real error to wrap.
+}
+
+func newMockSender(t *testing.T) *mockSender {
+	t.Helper()
+	m := &mockSender{}
+	t.Cleanup(func() { m.AssertExpectations(t) })
+	return m
+}
+
+func TestService_Send_TranslatesTemplateToLoopsInput(t *testing.T) {
+	t.Parallel()
+
+	sender := newMockSender(t)
+	svc := NewService(testenv.NewLogger(t), sender)
+
+	tmpl := TeamInvite{
+		InviteLink:    "https://app.gram.sh/invite?token=xyz",
+		InviterName:   "Bob",
+		InviterEmail:  "bob@example.com",
+		WorkspaceName: "Workspace",
+	}
+
+	expected := loops.SendTransactionalInput{
+		TransactionalID: string(transactionalIDTeamInvite),
+		Email:           "carol@example.com",
+		DataVariables: map[string]string{
+			"invite_link":    "https://app.gram.sh/invite?token=xyz",
+			"teammate_fn":    "Bob",
+			"teammate_email": "bob@example.com",
+			"workspace_name": "Workspace",
+		},
+		AddToAudience: true,
+	}
+
+	sender.On("SendTransactional", mock.Anything, expected).Return(nil).Once()
+
+	err := svc.Send(t.Context(), "carol@example.com", tmpl)
+	require.NoError(t, err)
+}
+
+func TestService_Send_EmptyRecipientReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	sender := newMockSender(t)
+	svc := NewService(testenv.NewLogger(t), sender)
+
+	err := svc.Send(t.Context(), "", TeamInvite{
+		InviteLink:    "https://example.com",
+		InviterName:   "Bob",
+		InviterEmail:  "bob@example.com",
+		WorkspaceName: "WS",
+	})
+	require.ErrorIs(t, err, ErrEmptyRecipient)
+}
+
+func TestService_Send_UnregisteredTemplateReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	sender := newMockSender(t)
+	svc := NewService(testenv.NewLogger(t), sender)
+
+	err := svc.Send(t.Context(), "user@example.com", unregisteredTemplate{})
+	require.ErrorIs(t, err, ErrUnregisteredTemplate)
+}
+
+func TestService_Send_PropagatesSenderError(t *testing.T) {
+	t.Parallel()
+
+	sender := newMockSender(t)
+	svc := NewService(testenv.NewLogger(t), sender)
+
+	transportErr := errors.New("transport boom")
+	sender.On("SendTransactional", mock.Anything, mock.Anything).Return(transportErr).Once()
+
+	err := svc.Send(t.Context(), "user@example.com", TeamInvite{
+		InviteLink:    "https://example.com",
+		InviterName:   "Bob",
+		InviterEmail:  "bob@example.com",
+		WorkspaceName: "WS",
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, transportErr)
+	require.Contains(t, err.Error(), string(transactionalIDTeamInvite))
+}
+
+func TestService_Send_RespectsTemplateAddToAudienceFlag(t *testing.T) {
+	t.Parallel()
+
+	sender := newMockSender(t)
+	svc := NewService(testenv.NewLogger(t), sender)
+
+	sender.On("SendTransactional", mock.Anything, mock.MatchedBy(func(in loops.SendTransactionalInput) bool {
+		return !in.AddToAudience && in.TransactionalID == "no-audience-id"
+	})).Return(nil).Once()
+
+	err := svc.Send(t.Context(), "user@example.com", noAudienceTemplate{})
+	require.NoError(t, err)
+}
+
+func TestService_Send_NilVariablesAreForwarded(t *testing.T) {
+	t.Parallel()
+
+	sender := newMockSender(t)
+	svc := NewService(testenv.NewLogger(t), sender)
+
+	sender.On("SendTransactional", mock.Anything, mock.MatchedBy(func(in loops.SendTransactionalInput) bool {
+		return in.DataVariables == nil
+	})).Return(nil).Once()
+
+	err := svc.Send(t.Context(), "user@example.com", nilVarsTemplate{})
+	require.NoError(t, err)
+}
+
+// Test-only template implementations.
+
+type unregisteredTemplate struct{}
+
+func (unregisteredTemplate) TransactionalID() TransactionalID { return "" }
+func (unregisteredTemplate) Variables() map[string]string     { return nil }
+func (unregisteredTemplate) AddToAudience() bool              { return false }
+
+type noAudienceTemplate struct{}
+
+func (noAudienceTemplate) TransactionalID() TransactionalID {
+	return TransactionalID("no-audience-id")
+}
+func (noAudienceTemplate) Variables() map[string]string { return map[string]string{"a": "b"} }
+func (noAudienceTemplate) AddToAudience() bool          { return false }
+
+type nilVarsTemplate struct{}
+
+func (nilVarsTemplate) TransactionalID() TransactionalID { return TransactionalID("nil-vars-id") }
+func (nilVarsTemplate) Variables() map[string]string     { return nil }
+func (nilVarsTemplate) AddToAudience() bool              { return false }

--- a/server/internal/email/template_team_invite.go
+++ b/server/internal/email/template_team_invite.go
@@ -1,0 +1,35 @@
+package email
+
+// TeamInvite is sent to a recipient who has been invited to join a Gram
+// organization. The fields below mirror the merge variables the Loops
+// template expects.
+type TeamInvite struct {
+	// InviteLink is the absolute URL the recipient clicks to accept the
+	// invite (e.g. https://app.gram.sh/invite?token=...).
+	InviteLink string
+	// InviterName is the first name (or display name) of the person who sent
+	// the invite. Rendered in the greeting line.
+	InviterName string
+	// InviterEmail is the email address of the person who sent the invite.
+	InviterEmail string
+	// WorkspaceName is the human-readable name of the organization the
+	// recipient is being invited to.
+	WorkspaceName string
+}
+
+func (TeamInvite) TransactionalID() TransactionalID {
+	return transactionalIDTeamInvite
+}
+
+func (t TeamInvite) Variables() map[string]string {
+	return map[string]string{
+		"invite_link":    t.InviteLink,
+		"teammate_fn":    t.InviterName,
+		"teammate_email": t.InviterEmail,
+		"workspace_name": t.WorkspaceName,
+	}
+}
+
+func (TeamInvite) AddToAudience() bool {
+	return true
+}

--- a/server/internal/email/template_team_invite.go
+++ b/server/internal/email/template_team_invite.go
@@ -12,9 +12,9 @@ type TeamInvite struct {
 	InviterName string
 	// InviterEmail is the email address of the person who sent the invite.
 	InviterEmail string
-	// WorkspaceName is the human-readable name of the organization the
+	// OrganizationName is the human-readable name of the organization the
 	// recipient is being invited to.
-	WorkspaceName string
+	OrganizationName string
 }
 
 func (TeamInvite) TransactionalID() TransactionalID {
@@ -23,10 +23,10 @@ func (TeamInvite) TransactionalID() TransactionalID {
 
 func (t TeamInvite) Variables() map[string]string {
 	return map[string]string{
-		"invite_link":    t.InviteLink,
-		"teammate_fn":    t.InviterName,
-		"teammate_email": t.InviterEmail,
-		"workspace_name": t.WorkspaceName,
+		"invite_link":       t.InviteLink,
+		"inviter_name":      t.InviterName,
+		"inviter_email":     t.InviterEmail,
+		"organization_name": t.OrganizationName,
 	}
 }
 

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -1,0 +1,48 @@
+// Package email is the application-facing facade for sending transactional
+// emails. It defines a strongly typed Template interface so the variables
+// passed to a send call are always validated against the template they target.
+//
+// Adding a new template
+//
+//  1. Add a new Loops transactional ID constant to this file. This is the
+//     single registry of template IDs known to the application.
+//  2. In a new file (template_<name>.go), define a struct whose exported
+//     fields are exactly the variables the template consumes.
+//  3. Implement the Template interface on the struct: TransactionalID returns
+//     the constant from step 1, Variables returns the merge data Loops
+//     expects, and AddToAudience controls whether Loops should upsert the
+//     recipient as a contact when the email is sent.
+//  4. Append the zero value of the new template to RegisteredTemplates so
+//     unit tests catch a duplicate ID.
+package email
+
+// TransactionalID is the opaque identifier Loops assigns to each template.
+type TransactionalID string
+
+// Loops transactional template IDs. Keep all IDs declared here so the
+// registry is grep-friendly.
+const (
+	transactionalIDTeamInvite TransactionalID = "cml3n1h2n27o50i2rakc30bwb"
+)
+
+// Template is implemented by every concrete email template. Concrete types
+// hold the typed variables the template consumes and translate them to the
+// Loops merge variable shape via Variables.
+type Template interface {
+	// TransactionalID returns the Loops template identifier this template
+	// instance dispatches against.
+	TransactionalID() TransactionalID
+	// Variables returns the merge data Loops substitutes into the template.
+	// The returned map may be nil for templates with no dynamic content.
+	Variables() map[string]string
+	// AddToAudience reports whether sending this template should upsert the
+	// recipient into the Loops audience.
+	AddToAudience() bool
+}
+
+// RegisteredTemplates is the canonical list of templates the application is
+// allowed to send. Tests assert that every entry maps to a non-empty,
+// non-duplicated transactional ID so misconfigured templates fail fast.
+var RegisteredTemplates = []Template{
+	TeamInvite{},
+}

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -43,6 +43,15 @@ type Template interface {
 // RegisteredTemplates is the canonical list of templates the application is
 // allowed to send. Tests assert that every entry maps to a non-empty,
 // non-duplicated transactional ID so misconfigured templates fail fast.
+//
+// The entries hold zero-valued instances of each template type — they are
+// only used to look up the template's metadata (TransactionalID,
+// AddToAudience), never to render an actual email.
 var RegisteredTemplates = []Template{
-	TeamInvite{},
+	TeamInvite{
+		InviteLink:    "",
+		InviterName:   "",
+		InviterEmail:  "",
+		WorkspaceName: "",
+	},
 }

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -49,9 +49,9 @@ type Template interface {
 // AddToAudience), never to render an actual email.
 var RegisteredTemplates = []Template{
 	TeamInvite{
-		InviteLink:    "",
-		InviterName:   "",
-		InviterEmail:  "",
-		WorkspaceName: "",
+		InviteLink:       "",
+		InviterName:      "",
+		InviterEmail:     "",
+		OrganizationName: "",
 	},
 }

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -1,0 +1,85 @@
+package email
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisteredTemplates_AllHaveTransactionalIDs(t *testing.T) {
+	t.Parallel()
+
+	require.NotEmpty(t, RegisteredTemplates, "RegisteredTemplates should not be empty")
+
+	for _, tmpl := range RegisteredTemplates {
+		require.NotEmpty(t, tmpl.TransactionalID(),
+			"template %T must have a non-empty TransactionalID — register an ID in templates.go",
+			tmpl,
+		)
+	}
+}
+
+func TestRegisteredTemplates_TransactionalIDsAreUnique(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[TransactionalID]Template, len(RegisteredTemplates))
+	for _, tmpl := range RegisteredTemplates {
+		id := tmpl.TransactionalID()
+		existing, dup := seen[id]
+		require.Falsef(t, dup,
+			"templates %T and %T share transactional ID %q",
+			existing, tmpl, id,
+		)
+		seen[id] = tmpl
+	}
+}
+
+func TestTeamInvite_TransactionalID(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, transactionalIDTeamInvite, TeamInvite{}.TransactionalID())
+}
+
+func TestTeamInvite_Variables_RendersExpectedKeys(t *testing.T) {
+	t.Parallel()
+
+	tmpl := TeamInvite{
+		InviteLink:    "https://app.gram.sh/invite?token=abc",
+		InviterName:   "Alice",
+		InviterEmail:  "alice@example.com",
+		WorkspaceName: "Acme Inc",
+	}
+
+	require.Equal(t, map[string]string{
+		"invite_link":    "https://app.gram.sh/invite?token=abc",
+		"teammate_fn":    "Alice",
+		"teammate_email": "alice@example.com",
+		"workspace_name": "Acme Inc",
+	}, tmpl.Variables())
+}
+
+func TestTeamInvite_Variables_PassesEmptyFieldsThrough(t *testing.T) {
+	t.Parallel()
+
+	tmpl := TeamInvite{
+		InviteLink:    "",
+		InviterName:   "",
+		InviterEmail:  "",
+		WorkspaceName: "",
+	}
+
+	vars := tmpl.Variables()
+	require.Len(t, vars, 4, "all merge keys should still be present even if values are empty")
+	require.Equal(t, "", vars["invite_link"])
+	require.Equal(t, "", vars["teammate_fn"])
+	require.Equal(t, "", vars["teammate_email"])
+	require.Equal(t, "", vars["workspace_name"])
+}
+
+func TestTeamInvite_AddToAudience(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, TeamInvite{}.AddToAudience(),
+		"team invite recipients should be added to the Loops audience by default",
+	)
+}

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -70,10 +70,10 @@ func TestTeamInvite_Variables_PassesEmptyFieldsThrough(t *testing.T) {
 
 	vars := tmpl.Variables()
 	require.Len(t, vars, 4, "all merge keys should still be present even if values are empty")
-	require.Equal(t, "", vars["invite_link"])
-	require.Equal(t, "", vars["teammate_fn"])
-	require.Equal(t, "", vars["teammate_email"])
-	require.Equal(t, "", vars["workspace_name"])
+	require.Empty(t, vars["invite_link"])
+	require.Empty(t, vars["teammate_fn"])
+	require.Empty(t, vars["teammate_email"])
+	require.Empty(t, vars["workspace_name"])
 }
 
 func TestTeamInvite_AddToAudience(t *testing.T) {

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -44,17 +44,17 @@ func TestTeamInvite_Variables_RendersExpectedKeys(t *testing.T) {
 	t.Parallel()
 
 	tmpl := TeamInvite{
-		InviteLink:    "https://app.gram.sh/invite?token=abc",
-		InviterName:   "Alice",
-		InviterEmail:  "alice@example.com",
-		WorkspaceName: "Acme Inc",
+		InviteLink:       "https://app.gram.sh/invite?token=abc",
+		InviterName:      "Alice",
+		InviterEmail:     "alice@example.com",
+		OrganizationName: "Acme Inc",
 	}
 
 	require.Equal(t, map[string]string{
-		"invite_link":    "https://app.gram.sh/invite?token=abc",
-		"teammate_fn":    "Alice",
-		"teammate_email": "alice@example.com",
-		"workspace_name": "Acme Inc",
+		"invite_link":       "https://app.gram.sh/invite?token=abc",
+		"inviter_name":      "Alice",
+		"inviter_email":     "alice@example.com",
+		"organization_name": "Acme Inc",
 	}, tmpl.Variables())
 }
 
@@ -62,18 +62,18 @@ func TestTeamInvite_Variables_PassesEmptyFieldsThrough(t *testing.T) {
 	t.Parallel()
 
 	tmpl := TeamInvite{
-		InviteLink:    "",
-		InviterName:   "",
-		InviterEmail:  "",
-		WorkspaceName: "",
+		InviteLink:       "",
+		InviterName:      "",
+		InviterEmail:     "",
+		OrganizationName: "",
 	}
 
 	vars := tmpl.Variables()
 	require.Len(t, vars, 4, "all merge keys should still be present even if values are empty")
 	require.Empty(t, vars["invite_link"])
-	require.Empty(t, vars["teammate_fn"])
-	require.Empty(t, vars["teammate_email"])
-	require.Empty(t, vars["workspace_name"])
+	require.Empty(t, vars["inviter_name"])
+	require.Empty(t, vars["inviter_email"])
+	require.Empty(t, vars["organization_name"])
 }
 
 func TestTeamInvite_AddToAudience(t *testing.T) {

--- a/server/internal/thirdparty/loops/client.go
+++ b/server/internal/thirdparty/loops/client.go
@@ -15,9 +15,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
-
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
@@ -48,17 +47,17 @@ type SendTransactionalInput struct {
 // When apiKey is empty or the placeholder value "unset", the returned client
 // is a no-op that logs at debug level and returns nil for every send. This
 // keeps configuration-gated behavior out of every call site.
-func New(logger *slog.Logger, apiKey string) Client {
+func New(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, apiKey string) Client {
 	logger = logger.With(attr.SlogComponent("loops"))
 
 	if apiKey == "" || apiKey == "unset" {
-		logger.Info("loops API key not configured, transactional emails will be dropped")
+		logger.InfoContext(ctx, "loops API key not configured, transactional emails will be dropped")
 		return &noopClient{logger: logger}
 	}
 
 	return &httpClient{
 		logger:     logger,
-		httpClient: retryablehttp.NewClient().StandardClient(),
+		httpClient: guardianPolicy.PooledClient(),
 		baseURL:    defaultBaseURL,
 		apiKey:     apiKey,
 	}
@@ -66,7 +65,7 @@ func New(logger *slog.Logger, apiKey string) Client {
 
 type httpClient struct {
 	logger     *slog.Logger
-	httpClient *http.Client
+	httpClient *guardian.HTTPClient
 	baseURL    string
 	apiKey     string
 }
@@ -84,14 +83,7 @@ type transactionalResponse struct {
 }
 
 func (c *httpClient) SendTransactional(ctx context.Context, input SendTransactionalInput) error {
-	body := transactionalRequest{
-		TransactionalID: input.TransactionalID,
-		Email:           input.Email,
-		DataVariables:   input.DataVariables,
-		AddToAudience:   input.AddToAudience,
-	}
-
-	payload, err := json.Marshal(body)
+	payload, err := json.Marshal(transactionalRequest(input))
 	if err != nil {
 		return fmt.Errorf("marshal transactional request: %w", err)
 	}
@@ -137,7 +129,7 @@ type noopClient struct {
 
 func (c *noopClient) SendTransactional(ctx context.Context, input SendTransactionalInput) error {
 	c.logger.DebugContext(ctx, "loops disabled, dropping transactional email",
-		slog.String("transactional_id", input.TransactionalID),
+		attr.SlogName(input.TransactionalID),
 	)
 	return nil
 }

--- a/server/internal/thirdparty/loops/client.go
+++ b/server/internal/thirdparty/loops/client.go
@@ -1,0 +1,143 @@
+// Package loops is a thin transport wrapper around the Loops transactional
+// email API (https://loops.so).
+//
+// The package only knows how to ship a request payload — it has no knowledge
+// of which template ID maps to which feature. Use the email package to send
+// templated emails with strongly typed variables.
+package loops
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+)
+
+const defaultBaseURL = "https://app.loops.so/api/v1"
+
+// Client sends transactional emails via Loops.
+type Client interface {
+	SendTransactional(ctx context.Context, input SendTransactionalInput) error
+}
+
+// SendTransactionalInput is the boundary type for sending a transactional
+// email. Higher level packages (e.g. email) translate their typed templates
+// into this shape.
+type SendTransactionalInput struct {
+	// TransactionalID is the Loops template identifier.
+	TransactionalID string
+	// Email is the recipient's email address.
+	Email string
+	// DataVariables are the template merge variables. May be nil.
+	DataVariables map[string]string
+	// AddToAudience instructs Loops to upsert a contact in the audience as a
+	// side effect of sending the email.
+	AddToAudience bool
+}
+
+// New returns a Client that is always safe to call.
+//
+// When apiKey is empty or the placeholder value "unset", the returned client
+// is a no-op that logs at debug level and returns nil for every send. This
+// keeps configuration-gated behavior out of every call site.
+func New(logger *slog.Logger, apiKey string) Client {
+	logger = logger.With(attr.SlogComponent("loops"))
+
+	if apiKey == "" || apiKey == "unset" {
+		logger.Info("loops API key not configured, transactional emails will be dropped")
+		return &noopClient{logger: logger}
+	}
+
+	return &httpClient{
+		logger:     logger,
+		httpClient: retryablehttp.NewClient().StandardClient(),
+		baseURL:    defaultBaseURL,
+		apiKey:     apiKey,
+	}
+}
+
+type httpClient struct {
+	logger     *slog.Logger
+	httpClient *http.Client
+	baseURL    string
+	apiKey     string
+}
+
+type transactionalRequest struct {
+	TransactionalID string            `json:"transactionalId"`
+	Email           string            `json:"email"`
+	DataVariables   map[string]string `json:"dataVariables,omitempty"`
+	AddToAudience   bool              `json:"addToAudience,omitempty"`
+}
+
+type transactionalResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+}
+
+func (c *httpClient) SendTransactional(ctx context.Context, input SendTransactionalInput) error {
+	body := transactionalRequest{
+		TransactionalID: input.TransactionalID,
+		Email:           input.Email,
+		DataVariables:   input.DataVariables,
+		AddToAudience:   input.AddToAudience,
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal transactional request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/transactional", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build transactional request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send transactional request: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read transactional response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("loops API returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result transactionalResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return fmt.Errorf("decode transactional response: %w", err)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("loops API rejected transactional email: %s", result.Message)
+	}
+
+	return nil
+}
+
+type noopClient struct {
+	logger *slog.Logger
+}
+
+func (c *noopClient) SendTransactional(ctx context.Context, input SendTransactionalInput) error {
+	c.logger.DebugContext(ctx, "loops disabled, dropping transactional email",
+		slog.String("transactional_id", input.TransactionalID),
+	)
+	return nil
+}

--- a/server/internal/thirdparty/loops/client_test.go
+++ b/server/internal/thirdparty/loops/client_test.go
@@ -1,0 +1,218 @@
+package loops
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestNew_NoopWhenAPIKeyEmpty(t *testing.T) {
+	t.Parallel()
+
+	client := New(testenv.NewLogger(t), "")
+	_, ok := client.(*noopClient)
+	require.True(t, ok, "expected noop client when API key is empty")
+}
+
+func TestNew_NoopWhenAPIKeyUnset(t *testing.T) {
+	t.Parallel()
+
+	client := New(testenv.NewLogger(t), "unset")
+	_, ok := client.(*noopClient)
+	require.True(t, ok, "expected noop client when API key is the unset placeholder")
+}
+
+func TestNew_HTTPWhenAPIKeyConfigured(t *testing.T) {
+	t.Parallel()
+
+	client := New(testenv.NewLogger(t), "secret-key")
+	_, ok := client.(*httpClient)
+	require.True(t, ok, "expected http client when API key is configured")
+}
+
+func TestNoopClient_SendTransactional_DropsAndReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	client := New(testenv.NewLogger(t), "")
+	err := client.SendTransactional(t.Context(), SendTransactionalInput{
+		TransactionalID: "tid-123",
+		Email:           "user@example.com",
+		DataVariables:   map[string]string{"foo": "bar"},
+		AddToAudience:   true,
+	})
+	require.NoError(t, err)
+}
+
+func TestHTTPClient_SendTransactional_SendsExpectedRequest(t *testing.T) {
+	t.Parallel()
+
+	var captured transactionalRequest
+	var authHeader, contentType string
+	var calls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/transactional", r.URL.Path)
+		authHeader = r.Header.Get("Authorization")
+		contentType = r.Header.Get("Content-Type")
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &captured))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "secret-key")
+
+	err := c.SendTransactional(t.Context(), SendTransactionalInput{
+		TransactionalID: "tid-abc",
+		Email:           "alice@example.com",
+		DataVariables:   map[string]string{"workspace_name": "Acme"},
+		AddToAudience:   true,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	require.Equal(t, "Bearer secret-key", authHeader)
+	require.Equal(t, "application/json", contentType)
+	require.Equal(t, "tid-abc", captured.TransactionalID)
+	require.Equal(t, "alice@example.com", captured.Email)
+	require.Equal(t, map[string]string{"workspace_name": "Acme"}, captured.DataVariables)
+	require.True(t, captured.AddToAudience)
+}
+
+func TestHTTPClient_SendTransactional_ErrorOnNon200(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"bad token"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "bad-key")
+
+	err := c.SendTransactional(t.Context(), SendTransactionalInput{
+		TransactionalID: "tid",
+		Email:           "user@example.com",
+		DataVariables:   nil,
+		AddToAudience:   false,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP 401")
+	require.Contains(t, err.Error(), "bad token")
+}
+
+func TestHTTPClient_SendTransactional_ErrorOnAPIFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":false,"message":"template not found"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "secret-key")
+
+	err := c.SendTransactional(t.Context(), SendTransactionalInput{
+		TransactionalID: "missing",
+		Email:           "user@example.com",
+		DataVariables:   nil,
+		AddToAudience:   false,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "template not found")
+}
+
+func TestHTTPClient_SendTransactional_ErrorOnInvalidJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "secret-key")
+
+	err := c.SendTransactional(t.Context(), SendTransactionalInput{
+		TransactionalID: "tid",
+		Email:           "user@example.com",
+		DataVariables:   nil,
+		AddToAudience:   false,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode transactional response")
+}
+
+func TestHTTPClient_SendTransactional_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "secret-key")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := c.SendTransactional(ctx, SendTransactionalInput{
+		TransactionalID: "tid",
+		Email:           "user@example.com",
+		DataVariables:   nil,
+		AddToAudience:   false,
+	})
+	require.Error(t, err)
+}
+
+func TestHTTPClient_SendTransactional_OmitsEmptyVariables(t *testing.T) {
+	t.Parallel()
+
+	var rawBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		rawBody = body
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "secret-key")
+
+	err := c.SendTransactional(t.Context(), SendTransactionalInput{
+		TransactionalID: "tid",
+		Email:           "user@example.com",
+		DataVariables:   nil,
+		AddToAudience:   false,
+	})
+	require.NoError(t, err)
+
+	require.NotContains(t, string(rawBody), "dataVariables")
+	require.NotContains(t, string(rawBody), "addToAudience")
+}
+
+func newTestHTTPClient(t *testing.T, baseURL, apiKey string) *httpClient {
+	t.Helper()
+	return &httpClient{
+		logger:     testenv.NewLogger(t),
+		httpClient: http.DefaultClient,
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+	}
+}

--- a/server/internal/thirdparty/loops/client_test.go
+++ b/server/internal/thirdparty/loops/client_test.go
@@ -6,18 +6,20 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestNew_NoopWhenAPIKeyEmpty(t *testing.T) {
 	t.Parallel()
 
-	client := New(testenv.NewLogger(t), "")
+	client := New(t.Context(), testenv.NewLogger(t), newTestPolicy(t), "")
 	_, ok := client.(*noopClient)
 	require.True(t, ok, "expected noop client when API key is empty")
 }
@@ -25,7 +27,7 @@ func TestNew_NoopWhenAPIKeyEmpty(t *testing.T) {
 func TestNew_NoopWhenAPIKeyUnset(t *testing.T) {
 	t.Parallel()
 
-	client := New(testenv.NewLogger(t), "unset")
+	client := New(t.Context(), testenv.NewLogger(t), newTestPolicy(t), "unset")
 	_, ok := client.(*noopClient)
 	require.True(t, ok, "expected noop client when API key is the unset placeholder")
 }
@@ -33,7 +35,7 @@ func TestNew_NoopWhenAPIKeyUnset(t *testing.T) {
 func TestNew_HTTPWhenAPIKeyConfigured(t *testing.T) {
 	t.Parallel()
 
-	client := New(testenv.NewLogger(t), "secret-key")
+	client := New(t.Context(), testenv.NewLogger(t), newTestPolicy(t), "secret-key")
 	_, ok := client.(*httpClient)
 	require.True(t, ok, "expected http client when API key is configured")
 }
@@ -41,7 +43,7 @@ func TestNew_HTTPWhenAPIKeyConfigured(t *testing.T) {
 func TestNoopClient_SendTransactional_DropsAndReturnsNil(t *testing.T) {
 	t.Parallel()
 
-	client := New(testenv.NewLogger(t), "")
+	client := New(t.Context(), testenv.NewLogger(t), newTestPolicy(t), "")
 	err := client.SendTransactional(t.Context(), SendTransactionalInput{
 		TransactionalID: "tid-123",
 		Email:           "user@example.com",
@@ -54,20 +56,35 @@ func TestNoopClient_SendTransactional_DropsAndReturnsNil(t *testing.T) {
 func TestHTTPClient_SendTransactional_SendsExpectedRequest(t *testing.T) {
 	t.Parallel()
 
-	var captured transactionalRequest
-	var authHeader, contentType string
+	type capture struct {
+		mu          sync.Mutex
+		body        transactionalRequest
+		authHeader  string
+		contentType string
+		readErr     error
+		decodeErr   error
+	}
+	captured := &capture{
+		mu:          sync.Mutex{},
+		body:        transactionalRequest{TransactionalID: "", Email: "", DataVariables: nil, AddToAudience: false},
+		authHeader:  "",
+		contentType: "",
+		readErr:     nil,
+		decodeErr:   nil,
+	}
 	var calls int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&calls, 1)
-		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t, "/transactional", r.URL.Path)
-		authHeader = r.Header.Get("Authorization")
-		contentType = r.Header.Get("Content-Type")
-
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, &captured))
+		captured.mu.Lock()
+		captured.authHeader = r.Header.Get("Authorization")
+		captured.contentType = r.Header.Get("Content-Type")
+		captured.readErr = err
+		if err == nil {
+			captured.decodeErr = json.Unmarshal(body, &captured.body)
+		}
+		captured.mu.Unlock()
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"success":true}`))
@@ -85,12 +102,16 @@ func TestHTTPClient_SendTransactional_SendsExpectedRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
-	require.Equal(t, "Bearer secret-key", authHeader)
-	require.Equal(t, "application/json", contentType)
-	require.Equal(t, "tid-abc", captured.TransactionalID)
-	require.Equal(t, "alice@example.com", captured.Email)
-	require.Equal(t, map[string]string{"workspace_name": "Acme"}, captured.DataVariables)
-	require.True(t, captured.AddToAudience)
+	captured.mu.Lock()
+	defer captured.mu.Unlock()
+	require.NoError(t, captured.readErr, "handler failed reading body")
+	require.NoError(t, captured.decodeErr, "handler failed decoding body")
+	require.Equal(t, "Bearer secret-key", captured.authHeader)
+	require.Equal(t, "application/json", captured.contentType)
+	require.Equal(t, "tid-abc", captured.body.TransactionalID)
+	require.Equal(t, "alice@example.com", captured.body.Email)
+	require.Equal(t, map[string]string{"workspace_name": "Acme"}, captured.body.DataVariables)
+	require.True(t, captured.body.AddToAudience)
 }
 
 func TestHTTPClient_SendTransactional_ErrorOnNon200(t *testing.T) {
@@ -182,12 +203,18 @@ func TestHTTPClient_SendTransactional_ContextCancelled(t *testing.T) {
 func TestHTTPClient_SendTransactional_OmitsEmptyVariables(t *testing.T) {
 	t.Parallel()
 
-	var rawBody []byte
+	var (
+		mu      sync.Mutex
+		rawBody []byte
+		readErr error
+	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		mu.Lock()
 		rawBody = body
+		readErr = err
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"success":true}`))
 	}))
@@ -203,15 +230,26 @@ func TestHTTPClient_SendTransactional_OmitsEmptyVariables(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	mu.Lock()
+	defer mu.Unlock()
+	require.NoError(t, readErr)
 	require.NotContains(t, string(rawBody), "dataVariables")
 	require.NotContains(t, string(rawBody), "addToAudience")
 }
 
+func newTestPolicy(t *testing.T) *guardian.Policy {
+	t.Helper()
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	return policy
+}
+
 func newTestHTTPClient(t *testing.T, baseURL, apiKey string) *httpClient {
 	t.Helper()
+	policy := newTestPolicy(t)
 	return &httpClient{
 		logger:     testenv.NewLogger(t),
-		httpClient: http.DefaultClient,
+		httpClient: policy.PooledClient(),
 		baseURL:    baseURL,
 		apiKey:     apiKey,
 	}

--- a/server/internal/thirdparty/loops/client_test.go
+++ b/server/internal/thirdparty/loops/client_test.go
@@ -96,7 +96,7 @@ func TestHTTPClient_SendTransactional_SendsExpectedRequest(t *testing.T) {
 	err := c.SendTransactional(t.Context(), SendTransactionalInput{
 		TransactionalID: "tid-abc",
 		Email:           "alice@example.com",
-		DataVariables:   map[string]string{"workspace_name": "Acme"},
+		DataVariables:   map[string]string{"organization_name": "Acme"},
 		AddToAudience:   true,
 	})
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestHTTPClient_SendTransactional_SendsExpectedRequest(t *testing.T) {
 	require.Equal(t, "application/json", captured.contentType)
 	require.Equal(t, "tid-abc", captured.body.TransactionalID)
 	require.Equal(t, "alice@example.com", captured.body.Email)
-	require.Equal(t, map[string]string{"workspace_name": "Acme"}, captured.body.DataVariables)
+	require.Equal(t, map[string]string{"organization_name": "Acme"}, captured.body.DataVariables)
 	require.True(t, captured.body.AddToAudience)
 }
 


### PR DESCRIPTION
## Summary

Extracts the Loops transactional email client from #1403 and wraps it in a strongly typed `email.Service` facade. The facade enforces at compile time that every send call passes the right merge variables for its template, so we can never ship a half-rendered email because someone misspelled a variable key.

### Packages

- `server/internal/thirdparty/loops` — pure HTTP transport. `loops.New(logger, apiKey)` always returns a usable `Client`: a real HTTP client when configured, a no-op that logs and drops calls otherwise. No `nil` checks needed at call sites.
- `server/internal/email` — application facade. Exposes `Service.Send(ctx, recipient, template)` plus the `Template` interface and the `RegisteredTemplates` registry that holds every Loops transactional ID we know about.

### Send API

```go
err := emailService.Send(ctx, "alice@example.com", email.TeamInvite{
    InviteLink:       "https://app.gram.sh/invite?token=...",
    InviterName:      "Bob",
    InviterEmail:     "bob@example.com",
    OrganizationName: "Acme Corp",
})
```

The compiler rejects passing fields the template doesn't define, and you cannot send a template without a registered transactional ID — `Send` returns `email.ErrUnregisteredTemplate` in that case (and `email.ErrEmptyRecipient` for an empty `To`).

### Adding a new template

1. **Register an ID** — add a `transactionalID<Name>` constant to `templates.go`. This file is the single, grep-friendly registry of every Loops template the application knows about.
2. **Define the struct** — create `template_<name>.go` with exported fields for the merge variables, e.g.:
   ```go
   type PasswordReset struct {
       ResetLink string
       UserName  string
   }
   ```
3. **Implement `Template`** — three small methods:
   ```go
   func (PasswordReset) TransactionalID() TransactionalID { return transactionalIDPasswordReset }
   func (p PasswordReset) Variables() map[string]string {
       return map[string]string{"reset_link": p.ResetLink, "user_name": p.UserName}
   }
   func (PasswordReset) AddToAudience() bool { return false }
   ```
4. **Append to `RegisteredTemplates`** — `templates_test.go` then automatically asserts the new ID is non-empty and unique.

### Tests (19 total)

- `loops`: noop selection on empty/`unset` API key, real client wiring, request shape (auth header, content-type, body), HTTP error and Loops `success:false` paths, malformed JSON, context cancellation, and that empty optional fields are omitted from the JSON payload.
- `email`: template → `loops.SendTransactionalInput` translation, sentinel errors for empty recipient and unregistered template, transport error propagation with template ID context, per-template `AddToAudience` honoured, nil variables forwarded.
- `email/templates`: every entry in `RegisteredTemplates` has a non-empty ID, IDs are unique, `TeamInvite` returns the expected merge keys.

## Test plan

- [x] `go build ./internal/thirdparty/loops/... ./internal/email/...`
- [x] `go test ./internal/thirdparty/loops/... ./internal/email/...`
- [x] `go vet ./...`
- [ ] `mise lint:server` (run in CI)