### PR TITLE
chore: add workOS backfill workflow

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -28,7 +28,6 @@ import (
 	"github.com/superfly/fly-go/tokens"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
-	"github.com/workos/workos-go/v6/pkg/events"
 	"github.com/workos/workos-go/v6/pkg/webhooks"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -491,25 +490,6 @@ func newWorkOSClient(guardianPolicy *guardian.Policy, c *cli.Context) (client *w
 	}
 
 	return workos.NewClient(guardianPolicy, apiKey, workosClientOpts(c)), haveAPIKey, nil
-}
-
-func newWorkOSEventsClient(c *cli.Context, guardianPolicy *guardian.Policy) (*events.Client, error) {
-	apiKey := c.String("workos-api-key")
-	if apiKey == "" || apiKey == "unset" {
-		if c.String("environment") != "local" {
-			return nil, errors.New("WorkOS API key not provided")
-		}
-		// Local dev without a configured key: return nil so the activity can
-		// surface a clear "not configured" error rather than calling WorkOS
-		// with an empty key and getting an opaque API failure.
-		return nil, nil
-	}
-
-	return &events.Client{
-		APIKey:     apiKey,
-		HTTPClient: guardianPolicy.PooledClient(),
-		Endpoint:   workosClientOpts(c).Endpoint,
-	}, nil
 }
 
 func newWorkOSWebhooksClient(c *cli.Context) *webhooks.Client {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -42,6 +42,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background"
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat"
@@ -89,6 +90,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/pylon"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/slack"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/triggers"
 
 	"github.com/speakeasy-api/gram/server/internal/tools"
@@ -503,6 +505,10 @@ func newStartCommand() *cli.Command {
 			workosClient, workosAvailable, err := newWorkOSClient(guardianPolicy, c)
 			if err != nil {
 				return fmt.Errorf("failed to create WorkOS client: %w", err)
+			}
+			var backgroundWorkOSClient activities.WorkOSClient = workosClient
+			if !workosAvailable {
+				backgroundWorkOSClient = workos.NewStubClient()
 			}
 
 			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, c)
@@ -1008,7 +1014,7 @@ func newStartCommand() *cli.Command {
 						PIIScanner:          piiScanner,
 						ShadowMCPClient:     shadowMCPClient,
 						AuditLogger:         auditLogger,
-						WorkOSClient:        conv.Ternary(workosAvailable, workosClient, nil),
+						WorkOSClient:        backgroundWorkOSClient,
 					})
 					if err := temporalWorker.Run(workerInterruptCh); err != nil {
 						logger.ErrorContext(ctx, "temporal worker failed", attr.SlogError(err))

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -505,11 +505,6 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to create WorkOS client: %w", err)
 			}
 
-			workosEventsClient, err := newWorkOSEventsClient(c, guardianPolicy)
-			if err != nil {
-				return fmt.Errorf("failed to create WorkOS events client: %w", err)
-			}
-
 			billingRepo, billingTracker, err := newBillingProvider(ctx, logger, tracerProvider, guardianPolicy, redisClient, posthogClient, c)
 			if err != nil {
 				return fmt.Errorf("failed to create billing provider: %w", err)
@@ -1013,7 +1008,7 @@ func newStartCommand() *cli.Command {
 						PIIScanner:          piiScanner,
 						ShadowMCPClient:     shadowMCPClient,
 						AuditLogger:         auditLogger,
-						WorkOSEventsClient:  workosEventsClient,
+						WorkOSClient:        conv.Ternary(workosAvailable, workosClient, nil),
 					})
 					if err := temporalWorker.Run(workerInterruptCh); err != nil {
 						logger.ErrorContext(ctx, "temporal worker failed", attr.SlogError(err))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -286,7 +286,7 @@ func newWorkerCommand() *cli.Command {
 		},
 		&cli.StringFlag{
 			Name:     "workos-api-key",
-			Usage:    "WorkOS API key for the events client",
+			Usage:    "WorkOS API key for WorkOS API calls",
 			EnvVars:  []string{"WORKOS_API_KEY"},
 			Required: false,
 		},
@@ -490,9 +490,9 @@ func newWorkerCommand() *cli.Command {
 				authz.EngineOpts{DevMode: c.String("environment") == "local"},
 			)
 
-			workosEventsClient, err := newWorkOSEventsClient(c, guardianPolicy)
+			workosClient, _, err := newWorkOSClient(guardianPolicy, c)
 			if err != nil {
-				return fmt.Errorf("failed to create WorkOS events client: %w", err)
+				return fmt.Errorf("failed to create WorkOS client: %w", err)
 			}
 
 			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, chDB, logsEnabled, toolIOLogsEnabled)
@@ -657,7 +657,7 @@ func newWorkerCommand() *cli.Command {
 				PIIScanner:          piiScanner,
 				ShadowMCPClient:     shadowMCPClient,
 				AuditLogger:         auditLogger,
-				WorkOSEventsClient:  workosEventsClient,
+				WorkOSClient:        workosClient,
 			})
 
 			return temporalWorker.Run(worker.InterruptCh())

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/speakeasyclient"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/background"
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat"
@@ -490,9 +491,13 @@ func newWorkerCommand() *cli.Command {
 				authz.EngineOpts{DevMode: c.String("environment") == "local"},
 			)
 
-			workosClient, _, err := newWorkOSClient(guardianPolicy, c)
+			workosClient, workosAvailable, err := newWorkOSClient(guardianPolicy, c)
 			if err != nil {
 				return fmt.Errorf("failed to create WorkOS client: %w", err)
+			}
+			var backgroundWorkOSClient activities.WorkOSClient = workosClient
+			if !workosAvailable {
+				backgroundWorkOSClient = workos.NewStubClient()
 			}
 
 			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, chDB, logsEnabled, toolIOLogsEnabled)
@@ -657,7 +662,7 @@ func newWorkerCommand() *cli.Command {
 				PIIScanner:          piiScanner,
 				ShadowMCPClient:     shadowMCPClient,
 				AuditLogger:         auditLogger,
-				WorkOSClient:        workosClient,
+				WorkOSClient:        backgroundWorkOSClient,
 			})
 
 			return temporalWorker.Run(worker.InterruptCh())

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -66,6 +66,12 @@ SELECT *
 FROM global_roles
 WHERE workos_slug = @workos_slug;
 
+-- name: ListGlobalRoles :many
+SELECT *
+FROM global_roles
+WHERE deleted_at IS NULL
+ORDER BY workos_slug;
+
 -- name: UpsertGlobalRole :exec
 -- Upsert an environment-level WorkOS role. Caller must have already passed
 -- the row through ShouldProcessEvent. Resurrects a previously soft-deleted
@@ -108,6 +114,13 @@ SELECT *
 FROM organization_roles
 WHERE organization_id = @organization_id
   AND workos_slug = @workos_slug;
+
+-- name: ListOrganizationRolesByOrg :many
+SELECT *
+FROM organization_roles
+WHERE organization_id = @organization_id
+  AND deleted_at IS NULL
+ORDER BY workos_slug;
 
 -- name: UpsertOrganizationRole :exec
 -- Upsert an org-scoped WorkOS role. Caller must have already passed the row

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -270,6 +270,90 @@ func (q *Queries) ListChallengeResolutions(ctx context.Context, arg ListChalleng
 	return items, nil
 }
 
