### PR TITLE
feat: send outbox events as svix webhooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/stretchr/testify v1.11.1
 	github.com/superfly/fly-go v0.3.1
+	github.com/svix/svix-webhooks v1.93.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -455,6 +455,8 @@ github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
 github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -741,6 +743,8 @@ github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/macaroon v0.3.0 h1:tdRq5VqBCNJIlvYByZZ3bGDOKX/v0llQM/Ljd27DbU8=
 github.com/superfly/macaroon v0.3.0/go.mod h1:ZAmlRD/Hmp/ddTxE8IonZ7NdTny2DcOffRvZhapQwJw=
+github.com/svix/svix-webhooks v1.93.0 h1:B62I/AKg9dWs1ERgDdiJF3M8XbFbY1SSrBKRaORauLw=
+github.com/svix/svix-webhooks v1.93.0/go.mod h1:BRbQWn/xdv6zSGULojHza0Yx+hDf+xUJ4s09t3HqJpI=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/testcontainers/testcontainers-go/modules/clickhouse v0.42.0 h1:SwtkmOTGr0P2+XA2WuDYYNMv2rx7XdIZLZcqJGHB4yA=

--- a/mise.toml
+++ b/mise.toml
@@ -228,3 +228,8 @@ POLAR_PRODUCT_ID_ASSISTANTS = ""
 POLAR_METER_ID_TOOL_CALLS = "7ec16f6d-6189-4262-9898-c64bed7b8a91"
 POLAR_METER_ID_SERVERS = "af37f394-69c8-4d46-8308-9b92407ee52e"
 POLAR_METER_ID_CREDITS = "b96fda22-2147-4089-bedb-72c3304b17eb"
+
+########################
+## Svix configuration ##
+########################
+GRAM_SVIX_API_KEY = "unset"

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -324,10 +324,12 @@ linters:
         - "go.temporal.io/sdk/temporal.NewApplicationErrorWithCause("
         - "go.temporal.io/sdk/temporal.NewNonRetryableApplicationError("
         - "go.temporal.io/sdk/workflow.NewContinueAsNewError("
+        - "go.temporal.io/sdk/workflow.Sleep("
         - "(go.temporal.io/sdk/client.Client).ExecuteWorkflow("
         - "(go.temporal.io/sdk/internal.WorkflowInboundInterceptor).ExecuteWorkflow("
         - "(go.temporal.io/sdk/internal.ActivityInboundInterceptor).ExecuteActivity("
         - "(go.temporal.io/sdk/internal.Future).Get("
