### PR TITLE
chore: improve members table and challenges pagination

### DIFF
--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -19,6 +19,7 @@ import { Check } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { countChallenges, scopeChallenges } from "./challengeHelpers";
+import { useChallengeGroups } from "./useChallengeGroups";
 import { useChallengeRowColumns } from "./useChallengeRowColumns";
 import { useGrantFlow } from "./useGrantFlow";
 
@@ -137,6 +138,18 @@ export function ChallengesTab() {
     setPrincipalFilter(identity ?? "all");
   }
   const [scopeFilter, setScopeFilter] = useState("all");
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleGroup = useCallback((groupKey: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupKey)) next.delete(groupKey);
+      else next.add(groupKey);
+      return next;
+    });
+  }, []);
+
   const groupSiblingIdsRef = useRef<Map<string, string[]>>(new Map());
   const getGroupChallengeIds = useCallback(
     (id: string) => groupSiblingIdsRef.current.get(id) ?? [id],
@@ -175,19 +188,7 @@ export function ChallengesTab() {
     return [...set].filter(Boolean).sort();
   }, [challenges]);
 
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const toggleGroup = useCallback((groupKey: string) => {
-    setExpandedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(groupKey)) next.delete(groupKey);
-      else next.add(groupKey);
-      return next;
-    });
-  }, []);
-
-  const { filtered, groupCounts, groupKeys } = useMemo(() => {
+  const filteredAndSorted = useMemo(() => {
     let base = scopedChallenges;
     if (outcomeFilter === "resolved") {
       base = base.filter(
@@ -200,43 +201,21 @@ export function ChallengesTab() {
           recentlyResolvedIds.has(c.id),
       );
     }
-    const sorted = [...base].sort((a, b) => {
+    return [...base].sort((a, b) => {
       const order = (o: Outcome) => (o === "deny" ? 0 : o === "error" ? 1 : 2);
       const diff = order(a.outcome) - order(b.outcome);
       if (diff !== 0) return diff;
       return b.timestamp.getTime() - a.timestamp.getTime();
     });
+  }, [scopedChallenges, outcomeFilter, recentlyResolvedIds]);
 
-    // Group by (principal, scope, outcome, resource)
-    const groups = new Map<string, AuthzChallenge[]>();
-    for (const c of sorted) {
-      const displayIdentity = c.userEmail ?? c.principalUrn;
-      const key = `${displayIdentity}|${c.scope}|${c.outcome}|${c.resourceKind ?? ""}|${c.resourceId ?? ""}`;
-      const arr = groups.get(key);
-      if (arr) arr.push(c);
-      else groups.set(key, [c]);
-    }
-
-    const result: AuthzChallenge[] = [];
-    const counts = new Map<string, number>();
-    const keys = new Map<string, string>();
-    const siblingIds = new Map<string, string[]>();
-    for (const [key, members] of groups) {
-      const memberIds = members.map((m) => m.id);
-      counts.set(members[0].id, members.length);
-      for (const m of members) {
-        keys.set(m.id, key);
-        siblingIds.set(m.id, memberIds);
-      }
-      if (expandedGroups.has(key)) {
-        result.push(...members);
-      } else {
-        result.push(members[0]);
-      }
-    }
-    groupSiblingIdsRef.current = siblingIds;
-    return { filtered: result, groupCounts: counts, groupKeys: keys };
-  }, [scopedChallenges, outcomeFilter, recentlyResolvedIds, expandedGroups]);
+  const {
+    grouped: filtered,
+    groupCounts,
+    groupKeys,
+    groupSiblingIdsRef: siblingIdsRef,
+  } = useChallengeGroups(filteredAndSorted, expandedGroups);
+  groupSiblingIdsRef.current = siblingIdsRef.current;
 
   const challengeRowColumns = useChallengeRowColumns(
     animatingOutIds,

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -240,12 +240,30 @@ export function ChallengesTab() {
   }, [scopedChallenges, outcomeFilter, recentlyResolvedIds]);
 
   const {
-    grouped: filtered,
+    grouped: allFiltered,
     groupCounts,
     groupKeys,
     groupSiblingIdsRef: siblingIdsRef,
   } = useChallengeGroups(filteredAndSorted, expandedGroups);
   groupSiblingIdsRef.current = siblingIdsRef.current;
+
+  const VISIBLE_PAGE_SIZE = 15;
+  const [visibleLimit, setVisibleLimit] = useState(VISIBLE_PAGE_SIZE);
+
+  // Reset visible limit when filters change
+  const filterKey = `${outcomeFilter}|${principalFilter}|${scopeFilter}`;
+  const prevFilterKeyRef = useRef(filterKey);
+  if (filterKey !== prevFilterKeyRef.current) {
+    prevFilterKeyRef.current = filterKey;
+    setVisibleLimit(VISIBLE_PAGE_SIZE);
+  }
+
+  const filtered = useMemo(
+    () => allFiltered.slice(0, visibleLimit),
+    [allFiltered, visibleLimit],
+  );
+  const hasMoreVisible = visibleLimit < allFiltered.length;
+  const needsServerPage = !hasMoreVisible && hasMore;
 
   const challengeRowColumns = useChallengeRowColumns(
     animatingOutIds,
@@ -326,10 +344,19 @@ export function ChallengesTab() {
           {(filtered.length > 0 || isLoadingMore) && (
             <div className="bg-muted/20 flex items-center justify-between border-t px-4 py-3">
               <Type muted small>
-                {filtered.length.toLocaleString()} challenge
-                {filtered.length === 1 ? "" : "s"}
+                {filtered.length.toLocaleString()} of{" "}
+                {allFiltered.length.toLocaleString()} challenge
+                {allFiltered.length === 1 ? "" : "s"}
               </Type>
-              {hasMore ? (
+              {hasMoreVisible ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setVisibleLimit((v) => v + VISIBLE_PAGE_SIZE)}
+                >
+                  Load more
+                </Button>
+              ) : needsServerPage ? (
                 <Button
                   variant="outline"
                   size="sm"

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -323,12 +323,11 @@ export function ChallengesTab() {
       ) : (
         <>
           <Table columns={columns} data={filtered} rowKey={(row) => row.id} />
-          {(challenges.length > 0 || isLoadingMore) && (
+          {(filtered.length > 0 || isLoadingMore) && (
             <div className="bg-muted/20 flex items-center justify-between border-t px-4 py-3">
               <Type muted small>
-                {challenges.length.toLocaleString()} challenge
-                {challenges.length === 1 ? "" : "s"}
-                {totalServer > 0 && ` of ${totalServer.toLocaleString()}`}
+                {filtered.length.toLocaleString()} challenge
+                {filtered.length === 1 ? "" : "s"}
               </Type>
               {hasMore ? (
                 <Button

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -316,7 +316,7 @@ export function ChallengesTab() {
         </Select>
       </div>
 
-      {isLoading ? (
+      {isLoading && accumulated.length === 0 ? (
         <SkeletonTable />
       ) : filtered.length === 0 ? (
         <ChallengesEmptyState outcomeFilter={outcomeFilter} />

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -15,8 +15,9 @@ import {
   type Column,
   Table,
 } from "@speakeasy-api/moonshine";
-import { Check } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Check, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { countChallenges, scopeChallenges } from "./challengeHelpers";
 import { useChallengeGroups } from "./useChallengeGroups";
@@ -162,10 +163,39 @@ export function ChallengesTab() {
     animatingOutIds,
   } = useGrantFlow(getGroupChallengeIds);
 
-  const { data, isLoading } = useChallenges({ limit: 200 });
+  const PAGE_SIZE = 200;
+  const [pageCount, setPageCount] = useState(1);
+  const [accumulated, setAccumulated] = useState<AuthzChallenge[]>([]);
+  const [totalServer, setTotalServer] = useState(0);
+
+  // Fetch current page
+  const offset = (pageCount - 1) * PAGE_SIZE;
+  const { data, isLoading, isFetching } = useChallenges({
+    limit: PAGE_SIZE,
+    offset,
+  });
+
+  // Accumulate results as pages load
+  useEffect(() => {
+    if (!data?.challenges) return;
+    setTotalServer(data.total);
+    if (pageCount === 1) {
+      setAccumulated(data.challenges);
+    } else {
+      setAccumulated((prev) => {
+        const existingIds = new Set(prev.map((c) => c.id));
+        const newItems = data.challenges.filter((c) => !existingIds.has(c.id));
+        return [...prev, ...newItems];
+      });
+    }
+  }, [data, pageCount]);
+
+  const hasMore = accumulated.length < totalServer;
+  const isLoadingMore = isFetching && pageCount > 1;
+
   const challenges = useMemo(
-    () => (data?.challenges ?? []).filter((c) => !!c.scope),
-    [data?.challenges],
+    () => accumulated.filter((c) => !!c.scope),
+    [accumulated],
   );
 
   const scopedChallenges = useMemo(
@@ -291,7 +321,39 @@ export function ChallengesTab() {
       ) : filtered.length === 0 ? (
         <ChallengesEmptyState outcomeFilter={outcomeFilter} />
       ) : (
-        <Table columns={columns} data={filtered} rowKey={(row) => row.id} />
+        <>
+          <Table columns={columns} data={filtered} rowKey={(row) => row.id} />
+          {(challenges.length > 0 || isLoadingMore) && (
+            <div className="bg-muted/20 flex items-center justify-between border-t px-4 py-3">
+              <Type muted small>
+                {challenges.length.toLocaleString()} challenge
+                {challenges.length === 1 ? "" : "s"}
+                {totalServer > 0 && ` of ${totalServer.toLocaleString()}`}
+              </Type>
+              {hasMore ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPageCount((p) => p + 1)}
+                  disabled={isLoadingMore}
+                >
+                  {isLoadingMore ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Loading...
+                    </>
+                  ) : (
+                    "Load more"
+                  )}
+                </Button>
+              ) : (
+                <Type muted small>
+                  All challenges loaded
+                </Type>
+              )}
+            </div>
+          )}
+        </>
       )}
 
       <div className="border-border/50 bg-muted/30 mt-8 rounded-md border px-4 py-3">

--- a/client/dashboard/src/pages/access/MembersTab.tsx
+++ b/client/dashboard/src/pages/access/MembersTab.tsx
@@ -19,7 +19,7 @@ import {
 } from "@speakeasy-api/moonshine";
 import { Ellipsis } from "lucide-react";
 import { useState } from "react";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { ChangeRoleDialog } from "./ChangeRoleDialog";
 import { RequireScope } from "@/components/require-scope";
 import { useOrganization } from "@/contexts/Auth";
@@ -84,11 +84,9 @@ export function MembersTab() {
   const { data: membersData, isLoading: membersLoading } = useMembers();
   const { data: rolesData } = useRoles();
   const roles = rolesData?.roles ?? [];
-  const members = [...(membersData?.members ?? [])].sort((a, b) => {
-    const aSystem = roles.find((r) => r.id === a.roleId)?.isSystem ?? false;
-    const bSystem = roles.find((r) => r.id === b.roleId)?.isSystem ?? false;
-    return Number(bSystem) - Number(aSystem);
-  });
+  const members = [...(membersData?.members ?? [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
   const getRoleName = (roleId: string) =>
     roles.find((r) => r.id === roleId)?.name ?? "Unknown";
@@ -99,8 +97,8 @@ export function MembersTab() {
       header: "Member",
       width: "200px",
       render: (member) => (
-        <div className="flex items-center gap-3">
-          <Avatar className="h-8 w-8">
+        <div className="flex items-center gap-3 overflow-hidden">
+          <Avatar className="h-8 w-8 shrink-0">
             {member.photoUrl && (
               <AvatarImage src={member.photoUrl} alt={member.name} />
             )}
@@ -108,7 +106,7 @@ export function MembersTab() {
               {getInitials(member.name)}
             </AvatarFallback>
           </Avatar>
-          <Type variant="body" className="font-medium">
+          <Type variant="body" className="truncate font-medium">
             {member.name}
           </Type>
         </div>
@@ -129,14 +127,25 @@ export function MembersTab() {
       header: "Role",
       width: "140px",
       render: (member) => (
-        <Type variant="body">{getRoleName(member.roleId)}</Type>
+        <Type variant="body">
+          <Link
+            to={`${orgRoutes.access.roles.href()}?editRole=${member.roleId}`}
+            className="text-primary hover:text-primary/80 underline decoration-dotted underline-offset-4 transition-colors"
+          >
+            {getRoleName(member.roleId)}
+          </Link>
+        </Type>
       ),
     },
     {
       key: "joinedAt",
       header: "Joined",
       width: "160px",
-      render: (member) => <HumanizeDateTime date={member.joinedAt} />,
+      render: (member) => (
+        <Type variant="body" className="text-muted-foreground">
+          <HumanizeDateTime date={member.joinedAt} />
+        </Type>
+      ),
     },
     {
       key: "actions",
@@ -178,7 +187,7 @@ export function MembersTab() {
           className="mt-4 rounded-b-none"
         />
       )}
-      <div className="border-border flex justify-center rounded-b-lg border border-t-0 py-3">
+      <div className="border-border bg-muted/20 flex justify-center rounded-b-lg border border-t-0 py-3">
         <RequireScope scope="org:admin" level="component">
           {isTeamPageEnabled ? (
             <Button

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -23,7 +23,8 @@ import {
   Table,
 } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
 import { CreateRoleDialog } from "./CreateRoleDialog";
 import { DeleteRoleDialog } from "./DeleteRoleDialog";
 import { Ellipsis } from "lucide-react";
@@ -74,6 +75,7 @@ export function RolesTab() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingRole, setEditingRole] = useState<Role | null>(null);
   const [deletingRole, setDeletingRole] = useState<Role | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const { data: rolesData, isLoading } = useRoles();
   const roles = [...(rolesData?.roles ?? [])].sort(
@@ -81,6 +83,23 @@ export function RolesTab() {
   );
   const { data: membersData } = useMembers();
   const members = membersData?.members ?? [];
+
+  useEffect(() => {
+    const editRoleId = searchParams.get("editRole");
+    if (editRoleId && roles.length > 0) {
+      const role = roles.find((r) => r.id === editRoleId);
+      if (role) {
+        setEditingRole(role);
+        setSearchParams(
+          (prev) => {
+            prev.delete("editRole");
+            return prev;
+          },
+          { replace: true },
+        );
+      }
+    }
+  }, [searchParams, roles, setSearchParams]);
 
   const defaultRole =
     roles.find((r) => r.isSystem && r.name === "Member") ?? null;

--- a/client/dashboard/src/pages/access/useChallengeGroups.test.ts
+++ b/client/dashboard/src/pages/access/useChallengeGroups.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import type { AuthzChallenge } from "@gram/client/models/components/authzchallenge.js";
+import { challengeGroupKey, groupChallenges } from "./useChallengeGroups";
+
+function makeChallenge(
+  overrides: Partial<AuthzChallenge> = {},
+): AuthzChallenge {
+  return {
+    id: "ch-1",
+    evaluatedGrantCount: 1,
+    matchedGrantCount: 0,
+    operation: "require",
+    organizationId: "org-1",
+    outcome: "deny",
+    principalType: "user",
+    principalUrn: "user:u1",
+    reason: "scope_unsatisfied",
+    roleSlugs: [],
+    scope: "project:read",
+    timestamp: new Date("2026-05-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("challengeGroupKey", () => {
+  it("uses userEmail when available", () => {
+    const c = makeChallenge({ userEmail: "alice@acme.com" });
+    expect(challengeGroupKey(c)).toBe("alice@acme.com|project:read|deny||");
+  });
+
+  it("falls back to principalUrn when no userEmail", () => {
+    const c = makeChallenge({ userEmail: undefined });
+    expect(challengeGroupKey(c)).toBe("user:u1|project:read|deny||");
+  });
+
+  it("includes resourceKind and resourceId", () => {
+    const c = makeChallenge({
+      userEmail: "alice@acme.com",
+      resourceKind: "project",
+      resourceId: "proj-1",
+    });
+    expect(challengeGroupKey(c)).toBe(
+      "alice@acme.com|project:read|deny|project|proj-1",
+    );
+  });
+
+  it("produces different keys for different outcomes", () => {
+    const deny = makeChallenge({ userEmail: "a@b.com", outcome: "deny" });
+    const allow = makeChallenge({ userEmail: "a@b.com", outcome: "allow" });
+    expect(challengeGroupKey(deny)).not.toBe(challengeGroupKey(allow));
+  });
+
+  it("produces different keys for different scopes", () => {
+    const a = makeChallenge({ userEmail: "a@b.com", scope: "org:read" });
+    const b = makeChallenge({ userEmail: "a@b.com", scope: "org:admin" });
+    expect(challengeGroupKey(a)).not.toBe(challengeGroupKey(b));
+  });
+});
+
+describe("groupChallenges", () => {
+  it("returns empty results for empty input", () => {
+    const result = groupChallenges([]);
+    expect(result.grouped).toHaveLength(0);
+    expect(result.groupCounts.size).toBe(0);
+    expect(result.groupKeys.size).toBe(0);
+    expect(result.siblingIds.size).toBe(0);
+  });
+
+  it("returns single challenge ungrouped", () => {
+    const c = makeChallenge({ id: "1", userEmail: "a@b.com" });
+    const result = groupChallenges([c]);
+    expect(result.grouped).toEqual([c]);
+    expect(result.groupCounts.get("1")).toBe(1);
+  });
+
+  it("collapses identical-key challenges into one row", () => {
+    const challenges = [
+      makeChallenge({ id: "1", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "2", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "3", userEmail: "a@b.com", scope: "org:read" }),
+    ];
+    const result = groupChallenges(challenges);
+    expect(result.grouped).toHaveLength(1);
+    expect(result.grouped[0].id).toBe("1");
+    expect(result.groupCounts.get("1")).toBe(3);
+  });
+
+  it("keeps different-key challenges as separate rows", () => {
+    const challenges = [
+      makeChallenge({ id: "1", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "2", userEmail: "b@b.com", scope: "org:read" }),
+    ];
+    const result = groupChallenges(challenges);
+    expect(result.grouped).toHaveLength(2);
+  });
+
+  it("tracks groupKeys for every member", () => {
+    const challenges = [
+      makeChallenge({ id: "1", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "2", userEmail: "a@b.com", scope: "org:read" }),
+    ];
+    const result = groupChallenges(challenges);
+    const key1 = result.groupKeys.get("1");
+    const key2 = result.groupKeys.get("2");
+    expect(key1).toBeDefined();
+    expect(key1).toBe(key2);
+  });
+
+  it("populates siblingIds for all members in a group", () => {
+    const challenges = [
+      makeChallenge({ id: "1", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "2", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "3", userEmail: "a@b.com", scope: "org:read" }),
+    ];
+    const result = groupChallenges(challenges);
+    expect(result.siblingIds.get("1")).toEqual(["1", "2", "3"]);
+    expect(result.siblingIds.get("2")).toEqual(["1", "2", "3"]);
+    expect(result.siblingIds.get("3")).toEqual(["1", "2", "3"]);
+  });
+
+  it("expands a group when its key is in expandedGroups", () => {
+    const challenges = [
+      makeChallenge({ id: "1", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "2", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "3", userEmail: "a@b.com", scope: "org:read" }),
+    ];
+    const groupKey = challengeGroupKey(challenges[0]);
+    const expanded = new Set([groupKey]);
+    const result = groupChallenges(challenges, expanded);
+    expect(result.grouped).toHaveLength(3);
+    expect(result.grouped.map((c) => c.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("only expands matching groups, collapses others", () => {
+    const challenges = [
+      makeChallenge({ id: "1", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "2", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({
+        id: "3",
+        userEmail: "b@b.com",
+        scope: "org:read",
+        outcome: "deny",
+      }),
+      makeChallenge({
+        id: "4",
+        userEmail: "b@b.com",
+        scope: "org:read",
+        outcome: "deny",
+      }),
+    ];
+    const expandKey = challengeGroupKey(challenges[0]);
+    const expanded = new Set([expandKey]);
+    const result = groupChallenges(challenges, expanded);
+    // Group A (a@b.com) expanded → 2 rows, Group B (b@b.com) collapsed → 1 row
+    expect(result.grouped).toHaveLength(3);
+    expect(result.grouped.map((c) => c.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("groups by resource fields", () => {
+    const challenges = [
+      makeChallenge({
+        id: "1",
+        userEmail: "a@b.com",
+        resourceKind: "project",
+        resourceId: "p1",
+      }),
+      makeChallenge({
+        id: "2",
+        userEmail: "a@b.com",
+        resourceKind: "project",
+        resourceId: "p2",
+      }),
+    ];
+    const result = groupChallenges(challenges);
+    // Different resourceId → different groups
+    expect(result.grouped).toHaveLength(2);
+  });
+
+  it("count is only set on first member of each group", () => {
+    const challenges = [
+      makeChallenge({ id: "1", userEmail: "a@b.com", scope: "org:read" }),
+      makeChallenge({ id: "2", userEmail: "a@b.com", scope: "org:read" }),
+    ];
+    const result = groupChallenges(challenges);
+    expect(result.groupCounts.get("1")).toBe(2);
+    expect(result.groupCounts.has("2")).toBe(false);
+  });
+});

--- a/client/dashboard/src/pages/access/useChallengeGroups.ts
+++ b/client/dashboard/src/pages/access/useChallengeGroups.ts
@@ -1,16 +1,54 @@
 import type { AuthzChallenge } from "@gram/client/models/components/authzchallenge.js";
 import { useMemo, useRef } from "react";
 
-function challengeGroupKey(c: AuthzChallenge): string {
+export function challengeGroupKey(c: AuthzChallenge): string {
   const displayIdentity = c.userEmail ?? c.principalUrn;
   return `${displayIdentity}|${c.scope}|${c.outcome}|${c.resourceKind ?? ""}|${c.resourceId ?? ""}`;
+}
+
+export interface GroupChallengesResult {
+  grouped: AuthzChallenge[];
+  groupCounts: Map<string, number>;
+  groupKeys: Map<string, string>;
+  siblingIds: Map<string, string[]>;
+}
+
+export function groupChallenges(
+  challenges: AuthzChallenge[],
+  expandedGroups?: Set<string>,
+): GroupChallengesResult {
+  const groups = new Map<string, AuthzChallenge[]>();
+  for (const c of challenges) {
+    const key = challengeGroupKey(c);
+    const arr = groups.get(key);
+    if (arr) arr.push(c);
+    else groups.set(key, [c]);
+  }
+
+  const result: AuthzChallenge[] = [];
+  const counts = new Map<string, number>();
+  const keys = new Map<string, string>();
+  const siblingIds = new Map<string, string[]>();
+  for (const [key, members] of groups) {
+    const memberIds = members.map((m) => m.id);
+    counts.set(members[0].id, members.length);
+    for (const m of members) {
+      keys.set(m.id, key);
+      siblingIds.set(m.id, memberIds);
+    }
+    if (expandedGroups?.has(key)) {
+      result.push(...members);
+    } else {
+      result.push(members[0]);
+    }
+  }
+  return { grouped: result, groupCounts: counts, groupKeys: keys, siblingIds };
 }
 
 interface ChallengeGroupsResult {
   grouped: AuthzChallenge[];
   groupCounts: Map<string, number>;
   groupKeys: Map<string, string>;
-  /** Ref populated after each grouping — read via getGroupChallengeIds callback. */
   groupSiblingIdsRef: React.RefObject<Map<string, string[]>>;
 }
 
@@ -21,33 +59,9 @@ export function useChallengeGroups(
   const groupSiblingIdsRef = useRef<Map<string, string[]>>(new Map());
 
   const { grouped, groupCounts, groupKeys } = useMemo(() => {
-    const groups = new Map<string, AuthzChallenge[]>();
-    for (const c of challenges) {
-      const key = challengeGroupKey(c);
-      const arr = groups.get(key);
-      if (arr) arr.push(c);
-      else groups.set(key, [c]);
-    }
-
-    const result: AuthzChallenge[] = [];
-    const counts = new Map<string, number>();
-    const keys = new Map<string, string>();
-    const siblingIds = new Map<string, string[]>();
-    for (const [key, members] of groups) {
-      const memberIds = members.map((m) => m.id);
-      counts.set(members[0].id, members.length);
-      for (const m of members) {
-        keys.set(m.id, key);
-        siblingIds.set(m.id, memberIds);
-      }
-      if (expandedGroups?.has(key)) {
-        result.push(...members);
-      } else {
-        result.push(members[0]);
-      }
-    }
-    groupSiblingIdsRef.current = siblingIds;
-    return { grouped: result, groupCounts: counts, groupKeys: keys };
+    const result = groupChallenges(challenges, expandedGroups);
+    groupSiblingIdsRef.current = result.siblingIds;
+    return result;
   }, [challenges, expandedGroups]);
 
   return { grouped, groupCounts, groupKeys, groupSiblingIdsRef };

--- a/client/dashboard/src/pages/access/useChallengeGroups.ts
+++ b/client/dashboard/src/pages/access/useChallengeGroups.ts
@@ -1,0 +1,54 @@
+import type { AuthzChallenge } from "@gram/client/models/components/authzchallenge.js";
+import { useMemo, useRef } from "react";
+
+function challengeGroupKey(c: AuthzChallenge): string {
+  const displayIdentity = c.userEmail ?? c.principalUrn;
+  return `${displayIdentity}|${c.scope}|${c.outcome}|${c.resourceKind ?? ""}|${c.resourceId ?? ""}`;
+}
+
+interface ChallengeGroupsResult {
+  grouped: AuthzChallenge[];
+  groupCounts: Map<string, number>;
+  groupKeys: Map<string, string>;
+  /** Ref populated after each grouping — read via getGroupChallengeIds callback. */
+  groupSiblingIdsRef: React.RefObject<Map<string, string[]>>;
+}
+
+export function useChallengeGroups(
+  challenges: AuthzChallenge[],
+  expandedGroups?: Set<string>,
+): ChallengeGroupsResult {
+  const groupSiblingIdsRef = useRef<Map<string, string[]>>(new Map());
+
+  const { grouped, groupCounts, groupKeys } = useMemo(() => {
+    const groups = new Map<string, AuthzChallenge[]>();
+    for (const c of challenges) {
+      const key = challengeGroupKey(c);
+      const arr = groups.get(key);
+      if (arr) arr.push(c);
+      else groups.set(key, [c]);
+    }
+
+    const result: AuthzChallenge[] = [];
+    const counts = new Map<string, number>();
+    const keys = new Map<string, string>();
+    const siblingIds = new Map<string, string[]>();
+    for (const [key, members] of groups) {
+      const memberIds = members.map((m) => m.id);
+      counts.set(members[0].id, members.length);
+      for (const m of members) {
+        keys.set(m.id, key);
+        siblingIds.set(m.id, memberIds);
+      }
+      if (expandedGroups?.has(key)) {
+        result.push(...members);
+      } else {
+        result.push(members[0]);
+      }
+    }
+    groupSiblingIdsRef.current = siblingIds;
+    return { grouped: result, groupCounts: counts, groupKeys: keys };
+  }, [challenges, expandedGroups]);
+
+  return { grouped, groupCounts, groupKeys, groupSiblingIdsRef };
+}

--- a/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
+++ b/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
@@ -205,12 +205,12 @@ export function useChallengeRowColumns(
                   {row.timestamp.toLocaleString()}
                 </TooltipContent>
               </Tooltip>
-              {count > 1 && (
+              {count > 1 && onToggleGroup && (
                 <button
                   type="button"
                   onClick={() => {
                     const key = groupKeys?.get(row.id);
-                    if (key) onToggleGroup?.(key);
+                    if (key) onToggleGroup(key);
                   }}
                   className="text-muted-foreground bg-muted hover:bg-primary/10 hover:text-primary cursor-pointer rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums transition-colors"
                 >

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -15,10 +15,11 @@ import { useRBAC } from "@/hooks/useRBAC";
 import { useChallenges } from "@gram/client/react-query/challenges.js";
 import { ChallengesEmptyState } from "@/pages/access/ChallengesTab";
 import { useChallengeRowColumns } from "@/pages/access/useChallengeRowColumns";
+import { useChallengeGroups } from "@/pages/access/useChallengeGroups";
 import { useGrantFlow } from "@/pages/access/useGrantFlow";
 import { Table } from "@speakeasy-api/moonshine";
 import { ArrowRight, ChevronDown, ChevronUp } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 const PROJECT_LIMIT = 5;
@@ -223,15 +224,38 @@ function RecentChallenges() {
   const orgRoutes = useOrgRoutes();
   const { hasScope } = useRBAC();
   const canAdmin = hasScope("org:admin");
-  const { actionsColumn, grantFlowPortals } = useGrantFlow();
-  const challengeRowColumns = useChallengeRowColumns();
+  const groupSiblingIdsRef = useRef<Map<string, string[]>>(new Map());
+  const getGroupChallengeIds = useCallback(
+    (id: string) => groupSiblingIdsRef.current.get(id) ?? [id],
+    [],
+  );
+  const { actionsColumn, grantFlowPortals } =
+    useGrantFlow(getGroupChallengeIds);
   const { data: challengesData, isLoading } = useChallenges({
     outcome: "deny",
     resolved: false,
-    limit: 5,
+    limit: 50,
   });
-  const recentChallenges = (challengesData?.challenges ?? []).filter(
-    (c) => !!c.scope,
+
+  const scopeFiltered = useMemo(
+    () => (challengesData?.challenges ?? []).filter((c) => !!c.scope),
+    [challengesData?.challenges],
+  );
+
+  const {
+    grouped: allGrouped,
+    groupCounts,
+    groupKeys,
+    groupSiblingIdsRef: siblingIdsRef,
+  } = useChallengeGroups(scopeFiltered);
+  groupSiblingIdsRef.current = siblingIdsRef.current;
+
+  const grouped = useMemo(() => allGrouped.slice(0, 5), [allGrouped]);
+
+  const challengeRowColumns = useChallengeRowColumns(
+    undefined,
+    groupCounts,
+    groupKeys,
   );
 
   const columns = useMemo(
@@ -250,14 +274,10 @@ function RecentChallenges() {
           Show more
         </orgRoutes.access.challenges.Link>
       </div>
-      {recentChallenges.length === 0 ? (
+      {grouped.length === 0 ? (
         <ChallengesEmptyState outcomeFilter="deny" />
       ) : (
-        <Table
-          columns={columns}
-          data={recentChallenges}
-          rowKey={(row) => row.id}
-        />
+        <Table columns={columns} data={grouped} rowKey={(row) => row.id} />
       )}
       {grantFlowPortals}
     </div>


### PR DESCRIPTION
## Summary

- **Members table**: sort alphabetically, prevent name wrapping, role column links to role editor, normalize font sizes, grey footer
- **Challenges tab**: add "Load more" pagination (15 groups per page, fetches next 200 from server when exhausted), extract shared `useChallengeGroups` hook
- **OrgHome recent challenges**: fix empty state (fetch 50, filter then slice), add grouping via shared hook, hide ×N badge on preview

## Changes

### Members table (`MembersTab.tsx`)
- Sort by `name.localeCompare` instead of system role
- Role cell is a `<Link>` to roles tab with `?editRole=` param
- Consistent `<Type variant="body">` wrappers on all cells
- `bg-muted/20` footer background

### Roles tab (`RolesTab.tsx`)
- Read `?editRole=` search param to auto-open role editor drawer

### Challenges (`ChallengesTab.tsx`)
- Accumulate server pages (200/page) with "Load more"
- Client-side pagination: 15 visible groups, expand by 15
- Skeleton only on initial load, not on Load more
- Refactored to use `useChallengeGroups` hook

### Shared hook (`useChallengeGroups.ts`)
- Extracted grouping logic from ChallengesTab
- Pure `groupChallenges` function + thin `useChallengeGroups` wrapper
- 15 unit tests covering key generation, collapsing, expansion, sibling tracking

### OrgHome (`OrgHome.tsx`)
- Fix: fetch limit 50 → filter → slice(0, 5) instead of limit 5
- Use `useChallengeGroups` for consistent grouping
- Hide ×N badge when no toggle handler

### Row columns (`useChallengeRowColumns.tsx`)
- Only render ×N expand button when `onToggleGroup` is provided

## Test plan

- [ ] Members tab sorts alphabetically, role links open editor drawer
- [ ] Challenges tab loads 15 groups, "Load more" reveals more
- [ ] OrgHome shows denied challenges correctly
- [ ] `npx vitest run src/pages/access/` — 96 tests pass