### PR TITLE
mig: add remote_mcp_server_id materialized column to telemetry_logs

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260508132129_add-remote-mcp-server-id-materialized-col.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260508132129_add-remote-mcp-server-id-materialized-col.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` DROP INDEX `idx_telemetry_logs_mat_remote_mcp_server_id`;
+ALTER TABLE `telemetry_logs` DROP COLUMN `remote_mcp_server_id`;

--- a/server/clickhouse/local/golang_migrate/20260508132129_add-remote-mcp-server-id-materialized-col.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260508132129_add-remote-mcp-server-id-materialized-col.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `remote_mcp_server_id` String MATERIALIZED toString(attributes.gram.remote_mcp_server.id) COMMENT 'Remote MCP server ID (materialized from attributes.gram.remote_mcp_server.id).';
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_remote_mcp_server_id` ((remote_mcp_server_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:mtsYaGGBfG25yFXJkc34Xc7cuypeUbKHofEY3rdcs1o=
+h1:WBjuovWQfWDNFlMiFXwzs7A+/MUS0LCABCgqu5EPCtg=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -34,3 +34,4 @@ h1:mtsYaGGBfG25yFXJkc34Xc7cuypeUbKHofEY3rdcs1o=
 20260427192006_add-hook-block-reason.up.sql h1:AYNAwIQG07w6OoCgLMKrgyuLi6n+9GoM3r9NPG/bZSo=
 20260428192411_fix-block-reason-merge.up.sql h1:wwVaPA93KqQ/rN62the3FDyQ2Blv4Z6F61q9w2oRjqE=
 20260430104153_add-authz-challenges-table.up.sql h1:xzosYIiO3fRbLIoIjkhqXnH0zxbhhusvO7HZ80u1w1M=
+20260508132129_add-remote-mcp-server-id-materialized-col.up.sql h1:ONn0mdquOH8+96lVqIInQ881GJ2lTMN+ldJ+LJ9O9KU=

--- a/server/clickhouse/migrations/20260508132124_add-remote-mcp-server-id-materialized-col.sql
+++ b/server/clickhouse/migrations/20260508132124_add-remote-mcp-server-id-materialized-col.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `telemetry_logs` ADD COLUMN `remote_mcp_server_id` String MATERIALIZED toString(attributes.gram.remote_mcp_server.id) COMMENT 'Remote MCP server ID (materialized from attributes.gram.remote_mcp_server.id).';
+ALTER TABLE `telemetry_logs` ADD INDEX `idx_telemetry_logs_mat_remote_mcp_server_id` ((remote_mcp_server_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LVrxiTGaXZiaeo9xnVmcqDmVuQ1pK62jM/+NK+biPCo=
+h1:xQWfgO588JRN80LhFWCZqWe2Z+/QjLA1ZxyLu6fC03o=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -39,3 +39,4 @@ h1:LVrxiTGaXZiaeo9xnVmcqDmVuQ1pK62jM/+NK+biPCo=
 20260427192001_add-hook-block-reason.sql h1:z2tGtdozJRVWhCCyT4KYSNVvhg9/56LJS4GILZvsuxY=
 20260428192408_fix-block-reason-merge.sql h1:bwCGH0lNK9KN4Utw7Bet0CUhtol0LX0BnMgofKKjOCo=
 20260430104149_add-authz-challenges-table.sql h1:1RrvgeCMeUvKN1I8R8whY46WfulVK85U/FZooAIhuu4=
+20260508132124_add-remote-mcp-server-id-materialized-col.sql h1:gmEL5G+Mnjf3KaYVglJ6xxHfCPR8R4Hk3wUn6Sib9sw=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS telemetry_logs (
     user_email String MATERIALIZED toString(attributes.user.email) COMMENT 'User email (materialized from attributes.user.email).',
     hook_source String MATERIALIZED toString(attributes.gram.hook.source) COMMENT 'Hook source (materialized from attributes.gram.hook.source).',
     hook_block_reason String MATERIALIZED toString(attributes.gram.hook.block_reason) COMMENT 'Hook block reason set when the Gram hook denied a tool call (materialized from attributes.gram.hook.block_reason).',
+    remote_mcp_server_id String MATERIALIZED toString(attributes.gram.remote_mcp_server.id) COMMENT 'Remote MCP server ID (materialized from attributes.gram.remote_mcp_server.id).',
     skill_name String MATERIALIZED if(toString(attributes.gram.tool.name) = 'Skill', JSONExtractString(toString(attributes.gen_ai.tool.call.arguments), 'skill'), '') COMMENT 'Skill name extracted from tool arguments when tool_name is Skill (materialized).'
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(fromUnixTimestamp64Nano(time_unix_nano))
@@ -87,6 +88,7 @@ CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_toolset_slug ON telemetry_logs
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_user_email ON telemetry_logs (user_email) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_hook_source ON telemetry_logs (hook_source) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_hook_block_reason ON telemetry_logs (hook_block_reason) TYPE bloom_filter(0.01) GRANULARITY 1;
+CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_remote_mcp_server_id ON telemetry_logs (remote_mcp_server_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_telemetry_logs_mat_skill_name ON telemetry_logs (skill_name) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 CREATE TABLE IF NOT EXISTS trace_summaries (

--- a/server/internal/telemetry/repo/materialized_columns_gen.go
+++ b/server/internal/telemetry/repo/materialized_columns_gen.go
@@ -22,4 +22,5 @@ var materializedColumns = map[string]string{
 	"user.email":                    "user_email",
 	"gram.hook.source":              "hook_source",
 	"gram.hook.block_reason":        "hook_block_reason",
+	"gram.remote_mcp_server.id":     "remote_mcp_server_id",
 }


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2213/add-remote-mcp-server-id-materialized-column-to-telemetry-logs

## Summary

Materializes `attributes.gram.remote_mcp_server.id` on `telemetry_logs` following the `toolset_slug` pattern. Regenerates the `materializedColumns` map so `AttributeFilter.Path` lookups route to the new column.

Unlocks `remote_mcp_server.id` filtering for the upcoming Source Activity panel (AGE-2214). Schema-only change; no app wiring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->