+        - "(github.com/stretchr/testify/mock.Arguments).Error("
 
         - "github.com/speakeasy-api/gram/server/internal/oops.C("
         - "github.com/speakeasy-api/gram/server/internal/oops.E("

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -26,6 +26,7 @@ import (
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
 	"github.com/superfly/fly-go/tokens"
+	svix "github.com/svix/svix-webhooks/go"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 	"github.com/workos/workos-go/v6/pkg/webhooks"
@@ -59,6 +60,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/polar"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
+	sv "github.com/speakeasy-api/gram/server/internal/thirdparty/svix"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/tracking"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
@@ -745,4 +747,40 @@ func newTriggersApp(
 
 func newAuditLogger() *audit.Logger {
 	return audit.NewLogger()
+}
+
+func newSvixClient(c *cli.Context, logger *slog.Logger, guardianPolicy *guardian.Policy) (*svix.Svix, func(context.Context) error, error) {
+	var svixAPIURL *url.URL
+	shutdownFunc := func(context.Context) error { return nil }
+	hasAPIKey := c.String("svix-api-key") != "" && c.String("svix-api-key") != "unset"
+	if c.String("environment") == "local" && !hasAPIKey {
+		logger.InfoContext(c.Context, "no svix api key provided in local environment, using stub svix server")
+		svixServer := sv.NewStubServer(logger)
+		u, err := url.Parse(svixServer.URL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse svix stub server url: %w", err)
+		}
+
+		svixAPIURL = u
+		shutdownFunc = func(ctx context.Context) error {
+			svixServer.Close()
+			return nil
+		}
+	}
+
+	svixClient, err := svix.New(
+		c.String("svix-api-key"),
+		&svix.SvixOptions{
+			HTTPClient:       guardianPolicy.PooledClient(),
+			Debug:            false,
+			ServerUrl:        svixAPIURL,
+			TransportWrapper: nil,
+			RetrySchedule:    nil,
+		},
+	)
+	if err != nil {
+		return nil, shutdownFunc, fmt.Errorf("create svix client: %w", err)
+	}
+
+	return svixClient, shutdownFunc, nil
 }

--- a/server/cmd/gram/flags_svix.go
+++ b/server/cmd/gram/flags_svix.go
@@ -1,0 +1,11 @@
+package gram
+
+import "github.com/urfave/cli/v2"
+
+var svixFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "svix-api-key",
+		Usage:   "API key for Svix used to send webhook events",
+		EnvVars: []string{"GRAM_SVIX_API_KEY"},
+	},
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -411,6 +411,7 @@ func newStartCommand() *cli.Command {
 	flags = append(flags, pluginsFlags...)
 	flags = append(flags, assistantRuntimeFlags...)
 	flags = append(flags, pulseMCPFlags...)
+	flags = append(flags, svixFlags...)
 
 	return &cli.Command{
 		Name:  "start",
@@ -800,6 +801,14 @@ func newStartCommand() *cli.Command {
 				return nil
 			})
 
+			svixClient, shutdown, err := newSvixClient(c, logger, guardianPolicy)
+			if shutdown != nil {
+				shutdownFuncs = append(shutdownFuncs, shutdown)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to create svix webhook sender: %w", err)
+			}
+
 			// Construct the GitHub App client once; share with the plugin publish
 			// flow and the marketplace proxy so they hit the same token cache and
 			// the same App identity. nil when the App isn't configured.
@@ -1032,6 +1041,8 @@ func newStartCommand() *cli.Command {
 						ShadowMCPClient:     shadowMCPClient,
 						AuditLogger:         auditLogger,
 						WorkOSClient:        backgroundWorkOSClient,
+						SvixClient:          svixClient,
+						ProductFeatures:     productFeatures,
 					})
 					if err := temporalWorker.Run(workerInterruptCh); err != nil {
 						logger.ErrorContext(ctx, "temporal worker failed", attr.SlogError(err))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -310,6 +310,7 @@ func newWorkerCommand() *cli.Command {
 	flags = append(flags, functionsFlags...)
 	flags = append(flags, pulseMCPFlags...)
 	flags = append(flags, assistantRuntimeFlags...)
+	flags = append(flags, svixFlags...)
 
 	return &cli.Command{
 		Name:  "worker",
@@ -449,6 +450,14 @@ func newWorkerCommand() *cli.Command {
 				openRouter = openrouter.NewDevelopment(c.String("openrouter-dev-key"))
 			} else {
 				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}, productFeatures, billingTracker)
+			}
+
+			svixClient, shutdown, err := newSvixClient(c, logger, guardianPolicy)
+			if shutdown != nil {
+				shutdownFuncs = append(shutdownFuncs, shutdown)
+			}
+			if err != nil {
+				return fmt.Errorf("failed to create svix webhook sender: %w", err)
 			}
 
 			tigrisStore, shutdown, err := newTigrisStore(ctx, c, logger)
@@ -667,6 +676,8 @@ func newWorkerCommand() *cli.Command {
 				ShadowMCPClient:     shadowMCPClient,
 				AuditLogger:         auditLogger,
 				WorkOSClient:        backgroundWorkOSClient,
+				SvixClient:          svixClient,
+				ProductFeatures:     productFeatures,
 			})
 
 			return temporalWorker.Run(worker.InterruptCh())

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -199,6 +199,10 @@ const (
 	OpenRouterKeyLimitKey           = attribute.Key("gram.openrouter.key.limit")
 	OrganizationAccountTypeKey      = attribute.Key("gram.org.account_type")
 	OrganizationInviteIDKey         = attribute.Key("gram.org.invite.id")
+	OutboxIDKey                     = attribute.Key("gram.outbox.id")
+	OutboxPublicIDKey               = attribute.Key("gram.outbox.public_id")
+	OutboxBatchSizeKey              = attribute.Key("gram.outbox.batch_size")
+	OutboxNoopRowsKey               = attribute.Key("gram.outbox.noop_rows")
 	AccessMemberIDKey               = attribute.Key("gram.access.member.id")
 	AccessRoleIDKey                 = attribute.Key("gram.access.role.id")
 	AccessRoleSlugKey               = attribute.Key("gram.access.role.slug")
@@ -242,6 +246,8 @@ const (
 	ResourceNameKey                 = attribute.Key("gram.resource.name")
 	ResourceURNKey                  = attribute.Key("gram.resource.urn")
 	ResourceURIKey                  = attribute.Key("gram.resource.uri")
+	SvixAppIDKey                    = attribute.Key("gram.svix.app_id")
+	SvixPreviousAppIDKey            = attribute.Key("gram.svix.previous_app_id")
 	ToolsetIDKey                    = attribute.Key("gram.toolset.id")
 	ToolsetSlugKey                  = attribute.Key("gram.toolset.slug")
 	ToolsetMCPSlugKey               = attribute.Key("gram.toolset.mcp_slug")
@@ -896,6 +902,18 @@ func SlogWorkOSLinkedUserID(v string) slog.Attr {
 	return slog.String(string(WorkOSLinkedUserIDKey), v)
 }
 
+func OutboxID(v int64) attribute.KeyValue { return OutboxIDKey.Int64(v) }
+func SlogOutboxID(v int64) slog.Attr      { return slog.Int64(string(OutboxIDKey), v) }
+
+func OutboxPublicID(v string) attribute.KeyValue { return OutboxPublicIDKey.String(v) }
+func SlogOutboxPublicID(v string) slog.Attr      { return slog.String(string(OutboxPublicIDKey), v) }
+
+func OutboxBatchSize(v int) attribute.KeyValue { return OutboxBatchSizeKey.Int(v) }
+func SlogOutboxBatchSize(v int) slog.Attr      { return slog.Int(string(OutboxBatchSizeKey), v) }
+
+func OutboxNoopRows(v int) attribute.KeyValue { return OutboxNoopRowsKey.Int(v) }
+func SlogOutboxNoopRows(v int) slog.Attr      { return slog.Int(string(OutboxNoopRowsKey), v) }
+
 func OrganizationAccountType(v string) attribute.KeyValue {
 	return OrganizationAccountTypeKey.String(v)
 }
@@ -1012,6 +1030,12 @@ func SlogSlackEventType(v string) slog.Attr      { return slog.String(string(Sla
 
 func SlackTeamID(v string) attribute.KeyValue { return SlackTeamIDKey.String(v) }
 func SlogSlackTeamID(v string) slog.Attr      { return slog.String(string(SlackTeamIDKey), v) }
+
+func SvixAppID(v string) attribute.KeyValue { return SvixAppIDKey.String(v) }
+func SlogSvixAppID(v string) slog.Attr      { return slog.String(string(SvixAppIDKey), v) }
+
+func SvixPreviousAppID(v string) attribute.KeyValue { return SvixPreviousAppIDKey.String(v) }
+func SlogSvixPreviousAppID(v string) slog.Attr      { return slog.String(string(SvixPreviousAppIDKey), v) }
 
 func GenAIToolCallArguments(v string) attribute.KeyValue { return GenAIToolCallArgumentsKey.String(v) }
 func SlogGenAIToolCallArguments(v string) slog.Attr {

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	svix "github.com/svix/svix-webhooks/go"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	resolution_activities "github.com/speakeasy-api/gram/server/internal/background/activities/chat_resolutions"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -27,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -82,6 +85,8 @@ type Activities struct {
 	processWorkOSGlobalRoleEvents   *activities.ProcessWorkOSGlobalRoleEvents
 	processWorkOSUserEvents         *activities.ProcessWorkOSUserEvents
 	cancelAssistantsSubscription    *activities.CancelAssistantsSubscription
+	outboxRelay                     *outbox_relay.Relay
+	outboxGC                        *outbox_relay.GC
 }
 
 func NewActivities(
@@ -114,6 +119,8 @@ func NewActivities(
 	shadowMCPClient *shadowmcp.Client,
 	auditLogger *audit.Logger,
 	workosClient activities.WorkOSClient,
+	svixClient *svix.Svix,
+	productFeatures *productfeatures.Client,
 ) *Activities {
 	usageTrackingStrategy := chat.NewDefaultUsageTrackingStrategy(db, logger, openrouterProvisioner, billingTracker, nil)
 
@@ -162,6 +169,8 @@ func NewActivities(
 		processWorkOSGlobalRoleEvents:   activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosClient),
 		processWorkOSUserEvents:         activities.NewProcessWorkOSUserEvents(logger, db, workosClient),
 		cancelAssistantsSubscription:    activities.NewCancelAssistantsSubscription(logger, billingRepo),
+		outboxRelay:                     outbox_relay.New(logger, tracerProvider, db, svixClient, productFeatures),
+		outboxGC:                        outbox_relay.NewGC(logger, meterProvider, db),
 	}
 }
 
@@ -364,4 +373,35 @@ func (a *Activities) SignalAssistantThread(ctx context.Context, input activities
 
 func (a *Activities) CancelAssistantsSubscription(ctx context.Context, args activities.CancelAssistantsSubscriptionArgs) error {
 	return a.cancelAssistantsSubscription.Do(ctx, args)
+}
+
+func (a *Activities) FetchPendingOutboxEvents(ctx context.Context, events outbox_relay.FetchEventArgs) (outbox_relay.FetchEventsResult, error) {
+	result, err := a.outboxRelay.FetchEvents(ctx, events)
+	if err != nil {
+		return outbox_relay.FetchEventsResult{}, fmt.Errorf("fetch pending outbox events: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) FilterNoopOutboxEvents(ctx context.Context, events []*outbox_relay.Event) ([]*outbox_relay.Event, error) {
+	result, err := a.outboxRelay.FilterNoopEvents(ctx, events)
+	if err != nil {
+		return nil, fmt.Errorf("mark outbox events noop: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) RelayOutboxEvents(ctx context.Context, args []*outbox_relay.Event) error {
+	if err := a.outboxRelay.RelayEvents(ctx, args); err != nil {
+		return fmt.Errorf("relay outbox events: %w", err)
+	}
+	return nil
+}
+
+func (a *Activities) GCOutboxProcessedRows(ctx context.Context, cutoff time.Time, batchSize int32) (int64, error) {
+	n, err := a.outboxGC.DeleteProcessedRows(ctx, cutoff, batchSize)
+	if err != nil {
+		return 0, fmt.Errorf("gc outbox processed rows: %w", err)
+	}
+	return n, nil
 }

--- a/server/internal/background/activities/outbox_relay/gc.go
+++ b/server/internal/background/activities/outbox_relay/gc.go
@@ -1,0 +1,52 @@
+package outbox_relay
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+)
+
+const meterOutboxGCDeletedRows = "outbox.gc.deleted_rows"
+
+// GC hard-deletes terminal outbox rows (processed, noop, or dead-lettered)
+// older than a configurable retention period.
+type GC struct {
+	db          *pgxpool.Pool
+	deletedRows metric.Int64Counter
+}
+
+func NewGC(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool) *GC {
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay")
+	deletedRows, err := meter.Int64Counter(
+		meterOutboxGCDeletedRows,
+		metric.WithDescription("Number of terminal outbox rows hard-deleted by the GC job"),
+		metric.WithUnit("{row}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric error", attr.SlogMetricName(meterOutboxGCDeletedRows), attr.SlogError(err))
+	}
+	return &GC{db: db, deletedRows: deletedRows}
+}
+
+func (g *GC) DeleteProcessedRows(ctx context.Context, cutoff time.Time, batchSize int32) (int64, error) {
+	q := repo.New(g.db)
+	n, err := q.GCProcessedOutboxRows(ctx, repo.GCProcessedOutboxRowsParams{
+		Cutoff:    pgtype.Timestamptz{Time: cutoff, InfinityModifier: pgtype.Finite, Valid: true},
+		BatchSize: batchSize,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("gc processed outbox rows: %w", err)
+	}
+	if g.deletedRows != nil {
+		g.deletedRows.Add(ctx, n)
+	}
+	return n, nil
+}

--- a/server/internal/background/activities/outbox_relay/gc_test.go
+++ b/server/internal/background/activities/outbox_relay/gc_test.go
@@ -1,0 +1,180 @@
+package outbox_relay_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"
+	bgactivitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+type gcTestInstance struct {
+	conn *pgxpool.Pool
+	gc   *outbox_relay.GC
+}
+
+func newGCTestInstance(t *testing.T) *gcTestInstance {
+	t.Helper()
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	return &gcTestInstance{conn: conn, gc: outbox_relay.NewGC(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn)}
+}
+
+func TestGCDeletesTerminalRows(t *testing.T) {
+	t.Parallel()
+
+	inst := newGCTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-gc", true)
+	q := bgactivitiesrepo.New(inst.conn)
+
+	// Row 1: processed (successfully delivered).
+	processedID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	err := q.MarkOutboxRelayProcessed(ctx, bgactivitiesrepo.MarkOutboxRelayProcessedParams{
+		OutboxID:      processedID,
+		SvixMessageID: conv.ToPGTextEmpty("svix-123"),
+	})
+	require.NoError(t, err)
+
+	// Row 2: dead-lettered (retry budget exhausted).
+	deadID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	err = q.MarkOutboxRelayDeadLettered(ctx, bgactivitiesrepo.MarkOutboxRelayDeadLetteredParams{
+		OutboxID:  deadID,
+		LastError: conv.ToPGTextEmpty("permanent error"),
+	})
+	require.NoError(t, err)
+
+	// Row 3: pending — no relay row yet, must survive.
+	pendingID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	// cutoff is in the future so all rows created now are eligible by age.
+	deleted, err := inst.gc.DeleteProcessedRows(ctx, time.Now().Add(time.Hour), 500)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), deleted)
+
+	tr := testrepo.New(inst.conn)
+
+	_, err = tr.GetOutboxEntry(ctx, processedID)
+	require.Error(t, err, "processed row should be gone")
+
+	_, err = tr.GetOutboxEntry(ctx, deadID)
+	require.Error(t, err, "dead-lettered row should be gone")
+
+	id, err := tr.GetOutboxEntry(ctx, pendingID)
+	require.NoError(t, err, "pending row must survive")
+	require.Equal(t, pendingID, id)
+}
+
+func TestGCRetainsRecentRows(t *testing.T) {
+	t.Parallel()
+
+	inst := newGCTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-gc-recent", true)
+	q := bgactivitiesrepo.New(inst.conn)
+
+	id1 := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	id2 := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	for _, id := range []int64{id1, id2} {
+		err := q.MarkOutboxRelayProcessed(ctx, bgactivitiesrepo.MarkOutboxRelayProcessedParams{
+			OutboxID:      id,
+			SvixMessageID: conv.ToPGTextEmpty("svix-ok"),
+		})
+		require.NoError(t, err)
+	}
+
+	// Cutoff 24 hours ago — rows were just created, so they are within retention.
+	deleted, err := inst.gc.DeleteProcessedRows(ctx, time.Now().Add(-24*time.Hour), 500)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), deleted)
+
+	tr := testrepo.New(inst.conn)
+	for _, id := range []int64{id1, id2} {
+		_, err := tr.GetOutboxEntry(ctx, id)
+		require.NoError(t, err)
+	}
+}
+
+func TestGCRespectsMaxBatchSize(t *testing.T) {
+	t.Parallel()
+
+	inst := newGCTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-gc-batch", true)
+	q := bgactivitiesrepo.New(inst.conn)
+
+	for range 10 {
+		id := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+		err := q.MarkOutboxRelayProcessed(ctx, bgactivitiesrepo.MarkOutboxRelayProcessedParams{
+			OutboxID:      id,
+			SvixMessageID: conv.ToPGTextEmpty("svix-ok"),
+		})
+		require.NoError(t, err)
+	}
+
+	deleted, err := inst.gc.DeleteProcessedRows(ctx, time.Now().Add(time.Hour), 5)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), deleted)
+}
+
+func TestFetchEvents_SkipsCoolingOffRows(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-backoff", true)
+	coolingID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	eligibleID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	q := bgactivitiesrepo.New(inst.conn)
+	err := q.MarkOutboxRelayFailed(ctx, bgactivitiesrepo.MarkOutboxRelayFailedParams{
+		OutboxID:   coolingID,
+		LastError:  conv.ToPGTextEmpty("transient"),
+		RetryAfter: pgtype.Timestamptz{Time: time.Now().Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+
+	result, err := inst.relay.FetchEvents(ctx, outbox_relay.FetchEventArgs{})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 1)
+	require.Equal(t, eligibleID, result.Events[0].OutboxID)
+}
+
+func TestFetchEvents_IncludesRowAfterCooldown(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-backoff-expired", true)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	q := bgactivitiesrepo.New(inst.conn)
+	err := q.MarkOutboxRelayFailed(ctx, bgactivitiesrepo.MarkOutboxRelayFailedParams{
+		OutboxID:   outboxID,
+		LastError:  conv.ToPGTextEmpty("transient"),
+		RetryAfter: pgtype.Timestamptz{Time: time.Now().Add(-time.Minute), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+
+	result, err := inst.relay.FetchEvents(ctx, outbox_relay.FetchEventArgs{})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 1)
+	require.Equal(t, outboxID, result.Events[0].OutboxID)
+}

--- a/server/internal/background/activities/outbox_relay/relay.go
+++ b/server/internal/background/activities/outbox_relay/relay.go
@@ -1,0 +1,370 @@
+// Package outbox_relay drains the global event outbox.
+//
+// Activities here back the ProcessOutboxWorkflow defined in the parent
+// background package. The workflow runs continuously: each iteration fetches
+// a batch of pending outbox IDs (returning a HasMore flag to signal back-
+// pressure), filters out rows for orgs with no Svix app (marking them noop
+// in the DB), and relays the remainder to Svix. Per-row delivery failures
+// are persisted in the DB and retried on the next iteration; rows exceeding
+// MaxAttempts are dead-lettered. Infrastructure failures (DB unavailable)
+// are returned as activity errors so Temporal can retry the activity.
+//
+// Only IDs and the svix_app_id cross activity boundaries to keep Temporal
+// history payloads small — full rows are re-queried inside RelayEvents.
+package outbox_relay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	svix "github.com/svix/svix-webhooks/go"
+	"github.com/svix/svix-webhooks/go/models"
+	"go.opentelemetry.io/otel/trace"
+	"go.temporal.io/sdk/activity"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+)
+
+// maxBatchSize is the max number of outbox rows fetched per workflow run.
+const maxBatchSize int32 = 50
+
+// maxAttempts caps retry attempts before a row is dead-lettered.
+const maxAttempts int32 = 10
+
+const (
+	retryBaseDelay = 5 * time.Second
+	retryMaxDelay  = 10 * time.Minute
+)
+
+// calcRetryAfter returns a jittered retry timestamp using full-jitter
+// exponential back-off: delay = random(0, min(cap, base * 2^attempts)).
+// Jitter prevents a wave of failures from all becoming eligible again
+// simultaneously (thundering herd).
+func calcRetryAfter(attempts int32) pgtype.Timestamptz {
+	exp := min(
+		// cap shift to avoid overflow
+		retryBaseDelay*(1<<min(attempts, 20)), retryMaxDelay)
+	jitter := time.Duration(rand.Int64N(int64(exp))) // #nosec G404 - retry jitter is not security-sensitive
+	return pgtype.Timestamptz{Time: time.Now().Add(jitter), InfinityModifier: pgtype.Finite, Valid: true}
+}
+
+type FetchEventArgs struct{}
+
+// FetchEventsResult is returned by FetchEvents. HasMore is true when the
+// outbox has more rows beyond this batch (N+1 probe).
+type FetchEventsResult struct {
+	Events  []*Event
+	HasMore bool
+}
+
+type Event struct {
+	OutboxID        int64
+	OrganizationID  string
+	SvixAppID       string
+	WebhooksEnabled bool
+}
+
+type Relay struct {
+	logger      *slog.Logger
+	tracer      trace.Tracer
+	db          *pgxpool.Pool
+	svixClient  *svix.Svix
+	maxAttempts int32
+	features    *productfeatures.Client
+}
+
+func New(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, svixClient *svix.Svix, features *productfeatures.Client) *Relay {
+	return &Relay{
+		logger:      logger,
+		tracer:      tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"),
+		db:          db,
+		svixClient:  svixClient,
+		features:    features,
+		maxAttempts: maxAttempts,
+	}
+}
+
+func (r *Relay) FetchEvents(ctx context.Context, args FetchEventArgs) (FetchEventsResult, error) {
+	q := repo.New(r.db)
+
+	// Fetch one extra row to detect whether more remain beyond this batch.
+	rows, err := q.FetchPendingOutboxIDs(ctx, maxBatchSize+1)
+	if err != nil {
+		return FetchEventsResult{}, fmt.Errorf("fetch pending outbox ids: %w", err)
+	}
+
+	hasMore := len(rows) > int(maxBatchSize)
+	if hasMore {
+		rows = rows[:maxBatchSize]
+	}
+
+	results := make([]*Event, 0, len(rows))
+	for _, row := range rows {
+		results = append(results, &Event{
+			OutboxID:        row.ID,
+			OrganizationID:  row.OrganizationID,
+			SvixAppID:       row.SvixAppID.String,
+			WebhooksEnabled: row.WebhooksEnabled.Bool,
+		})
+	}
+
+	trace.SpanFromContext(ctx).SetAttributes(
+		attr.OutboxBatchSize(len(results)),
+	)
+
+	return FetchEventsResult{Events: results, HasMore: hasMore}, nil
+}
+
+func (r *Relay) FilterNoopEvents(ctx context.Context, events []*Event) ([]*Event, error) {
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attr.OutboxBatchSize(len(events)),
+	)
+
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	// Implementor's note: SQLc does not support bulk INSERT of rows. It does
+	// support COPY protocol but that is all or nothing and would fail a whole
+	// batch if even one row has a constraint violation. We need upsert
+	// semantics to efficiently processing the outbox.
+	// This was not a vibe coded design decision but a deliberate one.
+
+	psql := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
+	stmt := psql.Insert("outbox_relays").
+		Columns("outbox_id", "processed_at", "noop", "attempts", "last_error")
+
+	total := 0
+	validEvents := make([]*Event, 0, len(events))
+	featureCheck := make(map[string]bool, len(events))
+	for _, res := range events {
+		enabled, err := areWebhooksEnabled(ctx, r.features, featureCheck, res)
+		if err != nil {
+			return nil, err
+		}
+
+		if enabled {
+			validEvents = append(validEvents, res)
+			continue
+		}
+
+		stmt = stmt.Values(res.OutboxID, squirrel.Expr("clock_timestamp()"), true, 1, nil)
+		total++
+	}
+
+	if total == 0 {
+		span.SetAttributes(attr.OutboxNoopRows(0))
+		return validEvents, nil
+	}
+
+	stmt = stmt.Suffix(`
+		ON CONFLICT (outbox_id) DO UPDATE SET
+			processed_at = clock_timestamp(),
+			noop = TRUE,
+			attempts = outbox_relays.attempts + 1,
+			last_error = NULL,
+			updated_at = clock_timestamp()`)
+
+	query, args, err := stmt.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build mark batch noop sql: %w", err)
+	}
+
+	res, err := r.db.Exec(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("execute mark batch noop sql: %w", err)
+	}
+
+	span.SetAttributes(attr.OutboxNoopRows(int(res.RowsAffected())))
+
+	return validEvents, nil
+}
+
+func (r *Relay) RelayEvents(ctx context.Context, events []*Event) error {
+	trace.SpanFromContext(ctx).SetAttributes(
+		attr.OutboxBatchSize(len(events)),
+	)
+
+	if len(events) == 0 {
+		return nil
+	}
+
+	// FilterNoopSvixEvents must have already marked events without SvixAppID or
+	// WebhooksEnabled as noop. The re-check here is defensive: any event that
+	// slips through would be silently skipped by FetchOutboxRowsByIDs and left
+	// in a pending state forever, so we guard against that regression here.
+	filtered := make([]int64, 0, len(events))
+	appIDs := make(map[string]string, len(events)) // orgID -> svixAppID
+	for _, res := range events {
+		if res.SvixAppID != "" && res.WebhooksEnabled {
+			filtered = append(filtered, res.OutboxID)
+		}
+		if res.SvixAppID != "" {
+			appIDs[res.OrganizationID] = res.SvixAppID
+		}
+	}
+
+	q := repo.New(r.db)
+	rows, err := q.FetchOutboxRowsByIDs(ctx, filtered)
+	if err != nil {
+		return fmt.Errorf("fetch outbox rows by ids: %w", err)
+	}
+
+	for _, row := range rows {
+		if activity.IsActivity(ctx) {
+			activity.RecordHeartbeat(ctx, row.ID)
+		}
+
+		svixAppID := appIDs[row.OrganizationID]
+		rowErr, infraErr := r.deliverOne(ctx, q, svixAppID, row)
+		if infraErr != nil {
+			// DB or structural failure — fail the activity so Temporal retries.
+			// Svix idempotency keys make retries safe even if the Svix call succeeded.
+			return infraErr
+		}
+		if rowErr != nil {
+			r.logger.ErrorContext(ctx, "outbox svix relay delivery failed",
+				attr.SlogOrganizationID(row.OrganizationID),
+				attr.SlogOutboxID(row.ID),
+				attr.SlogOutboxPublicID(row.PublicID.String()),
+				attr.SlogSvixAppID(svixAppID),
+				attr.SlogError(rowErr),
+			)
+		}
+	}
+
+	return nil
+}
+
+// deliverOne publishes a single row and records the outcome.
+// rowErr is a per-row Svix-level failure already recorded in the DB — caller
+// logs it and moves on. infraErr is a DB or structural failure that prevents
+// recording the outcome — caller should fail the activity and let Temporal retry.
+func (r *Relay) deliverOne(ctx context.Context, q *repo.Queries, svixAppID string, row repo.FetchOutboxRowsByIDsRow) (rowErr, infraErr error) {
+	var payload map[string]any
+
+	// An org without a svix app ID should not have gotten to this point so this
+	// is mostly defensive coding against a bug.
+	if svixAppID == "" {
+		errMsg := "org has no svix_app_id"
+		if dbErr := q.MarkOutboxRelayDeadLettered(ctx, repo.MarkOutboxRelayDeadLetteredParams{
+			OutboxID:  row.ID,
+			LastError: conv.ToPGTextEmpty(errMsg),
+		}); dbErr != nil {
+			return nil, fmt.Errorf("mark dead-lettered for missing svix_app_id: %w", dbErr)
+		}
+		return errors.New(errMsg), nil
+	}
+
+	if err := json.Unmarshal(row.Payload, &payload); err != nil {
+		errMsg := fmt.Sprintf("invalid payload: %v", err)
+		// Bad payloads will never become valid; dead-letter immediately.
+		if dbErr := q.MarkOutboxRelayDeadLettered(ctx, repo.MarkOutboxRelayDeadLetteredParams{
+			OutboxID:  row.ID,
+			LastError: conv.ToPGTextEmpty(errMsg),
+		}); dbErr != nil {
+			return nil, fmt.Errorf("mark dead-lettered after payload error: %w", dbErr)
+		}
+		return errors.New(errMsg), nil
+	}
+
+	publicID := row.PublicID.String()
+	out, err := r.svixClient.Message.Create(ctx, svixAppID, models.MessageIn{
+		EventId:                &publicID,
+		EventType:              row.EventType,
+		Payload:                payload,
+		Application:            nil,
+		Channels:               nil,
+		DeliverAt:              nil,
+		PayloadRetentionHours:  nil,
+		PayloadRetentionPeriod: nil,
+		Tags:                   nil,
+		TransformationsParams:  nil,
+	}, &svix.MessageCreateOptions{
+		IdempotencyKey: &publicID,
+		WithContent:    nil,
+	})
+	if err == nil {
+		var msgID string
+		if out != nil {
+			msgID = out.Id
+		}
+		if dbErr := q.MarkOutboxRelayProcessed(ctx, repo.MarkOutboxRelayProcessedParams{
+			OutboxID:      row.ID,
+			SvixMessageID: conv.ToPGTextEmpty(msgID),
+		}); dbErr != nil {
+			return nil, fmt.Errorf("mark processed: %w", dbErr)
+		}
+		return nil, nil
+	}
+
+	wrapped := fmt.Errorf("svix message create: %w", err)
+	errMsg := wrapped.Error()
+	nextAttempts := row.Attempts + 1
+	permanent := isPermanentSvixError(err)
+	if permanent || nextAttempts >= r.maxAttempts {
+		if dbErr := q.MarkOutboxRelayDeadLettered(ctx, repo.MarkOutboxRelayDeadLetteredParams{
+			OutboxID:  row.ID,
+			LastError: conv.ToPGTextEmpty(errMsg),
+		}); dbErr != nil {
+			return nil, fmt.Errorf("mark dead-lettered: %w", dbErr)
+		}
+		return wrapped, nil
+	}
+
+	if dbErr := q.MarkOutboxRelayFailed(ctx, repo.MarkOutboxRelayFailedParams{
+		OutboxID:   row.ID,
+		LastError:  conv.ToPGTextEmpty(errMsg),
+		RetryAfter: calcRetryAfter(row.Attempts),
+	}); dbErr != nil {
+		return nil, fmt.Errorf("mark failed: %w", dbErr)
+	}
+	return wrapped, nil
+}
+
+// isPermanentSvixError returns true for Svix HTTP responses that will never
+// succeed on retry (e.g. 400/403/404). 429 and 5xx are treated as transient.
+func isPermanentSvixError(err error) bool {
+	var svixErr *svix.Error
+	if !errors.As(err, &svixErr) {
+		return false
+	}
+	status := svixErr.Status()
+	if status >= 400 && status < 500 && status != 429 {
+		return true
+	}
+	return false
+}
+
+func areWebhooksEnabled(
+	ctx context.Context,
+	client *productfeatures.Client,
+	inMemCache map[string]bool,
+	res *Event,
+) (bool, error) {
+	if _, ok := inMemCache[res.OrganizationID]; !ok {
+		featureEnabled, err := client.IsFeatureEnabled(ctx, res.OrganizationID, productfeatures.FeatureWebhooks)
+		if err != nil {
+			return false, fmt.Errorf("check webhooks feature flag: %w", err)
+		}
+
+		// 1. check the feature flag for the given org
+		// 2. check if the org has onboarded to Svix
+		// 3. check that even if they onboarded, they haven't later disabled webhooks
+		inMemCache[res.OrganizationID] = featureEnabled && res.SvixAppID != "" && res.WebhooksEnabled
+	}
+
+	return inMemCache[res.OrganizationID], nil
+}

--- a/server/internal/background/activities/outbox_relay/relay_test.go
+++ b/server/internal/background/activities/outbox_relay/relay_test.go
@@ -1,0 +1,476 @@
+package outbox_relay_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/svix/svix-webhooks/go/models"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"
+	bgactivitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	svixtest "github.com/speakeasy-api/gram/server/internal/thirdparty/svix/svixtest"
+)
+
+func TestFetchEvents_EmptyOutbox(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	result, err := inst.relay.FetchEvents(ctx, outbox_relay.FetchEventArgs{})
+	require.NoError(t, err)
+	require.Empty(t, result.Events)
+	require.False(t, result.HasMore)
+}
+
+func TestFetchEvents_ReturnsPendingRows(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-id", true)
+	for range 3 {
+		seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	}
+
+	result, err := inst.relay.FetchEvents(ctx, outbox_relay.FetchEventArgs{})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 3)
+	require.False(t, result.HasMore)
+}
+
+func TestFetchEvents_HasMoreProbe(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-id", true)
+	for range 51 {
+		seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	}
+
+	result, err := inst.relay.FetchEvents(ctx, outbox_relay.FetchEventArgs{})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 50)
+	require.True(t, result.HasMore)
+}
+
+func TestFetchEvents_ExcludesProcessed(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-id", true)
+	processedID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	pendingID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	err := bgactivitiesrepo.New(inst.conn).MarkOutboxRelayProcessed(ctx, bgactivitiesrepo.MarkOutboxRelayProcessedParams{
+		OutboxID:      processedID,
+		SvixMessageID: conv.ToPGTextEmpty("svix-123"),
+	})
+	require.NoError(t, err)
+
+	result, err := inst.relay.FetchEvents(ctx, outbox_relay.FetchEventArgs{})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 1)
+	require.Equal(t, pendingID, result.Events[0].OutboxID)
+}
+
+func TestFetchEvents_ExcludesDeadLettered(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-id", true)
+	deadID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	pendingID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	err := bgactivitiesrepo.New(inst.conn).MarkOutboxRelayDeadLettered(ctx, bgactivitiesrepo.MarkOutboxRelayDeadLetteredParams{
+		OutboxID:  deadID,
+		LastError: conv.ToPGTextEmpty("permanent error"),
+	})
+	require.NoError(t, err)
+
+	result, err := inst.relay.FetchEvents(ctx, outbox_relay.FetchEventArgs{})
+	require.NoError(t, err)
+	require.Len(t, result.Events, 1)
+	require.Equal(t, pendingID, result.Events[0].OutboxID)
+}
+
+func TestFilterNoopEvents_Empty(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	result, err := inst.relay.FilterNoopEvents(ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestFilterNoopEvents_PassesThroughEnabled(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-123", true)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	events := []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-123", WebhooksEnabled: true},
+	}
+
+	result, err := inst.relay.FilterNoopEvents(ctx, events)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, outboxID, result[0].OutboxID)
+
+	// no noop row should have been written
+	_, relayErr := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.ErrorIs(t, relayErr, pgx.ErrNoRows)
+}
+
+func TestFilterNoopEvents_NoSvixAppID(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "", false)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	events := []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "", WebhooksEnabled: false},
+	}
+
+	result, err := inst.relay.FilterNoopEvents(ctx, events)
+	require.NoError(t, err)
+	require.Empty(t, result)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.True(t, state.Noop)
+}
+
+func TestFilterNoopEvents_WebhooksDisabled(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	orgID := seedOrg(t, inst.conn, "app-123", false)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	events := []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-123", WebhooksEnabled: false},
+	}
+
+	result, err := inst.relay.FilterNoopEvents(ctx, events)
+	require.NoError(t, err)
+	require.Empty(t, result)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.True(t, state.Noop)
+}
+
+func TestFilterNoopEvents_FeatureFlagDisabled(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	// Org has svix configured but feature flag is NOT enabled.
+	orgID := seedOrg(t, inst.conn, "app-123", true)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	events := []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-123", WebhooksEnabled: true},
+	}
+
+	result, err := inst.relay.FilterNoopEvents(ctx, events)
+	require.NoError(t, err)
+	require.Empty(t, result)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.True(t, state.Noop)
+}
+
+func TestFilterNoopEvents_Mixed(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	// Org A: webhooks enabled — event should pass through.
+	orgA := seedOrg(t, inst.conn, "app-a", true)
+	enableWebhooksFeature(t, inst.conn, orgA)
+	idA := seedOutboxEntry(t, inst.conn, orgA, "test.event", payload)
+
+	// Org B: no svix app ID — event should be noop'd.
+	orgB := seedOrg(t, inst.conn, "", false)
+	idB := seedOutboxEntry(t, inst.conn, orgB, "test.event", payload)
+
+	// Org C: feature flag disabled — event should be noop'd.
+	orgC := seedOrg(t, inst.conn, "app-c", true)
+	idC := seedOutboxEntry(t, inst.conn, orgC, "test.event", payload)
+
+	events := []*outbox_relay.Event{
+		{OutboxID: idA, OrganizationID: orgA, SvixAppID: "app-a", WebhooksEnabled: true},
+		{OutboxID: idB, OrganizationID: orgB, SvixAppID: "", WebhooksEnabled: false},
+		{OutboxID: idC, OrganizationID: orgC, SvixAppID: "app-c", WebhooksEnabled: true},
+	}
+
+	result, err := inst.relay.FilterNoopEvents(ctx, events)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, idA, result[0].OutboxID)
+
+	q := testrepo.New(inst.conn)
+	_, errA := q.GetOutboxRelayState(ctx, idA)
+	require.ErrorIs(t, errA, pgx.ErrNoRows)
+
+	stateB, err := q.GetOutboxRelayState(ctx, idB)
+	require.NoError(t, err)
+	require.True(t, stateB.Noop)
+
+	stateC, err := q.GetOutboxRelayState(ctx, idC)
+	require.NoError(t, err)
+	require.True(t, stateC.Noop)
+}
+
+func TestFilterNoopEvents_CachesPerOrg(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+	payload := mustMarshal(t, map[string]any{"key": "value"})
+
+	// Same org, two events: feature flag disabled → both noop'd.
+	orgID := seedOrg(t, inst.conn, "app-123", true)
+	id1 := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+	id2 := seedOutboxEntry(t, inst.conn, orgID, "test.event", payload)
+
+	events := []*outbox_relay.Event{
+		{OutboxID: id1, OrganizationID: orgID, SvixAppID: "app-123", WebhooksEnabled: true},
+		{OutboxID: id2, OrganizationID: orgID, SvixAppID: "app-123", WebhooksEnabled: true},
+	}
+
+	result, err := inst.relay.FilterNoopEvents(ctx, events)
+	require.NoError(t, err)
+	// Feature flag not enabled, so both events are noop'd.
+	require.Empty(t, result)
+
+	q := testrepo.New(inst.conn)
+	s1, err := q.GetOutboxRelayState(ctx, id1)
+	require.NoError(t, err)
+	require.True(t, s1.Noop)
+
+	s2, err := q.GetOutboxRelayState(ctx, id2)
+	require.NoError(t, err)
+	require.True(t, s2.Noop)
+}
+
+func TestRelayEvents_Empty(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	err := inst.relay.RelayEvents(ctx, nil)
+	require.NoError(t, err)
+}
+
+func TestRelayEvents_SuccessfulDelivery(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	orgID := seedOrg(t, inst.conn, "app-success", true)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", mustMarshal(t, map[string]any{"action": "created"}))
+
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+		Return(&models.MessageOut{
+			Id:        "svix-msg-abc",
+			EventType: "test.event",
+			Payload:   map[string]any{"action": "created"},
+			Timestamp: time.Now(),
+		}, nil)
+
+	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-success", WebhooksEnabled: true},
+	})
+	require.NoError(t, err)
+	inst.svixSrv.AssertExpectations(t)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.True(t, state.ProcessedAt.Valid)
+	require.False(t, state.DeadLettered)
+	require.False(t, state.Noop)
+	require.Equal(t, "svix-msg-abc", state.SvixMessageID.String)
+}
+
+func TestRelayEvents_PermanentError_400(t *testing.T) {
+	t.Parallel()
+	testRelayPermanentError(t, 400)
+}
+
+func TestRelayEvents_PermanentError_403(t *testing.T) {
+	t.Parallel()
+	testRelayPermanentError(t, 403)
+}
+
+func TestRelayEvents_PermanentError_404(t *testing.T) {
+	t.Parallel()
+	testRelayPermanentError(t, 404)
+}
+
+func testRelayPermanentError(t *testing.T, httpStatus int) {
+	t.Helper()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	orgID := seedOrg(t, inst.conn, "app-perm", true)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", mustMarshal(t, map[string]any{"x": 1}))
+
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+		Return(nil, &svixtest.HTTPStatusError{Code: httpStatus})
+
+	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-perm", WebhooksEnabled: true},
+	})
+	require.NoError(t, err) // per-row errors are logged, not returned
+	inst.svixSrv.AssertExpectations(t)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.True(t, state.DeadLettered)
+	require.False(t, state.ProcessedAt.Valid)
+	require.True(t, state.LastError.Valid)
+}
+
+func TestRelayEvents_TransientError_429(t *testing.T) {
+	t.Parallel()
+	testRelayTransientError(t, 429)
+}
+
+func TestRelayEvents_TransientError_500(t *testing.T) {
+	t.Parallel()
+	testRelayTransientError(t, 500)
+}
+
+func testRelayTransientError(t *testing.T, httpStatus int) {
+	t.Helper()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	orgID := seedOrg(t, inst.conn, "app-trans", true)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", mustMarshal(t, map[string]any{"x": 1}))
+
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+		Return(nil, &svixtest.HTTPStatusError{Code: httpStatus})
+
+	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-trans", WebhooksEnabled: true},
+	})
+	require.NoError(t, err)
+	inst.svixSrv.AssertExpectations(t)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.False(t, state.DeadLettered)
+	require.False(t, state.ProcessedAt.Valid)
+	require.Equal(t, int32(1), state.Attempts)
+	require.True(t, state.LastError.Valid)
+}
+
+func TestRelayEvents_MaxAttemptsExceeded(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	orgID := seedOrg(t, inst.conn, "app-maxretry", true)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", mustMarshal(t, map[string]any{"x": 1}))
+
+	// Pre-seed 9 failed attempts — next failure (attempt 10) should dead-letter.
+	preloadAttempts(t, inst.conn, outboxID, 9)
+
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+		Return(nil, &svixtest.HTTPStatusError{Code: 500})
+
+	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-maxretry", WebhooksEnabled: true},
+	})
+	require.NoError(t, err)
+	inst.svixSrv.AssertExpectations(t)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.True(t, state.DeadLettered)
+	require.False(t, state.ProcessedAt.Valid)
+}
+
+func TestRelayEvents_InvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	inst := newRelayTestInstance(t)
+	ctx := t.Context()
+
+	orgID := seedOrg(t, inst.conn, "app-badpayload", true)
+	enableWebhooksFeature(t, inst.conn, orgID)
+	// JSON array is valid JSONB but fails json.Unmarshal to map[string]any.
+	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", []byte(`[1, 2, 3]`))
+
+	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{
+		{OutboxID: outboxID, OrganizationID: orgID, SvixAppID: "app-badpayload", WebhooksEnabled: true},
+	})
+	require.NoError(t, err)
+	// No Svix call should have been made.
+	inst.svixSrv.AssertExpectations(t)
+
+	state, err := testrepo.New(inst.conn).GetOutboxRelayState(ctx, outboxID)
+	require.NoError(t, err)
+	require.True(t, state.DeadLettered)
+	require.True(t, state.LastError.Valid)
+	require.Contains(t, state.LastError.String, "invalid payload")
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/server/internal/background/activities/outbox_relay/setup_test.go
+++ b/server/internal/background/activities/outbox_relay/setup_test.go
@@ -1,0 +1,145 @@
+package outbox_relay_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+	svix "github.com/svix/svix-webhooks/go"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"
+	bgactivitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	outboxrepo "github.com/speakeasy-api/gram/server/internal/outbox/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	productfeaturesrepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	svixtest "github.com/speakeasy-api/gram/server/internal/thirdparty/svix/svixtest"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true})
+	if err != nil {
+		log.Fatalf("failed to launch test infrastructure: %v", err)
+	}
+	infra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Printf("cleanup failed: %v", err)
+	}
+	os.Exit(code)
+}
+
+type relayTestInstance struct {
+	conn     *pgxpool.Pool
+	relay    *outbox_relay.Relay
+	svixSrv  *svixtest.MockServer
+	features *productfeatures.Client
+}
+
+func newRelayTestInstance(t *testing.T) *relayTestInstance {
+	t.Helper()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	logger := testenv.NewLogger(t)
+	tp := testenv.NewTracerProvider(t)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	svixSrv := svixtest.NewMockServer(logger)
+	t.Cleanup(svixSrv.Close)
+
+	svixClient, err := svix.New("test-token", &svix.SvixOptions{
+		ServerUrl:     svixSrv.URL(),
+		RetrySchedule: &[]time.Duration{},
+	})
+	require.NoError(t, err)
+
+	features := productfeatures.NewClient(logger, tp, conn, redisClient)
+	relay := outbox_relay.New(logger, tp, conn, svixClient, features)
+	return &relayTestInstance{
+		conn:     conn,
+		relay:    relay,
+		svixSrv:  svixSrv,
+		features: features,
+	}
+}
+
+// seedOrg inserts an organization_metadata row and configures its svix settings.
+// Returns a unique orgID.
+func seedOrg(t *testing.T, conn *pgxpool.Pool, svixAppID string, webhooksEnabled bool) string {
+	t.Helper()
+	ctx := t.Context()
+	orgID := uuid.NewString()
+
+	q := orgsrepo.New(conn)
+	_, err := q.UpsertOrganizationMetadata(ctx, orgsrepo.UpsertOrganizationMetadataParams{
+		ID:   orgID,
+		Name: orgID,
+		Slug: orgID,
+	})
+	require.NoError(t, err)
+
+	err = testrepo.New(conn).SetOrgWebhookConfig(ctx, testrepo.SetOrgWebhookConfigParams{
+		OrganizationID:  orgID,
+		SvixAppID:       conv.ToPGTextEmpty(svixAppID),
+		WebhooksEnabled: pgtype.Bool{Bool: webhooksEnabled, Valid: true},
+	})
+	require.NoError(t, err)
+
+	return orgID
+}
+
+// seedOutboxEntry inserts a row into the outbox table and returns its ID.
+func seedOutboxEntry(t *testing.T, conn *pgxpool.Pool, orgID, eventType string, payload []byte) int64 {
+	t.Helper()
+	ctx := t.Context()
+	row, err := outboxrepo.New(conn).InsertOutboxEntry(ctx, outboxrepo.InsertOutboxEntryParams{
+		OrganizationID: orgID,
+		EventType:      eventType,
+		Payload:        payload,
+	})
+	require.NoError(t, err)
+	return row.ID
+}
+
+// enableWebhooksFeature enables the webhooks feature flag for an org in the DB.
+func enableWebhooksFeature(t *testing.T, conn *pgxpool.Pool, orgID string) {
+	t.Helper()
+	ctx := t.Context()
+	_, err := productfeaturesrepo.New(conn).EnableFeature(ctx, productfeaturesrepo.EnableFeatureParams{
+		OrganizationID: orgID,
+		FeatureName:    string(productfeatures.FeatureWebhooks),
+	})
+	require.NoError(t, err)
+}
+
+// preloadAttempts calls MarkOutboxRelayFailed n times to simulate prior retry attempts.
+func preloadAttempts(t *testing.T, conn *pgxpool.Pool, outboxID int64, n int) {
+	t.Helper()
+	ctx := t.Context()
+	q := bgactivitiesrepo.New(conn)
+	for range n {
+		err := q.MarkOutboxRelayFailed(ctx, bgactivitiesrepo.MarkOutboxRelayFailedParams{
+			OutboxID:   outboxID,
+			LastError:  conv.ToPGTextEmpty("prior error"),
+			RetryAfter: pgtype.Timestamptz{},
+		})
+		require.NoError(t, err)
+	}
+}

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -59,7 +59,84 @@ JOIN users u ON d.user_id = u.id
 WHERE d.organization_id = ANY($1::text[])
   AND d.id IN (
     SELECT DISTINCT ON (organization_id) id
-    FROM deployments 
+    FROM deployments
     WHERE organization_id = ANY($1::text[])
     ORDER BY organization_id, created_at DESC
   );
