### PR TITLE
fix(assistants): slack onboarding flow + manifest validity

### DIFF
--- a/.changeset/slack-onboarding-flow.md
+++ b/.changeset/slack-onboarding-flow.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Assistant onboarding now installs a Slack app reliably end-to-end: the install card stays in view until you click "I've installed it", a single approval grants both the bot and user OAuth tokens, and the generated manifest can no longer be rejected by Slack. Slack-touching assistants now get a Slack trigger by default — additive with any cron or other trigger you asked for — so the bot is reachable bidirectionally and you can talk back to it.

--- a/client/dashboard/src/pages/assistants/onboarding/docs/slack.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/docs/slack.ts
@@ -4,70 +4,87 @@ export const SLACK_DOCS: IntegrationDoc = {
   slug: "slack",
   title: "Slack",
   summary:
-    "Trigger an assistant from Slack messages, mentions, and reactions; reply via the bot.",
+    "Wire an assistant to a Slack workspace end-to-end: respond to events, talk to users, and react to schedules.",
   body: `# Slack integration
 
-Fires the assistant from Slack events (\`app_mention\`, \`message\`, \`reaction_added\`, etc.). Requires a bot token (\`xoxb-\`) and signing secret. The user creates and installs a Slack app, then pastes the credentials into the assistant's environment — Slack does not let us OAuth on their behalf for a brand-new app.
+Wire the assistant end-to-end with the user's Slack workspace: it reads/sends messages via the bot AND can be triggered by Slack events. The user creates and installs a Slack app, then pastes credentials into the assistant's environment — Slack does not let us OAuth on their behalf for a brand-new app.
+
+## Default rule: always create a slack trigger
+
+If the user's request involves Slack at all, create a slack trigger as part of setup — even if their stated goal is one-directional ("summarize my DMs at 8am", "post a daily standup"). A bot the user can talk to is strictly more useful than one they can't: once it has DM'd them, they'll want to reply, ask follow-ups, or correct it. Skip the slack trigger only when the user has explicitly said they do not want the assistant to react to Slack events.
+
+The slack trigger is additive — pair it with any cron/other trigger the user asked for. A "morning digest" assistant gets BOTH a cron trigger (fires the daily summary) AND a slack trigger (lets the user reply / chat).
+
+For event_types on the default slack trigger: \`["app_mention", "message"]\` covers the common cases (mentions in channels, DMs to the bot). Add a \`filter\` if \`message\` produces too much noise.
 
 ## Environment
 
 The assistant owns one shared environment. Extend it with \`add_environment_keys\`; populate values with \`request_environment_secrets\`. Do not create a separate env per integration.
 
-## Recommended flow (pre-filled webhook)
+Required keys for the default flow:
+- \`SLACK_BOT_TOKEN\` (xoxb-) — bot Web API auth.
+- \`SLACK_USER_TOKEN\` (xoxp-) — user-token Web API auth. The manifest always pre-fills the full user-scope superset so Slack issues xoxp- in the same install as xoxb-.
+- \`SLACK_SIGNING_SECRET\` — verifies inbound webhooks from the slack trigger.
 
-1. **Attach a Slack toolset.** \`list_integrations\` (\`"slack"\`) → \`create_toolset\` if needed → \`attach_toolset\`. Required so the bot's tools are callable in step 7. After attach, default-add the reaction platform tools (\`tools:platform:slack:add_reaction\`, \`tools:platform:slack:remove_reaction\`, \`tools:platform:slack:get_reactions\`, \`tools:platform:slack:list_reactions\`, \`tools:platform:slack:list_emoji\`) via \`add_tools_to_toolset\` — skip only if the user has explicitly said they don't want reaction tooling.
-2. **Declare keys.** \`add_environment_keys({ keys: ["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"] })\`.
-3. **Create the trigger.** \`create_trigger\` with \`definition_slug: "slack"\` and the relevant \`event_types\`. The response includes a \`webhook_url\` that already responds to Slack's \`url_verification\` challenge. Remember the trigger \`id\` for step 7d.
-4. **Show the app guide — only if the bot doesn't exist.** Check \`list_environments\` → \`populated_entry_names\`; skip if \`SLACK_BOT_TOKEN\` is already set. Otherwise \`show_slack_app_guide\` with the \`webhook_url\`. The component derives bot scopes and \`bot_events\` from the attached toolset and trigger; do not pass overrides unless adding a scope the catalog lacks.
-5. **User installs the app.** Separate click from Create. Slack mints \`xoxb-...\` only after install + approval.
-6. **Request values.** \`request_environment_secrets\` for \`SLACK_BOT_TOKEN\` (sensitive, OAuth & Permissions) and \`SLACK_SIGNING_SECRET\` (sensitive, Basic Information → App Credentials).
-7. **Self-handshake.** Single short burst, no confirmation:
+## Recommended flow (slack trigger + any extras)
+
+1. **Attach a Slack toolset.** \`list_integrations\` (\`"slack"\`) → \`create_toolset\` if needed → \`attach_toolset\`. After attach, default-add the reaction platform tools (\`tools:platform:slack:add_reaction\`, \`tools:platform:slack:remove_reaction\`, \`tools:platform:slack:get_reactions\`, \`tools:platform:slack:list_reactions\`, \`tools:platform:slack:list_emoji\`) via \`add_tools_to_toolset\` — skip only if the user has explicitly said they don't want reaction tooling.
+2. **Declare keys.** \`add_environment_keys({ keys: ["SLACK_BOT_TOKEN", "SLACK_USER_TOKEN", "SLACK_SIGNING_SECRET"] })\`.
+3. **Create the slack trigger.** \`create_trigger\` with \`definition_slug: "slack"\` and the relevant \`event_types\` (default \`["app_mention", "message"]\`). The response includes a \`webhook_url\` that already responds to Slack's \`url_verification\` challenge. Remember the trigger \`id\` for step 8d.
+4. **Create any additional triggers the user asked for** (e.g. \`cron\` for a scheduled digest). These are additive.
+5. **Show the app guide.** Skip if \`SLACK_BOT_TOKEN\` is already populated (check \`list_environments\` → \`populated_entry_names\`). Otherwise \`show_slack_app_guide\` with the slack trigger's \`webhook_url\`. The manifest always grants the full bot- and user-scope supersets; do not pass scope overrides. **This tool BLOCKS** until the user clicks "I've installed it" — do not call other tools in parallel with it.
+6. **User installs the app.** Slack mints both \`xoxb-\` (bot) and \`xoxp-\` (user) tokens at install + approval.
+7. **Request values.** Once the guide resolves with \`installed: true\`, call \`request_environment_secrets\` for \`SLACK_BOT_TOKEN\` (OAuth & Permissions → Bot User OAuth Token), \`SLACK_USER_TOKEN\` (OAuth & Permissions → User OAuth Token), and \`SLACK_SIGNING_SECRET\` (Basic Information → App Credentials). If the guide resolved with \`cancelled: true\`, do not call \`request_environment_secrets\` — they have nothing to paste.
+8. **Self-handshake.** Single short burst, no confirmation:
    - **a.** Ask for the user's Slack handle.
    - **b.** DM the user a greeting in the assistant's voice (the persona picked via \`propose_identity\`). Do not template.
    - **c.** Search your own messages for the greeting; read \`bot_id\` off the bot-authored message. Do not substitute a user id.
    - **d.** \`update_trigger(id, config)\` adding \`event.bot_id != "<bot_id>"\` to \`config.filter\` (AND with any existing filter). Required to break reply loops.
 
-## Fallback flow (no pre-filled webhook)
+## Opt-out: no slack trigger
 
-Use only when the webhook URL isn't available yet.
+Only when the user has explicitly said the assistant should NOT react to Slack events. The bot still sends messages via API but cannot receive any.
 
-1. \`attach_toolset\`.
-2. If \`SLACK_BOT_TOKEN\` not yet populated, \`show_slack_app_guide\` without a webhook (subscriptions stay empty since Slack rejects unverified URLs).
-3. User installs, copies bot token + signing secret.
-4. \`add_environment_keys\` + \`request_environment_secrets\`.
-5. \`create_trigger\` — returns the webhook URL.
-6. \`show_webhook_url\` so the user can paste it into Event Subscriptions → Request URL and verify. User subscribes to \`bot_events\` in Slack's UI.
-7. Self-handshake (steps 7a–7d above).
+Same as the recommended flow with these differences:
+- Skip step 3 (no slack trigger).
+- In step 2, do NOT add \`SLACK_SIGNING_SECRET\` — there is no inbound webhook to verify. Still declare \`SLACK_BOT_TOKEN\` and \`SLACK_USER_TOKEN\`.
+- In step 5, call \`show_slack_app_guide\` without \`webhook_url\`. The manifest is scope-only (no \`event_subscriptions\`); both xoxb- and xoxp- are still issued.
+- In step 7, omit \`SLACK_SIGNING_SECRET\` from the secrets request.
+- Skip step 8 (self-handshake) — without a trigger, the bot will never see the reply anyway.
+
+## Webhook URL not yet available
+
+If for some reason the webhook URL isn't available at step 5 (e.g. trigger creation deferred): call \`show_slack_app_guide\` without \`webhook_url\`. The manifest is scope-only and Slack accepts it. After install, create the slack trigger and use \`show_webhook_url\` so the user pastes the URL into Event Subscriptions → Request URL manually and subscribes to \`bot_events\` in Slack's UI.
 
 ## Trigger config
 
 - \`event_types\` *(string[])* — required. Common: \`app_mention\`, \`message\` (noisy; pair with \`filter\`), \`reaction_added\`. Use bare event names — dotted names (\`message.im\` etc.) are rejected.
-- \`filter\` *(string, optional)* — CEL expression. Do not mention CEL to the user; describe rules in plain English. Available fields on \`event\`: \`envelope_type\`, \`event_type\`, \`subtype\`, \`team_id\`, \`channel_id\`, \`thread_id\`, \`user_id\`, \`bot_id\`, \`app_id\`, \`text\`, \`timestamp\`. AND multiple conditions with \`&&\`. Use \`event.bot_id != "<id>"\` to break reply loops (id from step 7c).
+- \`filter\` *(string, optional)* — CEL expression. Do not mention CEL to the user; describe rules in plain English. Available fields on \`event\`: \`envelope_type\`, \`event_type\`, \`subtype\`, \`team_id\`, \`channel_id\`, \`thread_id\`, \`user_id\`, \`bot_id\`, \`app_id\`, \`text\`, \`timestamp\`. AND multiple conditions with \`&&\`. Use \`event.bot_id != "<id>"\` to break reply loops (id from step 8c).
 
 ## Recommended event_types
 
 | Use case | event_types |
 |----------|-------------|
-| @-mention | \`["app_mention"]\` |
-| Watch channel/DM messages | \`["message"]\` (filter required) |
+| Default (responsive bot) | \`["app_mention", "message"]\` |
+| @-mention only | \`["app_mention"]\` |
 | Reaction-driven | \`["reaction_added"]\` |
-| Scheduled summary | cron trigger; assistant fetches Slack via toolset |
+| Scheduled-only + replies | \`["app_mention", "message"]\` + cron trigger |
 
 ## Tokens
 
-- **Signing Secret** → \`SLACK_SIGNING_SECRET\`. HMAC-SHA256 key for verifying \`x-slack-signature\`.
-- **Bot User OAuth Token** (\`xoxb-\`) → \`SLACK_BOT_TOKEN\`. Web API auth.
+- **Bot User OAuth Token** (\`xoxb-\`) → \`SLACK_BOT_TOKEN\`. Bot-token Web API auth (acts as the bot).
+- **User OAuth Token** (\`xoxp-\`) → \`SLACK_USER_TOKEN\`. User-token Web API auth (acts as the installing user — required for reading the user's own DMs, groups, etc.).
+- **Signing Secret** → \`SLACK_SIGNING_SECRET\`. HMAC-SHA256 key for verifying \`x-slack-signature\` on the slack trigger's webhook.
 - Client Secret and Verification Token are not used here.
 
 ## Gotchas
 
-- **Reply loops.** Without step 7d, every bot reply re-triggers the assistant.
+- **Reply loops.** Without step 8d, every bot reply re-triggers the assistant.
 - **Install ≠ Create.** \`xoxb-\` only appears after install + approval. Users frequently stop after Create.
-- **Scope changes need re-install.** Ship the full intended scope list in the first manifest.
+- **Scope changes need re-install.** Ship the full intended scope list in the first manifest — including user scopes.
 - **App name unique per workspace.** \`duplicate_app_name\` → suggest renaming.
 - **Bot must be invited to channels** for non-mention events in public channels.
 - **Enterprise Grid** workspaces may require admin approval to install.
-- **\`xoxp-\` is wrong.** That's a user token. Bot tokens start with \`xoxb-\`.
-- **\`search.all\` needs a user token.** The \`search_messages_and_files\` platform tool calls Slack's \`search.all\`, which requires a user-token \`search:read\` scope. The manifest builder skips it; if attached, also collect a user token from OAuth & Permissions → User Token Scopes → \`search:read\` and store as \`SLACK_USER_TOKEN\`.
+- **\`xoxp-\` is for user tokens, \`xoxb-\` for bot.** Don't confuse them in the secrets form.
 `,
 };

