### PR TITLE
chore: internal dev runner now has an MCP server

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.madprocs]
+url = "https://localhost:35294/mcp"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "madprocs": {
+      "type": "http",
+      "url": "https://localhost:35294/mcp"
+    }
+  }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -24,7 +24,7 @@ uv = "0.10.9"
 yq = "4.52.4"
 hk = "1.38.0"
 pkl = "0.31.0"
-"github:speakeasy-api/madprocs" = "0.1.32"
+"github:speakeasy-api/madprocs" = "0.1.33"
 "github:temporalio/cli" = "1.6.1"
 
 # ℹ️ The settings below are sensible defaults for local development. When

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,4 +1,5 @@
 # mprocs configuration
+web_port: 35294
 procs:
   otel-collector:
     cmd: ["docker", "compose", "logs", "-f", "otel-collector"]


### PR DESCRIPTION
 * Agents can reboot services and read logs now.