+
+-- name: FetchPendingOutboxIDs :many
+-- Fetch the next batch of outbox row IDs (across all organizations) that the
+-- Svix relay has not finished processing. A row is "pending" when no relay
+-- tracking row exists OR a tracking row exists with processed_at IS NULL and
+-- not dead-lettered. Returns only IDs to keep the activity payload small —
+-- workflows pass IDs to RelayBatch which re-queries the full rows.
+SELECT o.id, o.organization_id, om.svix_app_id, om.webhooks_enabled
+FROM outbox o
+LEFT JOIN organization_metadata om ON o.organization_id = om.id
+LEFT JOIN outbox_relays r ON r.outbox_id = o.id
+WHERE r.outbox_id IS NULL OR (r.processed_at IS NULL AND r.dead_lettered IS FALSE AND (r.retry_after IS NULL OR r.retry_after <= clock_timestamp()))
+ORDER BY o.id ASC
+LIMIT @batch_size;
+
+-- name: FetchOutboxRowsByIDs :many
+-- Hydrate a set of outbox IDs back into full rows along with their current
+-- relay attempt count. Intended to be called inside the relay activity after
+-- the workflow has handed it a batch of IDs.
+SELECT
+    o.id,
+    o.public_id,
+    o.organization_id,
+    o.event_type,
+    o.payload,
+    COALESCE(r.attempts, 0)::int AS attempts
+FROM outbox o
+LEFT JOIN outbox_relays r ON r.outbox_id = o.id
+WHERE o.id = ANY(@ids::bigint[])
+ORDER BY o.id ASC;
+
+-- name: MarkOutboxRelayProcessed :exec
+-- Marks a relay as successfully delivered to Svix.
+INSERT INTO outbox_relays (outbox_id, processed_at, svix_message_id, attempts, last_error)
+VALUES (@outbox_id, clock_timestamp(), @svix_message_id, 1, NULL)
+ON CONFLICT (outbox_id) DO UPDATE SET
+    processed_at = clock_timestamp(),
+    svix_message_id = EXCLUDED.svix_message_id,
+    attempts = outbox_relays.attempts + 1,
+    last_error = NULL,
+    updated_at = clock_timestamp();
+
+-- name: MarkOutboxRelayFailed :exec
+-- Records a failed delivery attempt; the row remains pending for retry.
+INSERT INTO outbox_relays (outbox_id, attempts, last_error, retry_after)
+VALUES (@outbox_id, 1, @last_error, @retry_after)
+ON CONFLICT (outbox_id) DO UPDATE SET
+    attempts = outbox_relays.attempts + 1,
+    last_error = EXCLUDED.last_error,
+    retry_after = EXCLUDED.retry_after,
+    updated_at = clock_timestamp();
+
+-- name: GCProcessedOutboxRows :execrows
+-- Hard-deletes terminal outbox rows older than @cutoff. Terminal means the
+-- relay row is processed, noop, or dead-lettered. The cascade FK removes the
+-- outbox_relays row automatically. Batched via LIMIT to bound lock time.
+DELETE FROM outbox
+WHERE id IN (
+  SELECT o.id
+  FROM outbox o
+  JOIN outbox_relays r ON r.outbox_id = o.id
+  WHERE o.created_at < @cutoff
+    AND (r.processed_at IS NOT NULL OR r.noop = TRUE OR r.dead_lettered = TRUE)
+  ORDER BY o.id ASC
+  LIMIT @batch_size
+);
+
+-- name: MarkOutboxRelayDeadLettered :exec
+-- Permanently parks a row after exceeding the retry budget. The pending
+-- partial index excludes dead_lettered rows so they will not be re-fetched.
+INSERT INTO outbox_relays (outbox_id, attempts, last_error, dead_lettered)
+VALUES (@outbox_id, 1, @last_error, TRUE)
+ON CONFLICT (outbox_id) DO UPDATE SET
+    attempts = outbox_relays.attempts + 1,
+    last_error = EXCLUDED.last_error,
+    dead_lettered = TRUE,
+    updated_at = clock_timestamp();

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -7,7 +7,139 @@ package repo
 
 import (
 	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const fetchOutboxRowsByIDs = `-- name: FetchOutboxRowsByIDs :many
+SELECT
+    o.id,
+    o.public_id,
+    o.organization_id,
+    o.event_type,
+    o.payload,
+    COALESCE(r.attempts, 0)::int AS attempts
+FROM outbox o
+LEFT JOIN outbox_relays r ON r.outbox_id = o.id
+WHERE o.id = ANY($1::bigint[])
+ORDER BY o.id ASC
+`
+
+type FetchOutboxRowsByIDsRow struct {
+	ID             int64
+	PublicID       uuid.UUID
+	OrganizationID string
+	EventType      string
+	Payload        []byte
+	Attempts       int32
+}
+
+// Hydrate a set of outbox IDs back into full rows along with their current
+// relay attempt count. Intended to be called inside the relay activity after
+// the workflow has handed it a batch of IDs.
+func (q *Queries) FetchOutboxRowsByIDs(ctx context.Context, ids []int64) ([]FetchOutboxRowsByIDsRow, error) {
+	rows, err := q.db.Query(ctx, fetchOutboxRowsByIDs, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FetchOutboxRowsByIDsRow
+	for rows.Next() {
+		var i FetchOutboxRowsByIDsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.PublicID,
+			&i.OrganizationID,
+			&i.EventType,
+			&i.Payload,
+			&i.Attempts,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const fetchPendingOutboxIDs = `-- name: FetchPendingOutboxIDs :many
+SELECT o.id, o.organization_id, om.svix_app_id, om.webhooks_enabled
+FROM outbox o
+LEFT JOIN organization_metadata om ON o.organization_id = om.id
+LEFT JOIN outbox_relays r ON r.outbox_id = o.id
+WHERE r.outbox_id IS NULL OR (r.processed_at IS NULL AND r.dead_lettered IS FALSE AND (r.retry_after IS NULL OR r.retry_after <= clock_timestamp()))
+ORDER BY o.id ASC
+LIMIT $1
+`
+
+type FetchPendingOutboxIDsRow struct {
+	ID              int64
+	OrganizationID  string
+	SvixAppID       pgtype.Text
+	WebhooksEnabled pgtype.Bool
+}
+
+// Fetch the next batch of outbox row IDs (across all organizations) that the
+// Svix relay has not finished processing. A row is "pending" when no relay
+// tracking row exists OR a tracking row exists with processed_at IS NULL and
+// not dead-lettered. Returns only IDs to keep the activity payload small —
+// workflows pass IDs to RelayBatch which re-queries the full rows.
+func (q *Queries) FetchPendingOutboxIDs(ctx context.Context, batchSize int32) ([]FetchPendingOutboxIDsRow, error) {
+	rows, err := q.db.Query(ctx, fetchPendingOutboxIDs, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FetchPendingOutboxIDsRow
+	for rows.Next() {
+		var i FetchPendingOutboxIDsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.SvixAppID,
+			&i.WebhooksEnabled,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const gCProcessedOutboxRows = `-- name: GCProcessedOutboxRows :execrows
+DELETE FROM outbox
+WHERE id IN (
+  SELECT o.id
+  FROM outbox o
+  JOIN outbox_relays r ON r.outbox_id = o.id
+  WHERE o.created_at < $1
+    AND (r.processed_at IS NOT NULL OR r.noop = TRUE OR r.dead_lettered = TRUE)
+  ORDER BY o.id ASC
+  LIMIT $2
+)
+`
+
+type GCProcessedOutboxRowsParams struct {
+	Cutoff    pgtype.Timestamptz
+	BatchSize int32
+}
+
+// Hard-deletes terminal outbox rows older than @cutoff. Terminal means the
+// relay row is processed, noop, or dead-lettered. The cascade FK removes the
+// outbox_relays row automatically. Batched via LIMIT to bound lock time.
+func (q *Queries) GCProcessedOutboxRows(ctx context.Context, arg GCProcessedOutboxRowsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, gCProcessedOutboxRows, arg.Cutoff, arg.BatchSize)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
 
 const getAllOrganizationsWithToolsets = `-- name: GetAllOrganizationsWithToolsets :many
 SELECT
@@ -139,7 +271,7 @@ JOIN users u ON d.user_id = u.id
 WHERE d.organization_id = ANY($1::text[])
   AND d.id IN (
     SELECT DISTINCT ON (organization_id) id
-    FROM deployments 
+    FROM deployments
     WHERE organization_id = ANY($1::text[])
     ORDER BY organization_id, created_at DESC
   )
@@ -169,4 +301,70 @@ func (q *Queries) GetUserEmailsByOrgIDs(ctx context.Context, dollar_1 []string) 
 		return nil, err
 	}
 	return items, nil
+}
+
+const markOutboxRelayDeadLettered = `-- name: MarkOutboxRelayDeadLettered :exec
+INSERT INTO outbox_relays (outbox_id, attempts, last_error, dead_lettered)
+VALUES ($1, 1, $2, TRUE)
+ON CONFLICT (outbox_id) DO UPDATE SET
+    attempts = outbox_relays.attempts + 1,
+    last_error = EXCLUDED.last_error,
+    dead_lettered = TRUE,
+    updated_at = clock_timestamp()
+`
+
+type MarkOutboxRelayDeadLetteredParams struct {
+	OutboxID  int64
+	LastError pgtype.Text
+}
+
+// Permanently parks a row after exceeding the retry budget. The pending
+// partial index excludes dead_lettered rows so they will not be re-fetched.
+func (q *Queries) MarkOutboxRelayDeadLettered(ctx context.Context, arg MarkOutboxRelayDeadLetteredParams) error {
+	_, err := q.db.Exec(ctx, markOutboxRelayDeadLettered, arg.OutboxID, arg.LastError)
+	return err
+}
+
+const markOutboxRelayFailed = `-- name: MarkOutboxRelayFailed :exec
+INSERT INTO outbox_relays (outbox_id, attempts, last_error, retry_after)
+VALUES ($1, 1, $2, $3)
+ON CONFLICT (outbox_id) DO UPDATE SET
+    attempts = outbox_relays.attempts + 1,
+    last_error = EXCLUDED.last_error,
+    retry_after = EXCLUDED.retry_after,
+    updated_at = clock_timestamp()
+`
+
+type MarkOutboxRelayFailedParams struct {
+	OutboxID   int64
+	LastError  pgtype.Text
+	RetryAfter pgtype.Timestamptz
+}
+
+// Records a failed delivery attempt; the row remains pending for retry.
+func (q *Queries) MarkOutboxRelayFailed(ctx context.Context, arg MarkOutboxRelayFailedParams) error {
+	_, err := q.db.Exec(ctx, markOutboxRelayFailed, arg.OutboxID, arg.LastError, arg.RetryAfter)
+	return err
+}
+
+const markOutboxRelayProcessed = `-- name: MarkOutboxRelayProcessed :exec
+INSERT INTO outbox_relays (outbox_id, processed_at, svix_message_id, attempts, last_error)
+VALUES ($1, clock_timestamp(), $2, 1, NULL)
+ON CONFLICT (outbox_id) DO UPDATE SET
+    processed_at = clock_timestamp(),
+    svix_message_id = EXCLUDED.svix_message_id,
+    attempts = outbox_relays.attempts + 1,
+    last_error = NULL,
+    updated_at = clock_timestamp()
+`
+
+type MarkOutboxRelayProcessedParams struct {
+	OutboxID      int64
+	SvixMessageID pgtype.Text
+}
+
+// Marks a relay as successfully delivered to Svix.
+func (q *Queries) MarkOutboxRelayProcessed(ctx context.Context, arg MarkOutboxRelayProcessedParams) error {
+	_, err := q.db.Exec(ctx, markOutboxRelayProcessed, arg.OutboxID, arg.SvixMessageID)
+	return err
 }

--- a/server/internal/background/outbox_gc.go
+++ b/server/internal/background/outbox_gc.go
@@ -1,0 +1,81 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	outboxGCScheduleID            = "v1:outbox-gc-schedule"
+	outboxGCWorkflowID            = outboxGCScheduleID + "/scheduled"
+	outboxGCInterval              = 6 * time.Hour
+	outboxGCRetentionPeriod       = 7 * 24 * time.Hour
+	outboxGCBatchSize       int32 = 100
+	outboxGCSleepInterval         = time.Hour
+)
+
+func OutboxGCWorkflow(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    time.Minute,
+		},
+	})
+
+	var a *Activities
+
+	for {
+		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+			return workflow.NewContinueAsNewError(ctx, OutboxGCWorkflow)
+		}
+
+		cutoff := workflow.Now(ctx).Add(-outboxGCRetentionPeriod)
+
+		var rows int64
+		if err := workflow.ExecuteActivity(ctx, a.GCOutboxProcessedRows, cutoff, outboxGCBatchSize).Get(ctx, &rows); err != nil {
+			return fmt.Errorf("gc outbox processed rows: %w", err)
+		}
+
+		workflow.GetLogger(ctx).Info("outbox gc batch completed", "rows_deleted", rows)
+
+		if rows >= int64(outboxGCBatchSize) {
+			continue // batch was full — more rows likely remain
+		}
+
+		if err := workflow.Sleep(ctx, outboxGCSleepInterval); err != nil {
+			return err
+		}
+	}
+}
+
+func AddOutboxGCSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	_, err := temporalEnv.Client().ScheduleClient().Create(ctx, client.ScheduleOptions{
+		ID:      outboxGCScheduleID,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Spec: client.ScheduleSpec{
+			Intervals: []client.ScheduleIntervalSpec{{Every: outboxGCInterval}},
+		},
+		Action: &client.ScheduleWorkflowAction{
+			ID:                 outboxGCWorkflowID,
+			Workflow:           OutboxGCWorkflow,
+			TaskQueue:          string(temporalEnv.Queue()),
+			WorkflowRunTimeout: 15 * time.Minute,
+		},
+	})
+	if err != nil && !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+		return fmt.Errorf("create outbox gc schedule: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/outbox_gc_test.go
+++ b/server/internal/background/outbox_gc_test.go
@@ -1,0 +1,93 @@
+package background
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func TestOutboxGCWorkflow_PartialBatch(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	gcCallCount := 0
+	var gotCutoff time.Time
+	var gotBatchSize int32
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, cutoff time.Time, batchSize int32) (int64, error) {
+			gcCallCount++
+			if gcCallCount == 1 {
+				gotCutoff = cutoff
+				gotBatchSize = batchSize
+				// Partial batch — fewer rows than limit, workflow should sleep then loop again.
+				return int64(outboxGCBatchSize) - 1, nil
+			}
+			return 0, errStop
+		},
+		activity.RegisterOptions{Name: "GCOutboxProcessedRows"},
+	)
+
+	env.ExecuteWorkflow(OutboxGCWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError()) // stopped by sentinel
+	require.Equal(t, 2, gcCallCount)         // first partial batch, second errStop after sleep
+	require.Equal(t, outboxGCBatchSize, gotBatchSize)
+	require.WithinDuration(t, time.Now().Add(-outboxGCRetentionPeriod), gotCutoff, time.Second)
+}
+
+func TestOutboxGCWorkflow_FullBatchSkipsSleep(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	gcCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ time.Time, _ int32) (int64, error) {
+			gcCallCount++
+			switch gcCallCount {
+			case 1:
+				// Full batch — workflow must NOT sleep before next poll.
+				return int64(outboxGCBatchSize), nil
+			case 2:
+				// Partial batch — workflow sleeps, then loops.
+				return 0, nil
+			default:
+				return 0, errStop
+			}
+		},
+		activity.RegisterOptions{Name: "GCOutboxProcessedRows"},
+	)
+
+	env.ExecuteWorkflow(OutboxGCWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError()) // stopped by sentinel
+	require.Equal(t, 3, gcCallCount)         // full batch → immediate re-poll → partial batch → sleep → errStop
+}
+
+func TestOutboxGCWorkflow_ActivityError(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ time.Time, _ int32) (int64, error) {
+			return 0, errStop
+		},
+		activity.RegisterOptions{Name: "GCOutboxProcessedRows"},
+	)
+
+	env.ExecuteWorkflow(OutboxGCWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError())
+}

--- a/server/internal/background/process_outbox.go
+++ b/server/internal/background/process_outbox.go
@@ -1,0 +1,93 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	relay "github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+type ProcessOutboxResult struct {
+}
+
+func ProcessOutboxWorkflow(ctx workflow.Context) (ProcessOutboxResult, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Minute,
+		HeartbeatTimeout:    2 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    5,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    60 * time.Second,
+		},
+	})
+
+	var a *Activities
+
+	for {
+		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+			return ProcessOutboxResult{}, workflow.NewContinueAsNewError(ctx, ProcessOutboxWorkflow)
+		}
+
+		var result relay.FetchEventsResult
+		if err := workflow.ExecuteActivity(ctx, a.FetchPendingOutboxEvents, relay.FetchEventArgs{}).Get(ctx, &result); err != nil {
+			return ProcessOutboxResult{}, fmt.Errorf("fetch pending outbox batch: %w", err)
+		}
+
+		if len(result.Events) > 0 {
+			var filtered []*relay.Event
+			if err := workflow.ExecuteActivity(ctx, a.FilterNoopOutboxEvents, result.Events).Get(ctx, &filtered); err != nil {
+				return ProcessOutboxResult{}, fmt.Errorf("mark outbox svix events noop: %w", err)
+			}
+
+			if err := workflow.ExecuteActivity(ctx, a.RelayOutboxEvents, filtered).Get(ctx, nil); err != nil {
+				return ProcessOutboxResult{}, fmt.Errorf("relay svix events: %w", err)
+			}
+
+			if result.HasMore {
+				continue // more events waiting — poll immediately without sleeping
+			}
+		}
+
+		if err := workflow.Sleep(ctx, 5*time.Second); err != nil {
+			return ProcessOutboxResult{}, err
+		}
+	}
+}
+
+func AddProcessOutboxSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	scheduleID := "v1:process-outbox-schedule"
+	workflowID := scheduleID + "/scheduled"
+
+	_, err := temporalEnv.Client().ScheduleClient().Create(ctx, client.ScheduleOptions{
+		ID:      scheduleID,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		// The schedule acts as a watchdog: the workflow polls internally every
+		// 5 s and runs continuously until ContinueAsNew. This 1-minute interval
+		// only restarts the workflow if it exits or exhausts its retry budget.
+		Spec: client.ScheduleSpec{
+			Intervals: []client.ScheduleIntervalSpec{
+				{
+					Every: 1 * time.Minute,
+				},
+			},
+		},
+		Action: &client.ScheduleWorkflowAction{
+			ID:        workflowID,
+			Workflow:  ProcessOutboxWorkflow,
+			TaskQueue: string(temporalEnv.Queue()),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create process outbox schedule: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/background/process_outbox_test.go
+++ b/server/internal/background/process_outbox_test.go
@@ -1,0 +1,225 @@
+package background
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+
+	relay "github.com/speakeasy-api/gram/server/internal/background/activities/outbox_relay"
+)
+
+// errStop is a non-retryable sentinel used to break the workflow's infinite loop in tests.
+var errStop = temporal.NewNonRetryableApplicationError("test-stop", "test-stop", nil)
+
+func TestProcessOutboxWorkflow_EmptyBatch(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	fetchCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ relay.FetchEventArgs) (relay.FetchEventsResult, error) {
+			fetchCallCount++
+			if fetchCallCount == 1 {
+				return relay.FetchEventsResult{Events: nil, HasMore: false}, nil
+			}
+			return relay.FetchEventsResult{}, errStop
+		},
+		activity.RegisterOptions{Name: "FetchPendingOutboxEvents"},
+	)
+
+	filterCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) ([]*relay.Event, error) {
+			filterCallCount++
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "FilterNoopOutboxEvents"},
+	)
+
+	relayCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) error {
+			relayCallCount++
+			return nil
+		},
+		activity.RegisterOptions{Name: "RelayOutboxEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessOutboxWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError()) // stopped by sentinel
+	require.Equal(t, 2, fetchCallCount)      // first empty, second errStop
+	require.Equal(t, 0, filterCallCount)     // never called on empty batch
+	require.Equal(t, 0, relayCallCount)
+}
+
+func TestProcessOutboxWorkflow_HasMore(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	events := []*relay.Event{
+		{OutboxID: 1, OrganizationID: "org1", SvixAppID: "app1", WebhooksEnabled: true},
+	}
+
+	fetchCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ relay.FetchEventArgs) (relay.FetchEventsResult, error) {
+			fetchCallCount++
+			switch fetchCallCount {
+			case 1:
+				// First iteration: HasMore=true → workflow must NOT sleep before next poll.
+				return relay.FetchEventsResult{Events: events, HasMore: true}, nil
+			case 2:
+				return relay.FetchEventsResult{Events: events, HasMore: false}, nil
+			default:
+				return relay.FetchEventsResult{}, errStop
+			}
+		},
+		activity.RegisterOptions{Name: "FetchPendingOutboxEvents"},
+	)
+
+	filterCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, evts []*relay.Event) ([]*relay.Event, error) {
+			filterCallCount++
+			return evts, nil
+		},
+		activity.RegisterOptions{Name: "FilterNoopOutboxEvents"},
+	)
+
+	relayCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) error {
+			relayCallCount++
+			return nil
+		},
+		activity.RegisterOptions{Name: "RelayOutboxEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessOutboxWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError()) // stopped by sentinel
+	require.Equal(t, 3, fetchCallCount)      // iteration 1 (HasMore), iteration 2 (no more), iteration 3 (errStop)
+	require.Equal(t, 2, filterCallCount)     // called for each iteration that returned events
+	require.Equal(t, 2, relayCallCount)      // called for each iteration that returned events
+}
+
+func TestProcessOutboxWorkflow_FetchError(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ relay.FetchEventArgs) (relay.FetchEventsResult, error) {
+			return relay.FetchEventsResult{}, errStop
+		},
+		activity.RegisterOptions{Name: "FetchPendingOutboxEvents"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) ([]*relay.Event, error) {
+			t.Fatal("FilterNoopOutboxEvents must not be called when FetchPendingOutboxEvents fails")
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "FilterNoopOutboxEvents"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) error {
+			t.Fatal("RelayOutboxEvents must not be called when FetchPendingOutboxEvents fails")
+			return nil
+		},
+		activity.RegisterOptions{Name: "RelayOutboxEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessOutboxWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError())
+}
+
+func TestProcessOutboxWorkflow_FilterError(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	events := []*relay.Event{
+		{OutboxID: 1, OrganizationID: "org1", SvixAppID: "app1", WebhooksEnabled: true},
+	}
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ relay.FetchEventArgs) (relay.FetchEventsResult, error) {
+			return relay.FetchEventsResult{Events: events, HasMore: false}, nil
+		},
+		activity.RegisterOptions{Name: "FetchPendingOutboxEvents"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) ([]*relay.Event, error) {
+			return nil, errStop
+		},
+		activity.RegisterOptions{Name: "FilterNoopOutboxEvents"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) error {
+			t.Fatal("RelayOutboxEvents must not be called when FilterNoopOutboxEvents fails")
+			return nil
+		},
+		activity.RegisterOptions{Name: "RelayOutboxEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessOutboxWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError())
+}
+
+func TestProcessOutboxWorkflow_RelayError(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	events := []*relay.Event{
+		{OutboxID: 1, OrganizationID: "org1", SvixAppID: "app1", WebhooksEnabled: true},
+	}
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ relay.FetchEventArgs) (relay.FetchEventsResult, error) {
+			return relay.FetchEventsResult{Events: events, HasMore: false}, nil
+		},
+		activity.RegisterOptions{Name: "FetchPendingOutboxEvents"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, evts []*relay.Event) ([]*relay.Event, error) {
+			return evts, nil
+		},
+		activity.RegisterOptions{Name: "FilterNoopOutboxEvents"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []*relay.Event) error {
+			return errStop
+		},
+		activity.RegisterOptions{Name: "RelayOutboxEvents"},
+	)
+
+	env.ExecuteWorkflow(ProcessOutboxWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError())
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
+	svix "github.com/svix/svix-webhooks/go"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/sdk/interceptor"
@@ -32,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -70,6 +72,8 @@ type WorkerOptions struct {
 	ShadowMCPClient     *shadowmcp.Client
 	AuditLogger         *audit.Logger
 	WorkOSClient        activities.WorkOSClient
+	SvixClient          *svix.Svix
+	ProductFeatures     *productfeatures.Client
 }
 
 func ForDeploymentProcessing(
@@ -110,6 +114,8 @@ func ForDeploymentProcessing(
 		PIIScanner:          nil,
 		ShadowMCPClient:     nil,
 		WorkOSClient:        workos.NewStubClient(),
+		SvixClient:          nil,
+		ProductFeatures:     nil,
 	}
 }
 
@@ -148,6 +154,8 @@ func NewTemporalWorker(
 		ShadowMCPClient:     nil,
 		AuditLogger:         nil,
 		WorkOSClient:        workos.NewStubClient(),
+		SvixClient:          nil,
+		ProductFeatures:     nil,
 	}
 
 	for _, o := range options {
@@ -179,6 +187,8 @@ func NewTemporalWorker(
 			ShadowMCPClient:     conv.Default(o.ShadowMCPClient, opts.ShadowMCPClient),
 			AuditLogger:         conv.Default(o.AuditLogger, opts.AuditLogger),
 			WorkOSClient:        conv.Default(o.WorkOSClient, opts.WorkOSClient),
+			SvixClient:          conv.Default(o.SvixClient, opts.SvixClient),
+			ProductFeatures:     conv.Default(o.ProductFeatures, opts.ProductFeatures),
 		}
 	}
 
@@ -227,6 +237,8 @@ func NewTemporalWorker(
 		opts.ShadowMCPClient,
 		opts.AuditLogger,
 		opts.WorkOSClient,
+		opts.SvixClient,
+		opts.ProductFeatures,
 	)
 
 	temporalWorker.RegisterActivity(activities.ProcessDeployment)
@@ -269,6 +281,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.ReapSoftDeletedAssistantMemories)
 	temporalWorker.RegisterActivity(activities.SignalAssistantCoordinator)
 	temporalWorker.RegisterActivity(activities.SignalAssistantThread)
+	temporalWorker.RegisterActivity(activities.CancelAssistantsSubscription)
 	// WorkOS sync activities
 	temporalWorker.RegisterActivity(activities.ListWorkOSOrganizations)
 	temporalWorker.RegisterActivity(activities.BackfillWorkOSOrganization)
@@ -276,8 +289,11 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSOrganizationEvents)
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSGlobalRoleEvents)
 	temporalWorker.RegisterActivity(activities.ProcessWorkOSUserEvents)
-
-	temporalWorker.RegisterActivity(activities.CancelAssistantsSubscription)
+	// Outbox relay activities
+	temporalWorker.RegisterActivity(activities.FetchPendingOutboxEvents)
+	temporalWorker.RegisterActivity(activities.FilterNoopOutboxEvents)
+	temporalWorker.RegisterActivity(activities.RelayOutboxEvents)
+	temporalWorker.RegisterActivity(activities.GCOutboxProcessedRows)
 
 	temporalWorker.RegisterWorkflow(ProcessDeploymentWorkflow)
 	temporalWorker.RegisterWorkflow(FunctionsReaperWorkflow)
@@ -313,6 +329,9 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(BackfillWorkOSWorkflow)
 	// Assistants signup followups
 	temporalWorker.RegisterWorkflow(CancelAssistantsSubscriptionWorkflow)
+	// Outbox -> Relay workflow and GC
+	temporalWorker.RegisterWorkflow(ProcessOutboxWorkflow)
+	temporalWorker.RegisterWorkflow(OutboxGCWorkflow)
 
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
@@ -326,6 +345,12 @@ func NewTemporalWorker(
 		}
 	}
 
+	if err := AddProcessOutboxSchedule(context.Background(), env); err != nil {
+		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+			logger.ErrorContext(context.Background(), "failed to add relay outbox to svix schedule", attr.SlogError(err))
+		}
+	}
+
 	if err := AddAssistantReaperSchedule(context.Background(), env); err != nil {
 		logger.ErrorContext(context.Background(), "failed to add assistant reaper schedule", attr.SlogError(err))
 	}
@@ -336,6 +361,10 @@ func NewTemporalWorker(
 
 	if err := AddAssistantMemoriesReaperSchedule(context.Background(), env); err != nil {
 		logger.ErrorContext(context.Background(), "failed to add assistant memories reaper schedule", attr.SlogError(err))
+	}
+
+	if err := AddOutboxGCSchedule(context.Background(), env); err != nil {
+		logger.ErrorContext(context.Background(), "failed to add outbox gc schedule", attr.SlogError(err))
 	}
 
 	return &Workers{main: temporalWorker, riskAnalysis: riskWorker}

--- a/server/internal/email/service_test.go
+++ b/server/internal/email/service_test.go
@@ -18,7 +18,7 @@ type mockSender struct {
 
 func (m *mockSender) SendTransactional(ctx context.Context, input loops.SendTransactionalInput) error {
 	args := m.Called(ctx, input)
-	return args.Error(0) //nolint:wrapcheck // mock return is not a real error to wrap.
+	return args.Error(0)
 }
 
 func newMockSender(t *testing.T) *mockSender {

--- a/server/internal/memory/contradiction_test.go
+++ b/server/internal/memory/contradiction_test.go
@@ -23,19 +23,19 @@ type mockCompletionClient struct {
 func (m *mockCompletionClient) GetCompletion(ctx context.Context, request openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
 	args := m.Called(ctx, request)
 	resp, _ := args.Get(0).(*openrouter.CompletionResponse)
-	return resp, args.Error(1) //nolint:wrapcheck // mock pass-through
+	return resp, args.Error(1)
 }
 
 func (m *mockCompletionClient) GetCompletionStream(ctx context.Context, request openrouter.CompletionRequest) (openrouter.StreamReader, error) {
 	args := m.Called(ctx, request)
 	r, _ := args.Get(0).(openrouter.StreamReader)
-	return r, args.Error(1) //nolint:wrapcheck // mock pass-through
+	return r, args.Error(1)
 }
 
 func (m *mockCompletionClient) GetObjectCompletion(ctx context.Context, request openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
 	args := m.Called(ctx, request)
 	resp, _ := args.Get(0).(*openrouter.CompletionResponse)
-	return resp, args.Error(1) //nolint:wrapcheck // mock pass-through
+	return resp, args.Error(1)
 }
 
 func (m *mockCompletionClient) CreateEmbeddings(ctx context.Context, orgID string, model string, inputs []string, opts ...openrouter.EmbeddingOption) ([][]float32, error) {
@@ -45,7 +45,7 @@ func (m *mockCompletionClient) CreateEmbeddings(ctx context.Context, orgID strin
 	}
 	args := m.Called(ctx, orgID, model, inputs, resolved)
 	v, _ := args.Get(0).([][]float32)
-	return v, args.Error(1) //nolint:wrapcheck // mock pass-through
+	return v, args.Error(1)
 }
 
 func newAssistantTextResponse(text string) *openrouter.CompletionResponse {

--- a/server/internal/productfeatures/features.go
+++ b/server/internal/productfeatures/features.go
@@ -15,6 +15,7 @@ const (
 	FeatureRBAC                  Feature = "rbac"
 	FeatureSessionCapture        Feature = "session_capture"
 	FeatureAuthzChallengeLogging Feature = "authz_challenge_logging"
+	FeatureWebhooks              Feature = "webhooks"
 )
 
 type FeatureCache struct {

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -42,3 +42,28 @@ FROM risk_results
 WHERE project_id = @project_id
   AND risk_policy_id = @risk_policy_id
 ORDER BY id;
+
+-- name: GetOutboxEntry :one
+-- Returns the ID of an outbox row; errors with pgx.ErrNoRows if deleted.
+SELECT id FROM outbox WHERE id = @id;
+
+-- name: GetOutboxRelayState :one
+-- Reads the relay tracking state for a single outbox row.
+SELECT
+    outbox_id,
+    processed_at,
+    noop,
+    dead_lettered,
+    svix_message_id,
+    attempts,
+    last_error
+FROM outbox_relays
+WHERE outbox_id = @outbox_id;
+
+-- name: SetOrgWebhookConfig :exec
+-- Sets the Svix app ID and webhooks_enabled flag on an organization.
+UPDATE organization_metadata
+SET svix_app_id = @svix_app_id,
+    webhooks_enabled = @webhooks_enabled,
+    updated_at = clock_timestamp()
+WHERE id = @organization_id;

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const countFunctionsAccess = `-- name: CountFunctionsAccess :one
@@ -42,6 +43,56 @@ func (q *Queries) CountOutboxEntriesByEventType(ctx context.Context, eventType s
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const getOutboxEntry = `-- name: GetOutboxEntry :one
+SELECT id FROM outbox WHERE id = $1
+`
+
+// Returns the ID of an outbox row; errors with pgx.ErrNoRows if deleted.
+func (q *Queries) GetOutboxEntry(ctx context.Context, id int64) (int64, error) {
+	row := q.db.QueryRow(ctx, getOutboxEntry, id)
+	err := row.Scan(&id)
+	return id, err
+}
+
+const getOutboxRelayState = `-- name: GetOutboxRelayState :one
+SELECT
+    outbox_id,
+    processed_at,
+    noop,
+    dead_lettered,
+    svix_message_id,
+    attempts,
+    last_error
+FROM outbox_relays
+WHERE outbox_id = $1
+`
+
+type GetOutboxRelayStateRow struct {
+	OutboxID      int64
+	ProcessedAt   pgtype.Timestamptz
+	Noop          bool
+	DeadLettered  bool
+	SvixMessageID pgtype.Text
+	Attempts      int32
+	LastError     pgtype.Text
+}
+
+// Reads the relay tracking state for a single outbox row.
+func (q *Queries) GetOutboxRelayState(ctx context.Context, outboxID int64) (GetOutboxRelayStateRow, error) {
+	row := q.db.QueryRow(ctx, getOutboxRelayState, outboxID)
+	var i GetOutboxRelayStateRow
+	err := row.Scan(
+		&i.OutboxID,
+		&i.ProcessedAt,
+		&i.Noop,
+		&i.DeadLettered,
+		&i.SvixMessageID,
+		&i.Attempts,
+		&i.LastError,
+	)
+	return i, err
 }
 
 const insertChatMessage = `-- name: InsertChatMessage :one
@@ -286,5 +337,25 @@ UPDATE deployments_functions SET memory_mib = NULL, scale = NULL WHERE deploymen
 // Simulates a legacy deployment by NULLing out memory_mib and scale, as if the row was inserted before these columns existed.
 func (q *Queries) ScrubDeploymentFunctionMachineSpecs(ctx context.Context, deploymentID uuid.UUID) error {
 	_, err := q.db.Exec(ctx, scrubDeploymentFunctionMachineSpecs, deploymentID)
+	return err
+}
+
+const setOrgWebhookConfig = `-- name: SetOrgWebhookConfig :exec
+UPDATE organization_metadata
+SET svix_app_id = $1,
+    webhooks_enabled = $2,
+    updated_at = clock_timestamp()
+WHERE id = $3
+`
+
+type SetOrgWebhookConfigParams struct {
+	SvixAppID       pgtype.Text
+	WebhooksEnabled pgtype.Bool
+	OrganizationID  string
+}
+
+// Sets the Svix app ID and webhooks_enabled flag on an organization.
+func (q *Queries) SetOrgWebhookConfig(ctx context.Context, arg SetOrgWebhookConfigParams) error {
+	_, err := q.db.Exec(ctx, setOrgWebhookConfig, arg.SvixAppID, arg.WebhooksEnabled, arg.OrganizationID)
 	return err
 }

--- a/server/internal/thirdparty/svix/stub.go
+++ b/server/internal/thirdparty/svix/stub.go
@@ -1,0 +1,140 @@
+package svix
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/inv"
+	"github.com/speakeasy-api/gram/server/internal/must"
+	"github.com/svix/svix-webhooks/go/models"
+)
+
+type stub struct {
+	logger *slog.Logger
+	mux    *http.ServeMux
+	apps   sync.Map
+}
+
+func NewStubServer(logger *slog.Logger) *httptest.Server {
+	var s stub
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/app", s.handleAppCreate)
+	mux.HandleFunc("POST /api/v1/app/{appID}/msg", s.handleMessageCreate)
+	mux.HandleFunc("POST /api/v1/auth/app-portal-access/{app_id}", s.handleAppPortalAccessCreate)
+
+	s.logger = logger
+	s.mux = mux
+
+	return httptest.NewServer(&s)
+}
+
+func (s *stub) handleAppCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	var inp models.ApplicationIn
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	getIfExists, _ := strconv.ParseBool(r.URL.Query().Get("get_if_exists"))
+	var out *models.ApplicationOut
+	var found bool
+	if inp.Uid == nil {
+		id := must.Value(uuid.NewV7()).String()
+		out = &models.ApplicationOut{
+			Id:           id,
+			Uid:          inp.Uid,
+			Name:         inp.Name,
+			RateLimit:    inp.RateLimit,
+			ThrottleRate: inp.ThrottleRate,
+			Metadata:     *conv.Default(inp.Metadata, new(map[string]string{})),
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}
+	} else {
+		if val, exists := s.apps.Load(*inp.Uid); exists {
+			found = true
+			if getIfExists {
+				out, _ = val.(*models.ApplicationOut)
+			} else {
+				http.Error(w, "application with this UID already exists", http.StatusConflict)
+				return
+			}
+		} else {
+			id := must.Value(uuid.NewV7()).String()
+			out = &models.ApplicationOut{
+				Id:           id,
+				Uid:          inp.Uid,
+				Name:         inp.Name,
+				RateLimit:    inp.RateLimit,
+				ThrottleRate: inp.ThrottleRate,
+				Metadata:     *conv.Default(inp.Metadata, new(map[string]string{})),
+				CreatedAt:    time.Now(),
+				UpdatedAt:    time.Now(),
+			}
+			s.apps.Store(*inp.Uid, out)
+		}
+	}
+
+	if err := inv.Check(
+		"well formed application result",
+		"result is not nil", out != nil && out.Id != "",
+	); err != nil {
+		http.Error(w, fmt.Sprintf("invalid application result: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(conv.Ternary(found, http.StatusOK, http.StatusCreated))
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		s.logger.ErrorContext(ctx, "failed to write stub svix response", attr.SlogError(err))
+		return
+	}
+}
+
+func (s *stub) handleMessageCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var inp models.MessageIn
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	id := must.Value(uuid.NewV7()).String()
+	out := models.MessageOut{
+		Id:        id,
+		Channels:  inp.Channels,
+		DeliverAt: inp.DeliverAt,
+		EventId:   inp.EventId,
+		EventType: inp.EventType,
+		Payload:   inp.Payload,
+		Tags:      inp.Tags,
+		Timestamp: time.Now(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		s.logger.ErrorContext(ctx, "failed to write stub svix response", attr.SlogError(err))
+		return
+	}
+}
+
+func (s *stub) handleAppPortalAccessCreate(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "svix app portal access unavailable in local development", http.StatusNotImplemented)
+}
+
+func (s *stub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}

--- a/server/internal/thirdparty/svix/svixtest/server.go
+++ b/server/internal/thirdparty/svix/svixtest/server.go
@@ -1,0 +1,164 @@
+package svixtest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/must"
+	"github.com/stretchr/testify/mock"
+	"github.com/svix/svix-webhooks/go/models"
+)
+
+// HTTPStatusError is a sentinel error that overrides the default 500 status
+// code returned by mock handlers. Return it from a mock method to simulate
+// a specific HTTP error code (e.g. 400, 403, 429).
+type HTTPStatusError struct {
+	Code int
+	Msg  string
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return http.StatusText(e.Code)
+}
+
+type MockServer struct {
+	mock.Mock
+	logger *slog.Logger
+	mux    *http.ServeMux
+	srv    *httptest.Server
+}
+
+func NewMockServer(logger *slog.Logger) *MockServer {
+	var m MockServer
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/app", m.handleGetOrCreateApp)
+	mux.HandleFunc("POST /api/v1/app/{appID}/msg", m.handleMessageCreate)
+	mux.HandleFunc("POST /api/v1/auth/app-portal-access/{appID}", m.handleAppPortalAccessCreate)
+
+	m.logger = logger
+	m.mux = mux
+	m.srv = httptest.NewServer(m.mux)
+
+	return &m
+}
+
+func (m *MockServer) GetOrCreateApp(ctx context.Context, inp *models.ApplicationIn) (_ *models.ApplicationOut, created bool, err error) {
+	args := m.Called(ctx, inp)
+
+	app, _ := args.Get(0).(*models.ApplicationOut)
+	return app, args.Bool(1), args.Error(2)
+}
+
+func (m *MockServer) handleGetOrCreateApp(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var inp models.ApplicationIn
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	out, created, err := m.GetOrCreateApp(ctx, &inp)
+	if err != nil {
+		code := http.StatusInternalServerError
+		var httpErr *HTTPStatusError
+		if errors.As(err, &httpErr) {
+			code = httpErr.Code
+		}
+		http.Error(w, err.Error(), code)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(conv.Ternary(created, http.StatusCreated, http.StatusOK))
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		m.logger.ErrorContext(ctx, "failed to write mock svix response", attr.SlogError(err))
+		return
+	}
+}
+
+func (m *MockServer) CreateMessage(ctx context.Context, inp *models.MessageIn) (*models.MessageOut, error) {
+	args := m.Called(ctx, inp)
+
+	msg, _ := args.Get(0).(*models.MessageOut)
+	return msg, args.Error(1)
+}
+
+func (m *MockServer) handleMessageCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var inp models.MessageIn
+	if err := json.NewDecoder(r.Body).Decode(&inp); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	out, err := m.CreateMessage(ctx, &inp)
+	if err != nil {
+		code := http.StatusInternalServerError
+		var httpErr *HTTPStatusError
+		if errors.As(err, &httpErr) {
+			code = httpErr.Code
+		}
+		http.Error(w, err.Error(), code)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		m.logger.ErrorContext(ctx, "failed to write mock svix response", attr.SlogError(err))
+		return
+	}
+}
+
+func (m *MockServer) CreateAppPortalSession(ctx context.Context, appID string) (*models.AppPortalAccessOut, error) {
+	args := m.Called(ctx, appID)
+
+	session, _ := args.Get(0).(*models.AppPortalAccessOut)
+	return session, args.Error(1)
+}
+
+func (m *MockServer) handleAppPortalAccessCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	appID := r.PathValue("appID")
+
+	out, err := m.CreateAppPortalSession(ctx, appID)
+	if err != nil {
+		code := http.StatusInternalServerError
+		var httpErr *HTTPStatusError
+		if errors.As(err, &httpErr) {
+			code = httpErr.Code
+		}
+		http.Error(w, err.Error(), code)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		m.logger.ErrorContext(ctx, "failed to write mock svix response", attr.SlogError(err))
+		return
+	}
+}
+
+func (m *MockServer) URL() *url.URL {
+	return must.Value(url.Parse(m.srv.URL))
+}
+
+func (m *MockServer) Close() {
+	m.srv.Close()
+}

--- a/server/internal/thirdparty/svix/svixtest/server_test.go
+++ b/server/internal/thirdparty/svix/svixtest/server_test.go
@@ -1,0 +1,215 @@
+package svixtest_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	svix "github.com/svix/svix-webhooks/go"
+	"github.com/svix/svix-webhooks/go/models"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/svix/svixtest"
+)
+
+func newSDKClient(t *testing.T, serverURL *url.URL) *svix.Svix {
+	t.Helper()
+
+	noRetries := []time.Duration{}
+	client, err := svix.New("test-token", &svix.SvixOptions{
+		ServerUrl:     serverURL,
+		RetrySchedule: &noRetries,
+	})
+	require.NoError(t, err, "create svix sdk client")
+	return client
+}
+
+func TestMockServer_GetOrCreateApp_Created(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	srv := svixtest.NewMockServer(logger)
+	t.Cleanup(srv.Close)
+
+	uid := "app-uid-1"
+	wantOut := &models.ApplicationOut{
+		Id:        "app_123",
+		Uid:       &uid,
+		Name:      "test app",
+		Metadata:  map[string]string{},
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+		UpdatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+
+	srv.On("GetOrCreateApp", mock.Anything, mock.MatchedBy(func(in *models.ApplicationIn) bool {
+		return in != nil && in.Name == "test app" && in.Uid != nil && *in.Uid == uid
+	})).Return(wantOut, true, nil).Once()
+
+	client := newSDKClient(t, srv.URL())
+
+	got, err := client.Application.GetOrCreate(context.Background(), models.ApplicationIn{
+		Name: "test app",
+		Uid:  &uid,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, wantOut.Id, got.Id)
+	require.Equal(t, wantOut.Name, got.Name)
+	require.NotNil(t, got.Uid)
+	require.Equal(t, uid, *got.Uid)
+
+	srv.AssertExpectations(t)
+}
+
+func TestMockServer_GetOrCreateApp_Existing(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	srv := svixtest.NewMockServer(logger)
+	t.Cleanup(srv.Close)
+
+	wantOut := &models.ApplicationOut{
+		Id:        "app_existing",
+		Name:      "existing",
+		Metadata:  map[string]string{},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	srv.On("GetOrCreateApp", mock.Anything, mock.AnythingOfType("*models.ApplicationIn")).
+		Return(wantOut, false, nil).Once()
+
+	client := newSDKClient(t, srv.URL())
+
+	got, err := client.Application.GetOrCreate(context.Background(), models.ApplicationIn{
+		Name: "existing",
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "app_existing", got.Id)
+
+	srv.AssertExpectations(t)
+}
+
+func TestMockServer_GetOrCreateApp_Error(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	srv := svixtest.NewMockServer(logger)
+	t.Cleanup(srv.Close)
+
+	srv.On("GetOrCreateApp", mock.Anything, mock.AnythingOfType("*models.ApplicationIn")).
+		Return((*models.ApplicationOut)(nil), false, errors.New("boom")).Once()
+
+	client := newSDKClient(t, srv.URL())
+
+	_, err := client.Application.GetOrCreate(context.Background(), models.ApplicationIn{
+		Name: "bad",
+	}, nil)
+	require.Error(t, err)
+
+	var sErr *svix.Error
+	require.ErrorAs(t, err, &sErr)
+	require.Equal(t, http.StatusInternalServerError, sErr.Status())
+
+	srv.AssertExpectations(t)
+}
+
+func TestMockServer_CreateMessage_Success(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	srv := svixtest.NewMockServer(logger)
+	t.Cleanup(srv.Close)
+
+	eventID := "evt_1"
+	wantOut := &models.MessageOut{
+		Id:        "msg_123",
+		EventId:   &eventID,
+		EventType: "user.created",
+		Payload:   map[string]any{"hello": "world"},
+		Timestamp: time.Now().UTC().Truncate(time.Second),
+	}
+
+	srv.On("CreateMessage", mock.Anything, mock.MatchedBy(func(in *models.MessageIn) bool {
+		return in != nil && in.EventType == "user.created" &&
+			in.EventId != nil && *in.EventId == eventID &&
+			in.Payload["hello"] == "world"
+	})).Return(wantOut, nil).Once()
+
+	client := newSDKClient(t, srv.URL())
+
+	got, err := client.Message.Create(context.Background(), "app_123", models.MessageIn{
+		EventId:   &eventID,
+		EventType: "user.created",
+		Payload:   map[string]any{"hello": "world"},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "msg_123", got.Id)
+	require.Equal(t, "user.created", got.EventType)
+
+	srv.AssertExpectations(t)
+}
+
+func TestMockServer_CreateMessage_Error(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	srv := svixtest.NewMockServer(logger)
+	t.Cleanup(srv.Close)
+
+	srv.On("CreateMessage", mock.Anything, mock.AnythingOfType("*models.MessageIn")).
+		Return((*models.MessageOut)(nil), errors.New("publish failed")).Once()
+
+	client := newSDKClient(t, srv.URL())
+
+	_, err := client.Message.Create(context.Background(), "app_123", models.MessageIn{
+		EventType: "user.deleted",
+		Payload:   map[string]any{},
+	}, nil)
+	require.Error(t, err)
+
+	var sErr *svix.Error
+	require.ErrorAs(t, err, &sErr)
+	require.Equal(t, http.StatusInternalServerError, sErr.Status())
+
+	srv.AssertExpectations(t)
+}
+
+func TestMockServer_URL(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	srv := svixtest.NewMockServer(logger)
+	t.Cleanup(srv.Close)
+
+	require.NotEmpty(t, srv.URL())
+	require.NotEmpty(t, srv.URL().String())
+}
+
+func TestMockServer_Close_StopsServer(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	srv := svixtest.NewMockServer(logger)
+
+	u := srv.URL()
+	srv.Close()
+
+	// After close, requests to the URL should fail.
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, u.JoinPath("/api/v1/app").String(), http.NoBody)
+	require.NoError(t, err)
+
+	httpClient := &http.Client{Timeout: 500 * time.Millisecond}
+	resp, err := httpClient.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err, "expected request after Close to fail")
+}


### PR DESCRIPTION
This change introduces a temporal workflow to dispatch webhooks from outbox events. The workflow runs continuously with brief sleeps between polling the outbox table in the database. If for any reason this workflow is terminated abruptly, a "watchdog" schedule is also present to restart it.