+const listGlobalRoles = `-- name: ListGlobalRoles :many
+SELECT id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, workos_deleted_at, workos_deleted, workos_last_event_id, created_at, updated_at, deleted_at, deleted
+FROM global_roles
+WHERE deleted_at IS NULL
+ORDER BY workos_slug
+`
+
+func (q *Queries) ListGlobalRoles(ctx context.Context) ([]GlobalRole, error) {
+	rows, err := q.db.Query(ctx, listGlobalRoles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GlobalRole
+	for rows.Next() {
+		var i GlobalRole
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkosSlug,
+			&i.WorkosName,
+			&i.WorkosDescription,
+			&i.WorkosCreatedAt,
+			&i.WorkosUpdatedAt,
+			&i.WorkosDeletedAt,
+			&i.WorkosDeleted,
+			&i.WorkosLastEventID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOrganizationRolesByOrg = `-- name: ListOrganizationRolesByOrg :many
+SELECT id, organization_id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, workos_deleted_at, workos_deleted, workos_last_event_id, created_at, updated_at, deleted_at, deleted
+FROM organization_roles
+WHERE organization_id = $1
+  AND deleted_at IS NULL
+ORDER BY workos_slug
+`
+
+func (q *Queries) ListOrganizationRolesByOrg(ctx context.Context, organizationID string) ([]OrganizationRole, error) {
+	rows, err := q.db.Query(ctx, listOrganizationRolesByOrg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OrganizationRole
+	for rows.Next() {
+		var i OrganizationRole
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.WorkosSlug,
+			&i.WorkosName,
+			&i.WorkosDescription,
+			&i.WorkosCreatedAt,
+			&i.WorkosUpdatedAt,
+			&i.WorkosDeletedAt,
+			&i.WorkosDeleted,
+			&i.WorkosLastEventID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPrincipalGrantsByOrg = `-- name: ListPrincipalGrantsByOrg :many
 
 SELECT id, organization_id, principal_urn, principal_type, scope, selectors, created_at, updated_at

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -35,7 +35,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
 	slacktypes "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/types"
-	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
 type Activities struct {
@@ -113,25 +112,9 @@ func NewActivities(
 	piiScanner risk_analysis.PIIScanner,
 	shadowMCPClient *shadowmcp.Client,
 	auditLogger *audit.Logger,
-	workosClient *workos.Client,
+	workosClient activities.WorkOSClient,
 ) *Activities {
 	usageTrackingStrategy := chat.NewDefaultUsageTrackingStrategy(db, logger, openrouterProvisioner, billingTracker, nil)
-
-	// Only construct WorkOS sync activities when the WorkOS client is
-	// configured. Local dev without a key passes nil; the wrapper methods below
-	// return clear errors if the activities are invoked unconfigured.
-	var processWorkOSOrgEvents *activities.ProcessWorkOSOrganizationEvents
-	var processWorkOSGlobalRoleEvents *activities.ProcessWorkOSGlobalRoleEvents
-	var backfillWorkOSOrganization *activities.BackfillWorkOSOrganization
-	var backfillWorkOSGlobalRoles *activities.BackfillWorkOSGlobalRoles
-	var listWorkOSOrganizations *activities.ListWorkOSOrganizations
-	if workosClient != nil {
-		listWorkOSOrganizations = activities.NewListWorkOSOrganizations(logger, workosClient)
-		processWorkOSOrgEvents = activities.NewProcessWorkOSOrganizationEvents(logger, db, workosClient)
-		processWorkOSGlobalRoleEvents = activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosClient)
-		backfillWorkOSOrganization = activities.NewBackfillWorkOSOrganization(logger, db, workosClient)
-		backfillWorkOSGlobalRoles = activities.NewBackfillWorkOSGlobalRoles(logger, db, workosClient)
-	}
 
 	return &Activities{
 		collectPlatformUsageMetrics:     activities.NewCollectPlatformUsageMetrics(logger, db),
@@ -171,19 +154,16 @@ func NewActivities(
 		reapSoftDeletedAssistantMems:    activities.NewReapSoftDeletedAssistantMemories(logger, db),
 		signalAssistantCoordinator:      activities.NewSignalAssistantCoordinator(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		signalAssistantThread:           activities.NewSignalAssistantThread(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
-		listWorkOSOrganizations:         listWorkOSOrganizations,
-		backfillWorkOSOrganization:      backfillWorkOSOrganization,
-		backfillWorkOSGlobalRoles:       backfillWorkOSGlobalRoles,
-		processWorkOSOrganizationEvents: processWorkOSOrgEvents,
-		processWorkOSGlobalRoleEvents:   processWorkOSGlobalRoleEvents,
+		listWorkOSOrganizations:         activities.NewListWorkOSOrganizations(logger, workosClient),
+		backfillWorkOSOrganization:      activities.NewBackfillWorkOSOrganization(logger, db, workosClient),
+		backfillWorkOSGlobalRoles:       activities.NewBackfillWorkOSGlobalRoles(logger, db, workosClient),
+		processWorkOSOrganizationEvents: activities.NewProcessWorkOSOrganizationEvents(logger, db, workosClient),
+		processWorkOSGlobalRoleEvents:   activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosClient),
 		cancelAssistantsSubscription:    activities.NewCancelAssistantsSubscription(logger, billingRepo),
 	}
 }
 
 func (a *Activities) ListWorkOSOrganizations(ctx context.Context) ([]string, error) {
-	if a.listWorkOSOrganizations == nil {
-		return nil, fmt.Errorf("WorkOS client is not configured")
-	}
 	return a.listWorkOSOrganizations.Do(ctx)
 }
 

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -35,7 +35,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
 	slacktypes "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/types"
-	"github.com/workos/workos-go/v6/pkg/events"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
 type Activities struct {
@@ -76,6 +76,9 @@ type Activities struct {
 	reapSoftDeletedAssistantMems    *activities.ReapSoftDeletedAssistantMemories
 	signalAssistantCoordinator      *activities.SignalAssistantCoordinator
 	signalAssistantThread           *activities.SignalAssistantThread
+	listWorkOSOrganizations         *activities.ListWorkOSOrganizations
+	backfillWorkOSOrganization      *activities.BackfillWorkOSOrganization
+	backfillWorkOSGlobalRoles       *activities.BackfillWorkOSGlobalRoles
 	processWorkOSOrganizationEvents *activities.ProcessWorkOSOrganizationEvents
 	processWorkOSGlobalRoleEvents   *activities.ProcessWorkOSGlobalRoleEvents
 	cancelAssistantsSubscription    *activities.CancelAssistantsSubscription
@@ -110,18 +113,24 @@ func NewActivities(
 	piiScanner risk_analysis.PIIScanner,
 	shadowMCPClient *shadowmcp.Client,
 	auditLogger *audit.Logger,
-	workosEventsClient *events.Client,
+	workosClient *workos.Client,
 ) *Activities {
 	usageTrackingStrategy := chat.NewDefaultUsageTrackingStrategy(db, logger, openrouterProvisioner, billingTracker, nil)
 
-	// Only construct the WorkOS sync activity when the events client is
-	// configured. Local dev without a key passes nil; the wrapper method below
-	// returns a clear error if the activity is invoked unconfigured.
+	// Only construct WorkOS sync activities when the WorkOS client is
+	// configured. Local dev without a key passes nil; the wrapper methods below
+	// return clear errors if the activities are invoked unconfigured.
 	var processWorkOSOrgEvents *activities.ProcessWorkOSOrganizationEvents
 	var processWorkOSGlobalRoleEvents *activities.ProcessWorkOSGlobalRoleEvents
-	if workosEventsClient != nil {
-		processWorkOSOrgEvents = activities.NewProcessWorkOSOrganizationEvents(logger, db, workosEventsClient)
-		processWorkOSGlobalRoleEvents = activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosEventsClient)
+	var backfillWorkOSOrganization *activities.BackfillWorkOSOrganization
+	var backfillWorkOSGlobalRoles *activities.BackfillWorkOSGlobalRoles
+	var listWorkOSOrganizations *activities.ListWorkOSOrganizations
+	if workosClient != nil {
+		listWorkOSOrganizations = activities.NewListWorkOSOrganizations(logger, workosClient)
+		processWorkOSOrgEvents = activities.NewProcessWorkOSOrganizationEvents(logger, db, workosClient)
+		processWorkOSGlobalRoleEvents = activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosClient)
+		backfillWorkOSOrganization = activities.NewBackfillWorkOSOrganization(logger, db, workosClient)
+		backfillWorkOSGlobalRoles = activities.NewBackfillWorkOSGlobalRoles(logger, db, workosClient)
 	}
 
 	return &Activities{
@@ -162,23 +171,35 @@ func NewActivities(
 		reapSoftDeletedAssistantMems:    activities.NewReapSoftDeletedAssistantMemories(logger, db),
 		signalAssistantCoordinator:      activities.NewSignalAssistantCoordinator(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		signalAssistantThread:           activities.NewSignalAssistantThread(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
+		listWorkOSOrganizations:         listWorkOSOrganizations,
+		backfillWorkOSOrganization:      backfillWorkOSOrganization,
+		backfillWorkOSGlobalRoles:       backfillWorkOSGlobalRoles,
 		processWorkOSOrganizationEvents: processWorkOSOrgEvents,
 		processWorkOSGlobalRoleEvents:   processWorkOSGlobalRoleEvents,
 		cancelAssistantsSubscription:    activities.NewCancelAssistantsSubscription(logger, billingRepo),
 	}
 }
 
-func (a *Activities) ProcessWorkOSOrganizationEvents(ctx context.Context, params activities.ProcessWorkOSOrganizationEventsParams) (*activities.ProcessWorkOSOrganizationEventsResult, error) {
-	if a.processWorkOSOrganizationEvents == nil {
-		return nil, fmt.Errorf("WorkOS events client is not configured")
+func (a *Activities) ListWorkOSOrganizations(ctx context.Context) ([]string, error) {
+	if a.listWorkOSOrganizations == nil {
+		return nil, fmt.Errorf("WorkOS client is not configured")
 	}
+	return a.listWorkOSOrganizations.Do(ctx)
+}
+
+func (a *Activities) BackfillWorkOSOrganization(ctx context.Context, params activities.BackfillWorkOSOrganizationParams) error {
+	return a.backfillWorkOSOrganization.Do(ctx, params)
+}
+
+func (a *Activities) BackfillWorkOSGlobalRoles(ctx context.Context) error {
+	return a.backfillWorkOSGlobalRoles.Do(ctx)
+}
+
+func (a *Activities) ProcessWorkOSOrganizationEvents(ctx context.Context, params activities.ProcessWorkOSOrganizationEventsParams) (*activities.ProcessWorkOSOrganizationEventsResult, error) {
 	return a.processWorkOSOrganizationEvents.Do(ctx, params)
 }
 
 func (a *Activities) ProcessWorkOSGlobalRoleEvents(ctx context.Context, params activities.ProcessWorkOSGlobalRoleEventsParams) (*activities.ProcessWorkOSGlobalRoleEventsResult, error) {
-	if a.processWorkOSGlobalRoleEvents == nil {
-		return nil, fmt.Errorf("WorkOS events client is not configured")
-	}
 	return a.processWorkOSGlobalRoleEvents.Do(ctx, params)
 }
 

--- a/server/internal/background/activities/backfill_workos_global_roles.go
+++ b/server/internal/background/activities/backfill_workos_global_roles.go
@@ -20,10 +20,10 @@ import (
 type BackfillWorkOSGlobalRoles struct {
 	logger *slog.Logger
 	db     *pgxpool.Pool
-	workos WorkOSBackfillClient
+	workos WorkOSClient
 }
 
-func NewBackfillWorkOSGlobalRoles(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSBackfillClient) *BackfillWorkOSGlobalRoles {
+func NewBackfillWorkOSGlobalRoles(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSClient) *BackfillWorkOSGlobalRoles {
 	return &BackfillWorkOSGlobalRoles{
 		logger: logger.With(attr.SlogComponent("backfill_workos_global_roles")),
 		db:     db,

--- a/server/internal/background/activities/backfill_workos_global_roles.go
+++ b/server/internal/background/activities/backfill_workos_global_roles.go
@@ -1,0 +1,125 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+type BackfillWorkOSGlobalRoles struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+	workos WorkOSBackfillClient
+}
+
+func NewBackfillWorkOSGlobalRoles(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSBackfillClient) *BackfillWorkOSGlobalRoles {
+	return &BackfillWorkOSGlobalRoles{
+		logger: logger.With(attr.SlogComponent("backfill_workos_global_roles")),
+		db:     db,
+		workos: workosClient,
+	}
+}
+
+func (b *BackfillWorkOSGlobalRoles) Do(ctx context.Context) error {
+	roles, err := b.workos.ListGlobalRoles(ctx)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list WorkOS global roles").Log(ctx, b.logger)
+	}
+
+	tx, err := b.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	repo := accessrepo.New(tx)
+	snapshotSlugs := make(map[string]time.Time, len(roles))
+	for _, role := range roles {
+		createdAt, err := parseWorkOSTime(role.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("parse global role %q created_at: %w", role.Slug, err)
+		}
+		updatedAt, err := parseWorkOSTime(role.UpdatedAt)
+		if err != nil {
+			return fmt.Errorf("parse global role %q updated_at: %w", role.Slug, err)
+		}
+		snapshotSlugs[role.Slug] = updatedAt
+
+		existing, err := repo.GetGlobalRoleBySlug(ctx, role.Slug)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("get global role %q: %w", role.Slug, err)
+		}
+
+		var lastEventID *string
+		if existing.WorkosLastEventID.Valid {
+			lastEventID = &existing.WorkosLastEventID.String
+		}
+		var rowUpdatedAt *time.Time
+		if existing.WorkosUpdatedAt.Valid {
+			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+		}
+		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, "", updatedAt) {
+			continue
+		}
+
+		if err := repo.UpsertGlobalRole(ctx, accessrepo.UpsertGlobalRoleParams{
+			WorkosSlug:        role.Slug,
+			WorkosName:        role.Name,
+			WorkosDescription: conv.ToPGTextEmpty(role.Description),
+			WorkosCreatedAt:   conv.ToPGTimestamptz(createdAt),
+			WorkosUpdatedAt:   conv.ToPGTimestamptz(updatedAt),
+			WorkosLastEventID: conv.ToPGText(""),
+		}); err != nil {
+			return fmt.Errorf("upsert global role %q: %w", role.Slug, err)
+		}
+	}
+
+	localRoles, err := repo.ListGlobalRoles(ctx)
+	if err != nil {
+		return fmt.Errorf("list local global roles: %w", err)
+	}
+	for _, localRole := range localRoles {
+		if _, ok := snapshotSlugs[localRole.WorkosSlug]; ok {
+			continue
+		}
+
+		var lastEventID *string
+		if localRole.WorkosLastEventID.Valid {
+			lastEventID = &localRole.WorkosLastEventID.String
+		}
+		var rowUpdatedAt *time.Time
+		if localRole.WorkosUpdatedAt.Valid {
+			rowUpdatedAt = &localRole.WorkosUpdatedAt.Time
+		}
+		deletedAt := time.Now().UTC()
+		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, "", deletedAt) {
+			continue
+		}
+
+		if _, err := repo.MarkGlobalRoleDeleted(ctx, accessrepo.MarkGlobalRoleDeletedParams{
+			WorkosSlug:        localRole.WorkosSlug,
+			WorkosDeletedAt:   conv.ToPGTimestamptz(deletedAt),
+			WorkosLastEventID: conv.ToPGText(""),
+		}); err != nil {
+			return fmt.Errorf("mark global role %q deleted: %w", localRole.WorkosSlug, err)
+		}
+		b.logger.DebugContext(ctx, "soft-deleted WorkOS global role missing from snapshot", attr.SlogAccessRoleSlug(localRole.WorkosSlug))
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/workos/workos-go/v6/pkg/events"
 
@@ -258,11 +259,11 @@ func backfillOrganizationMember(ctx context.Context, dbtx pgx.Tx, organizationID
 		return fmt.Errorf("get user by workos id %q: %w", member.UserID, err)
 	}
 
-	baseline, err := freshestLocalWorkOSMembershipBaseline(ctx, orgQueries, organizationID, gramUserID, member.UserID)
+	cursor, err := latestMembershipCursor(ctx, orgQueries, organizationID, gramUserID, member.UserID)
 	if err != nil {
 		return err
 	}
-	if !ShouldProcessEvent(baseline.lastEventID, baseline.updatedAt, "", parsed.updatedAt) {
+	if !ShouldProcessEvent(cursor.lastEventID, cursor.updatedAt, "", parsed.updatedAt) {
 		return nil
 	}
 
@@ -297,58 +298,51 @@ func backfillOrganizationMember(ctx context.Context, dbtx pgx.Tx, organizationID
 	return nil
 }
 
-type workOSMembershipBaseline struct {
+type membershipCursor struct {
 	lastEventID *string
 	updatedAt   *time.Time
 }
 
-func freshestLocalWorkOSMembershipBaseline(ctx context.Context, repo *orgrepo.Queries, organizationID, gramUserID, workosUserID string) (workOSMembershipBaseline, error) {
-	var baseline workOSMembershipBaseline
-
-	if gramUserID != "" {
-		existing, err := repo.GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
-			OrganizationID: organizationID,
-			UserID:         gramUserID,
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-		case err != nil:
-			return workOSMembershipBaseline{}, fmt.Errorf("get organization membership for user %q: %w", gramUserID, err)
-		default:
-			if existing.WorkosLastEventID.Valid {
-				if baseline.lastEventID == nil || existing.WorkosLastEventID.String > *baseline.lastEventID {
-					baseline.lastEventID = &existing.WorkosLastEventID.String
-				}
-			}
-			if existing.WorkosUpdatedAt.Valid {
-				if baseline.updatedAt == nil || existing.WorkosUpdatedAt.Time.After(*baseline.updatedAt) {
-					baseline.updatedAt = &existing.WorkosUpdatedAt.Time
-				}
-			}
-		}
-	}
+// latestMembershipCursor returns the newest local WorkOS state
+// for a membership before applying a snapshot. Membership backfill writes two
+// local shapes: organization_user_relationships when the WorkOS user is linked
+// to a Gram user, and organization_role_assignments even when the user is still
+// unknown locally. Both can be updated by event processing, so the snapshot must
+// compare against the freshest cursor/timestamp from both tables before it
+// overwrites either table.
+func latestMembershipCursor(ctx context.Context, repo *orgrepo.Queries, organizationID, gramUserID, workosUserID string) (membershipCursor, error) {
+	var cursor membershipCursor
 
 	assignments, err := repo.ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
 		OrganizationID: organizationID,
 		WorkosUserID:   workosUserID,
 	})
 	if err != nil {
-		return workOSMembershipBaseline{}, fmt.Errorf("list organization role assignments for WorkOS user %q: %w", workosUserID, err)
+		return membershipCursor{}, fmt.Errorf("list organization role assignments for WorkOS user %q: %w", workosUserID, err)
 	}
 	for _, assignment := range assignments {
-		if assignment.WorkosLastEventID.Valid {
-			if baseline.lastEventID == nil || assignment.WorkosLastEventID.String > *baseline.lastEventID {
-				baseline.lastEventID = &assignment.WorkosLastEventID.String
-			}
-		}
-		if assignment.WorkosUpdatedAt.Valid {
-			if baseline.updatedAt == nil || assignment.WorkosUpdatedAt.Time.After(*baseline.updatedAt) {
-				baseline.updatedAt = &assignment.WorkosUpdatedAt.Time
-			}
-		}
+		moveMembershipCursor(&cursor, assignment.WorkosLastEventID, assignment.WorkosUpdatedAt)
 	}
 
-	return baseline, nil
+	// we don't have a relationship for a user with no gram user ID, so return the membership cursor
+	if gramUserID == "" {
+		return cursor, nil
+	}
+
+	existing, err := repo.GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         gramUserID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return cursor, nil
+	case err != nil:
+		return membershipCursor{}, fmt.Errorf("get organization membership for user %q: %w", gramUserID, err)
+	}
+
+	moveMembershipCursor(&cursor, existing.WorkosLastEventID, existing.WorkosUpdatedAt)
+
+	return cursor, nil
 }
 
 func parseWorkOSTime(raw string) (time.Time, error) {
@@ -364,4 +358,18 @@ func isWorkOSOrganizationRole(role workos.Role) bool {
 		return role.Type == "OrganizationRole"
 	}
 	return strings.HasPrefix(role.Slug, "org-")
+}
+
+func moveMembershipCursor(cursor *membershipCursor, eventID pgtype.Text, updatedAt pgtype.Timestamptz) {
+	if eventID.Valid {
+		if cursor.lastEventID == nil || eventID.String > *cursor.lastEventID {
+			cursor.lastEventID = &eventID.String
+		}
+	}
+
+	if updatedAt.Valid {
+		if cursor.updatedAt == nil || updatedAt.Time.After(*cursor.updatedAt) {
+			cursor.updatedAt = &updatedAt.Time
+		}
+	}
 }

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -162,7 +161,7 @@ func backfillOrganizationRoles(ctx context.Context, logger *slog.Logger, dbtx pg
 	snapshotSlugs := make(map[string]time.Time)
 
 	for _, role := range roles {
-		if !isWorkOSOrganizationRole(role) {
+		if role.Type != "OrganizationRole" {
 			continue
 		}
 		createdAt, err := parseWorkOSTime(role.CreatedAt)
@@ -303,13 +302,13 @@ type membershipCursor struct {
 	updatedAt   *time.Time
 }
 
-// latestMembershipCursor returns the newest local WorkOS state
-// for a membership before applying a snapshot. Membership backfill writes two
-// local shapes: organization_user_relationships when the WorkOS user is linked
-// to a Gram user, and organization_role_assignments even when the user is still
-// unknown locally. Both can be updated by event processing, so the snapshot must
-// compare against the freshest cursor/timestamp from both tables before it
-// overwrites either table.
+// latestMembershipCursor returns the newest local WorkOS state for a membership
+// before applying a snapshot. Membership backfill writes two local shapes:
+// organization_user_relationships when the WorkOS user is linked to a Gram
+// user, and organization_role_assignments even when the user is still unknown
+// locally. Both can be updated by event processing, so the snapshot must compare
+// against the freshest cursor/timestamp from both tables before it overwrites
+// either table.
 func latestMembershipCursor(ctx context.Context, repo *orgrepo.Queries, organizationID, gramUserID, workosUserID string) (membershipCursor, error) {
 	var cursor membershipCursor
 
@@ -324,7 +323,7 @@ func latestMembershipCursor(ctx context.Context, repo *orgrepo.Queries, organiza
 		moveMembershipCursor(&cursor, assignment.WorkosLastEventID, assignment.WorkosUpdatedAt)
 	}
 
-	// we don't have a relationship for a user with no gram user ID, so return the membership cursor
+	// No relationship row exists when the WorkOS user is not linked to a Gram user.
 	if gramUserID == "" {
 		return cursor, nil
 	}
@@ -353,13 +352,10 @@ func parseWorkOSTime(raw string) (time.Time, error) {
 	return t, nil
 }
 
-func isWorkOSOrganizationRole(role workos.Role) bool {
-	if role.Type != "" {
-		return role.Type == "OrganizationRole"
-	}
-	return strings.HasPrefix(role.Slug, "org-")
-}
-
+// moveMembershipCursor tracks per-field upper bounds rather than a coherent
+// row state. Backfill only uses the cursor as a conservative skip signal, so any
+// newer event ID or updated timestamp from either local membership shape should
+// block an older snapshot from overwriting local state.
 func moveMembershipCursor(cursor *membershipCursor, eventID pgtype.Text, updatedAt pgtype.Timestamptz) {
 	if eventID.Valid {
 		if cursor.lastEventID == nil || eventID.String > *cursor.lastEventID {

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -1,0 +1,323 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+type WorkOSBackfillClient interface {
+	GetOrganization(ctx context.Context, orgID string) (*workos.Organization, error)
+	ListOrganizations(ctx context.Context) ([]workos.Organization, error)
+	ListRoles(ctx context.Context, orgID string) ([]workos.Role, error)
+	ListOrgMemberships(ctx context.Context, orgID string) ([]workos.Member, error)
+	ListGlobalRoles(ctx context.Context) ([]workos.Role, error)
+}
+
+type BackfillWorkOSOrganizationParams struct {
+	WorkOSOrganizationID string `json:"workos_organization_id"`
+}
+
+type BackfillWorkOSOrganization struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+	workos WorkOSBackfillClient
+}
+
+type backfillWorkOSMember struct {
+	member    workos.Member
+	updatedAt time.Time
+}
+
+func NewBackfillWorkOSOrganization(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSBackfillClient) *BackfillWorkOSOrganization {
+	return &BackfillWorkOSOrganization{
+		logger: logger.With(attr.SlogComponent("backfill_workos_organization")),
+		db:     db,
+		workos: workosClient,
+	}
+}
+
+func (b *BackfillWorkOSOrganization) Do(ctx context.Context, params BackfillWorkOSOrganizationParams) error {
+	logger := b.logger.With(attr.SlogWorkOSOrganizationID(params.WorkOSOrganizationID))
+
+	workosOrg, err := b.workos.GetOrganization(ctx, params.WorkOSOrganizationID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "get WorkOS organization").Log(ctx, logger)
+	}
+	orgUpdatedAt, err := parseWorkOSTime(workosOrg.UpdatedAt)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "parse WorkOS organization updated_at").Log(ctx, logger)
+	}
+
+	roles, err := b.workos.ListRoles(ctx, params.WorkOSOrganizationID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list WorkOS organization roles").Log(ctx, logger)
+	}
+
+	members, err := b.workos.ListOrgMemberships(ctx, params.WorkOSOrganizationID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list WorkOS organization memberships").Log(ctx, logger)
+	}
+	parsedMembers := make([]backfillWorkOSMember, 0, len(members))
+	for _, member := range members {
+		updatedAt, err := parseWorkOSTime(member.UpdatedAt)
+		if err != nil {
+			logger.WarnContext(ctx, "skipping WorkOS membership with invalid updated_at",
+				attr.SlogWorkOSUserID(member.UserID),
+				attr.SlogError(err),
+			)
+			continue
+		}
+		parsedMembers = append(parsedMembers, backfillWorkOSMember{member: member, updatedAt: updatedAt})
+	}
+
+	tx, err := b.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	orgQueries := orgrepo.New(tx)
+	org, err := orgQueries.GetOrganizationByWorkosID(ctx, conv.ToPGText(params.WorkOSOrganizationID))
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		if workosOrg.ExternalID == "" {
+			logger.DebugContext(ctx, "skipping WorkOS organization backfill for unlinked organization with no external_id")
+			return nil
+		}
+		org.ID = workosOrg.ExternalID
+	case err != nil:
+		return fmt.Errorf("get organization by workos id %q: %w", params.WorkOSOrganizationID, err)
+	}
+
+	org, err = backfillOrganizationMetadata(ctx, orgQueries, org, *workosOrg, orgUpdatedAt)
+	if err != nil {
+		return err
+	}
+	if err := backfillOrganizationRoles(ctx, logger, tx, org.ID, roles); err != nil {
+		return err
+	}
+	for _, member := range parsedMembers {
+		if err := backfillOrganizationMember(ctx, tx, org.ID, member); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+func backfillOrganizationMetadata(ctx context.Context, repo *orgrepo.Queries, org orgrepo.OrganizationMetadatum, workosOrg workos.Organization, updatedAt time.Time) (orgrepo.OrganizationMetadatum, error) {
+	var lastEventID *string
+	if org.WorkosLastEventID.Valid {
+		lastEventID = &org.WorkosLastEventID.String
+	}
+	var rowUpdatedAt *time.Time
+	if org.WorkosUpdatedAt.Valid {
+		rowUpdatedAt = &org.WorkosUpdatedAt.Time
+	}
+	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, "", updatedAt) {
+		return org, nil
+	}
+
+	updatedOrg, err := repo.UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:                org.ID,
+		Name:              workosOrg.Name,
+		Slug:              conv.ToSlug(workosOrg.Name),
+		WorkosID:          conv.ToPGText(workosOrg.ID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(updatedAt),
+		WorkosLastEventID: conv.ToPGText(""),
+	})
+	if err != nil {
+		return orgrepo.OrganizationMetadatum{}, fmt.Errorf("upsert organization %q from WorkOS snapshot: %w", workosOrg.ID, err)
+	}
+
+	return updatedOrg, nil
+}
+
+func backfillOrganizationRoles(ctx context.Context, logger *slog.Logger, dbtx pgx.Tx, organizationID string, roles []workos.Role) error {
+	repo := accessrepo.New(dbtx)
+	snapshotSlugs := make(map[string]time.Time)
+
+	for _, role := range roles {
+		if !isWorkOSOrganizationRole(role) {
+			continue
+		}
+		createdAt, err := parseWorkOSTime(role.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("parse role %q created_at: %w", role.Slug, err)
+		}
+		updatedAt, err := parseWorkOSTime(role.UpdatedAt)
+		if err != nil {
+			return fmt.Errorf("parse role %q updated_at: %w", role.Slug, err)
+		}
+		snapshotSlugs[role.Slug] = updatedAt
+
+		existing, err := repo.GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+			OrganizationID: organizationID,
+			WorkosSlug:     role.Slug,
+		})
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("get organization role %q: %w", role.Slug, err)
+		}
+
+		var lastEventID *string
+		if existing.WorkosLastEventID.Valid {
+			lastEventID = &existing.WorkosLastEventID.String
+		}
+		var rowUpdatedAt *time.Time
+		if existing.WorkosUpdatedAt.Valid {
+			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+		}
+		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, "", updatedAt) {
+			continue
+		}
+
+		if err := repo.UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+			OrganizationID:    organizationID,
+			WorkosSlug:        role.Slug,
+			WorkosName:        role.Name,
+			WorkosDescription: conv.ToPGTextEmpty(role.Description),
+			WorkosCreatedAt:   conv.ToPGTimestamptz(createdAt),
+			WorkosUpdatedAt:   conv.ToPGTimestamptz(updatedAt),
+			WorkosLastEventID: conv.ToPGText(""),
+		}); err != nil {
+			return fmt.Errorf("upsert organization role %q: %w", role.Slug, err)
+		}
+	}
+
+	localRoles, err := repo.ListOrganizationRolesByOrg(ctx, organizationID)
+	if err != nil {
+		return fmt.Errorf("list organization roles for %q: %w", organizationID, err)
+	}
+	for _, localRole := range localRoles {
+		if _, ok := snapshotSlugs[localRole.WorkosSlug]; ok {
+			continue
+		}
+
+		var lastEventID *string
+		if localRole.WorkosLastEventID.Valid {
+			lastEventID = &localRole.WorkosLastEventID.String
+		}
+		var rowUpdatedAt *time.Time
+		if localRole.WorkosUpdatedAt.Valid {
+			rowUpdatedAt = &localRole.WorkosUpdatedAt.Time
+		}
+		deletedAt := time.Now().UTC()
+		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, "", deletedAt) {
+			continue
+		}
+
+		if _, err := repo.MarkOrganizationRoleDeleted(ctx, accessrepo.MarkOrganizationRoleDeletedParams{
+			OrganizationID:    organizationID,
+			WorkosSlug:        localRole.WorkosSlug,
+			WorkosDeletedAt:   conv.ToPGTimestamptz(deletedAt),
+			WorkosLastEventID: conv.ToPGText(""),
+		}); err != nil {
+			return fmt.Errorf("mark organization role %q deleted: %w", localRole.WorkosSlug, err)
+		}
+		if _, err := repo.DeletePrincipalGrantsByPrincipal(ctx, accessrepo.DeletePrincipalGrantsByPrincipalParams{
+			OrganizationID: organizationID,
+			PrincipalUrn:   urn.NewPrincipal(urn.PrincipalTypeRole, localRole.WorkosSlug),
+		}); err != nil {
+			return fmt.Errorf("delete grants for organization role %q: %w", localRole.WorkosSlug, err)
+		}
+		logger.DebugContext(ctx, "soft-deleted WorkOS organization role missing from snapshot", attr.SlogAccessRoleSlug(localRole.WorkosSlug))
+	}
+
+	return nil
+}
+
+func backfillOrganizationMember(ctx context.Context, dbtx pgx.Tx, organizationID string, parsed backfillWorkOSMember) error {
+	member := parsed.member
+	orgQueries := orgrepo.New(dbtx)
+
+	gramUserID, err := usersrepo.New(dbtx).GetUserIDByWorkosID(ctx, conv.ToPGText(member.UserID))
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get user by workos id %q: %w", member.UserID, err)
+	}
+
+	if gramUserID != "" {
+		existing, err := orgQueries.GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+			OrganizationID: organizationID,
+			UserID:         gramUserID,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+		case err != nil:
+			return fmt.Errorf("get organization membership %q: %w", member.ID, err)
+		}
+
+		var lastEventID *string
+		if existing.WorkosLastEventID.Valid {
+			lastEventID = &existing.WorkosLastEventID.String
+		}
+		var rowUpdatedAt *time.Time
+		if existing.WorkosUpdatedAt.Valid {
+			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+		}
+		if ShouldProcessEvent(lastEventID, rowUpdatedAt, "", parsed.updatedAt) {
+			if err := orgQueries.UpsertOrganizationUserRelationshipFromWorkOS(ctx, orgrepo.UpsertOrganizationUserRelationshipFromWorkOSParams{
+				OrganizationID:     organizationID,
+				UserID:             gramUserID,
+				WorkosMembershipID: conv.ToPGText(member.ID),
+				WorkosUpdatedAt:    conv.ToPGTimestamptz(parsed.updatedAt),
+				WorkosLastEventID:  conv.ToPGText(""),
+			}); err != nil {
+				return fmt.Errorf("upsert organization membership %q: %w", member.ID, err)
+			}
+		}
+	}
+
+	roleSlugs := []string{}
+	if member.RoleSlug != "" {
+		roleSlugs = []string{member.RoleSlug}
+	}
+	if err := orgQueries.SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       member.UserID,
+		UserID:             conv.ToPGTextEmpty(gramUserID),
+		WorkosMembershipID: conv.ToPGText(member.ID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(parsed.updatedAt),
+		WorkosLastEventID:  conv.ToPGText(""),
+		WorkosRoleSlugs:    roleSlugs,
+	}); err != nil {
+		return fmt.Errorf("sync organization role assignments for membership %q: %w", member.ID, err)
+	}
+
+	return nil
+}
+
+func parseWorkOSTime(raw string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse WorkOS timestamp %q: %w", raw, err)
+	}
+	return t, nil
+}
+
+func isWorkOSOrganizationRole(role workos.Role) bool {
+	if role.Type != "" {
+		return role.Type == "OrganizationRole"
+	}
+	return strings.HasPrefix(role.Slug, "org-")
+}

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/workos/workos-go/v6/pkg/events"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -22,12 +23,13 @@ import (
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
-type WorkOSBackfillClient interface {
+type WorkOSClient interface {
 	GetOrganization(ctx context.Context, orgID string) (*workos.Organization, error)
 	ListOrganizations(ctx context.Context) ([]workos.Organization, error)
 	ListRoles(ctx context.Context, orgID string) ([]workos.Role, error)
 	ListOrgMemberships(ctx context.Context, orgID string) ([]workos.Member, error)
 	ListGlobalRoles(ctx context.Context) ([]workos.Role, error)
+	ListEvents(ctx context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error)
 }
 
 type BackfillWorkOSOrganizationParams struct {
@@ -37,7 +39,7 @@ type BackfillWorkOSOrganizationParams struct {
 type BackfillWorkOSOrganization struct {
 	logger *slog.Logger
 	db     *pgxpool.Pool
-	workos WorkOSBackfillClient
+	workos WorkOSClient
 }
 
 type backfillWorkOSMember struct {
@@ -45,7 +47,7 @@ type backfillWorkOSMember struct {
 	updatedAt time.Time
 }
 
-func NewBackfillWorkOSOrganization(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSBackfillClient) *BackfillWorkOSOrganization {
+func NewBackfillWorkOSOrganization(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSClient) *BackfillWorkOSOrganization {
 	return &BackfillWorkOSOrganization{
 		logger: logger.With(attr.SlogComponent("backfill_workos_organization")),
 		db:     db,
@@ -256,35 +258,23 @@ func backfillOrganizationMember(ctx context.Context, dbtx pgx.Tx, organizationID
 		return fmt.Errorf("get user by workos id %q: %w", member.UserID, err)
 	}
 
-	if gramUserID != "" {
-		existing, err := orgQueries.GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
-			OrganizationID: organizationID,
-			UserID:         gramUserID,
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-		case err != nil:
-			return fmt.Errorf("get organization membership %q: %w", member.ID, err)
-		}
+	baseline, err := freshestLocalWorkOSMembershipBaseline(ctx, orgQueries, organizationID, gramUserID, member.UserID)
+	if err != nil {
+		return err
+	}
+	if !ShouldProcessEvent(baseline.lastEventID, baseline.updatedAt, "", parsed.updatedAt) {
+		return nil
+	}
 
-		var lastEventID *string
-		if existing.WorkosLastEventID.Valid {
-			lastEventID = &existing.WorkosLastEventID.String
-		}
-		var rowUpdatedAt *time.Time
-		if existing.WorkosUpdatedAt.Valid {
-			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
-		}
-		if ShouldProcessEvent(lastEventID, rowUpdatedAt, "", parsed.updatedAt) {
-			if err := orgQueries.UpsertOrganizationUserRelationshipFromWorkOS(ctx, orgrepo.UpsertOrganizationUserRelationshipFromWorkOSParams{
-				OrganizationID:     organizationID,
-				UserID:             gramUserID,
-				WorkosMembershipID: conv.ToPGText(member.ID),
-				WorkosUpdatedAt:    conv.ToPGTimestamptz(parsed.updatedAt),
-				WorkosLastEventID:  conv.ToPGText(""),
-			}); err != nil {
-				return fmt.Errorf("upsert organization membership %q: %w", member.ID, err)
-			}
+	if gramUserID != "" {
+		if err := orgQueries.UpsertOrganizationUserRelationshipFromWorkOS(ctx, orgrepo.UpsertOrganizationUserRelationshipFromWorkOSParams{
+			OrganizationID:     organizationID,
+			UserID:             gramUserID,
+			WorkosMembershipID: conv.ToPGText(member.ID),
+			WorkosUpdatedAt:    conv.ToPGTimestamptz(parsed.updatedAt),
+			WorkosLastEventID:  conv.ToPGText(""),
+		}); err != nil {
+			return fmt.Errorf("upsert organization membership %q: %w", member.ID, err)
 		}
 	}
 
@@ -305,6 +295,60 @@ func backfillOrganizationMember(ctx context.Context, dbtx pgx.Tx, organizationID
 	}
 
 	return nil
+}
+
+type workOSMembershipBaseline struct {
+	lastEventID *string
+	updatedAt   *time.Time
+}
+
+func freshestLocalWorkOSMembershipBaseline(ctx context.Context, repo *orgrepo.Queries, organizationID, gramUserID, workosUserID string) (workOSMembershipBaseline, error) {
+	var baseline workOSMembershipBaseline
+
+	if gramUserID != "" {
+		existing, err := repo.GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+			OrganizationID: organizationID,
+			UserID:         gramUserID,
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+		case err != nil:
+			return workOSMembershipBaseline{}, fmt.Errorf("get organization membership for user %q: %w", gramUserID, err)
+		default:
+			if existing.WorkosLastEventID.Valid {
+				if baseline.lastEventID == nil || existing.WorkosLastEventID.String > *baseline.lastEventID {
+					baseline.lastEventID = &existing.WorkosLastEventID.String
+				}
+			}
+			if existing.WorkosUpdatedAt.Valid {
+				if baseline.updatedAt == nil || existing.WorkosUpdatedAt.Time.After(*baseline.updatedAt) {
+					baseline.updatedAt = &existing.WorkosUpdatedAt.Time
+				}
+			}
+		}
+	}
+
+	assignments, err := repo.ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	if err != nil {
+		return workOSMembershipBaseline{}, fmt.Errorf("list organization role assignments for WorkOS user %q: %w", workosUserID, err)
+	}
+	for _, assignment := range assignments {
+		if assignment.WorkosLastEventID.Valid {
+			if baseline.lastEventID == nil || assignment.WorkosLastEventID.String > *baseline.lastEventID {
+				baseline.lastEventID = &assignment.WorkosLastEventID.String
+			}
+		}
+		if assignment.WorkosUpdatedAt.Valid {
+			if baseline.updatedAt == nil || assignment.WorkosUpdatedAt.Time.After(*baseline.updatedAt) {
+				baseline.updatedAt = &assignment.WorkosUpdatedAt.Time
+			}
+		}
+	}
+
+	return baseline, nil
 }
 
 func parseWorkOSTime(raw string) (time.Time, error) {

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -1,0 +1,258 @@
+package activities_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+)
+
+type stubWorkOSBackfillClient struct {
+	org         workos.Organization
+	orgs        []workos.Organization
+	roles       []workos.Role
+	globalRoles []workos.Role
+	members     []workos.Member
+}
+
+func (s *stubWorkOSBackfillClient) GetOrganization(_ context.Context, _ string) (*workos.Organization, error) {
+	return &s.org, nil
+}
+
+func (s *stubWorkOSBackfillClient) ListOrganizations(_ context.Context) ([]workos.Organization, error) {
+	return s.orgs, nil
+}
+
+func (s *stubWorkOSBackfillClient) ListRoles(_ context.Context, _ string) ([]workos.Role, error) {
+	return s.roles, nil
+}
+
+func (s *stubWorkOSBackfillClient) ListOrgMemberships(_ context.Context, _ string) ([]workos.Member, error) {
+	return s.members, nil
+}
+
+func (s *stubWorkOSBackfillClient) ListGlobalRoles(_ context.Context) ([]workos.Role, error) {
+	return s.globalRoles, nil
+}
+
+func TestBackfillWorkOSOrganization_CreatesUnlinkedOrganizationWithExternalID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_create_org_external_id")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_from_workos_external_id"
+	const workosOrgID = "org_01JBACKFILLCREATE"
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
+		org: workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Created Org",
+			ExternalID: organizationID,
+			CreatedAt:  "2026-05-07T11:00:00Z",
+			UpdatedAt:  "2026-05-07T11:00:00Z",
+		},
+		roles:   []workos.Role{},
+		members: []workos.Member{},
+	})
+
+	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	org, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, organizationID, org.ID)
+	require.Equal(t, "Backfill Created Org", org.Name)
+	require.Equal(t, "backfill-created-org", org.Slug)
+	require.Equal(t, workosOrgID, org.WorkosID.String)
+	require.Empty(t, org.WorkosLastEventID.String)
+}
+
+func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_unknown_user_single_role")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_backfill_unknown_user"
+	const workosOrgID = "org_01JBACKFILLUNKNOWN"
+	const workosUserID = "user_01JBACKFILLUNKNOWN"
+	const membershipID = "mem_01JBACKFILLUNKNOWN"
+	const roleSlug = "org-support"
+
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
+		org: workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Unknown User",
+			ExternalID: "",
+			CreatedAt:  "2026-05-07T11:00:00Z",
+			UpdatedAt:  "2026-05-07T11:00:00Z",
+		},
+		roles: []workos.Role{{
+			ID:          "role_01JSUPPORT",
+			Name:        "Support",
+			Slug:        roleSlug,
+			Description: "Support operators",
+			Type:        "OrganizationRole",
+			CreatedAt:   "2026-05-07T11:00:00Z",
+			UpdatedAt:   "2026-05-07T11:00:00Z",
+		}},
+		members: []workos.Member{{
+			ID:             membershipID,
+			UserID:         workosUserID,
+			OrganizationID: workosOrgID,
+			Organization:   "Backfill Unknown User",
+			RoleSlug:       roleSlug,
+			Status:         "active",
+			CreatedAt:      "2026-05-07T11:05:00Z",
+			UpdatedAt:      "2026-05-07T11:05:00Z",
+		}},
+	})
+
+	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	role, err := accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: organizationID,
+		WorkosSlug:     roleSlug,
+	})
+	require.NoError(t, err)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	require.Equal(t, fmt.Sprintf("role:organization:%s", role.ID.String()), assignments[0].RoleUrn)
+	require.False(t, assignments[0].UserID.Valid)
+	require.Equal(t, membershipID, assignments[0].WorkosMembershipID.String)
+	require.Empty(t, assignments[0].WorkosLastEventID.String)
+}
+
+func TestBackfillWorkOSOrganization_RoleWithLastEventIDSkipsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_role_last_event_wins")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_backfill_event_wins"
+	const workosOrgID = "org_01JBACKFILLEVENTWINS"
+	const roleSlug = "org-billing"
+
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedOrganizationRoleWithCursor(t, ctx, conn, organizationID, roleSlug, "Billing From Event", "event_01JNEWER")
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
+		org: workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Event Wins",
+			ExternalID: "",
+			CreatedAt:  "2026-05-07T11:00:00Z",
+			UpdatedAt:  "2026-05-07T11:00:00Z",
+		},
+		roles: []workos.Role{{
+			ID:          "role_01JBILLING",
+			Name:        "Billing From Snapshot",
+			Slug:        roleSlug,
+			Description: "",
+			Type:        "OrganizationRole",
+			CreatedAt:   "2026-05-07T11:00:00Z",
+			UpdatedAt:   "2026-05-07T12:00:00Z",
+		}},
+	})
+
+	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	role, err := accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: organizationID,
+		WorkosSlug:     roleSlug,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Billing From Event", role.WorkosName)
+	require.Equal(t, "event_01JNEWER", role.WorkosLastEventID.String)
+}
+
+func TestBackfillWorkOSOrganization_MissingRoleSoftDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_role_deleted")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_backfill_delete_role"
+	const workosOrgID = "org_01JBACKFILLDELETE"
+	const roleSlug = "org-obsolete"
+
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedOrganizationRoleWithCursor(t, ctx, conn, organizationID, roleSlug, "Obsolete", "")
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
+		org: workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Delete Role",
+			ExternalID: "",
+			CreatedAt:  "2026-05-07T11:00:00Z",
+			UpdatedAt:  "2026-05-07T11:00:00Z",
+		},
+		roles: []workos.Role{},
+	})
+
+	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	role, err := accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: organizationID,
+		WorkosSlug:     roleSlug,
+	})
+	require.NoError(t, err)
+	require.True(t, role.Deleted)
+	require.True(t, role.WorkosDeleted)
+	require.Empty(t, role.WorkosLastEventID.String)
+}
+
+func seedLinkedWorkOSOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, workosOrgID string) {
+	t.Helper()
+
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        organizationID,
+		Slug:        organizationID,
+		WorkosID:    conv.ToPGText(workosOrgID),
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	})
+	require.NoError(t, err)
+}
+
+func seedOrganizationRoleWithCursor(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, slug, name, lastEventID string) {
+	t.Helper()
+
+	updatedAt := time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC)
+	err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    organizationID,
+		WorkosSlug:        slug,
+		WorkosName:        name,
+		WorkosDescription: conv.ToPGText(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(updatedAt),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(updatedAt),
+		WorkosLastEventID: conv.ToPGText(lastEventID),
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -78,6 +79,43 @@ func TestBackfillWorkOSOrganization_CreatesUnlinkedOrganizationWithExternalID(t 
 	require.Equal(t, "backfill-created-org", org.Slug)
 	require.Equal(t, workosOrgID, org.WorkosID.String)
 	require.Empty(t, org.WorkosLastEventID.String)
+}
+
+func TestBackfillWorkOSOrganization_ExternalIDChangeDoesNotChangeOrganizationID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_external_id_immutable")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_original_external_id"
+	const changedExternalID = "gram_org_changed_external_id"
+	const workosOrgID = "org_01JBACKFILLIMMUTABLE"
+
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
+		org: workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Immutable Org",
+			ExternalID: changedExternalID,
+			CreatedAt:  "2026-05-07T11:00:00Z",
+			UpdatedAt:  "2026-05-07T11:00:00Z",
+		},
+		roles:   []workos.Role{},
+		members: []workos.Member{},
+	})
+
+	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	org, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, organizationID, org.ID)
+	require.Equal(t, "Backfill Immutable Org", org.Name)
+
+	_, err = orgrepo.New(conn).GetOrganizationMetadata(ctx, changedExternalID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *testing.T) {

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -19,34 +19,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
-type stubWorkOSBackfillClient struct {
-	org         workos.Organization
-	orgs        []workos.Organization
-	roles       []workos.Role
-	globalRoles []workos.Role
-	members     []workos.Member
-}
-
-func (s *stubWorkOSBackfillClient) GetOrganization(_ context.Context, _ string) (*workos.Organization, error) {
-	return &s.org, nil
-}
-
-func (s *stubWorkOSBackfillClient) ListOrganizations(_ context.Context) ([]workos.Organization, error) {
-	return s.orgs, nil
-}
-
-func (s *stubWorkOSBackfillClient) ListRoles(_ context.Context, _ string) ([]workos.Role, error) {
-	return s.roles, nil
-}
-
-func (s *stubWorkOSBackfillClient) ListOrgMemberships(_ context.Context, _ string) ([]workos.Member, error) {
-	return s.members, nil
-}
-
-func (s *stubWorkOSBackfillClient) ListGlobalRoles(_ context.Context) ([]workos.Role, error) {
-	return s.globalRoles, nil
-}
-
 func TestBackfillWorkOSOrganization_CreatesUnlinkedOrganizationWithExternalID(t *testing.T) {
 	t.Parallel()
 
@@ -57,17 +29,18 @@ func TestBackfillWorkOSOrganization_CreatesUnlinkedOrganizationWithExternalID(t 
 	const organizationID = "gram_org_from_workos_external_id"
 	const workosOrgID = "org_01JBACKFILLCREATE"
 
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
-		org: workos.Organization{
+	workosClient := newStubWorkOSBackfillClient(t, ctx,
+		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Created Org",
 			ExternalID: organizationID,
 			CreatedAt:  "2026-05-07T11:00:00Z",
 			UpdatedAt:  "2026-05-07T11:00:00Z",
 		},
-		roles:   []workos.Role{},
-		members: []workos.Member{},
-	})
+		nil,
+		nil,
+	)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -94,17 +67,18 @@ func TestBackfillWorkOSOrganization_ExternalIDChangeDoesNotChangeOrganizationID(
 
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
-		org: workos.Organization{
+	workosClient := newStubWorkOSBackfillClient(t, ctx,
+		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Immutable Org",
 			ExternalID: changedExternalID,
 			CreatedAt:  "2026-05-07T11:00:00Z",
 			UpdatedAt:  "2026-05-07T11:00:00Z",
 		},
-		roles:   []workos.Role{},
-		members: []workos.Member{},
-	})
+		nil,
+		nil,
+	)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -133,15 +107,15 @@ func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *test
 
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
-		org: workos.Organization{
+	workosClient := newStubWorkOSBackfillClient(t, ctx,
+		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Unknown User",
 			ExternalID: "",
 			CreatedAt:  "2026-05-07T11:00:00Z",
 			UpdatedAt:  "2026-05-07T11:00:00Z",
 		},
-		roles: []workos.Role{{
+		[]workos.Role{{
 			ID:          "role_01JSUPPORT",
 			Name:        "Support",
 			Slug:        roleSlug,
@@ -150,7 +124,7 @@ func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *test
 			CreatedAt:   "2026-05-07T11:00:00Z",
 			UpdatedAt:   "2026-05-07T11:00:00Z",
 		}},
-		members: []workos.Member{{
+		[]workos.Member{{
 			ID:             membershipID,
 			UserID:         workosUserID,
 			OrganizationID: workosOrgID,
@@ -160,7 +134,8 @@ func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *test
 			CreatedAt:      "2026-05-07T11:05:00Z",
 			UpdatedAt:      "2026-05-07T11:05:00Z",
 		}},
-	})
+	)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -197,15 +172,15 @@ func TestBackfillWorkOSOrganization_RoleWithLastEventIDSkipsSnapshot(t *testing.
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 	seedOrganizationRoleWithCursor(t, ctx, conn, organizationID, roleSlug, "Billing From Event", "event_01JNEWER")
 
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
-		org: workos.Organization{
+	workosClient := newStubWorkOSBackfillClient(t, ctx,
+		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Event Wins",
 			ExternalID: "",
 			CreatedAt:  "2026-05-07T11:00:00Z",
 			UpdatedAt:  "2026-05-07T11:00:00Z",
 		},
-		roles: []workos.Role{{
+		[]workos.Role{{
 			ID:          "role_01JBILLING",
 			Name:        "Billing From Snapshot",
 			Slug:        roleSlug,
@@ -214,7 +189,9 @@ func TestBackfillWorkOSOrganization_RoleWithLastEventIDSkipsSnapshot(t *testing.
 			CreatedAt:   "2026-05-07T11:00:00Z",
 			UpdatedAt:   "2026-05-07T12:00:00Z",
 		}},
-	})
+		nil,
+	)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -242,16 +219,18 @@ func TestBackfillWorkOSOrganization_MissingRoleSoftDeleted(t *testing.T) {
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 	seedOrganizationRoleWithCursor(t, ctx, conn, organizationID, roleSlug, "Obsolete", "")
 
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, &stubWorkOSBackfillClient{
-		org: workos.Organization{
+	workosClient := newStubWorkOSBackfillClient(t, ctx,
+		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Delete Role",
 			ExternalID: "",
 			CreatedAt:  "2026-05-07T11:00:00Z",
 			UpdatedAt:  "2026-05-07T11:00:00Z",
 		},
-		roles: []workos.Role{},
-	})
+		nil,
+		nil,
+	)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -264,6 +243,26 @@ func TestBackfillWorkOSOrganization_MissingRoleSoftDeleted(t *testing.T) {
 	require.True(t, role.Deleted)
 	require.True(t, role.WorkosDeleted)
 	require.Empty(t, role.WorkosLastEventID.String)
+}
+
+func newStubWorkOSBackfillClient(t *testing.T, ctx context.Context, org workos.Organization, roles []workos.Role, members []workos.Member) *workos.StubClient {
+	t.Helper()
+
+	client := workos.NewStubClient()
+	client.UpsertOrganization(org)
+	for _, role := range roles {
+		_, err := client.CreateRole(ctx, org.ID, workos.CreateRoleOpts{
+			Name:        role.Name,
+			Slug:        role.Slug,
+			Description: role.Description,
+		})
+		require.NoError(t, err)
+	}
+	for _, member := range members {
+		client.UpsertOrganizationMembership(member)
+	}
+
+	return client
 }
 
 func seedLinkedWorkOSOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, workosOrgID string) {

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -29,7 +29,7 @@ func TestBackfillWorkOSOrganization_CreatesUnlinkedOrganizationWithExternalID(t 
 	const organizationID = "gram_org_from_workos_external_id"
 	const workosOrgID = "org_01JBACKFILLCREATE"
 
-	workosClient := newStubWorkOSBackfillClient(t, ctx,
+	workosClient := newWorkOSSnapshotClient(t, ctx,
 		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Created Org",
@@ -67,7 +67,7 @@ func TestBackfillWorkOSOrganization_ExternalIDChangeDoesNotChangeOrganizationID(
 
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 
-	workosClient := newStubWorkOSBackfillClient(t, ctx,
+	workosClient := newWorkOSSnapshotClient(t, ctx,
 		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Immutable Org",
@@ -107,7 +107,7 @@ func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *test
 
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 
-	workosClient := newStubWorkOSBackfillClient(t, ctx,
+	workosClient := newWorkOSSnapshotClient(t, ctx,
 		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Unknown User",
@@ -158,6 +158,74 @@ func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *test
 	require.Empty(t, assignments[0].WorkosLastEventID.String)
 }
 
+func TestBackfillWorkOSOrganization_MembershipWithNewerEventSkipsRoleSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_membership_newer_event_wins")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_backfill_membership_event_wins"
+	const workosOrgID = "org_01JBACKFILLMEMEVENT"
+	const workosUserID = "user_01JBACKFILLMEMEVENT"
+	const membershipID = "mem_01JBACKFILLMEMEVENT"
+	const roleSlug = "org-member"
+
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedOrganizationRoleWithCursor(t, ctx, conn, organizationID, roleSlug, "Member", "")
+	err := orgrepo.New(conn).SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       workosUserID,
+		WorkosRoleSlugs:    []string{roleSlug},
+		UserID:             conv.ToPGTextEmpty(""),
+		WorkosMembershipID: conv.ToPGText(membershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)),
+		WorkosLastEventID:  conv.ToPGText("event_99FRESH"),
+	})
+	require.NoError(t, err)
+
+	workosClient := newWorkOSSnapshotClient(t, ctx,
+		workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Membership Event Wins",
+			ExternalID: "",
+			CreatedAt:  "2026-05-07T11:00:00Z",
+			UpdatedAt:  "2026-05-07T11:00:00Z",
+		},
+		[]workos.Role{{
+			ID:          "role_01JMEMBER",
+			Name:        "Member",
+			Slug:        roleSlug,
+			Description: "",
+			Type:        "OrganizationRole",
+			CreatedAt:   "2026-05-07T11:00:00Z",
+			UpdatedAt:   "2026-05-07T11:00:00Z",
+		}},
+		[]workos.Member{{
+			ID:             membershipID,
+			UserID:         workosUserID,
+			OrganizationID: workosOrgID,
+			Organization:   "Backfill Membership Event Wins",
+			RoleSlug:       "",
+			Status:         "active",
+			CreatedAt:      "2026-05-07T11:00:00Z",
+			UpdatedAt:      "2026-05-07T11:00:00Z",
+		}},
+	)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+
+	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	require.Equal(t, "event_99FRESH", assignments[0].WorkosLastEventID.String)
+}
+
 func TestBackfillWorkOSOrganization_RoleWithLastEventIDSkipsSnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -172,7 +240,7 @@ func TestBackfillWorkOSOrganization_RoleWithLastEventIDSkipsSnapshot(t *testing.
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 	seedOrganizationRoleWithCursor(t, ctx, conn, organizationID, roleSlug, "Billing From Event", "event_01JNEWER")
 
-	workosClient := newStubWorkOSBackfillClient(t, ctx,
+	workosClient := newWorkOSSnapshotClient(t, ctx,
 		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Event Wins",
@@ -219,7 +287,7 @@ func TestBackfillWorkOSOrganization_MissingRoleSoftDeleted(t *testing.T) {
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 	seedOrganizationRoleWithCursor(t, ctx, conn, organizationID, roleSlug, "Obsolete", "")
 
-	workosClient := newStubWorkOSBackfillClient(t, ctx,
+	workosClient := newWorkOSSnapshotClient(t, ctx,
 		workos.Organization{
 			ID:         workosOrgID,
 			Name:       "Backfill Delete Role",
@@ -245,7 +313,7 @@ func TestBackfillWorkOSOrganization_MissingRoleSoftDeleted(t *testing.T) {
 	require.Empty(t, role.WorkosLastEventID.String)
 }
 
-func newStubWorkOSBackfillClient(t *testing.T, ctx context.Context, org workos.Organization, roles []workos.Role, members []workos.Member) *workos.StubClient {
+func newWorkOSSnapshotClient(t *testing.T, ctx context.Context, org workos.Organization, roles []workos.Role, members []workos.Member) *workos.StubClient {
 	t.Helper()
 
 	client := workos.NewStubClient()

--- a/server/internal/background/activities/list_workos_organizations.go
+++ b/server/internal/background/activities/list_workos_organizations.go
@@ -10,10 +10,10 @@ import (
 
 type ListWorkOSOrganizations struct {
 	logger *slog.Logger
-	workos WorkOSBackfillClient
+	workos WorkOSClient
 }
 
-func NewListWorkOSOrganizations(logger *slog.Logger, workosClient WorkOSBackfillClient) *ListWorkOSOrganizations {
+func NewListWorkOSOrganizations(logger *slog.Logger, workosClient WorkOSClient) *ListWorkOSOrganizations {
 	return &ListWorkOSOrganizations{
 		logger: logger.With(attr.SlogComponent("list_workos_organizations")),
 		workos: workosClient,

--- a/server/internal/background/activities/list_workos_organizations.go
+++ b/server/internal/background/activities/list_workos_organizations.go
@@ -1,0 +1,37 @@
+package activities
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+type ListWorkOSOrganizations struct {
+	logger *slog.Logger
+	workos WorkOSBackfillClient
+}
+
+func NewListWorkOSOrganizations(logger *slog.Logger, workosClient WorkOSBackfillClient) *ListWorkOSOrganizations {
+	return &ListWorkOSOrganizations{
+		logger: logger.With(attr.SlogComponent("list_workos_organizations")),
+		workos: workosClient,
+	}
+}
+
+func (l *ListWorkOSOrganizations) Do(ctx context.Context) ([]string, error) {
+	orgs, err := l.workos.ListOrganizations(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list WorkOS organizations").Log(ctx, l.logger)
+	}
+
+	orgIDs := make([]string, 0, len(orgs))
+	for _, org := range orgs {
+		if org.ID != "" {
+			orgIDs = append(orgIDs, org.ID)
+		}
+	}
+
+	return orgIDs, nil
+}

--- a/server/internal/background/activities/process_workos_global_role_events.go
+++ b/server/internal/background/activities/process_workos_global_role_events.go
@@ -44,14 +44,14 @@ type ProcessWorkOSGlobalRoleEventsResult struct {
 type ProcessWorkOSGlobalRoleEvents struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
-	eventsClient EventsLister
+	workosClient EventsLister
 }
 
-func NewProcessWorkOSGlobalRoleEvents(logger *slog.Logger, db *pgxpool.Pool, eventsClient EventsLister) *ProcessWorkOSGlobalRoleEvents {
+func NewProcessWorkOSGlobalRoleEvents(logger *slog.Logger, db *pgxpool.Pool, workosClient EventsLister) *ProcessWorkOSGlobalRoleEvents {
 	return &ProcessWorkOSGlobalRoleEvents{
 		db:           db,
 		logger:       logger,
-		eventsClient: eventsClient,
+		workosClient: workosClient,
 	}
 }
 
@@ -68,7 +68,7 @@ func (p *ProcessWorkOSGlobalRoleEvents) Do(ctx context.Context, params ProcessWo
 		}
 	}
 
-	resp, err := p.eventsClient.ListEvents(ctx, events.ListEventsOpts{
+	resp, err := p.workosClient.ListEvents(ctx, events.ListEventsOpts{
 		Events: []string{
 			string(workos.EventKindRoleCreated),
 			string(workos.EventKindRoleUpdated),

--- a/server/internal/background/activities/process_workos_global_role_events.go
+++ b/server/internal/background/activities/process_workos_global_role_events.go
@@ -44,10 +44,10 @@ type ProcessWorkOSGlobalRoleEventsResult struct {
 type ProcessWorkOSGlobalRoleEvents struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
-	workosClient EventsLister
+	workosClient WorkOSClient
 }
 
-func NewProcessWorkOSGlobalRoleEvents(logger *slog.Logger, db *pgxpool.Pool, workosClient EventsLister) *ProcessWorkOSGlobalRoleEvents {
+func NewProcessWorkOSGlobalRoleEvents(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSClient) *ProcessWorkOSGlobalRoleEvents {
 	return &ProcessWorkOSGlobalRoleEvents{
 		db:           db,
 		logger:       logger,

--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -26,7 +26,7 @@ import (
 
 const workosOrgEventsPageSize = 100
 
-// EventsLister is the subset of the WorkOS events client used by this activity.
+// EventsLister is the subset of the WorkOS client used by this activity.
 type EventsLister interface {
 	ListEvents(ctx context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error)
 }
@@ -54,14 +54,14 @@ type ProcessWorkOSOrganizationEventsResult struct {
 type ProcessWorkOSOrganizationEvents struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
-	eventsClient EventsLister
+	workosClient EventsLister
 }
 
-func NewProcessWorkOSOrganizationEvents(logger *slog.Logger, db *pgxpool.Pool, eventsClient EventsLister) *ProcessWorkOSOrganizationEvents {
+func NewProcessWorkOSOrganizationEvents(logger *slog.Logger, db *pgxpool.Pool, workosClient EventsLister) *ProcessWorkOSOrganizationEvents {
 	return &ProcessWorkOSOrganizationEvents{
 		db:           db,
 		logger:       logger,
-		eventsClient: eventsClient,
+		workosClient: workosClient,
 	}
 }
 
@@ -84,7 +84,7 @@ func (p *ProcessWorkOSOrganizationEvents) Do(ctx context.Context, params Process
 		}
 	}
 
-	resp, err := p.eventsClient.ListEvents(ctx, events.ListEventsOpts{
+	resp, err := p.workosClient.ListEvents(ctx, events.ListEventsOpts{
 		Events: []string{
 			string(workos.EventKindOrganizationCreated),
 			string(workos.EventKindOrganizationUpdated),

--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -26,11 +26,6 @@ import (
 
 const workosOrgEventsPageSize = 100
 
-// EventsLister is the subset of the WorkOS client used by this activity.
-type EventsLister interface {
-	ListEvents(ctx context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error)
-}
-
 type ProcessWorkOSOrganizationEventsParams struct {
 	WorkOSOrganizationID string `json:"workos_organization_id,omitempty"`
 	// SinceEventID lets a caller override the DB cursor for this run. Workflow
@@ -54,10 +49,10 @@ type ProcessWorkOSOrganizationEventsResult struct {
 type ProcessWorkOSOrganizationEvents struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
-	workosClient EventsLister
+	workosClient WorkOSClient
 }
 
-func NewProcessWorkOSOrganizationEvents(logger *slog.Logger, db *pgxpool.Pool, workosClient EventsLister) *ProcessWorkOSOrganizationEvents {
+func NewProcessWorkOSOrganizationEvents(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSClient) *ProcessWorkOSOrganizationEvents {
 	return &ProcessWorkOSOrganizationEvents{
 		db:           db,
 		logger:       logger,

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -17,25 +17,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
-
-type stubWorkOSClient struct {
-	pages [][]events.Event
-	calls []events.ListEventsOpts
-}
-
-func (s *stubWorkOSClient) ListEvents(_ context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error) {
-	s.calls = append(s.calls, opts)
-
-	idx := len(s.calls) - 1
-	if idx >= len(s.pages) {
-		return events.ListEventsResponse{Data: nil}, nil
-	}
-	return events.ListEventsResponse{Data: s.pages[idx]}, nil
-}
 
 func newOrgEventsTestConn(t *testing.T, name string) *pgxpool.Pool {
 	t.Helper()
@@ -52,6 +38,12 @@ func newOrgEventPayload(t *testing.T, workosOrgID string) []byte {
 	return []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Test","external_id":"sb_` + workosOrgID + `","updated_at":"2026-05-06T12:00:00Z"}`)
 }
 
+func newWorkOSClientWithEvents(pages [][]events.Event) *workos.StubClient {
+	client := workos.NewStubClient()
+	client.SetEventPages(pages)
+	return client
+}
+
 func TestProcessWorkOSOrganizationEvents_AdvancesCursor(t *testing.T) {
 	t.Parallel()
 
@@ -61,14 +53,12 @@ func TestProcessWorkOSOrganizationEvents_AdvancesCursor(t *testing.T) {
 
 	const workosOrgID = "org_01HZTESTADVANCE"
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{
-			{
-				{ID: "event_01HZA", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)},
-				{ID: "event_01HZB", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)},
-			},
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{ID: "event_01HZA", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)},
+			{ID: "event_01HZB", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)},
 		},
-	}
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
@@ -100,11 +90,9 @@ func TestProcessWorkOSOrganizationEvents_ResumesFromCursor(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{
-			{{ID: "event_01HZNEXT", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)}},
-		},
-	}
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{{ID: "event_01HZNEXT", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)}},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
@@ -115,8 +103,8 @@ func TestProcessWorkOSOrganizationEvents_ResumesFromCursor(t *testing.T) {
 	require.Equal(t, "event_01HZSEED", res.SinceEventID)
 	require.Equal(t, "event_01HZNEXT", res.LastEventID)
 
-	require.Len(t, stub.calls, 1)
-	require.Equal(t, "event_01HZSEED", stub.calls[0].After)
+	require.Len(t, stub.EventCalls(), 1)
+	require.Equal(t, "event_01HZSEED", stub.EventCalls()[0].After)
 }
 
 func TestProcessWorkOSOrganizationEvents_FullPageHasMore(t *testing.T) {
@@ -138,7 +126,7 @@ func TestProcessWorkOSOrganizationEvents_FullPageHasMore(t *testing.T) {
 		}
 	}
 
