### PR TITLE
fix(assistants): set posthog disposition person property on signup

### DIFF
--- a/.changeset/assistants-disposition-person-property.md
+++ b/.changeset/assistants-disposition-person-property.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Tag users who sign up with `disposition=assistants` with a PostHog person property so the assistants feature flag can target them.

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -605,6 +605,12 @@ func (s *Service) autoProvisionForAssistants(ctx context.Context, idToken string
 		return "", fmt.Errorf("store session: %w", err)
 	}
 
+	if err := s.posthog.IdentifyUser(ctx, userInfo.Email, map[string]any{
+		"disposition": dispositionAssistants,
+	}); err != nil {
+		s.logger.ErrorContext(ctx, "failed to set assistants disposition person property", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
+	}
+
 	if err := s.posthog.CaptureEvent(ctx, "gram_assistants_signup", userInfo.Email, map[string]any{
 		"email":                       userInfo.Email,
 		"organization_id":             org.ID,

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -5,4 +5,5 @@ type Flag string
 const (
 	FlagSpeakeasyOpenAPIParserV0 Flag = "speakeasy-openapi-parser-v0"
 	FlagClickhouseToolMetrics    Flag = "clickhouse-tool-metrics"
+	FlagAssistants               Flag = "assistants"
 )

--- a/server/internal/thirdparty/posthog/posthog.go
+++ b/server/internal/thirdparty/posthog/posthog.go
@@ -97,6 +97,27 @@ func (p *Posthog) IsFlagEnabled(ctx context.Context, flag feature.Flag, distinct
 	return string(j) == "true", nil
 }
 
+func (p *Posthog) IdentifyUser(ctx context.Context, distinctID string, personProperties map[string]any) error {
+	if p.disabled {
+		p.logger.InfoContext(ctx, "posthog is disabled, dropping identify")
+		return nil
+	}
+
+	properties := posthog.NewProperties()
+	for k, v := range personProperties {
+		properties.Set(k, v)
+	}
+
+	if err := p.client.Enqueue(posthog.Identify{
+		DistinctId: distinctID,
+		Properties: properties,
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue identify: %w", err)
+	}
+
+	return nil
+}
+
 func (p *Posthog) CaptureEvent(ctx context.Context, eventName string, distinctID string, eventProperties map[string]any) error {
 	// If posthog is disabled, we return true so we don't block the user from using the product
 	if p.disabled {


### PR DESCRIPTION
## Summary

- Calls `posthog.Identify` for `disposition=assistants` signups so PostHog persists `disposition: "assistants"` as a person property keyed by email — the same `distinct_id` `posthog-js` uses on the dashboard.
- Once persisted, the PostHog `assistants` feature flag can release on the property and `telemetry.isFeatureEnabled("assistants")` will start returning `true` for those users, unblocking the assistants sidebar nav.
- Registers `FlagAssistants` in `server/internal/feature/flags.go` so the flag has a canonical Go-side identifier.

Note: existing assistants signups that predate this fix still need their person property backfilled manually in PostHog (or the flag temporarily released to those emails).

Closes [AGE-2260](https://linear.app/speakeasy/issue/AGE-2260)

✻ Clauded...