### PR TITLE
feat(dashboard): track sso and directory sync interest

### DIFF
--- a/.changeset/identity-sso-tracking.md
+++ b/.changeset/identity-sso-tracking.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Rename the org "Security" tab to "Identity" and refresh the SSO / Directory Sync cards: drop the SAML-specific branding (Single Sign-On / SSO instead of SAML SSO), replace the hover popover with a tooltip on a fully clickable Configure button, and capture an `identity_provider_interest` PostHog event on click so the team is pinged in Slack when a customer expresses interest. Clicking now confirms with a success toast.

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -8,15 +8,19 @@ import {
 } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { Type } from "@/components/ui/type";
+import { useSessionData } from "@/contexts/Auth";
+import { useTelemetry } from "@/contexts/Telemetry";
 import { Button } from "@speakeasy-api/moonshine";
 import { FolderSync, Lock } from "lucide-react";
 import { useRef, useState } from "react";
 
 const CONTACT_SALES_URL = "https://www.speakeasy.com/book-demo";
-const UPSELL_COPY =
-  "SAML SSO is only available on Enterprise plans. Upgrade to get started.";
+const UPSELL_COPY = "Contact our team to setup SSO and Directory Sync";
+
+type IdentitySectionId = "sso" | "directory_sync";
 
 type IdentityCardProps = {
+  sectionId: IdentitySectionId;
   heading: string;
   description: string;
   providerIcon: React.ReactNode;
@@ -27,9 +31,26 @@ type IdentityCardProps = {
   children?: React.ReactNode;
 };
 
-function ConfigureButton() {
+function useIdentityInterestCapture(sectionId: IdentitySectionId) {
+  const telemetry = useTelemetry();
+  const { session } = useSessionData();
+
+  return (action: "configure_clicked" | "contact_sales_clicked") => {
+    telemetry.capture("identity_provider_interest", {
+      section: sectionId,
+      action,
+      email: session?.user.email ?? "",
+      organization_id: session?.organization?.id ?? "",
+      organization_name: session?.organization?.name ?? "",
+      organization_slug: session?.organization?.slug ?? "",
+    });
+  };
+}
+
+function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
   const [open, setOpen] = useState(false);
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const captureInterest = useIdentityInterestCapture(sectionId);
 
   const show = () => {
     if (hideTimeout.current) clearTimeout(hideTimeout.current);
@@ -53,7 +74,10 @@ function ConfigureButton() {
           onMouseLeave={scheduleHide}
           onFocus={show}
           onBlur={scheduleHide}
-          onClick={(e) => e.preventDefault()}
+          onClick={(e) => {
+            e.preventDefault();
+            captureInterest("configure_clicked");
+          }}
         >
           Configure
         </Button>
@@ -74,6 +98,7 @@ function ConfigureButton() {
               href={CONTACT_SALES_URL}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => captureInterest("contact_sales_clicked")}
             >
               Contact sales
             </a>
@@ -85,6 +110,7 @@ function ConfigureButton() {
 }
 
 function IdentitySection({
+  sectionId,
   heading,
   description,
   providerIcon,
@@ -116,7 +142,7 @@ function IdentitySection({
                 {providerSubtitle}
               </Type>
             </div>
-            <ConfigureButton />
+            <ConfigureButton sectionId={sectionId} />
           </div>
           {children}
         </div>
@@ -168,21 +194,23 @@ export default function OrgIdentity() {
 function OrgIdentityInner() {
   return (
     <div className="flex flex-col gap-6">
-      <Heading variant="h4">Security</Heading>
+      <Heading variant="h4">Identity</Heading>
       <div className="flex flex-col gap-6">
         <IdentitySection
-          heading="SAML Single Sign-On"
-          description="Set up SAML Single Sign-On (SSO) to allow your team to sign in to Speakeasy with your identity provider."
+          sectionId="sso"
+          heading="Single Sign-On"
+          description="Set up Single Sign-On (SSO) to allow your team to sign in to Speakeasy with your identity provider."
           providerIcon={<Lock className="text-muted-foreground h-5 w-5" />}
-          providerTitle="SAML"
+          providerTitle="SSO"
           providerSubtitle="Choose an identity provider to get started."
-          learnMoreText="Learn more about SAML SSO"
+          learnMoreText="Learn more about SSO"
           learnMoreHref="https://www.speakeasy.com/docs"
         >
           <RequireSsoRow />
         </IdentitySection>
 
         <IdentitySection
+          sectionId="directory_sync"
           heading="Directory Sync"
           description="Automatically provision and deprovision users from your identity provider."
           providerIcon={

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -13,6 +13,7 @@ import { useTelemetry } from "@/contexts/Telemetry";
 import { Button } from "@speakeasy-api/moonshine";
 import { FolderSync, Lock } from "lucide-react";
 import { useRef, useState } from "react";
+import { toast } from "sonner";
 
 const CONTACT_SALES_URL = "https://www.speakeasy.com/book-demo";
 const UPSELL_COPY = "Contact our team to setup SSO and Directory Sync";
@@ -77,6 +78,9 @@ function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
           onClick={(e) => {
             e.preventDefault();
             captureInterest("configure_clicked");
+            toast.success(
+              "Our team has been contacted to enable SSO and Directory Sync",
+            );
           }}
         >
           Configure

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -1,31 +1,22 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
+import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { useSessionData } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Button } from "@speakeasy-api/moonshine";
 import { FolderSync, Lock } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
-const CONTACT_SALES_URL = "https://www.speakeasy.com/book-demo";
 const UPSELL_COPY = "Contact our team to setup SSO and Directory Sync";
 
 type IdentitySectionId = "sso" | "directory_sync";
 
 type IdentityCardProps = {
   sectionId: IdentitySectionId;
-  openSectionId: IdentitySectionId | null;
-  setOpenSectionId: React.Dispatch<
-    React.SetStateAction<IdentitySectionId | null>
-  >;
   heading: string;
   description: string;
   providerIcon: React.ReactNode;
@@ -40,10 +31,10 @@ function useIdentityInterestCapture(sectionId: IdentitySectionId) {
   const telemetry = useTelemetry();
   const { session } = useSessionData();
 
-  return (action: "configure_clicked" | "contact_sales_clicked") => {
+  return () => {
     telemetry.capture("identity_provider_interest", {
       section: sectionId,
-      action,
+      action: "configure_clicked",
       email: session?.user.email ?? "",
       organization_id: session?.organization?.id ?? "",
       organization_name: session?.organization?.name ?? "",
@@ -52,92 +43,29 @@ function useIdentityInterestCapture(sectionId: IdentitySectionId) {
   };
 }
 
-function ConfigureButton({
-  sectionId,
-  openSectionId,
-  setOpenSectionId,
-}: {
-  sectionId: IdentitySectionId;
-  openSectionId: IdentitySectionId | null;
-  setOpenSectionId: React.Dispatch<
-    React.SetStateAction<IdentitySectionId | null>
-  >;
-}) {
-  const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
   const captureInterest = useIdentityInterestCapture(sectionId);
-  const open = openSectionId === sectionId;
-
-  const show = () => {
-    if (hideTimeout.current) clearTimeout(hideTimeout.current);
-    setOpenSectionId(sectionId);
-  };
-
-  const scheduleHide = () => {
-    if (hideTimeout.current) clearTimeout(hideTimeout.current);
-    hideTimeout.current = setTimeout(() => {
-      setOpenSectionId((prev) => (prev === sectionId ? null : prev));
-    }, 150);
-  };
 
   return (
-    <Popover
-      open={open}
-      onOpenChange={(next) => {
-        if (!next && openSectionId === sectionId) setOpenSectionId(null);
-      }}
-    >
-      <PopoverTrigger asChild>
-        <Button
-          variant="secondary"
-          size="sm"
-          aria-disabled="true"
-          className="cursor-not-allowed opacity-60"
-          onMouseEnter={show}
-          onMouseLeave={scheduleHide}
-          onFocus={show}
-          onBlur={scheduleHide}
-          onClick={(e) => {
-            e.preventDefault();
-            captureInterest("configure_clicked");
-            toast.success(
-              "Our team has been contacted to enable SSO and Directory Sync",
-            );
-          }}
-        >
-          Configure
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        side="top"
-        align="end"
-        sideOffset={8}
-        className="w-72"
-        onMouseEnter={show}
-        onMouseLeave={scheduleHide}
-        onOpenAutoFocus={(e) => e.preventDefault()}
+    <SimpleTooltip tooltip={UPSELL_COPY}>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => {
+          captureInterest();
+          toast.success(
+            "Our team has been contacted to enable SSO and Directory Sync",
+          );
+        }}
       >
-        <div className="flex flex-col items-center gap-3 text-center">
-          <Type small>{UPSELL_COPY}</Type>
-          <Button variant="brand" size="sm" asChild>
-            <a
-              href={CONTACT_SALES_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => captureInterest("contact_sales_clicked")}
-            >
-              Talk To Us
-            </a>
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+        Configure
+      </Button>
+    </SimpleTooltip>
   );
 }
 
 function IdentitySection({
   sectionId,
-  openSectionId,
-  setOpenSectionId,
   heading,
   description,
   providerIcon,
@@ -169,11 +97,7 @@ function IdentitySection({
                 {providerSubtitle}
               </Type>
             </div>
-            <ConfigureButton
-              sectionId={sectionId}
-              openSectionId={openSectionId}
-              setOpenSectionId={setOpenSectionId}
-            />
+            <ConfigureButton sectionId={sectionId} />
           </div>
           {children}
         </div>
@@ -223,18 +147,12 @@ export default function OrgIdentity() {
 }
 
 function OrgIdentityInner() {
-  const [openSectionId, setOpenSectionId] = useState<IdentitySectionId | null>(
-    null,
-  );
-
   return (
     <div className="flex flex-col gap-6">
       <Heading variant="h4">Identity</Heading>
       <div className="flex flex-col gap-6">
         <IdentitySection
           sectionId="sso"
-          openSectionId={openSectionId}
-          setOpenSectionId={setOpenSectionId}
           heading="Single Sign-On"
           description="Set up Single Sign-On (SSO) to allow your team to sign in to Speakeasy with your identity provider."
           providerIcon={<Lock className="text-muted-foreground h-5 w-5" />}
@@ -248,8 +166,6 @@ function OrgIdentityInner() {
 
         <IdentitySection
           sectionId="directory_sync"
-          openSectionId={openSectionId}
-          setOpenSectionId={setOpenSectionId}
           heading="Directory Sync"
           description="Automatically provision and deprovision users from your identity provider."
           providerIcon={

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -22,6 +22,10 @@ type IdentitySectionId = "sso" | "directory_sync";
 
 type IdentityCardProps = {
   sectionId: IdentitySectionId;
+  openSectionId: IdentitySectionId | null;
+  setOpenSectionId: React.Dispatch<
+    React.SetStateAction<IdentitySectionId | null>
+  >;
   heading: string;
   description: string;
   providerIcon: React.ReactNode;
@@ -48,23 +52,40 @@ function useIdentityInterestCapture(sectionId: IdentitySectionId) {
   };
 }
 
-function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
-  const [open, setOpen] = useState(false);
+function ConfigureButton({
+  sectionId,
+  openSectionId,
+  setOpenSectionId,
+}: {
+  sectionId: IdentitySectionId;
+  openSectionId: IdentitySectionId | null;
+  setOpenSectionId: React.Dispatch<
+    React.SetStateAction<IdentitySectionId | null>
+  >;
+}) {
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const captureInterest = useIdentityInterestCapture(sectionId);
+  const open = openSectionId === sectionId;
 
   const show = () => {
     if (hideTimeout.current) clearTimeout(hideTimeout.current);
-    setOpen(true);
+    setOpenSectionId(sectionId);
   };
 
   const scheduleHide = () => {
     if (hideTimeout.current) clearTimeout(hideTimeout.current);
-    hideTimeout.current = setTimeout(() => setOpen(false), 150);
+    hideTimeout.current = setTimeout(() => {
+      setOpenSectionId((prev) => (prev === sectionId ? null : prev));
+    }, 150);
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && openSectionId === sectionId) setOpenSectionId(null);
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           variant="secondary"
@@ -104,7 +125,7 @@ function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
               rel="noopener noreferrer"
               onClick={() => captureInterest("contact_sales_clicked")}
             >
-              Contact sales
+              Talk To Us
             </a>
           </Button>
         </div>
@@ -115,6 +136,8 @@ function ConfigureButton({ sectionId }: { sectionId: IdentitySectionId }) {
 
 function IdentitySection({
   sectionId,
+  openSectionId,
+  setOpenSectionId,
   heading,
   description,
   providerIcon,
@@ -146,7 +169,11 @@ function IdentitySection({
                 {providerSubtitle}
               </Type>
             </div>
-            <ConfigureButton sectionId={sectionId} />
+            <ConfigureButton
+              sectionId={sectionId}
+              openSectionId={openSectionId}
+              setOpenSectionId={setOpenSectionId}
+            />
           </div>
           {children}
         </div>
@@ -196,12 +223,18 @@ export default function OrgIdentity() {
 }
 
 function OrgIdentityInner() {
+  const [openSectionId, setOpenSectionId] = useState<IdentitySectionId | null>(
+    null,
+  );
+
   return (
     <div className="flex flex-col gap-6">
       <Heading variant="h4">Identity</Heading>
       <div className="flex flex-col gap-6">
         <IdentitySection
           sectionId="sso"
+          openSectionId={openSectionId}
+          setOpenSectionId={setOpenSectionId}
           heading="Single Sign-On"
           description="Set up Single Sign-On (SSO) to allow your team to sign in to Speakeasy with your identity provider."
           providerIcon={<Lock className="text-muted-foreground h-5 w-5" />}
@@ -215,6 +248,8 @@ function OrgIdentityInner() {
 
         <IdentitySection
           sectionId="directory_sync"
+          openSectionId={openSectionId}
+          setOpenSectionId={setOpenSectionId}
           heading="Directory Sync"
           description="Automatically provision and deprovision users from your identity provider."
           providerIcon={


### PR DESCRIPTION
## Summary

- Renames the org "Security" tab to **Identity** and removes the SAML branding from the SSO card (now just "Single Sign-On" / "SSO"), since the underlying offering covers more than SAML.
- Updates the Configure-button upsell popover to read: _"Contact our team to setup SSO and Directory Sync"_.
- Wires up a PostHog `identity_provider_interest` event captured when users click **Configure** or **Contact sales** on either the SSO or Directory Sync card. A matching PostHog destination (`019e1d58-da2f-0000-76ab-30654992997a`, enabled) forwards these events to `#gram-support-feed` so the team gets a Slack ping for every enterprise-identity signal.

## Event payload

`identity_provider_interest` carries `section` (`sso` | `directory_sync`), `action` (`configure_clicked` | `contact_sales_clicked`), and org/user context (`email`, `organization_id`, `organization_name`, `organization_slug`).

## Test plan

- [ ] Visit the org **Identity** tab — confirm heading reads "Identity", first card is "Single Sign-On" with provider title "SSO", popover copy says "Contact our team to setup SSO and Directory Sync"
- [ ] Click Configure on the SSO card → confirm `identity_provider_interest` event in PostHog with `section=sso`, `action=configure_clicked`
- [ ] Click Configure on the Directory Sync card → confirm event with `section=directory_sync`
- [ ] Click Contact sales in either popover → confirm `action=contact_sales_clicked` event
- [ ] Confirm Slack message arrives in `#gram-support-feed`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/speakeasy-api/gram/pull/2755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->