### PR TITLE
feat(elements): support multiple MCP servers in chat config

### DIFF
--- a/.changeset/assistant-onboarding-multi-mcp.md
+++ b/.changeset/assistant-onboarding-multi-mcp.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+The assistant onboarding chat now connects to every MCP server attached to the assistant, not just the first one, so the agent can call tools across all configured toolsets.

--- a/.changeset/elements-drop-malformed-tool-calls.md
+++ b/.changeset/elements-drop-malformed-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Drop persisted tool calls that arrive without a `toolCallId` instead of giving them an empty-string id. Previously two such parts in the same restored thread would alias under the same key and the runtime would throw "Tool call argsText can only be appended, not updated" while loading the chat.

--- a/.changeset/elements-multi-mcp.md
+++ b/.changeset/elements-multi-mcp.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": minor
+---
+
+`mcp` config now accepts an array of MCP servers in addition to a single URL. Tools from multiple servers are merged and namespaced as `<name>__<tool>` so identical tool names from different servers don't collide. Each entry can carry its own `gramEnvironment` to override the top-level value.

--- a/.changeset/elements-multi-mcp.md
+++ b/.changeset/elements-multi-mcp.md
@@ -2,4 +2,4 @@
 "@gram-ai/elements": minor
 ---
 
-`mcp` config now accepts an array of MCP servers in addition to a single URL. Tools from multiple servers are merged and namespaced as `<name>__<tool>` so identical tool names from different servers don't collide. Each entry can carry its own `gramEnvironment` to override the top-level value.
+Add an `mcps` config option that connects a single chat to multiple MCP servers. Tools across servers are merged and namespaced as `<name>__<tool>` so identical names don't collide; each entry can pin its own `environment` slug. When set, `mcps` takes precedence over the existing single-server `mcp` option, which continues to work unchanged.

--- a/client/dashboard/src/hooks/useToolsetUrl.ts
+++ b/client/dashboard/src/hooks/useToolsetUrl.ts
@@ -79,12 +79,20 @@ export function useInternalMcpUrl(
     | undefined,
 ): string | undefined {
   const project = useProject();
-
   if (!toolset) return undefined;
+  return internalMcpUrl({ slug: project.slug }, toolset);
+}
 
+/**
+ * Non-hook variant of {@link useInternalMcpUrl}. Use this when the project and
+ * toolset are already in scope (e.g. when mapping over an array of toolsets).
+ */
+export function internalMcpUrl(
+  project: { slug: string },
+  toolset: Pick<ToolsetEntry, "slug" | "mcpSlug" | "defaultEnvironmentSlug">,
+): string {
   const urlSuffix = toolset.mcpSlug
     ? toolset.mcpSlug
     : `${project.slug}/${toolset.slug}/${toolset.defaultEnvironmentSlug}`;
-
   return `${getServerURL()}/mcp/${urlSuffix}`;
 }

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -108,7 +108,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
   const onboarding = useOnboardingTools();
 
   const { data: toolsetsData } = useListToolsets();
