### PR TITLE
fix: merge scope defs into stored override state + complete allScopesGrants

### DIFF
--- a/.changeset/dev-toolbar-merge-scope-defs.md
+++ b/.changeset/dev-toolbar-merge-scope-defs.md
@@ -1,0 +1,17 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Fix two related gaps that surfaced after the `environment:read`/`environment:write`
+scopes shipped:
+
+- Dev toolbar: `loadState` now merges `SCOPE_DEFS` defaults into any persisted
+  override state. Previously, scopes added to `SCOPE_DEFS` _after_ a user had
+  already saved override state would render as "checked" via a per-row fallback
+  but were absent from `state.scopes`, so `getRBACScopeOverrideHeader` silently
+  omitted them — leaving the kebab disabled despite looking enabled.
+- `access.listGrants`: the `allScopesGrants()` fallback (used for non-enterprise
+  orgs and admin impersonation) now includes `environment:read` and
+  `environment:write`. Without them the dashboard's effective-grants surface
+  was missing two valid scopes.

--- a/.changeset/dev-toolbar-merge-scope-defs.md
+++ b/.changeset/dev-toolbar-merge-scope-defs.md
@@ -3,15 +3,5 @@
 "server": patch
 ---
 
-Fix two related gaps that surfaced after the `environment:read`/`environment:write`
-scopes shipped:
-
-- Dev toolbar: `loadState` now merges `SCOPE_DEFS` defaults into any persisted
-  override state. Previously, scopes added to `SCOPE_DEFS` _after_ a user had
-  already saved override state would render as "checked" via a per-row fallback
-  but were absent from `state.scopes`, so `getRBACScopeOverrideHeader` silently
-  omitted them — leaving the kebab disabled despite looking enabled.
-- `access.listGrants`: the `allScopesGrants()` fallback (used for non-enterprise
-  orgs and admin impersonation) now includes `environment:read` and
-  `environment:write`. Without them the dashboard's effective-grants surface
-  was missing two valid scopes.
+Surface `environment:read` / `environment:write` in the RBAC dev toolbar and the
+`access.listGrants` fallback so the env-clone permission picker works end-to-end.

--- a/client/dashboard/src/components/dev-toolbar.tsx
+++ b/client/dashboard/src/components/dev-toolbar.tsx
@@ -114,20 +114,39 @@ function loadState(): OverrideState {
       ) {
         return {
           enabled: parsed.enabled,
-          scopes: Object.fromEntries(
-            Object.entries(parsed.scopes).map(([scope, enabled]) => [
-              scope,
-              { enabled: enabled as boolean, resources: null },
-            ]),
+          scopes: mergeWithDefaults(
+            Object.fromEntries(
+              Object.entries(parsed.scopes).map(([scope, enabled]) => [
+                scope,
+                { enabled: enabled as boolean, resources: null },
+              ]),
+            ),
           ),
         };
       }
-      return parsed;
+      // Merge SCOPE_DEFS defaults so any newly added scopes (since the user last
+      // saved state) are materialized in localStorage. Without this, new entries
+      // render as visually "enabled" via the per-row fallback in the JSX, but
+      // getRBACScopeOverrideHeader only iterates keys that exist in state.scopes
+      // — so the override header omits them and the kebab is disabled despite
+      // looking checked.
+      return {
+        enabled: parsed.enabled ?? false,
+        scopes: mergeWithDefaults(parsed.scopes ?? {}),
+      };
     }
   } catch {
     // ignore malformed localStorage
   }
   return { enabled: false, scopes: defaultScopeState() };
