### PR TITLE
fix: scope picker search, scroll fixes & dedupe challenges section

### DIFF
--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -29,10 +29,6 @@ import { DeleteRoleDialog } from "./DeleteRoleDialog";
 import { Ellipsis } from "lucide-react";
 import { RequireScope } from "@/components/require-scope";
 import { cn } from "@/lib/utils";
-import { useOrgRoutes } from "@/routes";
-import { useChallenges } from "@gram/client/react-query/challenges.js";
-import { useChallengeRowColumns } from "./useChallengeRowColumns";
-import { useGrantFlow } from "./useGrantFlow";
 
 function RoleActionsMenu({
   role,
@@ -75,12 +71,9 @@ function RoleActionsMenu({
 }
 
 export function RolesTab() {
-  const orgRoutes = useOrgRoutes();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingRole, setEditingRole] = useState<Role | null>(null);
   const [deletingRole, setDeletingRole] = useState<Role | null>(null);
-  const { actionsColumn, grantFlowPortals } = useGrantFlow();
-  const challengeRowColumns = useChallengeRowColumns();
   const queryClient = useQueryClient();
   const { data: rolesData, isLoading } = useRoles();
   const roles = [...(rolesData?.roles ?? [])].sort(
@@ -91,11 +84,6 @@ export function RolesTab() {
 
   const defaultRole =
     roles.find((r) => r.isSystem && r.name === "Member") ?? null;
-
-  const { data: challengesData } = useChallenges({ limit: 5 });
-  const recentChallenges = (challengesData?.challenges ?? []).filter(
-    (c) => !!c.scope,
-  );
 
   const membersOfDeletingRole = deletingRole
     ? members.filter((m) => m.roleId === deletingRole.id)
@@ -228,21 +216,6 @@ export function RolesTab() {
         </div>
       </div>
 
-      {/* Recent Challenges */}
-      <div className="mt-12">
-        <div className="mb-3 flex items-center justify-between">
-          <Heading variant="h4">Recent Challenges</Heading>
-          <orgRoutes.access.challenges.Link className="text-primary cursor-pointer text-sm font-medium hover:underline">
-            Show more
-          </orgRoutes.access.challenges.Link>
-        </div>
-        <Table
-          columns={[...challengeRowColumns, actionsColumn]}
-          data={recentChallenges}
-          rowKey={(row) => row.id}
-        />
-      </div>
-
       <CreateRoleDialog
         open={isCreateOpen || !!editingRole}
         onOpenChange={(open) => {
@@ -253,8 +226,6 @@ export function RolesTab() {
         }}
         editingRole={editingRole}
       />
-
-      {grantFlowPortals}
 
       <DeleteRoleDialog
         isOpen={!!deletingRole}

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -149,6 +149,17 @@ export function ScopePickerPopover({
   const [expanded, setExpanded] = useState(false);
   // Override for when user clicks a mode but selectors are still empty
   const [panelOverride, setPanelOverride] = useState<ActivePanel | null>(null);
+  const [resourceSearch, setResourceSearch] = useState("");
+
+  // Explicit wheel handler for the resource list — the Popover portal renders
+  // outside the Sheet's scroll-lock region, so native CSS overflow scrolling
+  // is blocked. Directly setting scrollTop bypasses react-remove-scroll.
+  const resourceListRef = useRef<HTMLDivElement>(null);
+  const handleResourceWheel = useCallback((e: React.WheelEvent) => {
+    if (resourceListRef.current) {
+      resourceListRef.current.scrollTop += e.deltaY;
+    }
+  }, []);
 
   const isMcpConnect = scope === "mcp:connect";
   const collectionGroups = useCollectionGroups(mcpServers, isMcpConnect);
@@ -187,6 +198,23 @@ export function ScopePickerPopover({
     name: p.name,
   }));
 
+  // TODO: TEMP — remove after testing scroll
+  const fakeMcpServers: ServerGroup[] = [
+    {
+      projectId: "fake-project",
+      projectName: "test-project",
+      servers: Array.from({ length: 30 }, (_, i) => ({
+        id: `fake-server-${i}`,
+        name: `test-server-${i}`,
+        slug: `test-project/test-server-${i}`,
+        tools: [{ id: `tool-${i}`, name: `tool-${i}`, type: "http" }],
+      })),
+    },
+  ];
+  const _realMcpServers = mcpServers;
+  const mcpServersOverride =
+    mcpServers.length === 0 ? fakeMcpServers : mcpServers;
+
   const resourceKind = resourceType === "project" ? "project" : "mcp";
 
   const toggleResource = (id: string) => {
@@ -210,6 +238,7 @@ export function ScopePickerPopover({
 
   const switchPanel = (panel: ActivePanel) => {
     setPanelOverride(panel);
+    setResourceSearch("");
     if (panel === "all") {
       onChangeSelectors(null);
     } else {
@@ -255,12 +284,69 @@ export function ScopePickerPopover({
     </div>
   );
 
+  const filteredProjectList = useMemo(
+    () =>
+      resourceSearch
+        ? projectList.filter((p) =>
+            p.name.toLowerCase().includes(resourceSearch.toLowerCase()),
+          )
+        : projectList,
+    [projectList, resourceSearch],
+  );
+
+  const filteredMcpServers = useMemo(() => {
+    if (!resourceSearch) return mcpServersOverride;
+    const q = resourceSearch.toLowerCase();
+    return mcpServersOverride
+      .map((group) => ({
+        ...group,
+        servers: group.servers.filter(
+          (s) =>
+            s.name.toLowerCase().includes(q) ||
+            group.projectName.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((g) => g.servers.length > 0);
+  }, [mcpServersOverride, resourceSearch]);
+
   const resourceList = activePanel === "servers" && (
     <>
-      <div className="bg-border my-1 h-px" />
-      <div className="max-h-[250px] overflow-y-auto">
-        {resourceType === "project"
-          ? projectList.map((resource) => (
+      <div className="bg-border mt-1 h-px" />
+      <div className="flex items-center gap-2 px-3 py-2">
+        <input
+          type="text"
+          placeholder={
+            resourceType === "project" ? "Search projects…" : "Search servers…"
+          }
+          value={resourceSearch}
+          onChange={(e) => setResourceSearch(e.target.value)}
+          className="placeholder:text-muted-foreground flex-1 bg-transparent text-sm outline-none"
+        />
+        {resourceSearch && (
+          <button
+            type="button"
+            onClick={() => setResourceSearch("")}
+            className="text-muted-foreground hover:text-foreground shrink-0"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+      <div className="bg-border h-px" />
+      <div
+        ref={resourceListRef}
+        onWheel={handleResourceWheel}
+        className="h-[250px] overflow-y-auto"
+      >
+        {resourceType === "project" ? (
+          filteredProjectList.length === 0 ? (
+            <div className="text-muted-foreground px-3 py-3 text-sm">
+              {projectList.length === 0
+                ? "No projects found"
+                : "No matching projects"}
+            </div>
+          ) : (
+            filteredProjectList.map((resource) => (
               <ResourceCheckbox
                 key={resource.id}
                 id={resource.id}
@@ -269,26 +355,35 @@ export function ScopePickerPopover({
                 onToggle={toggleResource}
               />
             ))
-          : mcpServers.map((group) => (
-              <div key={group.projectId}>
-                {group.servers.map((server) => (
-                  <ResourceCheckbox
-                    key={server.id}
-                    id={server.id}
-                    name={
-                      <>
-                        <span className="text-muted-foreground/60">
-                          {group.projectName.toLowerCase()}/
-                        </span>
-                        {server.name}
-                      </>
-                    }
-                    checked={isResourceSelected(server.id)}
-                    onToggle={toggleResource}
-                  />
-                ))}
-              </div>
-            ))}
+          )
+        ) : filteredMcpServers.length === 0 ? (
+          <div className="text-muted-foreground px-3 py-3 text-sm">
+            {mcpServersOverride.length === 0
+              ? "No servers found"
+              : "No matching servers"}
+          </div>
+        ) : (
+          filteredMcpServers.map((group) => (
+            <div key={group.projectId}>
+              {group.servers.map((server) => (
+                <ResourceCheckbox
+                  key={server.id}
+                  id={server.id}
+                  name={
+                    <>
+                      <span className="text-muted-foreground/60">
+                        {group.projectName.toLowerCase()}/
+                      </span>
+                      {server.name}
+                    </>
+                  }
+                  checked={isResourceSelected(server.id)}
+                  onToggle={toggleResource}
+                />
+              ))}
+            </div>
+          ))
+        )}
       </div>
     </>
   );

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -182,10 +182,14 @@ export function ScopePickerPopover({
   // selectors have content, so clearing it eagerly only causes the UI to
   // jump back to "servers" when the user deselects all items.
 
-  const projectList = organization.projects.map((p) => ({
-    id: p.id,
-    name: p.name,
-  }));
+  const projectList = useMemo(
+    () =>
+      organization.projects.map((p) => ({
+        id: p.id,
+        name: p.name,
+      })),
+    [organization.projects],
+  );
 
   const resourceKind = resourceType === "project" ? "project" : "mcp";
 

--- a/client/dashboard/src/pages/access/ScopePickerPopover.tsx
+++ b/client/dashboard/src/pages/access/ScopePickerPopover.tsx
@@ -182,6 +182,38 @@ export function ScopePickerPopover({
   // selectors have content, so clearing it eagerly only causes the UI to
   // jump back to "servers" when the user deselects all items.
 
+  const projectList = organization.projects.map((p) => ({
+    id: p.id,
+    name: p.name,
+  }));
+
+  const resourceKind = resourceType === "project" ? "project" : "mcp";
+
+  const filteredProjectList = useMemo(
+    () =>
+      resourceSearch
+        ? projectList.filter((p) =>
+            p.name.toLowerCase().includes(resourceSearch.toLowerCase()),
+          )
+        : projectList,
+    [projectList, resourceSearch],
+  );
+
+  const filteredMcpServers = useMemo(() => {
+    if (!resourceSearch) return mcpServers;
+    const q = resourceSearch.toLowerCase();
+    return mcpServers
+      .map((group) => ({
+        ...group,
+        servers: group.servers.filter(
+          (s) =>
+            s.name.toLowerCase().includes(q) ||
+            group.projectName.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((g) => g.servers.length > 0);
+  }, [mcpServers, resourceSearch]);
+
   // Fixed-scope permissions have no resource picker — their granularity is
   // baked into the scope definition. Org scopes are always org-wide;
   // environment scopes apply to every environment in the project.
@@ -192,30 +224,6 @@ export function ScopePickerPopover({
       </span>
     );
   }
-
-  const projectList = organization.projects.map((p) => ({
-    id: p.id,
-    name: p.name,
-  }));
-
-  // TODO: TEMP — remove after testing scroll
-  const fakeMcpServers: ServerGroup[] = [
-    {
-      projectId: "fake-project",
-      projectName: "test-project",
-      servers: Array.from({ length: 30 }, (_, i) => ({
-        id: `fake-server-${i}`,
-        name: `test-server-${i}`,
-        slug: `test-project/test-server-${i}`,
-        tools: [{ id: `tool-${i}`, name: `tool-${i}`, type: "http" }],
-      })),
-    },
-  ];
-  const _realMcpServers = mcpServers;
-  const mcpServersOverride =
-    mcpServers.length === 0 ? fakeMcpServers : mcpServers;
-
-  const resourceKind = resourceType === "project" ? "project" : "mcp";
 
   const toggleResource = (id: string) => {
     if (selectors === null) return;
@@ -284,31 +292,6 @@ export function ScopePickerPopover({
     </div>
   );
 
-  const filteredProjectList = useMemo(
-    () =>
-      resourceSearch
-        ? projectList.filter((p) =>
-            p.name.toLowerCase().includes(resourceSearch.toLowerCase()),
-          )
-        : projectList,
-    [projectList, resourceSearch],
-  );
-
-  const filteredMcpServers = useMemo(() => {
-    if (!resourceSearch) return mcpServersOverride;
-    const q = resourceSearch.toLowerCase();
-    return mcpServersOverride
-      .map((group) => ({
-        ...group,
-        servers: group.servers.filter(
-          (s) =>
-            s.name.toLowerCase().includes(q) ||
-            group.projectName.toLowerCase().includes(q),
-        ),
-      }))
-      .filter((g) => g.servers.length > 0);
-  }, [mcpServersOverride, resourceSearch]);
-
   const resourceList = activePanel === "servers" && (
     <>
       <div className="bg-border mt-1 h-px" />
@@ -358,7 +341,7 @@ export function ScopePickerPopover({
           )
         ) : filteredMcpServers.length === 0 ? (
           <div className="text-muted-foreground px-3 py-3 text-sm">
-            {mcpServersOverride.length === 0
+            {mcpServers.length === 0
               ? "No servers found"
               : "No matching servers"}
           </div>


### PR DESCRIPTION
## Summary

- **ScopePickerPopover**: Add search/filter for project and server resource lists, fix scroll wheel behavior inside popover portal, add empty state messaging
- **RolesTab**: Remove duplicate "Recent Challenges" section — this now lives exclusively on the Org Home page (gated behind `gram-rbac` feature flag)

## Test plan

- [ ] Open Roles & Permissions → verify "Recent Challenges" section no longer appears
- [ ] Org Home → verify "Recent Challenges" still renders when RBAC feature flag is enabled
- [ ] Open scope picker → select "Specific servers" or "Specific projects" → verify search input filters the list
- [ ] Verify scroll wheel works inside the resource list popover
- [ ] Verify empty states show when no resources match search query
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->