### PR TITLE
chore: upgrade Go to 1.26.3 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/speakeasy-api/gram
 
-go 1.26.0
+go 1.26.3
 
 tool (
 	github.com/sqlc-dev/sqlc/cmd/sqlc

--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,7 @@
 "github:FiloSottile/mkcert" = "1.4.4"
 apko = "1.1.3"
 flyctl = "0.4.6"
-go = "1.26.1"
+go = "1.26.3"
 golangci-lint = "2.11.2"
 gomigrate = "4.19.1"
 gum = "0.17.0"


### PR DESCRIPTION
## Summary

Bumps Go from `1.26.1` → `1.26.3` in `mise.toml` and from `go 1.26.0` → `go 1.26.3` in `go.mod` to pick up the 11 CVE fixes in the [2026-05-07 Go security release](https://groups.google.com/g/golang-announce/c/qcCIEXso47M).

CI's release workflow uses `go-version-file: "go.mod"` on `actions/setup-go`, so it picks up the new version automatically. Locally, `mise build:server`, `mise lint:server`, and `go mod tidy` all pass with no spurious diffs.

Linear: https://linear.app/speakeasy/issue/AGE-2245/upgrade-go-to-1263-for-security-fixes

Release notes: https://go.dev/doc/devel/release#go1.26.3