--- a/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/slackManifest.ts
@@ -23,10 +23,30 @@ export const SLACK_TOOL_SCOPES: Record<string, readonly string[]> = {
   get_reactions: ["reactions:read"],
   list_reactions: ["reactions:read"],
   list_emoji: ["emoji:read"],
-  // search_messages_and_files (search.all) requires a USER token scope
-  // (search:read) that Slack will not grant on a bot token, so it is omitted
-  // from the bot-scope manifest deliberately.
 };
+
+// Always grant the full user-scope superset alongside bot scopes. Slack mints
+// both xoxb- and xoxp- at install; the assistant uses whichever fits each
+// call site. No per-tool gating — same rationale as ALL_BOT_SCOPES: adding a
+// scope post-install forces a re-install.
+export const SLACK_USER_SCOPES: readonly string[] = [
+  "channels:history",
+  "channels:read",
+  "emoji:read",
+  "files:read",
+  "groups:history",
+  "groups:read",
+  "im:history",
+  "im:read",
+  "links:read",
+  "mpim:history",
+  "mpim:read",
+  "pins:read",
+  "reactions:read",
+  "search:read",
+  "users:read",
+  "users:read.email",
+];
 
 export type SlackEventBinding = {
   bot_events: readonly string[];
@@ -144,7 +164,6 @@ const SLACK_DISPLAY_NAME_LIMIT = 35;
 
 export type SlackManifestInput = {
   appName: string;
-  toolUrns?: readonly string[];
   webhookUrl?: string | undefined;
   extraScopes?: readonly string[];
   extraBotEvents?: readonly string[];
@@ -156,8 +175,8 @@ export type SlackManifestResult = {
   deepLink: string;
   displayName: string;
   scopes: string[];
+  userScopes: string[];
   botEvents: string[];
-  searchToolNeedsUserToken: boolean;
 };
 
 function uniqueSorted(values: Iterable<string>): string[] {
@@ -173,15 +192,25 @@ export function buildSlackManifest(
   );
 
   const scopes = new Set<string>(ALL_BOT_SCOPES);
-  const botEvents = new Set<string>(ALL_EVENT_BOT_EVENTS);
-  const searchUrn = `${SLACK_TOOL_URN_PREFIX}search_messages_and_files`;
-  const searchToolNeedsUserToken = (input.toolUrns ?? []).includes(searchUrn);
-
   for (const s of input.extraScopes ?? []) scopes.add(s);
-  for (const e of input.extraBotEvents ?? []) botEvents.add(e);
+
+  const userScopes = new Set<string>(SLACK_USER_SCOPES);
+
+  // Slack rejects an event_subscriptions block whose request_url is missing
+  // or unverified. Only emit bot_events when we have a webhook to anchor them
+  // to — otherwise produce a scope-only manifest that Slack will accept.
+  const botEvents = new Set<string>();
+  if (input.webhookUrl) {
+    for (const e of ALL_EVENT_BOT_EVENTS) botEvents.add(e);
+    for (const e of input.extraBotEvents ?? []) botEvents.add(e);
+  }
 
   const sortedScopes = uniqueSorted(scopes);
+  const sortedUserScopes = uniqueSorted(userScopes);
   const sortedEvents = uniqueSorted(botEvents);
+
+  const oauthScopes: { bot: string[]; user?: string[] } = { bot: sortedScopes };
+  if (sortedUserScopes.length > 0) oauthScopes.user = sortedUserScopes;
 
   const manifest: Record<string, unknown> = {
     _metadata: { major_version: 1, minor_version: 1 },
@@ -189,7 +218,7 @@ export function buildSlackManifest(
     features: {
       bot_user: { display_name: displayName, always_online: true },
     },
-    oauth_config: { scopes: { bot: sortedScopes } },
+    oauth_config: { scopes: oauthScopes },
   };
   if (input.webhookUrl) {
     manifest.settings = {
@@ -197,10 +226,6 @@ export function buildSlackManifest(
         request_url: input.webhookUrl,
         bot_events: sortedEvents,
       },
-    };
-  } else if (sortedEvents.length > 0) {
-    manifest.settings = {
-      event_subscriptions: { bot_events: sortedEvents },
     };
   }
 
@@ -213,55 +238,7 @@ export function buildSlackManifest(
     deepLink,
     displayName,
     scopes: sortedScopes,
+    userScopes: sortedUserScopes,
     botEvents: sortedEvents,
-    searchToolNeedsUserToken,
-  };
-}
-
-export type SlackContextSources = {
-  attachedToolsetSlugs: readonly string[];
-  toolsetsBySlug: ReadonlyMap<string, { toolUrns: readonly string[] }>;
-  triggers: readonly {
-    definitionSlug: string;
-    targetKind?: string;
-    targetRef?: string;
-    config: { [k: string]: unknown };
-  }[];
-  assistantId?: string | null;
-};
-
-export function deriveSlackContext(sources: SlackContextSources): {
-  toolUrns: string[];
-  eventTypes: string[];
-} {
-  const toolUrns = new Set<string>();
-  for (const slug of sources.attachedToolsetSlugs) {
-    const ts = sources.toolsetsBySlug.get(slug);
-    if (!ts) continue;
-    for (const urn of ts.toolUrns) {
-      if (urn.startsWith(SLACK_TOOL_URN_PREFIX)) toolUrns.add(urn);
-    }
-  }
-
-  const eventTypes = new Set<string>();
-  for (const trigger of sources.triggers) {
-    if (trigger.definitionSlug !== "slack") continue;
-    if (
-      sources.assistantId &&
-      trigger.targetKind === "assistant" &&
-      trigger.targetRef !== sources.assistantId
-    ) {
-      continue;
-    }
-    const raw = trigger.config["event_types"];
-    if (!Array.isArray(raw)) continue;
-    for (const e of raw) {
-      if (typeof e === "string" && e.length > 0) eventTypes.add(e);
-    }
-  }
-
-  return {
-    toolUrns: Array.from(toolUrns).sort(),
-    eventTypes: Array.from(eventTypes).sort(),
   };
 }

--- a/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
@@ -6,10 +6,6 @@ import { TextArea } from "@/components/ui/textarea";
 import { Type } from "@/components/ui/type";
 import { cn } from "@/lib/utils";
 import { ToolCallMessagePartProps } from "@assistant-ui/react";
-import {
-  useListToolsets,
-  useTriggers,
-} from "@gram/client/react-query/index.js";
 import { Icon } from "@speakeasy-api/moonshine";
 import {
   Check,
@@ -22,7 +18,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { useAssistantDraft } from "../useAssistantDraft";
 import { PERSONALITIES, getPersonality } from "../personalities";
-import { buildSlackManifest, deriveSlackContext } from "../slackManifest";
+import { buildSlackManifest } from "../slackManifest";
 
 type Status = ToolCallMessagePartProps["status"];
 
@@ -288,67 +284,80 @@ type SlackAppArgs = {
   webhook_url?: string;
 };
 
-export function ShowSlackAppGuideComponent({ args }: ToolCallMessagePartProps) {
+type SlackAppGuideResult = {
+  success: boolean;
+  installed?: boolean;
+  cancelled?: boolean;
+};
+
+export function ShowSlackAppGuideComponent({
+  args,
+  status,
+  result,
+  toolCallId,
+}: ToolCallMessagePartProps) {
   const a = (args ?? {}) as Partial<SlackAppArgs>;
   const draft = useAssistantDraft();
   const assistantName = draft.assistant?.name;
-  const assistantId = draft.assistantId;
-  const attachedToolsetSlugs = useMemo(
-    () => (draft.assistant?.toolsets ?? []).map((t) => t.toolsetSlug),
-    [draft.assistant?.toolsets],
-  );
-
-  const { data: toolsetsData } = useListToolsets(undefined, undefined, {
-    retry: false,
-    throwOnError: false,
-  });
-  const { data: triggersData } = useTriggers(undefined, undefined, {
-    retry: false,
-    throwOnError: false,
-    enabled: !!assistantId,
-  });
-
-  const toolsetsBySlug = useMemo(() => {
-    const map = new Map<string, { toolUrns: readonly string[] }>();
-    for (const ts of toolsetsData?.toolsets ?? []) {
-      map.set(ts.slug, { toolUrns: ts.toolUrns ?? [] });
-    }
-    return map;
-  }, [toolsetsData?.toolsets]);
-
-  const derived = useMemo(
-    () =>
-      deriveSlackContext({
-        attachedToolsetSlugs,
-        toolsetsBySlug,
-        triggers: triggersData?.triggers ?? [],
-        assistantId,
-      }),
-    [attachedToolsetSlugs, toolsetsBySlug, triggersData?.triggers, assistantId],
-  );
 
   const manifestResult = useMemo(
     () =>
       buildSlackManifest({
         appName: a.app_name ?? assistantName ?? "Gram Assistant",
-        toolUrns: derived.toolUrns,
         webhookUrl: a.webhook_url,
         extraScopes: a.bot_scopes,
         extraBotEvents: a.bot_events,
       }),
-    [
-      a.app_name,
-      a.webhook_url,
-      a.bot_scopes,
-      a.bot_events,
-      assistantName,
-      derived.toolUrns,
-    ],
+    [a.app_name, a.webhook_url, a.bot_scopes, a.bot_events, assistantName],
   );
 
   const webhookLive = !!a.webhook_url;
-  const { deepLink, scopes, botEvents, searchToolNeedsUserToken } =
-    manifestResult;
+  const { deepLink, scopes, userScopes, botEvents } = manifestResult;
+
+  const isPending = isExecuting(status);
+  const settled = !isPending;
+  const r = result as SlackAppGuideResult | undefined;
+
+  useEffect(() => {
+    if (!isPending) return;
+    return () => {
+      draft.resolvePending(toolCallId, {
+        success: false,
+        cancelled: true,
+      });
+    };
+  }, [draft, toolCallId, isPending]);
+
+  if (settled && r?.installed) {
+    return (
+      <ToolCard
+        title="Slack app installed"
+        tone="success"
+        icon={<Check className="text-emerald-600" size={16} />}
+      >
+        <Type small muted>
+          Ready to paste your tokens.
+        </Type>
+      </ToolCard>
+    );
+  }
+
+  if (settled && r?.cancelled) {
+    return (
+      <ToolCard title="Slack app guide — skipped">
+        <Type small muted>
+          You can come back to this from the Environments page later.
+        </Type>
+      </ToolCard>
+    );
+  }
+
+  const markInstalled = () => {
+    draft.resolvePending(toolCallId, { success: true, installed: true });
+  };
+  const skip = () => {
+    draft.resolvePending(toolCallId, { success: false, cancelled: true });
+  };
 
   return (
     <ToolCard
@@ -359,8 +368,9 @@ export function ShowSlackAppGuideComponent({ args }: ToolCallMessagePartProps) {
       <p className="text-muted-foreground mb-4 text-sm leading-relaxed">
         This link opens Slack with a manifest pre-filled — name
         {scopes.length > 0 ? ", bot scopes" : ""}
+        {userScopes.length > 0 ? ", user scopes" : ""}
         {webhookLive ? ", and webhook URL" : ""}. You'll still need to install
-        it to your workspace and copy two secrets back here.
+        it to your workspace and copy your tokens back here.
       </p>
 
       <ol className="space-y-3 text-sm leading-relaxed">
@@ -386,23 +396,38 @@ export function ShowSlackAppGuideComponent({ args }: ToolCallMessagePartProps) {
             <em>OAuth &amp; Permissions</em>. It starts with <code>xoxb-</code>.
             Not <code>xoxp-</code>; not the Client Secret.
           </>,
+          webhookLive ? (
+            <>
+              Copy the <strong>Signing Secret</strong> from{" "}
+              <em>Basic Information → App Credentials</em>. Not the Verification
+              Token (deprecated) and not the Client Secret.
+            </>
+          ) : null,
+          userScopes.length > 0 ? (
+            <>
+              Copy the <strong>User OAuth Token</strong> from{" "}
+              <em>OAuth &amp; Permissions</em>. It starts with{" "}
+              <code>xoxp-</code>. User scopes were pre-granted by the manifest —
+              no extra setup needed.
+            </>
+          ) : null,
           <>
-            Copy the <strong>Signing Secret</strong> from{" "}
-            <em>Basic Information → App Credentials</em>. Not the Verification
-            Token (deprecated) and not the Client Secret.
+            Click <strong>I've installed it</strong> below when done. The token
+            form will appear next.
           </>,
-          <>Paste both into the form that appears next.</>,
-        ].map((step, i) => (
-          <li key={i} className="flex gap-3">
-            <span className="text-muted-foreground shrink-0 tabular-nums">
-              {i + 1}.
-            </span>
-            <div className="flex-1">{step}</div>
-          </li>
-        ))}
+        ]
+          .filter(Boolean)
+          .map((step, i) => (
+            <li key={i} className="flex gap-3">
+              <span className="text-muted-foreground shrink-0 tabular-nums">
+                {i + 1}.
+              </span>
+              <div className="flex-1">{step}</div>
+            </li>
+          ))}
       </ol>
 
-      {(scopes.length > 0 || botEvents.length > 0) && (
+      {(scopes.length > 0 || userScopes.length > 0 || botEvents.length > 0) && (
         <div className="border-border bg-muted/30 mt-4 rounded-md border p-3 text-xs">
           <Type small muted className="mb-1.5 font-medium">
             Pre-filled in the manifest
@@ -411,6 +436,12 @@ export function ShowSlackAppGuideComponent({ args }: ToolCallMessagePartProps) {
             <div className="mb-1.5">
               <span className="text-muted-foreground">Bot scopes: </span>
               <span className="font-mono">{scopes.join(", ")}</span>
+            </div>
+          )}
+          {userScopes.length > 0 && (
+            <div className="mb-1.5">
+              <span className="text-muted-foreground">User scopes: </span>
+              <span className="font-mono">{userScopes.join(", ")}</span>
             </div>
           )}
           {botEvents.length > 0 && (
@@ -423,28 +454,23 @@ export function ShowSlackAppGuideComponent({ args }: ToolCallMessagePartProps) {
       )}
 
       <p className="text-muted-foreground mt-4 text-xs leading-relaxed">
-        Heads up: if you need to add a bot scope later, Slack requires a
-        re-install to grant it. We've included every scope this assistant needs
-        upfront.
+        Heads up: if you need to add a scope later, Slack requires a re-install
+        to grant it. We've included every scope this assistant needs upfront.
       </p>
 
-      {searchToolNeedsUserToken && (
-        <p className="text-muted-foreground mt-2 text-xs leading-relaxed">
-          The message-and-file search tool needs a Slack <em>user</em> token (
-          <code>search:read</code>), which Slack only grants on user tokens —
-          not bot tokens. After install, generate a user token from{" "}
-          <em>OAuth &amp; Permissions → User Token Scopes → search:read</em> and
-          store it as <code>SLACK_USER_TOKEN</code>.
-        </p>
-      )}
-
-      <div className="mt-4 flex gap-2">
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
         <Button asChild>
           <a href={deepLink} target="_blank" rel="noopener noreferrer">
             <ExternalLink className="mr-2 h-4 w-4" />
             Open Slack
           </a>
         </Button>
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={skip}>
+            Skip
+          </Button>
+          <Button onClick={markInstalled}>I've installed it</Button>
+        </div>
       </div>
     </ToolCard>
   );

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -1373,7 +1373,7 @@ function buildAssistantTools(deps: ToolDeps) {
   >(
     {
       description:
-        "Display a Slack app creation guide with a deep link that pre-fills the Slack app manifest. Use this ONLY when the user needs to create a brand-new Slack app for this assistant — i.e. SLACK_BOT_TOKEN is not yet populated on the assistant's env (check list_environments → populated_entry_names). If the bot token is already populated, the app already exists and was already installed; do not call this tool. The component derives the manifest automatically: name from the assistant's name, bot scopes from the slack platform tools attached to the assistant, and bot_events from the assistant's slack triggers. Pass the webhook_url from the Slack trigger you already created so Slack verifies it on Create. Only pass app_name / bot_scopes / bot_events to override the derived defaults. The component walks the user through Create → Install-to-Workspace → copying the xoxb- bot token and signing secret. Pure UI — no return value the model needs to act on.",
+        "Display a Slack app creation guide with a deep link that pre-fills the Slack app manifest. Use this ONLY when the user needs to create a brand-new Slack app for this assistant — i.e. SLACK_BOT_TOKEN is not yet populated on the assistant's env (check list_environments → populated_entry_names). If the bot token is already populated, the app already exists and was already installed; do not call this tool. This tool BLOCKS until the user clicks 'I've installed it' (or Skip). Do not call other tools in parallel with it — wait for it to resolve before calling request_environment_secrets so the user has tokens to paste. The tool errors if a slack trigger exists for this assistant and webhook_url was not supplied (the manifest's event_subscriptions block would be invalid). The manifest always grants both the full bot-scope and user-scope supersets so Slack issues both xoxb- and xoxp- in one install — don't reason about which scopes are needed for which tool. Returns { installed: true } on confirmation or { cancelled: true } if the user skipped — if cancelled, do not ask for credentials until the user revisits installation.",
       parameters: z.object({
         app_name: z
           .string()
@@ -1386,7 +1386,7 @@ function buildAssistantTools(deps: ToolDeps) {
           .array(z.string())
           .optional()
           .describe(
-            "Extra bot scopes to add on top of the ones derived from attached slack tools. Omit unless you know a tool needs a scope the catalog doesn't cover.",
+            "Extra bot scopes to add on top of the catalog superset. Omit in the normal flow.",
           ),
         bot_events: z
           .array(z.string())
@@ -1398,10 +1398,73 @@ function buildAssistantTools(deps: ToolDeps) {
           .string()
           .optional()
           .describe(
-            "Webhook URL of the slack trigger to pre-fill in the manifest's request_url so Slack verifies it on Create.",
+            "Webhook URL of the slack trigger to pre-fill in the manifest's request_url so Slack verifies it on Create. Required when the assistant has a slack trigger.",
           ),
       }),
-      execute: async () => okResult({ shown: true }),
+      execute: async (args, ctx) => {
+        const { webhook_url } = args as ShowSlackGuideArgs;
+        const toolCallId = ctx.toolCallId ?? "";
+
+        if (!webhook_url) {
+          try {
+            const list = await sdk.triggers.list();
+            const slackTriggers = (list.triggers ?? []).filter(
+              (t) =>
+                t.definitionSlug === "slack" &&
+                t.targetKind === "assistant" &&
+                t.targetRef === draft.assistantId,
+            );
+            if (slackTriggers.length > 0) {
+              const first = slackTriggers[0]!;
+              return errResult(
+                "Cannot show the Slack app guide without webhook_url because this assistant has a slack trigger — Slack rejects an event_subscriptions block whose request_url is missing or unverified. Pass the webhook_url from the slack trigger's create_trigger response and call this tool again.",
+                {
+                  slack_trigger: {
+                    id: first.id,
+                    name: first.name,
+                    webhook_url: first.webhookUrl,
+                  },
+                },
+              );
+            }
+          } catch (e) {
+            return errResult(
+              e instanceof Error ? e.message : "trigger lookup failed",
+            );
+          }
+        }
+
+        type GuideResult = {
+          success: boolean;
+          installed?: boolean;
+          cancelled?: boolean;
+        };
+        const userInput: GuideResult = await withTimeout(
+          new Promise<GuideResult>((resolve) => {
+            draft.registerPending(toolCallId, (r) => resolve(r as GuideResult));
+          }),
+          30 * 60 * 1000,
+          "show_slack_app_guide",
+        ).catch(
+          (): GuideResult => ({
+            success: false,
+            cancelled: true,
+            installed: false,
+          }),
+        );
+
+        if (userInput.installed) {
+          return okResult({
+            installed: true,
+            note: "User confirmed the Slack app is installed. Proceed to request_environment_secrets for SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET (if a slack trigger exists), and SLACK_USER_TOKEN (if any attached tool needs a user token).",
+          });
+        }
+        return okResult({
+          installed: false,
+          cancelled: true,
+          note: "User skipped the Slack app guide. Acknowledge briefly and do NOT call request_environment_secrets for Slack credentials in this turn — they have nothing to paste. Suggest they revisit installation later from the Environments page or by asking you to retry.",
+        });
+      },
     },
     "show_slack_app_guide",
   );


### PR DESCRIPTION
## Summary

Three concrete bugs surfaced while onboarding a real assistant against Slack:

1. **Invalid manifest could be created.** `buildSlackManifest` always seeded `bot_events` from the full superset and had an `else if` branch that emitted `event_subscriptions.bot_events` *without* `request_url`. Slack rejects that. The agent could (and did) generate a deep link with a manifest Slack refused — and Slack surfaces nothing about it, so the user was left stuck.

2. **Slack app guide card disappeared into a tool-batch group.** `show_slack_app_guide` returned synchronously, so the chat UI collapsed it with sibling tool calls in the same turn. The user saw "Executed N tools" and a credentials form, but no install card to click.

3. **Install only minted xoxb-, never xoxp-.** The manifest emitted `oauth_config.scopes.user` only when an attached tool matched a per-tool catalog (just `search_messages_and_files`). Reading user DMs needs a user token — the bot's `im:history` only reads conversations the bot is in — so the agent had to fall back to plain-text "go to OAuth & Permissions → User Token Scopes → add … then re-install" instructions.

## Changes

- `slackManifest.ts`
  - Builder can no longer produce an `event_subscriptions` block without `request_url`. Dropped the broken branch.
  - Bot- and user-scope supersets are both always emitted in `oauth_config.scopes` — one install grants both tokens. Dropped the per-tool gating catalog (`SLACK_TOOL_USER_SCOPES`) and the now-unused `deriveSlackContext`/`SlackContextSources` helpers.

- `tools/useOnboardingTools.tsx`
  - `show_slack_app_guide.execute` now blocks via `registerPending`/`withTimeout`, matching `propose_identity` and `request_environment_secrets`. The card stays visible until the user clicks **I've installed it** or **Skip**, forcing sequential ordering against the secrets form.
  - Pre-call guard: if the assistant has a slack trigger and no `webhook_url` was supplied, return an error (with the existing trigger's webhook URL in the result) so the agent retries correctly.
  - Description tightened: states the blocking contract, the two-token guarantee, and the "don't call in parallel" rule.

- `tools/components.tsx`
  - `ShowSlackAppGuideComponent` is now a pending tool component (settled / cancelled states, **I've installed it** / **Skip** buttons, unmount-resolves-cancel).
  - User scopes shown in the "Pre-filled in the manifest" panel.
  - Removed the manual "go to User Token Scopes" hint — manifest handles it now.

- `docs/slack.ts`
  - Default rule: any Slack-touching assistant gets a slack trigger (so the bot is reachable bidirectionally), additive with any cron/other trigger the user asked for. "Tool-only" is the explicit opt-out.
  - Updated step list: declare `SLACK_BOT_TOKEN` + `SLACK_USER_TOKEN` + `SLACK_SIGNING_SECRET` (latter only when slack trigger exists), show app guide (blocks), then request secrets.

✻ Clauded...