### PR TITLE
feat(dashboard): gate Create Assistant CTAs on project:write + mcp:write

### DIFF
--- a/.changeset/disable-create-assistant-without-scopes.md
+++ b/.changeset/disable-create-assistant-without-scopes.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Disable Create Assistant buttons in the dashboard when the user lacks the permissions needed to create one, with a tooltip explaining why.

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -44,12 +44,19 @@ function AssistantsEmptyState({ onCreate }: { onCreate: () => void }) {
       <Type small muted className="mb-4 max-w-md text-center">
         Create an assistant to wire a model up to your MCP servers.
       </Type>
-      <Button onClick={onCreate}>
-        <Button.LeftIcon>
-          <Plus className="h-4 w-4" />
-        </Button.LeftIcon>
-        <Button.Text>Create Assistant</Button.Text>
-      </Button>
+      <RequireScope
+        scope={["project:write", "mcp:write"]}
+        all
+        level="component"
+        reason="You don't have permission to create assistants."
+      >
+        <Button onClick={onCreate}>
+          <Button.LeftIcon>
+            <Plus className="h-4 w-4" />
+          </Button.LeftIcon>
+          <Button.Text>Create Assistant</Button.Text>
+        </Button>
+      </RequireScope>
     </div>
   );
 }
@@ -75,12 +82,19 @@ export default function AssistantsIndex() {
           Configure model, instructions, and MCP servers for each assistant.
         </Page.Section.Description>
         <Page.Section.CTA>
-          <Button onClick={() => routes.assistants.newAssistant.goTo()}>
-            <Button.LeftIcon>
-              <Plus className="h-4 w-4" />
-            </Button.LeftIcon>
-            <Button.Text>New Assistant</Button.Text>
-          </Button>
+          <RequireScope
+            scope={["project:write", "mcp:write"]}
+            all
+            level="component"
+            reason="You don't have permission to create assistants."
+          >
+            <Button onClick={() => routes.assistants.newAssistant.goTo()}>
+              <Button.LeftIcon>
+                <Plus className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>New Assistant</Button.Text>
+            </Button>
+          </RequireScope>
         </Page.Section.CTA>
         <Page.Section.Body>
           {isLoading ? (

--- a/client/dashboard/src/pages/slackapp/SlackApp.tsx
+++ b/client/dashboard/src/pages/slackapp/SlackApp.tsx
@@ -61,12 +61,19 @@ function SlackAppsEmptyState({ onCreate }: { onCreate: () => void }) {
         Create an assistant to let your team interact with Gram MCP servers
         directly.
       </Type>
-      <Button onClick={onCreate}>
-        <Button.LeftIcon>
-          <Icon name="plus" className="h-4 w-4" />
-        </Button.LeftIcon>
-        <Button.Text>Create new Assistant</Button.Text>
-      </Button>
+      <RequireScope
+        scope={["project:write", "mcp:write"]}
+        all
+        level="component"
+        reason="You don't have permission to create assistants."
+      >
+        <Button onClick={onCreate}>
+          <Button.LeftIcon>
+            <Icon name="plus" className="h-4 w-4" />
+          </Button.LeftIcon>
+          <Button.Text>Create new Assistant</Button.Text>
+        </Button>
+      </RequireScope>
     </div>
   );
 }
@@ -264,12 +271,19 @@ function CreateSlackAppDialog({
           <Button variant="tertiary" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
-          <Button
-            onClick={handleCreate}
-            disabled={!isValid || createMutation.isPending}
+          <RequireScope
+            scope={["project:write", "mcp:write"]}
+            all
+            level="component"
+            reason="You don't have permission to create assistants."
           >
-            {createMutation.isPending ? "Creating..." : "Create Assistant"}
-          </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!isValid || createMutation.isPending}
+            >
+              {createMutation.isPending ? "Creating..." : "Create Assistant"}
+            </Button>
+          </RequireScope>
         </Dialog.Footer>
       </Dialog.Content>
     </Dialog>
@@ -313,12 +327,19 @@ function SlackAppsInner() {
         </Page.Section.Description>
         <Page.Section.CTA>
           {apps.length > 0 && (
-            <Button onClick={() => setDialogOpen(true)}>
-              <Button.LeftIcon>
-                <Icon name="plus" className="h-4 w-4" />
-              </Button.LeftIcon>
-              <Button.Text>Create new Assistant</Button.Text>
-            </Button>
+            <RequireScope
+              scope={["project:write", "mcp:write"]}
+              all
+              level="component"
+              reason="You don't have permission to create assistants."
+            >
+              <Button onClick={() => setDialogOpen(true)}>
+                <Button.LeftIcon>
+                  <Icon name="plus" className="h-4 w-4" />
+                </Button.LeftIcon>
+                <Button.Text>Create new Assistant</Button.Text>
+              </Button>
+            </RequireScope>
           )}
         </Page.Section.CTA>
         <Page.Section.Body>


### PR DESCRIPTION
## Summary

- Disable the Create Assistant / New Assistant CTAs on the assistants index and Slack apps index when the current user is missing either `project:write` or `mcp:write` (both are needed to create an assistant end-to-end).
- The Slack apps create-dialog confirm button is gated for the same reason.
- Buttons render in a tooltip-explained disabled state via `RequireScope level="component" all` so users can't start a flow they can't finish.

Closes [AGE-2282](https://linear.app/speakeasy/issue/AGE-2282/disable-create-assistant-button-when-user-lacks-both-projectwrite-and).

✻ Clauded...