### PR TITLE
fix(dev-toolbar): crash when toggling environment scopes for first time

### DIFF
--- a/.changeset/dev-toolbar-env-scope-crash.md
+++ b/.changeset/dev-toolbar-env-scope-crash.md
@@ -1,0 +1,11 @@
+---
+"dashboard": patch
+---
+
+Fix a crash in the RBAC dev toolbar when toggling `environment:read` or
+`environment:write` for the first time. The toggle handler spread `undefined`
+into a new state entry, producing an object without the `resources` field;
+the next render then crashed reading `.length` on undefined. Hardened
+`toggleScope` and `setScopeResources` to materialize a known-good baseline
+before spreading, and added a defensive `!= null` at the render site so any
+legacy malformed localStorage state can't crash either.

--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -374,16 +374,19 @@ function RBACDevToolbarInner({ onHide }: { onHide: () => void }) {
 
   const toggleScope = useCallback(
     (scope: string) => {
-      setState((prev) => ({
-        ...prev,
-        scopes: {
-          ...prev.scopes,
-          [scope]: {
-            ...prev.scopes[scope],
-            enabled: !prev.scopes[scope]?.enabled,
+      setState((prev) => {
+        const existing = prev.scopes[scope] ?? {
+          enabled: true,
+          resources: null,
+        };
+        return {
+          ...prev,
+          scopes: {
+            ...prev.scopes,
+            [scope]: { ...existing, enabled: !existing.enabled },
           },
-        },
-      }));
+        };
+      });
       if (state.enabled) invalidate();
     },
     [state.enabled, invalidate],
@@ -391,13 +394,19 @@ function RBACDevToolbarInner({ onHide }: { onHide: () => void }) {
 
   const setScopeResources = useCallback(
     (scope: string, resources: string[] | null) => {
-      setState((prev) => ({
-        ...prev,
-        scopes: {
-          ...prev.scopes,
-          [scope]: { ...prev.scopes[scope], resources },
-        },
-      }));
+      setState((prev) => {
+        const existing = prev.scopes[scope] ?? {
+          enabled: true,
+          resources: null,
+        };
+        return {
+          ...prev,
+          scopes: {
+            ...prev.scopes,
+            [scope]: { ...existing, resources },
+          },
+        };
+      });
       if (state.enabled) invalidate();
     },
     [state.enabled, invalidate],
@@ -582,8 +591,10 @@ function RBACDevToolbarInner({ onHide }: { onHide: () => void }) {
                             enabled: true,
                             resources: null,
                           };
+                          // Defensive: legacy localStorage may have entries without `resources`.
+                          // Use loose != null so both null and undefined skip the length read.
                           const isRestricted =
-                            scopeState.resources !== null &&
+                            scopeState.resources != null &&
                             scopeState.resources.length > 0;
                           let knownResources: { id: string; label: string }[] =
                             [];


### PR DESCRIPTION
## Summary

Production bug surfaced after #2561 merged. The RBAC dev toolbar crashes with `TypeError: Cannot read properties of undefined (reading 'length')` at `dev-toolbar.tsx:587` when a user toggles `environment:read` or `environment:write` for the first time.

## Root cause

`toggleScope` (and the parallel `setScopeResources`) spread the previous state entry before applying the toggle:

```tsx
[scope]: {
  ...prev.scopes[scope],          // ← undefined for newly-added env scopes
  enabled: !prev.scopes[scope]?.enabled,
},
```

For users whose persisted localStorage was written before #2561 added `environment:read` / `environment:write` to `SCOPE_DEFS`, `prev.scopes["environment:write"]` is `undefined`. Spreading `undefined` into an object literal is valid JavaScript but yields no fields, so the new state entry becomes `{enabled: true}` with **no `resources` field**. On the next render, line 581's nullish coalesce `state.scopes[def.scope] ?? {...}` doesn't fire (the object exists), and line 587's `scopeState.resources.length` crashes.

This also explains the related "can't clone with `environment:write` enabled" symptom — once the toolbar is in a broken state, the override-header generation runs against malformed localStorage and the toolbar UI can't be re-toggled to fix itself.

## Fix

- `toggleScope` and `setScopeResources` materialize a known-good `{enabled:true, resources:null}` baseline before spreading, so any new entry always carries the full `ScopeState` shape.
- Render-site uses `!= null` (loose) instead of `!== null` so any legacy-shape entries from already-broken localStorage can't crash the toolbar — defensive belt-and-suspenders.

## Test plan

- [ ] Local: open dashboard with empty localStorage, open RBAC dev toolbar, toggle `environment:read` and `environment:write` → no crash, both rows render with the unrestricted state.
- [ ] Reproduce the broken-localStorage scenario by setting `gram-rbac-dev-override` to an entry like `{"enabled":true,"scopes":{"environment:write":{"enabled":true}}}` (no `resources` field) → reload page → toolbar should render without crashing thanks to the `!= null` guard.
- [ ] Verify the override header `X-Gram-Scope-Override` includes `environment:write` after toggling, and the Clone action on environment cards is reachable + functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)