### PR TITLE
chore: Add missing sqlc tool to mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -26,6 +26,7 @@ hk = "1.38.0"
 pkl = "0.31.0"
 "github:speakeasy-api/madprocs" = "0.1.33"
 "github:temporalio/cli" = "1.6.1"
+"github:sqlc-dev/sqlc" = "1.29.0"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.


### PR DESCRIPTION
Otherwise mise tasks such as `mise run gen:sqlc-server` cannot run when `sqlc` was installed via GOBIN and GOBIN is tied to specific Go install.