### PR TITLE
chore: create db:connect mise task

### DIFF
--- a/.mise-tasks/db/connect.sh
+++ b/.mise-tasks/db/connect.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#MISE description="Connect to the local development database with psql"
+
+#USAGE arg "<psql_args>..." help="Extra arguments forwarded to psql" default=""
+
+set -eo pipefail
+
+exec psql "${GRAM_DATABASE_URL%&search_path=*}" ${usage_psql_args:-}


### PR DESCRIPTION
Simplify connecting to local database with psql since it involves manipulating the `GRAM_DATABASE_URL` to strip `psql` unsupported `search_path`.