### PR TITLE
fix(dashboard): use moonshine Badge for OAuth Required badge

### DIFF
--- a/client/dashboard/src/components/mcp/MCPCard.tsx
+++ b/client/dashboard/src/components/mcp/MCPCard.tsx
@@ -21,7 +21,7 @@ import {
   useExternalMcpOAuthConfigStatus,
 } from "../sources/sources-hooks";
 import { ToolCollectionBadge } from "../tool-collection-badge";
-import { Badge } from "../ui/badge";
+import { Badge } from "@speakeasy-api/moonshine";
 
 export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
   const routes = useRoutes();
@@ -65,12 +65,11 @@ export function MCPCard({ toolset }: { toolset: ToolsetEntry }) {
       overlay={
         oauthStatus === "required-unconfigured" && (
           <div className="absolute bottom-3.5 left-1/2 z-10 -translate-x-1/2">
-            <Badge
-              variant="outline"
-              className="border-warning-foreground bg-warning text-warning-foreground text-xs backdrop-blur-sm"
-            >
-              <AlertTriangleIcon />
-              OAuth Required
+            <Badge variant="warning">
+              <Badge.LeftIcon>
+                <AlertTriangleIcon />
+              </Badge.LeftIcon>
+              <Badge.Text>OAuth Required</Badge.Text>
             </Badge>
           </div>
         )

--- a/client/dashboard/src/components/mcp/MCPTableRow.tsx
+++ b/client/dashboard/src/components/mcp/MCPTableRow.tsx
@@ -15,7 +15,7 @@ import {
   useExternalMcpOAuthConfigStatus,
 } from "../sources/sources-hooks";
 import { ToolCollectionBadge } from "../tool-collection-badge";
-import { Badge } from "../ui/badge";
+import { Badge } from "@speakeasy-api/moonshine";
 
 export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
   const routes = useRoutes();
@@ -80,12 +80,11 @@ export function MCPTableRow({ toolset }: { toolset: ToolsetEntry }) {
             {toolset.name}
           </Type>
           {oauthStatus === "required-unconfigured" && (
-            <Badge
-              variant="outline"
-              className="border-warning-foreground bg-warning text-warning-foreground text-xs backdrop-blur-sm"
-            >
-              <AlertTriangleIcon />
-              OAuth Required
+            <Badge variant="warning">
+              <Badge.LeftIcon>
+                <AlertTriangleIcon />
+              </Badge.LeftIcon>
+              <Badge.Text>OAuth Required</Badge.Text>
             </Badge>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Replaces local `Badge` (variant `outline` + manual warning color overrides) with moonshine `Badge` `variant="warning"` in MCP card and table row

<img width="1290" height="408" alt="CleanShot 2026-05-12 at 10 35 33@2x" src="https://github.com/user-attachments/assets/6ae76b0b-55f3-4187-b406-fa8ca2205533" />


## Test plan
- [ ] Toggle dark mode, navigate to MCP servers page with an OAuth-required server
- [ ] Verify badge is no longer bright orange, uses proper moonshine warning styling