### PR TITLE
fix(chat): map openrouter 402 to insufficient credits

### DIFF
--- a/.changeset/openrouter-insufficient-credits.md
+++ b/.changeset/openrouter-insufficient-credits.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+OpenRouter responses indicating exhausted credits now surface as 402 Payment Required to chat callers instead of a generic 5xx, and the chat-resolution analyzer stops burning retries against a request that cannot succeed.

--- a/server/internal/background/activities/chat_resolutions/analyze_segment.go
+++ b/server/internal/background/activities/chat_resolutions/analyze_segment.go
@@ -89,6 +89,9 @@ func (a *AnalyzeSegment) Do(ctx context.Context, args AnalyzeSegmentArgs) error 
 
 	result, err := a.analyzeWithLLM(ctx, args.OrgID, args.ProjectID, segmentText, applicableUserFeedback)
 	if err != nil {
+		if openrouter.IsInsufficientCredits(err) {
+			return newInsufficientCreditsError(fmt.Errorf("failed to analyze segment with LLM: %w", err))
+		}
 		return fmt.Errorf("failed to analyze segment with LLM: %w", err)
 	}
 

--- a/server/internal/background/activities/chat_resolutions/errors.go
+++ b/server/internal/background/activities/chat_resolutions/errors.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
 // ErrTypeGenerationBumped is the Temporal application error type returned when
@@ -40,6 +41,31 @@ func IsGenerationBumped(err error) bool {
 	var appErr *temporal.ApplicationError
 	if errors.As(err, &appErr) {
 		return appErr.Type() == ErrTypeGenerationBumped
+	}
+	return false
+}
+
+// ErrTypeInsufficientCredits tags the non-retryable Temporal application error
+// emitted when an LLM call fails with OpenRouter 402.
+const ErrTypeInsufficientCredits = "ChatResolutionInsufficientCredits"
+
+func newInsufficientCreditsError(cause error) error {
+	return temporal.NewNonRetryableApplicationError(
+		"insufficient openrouter credits",
+		ErrTypeInsufficientCredits,
+		cause,
+	)
+}
+
+// IsInsufficientCredits reports whether err is an insufficient-credits failure,
+// either pre- or post-activity boundary.
+func IsInsufficientCredits(err error) bool {
+	if openrouter.IsInsufficientCredits(err) {
+		return true
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) {
+		return appErr.Type() == ErrTypeInsufficientCredits
 	}
 	return false
 }

--- a/server/internal/background/activities/chat_resolutions/errors_test.go
+++ b/server/internal/background/activities/chat_resolutions/errors_test.go
@@ -1,0 +1,33 @@
+package resolution_activities
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+func TestIsInsufficientCredits_FromOpenRouterError(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("failed to analyze segment with LLM: %w", openrouter.ErrInsufficientCredits)
+	assert.True(t, IsInsufficientCredits(wrapped))
+}
+
+func TestIsInsufficientCredits_FromTemporalApplicationError(t *testing.T) {
+	t.Parallel()
+
+	original := fmt.Errorf("openrouter 402: %w", openrouter.ErrInsufficientCredits)
+	tempErr := newInsufficientCreditsError(original)
+	assert.True(t, IsInsufficientCredits(tempErr))
+}
+
+func TestIsInsufficientCredits_OtherErrorsReturnFalse(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsInsufficientCredits(errors.New("network blip")))
+	assert.False(t, IsInsufficientCredits(nil))
+}

--- a/server/internal/background/analyze_chat_resolutions.go
+++ b/server/internal/background/analyze_chat_resolutions.go
@@ -138,6 +138,15 @@ func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatReso
 				)
 				return workflow.NewContinueAsNewError(ctx, AnalyzeChatResolutionsWorkflow, params)
 			}
