### PR TITLE
chore: Relax first letter casing on PR titles

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -24,7 +24,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "$PR_TITLE" =~ ^(chore|fix|feat|mig)(\([a-zA-Z0-9_-]+\))?!?:\ [a-z] ]]; then
+          if [[ "$PR_TITLE" =~ ^(chore|fix|feat|mig)(\([a-zA-Z0-9_-]+\))?!?:\ [a-zA-Z] ]]; then
             echo "PR title format is valid."
           else
             echo "PR title must:"


### PR DESCRIPTION
PR titles were enforced to be of the form:

```
<qualifier>: <title>
```

Where title had to start with a lowercase letter. This specific restriction has been lifted as evidenced by this PR's title.