### PR TITLE
feat(assistants): recycle fly.io machines on runtime image upgrade

### DIFF
--- a/.changeset/assistant-runtime-image-recycle.md
+++ b/.changeset/assistant-runtime-image-recycle.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Propagate assistant runtime image upgrades to existing fly.io machines: on the next admission, an idle machine running an older runtime image is recycled in place to the latest version. Mid-turn admissions are left alone so a future idle window picks up the upgrade.

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -86,6 +86,7 @@ type flyRuntimeFlapsClient interface {
 	List(ctx context.Context, appName, state string) ([]*fly.Machine, error)
 	Start(ctx context.Context, appName, machineID string, nonce string) (*fly.MachineStartResponse, error)
 	Stop(ctx context.Context, appName string, in fly.StopMachineInput, nonce string) error
+	Update(ctx context.Context, appName string, input fly.LaunchMachineInput, nonce string) (*fly.Machine, error)
 	Wait(ctx context.Context, appName string, machine *fly.Machine, state string, timeout time.Duration) error
 }
 
@@ -273,6 +274,15 @@ func (f *FlyRuntimeBackend) ensureExisting(
 		machine = launched
 		if err := f.tracedWaitStarted(ctx, flapsClient, appName, machine, coldStart); err != nil {
 			return RuntimeBackendEnsureResult{}, fmt.Errorf("wait for assistant fly runtime machine launch: %w", err)
+		}
+	} else {
+		recycled, err := f.maybeRecycleImage(ctx, flapsClient, runtime, appName, appURL, appIP, machine)
+		if err != nil {
+			return RuntimeBackendEnsureResult{}, err
+		}
+		if recycled != nil {
+			machine = recycled
+			coldStart = true
 		}
 	}
 
@@ -550,6 +560,141 @@ func (f *FlyRuntimeBackend) tracedResolveMachine(
 		span.End()
 	}()
 	return f.resolveMachine(ctx, flapsClient, appName, threadID, machineID, lastBootID, sameAppIncarnation)