-	stub := &stubWorkOSClient{pages: [][]events.Event{page}}
+	stub := newWorkOSClientWithEvents([][]events.Event{page})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -155,7 +143,7 @@ func TestProcessWorkOSOrganizationEvents_EmptyPage(t *testing.T) {
 
 	const workosOrgID = "org_01HZTESTEMPTY"
 
-	stub := &stubWorkOSClient{pages: [][]events.Event{nil}}
+	stub := newWorkOSClientWithEvents([][]events.Event{nil})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -179,12 +167,12 @@ func TestProcessWorkOSOrganizationEvents_SkipsUnlinkedOrgWithoutExternalID(t *te
 	// First event has neither a Gram-side mapping nor an external_id — must
 	// not stall the stream. Second event in the same page carries the
 	// external_id and should be applied normally.
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{ID: "event_01HZBAD", Event: "organization.updated", CreatedAt: time.Now(), Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Pending","updated_at":"2026-05-06T11:00:00Z"}`)},
 			{ID: "event_01HZGOOD", Event: "organization.updated", CreatedAt: time.Now(), Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Resolved","external_id":"sb_resolved","updated_at":"2026-05-06T12:00:00Z"}`)},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
@@ -215,8 +203,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationCreatedAndUpdated(t *testin
 	created := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
 	updated := time.Date(2026, 5, 6, 11, 0, 0, 0, time.UTC)
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{
 				ID:        "event_01HZA",
 				Event:     "organization.created",
@@ -231,8 +219,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationCreatedAndUpdated(t *testin
 				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Acme Inc","external_id":"` + externalID +
 					`","updated_at":"2026-05-06T11:00:00Z"}`),
 			},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -259,8 +247,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationUpdateSkippedWhenStale(t *t
 	const workosOrgID = "org_01HZSTALE"
 	const externalID = "sb_01HZSTALE"
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{
 				ID:        "event_01HZ002",
 				Event:     "organization.updated",
@@ -276,8 +264,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationUpdateSkippedWhenStale(t *t
 				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Older","external_id":"` + externalID +
 					`","updated_at":"2026-05-06T11:00:00Z"}`),
 			},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -309,8 +297,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSetsDisabled(t *test
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{
 				ID:        "event_01HZDEL",
 				Event:     "organization.deleted",
@@ -318,8 +306,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSetsDisabled(t *test
 				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Doomed","external_id":"` + externalID +
 					`","updated_at":"2026-05-06T12:00:00Z"}`),
 			},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -340,8 +328,8 @@ func TestProcessWorkOSGlobalRoleEvents_UpsertAndDelete(t *testing.T) {
 
 	const slug = "platform-admin"
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{
 				ID:        "event_01HZG1",
 				Event:     "role.created",
@@ -358,8 +346,8 @@ func TestProcessWorkOSGlobalRoleEvents_UpsertAndDelete(t *testing.T) {
 					`"type":"EnvironmentRole","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T11:00:00Z",` +
 					`"deleted_at":"2026-05-06T11:00:00Z"}`),
 			},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSGlobalRoleEvents(logger, conn, stub)
 	_, err := activity.Do(ctx, activities.ProcessWorkOSGlobalRoleEventsParams{})
@@ -403,8 +391,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleUpsertAndDelete(t *test
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{
 				ID:        "event_01HZR1",
 				Event:     "organization_role.created",
@@ -421,8 +409,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleUpsertAndDelete(t *test
 					`","slug":"` + slug + `","name":"Billing Manager","type":"OrganizationRole",` +
 					`"created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T11:00:00Z","deleted_at":"2026-05-06T11:00:00Z"}`),
 			},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -466,8 +454,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSkippedWhenStale(t *
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{
 				ID:        "event_01HZSTALEDEL",
 				Event:     "organization.deleted",
@@ -475,8 +463,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSkippedWhenStale(t *
 				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Live","external_id":"` + externalID +
 					`","updated_at":"2026-05-06T11:00:00Z"}`),
 			},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -594,14 +582,14 @@ func TestProcessWorkOSOrganizationEvents_MembershipFilterIncludesMembershipTypes
 
 	const workosOrgID = "org_01HZMEMFILTER"
 
-	stub := &stubWorkOSClient{pages: [][]events.Event{nil}}
+	stub := newWorkOSClientWithEvents([][]events.Event{nil})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
 
-	require.Len(t, stub.calls, 1)
-	require.Equal(t, workosOrgID, stub.calls[0].OrganizationId)
+	require.Len(t, stub.EventCalls(), 1)
+	require.Equal(t, workosOrgID, stub.EventCalls()[0].OrganizationId)
 	require.ElementsMatch(t, []string{
 		"organization.created",
 		"organization.updated",
@@ -612,7 +600,7 @@ func TestProcessWorkOSOrganizationEvents_MembershipFilterIncludesMembershipTypes
 		"organization_membership.created",
 		"organization_membership.updated",
 		"organization_membership.deleted",
-	}, stub.calls[0].Events)
+	}, stub.EventCalls()[0].Events)
 }
 
 func TestProcessWorkOSOrganizationEvents_MembershipKnownUserSyncsRoles(t *testing.T) {
@@ -632,11 +620,11 @@ func TestProcessWorkOSOrganizationEvents_MembershipKnownUserSyncsRoles(t *testin
 	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
 	organizationRole := seedOrganizationRole(t, ctx, conn, organizationID, "member")
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEM1", "mem_01HZKNOWN", workosOrgID, workosUserID, updatedAt, "member"),
-		}},
-	}
+		},
+	})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -679,11 +667,11 @@ func TestProcessWorkOSOrganizationEvents_MembershipUnknownUserStillSyncsRoles(t 
 	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 	memberRole := seedOrganizationRole(t, ctx, conn, organizationID, "member")
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEMUNK", "mem_01HZUNKNOWN", workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
-		}},
-	}
+		},
+	})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -717,12 +705,12 @@ func TestProcessWorkOSOrganizationEvents_MembershipDeleteSoftDeletesAndClearsAss
 	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
 	seedOrganizationRole(t, ctx, conn, organizationID, "member")
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZDEL1", membershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
 			newWorkOSMembershipEvent(t, "organization_membership.deleted", "event_01HZDEL2", membershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 13, 0, 0, 0, time.UTC)),
-		}},
-	}
+		},
+	})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -761,11 +749,11 @@ func TestProcessWorkOSOrganizationEvents_MembershipUnknownOrganizationSkips(t *t
 
 	const workosOrgID = "org_01HZMEMUNKORG"
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEMUNKORG", "mem_01HZUNKNOWNORG", workosOrgID, "user_01HZUNKNOWNORG", time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
-		}},
-	}
+		},
+	})
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -786,8 +774,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleSkippedForUnknownOrg(t 
 
 	const workosOrgID = "org_01HZUNKNOWN"
 
-	stub := &stubWorkOSClient{
-		pages: [][]events.Event{{
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
 			{
 				ID:        "event_01HZUR1",
 				Event:     "organization_role.created",
@@ -796,8 +784,8 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleSkippedForUnknownOrg(t 
 					`","slug":"phantom","name":"Phantom","type":"OrganizationRole",` +
 					`"created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:00:00Z"}`),
 			},
-		}},
-	}
+		},
+	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -22,12 +22,12 @@ import (
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
-type stubWorkOSEventsClient struct {
+type stubWorkOSClient struct {
 	pages [][]events.Event
 	calls []events.ListEventsOpts
 }
 
-func (s *stubWorkOSEventsClient) ListEvents(_ context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error) {
+func (s *stubWorkOSClient) ListEvents(_ context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error) {
 	s.calls = append(s.calls, opts)
 
 	idx := len(s.calls) - 1
@@ -61,7 +61,7 @@ func TestProcessWorkOSOrganizationEvents_AdvancesCursor(t *testing.T) {
 
 	const workosOrgID = "org_01HZTESTADVANCE"
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{
 			{
 				{ID: "event_01HZA", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)},
@@ -100,7 +100,7 @@ func TestProcessWorkOSOrganizationEvents_ResumesFromCursor(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{
 			{{ID: "event_01HZNEXT", Event: "organization.updated", CreatedAt: time.Now(), Data: newOrgEventPayload(t, workosOrgID)}},
 		},
@@ -138,7 +138,7 @@ func TestProcessWorkOSOrganizationEvents_FullPageHasMore(t *testing.T) {
 		}
 	}
 
-	stub := &stubWorkOSEventsClient{pages: [][]events.Event{page}}
+	stub := &stubWorkOSClient{pages: [][]events.Event{page}}
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -155,7 +155,7 @@ func TestProcessWorkOSOrganizationEvents_EmptyPage(t *testing.T) {
 
 	const workosOrgID = "org_01HZTESTEMPTY"
 
-	stub := &stubWorkOSEventsClient{pages: [][]events.Event{nil}}
+	stub := &stubWorkOSClient{pages: [][]events.Event{nil}}
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -179,7 +179,7 @@ func TestProcessWorkOSOrganizationEvents_SkipsUnlinkedOrgWithoutExternalID(t *te
 	// First event has neither a Gram-side mapping nor an external_id — must
 	// not stall the stream. Second event in the same page carries the
 	// external_id and should be applied normally.
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{ID: "event_01HZBAD", Event: "organization.updated", CreatedAt: time.Now(), Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Pending","updated_at":"2026-05-06T11:00:00Z"}`)},
 			{ID: "event_01HZGOOD", Event: "organization.updated", CreatedAt: time.Now(), Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Resolved","external_id":"sb_resolved","updated_at":"2026-05-06T12:00:00Z"}`)},
@@ -215,7 +215,7 @@ func TestProcessWorkOSOrganizationEvents_OrganizationCreatedAndUpdated(t *testin
 	created := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
 	updated := time.Date(2026, 5, 6, 11, 0, 0, 0, time.UTC)
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{
 				ID:        "event_01HZA",
@@ -259,7 +259,7 @@ func TestProcessWorkOSOrganizationEvents_OrganizationUpdateSkippedWhenStale(t *t
 	const workosOrgID = "org_01HZSTALE"
 	const externalID = "sb_01HZSTALE"
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{
 				ID:        "event_01HZ002",
@@ -309,7 +309,7 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSetsDisabled(t *test
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{
 				ID:        "event_01HZDEL",
@@ -340,7 +340,7 @@ func TestProcessWorkOSGlobalRoleEvents_UpsertAndDelete(t *testing.T) {
 
 	const slug = "platform-admin"
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{
 				ID:        "event_01HZG1",
@@ -403,7 +403,7 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleUpsertAndDelete(t *test
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{
 				ID:        "event_01HZR1",
@@ -466,7 +466,7 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSkippedWhenStale(t *
 	})
 	require.NoError(t, err)
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{
 				ID:        "event_01HZSTALEDEL",
@@ -594,7 +594,7 @@ func TestProcessWorkOSOrganizationEvents_MembershipFilterIncludesMembershipTypes
 
 	const workosOrgID = "org_01HZMEMFILTER"
 
-	stub := &stubWorkOSEventsClient{pages: [][]events.Event{nil}}
+	stub := &stubWorkOSClient{pages: [][]events.Event{nil}}
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
 
 	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
@@ -632,7 +632,7 @@ func TestProcessWorkOSOrganizationEvents_MembershipKnownUserSyncsRoles(t *testin
 	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
 	organizationRole := seedOrganizationRole(t, ctx, conn, organizationID, "member")
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEM1", "mem_01HZKNOWN", workosOrgID, workosUserID, updatedAt, "member"),
 		}},
@@ -679,7 +679,7 @@ func TestProcessWorkOSOrganizationEvents_MembershipUnknownUserStillSyncsRoles(t 
 	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 	memberRole := seedOrganizationRole(t, ctx, conn, organizationID, "member")
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEMUNK", "mem_01HZUNKNOWN", workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
 		}},
@@ -717,7 +717,7 @@ func TestProcessWorkOSOrganizationEvents_MembershipDeleteSoftDeletesAndClearsAss
 	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
 	seedOrganizationRole(t, ctx, conn, organizationID, "member")
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZDEL1", membershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
 			newWorkOSMembershipEvent(t, "organization_membership.deleted", "event_01HZDEL2", membershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 13, 0, 0, 0, time.UTC)),
@@ -761,7 +761,7 @@ func TestProcessWorkOSOrganizationEvents_MembershipUnknownOrganizationSkips(t *t
 
 	const workosOrgID = "org_01HZMEMUNKORG"
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZMEMUNKORG", "mem_01HZUNKNOWNORG", workosOrgID, "user_01HZUNKNOWNORG", time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC), "member"),
 		}},
@@ -786,7 +786,7 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleSkippedForUnknownOrg(t 
 
 	const workosOrgID = "org_01HZUNKNOWN"
 
-	stub := &stubWorkOSEventsClient{
+	stub := &stubWorkOSClient{
 		pages: [][]events.Event{{
 			{
 				ID:        "event_01HZUR1",

--- a/server/internal/background/backfill_workos.go
+++ b/server/internal/background/backfill_workos.go
@@ -1,0 +1,59 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+func ExecuteBackfillWorkOSWorkflow(ctx context.Context, env *tenv.Environment) (client.WorkflowRun, error) {
+	return env.Client().ExecuteWorkflow(ctx,
+		client.StartWorkflowOptions{
+			ID:                       fmt.Sprintf("v1:backfill-workos:%d", time.Now().Unix()),
+			TaskQueue:                string(env.Queue()),
+			WorkflowExecutionTimeout: 2 * time.Hour,
+			WorkflowIDReusePolicy:    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		},
+		BackfillWorkOSWorkflow,
+	)
+}
+
+func BackfillWorkOSWorkflow(ctx workflow.Context) error {
+	var a *Activities
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			MaximumInterval:    time.Minute,
+			BackoffCoefficient: 2,
+			MaximumAttempts:    5,
+		},
+	})
+
+	var orgIDs []string
+	if err := workflow.ExecuteActivity(ctx, a.ListWorkOSOrganizations).Get(ctx, &orgIDs); err != nil {
+		return fmt.Errorf("list WorkOS organizations: %w", err)
+	}
+
+	if err := workflow.ExecuteActivity(ctx, a.BackfillWorkOSGlobalRoles).Get(ctx, nil); err != nil {
+		workflow.GetLogger(ctx).Warn("global role backfill failed", "error", err)
+	}
+
+	for _, orgID := range orgIDs {
+		if err := workflow.ExecuteActivity(ctx, a.BackfillWorkOSOrganization, activities.BackfillWorkOSOrganizationParams{
+			WorkOSOrganizationID: orgID,
+		}).Get(ctx, nil); err != nil {
+			workflow.GetLogger(ctx).Warn("WorkOS organization backfill failed", "workos_org_id", orgID, "error", err)
+		}
+	}
+
+	return nil
+}

--- a/server/internal/background/backfill_workos.go
+++ b/server/internal/background/backfill_workos.go
@@ -14,19 +14,29 @@ import (
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 )
 
-func ExecuteBackfillWorkOSWorkflow(ctx context.Context, env *tenv.Environment) (client.WorkflowRun, error) {
+type BackfillWorkOSParams struct {
+	WorkOSOrganizationID string `json:"workos_organization_id,omitempty"`
+}
+
+func ExecuteBackfillWorkOSWorkflow(ctx context.Context, env *tenv.Environment, params BackfillWorkOSParams) (client.WorkflowRun, error) {
+	workflowID := fmt.Sprintf("v1:backfill-workos:%d", time.Now().Unix())
+	if params.WorkOSOrganizationID != "" {
+		workflowID = fmt.Sprintf("v1:backfill-workos:%s:%d", params.WorkOSOrganizationID, time.Now().Unix())
+	}
+
 	return env.Client().ExecuteWorkflow(ctx,
 		client.StartWorkflowOptions{
-			ID:                       fmt.Sprintf("v1:backfill-workos:%d", time.Now().Unix()),
+			ID:                       workflowID,
 			TaskQueue:                string(env.Queue()),
 			WorkflowExecutionTimeout: 2 * time.Hour,
 			WorkflowIDReusePolicy:    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 		},
 		BackfillWorkOSWorkflow,
+		params,
 	)
 }
 
-func BackfillWorkOSWorkflow(ctx workflow.Context) error {
+func BackfillWorkOSWorkflow(ctx workflow.Context, params BackfillWorkOSParams) error {
 	var a *Activities
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 10 * time.Minute,
@@ -38,13 +48,23 @@ func BackfillWorkOSWorkflow(ctx workflow.Context) error {
 		},
 	})
 
+	if err := workflow.ExecuteActivity(ctx, a.BackfillWorkOSGlobalRoles).Get(ctx, nil); err != nil {
+		workflow.GetLogger(ctx).Warn("global role backfill failed", "error", err)
+	}
+
+	if params.WorkOSOrganizationID != "" {
+		if err := workflow.ExecuteActivity(ctx, a.BackfillWorkOSOrganization, activities.BackfillWorkOSOrganizationParams{
+			WorkOSOrganizationID: params.WorkOSOrganizationID,
+		}).Get(ctx, nil); err != nil {
+			return fmt.Errorf("backfill WorkOS organization %q: %w", params.WorkOSOrganizationID, err)
+		}
+
+		return nil
+	}
+
 	var orgIDs []string
 	if err := workflow.ExecuteActivity(ctx, a.ListWorkOSOrganizations).Get(ctx, &orgIDs); err != nil {
 		return fmt.Errorf("list WorkOS organizations: %w", err)
-	}
-
-	if err := workflow.ExecuteActivity(ctx, a.BackfillWorkOSGlobalRoles).Get(ctx, nil); err != nil {
-		workflow.GetLogger(ctx).Warn("global role backfill failed", "error", err)
 	}
 
 	for _, orgID := range orgIDs {

--- a/server/internal/background/backfill_workos_test.go
+++ b/server/internal/background/backfill_workos_test.go
@@ -1,0 +1,83 @@
+package background
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+)
+
+func TestBackfillWorkOSWorkflow_BackfillsAllOrganizations(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(context.Context) ([]string, error) {
+			return []string{"org_01", "org_02"}, nil
+		},
+		activity.RegisterOptions{Name: "ListWorkOSOrganizations"},
+	)
+
+	var globalRolesBackfilled bool
+	env.RegisterActivityWithOptions(
+		func(context.Context) error {
+			globalRolesBackfilled = true
+			return nil
+		},
+		activity.RegisterOptions{Name: "BackfillWorkOSGlobalRoles"},
+	)
+
+	var backfilledOrgIDs []string
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.BackfillWorkOSOrganizationParams) error {
+			backfilledOrgIDs = append(backfilledOrgIDs, params.WorkOSOrganizationID)
+			return nil
+		},
+		activity.RegisterOptions{Name: "BackfillWorkOSOrganization"},
+	)
+
+	env.ExecuteWorkflow(BackfillWorkOSWorkflow, BackfillWorkOSParams{})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.True(t, globalRolesBackfilled)
+	require.Equal(t, []string{"org_01", "org_02"}, backfilledOrgIDs)
+}
+
+func TestBackfillWorkOSWorkflow_BackfillsSingleOrganization(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	var globalRolesBackfilled bool
+	env.RegisterActivityWithOptions(
+		func(context.Context) error {
+			globalRolesBackfilled = true
+			return nil
+		},
+		activity.RegisterOptions{Name: "BackfillWorkOSGlobalRoles"},
+	)
+
+	var backfilledOrgIDs []string
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, params activities.BackfillWorkOSOrganizationParams) error {
+			backfilledOrgIDs = append(backfilledOrgIDs, params.WorkOSOrganizationID)
+			return nil
+		},
+		activity.RegisterOptions{Name: "BackfillWorkOSOrganization"},
+	)
+
+	env.ExecuteWorkflow(BackfillWorkOSWorkflow, BackfillWorkOSParams{WorkOSOrganizationID: "org_01TARGET"})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.True(t, globalRolesBackfilled)
+	require.Equal(t, []string{"org_01TARGET"}, backfilledOrgIDs)
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assistants"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/background/interceptors"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
@@ -68,7 +69,7 @@ type WorkerOptions struct {
 	PIIScanner          risk_analysis.PIIScanner
 	ShadowMCPClient     *shadowmcp.Client
 	AuditLogger         *audit.Logger
-	WorkOSClient        *workos.Client
+	WorkOSClient        activities.WorkOSClient
 }
 
 func ForDeploymentProcessing(
@@ -108,7 +109,7 @@ func ForDeploymentProcessing(
 		TemporalEnv:         nil,
 		PIIScanner:          nil,
 		ShadowMCPClient:     nil,
-		WorkOSClient:        nil,
+		WorkOSClient:        workos.NewStubClient(),
 	}
 }
 
@@ -146,7 +147,7 @@ func NewTemporalWorker(
 		PIIScanner:          nil,
 		ShadowMCPClient:     nil,
 		AuditLogger:         nil,
-		WorkOSClient:        nil,
+		WorkOSClient:        workos.NewStubClient(),
 	}
 
 	for _, o := range options {

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -38,7 +38,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
-	"github.com/workos/workos-go/v6/pkg/events"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
 type WorkerOptions struct {
@@ -68,7 +68,7 @@ type WorkerOptions struct {
 	PIIScanner          risk_analysis.PIIScanner
 	ShadowMCPClient     *shadowmcp.Client
 	AuditLogger         *audit.Logger
-	WorkOSEventsClient  *events.Client
+	WorkOSClient        *workos.Client
 }
 
 func ForDeploymentProcessing(
@@ -108,7 +108,7 @@ func ForDeploymentProcessing(
 		TemporalEnv:         nil,
 		PIIScanner:          nil,
 		ShadowMCPClient:     nil,
-		WorkOSEventsClient:  nil,
+		WorkOSClient:        nil,
 	}
 }
 
@@ -146,7 +146,7 @@ func NewTemporalWorker(
 		PIIScanner:          nil,
 		ShadowMCPClient:     nil,
 		AuditLogger:         nil,
-		WorkOSEventsClient:  nil,
+		WorkOSClient:        nil,
 	}
 
 	for _, o := range options {
@@ -177,7 +177,7 @@ func NewTemporalWorker(
 			PIIScanner:          conv.Default(o.PIIScanner, opts.PIIScanner),
 			ShadowMCPClient:     conv.Default(o.ShadowMCPClient, opts.ShadowMCPClient),
 			AuditLogger:         conv.Default(o.AuditLogger, opts.AuditLogger),
-			WorkOSEventsClient:  conv.Default(o.WorkOSEventsClient, opts.WorkOSEventsClient),
+			WorkOSClient:        conv.Default(o.WorkOSClient, opts.WorkOSClient),
 		}
 	}
 
@@ -225,7 +225,7 @@ func NewTemporalWorker(
 		opts.PIIScanner,
 		opts.ShadowMCPClient,
 		opts.AuditLogger,
-		opts.WorkOSEventsClient,
+		opts.WorkOSClient,
 	)
 
 	temporalWorker.RegisterActivity(activities.ProcessDeployment)
@@ -269,6 +269,9 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.SignalAssistantCoordinator)
 	temporalWorker.RegisterActivity(activities.SignalAssistantThread)
 	// WorkOS sync activities
+	temporalWorker.RegisterActivity(activities.ListWorkOSOrganizations)
+	temporalWorker.RegisterActivity(activities.BackfillWorkOSOrganization)
+	temporalWorker.RegisterActivity(activities.BackfillWorkOSGlobalRoles)
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSOrganizationEvents)
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSGlobalRoleEvents)
 
@@ -303,6 +306,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(ProcessWorkOSOrganizationEventsWorkflowDebounced)
 	temporalWorker.RegisterWorkflow(ProcessWorkOSGlobalRoleEventsWorkflow)
 	temporalWorker.RegisterWorkflow(ProcessWorkOSGlobalRoleEventsWorkflowDebounced)
+	temporalWorker.RegisterWorkflow(BackfillWorkOSWorkflow)
 	// Assistants signup followups
 	temporalWorker.RegisterWorkflow(CancelAssistantsSubscriptionWorkflow)
 

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -41,15 +41,6 @@ FROM organization_metadata
 WHERE workos_id = @workos_id
 LIMIT 1;
 
--- name: ListLinkedWorkOSOrganizations :many
--- Returns WorkOS organization IDs for enabled Gram organizations linked to WorkOS.
-SELECT workos_id
-FROM organization_metadata
-WHERE workos_id IS NOT NULL
-  AND workos_id <> ''
-  AND disabled_at IS NULL
-ORDER BY id;
-
 -- name: UpsertOrganizationUserRelationship :one
 INSERT INTO organization_user_relationships (
     organization_id,

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -41,6 +41,15 @@ FROM organization_metadata
 WHERE workos_id = @workos_id
 LIMIT 1;
 
+-- name: ListLinkedWorkOSOrganizations :many
+-- Returns WorkOS organization IDs for enabled Gram organizations linked to WorkOS.
+SELECT workos_id
+FROM organization_metadata
+WHERE workos_id IS NOT NULL
+  AND workos_id <> ''
+  AND disabled_at IS NULL
+ORDER BY id;
+
 -- name: UpsertOrganizationUserRelationship :one
 INSERT INTO organization_user_relationships (
     organization_id,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -279,36 +279,6 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 	return exists, err
 }
 
-const listLinkedWorkOSOrganizations = `-- name: ListLinkedWorkOSOrganizations :many
-SELECT workos_id
-FROM organization_metadata
-WHERE workos_id IS NOT NULL
-  AND workos_id <> ''
-  AND disabled_at IS NULL
-ORDER BY id
-`
-
-// Returns WorkOS organization IDs for enabled Gram organizations linked to WorkOS.
-func (q *Queries) ListLinkedWorkOSOrganizations(ctx context.Context) ([]pgtype.Text, error) {
-	rows, err := q.db.Query(ctx, listLinkedWorkOSOrganizations)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []pgtype.Text
-	for rows.Next() {
-		var workos_id pgtype.Text
-		if err := rows.Scan(&workos_id); err != nil {
-			return nil, err
-		}
-		items = append(items, workos_id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listOrganizationRoleAssignmentsByWorkOSUser = `-- name: ListOrganizationRoleAssignmentsByWorkOSUser :many
 SELECT id, organization_id, workos_user_id, user_id, role_urn, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at
 FROM organization_role_assignments

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -279,6 +279,36 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 	return exists, err
 }
 
+const listLinkedWorkOSOrganizations = `-- name: ListLinkedWorkOSOrganizations :many
+SELECT workos_id
+FROM organization_metadata
+WHERE workos_id IS NOT NULL
+  AND workos_id <> ''
+  AND disabled_at IS NULL
+ORDER BY id
+`
+
+// Returns WorkOS organization IDs for enabled Gram organizations linked to WorkOS.
+func (q *Queries) ListLinkedWorkOSOrganizations(ctx context.Context) ([]pgtype.Text, error) {
+	rows, err := q.db.Query(ctx, listLinkedWorkOSOrganizations)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []pgtype.Text
+	for rows.Next() {
+		var workos_id pgtype.Text
+		if err := rows.Scan(&workos_id); err != nil {
+			return nil, err
+		}
+		items = append(items, workos_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listOrganizationRoleAssignmentsByWorkOSUser = `-- name: ListOrganizationRoleAssignmentsByWorkOSUser :many
 SELECT id, organization_id, workos_user_id, user_id, role_urn, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at
 FROM organization_role_assignments

--- a/server/internal/thirdparty/workos/client.go
+++ b/server/internal/thirdparty/workos/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/workos/workos-go/v6/pkg/events"
 	"github.com/workos/workos-go/v6/pkg/organizations"
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
 	"github.com/workos/workos-go/v6/pkg/workos_errors"
@@ -58,6 +59,7 @@ type Client struct {
 	httpClient *guardian.HTTPClient
 	orgs       *organizations.Client
 	um         *usermanagement.Client
+	events     *events.Client
 }
 
 // ClientOpts configures optional overrides for New.
@@ -99,7 +101,16 @@ func NewClient(guardianPolicy *guardian.Policy, apiKey string, opts ...ClientOpt
 		httpClient: httpClient,
 		orgs:       &organizations.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint, JSONEncode: nil},
 		um:         um,
+		events:     &events.Client{APIKey: apiKey, HTTPClient: httpClient, Endpoint: opt.Endpoint},
 	}
+}
+
+func (wc *Client) ListEvents(ctx context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error) {
+	resp, err := wc.events.ListEvents(ctx, opts)
+	if err != nil {
+		return events.ListEventsResponse{}, wrapSDKError(err, "list events")
+	}
+	return resp, nil
 }
 
 // do performs a raw HTTP request against the WorkOS REST API.

--- a/server/internal/thirdparty/workos/organization.go
+++ b/server/internal/thirdparty/workos/organization.go
@@ -9,10 +9,11 @@ import (
 
 // Organization represents a WorkOS organization with the fields used by Gram.
 type Organization struct {
-	ID        string
-	Name      string
-	CreatedAt string
-	UpdatedAt string
+	ID         string
+	Name       string
+	ExternalID string
+	CreatedAt  string
+	UpdatedAt  string
 }
 
 // GetOrganization fetches a WorkOS organization by id.
@@ -23,9 +24,43 @@ func (wc *Client) GetOrganization(ctx context.Context, orgID string) (*Organizat
 	}
 
 	return &Organization{
-		ID:        o.ID,
-		Name:      o.Name,
-		CreatedAt: o.CreatedAt,
-		UpdatedAt: o.UpdatedAt,
+		ID:         o.ID,
+		Name:       o.Name,
+		ExternalID: o.ExternalID,
+		CreatedAt:  o.CreatedAt,
+		UpdatedAt:  o.UpdatedAt,
 	}, nil
+}
+
+func (wc *Client) ListOrganizations(ctx context.Context) ([]Organization, error) {
+	var out []Organization
+	var after string
+
+	for {
+		resp, err := wc.orgs.ListOrganizations(ctx, organizations.ListOrganizationsOpts{
+			Domains: nil,
+			Limit:   100,
+			Order:   "",
+			Before:  "",
+			After:   after,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list organizations: %w", err)
+		}
+
+		for _, o := range resp.Data {
+			out = append(out, Organization{
+				ID:         o.ID,
+				Name:       o.Name,
+				ExternalID: o.ExternalID,
+				CreatedAt:  o.CreatedAt,
+				UpdatedAt:  o.UpdatedAt,
+			})
+		}
+
+		if resp.ListMetadata.After == "" {
+			return out, nil
+		}
+		after = resp.ListMetadata.After
+	}
 }

--- a/server/internal/thirdparty/workos/role.go
+++ b/server/internal/thirdparty/workos/role.go
@@ -16,6 +16,7 @@ type Role struct {
 	Name        string `json:"name"`
 	Slug        string `json:"slug"`
 	Description string `json:"description"`
+	Type        string `json:"type"`
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`
 }
@@ -41,9 +42,21 @@ func (wc *Client) ListRoles(ctx context.Context, orgID string) ([]Role, error) {
 
 	out := make([]Role, len(resp.Data))
 	for i, r := range resp.Data {
-		out[i] = Role{ID: r.ID, Name: r.Name, Slug: r.Slug, Description: r.Description, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt}
+		out[i] = Role{ID: r.ID, Name: r.Name, Slug: r.Slug, Description: r.Description, Type: string(r.Type), CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt}
 	}
 	return out, nil
+}
+
+// ListGlobalRoles lists environment-level WorkOS roles.
+func (wc *Client) ListGlobalRoles(ctx context.Context) ([]Role, error) {
+	var resp struct {
+		Data []Role `json:"data"`
+	}
+	if err := wc.do(ctx, http.MethodGet, "/authorization/roles", nil, &resp); err != nil {
+		return nil, fmt.Errorf("list global roles: %w", err)
+	}
+
+	return resp.Data, nil
 }
 
 // CreateRole creates a custom role for an organization via the WorkOS REST API.

--- a/server/internal/thirdparty/workos/stub.go
+++ b/server/internal/thirdparty/workos/stub.go
@@ -11,6 +11,7 @@ import (
 type StubClient struct {
 	mut         sync.Mutex
 	orgs        map[string]*stubOrgState
+	orgOrder    []string
 	globalRoles map[string]Role
 	globalOrder []string
 	next        int
@@ -18,23 +19,58 @@ type StubClient struct {
 }
 
 type stubOrgState struct {
-	roles       map[string]Role
-	roleOrder   []string
-	memberships map[string]Member
-	users       map[string]User
-	invites     map[string]Invitation
-	inviteOrder []string
+	organization Organization
+	roles        map[string]Role
+	roleOrder    []string
+	memberships  map[string]Member
+	users        map[string]User
+	invites      map[string]Invitation
+	inviteOrder  []string
 }
 
 func NewStubClient() *StubClient {
 	return &StubClient{
 		mut:         sync.Mutex{},
 		orgs:        make(map[string]*stubOrgState),
+		orgOrder:    make([]string, 0),
 		globalRoles: stubDefaultGlobalRoles(),
 		globalOrder: []string{"admin", "member"},
 		next:        1,
 		nowFn:       time.Now,
 	}
+}
+
+func (s *StubClient) UpsertOrganization(org Organization) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	state := s.orgState(org.ID)
+	state.organization = org
+}
+
+func (s *StubClient) GetOrganization(_ context.Context, orgID string) (*Organization, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	state, ok := s.orgs[orgID]
+	if !ok {
+		return nil, &APIError{Method: "GET", Path: "/stub/organizations/" + orgID, StatusCode: 404, Body: "organization not found"}
+	}
+
+	org := state.organization
+	return &org, nil
+}
+
+func (s *StubClient) ListOrganizations(_ context.Context) ([]Organization, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	orgs := make([]Organization, 0, len(s.orgOrder))
+	for _, orgID := range s.orgOrder {
+		orgs = append(orgs, s.orgs[orgID].organization)
+	}
+
+	return orgs, nil
 }
 
 func (s *StubClient) ListRoles(_ context.Context, orgID string) ([]Role, error) {
@@ -136,6 +172,14 @@ func (s *StubClient) ListMembers(_ context.Context, orgID string) ([]Member, err
 	}
 
 	return members, nil
+}
+
+func (s *StubClient) UpsertOrganizationMembership(member Member) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	state := s.orgState(member.OrganizationID)
+	state.memberships[member.ID] = member
 }
 
 func (s *StubClient) UpdateMemberRole(_ context.Context, membershipID string, roleSlug string) (*Member, error) {
@@ -344,6 +388,7 @@ func (s *StubClient) orgState(orgID string) *stubOrgState {
 	}
 
 	state = &stubOrgState{
+		organization: Organization{ID: orgID, Name: orgID, ExternalID: "", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
 		roles: map[string]Role{
 			"admin":  {ID: "role_admin", Name: "Admin", Slug: "admin", Description: "", Type: "EnvironmentRole", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
 			"member": {ID: "role_member", Name: "Member", Slug: "member", Description: "", Type: "EnvironmentRole", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
@@ -355,6 +400,7 @@ func (s *StubClient) orgState(orgID string) *stubOrgState {
 		inviteOrder: make([]string, 0),
 	}
 	s.orgs[orgID] = state
+	s.orgOrder = append(s.orgOrder, orgID)
 
 	return state
 }

--- a/server/internal/thirdparty/workos/stub.go
+++ b/server/internal/thirdparty/workos/stub.go
@@ -9,10 +9,12 @@ import (
 )
 
 type StubClient struct {
-	mut   sync.Mutex
-	orgs  map[string]*stubOrgState
-	next  int
-	nowFn func() time.Time
+	mut         sync.Mutex
+	orgs        map[string]*stubOrgState
+	globalRoles map[string]Role
+	globalOrder []string
+	next        int
+	nowFn       func() time.Time
 }
 
 type stubOrgState struct {
@@ -26,10 +28,12 @@ type stubOrgState struct {
 
 func NewStubClient() *StubClient {
 	return &StubClient{
-		mut:   sync.Mutex{},
-		orgs:  make(map[string]*stubOrgState),
-		next:  1,
-		nowFn: time.Now,
+		mut:         sync.Mutex{},
+		orgs:        make(map[string]*stubOrgState),
+		globalRoles: stubDefaultGlobalRoles(),
+		globalOrder: []string{"admin", "member"},
+		next:        1,
+		nowFn:       time.Now,
 	}
 }
 
@@ -56,11 +60,23 @@ func (s *StubClient) CreateRole(_ context.Context, orgID string, opts CreateRole
 	}
 
 	now := s.nowFn().UTC().Format(time.RFC3339)
-	role := Role{ID: s.nextRoleID(), Name: opts.Name, Slug: opts.Slug, Description: opts.Description, CreatedAt: now, UpdatedAt: now}
+	role := Role{ID: s.nextRoleID(), Name: opts.Name, Slug: opts.Slug, Description: opts.Description, Type: "OrganizationRole", CreatedAt: now, UpdatedAt: now}
 	state.roles[role.Slug] = role
 	state.roleOrder = append(state.roleOrder, role.Slug)
 
 	return &role, nil
+}
+
+func (s *StubClient) ListGlobalRoles(_ context.Context) ([]Role, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	roles := make([]Role, 0, len(s.globalOrder))
+	for _, slug := range s.globalOrder {
+		roles = append(roles, s.globalRoles[slug])
+	}
+
+	return roles, nil
 }
 
 func (s *StubClient) UpdateRole(_ context.Context, orgID string, roleSlug string, opts UpdateRoleOpts) (*Role, error) {
@@ -329,8 +345,8 @@ func (s *StubClient) orgState(orgID string) *stubOrgState {
 
 	state = &stubOrgState{
 		roles: map[string]Role{
-			"admin":  {ID: "role_admin", Name: "Admin", Slug: "admin", Description: "", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
-			"member": {ID: "role_member", Name: "Member", Slug: "member", Description: "", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
+			"admin":  {ID: "role_admin", Name: "Admin", Slug: "admin", Description: "", Type: "EnvironmentRole", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
+			"member": {ID: "role_member", Name: "Member", Slug: "member", Description: "", Type: "EnvironmentRole", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
 		},
 		roleOrder:   []string{"admin", "member"},
 		memberships: make(map[string]Member),
@@ -341,6 +357,13 @@ func (s *StubClient) orgState(orgID string) *stubOrgState {
 	s.orgs[orgID] = state
 
 	return state
+}
+
+func stubDefaultGlobalRoles() map[string]Role {
+	return map[string]Role{
+		"admin":  {ID: "role_admin", Name: "Admin", Slug: "admin", Description: "", Type: "EnvironmentRole", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
+		"member": {ID: "role_member", Name: "Member", Slug: "member", Description: "", Type: "EnvironmentRole", CreatedAt: stubRoleTimestamp, UpdatedAt: stubRoleTimestamp},
+	}
 }
 
 func (s *StubClient) nextRoleID() string {

--- a/server/internal/thirdparty/workos/stub.go
+++ b/server/internal/thirdparty/workos/stub.go
@@ -6,6 +6,9 @@ import (
 	"maps"
 	"sync"
 	"time"
+
+	"github.com/workos/workos-go/v6/pkg/common"
+	"github.com/workos/workos-go/v6/pkg/events"
 )
 
 type StubClient struct {
@@ -14,6 +17,8 @@ type StubClient struct {
 	orgOrder    []string
 	globalRoles map[string]Role
 	globalOrder []string
+	eventPages  [][]events.Event
+	eventCalls  []events.ListEventsOpts
 	next        int
 	nowFn       func() time.Time
 }
@@ -35,6 +40,8 @@ func NewStubClient() *StubClient {
 		orgOrder:    make([]string, 0),
 		globalRoles: stubDefaultGlobalRoles(),
 		globalOrder: []string{"admin", "member"},
+		eventPages:  nil,
+		eventCalls:  make([]events.ListEventsOpts, 0),
 		next:        1,
 		nowFn:       time.Now,
 	}
@@ -71,6 +78,35 @@ func (s *StubClient) ListOrganizations(_ context.Context) ([]Organization, error
 	}
 
 	return orgs, nil
+}
+
+func (s *StubClient) SetEventPages(pages [][]events.Event) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	s.eventPages = append([][]events.Event(nil), pages...)
+	s.eventCalls = s.eventCalls[:0]
+}
+
+func (s *StubClient) EventCalls() []events.ListEventsOpts {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	return append([]events.ListEventsOpts(nil), s.eventCalls...)
+}
+
+func (s *StubClient) ListEvents(_ context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	s.eventCalls = append(s.eventCalls, opts)
+
+	idx := len(s.eventCalls) - 1
+	if idx >= len(s.eventPages) {
+		return events.ListEventsResponse{Data: nil, ListMetadata: common.ListMetadata{Before: "", After: ""}}, nil
+	}
+
+	return events.ListEventsResponse{Data: s.eventPages[idx], ListMetadata: common.ListMetadata{Before: "", After: ""}}, nil
 }
 
 func (s *StubClient) ListRoles(_ context.Context, orgID string) ([]Role, error) {


### PR DESCRIPTION
## What?

This adds a temporal workflow to backfill data from WorkOS into Gram (snapshot). This is meant to be run as a one off when required, and we'll run it for the first time before turning on webhooks.

Additionally, I've reconciled the workOS clients.
