### PR TITLE
mig: otel forwarding table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2050,6 +2050,35 @@ CREATE TABLE IF NOT EXISTS hooks_server_name_overrides (
 
 CREATE INDEX IF NOT EXISTS hooks_server_name_overrides_project_id_display_name_idx ON hooks_server_name_overrides(project_id, display_name);
 
+-- OTEL forwarding configs: forward raw OTLP payloads received on
+-- /rpc/hooks.otel/v1/* to a customer-owned endpoint. project_id is nullable
+-- because v1 ships as org-wide config; the column is retained so future UX
+-- can add per-project overrides without a schema change.
+CREATE TABLE IF NOT EXISTS otel_forwarding_configs (
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  endpoint_url TEXT NOT NULL,
+  headers_encrypted TEXT,
+  organization_id TEXT NOT NULL,
+  project_id uuid,
+  enabled boolean NOT NULL DEFAULT true,
+  id uuid PRIMARY KEY DEFAULT generate_uuidv7(),
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT otel_forwarding_configs_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+-- Only one org-wide row per org
+CREATE UNIQUE INDEX IF NOT EXISTS otel_forwarding_configs_org_key
+  ON otel_forwarding_configs (organization_id)
+  WHERE project_id IS NULL AND deleted IS FALSE;
+
+-- Only one per-project row per (org, project)
+CREATE UNIQUE INDEX IF NOT EXISTS otel_forwarding_configs_org_project_key
+  ON otel_forwarding_configs (organization_id, project_id)
+  WHERE project_id IS NOT NULL AND deleted IS FALSE;
+
 CREATE TABLE IF NOT EXISTS principal_grants (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -854,6 +854,19 @@ type OrganizationUserRelationship struct {
 	Deleted            bool
 }
 
+type OtelForwardingConfig struct {
+	CreatedAt        pgtype.Timestamptz
+	DeletedAt        pgtype.Timestamptz
+	UpdatedAt        pgtype.Timestamptz
+	EndpointUrl      string
+	HeadersEncrypted pgtype.Text
+	OrganizationID   string
+	ProjectID        uuid.NullUUID
+	Enabled          bool
+	ID               uuid.UUID
+	Deleted          bool
+}
+
 type Outbox struct {
 	ID             int64
 	PublicID       uuid.UUID

--- a/server/migrations/20260512175020_otel-forwarding-configs.sql
+++ b/server/migrations/20260512175020_otel-forwarding-configs.sql
@@ -1,0 +1,19 @@
+-- Create "otel_forwarding_configs" table
+CREATE TABLE "otel_forwarding_configs" (
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "endpoint_url" text NOT NULL,
+  "headers_encrypted" text NULL,
+  "organization_id" text NOT NULL,
+  "project_id" uuid NULL,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "otel_forwarding_configs_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "otel_forwarding_configs_org_key" to table: "otel_forwarding_configs"
+CREATE UNIQUE INDEX "otel_forwarding_configs_org_key" ON "otel_forwarding_configs" ("organization_id") WHERE ((project_id IS NULL) AND (deleted IS FALSE));
+-- Create index "otel_forwarding_configs_org_project_key" to table: "otel_forwarding_configs"
+CREATE UNIQUE INDEX "otel_forwarding_configs_org_project_key" ON "otel_forwarding_configs" ("organization_id", "project_id") WHERE ((project_id IS NOT NULL) AND (deleted IS FALSE));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:qb2WBUgWrvZKHmbFf6it4xxtLi1YnyHYhsrwm+xul9g=
+h1:8NU89Qb3H36IRgE+FeMB0MGjzbIiBaT0Fu21f1BQZSc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -168,3 +168,4 @@ h1:qb2WBUgWrvZKHmbFf6it4xxtLi1YnyHYhsrwm+xul9g=
 20260512093032_add-org-user-relationship-workos-id-column.sql h1:bfMGYN8vrqG3h3pncuHYh+Efh7Ud4FNhSiH0nswQm0Y=
 20260512103400_add-prompt-injection-rules.sql h1:X5zqk2CoHY9IrOJemHa+UvmRsmrHNcBO01wFfo2+H2U=
 20260512155737_add_workos_user_sync_metadata.sql h1:4VI2g6/r9x2TJyj3A9KRooa6pUi6zMUhrYNyaiKs/IQ=
+20260512175020_otel-forwarding-configs.sql h1:xmDFO0MH0Eyzrym5R1lV+0KTZeQwqMYzByhtmqUZSkM=


### PR DESCRIPTION
Schema and migrations split off `chase/otel-forwarding` so the database changes can land independently.