+}
+
+// mergeWithDefaults overlays existing scope state on top of defaultScopeState
+// so every scope in SCOPE_DEFS is present, but explicit user toggles win.
+function mergeWithDefaults(
+  existing: Record<string, ScopeState>,
+): Record<string, ScopeState> {
+  return { ...defaultScopeState(), ...existing };
 }
 
 function saveState(state: OverrideState) {

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -1123,6 +1123,8 @@ func allScopesGrants() []*gen.ListRoleGrant {
 		{Scope: string(authz.ScopeMCPRead), Selectors: nil},
 		{Scope: string(authz.ScopeMCPWrite), Selectors: nil},
 		{Scope: string(authz.ScopeMCPConnect), Selectors: nil},
+		{Scope: string(authz.ScopeEnvironmentRead), Selectors: nil},
+		{Scope: string(authz.ScopeEnvironmentWrite), Selectors: nil},
 	}
 }
 

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -25,6 +25,8 @@ var expectedFullAccessScopes = []string{
 	string(authz.ScopeMCPRead),
 	string(authz.ScopeMCPWrite),
 	string(authz.ScopeMCPConnect),
+	string(authz.ScopeEnvironmentRead),
+	string(authz.ScopeEnvironmentWrite),
 }
 
 func TestService_ListGrants(t *testing.T) {


### PR DESCRIPTION
## Summary

Two related gaps that surfaced after `environment:read` / `environment:write` shipped in #2561.

### 1. Dev toolbar UX bug — fixed in this PR

`loadState()` returned the persisted localStorage record verbatim. The toolbar's render path falls back to `{enabled: true, resources: null}` for any scope key missing from `state.scopes` (so the row visually appears checked), but `getRBACScopeOverrideHeader` (`dev-toolbar-utils.ts:31`) iterates only the keys that *exist* in `state.scopes`. Net effect: newly-added env scopes rendered as checked but were silently omitted from the override header.

User-visible symptom: "I have `environment:write` toggled in the toolbar, but `/rpc/access.listGrants` doesn't include it, and the Clone kebab is disabled despite looking enabled."

**Fix:** `loadState` now overlays parsed `scopes` on top of `defaultScopeState()` so every entry in `SCOPE_DEFS` is materialized in localStorage on next page load. The migration branch (boolean → object format) gets the same overlay.

### 2. `allScopesGrants()` missing env scopes — fixed in this PR

`server/internal/access/impl.go:allScopesGrants` returns the "everything is allowed" stub used by `ListGrants` for:

- non-enterprise orgs (`!enforce`, line 700)
- admin impersonation (line 713)

It hardcoded seven `org` / `project` / `mcp` scopes and never picked up the env scopes added in #2561. Even on enterprise tenants where the override path is admin-gated, this gap shows up for the admin impersonation case.

**Fix:** append `environment:read` and `environment:write` to the slice. The shared test fixture `expectedFullAccessScopes` in `listusergrants_test.go` updated to match (used by four assertions that compare result count and presence).

## Known caveat (not addressed in this PR — separate scope)

When a user toggles new scopes in the dev toolbar mid-session, React Query's `useGrants` (with `staleTime: 30_000`) may serve a stale response for up to 30 seconds before reflecting the new override header. `invalidate()` in the toolbar calls `queryClient.invalidateQueries()` which *should* refetch, but there appears to be a race in some cases — observed during testing of this PR, where toggling env scopes correctly produced the right localStorage and override header but the kebab remained disabled until a hard refresh (Cmd+Shift+R).

This is a pre-existing issue with the toolbar's invalidate-and-refetch flow, separate from the localStorage materialization bug fixed here. Worth a follow-up PR to either:

- Lower `useGrants` staleTime when devOverrideActive, or
- Switch to `queryClient.refetchQueries(['grants'])` for explicit refetch instead of just invalidate, or
- Force-bump the query key on `rbac-override-change` to bypass cache entirely.

Verified workaround: hard refresh after toggling clears React Query's cache and the new override takes effect.

## Why these are filed together

Both tracked back to "env scopes were added without sweeping all the places that enumerate scopes." Splitting would be artificial — single-line changes plus shared regression test, and they fix the same end-user symptom from two angles.

## Test plan

- [x] **Reproduce the localStorage materialization bug**: with `gram-rbac-dev-override` containing only `org`/`project`/`mcp` scopes (the pre-fix shape), reload the page → toolbar's localStorage now contains `environment:read` and `environment:write` entries materialized as `{enabled: true, resources: null}`. ✓ Verified locally — hard refresh after this fix is sufficient (no manual JSON.parse / setItem dance needed).
- [x] **Kebab interaction**: click the env card kebab → no longer disabled, opens the Clone modal. ✓
- [x] **Effective grants**: `fetch('/rpc/access.listGrants').then(r => r.json())` → includes `environment:read` and `environment:write` in the grants list. ✓ (note the staleness caveat above — hard refresh required after toggling)
- [x] **Toggle off**: turn `environment:write` off in the toolbar → kebab disables again, listGrants response no longer includes that scope. ✓
- [ ] `mise test:server -- ./internal/access/...` → all `expectedFullAccessScopes`-driven assertions pass against the 9-element fixture. (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)