### PR TITLE
chore: add mise tasks to open various dashboards

### DIFF
--- a/.mise-tasks/open/_thing.sh
+++ b/.mise-tasks/open/_thing.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #MISE description="Open a thing with the system default application"
-#MISE silent=true
+#MISE quiet=true
 #MISE hide=true
 
 #USAGE arg "<thing>" help="The thing to open (e.g. a file path or URL)"

--- a/.mise-tasks/open/_thing.sh
+++ b/.mise-tasks/open/_thing.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#MISE description="Open a thing with the system default application"
+#MISE silent=true
+#MISE hide=true
+
+#USAGE arg "<thing>" help="The thing to open (e.g. a file path or URL)"
+
+set -e
+
+thing="${usage_thing}"
+
+if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
+  if command -v wslview &>/dev/null; then
+    wslview "$thing"
+  else
+    powershell.exe -c "Start-Process '$thing'"
+  fi
+elif command -v xdg-open &>/dev/null; then
+  xdg-open "$thing"
+elif command -v open &>/dev/null; then
+  open "$thing"
+else
+  echo "error: no suitable open command found" >&2
+  exit 1
+fi

--- a/.mise-tasks/open/_thing.sh
+++ b/.mise-tasks/open/_thing.sh
@@ -14,7 +14,7 @@ if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
   if command -v wslview &>/dev/null; then
     wslview "$thing"
   else
-    powershell.exe -c "Start-Process '$thing'"
+    powershell.exe -c "Start-Process \"$thing\""
   fi
 elif command -v xdg-open &>/dev/null; then
   xdg-open "$thing"

--- a/.mise-tasks/open/dashboard.sh
+++ b/.mise-tasks/open/dashboard.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#MISE description="Open the dashboard site"
+#MISE description="Open the dashboard app"
 
 set -e
 

--- a/.mise-tasks/open/idp.sh
+++ b/.mise-tasks/open/idp.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#MISE description="Open the Mock IDP dashboard"
+
+set -e
+
+url="http://localhost:${GRAM_DEVIDP_DASHBOARD_PORT:?Environment variable GRAM_DEVIDP_DASHBOARD_PORT must be set}"
+
+exec mise run open:_thing "$url"

--- a/.mise-tasks/open/jaeger.sh
+++ b/.mise-tasks/open/jaeger.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#MISE description="Open the Jaeger OTEL UI"
+
+set -e
+
+url="http://localhost:${JAEGER_WEB_PORT:?Environment variable JAEGER_WEB_PORT must be set}"
+
+exec mise run open:_thing "$url"

--- a/.mise-tasks/open/site.sh
+++ b/.mise-tasks/open/site.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+#MISE description="Open the dashboard site"
+
+set -e
+
+exec mise run open:_thing "${GRAM_SITE_URL:?Environment variable GRAM_SITE_URL must be set}"

--- a/.mise-tasks/open/temporal.sh
+++ b/.mise-tasks/open/temporal.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#MISE description="Open the Temporal Web UI"
+
+set -e
+
+url="http://localhost:${TEMPORAL_WEB_PORT:?Environment variable TEMPORAL_WEB_PORT must be set}"
+
+exec mise run open:_thing "$url"


### PR DESCRIPTION
This change adds a bunch of mise tasks to open the various dashboards and apps used during local development.

You can open one thing like `mise open:dashboard` or `mise open:temporal` or all the things with `mise "open:*"`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->