### PR TITLE
feat: add pagination, and compliance token fix to employees tab

### DIFF
--- a/.changeset/ai-insights-employees-tab.md
+++ b/.changeset/ai-insights-employees-tab.md
@@ -1,0 +1,6 @@
+---
+"dashboard": minor
+"server": minor
+---
+
+Add an Employees tab to the AI Insights section that tracks Gram uptake and compliance across organization members. Shows per-member token usage, compliance status, and last activity over the last 30 days, paginated at 25 per page. Usage is attributed by matching the email reported by each AI coding tool (Claude Code, Cursor) to the member's Gram account. Includes a backend refactor to share user-by-email resolution logic across Claude and Cursor hook handlers.

--- a/.changeset/ai-insights-employees-tab.md
+++ b/.changeset/ai-insights-employees-tab.md
@@ -1,6 +1,5 @@
 ---
 "dashboard": minor
-"server": minor
 ---
 
-Add an Employees tab to the AI Insights section that tracks Gram uptake and compliance across organization members. Shows per-member token usage, compliance status, and last activity over the last 30 days, paginated at 25 per page. Usage is attributed by matching the email reported by each AI coding tool (Claude Code, Cursor) to the member's Gram account. Includes a backend refactor to share user-by-email resolution logic across Claude and Cursor hook handlers.
+Add an Employees tab to the AI Insights section that tracks Gram uptake and compliance across organization members. Shows per-member token usage, compliance status, and last activity over the last 30 days, paginated at 25 per page. Usage is attributed by matching the email reported by each AI coding tool (Claude Code, Cursor) to the member's Gram account.

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -170,8 +170,8 @@ export function InsightsEmployeesContent() {
               <h1 className="text-xl font-semibold">Employee Compliance</h1>
               <p className="text-muted-foreground text-sm">
                 Track Gram uptake for organization members in this project over
-                the last {LOOKBACK_DAYS} days. Employees with token usage are
-                marked compliant; employees without usage are marked not
+                the last {LOOKBACK_DAYS} days. Employees with hook activity are
+                marked compliant; employees without any activity are marked not
                 compliant.
               </p>
             </div>
@@ -224,14 +224,14 @@ export function InsightsEmployeesContent() {
                   value={compliantEmployees}
                   icon="circle-check"
                   accentColor="green"
-                  subtext="Token usage present"
+                  subtext="Hook activity present"
                 />
                 <MetricCard
                   title="Not Compliant"
                   value={notCompliantEmployees}
                   icon="triangle-alert"
                   accentColor="orange"
-                  subtext="No token usage found"
+                  subtext="No hook activity found"
                 />
                 <MetricCard
                   title="Token Count"
@@ -432,7 +432,7 @@ function buildEmployees(
       const tokenCount =
         (summary?.totalInputTokens ?? 0) + (summary?.totalOutputTokens ?? 0);
       const status: EmployeeStatus =
-        tokenCount > 0 ? "compliant" : "not_compliant";
+        summary != null ? "compliant" : "not_compliant";
 
       return {
         id: member.id,
@@ -443,7 +443,7 @@ function buildEmployees(
         tokenCount,
         lastActivity: summary
           ? formatUnixNano(summary.lastSeenUnixNano)
-          : "No token usage found",
+          : "No activity found",
       };
     })
     .sort((a, b) => {

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -25,8 +25,8 @@ import type {
 import { useGramContext, useMembers, useRoles } from "@gram/client/react-query";
 import { unwrapAsync } from "@gram/client/types/fp";
 import { useQuery } from "@tanstack/react-query";
-import { Info, Sparkles } from "lucide-react";
-import { useMemo } from "react";
+import { ChevronLeft, ChevronRight, Info, Sparkles } from "lucide-react";
+import { useMemo, useState } from "react";
 
 type EmployeeStatus = "compliant" | "not_compliant";
 
@@ -251,7 +251,16 @@ export function InsightsEmployeesContent() {
   );
 }
 
+const PAGE_SIZE = 25;
+
 function EmployeeTable({ employees }: { employees: Employee[] }) {
+  const [page, setPage] = useState(0);
+  const totalPages = Math.ceil(employees.length / PAGE_SIZE);
+  const pageEmployees = employees.slice(
+    page * PAGE_SIZE,
+    (page + 1) * PAGE_SIZE,
+  );
+
   return (
     <section className="bg-card rounded-xl border">
       <Table>
@@ -272,8 +281,8 @@ function EmployeeTable({ employees }: { employees: Employee[] }) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {employees.length > 0 ? (
-            employees.map((item) => (
+          {pageEmployees.length > 0 ? (
+            pageEmployees.map((item) => (
               <TableRow key={item.id}>
                 <TableCell>
                   <div className="flex items-center gap-3">
@@ -316,6 +325,33 @@ function EmployeeTable({ employees }: { employees: Employee[] }) {
           )}
         </TableBody>
       </Table>
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between border-t px-4 py-3">
+          <p className="text-muted-foreground text-sm">
+            {page * PAGE_SIZE + 1}–
+            {Math.min((page + 1) * PAGE_SIZE, employees.length)} of{" "}
+            {employees.length}
+          </p>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPage((p) => p - 1)}
+              disabled={page === 0}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={page >= totalPages - 1}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
+      )}
     </section>
   );
 }
@@ -393,7 +429,8 @@ function buildEmployees(
   return members
     .map((member) => {
       const summary = summaryByUserId.get(member.id);
-      const tokenCount = summary?.totalTokens ?? 0;
+      const tokenCount =
+        (summary?.totalInputTokens ?? 0) + (summary?.totalOutputTokens ?? 0);
       const status: EmployeeStatus =
         tokenCount > 0 ? "compliant" : "not_compliant";
 

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -251,6 +251,7 @@ func (s *Service) writeMetricsToClickHouse(ctx context.Context, payload *gen.Met
 		urn := "claude-code:usage:metrics"
 
 		attrs := map[attr.Key]any{
+			attr.EventSourceKey:    string(telemetry.EventSourceHook),
 			attr.LogBodyKey:        "Claude Code usage metrics",
 			attr.ProjectIDKey:      projectID,
 			attr.OrganizationIDKey: orgID,


### PR DESCRIPTION
## Summary

- Add client-side pagination (25 per page) to the employees compliance table
- Add email matching disclaimer tooltip on the Employee column header explaining how usage is attributed
- Fix compliance token count to sum `input_tokens + output_tokens` instead of `total_tokens` — Cursor hook events never populate `total_tokens`, only the individual fields, causing all Cursor users to show as not compliant despite having activity

## Test plan

- [ ] Verify employees table paginates correctly at 25 rows per page with working prev/next controls and range indicator
- [ ] Verify hovering the info icon on the Employee column shows the disclaimer tooltip
- [ ] Verify users with Cursor activity now show correct token counts and compliant status

🤖 Generated with [Claude Code](https://claude.com/claude-code)