### PR TITLE
chore: include service locations and statuses in summary

### DIFF
--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -1,9 +1,12 @@
 #!/usr/bin/env -S node
 
 //MISE description="Summarize development environment"
+//MISE alias="info"
 //MISE hide=true
 
-import { $, chalk } from "zx";
+import { $, chalk, tmpfile } from "zx";
+
+$.verbose = false;
 
 const trueish = new Set(["true", "1", "yes", "on"]);
 
@@ -65,10 +68,17 @@ if (assistantRuntimeServerURL) {
   );
 }
 
+const tableRows: [string, boolean, string][] = [];
+
+function row(name: string, running: boolean, detail: string) {
+  tableRows.push([name, running, detail]);
+}
+
 async function pokePostgreSQL() {
-  let result = await $`docker compose ps gram-db --format json`;
+  const dbURL = process.env["GRAM_DATABASE_URL"] ?? "postgres://localhost/gram";
+  let result = await $`docker compose ps gram-db --format json`.nothrow();
   if (!result.ok) {
-    return console.log("⚪︎ Gram database: not running.");
+    return row("Database", false, dbURL);
   }
 
   let parsed: unknown = {};
@@ -82,8 +92,8 @@ async function pokePostgreSQL() {
     ) {
       throw new Error("Unexpected container info");
     }
-  } catch (e: unknown) {
-    return console.log(`⚪︎ Gram database: unable to get info from docker: ${e}`);
+  } catch {
+    return row("Gram database", false, dbURL);
   }
 
   const portspec = parsed.Publishers.find((p) => {
@@ -100,24 +110,128 @@ async function pokePostgreSQL() {
     typeof portspec?.PublishedPort === "number" ? portspec.PublishedPort : null;
 
   if (p == null) {
-    return console.log(
-      "⚪︎ Gram database: container port 5432 does not appear to be published.",
-    );
+    return row("Gram database", false, dbURL);
   }
 
   result =
-    await $`docker compose exec -T gram-db psql -U ${process.env["DB_USER"]} -d ${process.env["DB_NAME"]} -c "SELECT 1"`;
+    await $`docker compose exec -T gram-db psql -U ${process.env["DB_USER"]} -d ${process.env["DB_NAME"]} -c "SELECT 1"`.nothrow();
   if (!result.ok) {
-    return console.log(
-      `⚪︎ Gram database: unable to connect to the database: ${result.stderr}`,
-    );
+    return row("Gram database", false, dbURL);
   }
 
-  console.log(
-    chalk.greenBright(
-      `⚫︎ Gram database is running on ${process.env["GRAM_DATABASE_URL"]}`,
-    ),
-  );
+  row("Gram database", true, dbURL);
 }
 
 await pokePostgreSQL();
+
+async function pokeDockerService(
+  serviceName: string,
+  displayName: string,
+  url: string,
+) {
+  let result =
+    await $`docker compose ps ${serviceName} --format json`.nothrow();
+  if (!result.ok) {
+    return row(displayName, false, url);
+  }
+
+  let parsed: unknown = {};
+  try {
+    parsed = JSON.parse(result.stdout);
+    if (typeof parsed !== "object" || !parsed || !("State" in parsed)) {
+      throw new Error("Unexpected container info");
+    }
+  } catch {
+    return row(displayName, false, url);
+  }
+
+  const state = (parsed as Record<string, unknown>).State;
+  row(displayName, state === "running", url);
+}
+
+async function pokeHTTPService(
+  displayName: string,
+  healthURL: string,
+  displayURL: string,
+) {
+  try {
+    const result =
+      await $`curl -sk -o /dev/null -w "%{http_code}" --connect-timeout 2 ${healthURL}`;
+    const code = parseInt(result.stdout.trim(), 10);
+    row(displayName, code >= 200 && code < 500, displayURL);
+  } catch {
+    row(displayName, false, displayURL);
+  }
+}
+
+const temporalWebPort = process.env["TEMPORAL_WEB_PORT"] ?? "8233";
+await pokeDockerService(
+  "gram-temporal",
+  "Temporal",
+  `http://localhost:${temporalWebPort}`,
+);
+
+const jaegerWebPort = process.env["JAEGER_WEB_PORT"] ?? "16686";
+await pokeDockerService(
+  "jaeger",
+  "Jaeger",
+  `http://localhost:${jaegerWebPort}`,
+);
+
+const clickhouseHTTPPort = process.env["CLICKHOUSE_HTTP_PORT"] ?? "8123";
+await pokeDockerService(
+  "clickhouse",
+  "ClickHouse",
+  `http://localhost:${clickhouseHTTPPort}`,
+);
+
+const devIdpPort = process.env["GRAM_DEVIDP_PORT"] ?? "35291";
+const devIdpURL = `http://localhost:${devIdpPort}`;
+await pokeHTTPService("Mock IdP server", `${devIdpURL}/healthz`, devIdpURL);
+
+const devIdpDashboardPort =
+  process.env["GRAM_DEVIDP_DASHBOARD_PORT"] ?? "35293";
+const devIdpDashboardURL = `http://localhost:${devIdpDashboardPort}`;
+await pokeHTTPService(
+  "Mock IdP dashboard",
+  devIdpDashboardURL,
+  devIdpDashboardURL,
+);
+
+const gramControlPort = process.env["GRAM_CONTROL_PORT"] ?? "8081";
+const gramServerURL =
+  process.env["GRAM_SERVER_URL"] ??
+  `https://localhost:${process.env["GRAM_SERVER_PORT"] ?? "8080"}`;
+await pokeHTTPService(
+  "Gram server",
+  `http://localhost:${gramControlPort}/healthz`,
+  gramServerURL,
+);
+
+const gramHost = process.env["GRAM_HOST"] ?? "localhost";
+const gramSitePort = process.env["GRAM_SITE_PORT"] ?? "5173";
+const gramDashboardURL = `https://${gramHost}:${gramSitePort}`;
+await pokeHTTPService("Gram dashboard", gramDashboardURL, gramDashboardURL);
+
+tableRows.sort(([nameA, runningA], [nameB, runningB]) => {
+  if (runningA !== runningB) return runningA ? -1 : 1;
+  return nameA.localeCompare(nameB);
+});
+
+const q = (s: string) => `"${s}"`;
+const csv = [
+  ["Service", "Status", "Address"].map(q).join(","),
+  ["", "", ""].join(","), // gum has a bug where first row is weirdly styled
+  ...tableRows.map(([name, running, detail]) => {
+    const status = running
+      ? chalk.greenBright("RUNNING")
+      : chalk.yellow("STOPPED");
+    return [name, status, detail].map(q).join(",");
+  }),
+].join("\n");
+
+const csvFile = tmpfile("services.csv", csv);
+process.stdout.write("\n");
+await $({
+  stdio: "inherit",
+})`gum table --print --selected.foreground="" --file ${csvFile}`;

--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -93,7 +93,7 @@ async function pokePostgreSQL() {
       throw new Error("Unexpected container info");
     }
   } catch {
-    return row("Gram database", false, dbURL);
+    return row("Database", false, dbURL);
   }
 
   const portspec = parsed.Publishers.find((p) => {
@@ -110,16 +110,16 @@ async function pokePostgreSQL() {
     typeof portspec?.PublishedPort === "number" ? portspec.PublishedPort : null;
 
   if (p == null) {
-    return row("Gram database", false, dbURL);
+    return row("Database", false, dbURL);
   }
 
   result =
     await $`docker compose exec -T gram-db psql -U ${process.env["DB_USER"]} -d ${process.env["DB_NAME"]} -c "SELECT 1"`.nothrow();
   if (!result.ok) {
-    return row("Gram database", false, dbURL);
+    return row("Database", false, dbURL);
   }
 
-  row("Gram database", true, dbURL);
+  row("Database", true, dbURL);
 }
 
 await pokePostgreSQL();


### PR DESCRIPTION
This change updates `mise zero:summary` to include a table of services, their statuses (running or not), and their addresses.

The task is also now aliased to `mise info` for easier access.

<img width="1838" height="798" alt="CleanShot 2026-05-08 at 16 50 24@2x" src="https://github.com/user-attachments/assets/e7560044-2503-42d1-a042-b487e797bf20" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->