### PR TITLE
mig: add nullable effect column to principal_grants

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2252,6 +2252,7 @@ CREATE TABLE IF NOT EXISTS principal_grants (
   principal_urn TEXT NOT NULL,
   principal_type TEXT NOT NULL GENERATED ALWAYS AS (split_part(principal_urn, ':', 1)) STORED,
   scope TEXT NOT NULL,
+  effect TEXT,
   drop_resource TEXT,
   selectors JSONB NOT NULL,
 
@@ -2260,7 +2261,8 @@ CREATE TABLE IF NOT EXISTS principal_grants (
 
   CONSTRAINT principal_grants_pkey PRIMARY KEY (id),
   CONSTRAINT principal_grants_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}')
+  CONSTRAINT principal_grants_selectors_check CHECK (jsonb_typeof(selectors) = 'object' AND selectors != '{}'),
+  CONSTRAINT principal_grants_effect_check CHECK (effect IS NULL OR effect IN ('allow', 'deny'))
 );
 
 COMMENT ON TABLE principal_grants IS 'RBAC grants. Normalized: one row per (org, principal, scope). Selectors can further constrain applicability.';
@@ -2268,11 +2270,15 @@ COMMENT ON COLUMN principal_grants.organization_id IS 'The organization this gra
 COMMENT ON COLUMN principal_grants.principal_urn IS 'URN identifying the principal, e.g. "user:user_abc", "role:admin". Format is type:id.';
 COMMENT ON COLUMN principal_grants.principal_type IS 'Derived from principal_urn. The type prefix, e.g. "user", "role".';
 COMMENT ON COLUMN principal_grants.scope IS 'The scope being granted, e.g. "build:read". Validated in application code, not via FK.';
+COMMENT ON COLUMN principal_grants.effect IS 'Whether this grant allows or denies the scope. NULL = allow for backward compatibility.';
 COMMENT ON COLUMN principal_grants.drop_resource IS 'Deprecated. Formerly ''*'' = unrestricted. Nullable, scheduled for removal.';
 COMMENT ON COLUMN principal_grants.selectors IS 'JSON selector constraints attached to a grant. Must be a non-empty JSONB object. Wildcard/unrestricted grants use {"resource_kind":"*","resource_id":"*"}.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_selector_key
 ON principal_grants (organization_id, principal_urn, scope, selectors);
+
+CREATE UNIQUE INDEX IF NOT EXISTS principal_grants_org_principal_scope_effect_selector_key
+ON principal_grants (organization_id, principal_urn, scope, COALESCE(effect, 'allow'), selectors);
 
 CREATE INDEX IF NOT EXISTS principal_grants_selectors_idx
 ON principal_grants

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1018,6 +1018,8 @@ type PrincipalGrant struct {
 	PrincipalType string
 	// The scope being granted, e.g. "build:read". Validated in application code, not via FK.
 	Scope string
+	// Whether this grant allows or denies the scope. NULL = allow for backward compatibility.
+	Effect pgtype.Text
 	// Deprecated. Formerly '*' = unrestricted. Nullable, scheduled for removal.
 	DropResource pgtype.Text
 	// JSON selector constraints attached to a grant. Must be a non-empty JSONB object. Wildcard/unrestricted grants use {"resource_kind":"*","resource_id":"*"}.

--- a/server/migrations/20260518114737_add_effect_to_principal_grants.sql
+++ b/server/migrations/20260518114737_add_effect_to_principal_grants.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Modify "principal_grants" table
+ALTER TABLE "principal_grants" ADD CONSTRAINT "principal_grants_effect_check" CHECK ((effect IS NULL) OR (effect = ANY (ARRAY['allow'::text, 'deny'::text]))), ADD COLUMN "effect" text NULL;
+-- Create index "principal_grants_org_principal_scope_effect_selector_key" to table: "principal_grants"
+CREATE UNIQUE INDEX CONCURRENTLY "principal_grants_org_principal_scope_effect_selector_key" ON "principal_grants" ("organization_id", "principal_urn", "scope", (COALESCE(effect, 'allow'::text)), "selectors");
+-- Set comment to column: "effect" on table: "principal_grants"
+COMMENT ON COLUMN "principal_grants"."effect" IS 'Whether this grant allows or denies the scope. NULL = allow for backward compatibility.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:BnjD78u1jVr/MTHa0+aj3OXveHotw7M9VzUpCYmfJoA=
+h1:85vcqCBvfObg3aFVoPEWT+d8ofrrSGY0nnkgk6JWfqM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -180,3 +180,4 @@ h1:BnjD78u1jVr/MTHa0+aj3OXveHotw7M9VzUpCYmfJoA=
 20260514200205_age-2320-assistant-runtime-v2.sql h1:gkTPaBGw63rZlYLc2LZvsjlU/jdfZYIq0p6osNzP+5U=
 20260515094400_add_workos_role_assignments_deleted_at.sql h1:peR1HLGXocOJyh1WwnuLyDKzP+R47IMEB5Kho7lNuXg=
 20260515120000_ai-integration-configs.sql h1:bR1UTZ9lHjJUsJL1LY0ByUTkWefnmPOhovosRGRSJc0=
+20260518114737_add_effect_to_principal_grants.sql h1:J3lR6SeKv0v+S+ecUzf2oHgI2nI5aXCZXKimjxWmLOo=


### PR DESCRIPTION
## Summary

- Adds a nullable `effect TEXT` column to `principal_grants` (after `scope`), with a CHECK constraint limiting values to `NULL`, `'allow'`, or `'deny'`
- Creates a new unique index `principal_grants_org_principal_scope_effect_selector_key` which includes `COALESCE(effect, 'allow')` so that NULL and explicit 'allow' are treated as the same value for uniqueness
- **Keeps the old unique index** `principal_grants_org_principal_scope_selector_key` alive for expand-contract compatibility — the existing `UpsertPrincipalGrant` `ON CONFLICT` clause depends on it. A follow-up app code PR will update the query, and a subsequent contract migration will drop the old index.
- Fully backward compatible: all existing rows have `effect = NULL`, which is treated as 'allow'

## Test plan

- [ ] Migration applies cleanly on a fresh database (`mise run db:reset && mise run db:migrate`)
- [ ] Existing grants (NULL effect) continue to work as before
- [ ] Inserting a grant with `effect = 'deny'` succeeds
- [ ] Inserting a grant with an invalid effect value is rejected by the CHECK constraint
- [ ] Both unique indexes exist after migration (old + new)