### PR TITLE
fix(assistants): one Fly app per assistant, not per thread

### DIFF
--- a/.changeset/fly-app-per-assistant.md
+++ b/.changeset/fly-app-per-assistant.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistant Fly runtime now provisions one app per assistant (with one machine per thread) instead of one app per thread. Reduces Fly app churn and speeds cold starts; reap continues to drain old per-thread apps automatically.

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -81,6 +81,7 @@ type flyRuntimeAPIClient interface {
 }
 
 type flyRuntimeFlapsClient interface {
+	Destroy(ctx context.Context, appName string, in fly.RemoveMachineInput, nonce string) error
 	Get(ctx context.Context, appName, machineID string) (*fly.Machine, error)
 	Launch(ctx context.Context, appName string, input fly.LaunchMachineInput) (*fly.Machine, error)
 	List(ctx context.Context, appName, state string) ([]*fly.Machine, error)
@@ -219,7 +220,7 @@ func (f *FlyRuntimeBackend) ensureExisting(
 ) (RuntimeBackendEnsureResult, error) {
 	appName := metadata.AppName
 	if appName == "" {
-		appName = f.appName(runtime.AssistantThreadID)
+		appName = f.appName(runtime.AssistantID)
 	}
 
 	appURL := metadata.AppURL
@@ -884,6 +885,11 @@ func (f *FlyRuntimeBackend) Stop(ctx context.Context, runtime assistantRuntimeRe
 	return nil
 }
 
+// Reap tears down one thread's slot in the assistant's Fly app: destroys
+// the thread's machine, then deletes the app only if no other thread still
+// holds a machine in it. Legacy per-thread apps (one machine each) collapse
+// to app deletion in one call; new per-assistant apps survive until the
+// last thread's machine is reaped.
 func (f *FlyRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRecord) error {
 	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
 		return err
@@ -895,6 +901,38 @@ func (f *FlyRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRe
 	if metadata.AppName == "" {
 		return nil
 	}
+
+	flapsClient, err := f.flapsFactory.New(ctx)
+	if err != nil {
+		return fmt.Errorf("create fly runtime flaps client: %w", err)
+	}
+
+	if metadata.MachineID != "" {
+		if err := flapsClient.Destroy(ctx, metadata.AppName, fly.RemoveMachineInput{
+			ID:   metadata.MachineID,
+			Kill: true,
+		}, ""); err != nil && !isFlyNotFound(err) {
+			return fmt.Errorf("destroy assistant fly runtime machine: %w", err)
+		}
+	}
+
+	machines, err := flapsClient.List(ctx, metadata.AppName, "")
+	switch {
+	case err == nil:
+		for _, m := range machines {
+			if m == nil || m.ID == metadata.MachineID {
+				continue
+			}
+			if m.IsActive() {
+				return nil
+			}
+		}
+	case isFlyNotFound(err):
+		return nil
+	default:
+		return fmt.Errorf("list assistant fly runtime machines: %w", err)
+	}
+
 	return f.deleteApp(ctx, metadata.AppName)
 }
 
@@ -1062,8 +1100,12 @@ func (f *FlyRuntimeBackend) runtimeRequest(ctx context.Context, target flyRuntim
 	return body, nil
 }
 
-func (f *FlyRuntimeBackend) appName(threadID uuid.UUID) string {
-	return fmt.Sprintf("%s-%s", f.config.AppNamePrefix, strings.ToLower(threadID.String()))
+// appName derives the Fly app name from the assistant ID. One app per
+// assistant, many machines (one per thread) inside it. Legacy rows whose
+// metadata still records a per-thread app name keep using that app until
+// Reap drains it.
+func (f *FlyRuntimeBackend) appName(assistantID uuid.UUID) string {
+	return fmt.Sprintf("%s-%s", f.config.AppNamePrefix, strings.ToLower(assistantID.String()))
 }
 
 func decodeFlyRuntimeMetadata(raw []byte) (flyRuntimeMetadata, error) {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -305,7 +305,7 @@ func (f *FlyRuntimeBackend) ensureExisting(
 		coldStart = true
 	}
 
-	target := flyRuntimeTarget{URL: appURL, IP: appIP}
+	target := flyRuntimeTarget{URL: appURL, IP: appIP, MachineID: machine.ID}
 	if err := f.tracedWaitHealth(ctx, target, coldStart); err != nil {
 		return RuntimeBackendEnsureResult{}, fmt.Errorf("wait for assistant fly runtime health: %w", err)
 	}
@@ -587,7 +587,7 @@ func (f *FlyRuntimeBackend) maybeRecycleImage(
 		return nil, nil
 	}
 
-	target := flyRuntimeTarget{URL: appURL, IP: appIP}
+	target := flyRuntimeTarget{URL: appURL, IP: appIP, MachineID: machine.ID}
 	if machine.State == fly.MachineStateStarted {
 		state, stateErr := f.runtimeState(ctx, target)
 		// /state probe success + idle_seconds==0 means a turn is in flight
@@ -1004,14 +1004,17 @@ func (f *FlyRuntimeBackend) machineConfig(runtime assistantRuntimeRecord) *fly.M
 // calls can bypass public DNS — a freshly created app's A record can take
 // 30-60s to propagate, but the shared IP is routable the moment Fly's proxy
 // sees the allocation. Dial the IP directly, keep the hostname on the URL so
-// SNI + wildcard cert verification still pass.
+// SNI + wildcard cert verification still pass. MachineID pins the Fly proxy
+// to this thread's VM via fly-force-instance-id so siblings sharing the
+// per-assistant app can't intercept the request.
 type flyRuntimeTarget struct {
-	URL string
-	IP  string
+	URL       string
+	IP        string
+	MachineID string
 }
 
 func targetFromMetadata(md flyRuntimeMetadata) flyRuntimeTarget {
-	return flyRuntimeTarget{URL: md.AppURL, IP: md.AppIP}
+	return flyRuntimeTarget{URL: md.AppURL, IP: md.AppIP, MachineID: md.MachineID}
 }
 
 func (f *FlyRuntimeBackend) waitForRuntimeHealth(ctx context.Context, target flyRuntimeTarget) error {
@@ -1079,6 +1082,14 @@ func (f *FlyRuntimeBackend) runtimeRequest(ctx context.Context, target flyRuntim
 	}
 	if request.IdempotencyKey != "" {
 		req.Header.Set("X-Idempotency-Key", request.IdempotencyKey)
+	}
+	if target.MachineID != "" {
+		// Pin the request to this thread's VM. With many machines on the
+		// per-assistant app, the proxy would otherwise round-robin and let
+		// /configure, /turn, /state hit a sibling — cross-thread leak that
+		// the runner cannot recover from (configure returns 409, turn
+		// enqueues onto the wrong runtime).
+		req.Header.Set("Fly-Force-Instance-Id", target.MachineID)
 	}
 
 	client := f.clientForTarget(target)

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -438,6 +438,81 @@ func TestFlyRuntimeBackendReapWithoutMetadataIsNoop(t *testing.T) {
 	require.Equal(t, 0, apiClient.deleteCalls)
 }
 
+func TestFlyRuntimeBackendReapDestroysMachineThenDeletesEmptyApp(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	flapsClient.listMachines = []*fly.Machine{
+		{ID: "machine-1", State: fly.MachineStateDestroying},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:   "gram-asst-only-thread",
+		MachineID: "machine-1",
+	})
+	require.NoError(t, err)
+
+	err = backend.Reap(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, flapsClient.destroyCalls)
+	require.Equal(t, "machine-1", flapsClient.destroyInputs[0].ID)
+	require.True(t, flapsClient.destroyInputs[0].Kill)
+	require.Equal(t, 1, apiClient.deleteCalls, "no live siblings — app should be deleted")
+}
+
+func TestFlyRuntimeBackendReapKeepsAppWhenSiblingMachineActive(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	flapsClient.listMachines = []*fly.Machine{
+		{ID: "machine-1", State: fly.MachineStateDestroying},
+		{ID: "machine-2", State: fly.MachineStateStarted},
+	}
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:   "gram-asst-shared",
+		MachineID: "machine-1",
+	})
+	require.NoError(t, err)
+
+	err = backend.Reap(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, flapsClient.destroyCalls)
+	require.Equal(t, 0, apiClient.deleteCalls, "another thread's machine still alive — app must not be deleted")
+}
+
+func TestFlyRuntimeBackendReapToleratesMissingMachine(t *testing.T) {
+	t.Parallel()
+
+	server := newTestAssistantRuntimeServer(t, true)
+	backend, apiClient, flapsClient := newTestFlyRuntimeBackend(t, server)
+
+	flapsClient.destroyErr = errors.New("not found")
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:   "gram-asst-shared",
+		MachineID: "machine-already-gone",
+	})
+	require.NoError(t, err)
+
+	err = backend.Reap(context.Background(), assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, apiClient.deleteCalls, "missing machine should not block app cleanup when no siblings remain")
+}
+
 func TestFlyRuntimeBackendReapTreatsAppNotFoundAsSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -846,11 +921,20 @@ type testFlyRuntimeFlapsClient struct {
 	startErr      error
 	stopErr       error
 	stopCalls     int
+	destroyErr    error
+	destroyCalls  int
+	destroyInputs []fly.RemoveMachineInput
 	updateMachine *fly.Machine
 	updateErr     error
 	updateCalls   int
 	updateInputs  []fly.LaunchMachineInput
 	waitErr       error
+}
+
+func (c *testFlyRuntimeFlapsClient) Destroy(_ context.Context, _ string, in fly.RemoveMachineInput, _ string) error {
+	c.destroyCalls++
+	c.destroyInputs = append(c.destroyInputs, in)
+	return c.destroyErr
 }
 
 func (c *testFlyRuntimeFlapsClient) Get(_ context.Context, _ string, _ string) (*fly.Machine, error) {

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -842,6 +842,67 @@ func TestFlyRuntimeBackendEnsureRecyclesWhenStateProbeErrors(t *testing.T) {
 	require.True(t, result.ColdStart)
 }
 
+func TestFlyRuntimeBackendPinsRequestsToOwningMachine(t *testing.T) {
+	t.Parallel()
+
+	// With one app shared across an assistant's threads, the Fly proxy round
+	// robins to any active machine unless the request explicitly pins to
+	// one. Configure and RunTurn would otherwise land on a sibling, returning
+	// 409 (configure) or — worse — enqueueing a turn onto the wrong thread's
+	// runtime.
+	var (
+		configureHeader string
+		turnHeader      string
+		stateHeader     string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/state", func(w http.ResponseWriter, r *http.Request) {
+		stateHeader = r.Header.Get("Fly-Force-Instance-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(runnerStateResponse{Configured: true})
+	})
+	mux.HandleFunc("/configure", func(w http.ResponseWriter, r *http.Request) {
+		configureHeader = r.Header.Get("Fly-Force-Instance-Id")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/turn", func(w http.ResponseWriter, r *http.Request) {
+		turnHeader = r.Header.Get("Fly-Force-Instance-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"finish_reason":"accepted","final_text":""}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	backend, _, _ := newTestFlyRuntimeBackend(t, srv)
+
+	rawMetadata, err := json.Marshal(flyRuntimeMetadata{
+		AppName:   "gram-asst-shared",
+		AppID:     "app-1",
+		AppURL:    srv.URL,
+		MachineID: "machine-thread-A",
+	})
+	require.NoError(t, err)
+
+	rec := assistantRuntimeRecord{
+		Backend:             runtimeBackendFlyIO,
+		BackendMetadataJSON: rawMetadata,
+	}
+
+	require.NoError(t, backend.Configure(context.Background(), rec, runtimeStartupConfig{}))
+	require.Equal(t, "machine-thread-A", configureHeader, "configure must pin to the owning machine")
+
+	require.NoError(t, backend.RunTurn(context.Background(), rec, "idem-1", "tok", "hi"))
+	require.Equal(t, "machine-thread-A", turnHeader, "run turn must pin to the owning machine")
+
+	_, err = backend.Status(context.Background(), rec)
+	require.NoError(t, err)
+	require.Equal(t, "machine-thread-A", stateHeader, "status must pin to the owning machine")
+}
+
 func TestFlyRuntimeBackendServerURLRejectsLoopback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Fly runtime backend now names apps after the **assistant ID**, not the thread ID — many threads of the same assistant share one app with one VM per thread inside it. Fixes the per-conversation app explosion that's been pushing us toward Fly's per-org limits.
- Per-thread `Reap` destroys just the thread's machine, then deletes the app only when no sibling machines remain. Legacy per-thread apps (one machine each) collapse to app deletion in one call, so the existing population drains naturally as threads get reaped.
- `tracedResolveMachine` already filters by `gram_assistant_thread_id` metadata, so machine→thread routing inside the shared app works without further change.

Closes [AGE-2253](https://linear.app/speakeasy/issue/AGE-2253/fly-app-mapping-wrong-app-per-thread-instead-of-app-per-assistant)

✻ Clauded...