+}
+
+// maybeRecycleImage applies an in-place machine update when the running
+// machine's image lags behind the configured runtime image. Preserves the
+// app + allocated IP so callers don't pay the DNS-propagation cost of a
+// fresh app, and gates on the runner's /state idle clock so an in-flight
+// turn isn't interrupted — the next admission catches it idle. Returns the
+// post-update machine when a recycle happened, nil otherwise.
+func (f *FlyRuntimeBackend) maybeRecycleImage(
+	ctx context.Context,
+	flapsClient flyRuntimeFlapsClient,
+	runtime assistantRuntimeRecord,
+	appName string,
+	appURL string,
+	appIP string,
+	machine *fly.Machine,
+) (*fly.Machine, error) {
+	desired := f.desiredImageRef()
+	actual := machineImageRef(machine)
+	// Empty ImageRef means flaps returned a partial machine record (e.g.
+	// HostStatus != ok or a stale list response). Recycling on missing data
+	// would churn healthy runtimes — skip and let the next admission retry.
+	if actual == "" || desired == actual {
+		return nil, nil
+	}
+
+	target := flyRuntimeTarget{URL: appURL, IP: appIP}
+	if machine.State == fly.MachineStateStarted {
+		state, stateErr := f.runtimeState(ctx, target)
+		// /state probe success + idle_seconds==0 means a turn is in flight
+		// (runner clears the idle clock synchronously on /turn enqueue).
+		// Skip recycling so we don't reboot mid-turn; a later admission with
+		// an idle runner picks the upgrade up. Probe errors fall through to
+		// recycle — the runner is unreachable on the stale image anyway and
+		// waitForRuntimeHealth would just fail next.
+		if stateErr == nil && state.IdleSeconds != nil && *state.IdleSeconds == 0 {
+			f.logger.InfoContext(ctx,
+				"assistant fly runtime image recycle skipped: turn in flight",
+				attr.SlogFlyAppName(appName),
+				attr.SlogAssistantImageDesired(desired),
+				attr.SlogAssistantImageActual(actual),
+			)
+			return nil, nil
+		}
+	}
+
+	f.logger.InfoContext(ctx,
+		"assistant fly runtime recycling: image upgrade",
+		attr.SlogFlyAppName(appName),
+		attr.SlogAssistantImageDesired(desired),
+		attr.SlogAssistantImageActual(actual),
+	)
+
+	updated, err := f.tracedRecycleMachine(ctx, flapsClient, runtime, appName, machine, desired, actual)
+	if err != nil {
+		return nil, fmt.Errorf("recycle assistant fly runtime machine: %w", err)
+	}
+	if err := f.tracedWaitStarted(ctx, flapsClient, appName, updated, true); err != nil {
+		return nil, fmt.Errorf("wait for assistant fly runtime machine recycle: %w", err)
+	}
+	return updated, nil
+}
+
+// desiredImageRef returns the configured runtime image reference in the same
+// "<repo>:<tag>" form fly's MachineImageRef serialises into.
+func (f *FlyRuntimeBackend) desiredImageRef() string {
+	return fmt.Sprintf("%s:%s", f.config.OCIImage, f.config.ImageVersion)
+}
+
+// machineImageRef rebuilds the "<registry>/<repo>:<tag>" form from a fly
+// Machine's ImageRef so it can be compared verbatim to desiredImageRef. The
+// digest is intentionally omitted — fly populates it post-pull, but the
+// configured image version is always a tag (helm sets it from image.tag).
+func machineImageRef(machine *fly.Machine) string {
+	if machine == nil {
+		return ""
+	}
+	ref := machine.ImageRef
+	repo := ref.Repository
+	if ref.Registry != "" && repo != "" {
+		repo = ref.Registry + "/" + ref.Repository
+	} else if ref.Registry != "" {
+		repo = ref.Registry
+	}
+	if ref.Tag == "" {
+		return repo
+	}
+	return repo + ":" + ref.Tag
+}
+
+func (f *FlyRuntimeBackend) recycleMachine(
+	ctx context.Context,
+	flapsClient flyRuntimeFlapsClient,
+	runtime assistantRuntimeRecord,
+	appName string,
+	machine *fly.Machine,
+) (*fly.Machine, error) {
+	updated, err := flapsClient.Update(ctx, appName, fly.LaunchMachineInput{
+		ID:                  machine.ID,
+		Config:              f.machineConfig(runtime),
+		Region:              firstNonEmpty(machine.Region, f.config.DefaultFlyRegion),
+		Name:                machine.Name,
+		RequiresReplacement: false,
+	}, "")
+	if err != nil {
+		return nil, fmt.Errorf("update assistant fly runtime machine: %w", err)
+	}
+	return updated, nil
+}
+
+func (f *FlyRuntimeBackend) tracedRecycleMachine(
+	ctx context.Context,
+	flapsClient flyRuntimeFlapsClient,
+	runtime assistantRuntimeRecord,
+	appName string,
+	machine *fly.Machine,
+	desired string,
+	actual string,
+) (updated *fly.Machine, err error) {
+	ctx, span := f.tracer.Start(ctx, "assistants.runtime.recycleMachine",
+		trace.WithAttributes(
+			attr.AssistantImageRecycle(true),
+			attr.AssistantImageDesired(desired),
+			attr.AssistantImageActual(actual),
+			attr.FlyAppName(appName),
+		),
+	)
+	defer func() {
+		if err != nil {
+			span.SetAttributes(attr.AssistantSetupFailureClass(classifySetupError(err)))
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+	return f.recycleMachine(ctx, flapsClient, runtime, appName, machine)
 }
 
 func (f *FlyRuntimeBackend) tracedLaunchMachine(

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -463,6 +463,310 @@ func TestFlyRuntimeBackendReapTreatsAppNotFoundAsSuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestFlyRuntimeBackendEnsureSkipsRecycleWhenImageMatches(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	threadID := uuid.New()
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "dev",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   threadID,
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, flapsClient.updateCalls)
+	require.False(t, result.ColdStart)
+	require.False(t, result.NeedsConfigure)
+}
+
+func TestFlyRuntimeBackendEnsureRecyclesStaleImageWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	idle := uint64(10)
+	server := newTestAssistantRuntimeServerWithState(t, runnerStateResponse{
+		Configured:  true,
+		IdleSeconds: &idle,
+	})
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	threadID := uuid.New()
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "v0",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+	flapsClient.updateMachine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-2",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "dev",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   threadID,
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, flapsClient.updateCalls)
+	require.True(t, result.ColdStart)
+
+	var metadata flyRuntimeMetadata
+	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &metadata))
+	require.Equal(t, "boot-2", metadata.LastBootID)
+}
+
+func TestFlyRuntimeBackendEnsureSkipsRecycleWhileTurnInFlight(t *testing.T) {
+	t.Parallel()
+
+	busy := uint64(0)
+	server := newTestAssistantRuntimeServerWithState(t, runnerStateResponse{
+		Configured:  true,
+		IdleSeconds: &busy,
+	})
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	threadID := uuid.New()
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "v0",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   threadID,
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, flapsClient.updateCalls)
+	require.False(t, result.ColdStart)
+	require.False(t, result.NeedsConfigure)
+}
+
+func TestFlyRuntimeBackendEnsureRecyclesStaleImageOnStoppedMachine(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, false)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	threadID := uuid.New()
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStopped,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "v0",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+	flapsClient.updateMachine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-2",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "dev",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     server.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   threadID,
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, flapsClient.updateCalls)
+	require.True(t, result.ColdStart)
+	require.True(t, result.NeedsConfigure)
+}
+
+func TestFlyRuntimeBackendEnsureRecyclesWhenStateProbeErrors(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	stateCalls := 0
+	mux.HandleFunc("/state", func(w http.ResponseWriter, _ *http.Request) {
+		stateCalls++
+		// Probe-time call from maybeRecycleImage fails; the post-recycle
+		// runtimeState lookup gets a configured response so Ensure completes.
+		if stateCalls == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(runnerStateResponse{Configured: true})
+	})
+	mux.HandleFunc("/configure", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, srv)
+
+	threadID := uuid.New()
+	apiClient.app = &fly.App{ID: "app-1", Name: "gram-asst-test"}
+	flapsClient.machine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-1",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "v0",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+	flapsClient.updateMachine = &fly.Machine{
+		ID:         "machine-1",
+		State:      fly.MachineStateStarted,
+		Region:     "iad",
+		InstanceID: "boot-2",
+		ImageRef: fly.MachineImageRef{
+			Registry:   "registry.fly.io",
+			Repository: "assistant-runtime",
+			Tag:        "dev",
+		},
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{flyMachineMetadataThreadID: threadID.String()},
+		},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:    "gram-asst-test",
+		AppID:      "app-1",
+		AppURL:     srv.URL,
+		MachineID:  "machine-1",
+		Region:     "iad",
+		LastBootID: "boot-1",
+	})
+	require.NoError(t, err)
+
+	result, err := backend.Ensure(context.Background(), assistantRuntimeRecord{
+		AssistantThreadID:   threadID,
+		AssistantID:         uuid.New(),
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, flapsClient.updateCalls)
+	require.True(t, result.ColdStart)
+}
+
 func TestFlyRuntimeBackendServerURLRejectsLoopback(t *testing.T) {
 	t.Parallel()
 
@@ -542,6 +846,10 @@ type testFlyRuntimeFlapsClient struct {
 	startErr      error
 	stopErr       error
 	stopCalls     int
+	updateMachine *fly.Machine
+	updateErr     error
+	updateCalls   int
+	updateInputs  []fly.LaunchMachineInput
 	waitErr       error
 }
 
@@ -594,6 +902,19 @@ func (c *testFlyRuntimeFlapsClient) Stop(_ context.Context, _ string, _ fly.Stop
 	return nil
 }
 
+func (c *testFlyRuntimeFlapsClient) Update(_ context.Context, _ string, input fly.LaunchMachineInput, _ string) (*fly.Machine, error) {
+	c.updateCalls++
+	c.updateInputs = append(c.updateInputs, input)
+	if c.updateErr != nil {
+		return nil, c.updateErr
+	}
+	if c.updateMachine != nil {
+		c.machine = c.updateMachine
+		return c.updateMachine, nil
+	}
+	return nil, errors.New("update machine not configured")
+}
+
 func (c *testFlyRuntimeFlapsClient) Wait(_ context.Context, _ string, _ *fly.Machine, _ string, _ time.Duration) error {
 	return c.waitErr
 }
@@ -608,6 +929,11 @@ func (f *testFlyRuntimeFlapsFactory) New(context.Context) (flyRuntimeFlapsClient
 
 func newTestAssistantRuntimeServer(t *testing.T, configured bool) *httptest.Server {
 	t.Helper()
+	return newTestAssistantRuntimeServerWithState(t, runnerStateResponse{Configured: configured})
+}
+
+func newTestAssistantRuntimeServerWithState(t *testing.T, state runnerStateResponse) *httptest.Server {
+	t.Helper()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -616,7 +942,7 @@ func newTestAssistantRuntimeServer(t *testing.T, configured bool) *httptest.Serv
 	})
 	mux.HandleFunc("/state", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(runnerStateResponse{Configured: configured})
+		_ = json.NewEncoder(w).Encode(state)
 	})
 	mux.HandleFunc("/configure", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -145,6 +145,9 @@ const (
 	AssistantAppCreatedKey         = attribute.Key("gram.assistant.app_created")
 	AssistantSetupFailureClassKey  = attribute.Key("gram.assistant.setup_failure_class")
 	AssistantServerIPKey           = attribute.Key("gram.assistant.server_ip")
+	AssistantImageRecycleKey       = attribute.Key("gram.assistant.image_recycle")
+	AssistantImageDesiredKey       = attribute.Key("gram.assistant.image_desired")
+	AssistantImageActualKey        = attribute.Key("gram.assistant.image_actual")
 	ChatModelKey                   = attribute.Key("gram.chat.model")
 	ChatToolCountKey               = attribute.Key("gram.chat.tool_count")
 	ChatToolNamesKey               = attribute.Key("gram.chat.tool_names")
@@ -1324,6 +1327,18 @@ func AssistantAppCreated(v bool) attribute.KeyValue { return AssistantAppCreated
 
 func AssistantSetupFailureClass(v string) attribute.KeyValue {
 	return AssistantSetupFailureClassKey.String(v)
+}
+
+func AssistantImageRecycle(v bool) attribute.KeyValue { return AssistantImageRecycleKey.Bool(v) }
+
+func AssistantImageDesired(v string) attribute.KeyValue { return AssistantImageDesiredKey.String(v) }
+func SlogAssistantImageDesired(v string) slog.Attr {
+	return slog.String(string(AssistantImageDesiredKey), v)
+}
+
+func AssistantImageActual(v string) attribute.KeyValue { return AssistantImageActualKey.String(v) }
+func SlogAssistantImageActual(v string) slog.Attr {
+	return slog.String(string(AssistantImageActualKey), v)
 }
 
 func ChatModel(v string) attribute.KeyValue { return ChatModelKey.String(v) }


### PR DESCRIPTION
## Summary

- When a fly.io assistant runtime machine is running an older image than the configured runtime image, the next admission upgrades it in place via flaps `Update` — same machine ID, same app, same allocated IPs, fresh boot. The runner's `/configure` reapplies on first request after the reboot.
- Mid-turn safety: gated on the runner's `/state` idle clock. If `idle_seconds == 0` (turn in flight), the upgrade is deferred so the next admission catches the runner idle. Stopped/suspended machines and unreachable runners recycle directly.
- Defensive: empty `ImageRef` (partial flaps response) skips recycling rather than guessing.

Closes [AGE-2215](https://linear.app/speakeasy/issue/AGE-2215/propagate-assistant-runtime-image-updates-to-flyio).

✻ Clauded...