### PR TITLE
mig: drop trigger_instances.status check constraint

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -539,7 +539,7 @@ CREATE TABLE IF NOT EXISTS trigger_instances (
   target_ref TEXT NOT NULL CHECK (target_ref <> '' AND CHAR_LENGTH(target_ref) <= 255),
   target_display TEXT NOT NULL CHECK (target_display <> '' AND CHAR_LENGTH(target_display) <= 255),
   config_json JSONB NOT NULL DEFAULT '{}'::jsonb,
-  status TEXT NOT NULL CHECK (status IN ('active', 'paused')) DEFAULT 'active',
+  status TEXT NOT NULL DEFAULT 'active',
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/migrations/20260510225920_drop-trigger-status-check.sql
+++ b/server/migrations/20260510225920_drop-trigger-status-check.sql
@@ -1,0 +1,2 @@
+-- Modify "trigger_instances" table
+ALTER TABLE "trigger_instances" DROP CONSTRAINT "trigger_instances_status_check";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:z94107n2Bz0XOu09f32U80NSZ7Y6ZyShV4BHcwFxGpA=
+h1:BrKtMWa4P3re0PW0JivAwK5DEDGxNKB/S46RZyyZLi8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -160,3 +160,4 @@ h1:z94107n2Bz0XOu09f32U80NSZ7Y6ZyShV4BHcwFxGpA=
 20260507132747_add-name-and-slug-to-mcp-server-tables.sql h1:COKpEgovsuMJbmjf6ZE5aZcsToJb/m3+jhzQbXZKMeg=
 20260507160200_usersessions-tables.sql h1:FdPdJM8N6wjlfpRof1fcsyS72hBdyHpfIzNbh3qArjM=
 20260510204635_assistant_memory.sql h1:1Ns0hFIOYaKVAk1PPIXZIPCPYIwt87w86JydD1uq38s=
+20260510225920_drop-trigger-status-check.sql h1:1304jDv1rgS77qCPFA1Ih/GafR1NUTRhsGJc0803NnU=


### PR DESCRIPTION
Drop the `status` CHECK constraint on `trigger_instances`. The constraint was preventing us from extending the lifecycle for the new wake trigger (`fired`/`cancelled`); rather than widen the enum each time, drop the constraint entirely. Status is set in the app layer and shouldn't have been DB-pinned to a fixed list.

Split out of #2709.