### PR TITLE
chore: skip challenge logging during admin impersonation

### DIFF
--- a/server/internal/authz/challenge_logger.go
+++ b/server/internal/authz/challenge_logger.go
@@ -51,6 +51,12 @@ func (l challengeLogger) Log(ctx context.Context, conn clickhouse.Conn, logger *
 		return
 	}
 
+	// Skip challenge logging when a Speakeasy admin is impersonating a
+	// customer org — challenges belong to the admin, not the customer.
+	if _, impersonating := contextvalues.GetAdminOverrideFromContext(ctx); impersonating {
+		return
+	}
+
 	enabled, err := isEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		logger.WarnContext(ctx, "failed to check authz challenge logging feature flag",

--- a/server/internal/authz/challenge_logger_test.go
+++ b/server/internal/authz/challenge_logger_test.go
@@ -40,6 +40,42 @@ func TestChallengeLogger_skipsWithoutAuthContext(t *testing.T) {
 	require.Equal(t, uint64(0), n)
 }
 
+func TestChallengeLogger_skipsWhenImpersonating(t *testing.T) {
+	t.Parallel()
+
+	orgID := "org_" + uuid.NewString()
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: orgID,
+		UserID:               "user_admin",
+		AccountType:          "enterprise",
+	})
+	ctx = contextvalues.SetAdminOverrideInContext(ctx, orgID)
+
+	conn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+	logger := testenv.NewLogger(t)
+
+	check := Check{Scope: ScopeProjectRead, ResourceID: "proj_impersonated"}
+	challengeLogger{
+		Operation: authzrepo.OperationRequire,
+		Outcome:   authzrepo.OutcomeAllow,
+		Reason:    authzrepo.ReasonGrantMatched,
+		Checks:    []Check{check},
+		Focus:     &check,
+	}.Log(ctx, conn, logger, staticChallengeLogging(true))
+
+	row, err := conn.Query(t.Context(), `
+		SELECT count() FROM authz_challenges WHERE organization_id = ?
+	`, orgID)
+	require.NoError(t, err)
+	defer func() { _ = row.Close() }()
+
+	var n uint64
+	require.True(t, row.Next())
+	require.NoError(t, row.Scan(&n))
+	require.Equal(t, uint64(0), n)
+}
+
 func TestChallengeLogger_writesUserPrincipal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- When Speakeasy admins impersonate a customer org, authz challenge decisions were being logged against the customer's org in ClickHouse
- These entries show up in the customer-facing challenge log UI, which is incorrect
- Added early return in `challengeLogger.Log` when `AdminOverrideContextKey` is present in context (set by `AdminOverrideMiddleware` on line 827 of `start.go`, before any handler runs)

## Test plan

- [x] Added `TestChallengeLogger_skipsWhenImpersonating` — sets auth context + admin override, fires challenge log, asserts zero rows in ClickHouse
- [ ] Verify existing challenge logger tests still pass (`go test ./server/internal/authz/...`)
- [ ] Manual: impersonate a customer org, perform actions, confirm no challenge rows appear for that org
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->