+			if activities.IsInsufficientCredits(err) {
+				workflow.GetLogger(ctx).Warn("skipping segment analysis: organization has insufficient OpenRouter credits",
+					"chat_id", params.ChatID.String(),
+					"org_id", params.OrgID,
+					"start_index", segment.StartIndex,
+					"end_index", segment.EndIndex,
+				)
+				continue
+			}
 			// Log but continue with other segments
 			workflow.GetLogger(ctx).Error("failed to analyze segment",
 				"error", err.Error(),

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -828,6 +828,9 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	if isStreaming {
 		streamBody, err := s.completionClient.GetCompletionStream(ctx, completionReq)
 		if err != nil {
+			if openrouter.IsInsufficientCredits(err) {
+				return oops.C(oops.CodeInsufficientCredits).Log(ctx, s.logger)
+			}
 			return oops.E(oops.CodeGatewayError, err, "get completion stream").Log(ctx, s.logger)
 		}
 		defer o11y.NoLogDefer(func() error { return streamBody.Close() })
@@ -849,6 +852,9 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	 */
 	response, err := s.completionClient.GetCompletion(ctx, completionReq)
 	if err != nil {
+		if openrouter.IsInsufficientCredits(err) {
+			return oops.C(oops.CodeInsufficientCredits).Log(ctx, s.logger)
+		}
 		return oops.E(oops.CodeGatewayError, err, "completion failed").Log(ctx, s.logger)
 	}
 

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -1,0 +1,27 @@
+package openrouter
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ErrInsufficientCredits is returned when OpenRouter rejects a request with
+// status 402: the org has exhausted its credit balance or requested more
+// tokens than the remaining balance can fund.
+var ErrInsufficientCredits = errors.New("openrouter: insufficient credits")
+
+// IsInsufficientCredits reports whether err originated from an OpenRouter 402
+// response anywhere in the error chain.
+func IsInsufficientCredits(err error) bool {
+	return errors.Is(err, ErrInsufficientCredits)
+}
+
+func classifyHTTPError(status int, body []byte) error {
+	msg := strings.TrimSpace(string(body))
+	if status == http.StatusPaymentRequired {
+		return fmt.Errorf("OpenRouter API error (status %d): %s: %w", status, msg, ErrInsufficientCredits)
+	}
+	return fmt.Errorf("OpenRouter API error (status %d): %s", status, msg)
+}

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -1,0 +1,107 @@
+package openrouter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	or "github.com/OpenRouterTeam/go-sdk/models/components"
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatClient_GetCompletion_402_WrapsInsufficientCredits(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte(`{"error":{"message":"This request requires more credits, or fewer max_tokens."}}`))
+	}))
+	defer t.Cleanup(server.Close)
+
+	client := newTestClientForServer(t, server)
+
+	_, err := client.GetCompletion(context.Background(), CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   uuid.New().String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("hi")},
+		ChatID:      uuid.New(),
+		UsageSource: billing.ModelUsageSourcePlayground,
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInsufficientCredits)
+	assert.True(t, IsInsufficientCredits(err))
+}
+
+func TestChatClient_GetCompletionStream_402_WrapsInsufficientCredits(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte(`{"error":{"message":"insufficient credits"}}`))
+	}))
+	defer t.Cleanup(server.Close)
+
+	client := newTestClientForServer(t, server)
+
+	_, err := client.GetCompletionStream(context.Background(), CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   uuid.New().String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("hi")},
+		ChatID:      uuid.New(),
+		UsageSource: billing.ModelUsageSourcePlayground,
+	})
+	require.Error(t, err)
+	assert.True(t, IsInsufficientCredits(err))
+}
+
+func TestChatClient_GetCompletion_Non402_DoesNotWrapInsufficientCredits(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"upstream error"}}`))
+	}))
+	defer t.Cleanup(server.Close)
+
+	client := newTestClientForServer(t, server)
+
+	_, err := client.GetCompletion(context.Background(), CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   uuid.New().String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("hi")},
+		ChatID:      uuid.New(),
+		UsageSource: billing.ModelUsageSourcePlayground,
+	})
+	require.Error(t, err)
+	assert.False(t, IsInsufficientCredits(err), "non-402 must not be classified as insufficient credits")
+}
+
+func newTestClientForServer(t *testing.T, server *httptest.Server) *ChatClient {
+	t.Helper()
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	client := NewUnifiedClient(
+		testenv.NewLogger(t),
+		guardianPolicy,
+		&mockProvisioner{apiKey: "test-api-key"},
+		&mockMessageCaptureStrategy{},
+		&mockUsageTrackingStrategy{},
+		&mockChatTitleGenerator{},
+		&mockChatResolutionAnalyzer{},
+		&mockTelemetryLogger{},
+	)
+	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
+	return client
+}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -297,7 +297,7 @@ func (c *ChatClient) GetCompletion(ctx context.Context, req CompletionRequest) (
 
 	// Handle non-200 responses
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("OpenRouter API error (status %d): %s", httpResp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, classifyHTTPError(httpResp.StatusCode, body)
 	}
 
 	// Parse response
@@ -385,7 +385,7 @@ func (c *ChatClient) GetCompletionStream(ctx context.Context, req CompletionRequ
 	if httpResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResp.Body)
 		o11y.NoLogDefer(func() error { return httpResp.Body.Close() })
-		return nil, fmt.Errorf("OpenRouter API error (status %d): %s", httpResp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, classifyHTTPError(httpResp.StatusCode, body)
 	}
 
 	// Wrap the response body with SSE parser that accumulates metadata


### PR DESCRIPTION
## Summary

- `openrouter.ErrInsufficientCredits` sentinel wraps 402 responses at the unified client boundary so callers can match with `errors.Is`.
- `HandleCompletion` surfaces it as `oops.CodeInsufficientCredits` (402) instead of `CodeGatewayError` (502) for both streaming and non-streaming paths.
- `AnalyzeSegment` Temporal activity wraps the error in a non-retryable application error tagged `ChatResolutionInsufficientCredits`, so the workflow stops burning its 3-retry budget against a request that cannot succeed.
- Workflow logs an explicit "insufficient credits" warning when skipping a segment, instead of the generic failure log.

Closes [AGE-2256](https://linear.app/speakeasy/issue/AGE-2256/bug-surface-token-usage-limit-reached-as-4xx)

✻ Clauded...