### PR TITLE
fix(assistants): drop stray order={0} on chat pane

### DIFF
--- a/.changeset/fix-assistant-panel-order.md
+++ b/.changeset/fix-assistant-panel-order.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix expanding panel animation on the assistant page.

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantOnboarding.tsx
@@ -78,7 +78,7 @@ function OnboardingShell() {
           direction="horizontal"
           className="[&>[role='separator']]:bg-neutral-softest [&>[role='separator']]:hover:bg-primary h-full [&>[role='separator']]:relative [&>[role='separator']]:w-px [&>[role='separator']]:border-0 [&>[role='separator']]:before:absolute [&>[role='separator']]:before:inset-y-0 [&>[role='separator']]:before:-right-1 [&>[role='separator']]:before:-left-1 [&>[role='separator']]:before:cursor-col-resize"
         >
-          <ResizablePanel.Pane minSize={35} order={0}>
+          <ResizablePanel.Pane minSize={35}>
             <ChatPane mode={mode} />
           </ResizablePanel.Pane>
           <ResizablePanel.Pane minSize={20} defaultSize={28}>


### PR DESCRIPTION
## Summary

- Removed the `order={0}` prop on the chat `ResizablePanel.Pane` in the assistant onboarding shell. Only one of the two sibling panes declared `order`, which left react-resizable-panels in a partially-ordered state and surfaced as the right-side panel sections appearing to animate the wrong direction when expanded/collapsed.
- Both panes are now unordered so layout state stays consistent across mounts.

Closes [AGE-2235](https://linear.app/speakeasy/issue/AGE-2235/bug-expanding-panel-animation-is-reversed-on-assistant-page)

✻ Clauded...