### PR TITLE
chore: mock Presidio analyzer in tests instead of pulling container

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -674,11 +674,8 @@ jobs:
             ${{ env.GOCACHE }}
             ${{ env.GOMODCACHE }}
 
-      - name: Install Go deps & pre-pull test images
-        run: |
-          docker pull mcr.microsoft.com/presidio-analyzer:2.2.362 &
-          mise run install:go
-          wait
+      - name: Install Go deps
+        run: mise run install:go
 
       - name: Test
         run: mise run test:server

--- a/server/internal/background/activities/risk_analysis/presidiotest/server.go
+++ b/server/internal/background/activities/risk_analysis/presidiotest/server.go
@@ -8,6 +8,7 @@ package presidiotest
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -50,17 +51,20 @@ type MockServer struct {
 }
 
 // NewMockServer starts an httptest server bound to a random localhost port
-// and registers t.Cleanup to shut it down at the end of the test. Pass
-// nil for testing.TB outside of a test (e.g. testenv.Launch) and call Close
+// and registers tb.Cleanup to shut it down at the end of the test. Pass
+// nil for *testing.T outside of a test (e.g. testenv.Launch) and call Close
 // manually.
-func NewMockServer(t testing.TB, logger *slog.Logger) *MockServer {
+func NewMockServer(tb *testing.T, logger *slog.Logger) *MockServer {
 	if logger == nil {
-		logger = slog.New(slog.DiscardHandler)
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 
 	m := &MockServer{
-		logger:   logger,
-		detector: DefaultDetector,
+		logger:      logger,
+		detector:    DefaultDetector,
+		srv:         nil,
+		mu:          sync.RWMutex{},
+		analyzeReqs: atomic.Int64{},
 	}
 
 	mux := http.NewServeMux()
@@ -68,8 +72,8 @@ func NewMockServer(t testing.TB, logger *slog.Logger) *MockServer {
 	mux.HandleFunc("POST /analyze", m.handleAnalyze)
 	m.srv = httptest.NewServer(mux)
 
-	if t != nil {
-		t.Cleanup(m.Close)
+	if tb != nil {
+		tb.Cleanup(m.Close)
 	}
 
 	return m

--- a/server/internal/background/activities/risk_analysis/presidiotest/server.go
+++ b/server/internal/background/activities/risk_analysis/presidiotest/server.go
@@ -1,0 +1,352 @@
+// Package presidiotest provides an in-process mock of the Presidio Analyzer
+// HTTP API. It speaks the same wire protocol as the real
+// mcr.microsoft.com/presidio-analyzer image but performs deterministic regex
+// based detection for the entity types Gram cares about. Tests get sub-second
+// startup and stable output instead of waiting on the ML container to boot.
+package presidiotest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// Result mirrors a single entity returned by the Presidio analyzer over the
+// wire. Exported so tests that override the detector can construct results
+// directly.
+type Result struct {
+	EntityType string  `json:"entity_type"`
+	Start      int     `json:"start"`
+	End        int     `json:"end"`
+	Score      float64 `json:"score"`
+}
+
+// Detector returns the entities Presidio would report for a single text.
+// When entities is empty, the detector should return its full default set.
+// When non-empty, it should return only entities in the allow-list.
+type Detector func(text string, entities []string) []Result
+
+// MockServer is an in-process HTTP server that responds on the Presidio
+// Analyzer endpoints (/health, /analyze). The default detector recognises
+// EMAIL_ADDRESS, CREDIT_CARD, PHONE_NUMBER, URL, and PERSON via regex; tests
+// can swap it out with SetDetector for failure-mode coverage.
+type MockServer struct {
+	logger      *slog.Logger
+	srv         *httptest.Server
+	mu          sync.RWMutex
+	detector    Detector
+	analyzeReqs atomic.Int64
+}
+
+// NewMockServer starts an httptest server bound to a random localhost port
+// and registers t.Cleanup to shut it down at the end of the test. Pass
+// nil for testing.TB outside of a test (e.g. testenv.Launch) and call Close
+// manually.
+func NewMockServer(t testing.TB, logger *slog.Logger) *MockServer {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+
+	m := &MockServer{
+		logger:   logger,
+		detector: DefaultDetector,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", m.handleHealth)
+	mux.HandleFunc("POST /analyze", m.handleAnalyze)
+	m.srv = httptest.NewServer(mux)
+
+	if t != nil {
+		t.Cleanup(m.Close)
+	}
+
+	return m
+}
+
+// URL returns the base URL of the mock server, suitable for passing to
+// risk_analysis.NewPresidioClient.
+func (m *MockServer) URL() string {
+	return m.srv.URL
+}
+
+// ParsedURL returns URL() pre-parsed for callers that need a *url.URL.
+func (m *MockServer) ParsedURL() *url.URL {
+	u, err := url.Parse(m.srv.URL)
+	if err != nil {
+		panic(fmt.Sprintf("presidiotest: parse server URL: %v", err))
+	}
+	return u
+}
+
+// Close shuts the underlying httptest server down. Safe to call multiple
+// times; the second call is a no-op.
+func (m *MockServer) Close() {
+	m.srv.Close()
+}
+
+// SetDetector overrides the default detector. Useful for tests that want to
+// simulate specific Presidio responses or failure modes.
+func (m *MockServer) SetDetector(d Detector) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if d == nil {
+		d = DefaultDetector
+	}
+	m.detector = d
+}
+
+// AnalyzeRequestCount returns the number of /analyze requests served. Useful
+// for tests that want to assert the client batched as expected.
+func (m *MockServer) AnalyzeRequestCount() int64 {
+	return m.analyzeReqs.Load()
+}
+
+func (m *MockServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("Presidio Analyzer service is up"))
+}
+
+type analyzeRequest struct {
+	Text     []string `json:"text"`
+	Language string   `json:"language"`
+	ScoreMin float64  `json:"score_threshold"`
+	Entities []string `json:"entities,omitempty"`
+}
+
+func (m *MockServer) handleAnalyze(w http.ResponseWriter, r *http.Request) {
+	m.analyzeReqs.Add(1)
+
+	ctx := r.Context()
+
+	var req analyzeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Real Presidio 500s on an empty text array; mirror that so client
+	// short-circuit logic stays honest.
+	if len(req.Text) == 0 {
+		http.Error(w, "No text provided", http.StatusInternalServerError)
+		return
+	}
+
+	m.mu.RLock()
+	detector := m.detector
+	m.mu.RUnlock()
+
+	out := make([][]Result, len(req.Text))
+	for i, text := range req.Text {
+		findings := detector(text, req.Entities)
+		// Apply the request's score threshold, matching real Presidio.
+		filtered := findings[:0]
+		for _, f := range findings {
+			if f.Score >= req.ScoreMin {
+				filtered = append(filtered, f)
+			}
+		}
+		out[i] = filtered
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		m.logger.ErrorContext(ctx, "presidiotest: encode response", attr.SlogError(err))
+	}
+}
+
+// DefaultDetector is the built-in deterministic detector used when callers
+// don't override one. It recognises a curated set of entities chosen to
+// satisfy the production code paths Gram exercises in tests:
+//
+//   - EMAIL_ADDRESS  matches RFC-ish local@domain.tld
+//   - CREDIT_CARD    13-19 digit groups with optional separators, Luhn-valid
+//   - PHONE_NUMBER   NANP triplet (3-3-4 with - or space) or +CC prefix
+//   - URL            http(s) URLs
+//   - PERSON         two adjacent capitalised words (mirrors NER false-positive
+//     prone behaviour of real Presidio)
+//
+// Score values are picked to roughly match what real Presidio returns so that
+// client-side confidence thresholds behave the same way.
+func DefaultDetector(text string, entities []string) []Result {
+	allowed := allowSet(entities)
+
+	var out []Result
+	if allowed("EMAIL_ADDRESS") {
+		out = append(out, matchAll(text, emailRegex, "EMAIL_ADDRESS", 1.0)...)
+	}
+	if allowed("URL") {
+		out = append(out, matchAll(text, urlRegex, "URL", 0.95)...)
+	}
+	if allowed("CREDIT_CARD") {
+		out = append(out, detectCreditCards(text)...)
+	}
+	if allowed("PHONE_NUMBER") {
+		out = append(out, detectPhoneNumbers(text)...)
+	}
+	if allowed("PERSON") {
+		out = append(out, detectPersons(text)...)
+	}
+	return out
+}
+
+// allowSet returns a predicate. When entities is empty, every entity type is
+// allowed; otherwise only those in the list.
+func allowSet(entities []string) func(string) bool {
+	if len(entities) == 0 {
+		return func(string) bool { return true }
+	}
+	set := make(map[string]struct{}, len(entities))
+	for _, e := range entities {
+		set[e] = struct{}{}
+	}
+	return func(e string) bool {
+		_, ok := set[e]
+		return ok
+	}
+}
+
+var (
+	emailRegex = regexp.MustCompile(`[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}`)
+	urlRegex   = regexp.MustCompile(`https?://[^\s"')]+`)
+	// NANP-style 3-3-4 with dash, dot, or space separators. Anchored on word
+	// boundaries so version strings like "1.234.567.890" don't match.
+	phoneNANPRegex = regexp.MustCompile(`\b\d{3}[-\s]\d{3}[-\s]\d{4}\b`)
+	// International prefix + at least 8 digits (any spacing in between).
+	phoneIntlRegex = regexp.MustCompile(`\+\d{1,3}(?:[\s\-]?\d){7,}`)
+	// Two adjacent capitalised words. Matches Presidio's NER bias toward
+	// over-flagging proper nouns.
+	personRegex = regexp.MustCompile(`\b[A-Z][a-z]+ [A-Z][a-z]+\b`)
+	// 13-19 digits with optional - or space separators. Luhn check applied.
+	creditCardRegex = regexp.MustCompile(`\b(?:\d[ \-]?){12,18}\d\b`)
+)
+
+func matchAll(text string, re *regexp.Regexp, entityType string, score float64) []Result {
+	idxs := re.FindAllStringIndex(text, -1)
+	if len(idxs) == 0 {
+		return nil
+	}
+	out := make([]Result, 0, len(idxs))
+	for _, idx := range idxs {
+		out = append(out, Result{
+			EntityType: entityType,
+			Start:      runeIndex(text, idx[0]),
+			End:        runeIndex(text, idx[1]),
+			Score:      score,
+		})
+	}
+	return out
+}
+
+func detectCreditCards(text string) []Result {
+	idxs := creditCardRegex.FindAllStringIndex(text, -1)
+	if len(idxs) == 0 {
+		return nil
+	}
+	var out []Result
+	for _, idx := range idxs {
+		raw := text[idx[0]:idx[1]]
+		digits := stripNonDigits(raw)
+		if len(digits) < 13 || len(digits) > 19 {
+			continue
+		}
+		if !luhnValid(digits) {
+			continue
+		}
+		out = append(out, Result{
+			EntityType: "CREDIT_CARD",
+			Start:      runeIndex(text, idx[0]),
+			End:        runeIndex(text, idx[1]),
+			Score:      1.0,
+		})
+	}
+	return out
+}
+
+func detectPhoneNumbers(text string) []Result {
+	var out []Result
+	for _, idx := range phoneNANPRegex.FindAllStringIndex(text, -1) {
+		out = append(out, Result{
+			EntityType: "PHONE_NUMBER",
+			Start:      runeIndex(text, idx[0]),
+			End:        runeIndex(text, idx[1]),
+			Score:      0.75,
+		})
+	}
+	for _, idx := range phoneIntlRegex.FindAllStringIndex(text, -1) {
+		out = append(out, Result{
+			EntityType: "PHONE_NUMBER",
+			Start:      runeIndex(text, idx[0]),
+			End:        runeIndex(text, idx[1]),
+			Score:      0.75,
+		})
+	}
+	return out
+}
+
+func detectPersons(text string) []Result {
+	idxs := personRegex.FindAllStringIndex(text, -1)
+	if len(idxs) == 0 {
+		return nil
+	}
+	out := make([]Result, 0, len(idxs))
+	for _, idx := range idxs {
+		out = append(out, Result{
+			EntityType: "PERSON",
+			Start:      runeIndex(text, idx[0]),
+			End:        runeIndex(text, idx[1]),
+			Score:      0.85,
+		})
+	}
+	return out
+}
+
+func stripNonDigits(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func luhnValid(digits string) bool {
+	sum := 0
+	parity := len(digits) % 2
+	for i, r := range digits {
+		d, err := strconv.Atoi(string(r))
+		if err != nil {
+			return false
+		}
+		if i%2 == parity {
+			d *= 2
+			if d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+	}
+	return sum%10 == 0
+}
+
+// runeIndex converts a byte offset into a rune offset, matching Presidio's
+// rune-based output positions. The PresidioClient converts back to bytes.
+func runeIndex(s string, byteOffset int) int {
+	if byteOffset >= len(s) {
+		return len([]rune(s))
+	}
+	return len([]rune(s[:byteOffset]))
+}

--- a/server/internal/background/activities/risk_analysis/presidiotest/server.go
+++ b/server/internal/background/activities/risk_analysis/presidiotest/server.go
@@ -150,7 +150,7 @@ func (m *MockServer) handleAnalyze(w http.ResponseWriter, r *http.Request) {
 	for i, text := range req.Text {
 		findings := detector(text, req.Entities)
 		// Apply the request's score threshold, matching real Presidio.
-		filtered := findings[:0]
+		var filtered []Result
 		for _, f := range findings {
 			if f.Score >= req.ScoreMin {
 				filtered = append(filtered, f)

--- a/server/internal/background/activities/risk_analysis/presidiotest/server.go
+++ b/server/internal/background/activities/risk_analysis/presidiotest/server.go
@@ -8,7 +8,6 @@ package presidiotest
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +17,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"testing"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
@@ -50,13 +48,14 @@ type MockServer struct {
 	analyzeReqs atomic.Int64
 }
 
-// NewMockServer starts an httptest server bound to a random localhost port
-// and registers tb.Cleanup to shut it down at the end of the test. Pass
-// nil for *testing.T outside of a test (e.g. testenv.Launch) and call Close
-// manually.
-func NewMockServer(tb *testing.T, logger *slog.Logger) *MockServer {
+// NewMockServer starts an httptest server bound to a random localhost port.
+// Callers are responsible for calling Close (or registering t.Cleanup) when
+// the server is no longer needed.
+func NewMockServer(logger *slog.Logger) *MockServer {
 	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+		// Import cycle (testenv → presidiotest → testenv) prevents calling
+		// testenv.NewLogger here, so we use slog.DiscardHandler directly.
+		logger = slog.New(slog.DiscardHandler) //nolint:forbidigo // import cycle prevents testenv.NewLogger
 	}
 
 	m := &MockServer{
@@ -71,10 +70,6 @@ func NewMockServer(tb *testing.T, logger *slog.Logger) *MockServer {
 	mux.HandleFunc("GET /health", m.handleHealth)
 	mux.HandleFunc("POST /analyze", m.handleAnalyze)
 	m.srv = httptest.NewServer(mux)
-
-	if tb != nil {
-		tb.Cleanup(m.Close)
-	}
 
 	return m
 }

--- a/server/internal/background/activities/risk_analysis/presidiotest/server_test.go
+++ b/server/internal/background/activities/risk_analysis/presidiotest/server_test.go
@@ -18,7 +18,8 @@ import (
 
 func newClient(t *testing.T) (*presidiotest.MockServer, *risk_analysis.PresidioClient) {
 	t.Helper()
-	server := presidiotest.NewMockServer(t, nil)
+	server := presidiotest.NewMockServer(nil)
+	t.Cleanup(server.Close)
 	client := risk_analysis.NewPresidioClient(
 		server.URL(),
 		testenv.NewTracerProvider(t),
@@ -208,7 +209,8 @@ func TestMockServer_AnalyzeRequestCount(t *testing.T) {
 
 func TestMockServer_HealthEndpointReturnsOK(t *testing.T) {
 	t.Parallel()
-	server := presidiotest.NewMockServer(t, nil)
+	server := presidiotest.NewMockServer(nil)
+	t.Cleanup(server.Close)
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL()+"/health", nil)
 	require.NoError(t, err)
@@ -224,7 +226,8 @@ func TestMockServer_HealthEndpointReturnsOK(t *testing.T) {
 
 func TestMockServer_ScoreThresholdFiltersResults(t *testing.T) {
 	t.Parallel()
-	server := presidiotest.NewMockServer(t, nil)
+	server := presidiotest.NewMockServer(nil)
+	t.Cleanup(server.Close)
 
 	// PHONE_NUMBER scores 0.75 in the default detector; threshold 0.9 drops it.
 	high := postAnalyze(t, server.URL(), `{"text":["call 425-882-8080"],"language":"en","score_threshold":0.9}`)

--- a/server/internal/background/activities/risk_analysis/presidiotest/server_test.go
+++ b/server/internal/background/activities/risk_analysis/presidiotest/server_test.go
@@ -1,0 +1,261 @@
+package presidiotest_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidiotest"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func newClient(t *testing.T) (*presidiotest.MockServer, *risk_analysis.PresidioClient) {
+	t.Helper()
+	server := presidiotest.NewMockServer(t, nil)
+	client := risk_analysis.NewPresidioClient(
+		server.URL(),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		testenv.NewLogger(t),
+	)
+	return server, client
+}
+
+func ruleIDs(findings []risk_analysis.Finding) []string {
+	out := make([]string, len(findings))
+	for i, f := range findings {
+		out[i] = f.RuleID
+	}
+	return out
+}
+
+func TestMockServer_DetectsEmail(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"contact me at john.smith@acmecorp.com",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	ids := ruleIDs(results[0])
+	assert.Contains(t, ids, "EMAIL_ADDRESS")
+	for _, f := range results[0] {
+		if f.RuleID == "EMAIL_ADDRESS" {
+			assert.Equal(t, "john.smith@acmecorp.com", f.Match)
+			assert.Equal(t, "presidio", f.Source)
+		}
+	}
+}
+
+func TestMockServer_DetectsCreditCardWithLuhnCheck(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"My credit card is 4111111111111111",
+		"Card: 5500-0000-0000-0004",
+		"Bogus card 4111111111111112 not detected",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	assert.Contains(t, ruleIDs(results[0]), "CREDIT_CARD")
+	assert.Contains(t, ruleIDs(results[1]), "CREDIT_CARD")
+	assert.NotContains(t, ruleIDs(results[2]), "CREDIT_CARD")
+}
+
+func TestMockServer_DetectsPhoneNumber(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"call me at 425-882-8080 thanks",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, ruleIDs(results[0]), "PHONE_NUMBER")
+}
+
+func TestMockServer_DetectsPersonName(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"My name is John Smith and I'm here",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Contains(t, ruleIDs(results[0]), "PERSON")
+}
+
+func TestMockServer_NoFalsePositiveOnVersionString(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"Version 1.234.567.890 was released",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	for _, f := range results[0] {
+		assert.NotEqual(t, "PHONE_NUMBER", f.RuleID, "version string should not match phone regex")
+	}
+}
+
+func TestMockServer_NoFalsePositiveOnUUID(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"Transaction: 550e8400-e29b-41d4-a716-446655440000",
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	for _, f := range results[0] {
+		assert.NotEqual(t, "CREDIT_CARD", f.RuleID)
+	}
+}
+
+func TestMockServer_EntityFilterRespected(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{
+		"call 425-882-8080 or email alice@example.com",
+	}, []string{"EMAIL_ADDRESS"}, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	ids := ruleIDs(results[0])
+	assert.Contains(t, ids, "EMAIL_ADDRESS")
+	assert.NotContains(t, ids, "PHONE_NUMBER")
+}
+
+func TestMockServer_BatchResultsMapBackToInputIndexes(t *testing.T) {
+	t.Parallel()
+	_, client := newClient(t)
+
+	const n = 75
+	emails := make([]string, n)
+	messages := make([]string, n)
+	for i := range messages {
+		emails[i] = "user" + strconv.Itoa(i) + "@example.com"
+		messages[i] = "message " + strconv.Itoa(i) + " contact " + emails[i] + " end"
+	}
+
+	results, err := client.AnalyzeBatch(t.Context(), messages, []string{"EMAIL_ADDRESS"}, nil)
+	require.NoError(t, err)
+	require.Len(t, results, n)
+
+	for i, findings := range results {
+		var got string
+		for _, f := range findings {
+			if f.RuleID == "EMAIL_ADDRESS" {
+				got = f.Match
+				break
+			}
+		}
+		assert.Equal(t, emails[i], got, "message %d mapped to wrong finding", i)
+	}
+}
+
+func TestMockServer_CustomDetectorOverride(t *testing.T) {
+	t.Parallel()
+	server, client := newClient(t)
+
+	server.SetDetector(func(text string, _ []string) []presidiotest.Result {
+		return []presidiotest.Result{{
+			EntityType: "CUSTOM_ENTITY",
+			Start:      0,
+			End:        len([]rune(text)),
+			Score:      1.0,
+		}}
+	})
+
+	results, err := client.AnalyzeBatch(t.Context(), []string{"anything"}, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0], 1)
+	assert.Equal(t, "CUSTOM_ENTITY", results[0][0].RuleID)
+	assert.Equal(t, "anything", results[0][0].Match)
+}
+
+func TestMockServer_AnalyzeRequestCount(t *testing.T) {
+	t.Parallel()
+	server, client := newClient(t)
+
+	messages := make([]string, 75)
+	for i := range messages {
+		messages[i] = "msg " + strconv.Itoa(i)
+	}
+
+	_, err := client.AnalyzeBatch(t.Context(), messages, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), server.AnalyzeRequestCount())
+}
+
+func TestMockServer_HealthEndpointReturnsOK(t *testing.T) {
+	t.Parallel()
+	server := presidiotest.NewMockServer(t, nil)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL()+"/health", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Presidio Analyzer")
+}
+
+func TestMockServer_ScoreThresholdFiltersResults(t *testing.T) {
+	t.Parallel()
+	server := presidiotest.NewMockServer(t, nil)
+
+	// PHONE_NUMBER scores 0.75 in the default detector; threshold 0.9 drops it.
+	high := postAnalyze(t, server.URL(), `{"text":["call 425-882-8080"],"language":"en","score_threshold":0.9}`)
+	require.Len(t, high, 1)
+	for _, r := range high[0] {
+		assert.NotEqual(t, "PHONE_NUMBER", r.EntityType)
+	}
+
+	low := postAnalyze(t, server.URL(), `{"text":["call 425-882-8080"],"language":"en","score_threshold":0.5}`)
+	require.Len(t, low, 1)
+	hasPhone := false
+	for _, r := range low[0] {
+		if r.EntityType == "PHONE_NUMBER" {
+			hasPhone = true
+		}
+	}
+	assert.True(t, hasPhone)
+}
+
+func postAnalyze(t *testing.T, baseURL, body string) [][]presidiotest.Result {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, baseURL+"/analyze", bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out [][]presidiotest.Result
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	return out
+}

--- a/server/internal/background/activities/risk_analysis/presidiotest/server_test.go
+++ b/server/internal/background/activities/risk_analysis/presidiotest/server_test.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
@@ -48,11 +47,11 @@ func TestMockServer_DetectsEmail(t *testing.T) {
 	require.Len(t, results, 1)
 
 	ids := ruleIDs(results[0])
-	assert.Contains(t, ids, "EMAIL_ADDRESS")
+	require.Contains(t, ids, "EMAIL_ADDRESS")
 	for _, f := range results[0] {
 		if f.RuleID == "EMAIL_ADDRESS" {
-			assert.Equal(t, "john.smith@acmecorp.com", f.Match)
-			assert.Equal(t, "presidio", f.Source)
+			require.Equal(t, "john.smith@acmecorp.com", f.Match)
+			require.Equal(t, "presidio", f.Source)
 		}
 	}
 }
@@ -69,9 +68,9 @@ func TestMockServer_DetectsCreditCardWithLuhnCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 
-	assert.Contains(t, ruleIDs(results[0]), "CREDIT_CARD")
-	assert.Contains(t, ruleIDs(results[1]), "CREDIT_CARD")
-	assert.NotContains(t, ruleIDs(results[2]), "CREDIT_CARD")
+	require.Contains(t, ruleIDs(results[0]), "CREDIT_CARD")
+	require.Contains(t, ruleIDs(results[1]), "CREDIT_CARD")
+	require.NotContains(t, ruleIDs(results[2]), "CREDIT_CARD")
 }
 
 func TestMockServer_DetectsPhoneNumber(t *testing.T) {
@@ -83,7 +82,7 @@ func TestMockServer_DetectsPhoneNumber(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Contains(t, ruleIDs(results[0]), "PHONE_NUMBER")
+	require.Contains(t, ruleIDs(results[0]), "PHONE_NUMBER")
 }
 
 func TestMockServer_DetectsPersonName(t *testing.T) {
@@ -95,7 +94,7 @@ func TestMockServer_DetectsPersonName(t *testing.T) {
 	}, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Contains(t, ruleIDs(results[0]), "PERSON")
+	require.Contains(t, ruleIDs(results[0]), "PERSON")
 }
 
 func TestMockServer_NoFalsePositiveOnVersionString(t *testing.T) {
@@ -109,7 +108,7 @@ func TestMockServer_NoFalsePositiveOnVersionString(t *testing.T) {
 	require.Len(t, results, 1)
 
 	for _, f := range results[0] {
-		assert.NotEqual(t, "PHONE_NUMBER", f.RuleID, "version string should not match phone regex")
+		require.NotEqual(t, "PHONE_NUMBER", f.RuleID, "version string should not match phone regex")
 	}
 }
 
@@ -124,7 +123,7 @@ func TestMockServer_NoFalsePositiveOnUUID(t *testing.T) {
 	require.Len(t, results, 1)
 
 	for _, f := range results[0] {
-		assert.NotEqual(t, "CREDIT_CARD", f.RuleID)
+		require.NotEqual(t, "CREDIT_CARD", f.RuleID)
 	}
 }
 
@@ -139,8 +138,8 @@ func TestMockServer_EntityFilterRespected(t *testing.T) {
 	require.Len(t, results, 1)
 
 	ids := ruleIDs(results[0])
-	assert.Contains(t, ids, "EMAIL_ADDRESS")
-	assert.NotContains(t, ids, "PHONE_NUMBER")
+	require.Contains(t, ids, "EMAIL_ADDRESS")
+	require.NotContains(t, ids, "PHONE_NUMBER")
 }
 
 func TestMockServer_BatchResultsMapBackToInputIndexes(t *testing.T) {
@@ -167,7 +166,7 @@ func TestMockServer_BatchResultsMapBackToInputIndexes(t *testing.T) {
 				break
 			}
 		}
-		assert.Equal(t, emails[i], got, "message %d mapped to wrong finding", i)
+		require.Equal(t, emails[i], got, "message %d mapped to wrong finding", i)
 	}
 }
 
@@ -188,8 +187,8 @@ func TestMockServer_CustomDetectorOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Len(t, results[0], 1)
-	assert.Equal(t, "CUSTOM_ENTITY", results[0][0].RuleID)
-	assert.Equal(t, "anything", results[0][0].Match)
+	require.Equal(t, "CUSTOM_ENTITY", results[0][0].RuleID)
+	require.Equal(t, "anything", results[0][0].Match)
 }
 
 func TestMockServer_AnalyzeRequestCount(t *testing.T) {
@@ -204,7 +203,7 @@ func TestMockServer_AnalyzeRequestCount(t *testing.T) {
 	_, err := client.AnalyzeBatch(t.Context(), messages, nil, nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(2), server.AnalyzeRequestCount())
+	require.Equal(t, int64(2), server.AnalyzeRequestCount())
 }
 
 func TestMockServer_HealthEndpointReturnsOK(t *testing.T) {
@@ -218,10 +217,10 @@ func TestMockServer_HealthEndpointReturnsOK(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Contains(t, string(body), "Presidio Analyzer")
+	require.Contains(t, string(body), "Presidio Analyzer")
 }
 
 func TestMockServer_ScoreThresholdFiltersResults(t *testing.T) {
@@ -233,7 +232,7 @@ func TestMockServer_ScoreThresholdFiltersResults(t *testing.T) {
 	high := postAnalyze(t, server.URL(), `{"text":["call 425-882-8080"],"language":"en","score_threshold":0.9}`)
 	require.Len(t, high, 1)
 	for _, r := range high[0] {
-		assert.NotEqual(t, "PHONE_NUMBER", r.EntityType)
+		require.NotEqual(t, "PHONE_NUMBER", r.EntityType)
 	}
 
 	low := postAnalyze(t, server.URL(), `{"text":["call 425-882-8080"],"language":"en","score_threshold":0.5}`)
@@ -244,7 +243,7 @@ func TestMockServer_ScoreThresholdFiltersResults(t *testing.T) {
 			hasPhone = true
 		}
 	}
-	assert.True(t, hasPhone)
+	require.True(t, hasPhone)
 }
 
 func postAnalyze(t *testing.T, baseURL, body string) [][]presidiotest.Result {

--- a/server/internal/testenv/launch.go
+++ b/server/internal/testenv/launch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidiotest"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -46,7 +47,7 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 	var pgcontainer terminateable
 	var rediscontainer terminateable
 	var clickhousecontainer terminateable
-	var presidiocontainer terminateable
+	var presidioserver *presidiotest.MockServer
 	var temporalserver *testsuite.DevServer
 	var temporalserverErr error
 	var temporalserverOnce sync.Once
@@ -98,24 +99,23 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 	}
 
 	if opts.Presidio {
-		launchEg.Go(func() error {
-			container, pcFactory, err := NewTestPresidio(ctx)
-			if err != nil {
-				return fmt.Errorf("start presidio container: %w", err)
-			}
-			presidiocontainer = container
-			res.NewPresidioClient = pcFactory
-			return nil
-		})
+		// In-process mock — no goroutine needed. The mock starts an
+		// httptest.Server synchronously and never fails.
+		server, pcFactory := NewTestPresidio()
+		presidioserver = server
+		res.NewPresidioClient = pcFactory
 	}
 
 	if err := launchEg.Wait(); err != nil {
-		for _, c := range []terminateable{pgcontainer, rediscontainer, clickhousecontainer, presidiocontainer} {
+		for _, c := range []terminateable{pgcontainer, rediscontainer, clickhousecontainer} {
 			if c != nil {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				_ = c.Terminate(ctx)
 				cancel()
 			}
+		}
+		if presidioserver != nil {
+			presidioserver.Close()
 		}
 		return nil, nil, fmt.Errorf("start containers: %w", err)
 	}
@@ -168,15 +168,8 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 				return nil
 			})
 		}
-		if presidiocontainer != nil {
-			eg.Go(func() error {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				defer cancel()
-				if err := presidiocontainer.Terminate(ctx); err != nil {
-					log.Printf("terminate presidio container: %v", err)
-				}
-				return nil
-			})
+		if presidioserver != nil {
+			presidioserver.Close()
 		}
 		if temporalserver != nil {
 			eg.Go(func() error {

--- a/server/internal/testenv/presidio.go
+++ b/server/internal/testenv/presidio.go
@@ -14,7 +14,7 @@ type PresidioClientFunc func(t *testing.T) *risk_analysis.PresidioClient
 // the same HTTP API the real Presidio Analyzer exposes, so tests skip the
 // 60s+ container boot and avoid CI flakes from the ML image.
 func NewTestPresidio() (*presidiotest.MockServer, PresidioClientFunc) {
-	server := presidiotest.NewMockServer(nil, nil)
+	server := presidiotest.NewMockServer(nil)
 	return server, newPresidioClientFunc(server)
 }
 

--- a/server/internal/testenv/presidio.go
+++ b/server/internal/testenv/presidio.go
@@ -1,58 +1,29 @@
 package testenv
 
 import (
-	"context"
-	"fmt"
-	"log"
 	"testing"
-	"time"
 
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidiotest"
 )
 
 type PresidioClientFunc func(t *testing.T) *risk_analysis.PresidioClient
 
-func NewTestPresidio(ctx context.Context) (testcontainers.Container, PresidioClientFunc, error) {
-	startedAt := time.Now()
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mcr.microsoft.com/presidio-analyzer:2.2.362",
-			ExposedPorts: []string{"3000/tcp"},
-			WaitingFor: wait.ForHTTP("/health").
-				WithPort("3000/tcp").
-				WithStartupTimeout(300 * time.Second),
-		},
-		Started: true,
-		Logger:  NewTestcontainersLogger(),
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("start presidio container: %w", err)
-	}
-	log.Printf("presidio container ready in %s", time.Since(startedAt).Round(time.Millisecond))
-
-	return container, newPresidioClientFunc(container), nil
+// NewTestPresidio returns a Presidio client factory backed by an in-process
+// mock server. The mock implements deterministic regex-based detection over
+// the same HTTP API the real Presidio Analyzer exposes, so tests skip the
+// 60s+ container boot and avoid CI flakes from the ML image.
+func NewTestPresidio() (*presidiotest.MockServer, PresidioClientFunc) {
+	server := presidiotest.NewMockServer(nil, nil)
+	return server, newPresidioClientFunc(server)
 }
 
-func newPresidioClientFunc(container testcontainers.Container) PresidioClientFunc {
+func newPresidioClientFunc(server *presidiotest.MockServer) PresidioClientFunc {
 	return func(t *testing.T) *risk_analysis.PresidioClient {
 		t.Helper()
 
-		host, err := container.Host(t.Context())
-		if err != nil {
-			t.Fatalf("get presidio container host: %v", err)
-		}
-
-		port, err := container.MappedPort(t.Context(), "3000/tcp")
-		if err != nil {
-			t.Fatalf("get presidio container port: %v", err)
-		}
-
-		baseURL := fmt.Sprintf("http://%s:%s", host, port.Port())
-
 		return risk_analysis.NewPresidioClient(
-			baseURL,
+			server.URL(),
 			NewTracerProvider(t),
 			NewMeterProvider(t),
 			NewLogger(t),


### PR DESCRIPTION
Replaces the testcontainers-backed Presidio Analyzer (300s startup, flaky
in CI) with an in-process httptest mock that speaks the same /analyze
and /health wire protocol. The mock's default detector recognises
EMAIL_ADDRESS, CREDIT_CARD (Luhn-validated), PHONE_NUMBER, URL, and
PERSON via regex — enough to satisfy the PII detection tests
deterministically. Tests can swap the detector via SetDetector for
failure-mode coverage.

Also drops the docker pull of mcr.microsoft.com/presidio-analyzer from
the PR workflow since it's no longer needed.