-  const mcpServers = useMemo<MCPServerEntry[] | undefined>(() => {
+  const mcps = useMemo<MCPServerEntry[] | undefined>(() => {
     const refs = draft.assistant?.toolsets;
     if (!refs?.length) return undefined;
     const fallbackEnv = draft.assistantEnv?.slug;
@@ -122,7 +122,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
       entries.push({
         url: internalMcpUrl({ slug: project.slug }, toolset),
         name: toolset.slug,
-        gramEnvironment: ref.environmentSlug ?? fallbackEnv,
+        environment: ref.environmentSlug ?? fallbackEnv,
       });
     }
     return entries.length ? entries : undefined;
@@ -226,7 +226,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           },
           variant: "standalone",
           systemPrompt,
-          mcp: mcpServers,
+          mcps,
           model: {
             defaultModel: "anthropic/claude-sonnet-4.6" as Model,
             showModelPicker: false,

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -1,9 +1,14 @@
 import { Page } from "@/components/page-layout";
 import { useProject, useSession } from "@/contexts/Auth";
-import { useToolset } from "@/hooks/toolTypes";
-import { useInternalMcpUrl } from "@/hooks/useToolsetUrl";
+import { internalMcpUrl } from "@/hooks/useToolsetUrl";
 import { getServerURL } from "@/lib/utils";
-import { Chat, GramElementsProvider, type Model } from "@gram-ai/elements";
+import {
+  Chat,
+  GramElementsProvider,
+  type MCPServerEntry,
+  type Model,
+} from "@gram-ai/elements";
+import { useListToolsets } from "@gram/client/react-query";
 import { useChatSessionsCreateMutation } from "@gram/client/react-query/chatSessionsCreate.js";
 import { ResizablePanel, useMoonshineConfig } from "@speakeasy-api/moonshine";
 import { Loader2 } from "lucide-react";
@@ -102,12 +107,31 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
 
   const onboarding = useOnboardingTools();
 
-  const firstToolset = draft.assistant?.toolsets[0];
-  const { data: firstToolsetData } = useToolset(firstToolset?.toolsetSlug);
-  const mcpUrl = useInternalMcpUrl(firstToolsetData);
-  const gramEnvironment = firstToolset
-    ? (firstToolset.environmentSlug ?? draft.assistantEnv?.slug)
-    : undefined;
+  const { data: toolsetsData } = useListToolsets();
+  const mcpServers = useMemo<MCPServerEntry[] | undefined>(() => {
+    const refs = draft.assistant?.toolsets;
+    if (!refs?.length) return undefined;
+    const fallbackEnv = draft.assistantEnv?.slug;
+    const toolsetBySlug = new Map(
+      (toolsetsData?.toolsets ?? []).map((t) => [t.slug, t]),
+    );
+    const entries: MCPServerEntry[] = [];
+    for (const ref of refs) {
+      const toolset = toolsetBySlug.get(ref.toolsetSlug);
+      if (!toolset) continue;
+      entries.push({
+        url: internalMcpUrl({ slug: project.slug }, toolset),
+        name: toolset.slug,
+        gramEnvironment: ref.environmentSlug ?? fallbackEnv,
+      });
+    }
+    return entries.length ? entries : undefined;
+  }, [
+    draft.assistant?.toolsets,
+    draft.assistantEnv?.slug,
+    toolsetsData?.toolsets,
+    project.slug,
+  ]);
 
   const getSession = useCallback(async () => {
     try {
@@ -202,8 +226,7 @@ function ChatPane({ mode }: { mode: "create" | "edit" }) {
           },
           variant: "standalone",
           systemPrompt,
-          mcp: mcpUrl,
-          gramEnvironment,
+          mcp: mcpServers,
           model: {
             defaultModel: "anthropic/claude-sonnet-4.6" as Model,
             showModelPicker: false,

--- a/elements/src/contexts/ElementsProvider.tsx
+++ b/elements/src/contexts/ElementsProvider.tsx
@@ -216,6 +216,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
   const { data: mcpTools, mcpHeaders } = useMCPTools({
     auth,
     mcp: config.mcp,
+    mcps: config.mcps,
     environment: config.environment ?? {},
     toolsToInclude: config.tools?.toolsToInclude,
     gramEnvironment: config.gramEnvironment,

--- a/elements/src/hooks/useMCPTools.ts
+++ b/elements/src/hooks/useMCPTools.ts
@@ -1,5 +1,5 @@
 import { assert } from "@/lib/utils";
-import type { MCPConfig, MCPServerEntry } from "@/types";
+import type { MCPServerEntry } from "@/types";
 import { ToolsFilter } from "@/types";
 import { experimental_createMCPClient as createMCPClient } from "@ai-sdk/mcp";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
@@ -13,18 +13,20 @@ type MCPToolsResult = Awaited<
 interface NormalizedServer {
   url: string;
   name: string;
-  gramEnvironment: string | undefined;
+  environment: string | undefined;
 }
 
 export function useMCPTools({
   auth,
   mcp,
+  mcps,
   environment,
   toolsToInclude,
   gramEnvironment,
 }: {
   auth: Auth;
-  mcp: MCPConfig | undefined;
+  mcp: string | undefined;
+  mcps: MCPServerEntry[] | undefined;
   environment: Record<string, unknown>;
   toolsToInclude?: ToolsFilter;
   gramEnvironment?: string;
@@ -32,8 +34,8 @@ export function useMCPTools({
   mcpHeaders: Record<string, string>;
 } {
   const servers = useMemo(
-    () => normalizeServers(mcp, gramEnvironment),
-    [mcp, gramEnvironment],
+    () => normalizeServers(mcp, mcps, gramEnvironment),
+    [mcp, mcps, gramEnvironment],
   );
 
   const envQueryKey = Object.entries(environment ?? {}).map(
@@ -43,7 +45,7 @@ export function useMCPTools({
     ([k, v]) => `${k}:${v}`,
   );
   const serversQueryKey = servers.map(
-    (s) => `${s.url}|${s.name}|${s.gramEnvironment ?? ""}`,
+    (s) => `${s.url}|${s.name}|${s.environment ?? ""}`,
   );
 
   // Each MCP transport stores a direct reference to its headers object and
@@ -87,8 +89,8 @@ export function useMCPTools({
         headers: {
           ...envHeaders,
           ...authHeaders,
-          ...(server.gramEnvironment && {
-            "Gram-Environment": server.gramEnvironment,
+          ...(server.environment && {
+            "Gram-Environment": server.environment,
           }),
         } satisfies Record<string, string>,
       }));
@@ -146,28 +148,21 @@ export function useMCPTools({
 }
 
 function normalizeServers(
-  mcp: MCPConfig | undefined,
+  mcp: string | undefined,
+  mcps: MCPServerEntry[] | undefined,
   fallbackEnv: string | undefined,
 ): NormalizedServer[] {
-  if (!mcp) return [];
-  const entries: Array<string | MCPServerEntry> = Array.isArray(mcp)
-    ? mcp
-    : [mcp];
-
-  return entries.map((entry) => {
-    if (typeof entry === "string") {
-      return {
-        url: entry,
-        name: deriveNameFromUrl(entry),
-        gramEnvironment: fallbackEnv,
-      };
-    }
-    return {
+  if (mcps && mcps.length > 0) {
+    return mcps.map((entry) => ({
       url: entry.url,
       name: entry.name ?? deriveNameFromUrl(entry.url),
-      gramEnvironment: entry.gramEnvironment ?? fallbackEnv,
-    };
-  });
+      environment: entry.environment,
+    }));
+  }
+  if (mcp) {
+    return [{ url: mcp, name: "Unknown", environment: fallbackEnv }];
+  }
+  return [];
 }
 
 function deriveNameFromUrl(url: string): string {

--- a/elements/src/hooks/useMCPTools.ts
+++ b/elements/src/hooks/useMCPTools.ts
@@ -12,7 +12,8 @@ type MCPToolsResult = Awaited<
 
 interface NormalizedServer {
   url: string;
-  name: string;
+  /** Namespace prefix for this server's tools; only consulted when more than one server is configured. */
+  name: string | undefined;
   environment: string | undefined;
 }
 
@@ -29,6 +30,7 @@ export function useMCPTools({
   mcps: MCPServerEntry[] | undefined;
   environment: Record<string, unknown>;
   toolsToInclude?: ToolsFilter;
+  /** Fallback `Gram-Environment` for the legacy single-`mcp` path only; ignored when `mcps` is set. */
   gramEnvironment?: string;
 }): UseQueryResult<MCPToolsResult, Error> & {
   mcpHeaders: Record<string, string>;
@@ -45,7 +47,7 @@ export function useMCPTools({
     ([k, v]) => `${k}:${v}`,
   );
   const serversQueryKey = servers.map(
-    (s) => `${s.url}|${s.name}|${s.environment ?? ""}`,
+    (s) => `${s.url}|${s.name ?? ""}|${s.environment ?? ""}`,
   );
 
   // Each MCP transport stores a direct reference to its headers object and
@@ -76,7 +78,7 @@ export function useMCPTools({
   const mcpHeaders = headersProxyRef.current;
 
   const queryResult = useQuery({
-    queryKey: ["mcpTools", ...serversQueryKey, ...envQueryKey, ...authQueryKey],
+    queryKey: ["mcpTools", serversQueryKey, envQueryKey, authQueryKey],
     queryFn: async () => {
       assert(!auth.isLoading, "No auth found");
       assert(servers.length > 0, "No MCP server configured");
@@ -109,8 +111,11 @@ export function useMCPTools({
       const merged: MCPToolsResult = {};
       const namespaced = servers.length > 1;
       for (const { server, tools } of perServerTools) {
+        const prefix = namespaced
+          ? (server.name ?? deriveNameFromUrl(server.url))
+          : null;
         for (const [toolName, tool] of Object.entries(tools)) {
-          const key = namespaced ? `${server.name}__${toolName}` : toolName;
+          const key = prefix ? `${prefix}__${toolName}` : toolName;
           merged[key] = tool;
         }
       }
@@ -153,16 +158,26 @@ function normalizeServers(
   fallbackEnv: string | undefined,
 ): NormalizedServer[] {
   if (mcps && mcps.length > 0) {
+    if (mcp) warnMcpAndMcpsBothSet();
     return mcps.map((entry) => ({
       url: entry.url,
-      name: entry.name ?? deriveNameFromUrl(entry.url),
+      name: entry.name,
       environment: entry.environment,
     }));
   }
   if (mcp) {
-    return [{ url: mcp, name: "Unknown", environment: fallbackEnv }];
+    return [{ url: mcp, name: undefined, environment: fallbackEnv }];
   }
   return [];
+}
+
+let warnedAboutBoth = false;
+function warnMcpAndMcpsBothSet() {
+  if (warnedAboutBoth) return;
+  warnedAboutBoth = true;
+  console.warn(
+    "[gram-elements] Both `mcp` and `mcps` are set on ElementsConfig; `mcps` takes precedence and `mcp` is ignored.",
+  );
 }
 
 function deriveNameFromUrl(url: string): string {

--- a/elements/src/hooks/useMCPTools.ts
+++ b/elements/src/hooks/useMCPTools.ts
@@ -1,4 +1,5 @@
 import { assert } from "@/lib/utils";
+import type { MCPConfig, MCPServerEntry } from "@/types";
 import { ToolsFilter } from "@/types";
 import { experimental_createMCPClient as createMCPClient } from "@ai-sdk/mcp";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
@@ -9,6 +10,12 @@ type MCPToolsResult = Awaited<
   ReturnType<Awaited<ReturnType<typeof createMCPClient>>["tools"]>
 >;
 
+interface NormalizedServer {
+  url: string;
+  name: string;
+  gramEnvironment: string | undefined;
+}
+
 export function useMCPTools({
   auth,
   mcp,
@@ -17,59 +24,98 @@ export function useMCPTools({
   gramEnvironment,
 }: {
   auth: Auth;
-  mcp: string | undefined;
+  mcp: MCPConfig | undefined;
   environment: Record<string, unknown>;
   toolsToInclude?: ToolsFilter;
   gramEnvironment?: string;
 }): UseQueryResult<MCPToolsResult, Error> & {
   mcpHeaders: Record<string, string>;
 } {
+  const servers = useMemo(
+    () => normalizeServers(mcp, gramEnvironment),
+    [mcp, gramEnvironment],
+  );
+
   const envQueryKey = Object.entries(environment ?? {}).map(
     ([k, v]) => `${k}:${v}`,
   );
   const authQueryKey = Object.entries(auth.headers ?? {}).map(
     ([k, v]) => `${k}:${v}`,
   );
+  const serversQueryKey = servers.map(
+    (s) => `${s.url}|${s.name}|${s.gramEnvironment ?? ""}`,
+  );
 
-  // Mutable headers object shared with the MCP transport. The transport stores
-  // a direct reference (`this.headers = headers`) and spreads it on every
-  // send() call, so mutating properties on this object (e.g. setting
-  // Gram-Chat-ID later) will be picked up by subsequent tool call requests.
-  const mcpHeaders = useRef<Record<string, string>>({}).current;
+  // Each MCP transport stores a direct reference to its headers object and
+  // spreads it on every send, so writes propagate to subsequent tool-call
+  // requests. `mcpHeaders` is a write-only proxy that fans cross-cutting
+  // header writes (e.g. Gram-Chat-ID) out to every per-server record.
+  const perServerHeadersRef = useRef<Record<string, string>[]>([]);
+  const headersProxyRef = useRef<Record<string, string> | null>(null);
+  if (!headersProxyRef.current) {
+    headersProxyRef.current = new Proxy<Record<string, string>>(
+      {},
+      {
+        set(_, key, value) {
+          for (const h of perServerHeadersRef.current) {
+            h[key as string] = value as string;
+          }
+          return true;
+        },
+        deleteProperty(_, key) {
+          for (const h of perServerHeadersRef.current) {
+            delete h[key as string];
+          }
+          return true;
+        },
+      },
+    );
+  }
+  const mcpHeaders = headersProxyRef.current;
 
   const queryResult = useQuery({
-    queryKey: [
-      "mcpTools",
-      mcp,
-      gramEnvironment,
-      ...envQueryKey,
-      ...authQueryKey,
-    ],
+    queryKey: ["mcpTools", ...serversQueryKey, ...envQueryKey, ...authQueryKey],
     queryFn: async () => {
       assert(!auth.isLoading, "No auth found");
-      assert(mcp, "No MCP URL found");
+      assert(servers.length > 0, "No MCP server configured");
 
-      // Populate the shared headers object (mutate in place so the same
-      // reference is used by the transport).
-      Object.keys(mcpHeaders).forEach((k) => delete mcpHeaders[k]);
-      Object.assign(mcpHeaders, {
-        ...transformEnvironmentToHeaders(environment ?? {}),
-        ...auth.headers,
-        ...(gramEnvironment && { "Gram-Environment": gramEnvironment }),
-      });
+      const envHeaders = transformEnvironmentToHeaders(environment ?? {});
+      const authHeaders = auth.headers ?? {};
 
-      const mcpClient = await createMCPClient({
-        name: "gram-elements-mcp-client",
-        transport: {
-          type: "http",
-          url: mcp,
-          headers: mcpHeaders,
-        },
-      });
+      const serverEntries = servers.map((server) => ({
+        server,
+        headers: {
+          ...envHeaders,
+          ...authHeaders,
+          ...(server.gramEnvironment && {
+            "Gram-Environment": server.gramEnvironment,
+          }),
+        } satisfies Record<string, string>,
+      }));
+      perServerHeadersRef.current = serverEntries.map((s) => s.headers);
 
-      return mcpClient.tools();
+      const perServerTools = await Promise.all(
+        serverEntries.map(async ({ server, headers }) => {
+          const client = await createMCPClient({
+            name: "gram-elements-mcp-client",
+            transport: { type: "http", url: server.url, headers },
+          });
+          return { server, tools: await client.tools() };
+        }),
+      );
+
+      const merged: MCPToolsResult = {};
+      const namespaced = servers.length > 1;
+      for (const { server, tools } of perServerTools) {
+        for (const [toolName, tool] of Object.entries(tools)) {
+          const key = namespaced ? `${server.name}__${toolName}` : toolName;
+          merged[key] = tool;
+        }
+      }
+
+      return merged;
     },
-    enabled: !auth.isLoading && !!mcp,
+    enabled: !auth.isLoading && servers.length > 0,
     staleTime: Infinity,
     gcTime: Infinity,
   });
@@ -97,6 +143,45 @@ export function useMCPTools({
   } as UseQueryResult<MCPToolsResult, Error> & {
     mcpHeaders: Record<string, string>;
   };
+}
+
+function normalizeServers(
+  mcp: MCPConfig | undefined,
+  fallbackEnv: string | undefined,
+): NormalizedServer[] {
+  if (!mcp) return [];
+  const entries: Array<string | MCPServerEntry> = Array.isArray(mcp)
+    ? mcp
+    : [mcp];
+
+  return entries.map((entry) => {
+    if (typeof entry === "string") {
+      return {
+        url: entry,
+        name: deriveNameFromUrl(entry),
+        gramEnvironment: fallbackEnv,
+      };
+    }
+    return {
+      url: entry.url,
+      name: entry.name ?? deriveNameFromUrl(entry.url),
+      gramEnvironment: entry.gramEnvironment ?? fallbackEnv,
+    };
+  });
+}
+
+function deriveNameFromUrl(url: string): string {
+  let path: string;
+  try {
+    path = new URL(url).pathname;
+  } catch {
+    path = url;
+  }
+  const after = path.split("/mcp/")[1] ?? path;
+  const sanitized = after
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/[^a-zA-Z0-9_-]+/g, "_");
+  return sanitized || "mcp";
 }
 
 const HEADER_PREFIX = "MCP-";

--- a/elements/src/index.ts
+++ b/elements/src/index.ts
@@ -55,7 +55,6 @@ export type {
   ErrorTrackingConfigOption,
   GetSessionFn,
   HistoryConfig,
-  MCPConfig,
   MCPServerEntry,
   ModalConfig,
   ModalTriggerPosition,

--- a/elements/src/index.ts
+++ b/elements/src/index.ts
@@ -55,6 +55,8 @@ export type {
   ErrorTrackingConfigOption,
   GetSessionFn,
   HistoryConfig,
+  MCPConfig,
+  MCPServerEntry,
   ModalConfig,
   ModalTriggerPosition,
   Model,

--- a/elements/src/lib/messageConverter.ts
+++ b/elements/src/lib/messageConverter.ts
@@ -167,11 +167,20 @@ function buildAssistantContentParts(
   }
 
   for (const tc of toolCalls) {
+    const toolCallId = tc.id ?? tc.toolCallId;
+    if (!toolCallId) {
+      // assistant-ui keys tool-call state by toolCallId; if two parts in the
+      // same restored thread share an empty fallback id, the second one's
+      // argsText regresses from the first's and the runtime throws
+      // "Tool call argsText can only be appended, not updated".
+      console.warn("Dropping persisted tool call with no id:", tc);
+      continue;
+    }
     const args = tc.function?.arguments ?? tc.args ?? {};
     const argsText = typeof args === "string" ? args : JSON.stringify(args);
     parts.push({
       type: "tool-call",
-      toolCallId: tc.id ?? tc.toolCallId ?? "",
+      toolCallId,
       toolName: tc.function?.name ?? tc.toolName ?? "",
       args: typeof args === "string" ? JSON.parse(args) : args,
       argsText,

--- a/elements/src/types/index.ts
+++ b/elements/src/types/index.ts
@@ -25,6 +25,32 @@ export type GetSessionFn = (init: { projectSlug: string }) => Promise<string>;
 
 type ServerUrl = string;
 
+/**
+ * Configuration for a single MCP server. Use the object form when connecting
+ * to multiple servers so that tool names can be disambiguated and per-server
+ * environment overrides can be supplied.
+ */
+export interface MCPServerEntry {
+  /** The MCP server URL. */
+  url: ServerUrl;
+  /**
+   * Optional namespace prefix prepended to tools from this server with `__`
+   * as the separator (e.g. `name__tool`). When omitted for an entry inside a
+   * multi-server array, a prefix is derived from the URL.
+   */
+  name?: string;
+  /**
+   * Override the `Gram-Environment` header for this server only. Falls back
+   * to the top-level `gramEnvironment` when omitted.
+   */
+  gramEnvironment?: string;
+}
+
+export type MCPConfig =
+  | ServerUrl
+  | MCPServerEntry
+  | Array<ServerUrl | MCPServerEntry>;
+
 export const VARIANTS = ["widget", "sidecar", "standalone"] as const;
 export type Variant = (typeof VARIANTS)[number];
 
@@ -91,17 +117,32 @@ export interface ElementsConfig {
   projectSlug: string;
 
   /**
-   * The Gram Server URL to use for the Elements library.
-   * Can be retrieved from https://app.getgram.ai/{team}/{project}/mcp/{mcp_slug}
+   * The Gram MCP server(s) to connect to. Accepts either:
    *
-   * Note: This config option will likely change in the future
+   * - a single URL string,
+   * - a single {@link MCPServerEntry} object, or
+   * - an array of either form, in which case tools from each server are
+   *   namespaced by a prefix (`<name>__<tool>`) to avoid collisions.
+   *
+   * Each entry may carry its own `gramEnvironment` to override the
+   * top-level setting for that server only.
    *
    * @example
+   * // Single server
    * const config: ElementsConfig = {
    *   mcp: 'https://app.getgram.ai/mcp/your-mcp-slug',
    * }
+   *
+   * @example
+   * // Multiple servers
+   * const config: ElementsConfig = {
+   *   mcp: [
+   *     { url: 'https://app.getgram.ai/mcp/billing', name: 'billing' },
+   *     { url: 'https://app.getgram.ai/mcp/support', name: 'support' },
+   *   ],
+   * }
    */
-  mcp?: ServerUrl;
+  mcp?: MCPConfig;
 
   /**
    * Custom environment variable overrides for the Elements library.

--- a/elements/src/types/index.ts
+++ b/elements/src/types/index.ts
@@ -26,30 +26,25 @@ export type GetSessionFn = (init: { projectSlug: string }) => Promise<string>;
 type ServerUrl = string;
 
 /**
- * Configuration for a single MCP server. Use the object form when connecting
- * to multiple servers so that tool names can be disambiguated and per-server
- * environment overrides can be supplied.
+ * Configuration for a single MCP server. Used by the {@link ElementsConfig.mcps}
+ * array form when connecting to more than one server.
  */
 export interface MCPServerEntry {
   /** The MCP server URL. */
   url: ServerUrl;
   /**
-   * Optional namespace prefix prepended to tools from this server with `__`
-   * as the separator (e.g. `name__tool`). When omitted for an entry inside a
-   * multi-server array, a prefix is derived from the URL.
+   * Namespace prefix prepended to tools from this server with `__` as the
+   * separator (e.g. `name__tool`) so that tools with identical names from
+   * different servers do not collide. When omitted, a prefix is derived from
+   * the URL.
    */
   name?: string;
   /**
-   * Override the `Gram-Environment` header for this server only. Falls back
-   * to the top-level `gramEnvironment` when omitted.
+   * Environment slug to bind this server's tools to. Sent as the
+   * `Gram-Environment` header on requests to this MCP server only.
    */
-  gramEnvironment?: string;
+  environment?: string;
 }
-
-export type MCPConfig =
-  | ServerUrl
-  | MCPServerEntry
-  | Array<ServerUrl | MCPServerEntry>;
 
 export const VARIANTS = ["widget", "sidecar", "standalone"] as const;
 export type Variant = (typeof VARIANTS)[number];
@@ -117,32 +112,34 @@ export interface ElementsConfig {
   projectSlug: string;
 
   /**
-   * The Gram MCP server(s) to connect to. Accepts either:
+   * The Gram Server URL to use for the Elements library.
+   * Can be retrieved from https://app.getgram.ai/{team}/{project}/mcp/{mcp_slug}
    *
-   * - a single URL string,
-   * - a single {@link MCPServerEntry} object, or
-   * - an array of either form, in which case tools from each server are
-   *   namespaced by a prefix (`<name>__<tool>`) to avoid collisions.
-   *
-   * Each entry may carry its own `gramEnvironment` to override the
-   * top-level setting for that server only.
+   * For multiple MCP servers in a single chat, use {@link mcps} instead;
+   * `mcps` takes precedence when both are provided.
    *
    * @example
-   * // Single server
    * const config: ElementsConfig = {
    *   mcp: 'https://app.getgram.ai/mcp/your-mcp-slug',
    * }
+   */
+  mcp?: ServerUrl;
+
+  /**
+   * One or more Gram MCP servers to connect to in a single chat. Tools from
+   * each server are merged and namespaced as `<name>__<tool>` to avoid
+   * collisions when names overlap. Takes precedence over {@link mcp} when
+   * both are provided.
    *
    * @example
-   * // Multiple servers
    * const config: ElementsConfig = {
-   *   mcp: [
+   *   mcps: [
    *     { url: 'https://app.getgram.ai/mcp/billing', name: 'billing' },
    *     { url: 'https://app.getgram.ai/mcp/support', name: 'support' },
    *   ],
    * }
    */
-  mcp?: MCPConfig;
+  mcps?: MCPServerEntry[];
 
   /**
    * Custom environment variable overrides for the Elements library.


### PR DESCRIPTION
## Summary

- `@gram-ai/elements` `mcp` config accepts a single URL, a `MCPServerEntry`, or an array. Tools from multiple servers are merged and namespaced as `<name>__<tool>` so identical names from different servers don't collide.
- Each entry can carry its own `gramEnvironment` to override the top-level value, useful when toolsets bind to different environments.
- The dashboard's assistant onboarding chat now connects to every toolset attached to the assistant (not just the first), so the agent can call tools across all of them in a single session.
- Internal: extracted a non-hook `internalMcpUrl(project, toolset)` helper alongside `useInternalMcpUrl` so callers that need to map over an array of toolsets can reuse the same URL-construction logic.

Closes [AGE-2266](https://linear.app/speakeasy/issue/AGE-2266/feat-support-multiple-mcp-servers-in-gram-elements-playground-chat).

✻ Clauded...