### PR TITLE
feat(risk-overview): polish risk overview layout and table styles

### DIFF
--- a/.changeset/slick-words-allow.md
+++ b/.changeset/slick-words-allow.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Refactor Security Overview to use Page.Section wrappers, scrollable tables, and a lighter category label.

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -260,42 +260,46 @@ function SecurityOverviewContent() {
             <Page.Section>
               <Page.Section.Title>Recent Chats</Page.Section.Title>
               <Page.Section.Body>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-6/12">Chat</TableHead>
-                      <TableHead className="w-3/12">User</TableHead>
-                      <TableHead className="w-1/12">Findings</TableHead>
-                      <TableHead className="w-2/12">Latest Detected</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {recentChats.map((chat) => (
-                      <TableRow
-                        key={chat.chatId}
-                        className="cursor-pointer"
-                        onClick={() => setSelectedChatId(chat.chatId)}
-                      >
-                        <TableCell className="text-muted-foreground truncate">
-                          {chat.chatTitle ?? "Untitled"}
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">
-                          {chat.userId ?? "-"}
-                        </TableCell>
-                        <TableCell className="text-foreground font-mono">
-                          {chat.findingsCount}
-                        </TableCell>
-                        <TableCell className="text-muted-foreground">
-                          {chat.latestDetected
-                            ? new Date(chat.latestDetected).toLocaleString()
-                            : "-"}
-                        </TableCell>
+                <div className="max-h-[412px] overflow-auto rounded-md border **:data-[slot=table-container]:overflow-visible">
+                  <Table>
+                    <TableHeader className="bg-background sticky top-0 z-10">
+                      <TableRow>
+                        <TableHead className="w-6/12 pl-4">Chat</TableHead>
+                        <TableHead className="w-3/12">User</TableHead>
+                        <TableHead className="w-1/12">Findings</TableHead>
+                        <TableHead className="w-2/12 pr-4">
+                          Latest Detected
+                        </TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {recentChats.map((chat) => (
+                        <TableRow
+                          key={chat.chatId}
+                          className="cursor-pointer"
+                          onClick={() => setSelectedChatId(chat.chatId)}
+                        >
+                          <TableCell className="text-muted-foreground truncate pl-4">
+                            {chat.chatTitle ?? "Untitled"}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {chat.userId ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-foreground font-mono">
+                            {chat.findingsCount}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground pr-4">
+                            {chat.latestDetected
+                              ? new Date(chat.latestDetected).toLocaleString()
+                              : "-"}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
                 {chatSummaryQuery.hasNextPage && (
-                  <div className="mt-2 flex justify-center">
+                  <div className="flex justify-center">
                     <Button
                       variant="ghost"
                       size="sm"
@@ -316,69 +320,73 @@ function SecurityOverviewContent() {
             <Page.Section>
               <Page.Section.Title>Recent Findings</Page.Section.Title>
               <Page.Section.Body>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-1/12">Category</TableHead>
-                      <TableHead className="w-1/12">Rule</TableHead>
-                      <TableHead className="w-1/12">Chat</TableHead>
-                      <TableHead className="w-1/12">User</TableHead>
-                      <TableHead className="w-1/12">Match</TableHead>
-                      <TableHead className="w-1/12">Policy Note</TableHead>
-                      <TableHead className="w-1/12">Detected</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {results.map((result) => {
-                      const policyNote = policyMessageById.get(result.policyId);
-                      return (
-                        <TableRow
-                          key={result.id}
-                          className="cursor-pointer"
-                          onClick={() => {
-                            if (result.chatId) {
-                              setSelectedChatId(result.chatId);
-                            }
-                          }}
-                        >
-                          <TableCell>
-                            <CategoryLabel
-                              source={result.source}
-                              ruleId={result.ruleId}
-                            />
-                          </TableCell>
-                          <TableCell>
-                            <span className="font-mono text-xs">
-                              {result.ruleId ? result.ruleId : "-"}
-                            </span>
-                          </TableCell>
-                          <TableCell className="text-muted-foreground truncate">
-                            {result.chatTitle ?? "Untitled"}
-                          </TableCell>
-                          <TableCell className="text-muted-foreground">
-                            {result.userId ?? "-"}
-                          </TableCell>
-                          <TableCell className="truncate">
-                            <MaskedMatch value={result.match} />
-                          </TableCell>
-                          <TableCell
-                            className="text-muted-foreground truncate italic"
-                            title={policyNote ?? undefined}
+                <div className="max-h-[412px] overflow-auto rounded-md border **:data-[slot=table-container]:overflow-visible">
+                  <Table>
+                    <TableHeader className="bg-background sticky top-0 z-10">
+                      <TableRow>
+                        <TableHead className="w-1/12 pl-4">Category</TableHead>
+                        <TableHead className="w-1/12">Rule</TableHead>
+                        <TableHead className="w-1/12">Chat</TableHead>
+                        <TableHead className="w-1/12">User</TableHead>
+                        <TableHead className="w-1/12">Match</TableHead>
+                        <TableHead className="w-1/12">Policy Note</TableHead>
+                        <TableHead className="w-1/12 pr-4">Detected</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {results.map((result) => {
+                        const policyNote = policyMessageById.get(
+                          result.policyId,
+                        );
+                        return (
+                          <TableRow
+                            key={result.id}
+                            className="cursor-pointer"
+                            onClick={() => {
+                              if (result.chatId) {
+                                setSelectedChatId(result.chatId);
+                              }
+                            }}
                           >
-                            {policyNote ?? "-"}
-                          </TableCell>
-                          <TableCell className="text-muted-foreground">
-                            {result.createdAt
-                              ? new Date(result.createdAt).toLocaleString()
-                              : "-"}
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
+                            <TableCell className="pl-4">
+                              <CategoryLabel
+                                source={result.source}
+                                ruleId={result.ruleId}
+                              />
+                            </TableCell>
+                            <TableCell>
+                              <span className="font-mono text-xs">
+                                {result.ruleId ? result.ruleId : "-"}
+                              </span>
+                            </TableCell>
+                            <TableCell className="text-muted-foreground truncate">
+                              {result.chatTitle ?? "Untitled"}
+                            </TableCell>
+                            <TableCell className="text-muted-foreground">
+                              {result.userId ?? "-"}
+                            </TableCell>
+                            <TableCell className="truncate">
+                              <MaskedMatch value={result.match} />
+                            </TableCell>
+                            <TableCell
+                              className="text-muted-foreground truncate italic"
+                              title={policyNote ?? undefined}
+                            >
+                              {policyNote ?? "-"}
+                            </TableCell>
+                            <TableCell className="text-muted-foreground pr-4">
+                              {result.createdAt
+                                ? new Date(result.createdAt).toLocaleString()
+                                : "-"}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
                 {resultsQuery.hasNextPage && (
-                  <div className="mt-2 flex justify-center">
+                  <div className="flex justify-center">
                     <Button
                       variant="ghost"
                       size="sm"

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -418,7 +418,7 @@ function SecurityOverviewContent() {
         onOpenChange={(open) => !open && setSelectedChatId(null)}
         direction="right"
       >
-        <DrawerContent className="!w-[720px] sm:!max-w-[720px]">
+        <DrawerContent className="data-[vaul-drawer-direction=right]:w-[720px] data-[vaul-drawer-direction=right]:sm:max-w-[720px]">
           {selectedChatId && (
             <ChatDetailPanel
               chatId={selectedChatId}

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -61,7 +61,14 @@ function CategoryBadge({
 export default function SecurityOverview() {
   return (
     <RequireScope scope="org:admin" level="page">
-      <SecurityOverviewContent />
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs />
+        </Page.Header>
+        <Page.Body>
+          <SecurityOverviewContent />
+        </Page.Body>
+      </Page>
     </RequireScope>
   );
 }
@@ -181,39 +188,25 @@ function SecurityOverviewContent() {
 
   if (isInitialLoading) {
     return (
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <div className="flex items-center justify-center py-20">
-            <p className="text-muted-foreground text-sm">Loading...</p>
-          </div>
-        </Page.Body>
-      </Page>
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground text-sm">Loading...</p>
+      </div>
     );
   }
 
   if (policies.length === 0) {
     return (
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <div className="flex flex-col items-center justify-center gap-4 py-20">
-            <Shield className="text-muted-foreground h-12 w-12" />
-            <h2 className="text-lg font-semibold">Risk Analysis</h2>
-            <p className="text-muted-foreground max-w-md text-center text-sm">
-              Monitor your chat messages for leaked secrets and sensitive data.
-              Set up a risk policy to get started.
-            </p>
-            <Button onClick={() => routes.policyCenter.goTo()}>
-              Go to Policy Center
-            </Button>
-          </div>
-        </Page.Body>
-      </Page>
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <Shield className="text-muted-foreground h-12 w-12" />
+        <h2 className="text-lg font-semibold">Risk Analysis</h2>
+        <p className="text-muted-foreground max-w-md text-center text-sm">
+          Monitor your chat messages for leaked secrets and sensitive data. Set
+          up a risk policy to get started.
+        </p>
+        <Button onClick={() => routes.policyCenter.goTo()}>
+          Go to Policy Center
+        </Button>
+      </div>
     );
   }
 
@@ -228,190 +221,175 @@ function SecurityOverviewContent() {
 
   return (
     <>
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-lg font-semibold">Risk Overview</h2>
-              <p className="text-muted-foreground text-sm">
-                Recent findings from risk analysis scans across your project.
-              </p>
-            </div>
-            <Button
-              variant="outline"
-              onClick={() => routes.policyCenter.goTo()}
-            >
-              Manage Policies
-            </Button>
-          </div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Risk Overview</h2>
+          <p className="text-muted-foreground text-sm">
+            Recent findings from risk analysis scans across your project.
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => routes.policyCenter.goTo()}>
+          Manage Policies
+        </Button>
+      </div>
 
-          <div className="mt-4 grid grid-cols-2 gap-4">
-            <MetricCard
-              title="Events Scanned"
-              value={totalScanned}
-              format="number"
-              icon="scan-search"
-            />
-            <MetricCard
-              title="Recent Findings"
-              value={totalFindings}
-              format="number"
-              icon="flag"
-            />
-          </div>
+      <div className="mt-4 grid grid-cols-2 gap-4">
+        <MetricCard
+          title="Events Scanned"
+          value={totalScanned}
+          format="number"
+          icon="scan-search"
+        />
+        <MetricCard
+          title="Recent Findings"
+          value={totalFindings}
+          format="number"
+          icon="flag"
+        />
+      </div>
 
-          {hasData ? (
-            <>
-              {recentChats.length > 0 && (
-                <div className="mt-6">
-                  <h3 className="mb-2 text-sm font-semibold">Recent Chats</h3>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Chat</TableHead>
-                        <TableHead>User</TableHead>
-                        <TableHead>Findings</TableHead>
-                        <TableHead>Latest Detected</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {recentChats.map((chat) => (
-                        <TableRow
-                          key={chat.chatId}
-                          className="cursor-pointer"
-                          onClick={() => setSelectedChatId(chat.chatId)}
-                        >
-                          <TableCell className="text-muted-foreground max-w-[300px] truncate text-xs">
-                            {chat.chatTitle ?? "Untitled"}
-                          </TableCell>
-                          <TableCell className="text-muted-foreground text-xs">
-                            {chat.userId ?? "-"}
-                          </TableCell>
-                          <TableCell className="font-mono text-xs">
-                            {chat.findingsCount}
-                          </TableCell>
-                          <TableCell className="text-muted-foreground text-xs">
-                            {chat.latestDetected
-                              ? new Date(chat.latestDetected).toLocaleString()
-                              : "-"}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                  {chatSummaryQuery.hasNextPage && (
-                    <div className="mt-2 flex justify-center">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={chatSummaryQuery.isFetchingNextPage}
-                        onClick={() => chatSummaryQuery.fetchNextPage()}
-                      >
-                        {chatSummaryQuery.isFetchingNextPage
-                          ? "Loading..."
-                          : "Load More"}
-                      </Button>
-                    </div>
-                  )}
+      {hasData ? (
+        <>
+          {recentChats.length > 0 && (
+            <div className="mt-6">
+              <h3 className="mb-2 text-sm font-semibold">Recent Chats</h3>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Chat</TableHead>
+                    <TableHead>User</TableHead>
+                    <TableHead>Findings</TableHead>
+                    <TableHead>Latest Detected</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {recentChats.map((chat) => (
+                    <TableRow
+                      key={chat.chatId}
+                      className="cursor-pointer"
+                      onClick={() => setSelectedChatId(chat.chatId)}
+                    >
+                      <TableCell className="text-muted-foreground max-w-[300px] truncate text-xs">
+                        {chat.chatTitle ?? "Untitled"}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-xs">
+                        {chat.userId ?? "-"}
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {chat.findingsCount}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-xs">
+                        {chat.latestDetected
+                          ? new Date(chat.latestDetected).toLocaleString()
+                          : "-"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {chatSummaryQuery.hasNextPage && (
+                <div className="mt-2 flex justify-center">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={chatSummaryQuery.isFetchingNextPage}
+                    onClick={() => chatSummaryQuery.fetchNextPage()}
+                  >
+                    {chatSummaryQuery.isFetchingNextPage
+                      ? "Loading..."
+                      : "Load More"}
+                  </Button>
                 </div>
               )}
-
-              {results.length > 0 && (
-                <div className="mt-6">
-                  <h3 className="mb-2 text-sm font-semibold">
-                    Recent Findings
-                  </h3>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Category</TableHead>
-                        <TableHead>Rule</TableHead>
-                        <TableHead>Chat</TableHead>
-                        <TableHead>User</TableHead>
-                        <TableHead className="w-[200px]">Match</TableHead>
-                        <TableHead className="w-[240px]">Policy Note</TableHead>
-                        <TableHead>Detected</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {results.map((result) => {
-                        const policyNote = policyMessageById.get(
-                          result.policyId,
-                        );
-                        return (
-                          <TableRow
-                            key={result.id}
-                            className="cursor-pointer"
-                            onClick={() => {
-                              if (result.chatId) {
-                                setSelectedChatId(result.chatId);
-                              }
-                            }}
-                          >
-                            <TableCell>
-                              <CategoryBadge
-                                source={result.source}
-                                ruleId={result.ruleId}
-                              />
-                            </TableCell>
-                            <TableCell className="font-mono text-xs">
-                              {result.ruleId ?? "-"}
-                            </TableCell>
-                            <TableCell className="text-muted-foreground max-w-[200px] truncate text-xs">
-                              {result.chatTitle ?? "Untitled"}
-                            </TableCell>
-                            <TableCell className="text-muted-foreground text-xs">
-                              {result.userId ?? "-"}
-                            </TableCell>
-                            <TableCell className="w-[200px] max-w-[200px] truncate">
-                              <MaskedMatch value={result.match} />
-                            </TableCell>
-                            <TableCell
-                              className="text-muted-foreground w-[240px] max-w-[240px] truncate text-xs italic"
-                              title={policyNote ?? undefined}
-                            >
-                              {policyNote ?? "-"}
-                            </TableCell>
-                            <TableCell className="text-muted-foreground text-xs">
-                              {result.createdAt
-                                ? new Date(result.createdAt).toLocaleString()
-                                : "-"}
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                  {resultsQuery.hasNextPage && (
-                    <div className="mt-2 flex justify-center">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={resultsQuery.isFetchingNextPage}
-                        onClick={() => resultsQuery.fetchNextPage()}
-                      >
-                        {resultsQuery.isFetchingNextPage
-                          ? "Loading..."
-                          : "Load More"}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="mt-8 text-center">
-              <p className="text-muted-foreground text-sm">
-                No findings yet. Findings will appear here as messages are
-                analyzed.
-              </p>
             </div>
           )}
-        </Page.Body>
-      </Page>
+
+          {results.length > 0 && (
+            <div className="mt-6">
+              <h3 className="mb-2 text-sm font-semibold">Recent Findings</h3>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Rule</TableHead>
+                    <TableHead>Chat</TableHead>
+                    <TableHead>User</TableHead>
+                    <TableHead className="w-[200px]">Match</TableHead>
+                    <TableHead className="w-[240px]">Policy Note</TableHead>
+                    <TableHead>Detected</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {results.map((result) => {
+                    const policyNote = policyMessageById.get(result.policyId);
+                    return (
+                      <TableRow
+                        key={result.id}
+                        className="cursor-pointer"
+                        onClick={() => {
+                          if (result.chatId) {
+                            setSelectedChatId(result.chatId);
+                          }
+                        }}
+                      >
+                        <TableCell>
+                          <CategoryBadge
+                            source={result.source}
+                            ruleId={result.ruleId}
+                          />
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {result.ruleId ?? "-"}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground max-w-[200px] truncate text-xs">
+                          {result.chatTitle ?? "Untitled"}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-xs">
+                          {result.userId ?? "-"}
+                        </TableCell>
+                        <TableCell className="w-[200px] max-w-[200px] truncate">
+                          <MaskedMatch value={result.match} />
+                        </TableCell>
+                        <TableCell
+                          className="text-muted-foreground w-[240px] max-w-[240px] truncate text-xs italic"
+                          title={policyNote ?? undefined}
+                        >
+                          {policyNote ?? "-"}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-xs">
+                          {result.createdAt
+                            ? new Date(result.createdAt).toLocaleString()
+                            : "-"}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+              {resultsQuery.hasNextPage && (
+                <div className="mt-2 flex justify-center">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={resultsQuery.isFetchingNextPage}
+                    onClick={() => resultsQuery.fetchNextPage()}
+                  >
+                    {resultsQuery.isFetchingNextPage
+                      ? "Loading..."
+                      : "Load More"}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="mt-8 text-center">
+          <p className="text-muted-foreground text-sm">
+            No findings yet. Findings will appear here as messages are analyzed.
+          </p>
+        </div>
+      )}
 
       <Drawer
         open={!!selectedChatId}

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -1,6 +1,5 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
-import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -33,29 +32,32 @@ for (const [category, rules] of Object.entries(DETECTION_RULES)) {
   }
 }
 
+const SOURCE_TO_CATEGORY = new Map<string, RuleCategory>([
+  ["destructive_tool", "destructive_tool"],
+  ["shadow_mcp", "shadow_mcp"],
+  ["prompt_injection", "prompt_injection"],
+]);
+
 function getCategoryForFinding(
   source: string | undefined,
   ruleId: string | undefined,
 ): RuleCategory | null {
-  if (source === "destructive_tool") return "destructive_tool";
-  if (source === "shadow_mcp") return "shadow_mcp";
-  if (source === "prompt_injection") return "prompt_injection";
+  const sourceCategory = source ? SOURCE_TO_CATEGORY.get(source) : null;
+  if (sourceCategory) return sourceCategory;
   if (!ruleId) return null;
   return RULE_ID_TO_CATEGORY.get(ruleId) ?? null;
 }
 
-function CategoryBadge({
+function CategoryLabel({
   source,
   ruleId,
 }: {
-  source: string | undefined;
-  ruleId: string | undefined;
+  source?: string;
+  ruleId?: string;
 }) {
   const category = getCategoryForFinding(source, ruleId);
-  if (!category) return null;
-  return (
-    <Badge variant="secondary">{RULE_CATEGORY_META[category].label}</Badge>
-  );
+  const label = category ? RULE_CATEGORY_META[category].label : null;
+  return <span className="font-mono text-xs">{label}</span>;
 }
 
 export default function SecurityOverview() {
@@ -256,10 +258,10 @@ function SecurityOverviewContent() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Chat</TableHead>
-                    <TableHead>User</TableHead>
-                    <TableHead>Findings</TableHead>
-                    <TableHead>Latest Detected</TableHead>
+                    <TableHead className="w-6/12">Chat</TableHead>
+                    <TableHead className="w-3/12">User</TableHead>
+                    <TableHead className="w-1/12">Findings</TableHead>
+                    <TableHead className="w-2/12">Latest Detected</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -269,16 +271,16 @@ function SecurityOverviewContent() {
                       className="cursor-pointer"
                       onClick={() => setSelectedChatId(chat.chatId)}
                     >
-                      <TableCell className="text-muted-foreground max-w-[300px] truncate text-xs">
+                      <TableCell className="text-muted-foreground truncate">
                         {chat.chatTitle ?? "Untitled"}
                       </TableCell>
-                      <TableCell className="text-muted-foreground text-xs">
+                      <TableCell className="text-muted-foreground">
                         {chat.userId ?? "-"}
                       </TableCell>
-                      <TableCell className="font-mono text-xs">
+                      <TableCell className="text-foreground font-mono">
                         {chat.findingsCount}
                       </TableCell>
-                      <TableCell className="text-muted-foreground text-xs">
+                      <TableCell className="text-muted-foreground">
                         {chat.latestDetected
                           ? new Date(chat.latestDetected).toLocaleString()
                           : "-"}
@@ -310,13 +312,13 @@ function SecurityOverviewContent() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Category</TableHead>
-                    <TableHead>Rule</TableHead>
-                    <TableHead>Chat</TableHead>
-                    <TableHead>User</TableHead>
-                    <TableHead className="w-[200px]">Match</TableHead>
-                    <TableHead className="w-[240px]">Policy Note</TableHead>
-                    <TableHead>Detected</TableHead>
+                    <TableHead className="w-1/12">Category</TableHead>
+                    <TableHead className="w-1/12">Rule</TableHead>
+                    <TableHead className="w-1/12">Chat</TableHead>
+                    <TableHead className="w-1/12">User</TableHead>
+                    <TableHead className="w-1/12">Match</TableHead>
+                    <TableHead className="w-1/12">Policy Note</TableHead>
+                    <TableHead className="w-1/12">Detected</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -333,30 +335,32 @@ function SecurityOverviewContent() {
                         }}
                       >
                         <TableCell>
-                          <CategoryBadge
+                          <CategoryLabel
                             source={result.source}
                             ruleId={result.ruleId}
                           />
                         </TableCell>
-                        <TableCell className="font-mono text-xs">
-                          {result.ruleId ?? "-"}
+                        <TableCell>
+                          <span className="font-mono text-xs">
+                            {result.ruleId ? result.ruleId : "-"}
+                          </span>
                         </TableCell>
-                        <TableCell className="text-muted-foreground max-w-[200px] truncate text-xs">
+                        <TableCell className="text-muted-foreground truncate">
                           {result.chatTitle ?? "Untitled"}
                         </TableCell>
-                        <TableCell className="text-muted-foreground text-xs">
+                        <TableCell className="text-muted-foreground">
                           {result.userId ?? "-"}
                         </TableCell>
-                        <TableCell className="w-[200px] max-w-[200px] truncate">
+                        <TableCell className="truncate">
                           <MaskedMatch value={result.match} />
                         </TableCell>
                         <TableCell
-                          className="text-muted-foreground w-[240px] max-w-[240px] truncate text-xs italic"
+                          className="text-muted-foreground truncate italic"
                           title={policyNote ?? undefined}
                         >
                           {policyNote ?? "-"}
                         </TableCell>
-                        <TableCell className="text-muted-foreground text-xs">
+                        <TableCell className="text-muted-foreground">
                           {result.createdAt
                             ? new Date(result.createdAt).toLocaleString()
                             : "-"}

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -223,168 +223,176 @@ function SecurityOverviewContent() {
 
   return (
     <>
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">Risk Overview</h2>
-          <p className="text-muted-foreground text-sm">
-            Recent findings from risk analysis scans across your project.
-          </p>
-        </div>
-        <Button variant="outline" onClick={() => routes.policyCenter.goTo()}>
-          Manage Policies
-        </Button>
-      </div>
+      <Page.Section>
+        <Page.Section.Title>Risk Overview</Page.Section.Title>
 
-      <div className="mt-4 grid grid-cols-2 gap-4">
-        <MetricCard
-          title="Events Scanned"
-          value={totalScanned}
-          format="number"
-          icon="scan-search"
-        />
-        <MetricCard
-          title="Recent Findings"
-          value={totalFindings}
-          format="number"
-          icon="flag"
-        />
-      </div>
+        <Page.Section.Description>
+          Recent findings from risk analysis scans across your project.
+        </Page.Section.Description>
+
+        <Page.Section.CTA>
+          <Button variant="outline" onClick={() => routes.policyCenter.goTo()}>
+            Manage Policies
+          </Button>
+        </Page.Section.CTA>
+
+        <Page.Section.Body>
+          <div className="mt-4 grid grid-cols-2 gap-4">
+            <MetricCard
+              title="Events Scanned"
+              value={totalScanned}
+              format="number"
+              icon="scan-search"
+            />
+            <MetricCard
+              title="Recent Findings"
+              value={totalFindings}
+              format="number"
+              icon="flag"
+            />
+          </div>
+        </Page.Section.Body>
+      </Page.Section>
 
       {hasData ? (
         <>
           {recentChats.length > 0 && (
-            <div className="mt-6">
-              <h3 className="mb-2 text-sm font-semibold">Recent Chats</h3>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-6/12">Chat</TableHead>
-                    <TableHead className="w-3/12">User</TableHead>
-                    <TableHead className="w-1/12">Findings</TableHead>
-                    <TableHead className="w-2/12">Latest Detected</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {recentChats.map((chat) => (
-                    <TableRow
-                      key={chat.chatId}
-                      className="cursor-pointer"
-                      onClick={() => setSelectedChatId(chat.chatId)}
-                    >
-                      <TableCell className="text-muted-foreground truncate">
-                        {chat.chatTitle ?? "Untitled"}
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {chat.userId ?? "-"}
-                      </TableCell>
-                      <TableCell className="text-foreground font-mono">
-                        {chat.findingsCount}
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {chat.latestDetected
-                          ? new Date(chat.latestDetected).toLocaleString()
-                          : "-"}
-                      </TableCell>
+            <Page.Section>
+              <Page.Section.Title>Recent Chats</Page.Section.Title>
+              <Page.Section.Body>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-6/12">Chat</TableHead>
+                      <TableHead className="w-3/12">User</TableHead>
+                      <TableHead className="w-1/12">Findings</TableHead>
+                      <TableHead className="w-2/12">Latest Detected</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-              {chatSummaryQuery.hasNextPage && (
-                <div className="mt-2 flex justify-center">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={chatSummaryQuery.isFetchingNextPage}
-                    onClick={() => chatSummaryQuery.fetchNextPage()}
-                  >
-                    {chatSummaryQuery.isFetchingNextPage
-                      ? "Loading..."
-                      : "Load More"}
-                  </Button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {results.length > 0 && (
-            <div className="mt-6">
-              <h3 className="mb-2 text-sm font-semibold">Recent Findings</h3>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-1/12">Category</TableHead>
-                    <TableHead className="w-1/12">Rule</TableHead>
-                    <TableHead className="w-1/12">Chat</TableHead>
-                    <TableHead className="w-1/12">User</TableHead>
-                    <TableHead className="w-1/12">Match</TableHead>
-                    <TableHead className="w-1/12">Policy Note</TableHead>
-                    <TableHead className="w-1/12">Detected</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {results.map((result) => {
-                    const policyNote = policyMessageById.get(result.policyId);
-                    return (
+                  </TableHeader>
+                  <TableBody>
+                    {recentChats.map((chat) => (
                       <TableRow
-                        key={result.id}
+                        key={chat.chatId}
                         className="cursor-pointer"
-                        onClick={() => {
-                          if (result.chatId) {
-                            setSelectedChatId(result.chatId);
-                          }
-                        }}
+                        onClick={() => setSelectedChatId(chat.chatId)}
                       >
-                        <TableCell>
-                          <CategoryLabel
-                            source={result.source}
-                            ruleId={result.ruleId}
-                          />
-                        </TableCell>
-                        <TableCell>
-                          <span className="font-mono text-xs">
-                            {result.ruleId ? result.ruleId : "-"}
-                          </span>
-                        </TableCell>
                         <TableCell className="text-muted-foreground truncate">
-                          {result.chatTitle ?? "Untitled"}
+                          {chat.chatTitle ?? "Untitled"}
                         </TableCell>
                         <TableCell className="text-muted-foreground">
-                          {result.userId ?? "-"}
+                          {chat.userId ?? "-"}
                         </TableCell>
-                        <TableCell className="truncate">
-                          <MaskedMatch value={result.match} />
-                        </TableCell>
-                        <TableCell
-                          className="text-muted-foreground truncate italic"
-                          title={policyNote ?? undefined}
-                        >
-                          {policyNote ?? "-"}
+                        <TableCell className="text-foreground font-mono">
+                          {chat.findingsCount}
                         </TableCell>
                         <TableCell className="text-muted-foreground">
-                          {result.createdAt
-                            ? new Date(result.createdAt).toLocaleString()
+                          {chat.latestDetected
+                            ? new Date(chat.latestDetected).toLocaleString()
                             : "-"}
                         </TableCell>
                       </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-              {resultsQuery.hasNextPage && (
-                <div className="mt-2 flex justify-center">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={resultsQuery.isFetchingNextPage}
-                    onClick={() => resultsQuery.fetchNextPage()}
-                  >
-                    {resultsQuery.isFetchingNextPage
-                      ? "Loading..."
-                      : "Load More"}
-                  </Button>
-                </div>
-              )}
-            </div>
+                    ))}
+                  </TableBody>
+                </Table>
+                {chatSummaryQuery.hasNextPage && (
+                  <div className="mt-2 flex justify-center">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={chatSummaryQuery.isFetchingNextPage}
+                      onClick={() => chatSummaryQuery.fetchNextPage()}
+                    >
+                      {chatSummaryQuery.isFetchingNextPage
+                        ? "Loading..."
+                        : "Load More"}
+                    </Button>
+                  </div>
+                )}
+              </Page.Section.Body>
+            </Page.Section>
+          )}
+
+          {results.length > 0 && (
+            <Page.Section>
+              <Page.Section.Title>Recent Findings</Page.Section.Title>
+              <Page.Section.Body>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-1/12">Category</TableHead>
+                      <TableHead className="w-1/12">Rule</TableHead>
+                      <TableHead className="w-1/12">Chat</TableHead>
+                      <TableHead className="w-1/12">User</TableHead>
+                      <TableHead className="w-1/12">Match</TableHead>
+                      <TableHead className="w-1/12">Policy Note</TableHead>
+                      <TableHead className="w-1/12">Detected</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {results.map((result) => {
+                      const policyNote = policyMessageById.get(result.policyId);
+                      return (
+                        <TableRow
+                          key={result.id}
+                          className="cursor-pointer"
+                          onClick={() => {
+                            if (result.chatId) {
+                              setSelectedChatId(result.chatId);
+                            }
+                          }}
+                        >
+                          <TableCell>
+                            <CategoryLabel
+                              source={result.source}
+                              ruleId={result.ruleId}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <span className="font-mono text-xs">
+                              {result.ruleId ? result.ruleId : "-"}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-muted-foreground truncate">
+                            {result.chatTitle ?? "Untitled"}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {result.userId ?? "-"}
+                          </TableCell>
+                          <TableCell className="truncate">
+                            <MaskedMatch value={result.match} />
+                          </TableCell>
+                          <TableCell
+                            className="text-muted-foreground truncate italic"
+                            title={policyNote ?? undefined}
+                          >
+                            {policyNote ?? "-"}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {result.createdAt
+                              ? new Date(result.createdAt).toLocaleString()
+                              : "-"}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+                {resultsQuery.hasNextPage && (
+                  <div className="mt-2 flex justify-center">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={resultsQuery.isFetchingNextPage}
+                      onClick={() => resultsQuery.fetchNextPage()}
+                    >
+                      {resultsQuery.isFetchingNextPage
+                        ? "Loading..."
+                        : "Load More"}
+                    </Button>
+                  </div>
+                )}
+              </Page.Section.Body>
+            </Page.Section>
           )}
         </>
       ) : (

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -24,6 +24,7 @@ import {
 } from "./policy-data";
 import { ChatDetailPanel } from "@/pages/chatLogs/ChatDetailPanel";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
+import { MetricCard } from "@/components/chart/MetricCard";
 
 const RULE_ID_TO_CATEGORY = new Map<string, RuleCategory>();
 for (const [category, rules] of Object.entries(DETECTION_RULES)) {
@@ -170,8 +171,6 @@ function SecurityOverviewContent() {
     () => resultsQuery.data?.pages.flatMap((p) => p.results) ?? [],
     [resultsQuery.data],
   );
-  const totalFindings =
-    resultsQuery.data?.pages[0]?.totalCount ?? results.length;
   const recentChats = useMemo(
     () => chatSummaryQuery.data?.pages.flatMap((p) => p.chats) ?? [],
     [chatSummaryQuery.data],
@@ -222,6 +221,8 @@ function SecurityOverviewContent() {
     (max, p) => Math.max(max, p.totalMessages - p.pendingMessages),
     0,
   );
+  const totalFindings =
+    resultsQuery.data?.pages[0]?.totalCount ?? results.length;
 
   const hasData = recentChats.length > 0 || results.length > 0;
 
@@ -248,18 +249,18 @@ function SecurityOverviewContent() {
           </div>
 
           <div className="mt-4 grid grid-cols-2 gap-4">
-            <div className="rounded-lg border p-4">
-              <p className="text-muted-foreground text-sm">Events Scanned</p>
-              <p className="text-2xl font-bold">
-                {totalScanned.toLocaleString()}
-              </p>
-            </div>
-            <div className="rounded-lg border p-4">
-              <p className="text-muted-foreground text-sm">Recent Findings</p>
-              <p className="text-2xl font-bold">
-                {totalFindings.toLocaleString()}
-              </p>
-            </div>
+            <MetricCard
+              title="Events Scanned"
+              value={totalScanned}
+              format="number"
+              icon="scan-search"
+            />
+            <MetricCard
+              title="Recent Findings"
+              value={totalFindings}
+              format="number"
+              icon="flag"
+            />
           </div>
 
           {hasData ? (


### PR DESCRIPTION
### Summary

- Lift `Page`/`Page.Header`/`Page.Body` wrappers up to route component — no more duplication across loading/empty/loaded states
- Replace ad-hoc `<div>` section wrappers with `Page.Section` / `Page.Section.Title` / `Page.Section.Body`
- Make both tables scrollable with fixed max-height and sticky headers. This could be improved but needs a separate PR to make the scroll table it's own component
- Fix `DrawerContent` width classes to use Vaul data-attribute selectors instead of `!important` overrides

### Visual

<img width="2284" height="1723" alt="image" src="https://github.com/user-attachments/assets/081888a7-98bc-4fcd-87bd-508509171a5c" />

### Test plan

- [x] Security Overview loads and shows breadcrumb header
- [x] Loading and empty states render without layout shift
- [x] Both tables scroll within their containers; sticky headers stay fixed
- [x] "Load More" buttons appear below each table
- [x] Clicking a row opens the chat detail drawer at correct width
- [x] Category column shows plain mono text, not a badge
