### PR TITLE
fix: auto-enable MCP on toolsets attached to assistants

### DIFF
--- a/.changeset/assistant-auto-enable-mcp.md
+++ b/.changeset/assistant-auto-enable-mcp.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Auto-enable MCP on toolsets when they are attached to an assistant, so the runtime can build a startup config without manual toggling.

--- a/server/internal/assistants/impl_test.go
+++ b/server/internal/assistants/impl_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/assistants"
@@ -18,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
 func TestServiceRequiresProjectGrants(t *testing.T) {
@@ -122,10 +125,121 @@ func TestServiceCreateAssistantMapsInvalidToolsetToBadRequest(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }
 
+func TestServiceCreateAssistantAutoEnablesMCPOnAttachedToolsets(t *testing.T) {
+	t.Parallel()
+
+	svc, ctx, projectID, conn := newRBACServiceWithConn(t, "assistants_mcp_autoenable")
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeProjectWrite,
+		Selector: authz.NewSelector(authz.ScopeProjectWrite, projectID.String()),
+	})
+
+	toolsetsQ := toolsetsRepo.New(conn)
+	ts, err := toolsetsQ.CreateToolset(t.Context(), toolsetsRepo.CreateToolsetParams{
+		OrganizationID:         "org-test",
+		ProjectID:              projectID,
+		Name:                   "Slack",
+		Slug:                   "slack",
+		Description:            pgtype.Text{},
+		DefaultEnvironmentSlug: pgtype.Text{},
+		McpSlug:                pgtype.Text{String: "org-test-slack-xyz", Valid: true},
+		McpEnabled:             false,
+	})
+	require.NoError(t, err)
+	require.False(t, ts.McpEnabled)
+
+	_, err = svc.CreateAssistant(ctx, &gen.CreateAssistantPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Name:             "Assistant",
+		Model:            "openai/gpt-4o-mini",
+		Instructions:     "",
+		Toolsets: []*types.AssistantToolsetRef{
+			{ToolsetSlug: ts.Slug, EnvironmentSlug: nil},
+		},
+		WarmTTLSeconds: nil,
+		MaxConcurrency: nil,
+		Status:         nil,
+	})
+	require.NoError(t, err)
+
+	reloaded, err := toolsetsQ.GetToolset(t.Context(), toolsetsRepo.GetToolsetParams{
+		Slug:      ts.Slug,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+	require.True(t, reloaded.McpEnabled, "attaching toolset to assistant must enable MCP")
+}
+
+func TestServiceUpdateAssistantAutoEnablesMCPOnAttachedToolsets(t *testing.T) {
+	t.Parallel()
+
+	svc, ctx, projectID, conn := newRBACServiceWithConn(t, "assistants_mcp_autoenable_update")
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeProjectWrite,
+		Selector: authz.NewSelector(authz.ScopeProjectWrite, projectID.String()),
+	})
+
+	toolsetsQ := toolsetsRepo.New(conn)
+	ts, err := toolsetsQ.CreateToolset(t.Context(), toolsetsRepo.CreateToolsetParams{
+		OrganizationID:         "org-test",
+		ProjectID:              projectID,
+		Name:                   "Slack",
+		Slug:                   "slack",
+		Description:            pgtype.Text{},
+		DefaultEnvironmentSlug: pgtype.Text{},
+		McpSlug:                pgtype.Text{String: "org-test-slack-xyz", Valid: true},
+		McpEnabled:             false,
+	})
+	require.NoError(t, err)
+
+	created, err := svc.CreateAssistant(ctx, &gen.CreateAssistantPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Name:             "Assistant",
+		Model:            "openai/gpt-4o-mini",
+		Instructions:     "",
+		Toolsets:         nil,
+		WarmTTLSeconds:   nil,
+		MaxConcurrency:   nil,
+		Status:           nil,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.UpdateAssistant(ctx, &gen.UpdateAssistantPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		ID:               created.ID,
+		Name:             nil,
+		Model:            nil,
+		Instructions:     nil,
+		Toolsets: []*types.AssistantToolsetRef{
+			{ToolsetSlug: ts.Slug, EnvironmentSlug: nil},
+		},
+		WarmTTLSeconds: nil,
+		MaxConcurrency: nil,
+		Status:         nil,
+	})
+	require.NoError(t, err)
+
+	reloaded, err := toolsetsQ.GetToolset(t.Context(), toolsetsRepo.GetToolsetParams{
+		Slug:      ts.Slug,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+	require.True(t, reloaded.McpEnabled, "updating assistant toolsets must enable MCP on newly attached toolsets")
+}
+
 func newRBACService(t *testing.T) (*Service, context.Context, uuid.UUID) {
 	t.Helper()
+	svc, ctx, projectID, _ := newRBACServiceWithConn(t, "assistants_rbac")
+	return svc, ctx, projectID
+}
 
-	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_rbac")
+func newRBACServiceWithConn(t *testing.T, dbName string) (*Service, context.Context, uuid.UUID, *pgxpool.Pool) {
+	t.Helper()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, dbName)
 	require.NoError(t, err)
 
 	proj, err := projectsRepo.New(conn).CreateProject(t.Context(), projectsRepo.CreateProjectParams{
@@ -168,7 +282,7 @@ func newRBACService(t *testing.T) (*Service, context.Context, uuid.UUID) {
 		IsAdmin:               false,
 	})
 
-	return service, ctx, projectID
+	return service, ctx, projectID, conn
 }
 
 func requireOopsCode(t *testing.T, err error, code oops.Code) {

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -90,6 +90,22 @@ INSERT INTO assistant_toolsets (
   @project_id
 );
 
+-- name: EnableMCPForToolsets :exec
+-- Flips mcp_enabled to TRUE for the listed toolsets in a project. Every
+-- toolset attached to an assistant must be MCP-reachable for the runtime's
+-- startup config to build; we enable on attach so users don't have to do it
+-- separately. Bypasses the unpaid-plan public-server cap on purpose: an
+-- assistant-attached toolset has no working alternative. mcp_slug is
+-- required for an MCP-reachable toolset, so we skip rows that lack one.
+UPDATE toolsets
+SET mcp_enabled = TRUE,
+    updated_at = clock_timestamp()
+WHERE id = ANY(@toolset_ids::UUID[])
+  AND project_id = @project_id
+  AND mcp_enabled IS FALSE
+  AND mcp_slug IS NOT NULL
+  AND deleted IS FALSE;
+
 -- name: CreateAssistant :one
 INSERT INTO assistants (
   project_id,

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -406,6 +406,33 @@ func (q *Queries) DeleteAssistant(ctx context.Context, arg DeleteAssistantParams
 	return err
 }
 
+const enableMCPForToolsets = `-- name: EnableMCPForToolsets :exec
+UPDATE toolsets
+SET mcp_enabled = TRUE,
+    updated_at = clock_timestamp()
+WHERE id = ANY($1::UUID[])
+  AND project_id = $2
+  AND mcp_enabled IS FALSE
+  AND mcp_slug IS NOT NULL
+  AND deleted IS FALSE
+`
+
+type EnableMCPForToolsetsParams struct {
+	ToolsetIds []uuid.UUID
+	ProjectID  uuid.UUID
+}
+
+// Flips mcp_enabled to TRUE for the listed toolsets in a project. Every
+// toolset attached to an assistant must be MCP-reachable for the runtime's
+// startup config to build; we enable on attach so users don't have to do it
+// separately. Bypasses the unpaid-plan public-server cap on purpose: an
+// assistant-attached toolset has no working alternative. mcp_slug is
+// required for an MCP-reachable toolset, so we skip rows that lack one.
+func (q *Queries) EnableMCPForToolsets(ctx context.Context, arg EnableMCPForToolsetsParams) error {
+	_, err := q.db.Exec(ctx, enableMCPForToolsets, arg.ToolsetIds, arg.ProjectID)
+	return err
+}
+
 const failAssistantThreadEvent = `-- name: FailAssistantThreadEvent :exec
 UPDATE assistant_thread_events
 SET

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -688,6 +688,7 @@ func writeAssistantToolsets(
 		return nil
 	}
 	rows := make([]assistantrepo.AddAssistantToolsetsParams, 0, len(resolved))
+	toolsetIDs := make([]uuid.UUID, 0, len(resolved))
 	for _, r := range resolved {
 		rows = append(rows, assistantrepo.AddAssistantToolsetsParams{
 			AssistantID:   assistantID,
@@ -695,9 +696,20 @@ func writeAssistantToolsets(
 			EnvironmentID: r.EnvironmentID,
 			ProjectID:     projectID,
 		})
+		toolsetIDs = append(toolsetIDs, r.ToolsetID)
 	}
 	if _, err := queries.AddAssistantToolsets(ctx, rows); err != nil {
 		return fmt.Errorf("insert assistant toolsets: %w", err)
+	}
+	// The runtime startup config requires every assistant-attached toolset
+	// to be MCP-reachable; assistants address tools via the MCP server.
+	// Auto-enable on attach so the user doesn't have to toggle it
+	// separately on each toolset.
+	if err := queries.EnableMCPForToolsets(ctx, assistantrepo.EnableMCPForToolsetsParams{
+		ToolsetIds: toolsetIDs,
+		ProjectID:  projectID,
+	}); err != nil {
+		return fmt.Errorf("enable mcp for assistant toolsets: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Auto-enable `mcp_enabled` on toolsets at the moment they are attached to an assistant (create or update path), in the same tx as the `assistant_toolsets` insert.
- The assistant runtime startup config requires every attached toolset to be MCP-reachable; without this, attaching a freshly-created (mcp-disabled) toolset traps the worker in a non-retryable failure loop (168 occurrences in 90 min in prod on 2026-05-11).
- Skips toolsets whose `mcp_slug` is `NULL` (can't be MCP-reachable anyway) and bypasses the unpaid-plan public-server cap intentionally — an assistant-attached toolset has no working alternative.
- Visibility is unchanged: only `mcp_enabled` is flipped. `mcp_is_public` is left at its existing value (default `FALSE`), so auto-enabled toolsets are private MCP servers.

Closes [AGE-2254](https://linear.app/speakeasy/issue/AGE-2254/enable-mcp-by-default-for-toolsets-added-by-an-assistant)

✻ Clauded...