### PR TITLE
fix: quiet false-positive Temporal workflow failure signals

### DIFF
--- a/.changeset/age-2285-quiet-temporal-failure-signals.md
+++ b/.changeset/age-2285-quiet-temporal-failure-signals.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+quiet false-positive Temporal workflow failure alerts: benign `ContinueAsNewError` and `CanceledError` log at Info, and `VerifyCustomDomain` is non-retryable on NXDOMAIN.

--- a/server/internal/background/activities/verify_custom_domain.go
+++ b/server/internal/background/activities/verify_custom_domain.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
@@ -21,6 +23,21 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
+
+// ErrTypeDNSNotFound tags the non-retryable Temporal application error emitted
+// when DNS records required for custom domain verification do not exist
+// (NXDOMAIN). The workflow terminates immediately instead of burning retries
+// on a customer-side configuration gap; the user re-triggers verification via
+// the dashboard's "Reverify" button once DNS is configured.
+const ErrTypeDNSNotFound = "CustomDomainDNSNotFound"
+
+func newDNSNotFoundError(cause error, missingHost string) error {
+	return temporal.NewNonRetryableApplicationError(
+		fmt.Sprintf("DNS record not found for %s", missingHost),
+		ErrTypeDNSNotFound,
+		cause,
+	)
+}
 
 type VerifyCustomDomain struct {
 	db                  *pgxpool.Pool
@@ -121,6 +138,11 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 		if aErr == nil && len(ips) > 0 {
 			d.logger.InfoContext(ctx, fmt.Sprintf("CNAME not found. Found A record(s): %s", strings.Join(ips, ", ")))
 		} else {
+			var dnsErr *net.DNSError
+			if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+				d.logger.InfoContext(ctx, "custom domain DNS not found, terminating non-retryable", attr.SlogURLDomain(domain.Domain), attr.SlogError(err))
+				return newDNSNotFoundError(err, domain.Domain)
+			}
 			return oops.E(oops.CodeUnexpected, err, "failed to find custom domain mapping for %s", domain.Domain).Log(ctx, d.logger)
 		}
 	} else {
@@ -134,6 +156,11 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 	txtName := "_gram." + domain.Domain
 	txts, err := d.resolver.LookupTXT(ctx, txtName)
 	if err != nil {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			d.logger.InfoContext(ctx, "custom domain verification TXT record not found, terminating non-retryable", attr.SlogURLDomain(domain.Domain), attr.SlogError(err))
+			return newDNSNotFoundError(err, txtName)
+		}
 		return oops.E(oops.CodeUnexpected, err, "failed to find TXT record for %s", txtName).Log(ctx, d.logger)
 	}
 	expectedTXT := fmt.Sprintf("gram-domain-verify=%s,%s", domain.Domain, args.OrgID)

--- a/server/internal/background/activities/verify_custom_domain_test.go
+++ b/server/internal/background/activities/verify_custom_domain_test.go
@@ -3,12 +3,14 @@ package activities_test
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
@@ -344,6 +346,64 @@ func TestVerifyCustomDomain_TXTLookupError(t *testing.T) {
 	got, dbErr := ti.repo.GetCustomDomainByDomain(ctx, domain)
 	require.NoError(t, dbErr)
 	require.Equal(t, orgID, got.OrganizationID)
+}
+
+func TestVerifyCustomDomain_NXDOMAINOnCNAMEAndA(t *testing.T) {
+	t.Parallel()
+
+	const orgID = "org-nxdomain-cname"
+	const domain = "nxdomain-cname.example.com"
+	ctx, ti := newTestInstance(t, orgID, domain)
+
+	nxdomain := &net.DNSError{Err: "no such host", Name: domain, IsNotFound: true}
+	cfg := newPassingDNSResolverConfig(testTargetCNAME, domain, orgID)
+	cfg.LookupCNAMEFunc = func(context.Context, string) (string, error) { return "", nxdomain }
+	cfg.LookupHostFunc = func(context.Context, string) ([]string, error) { return nil, nxdomain }
+	ti.resolver = dns.NewMockResolver(cfg)
+
+	activity := newActivity(t, ti)
+
+	err := activity.Do(ctx, activities.VerifyCustomDomainArgs{
+		OrgID:     orgID,
+		Domain:    domain,
+		CreatedBy: urn.NewPrincipal(urn.PrincipalTypeUser, "test-user"),
+	})
+	require.Error(t, err)
+
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, activities.ErrTypeDNSNotFound, appErr.Type())
+	require.True(t, appErr.NonRetryable(), "DNS-not-found should be non-retryable")
+	require.Contains(t, err.Error(), domain)
+}
+
+func TestVerifyCustomDomain_NXDOMAINOnTXT(t *testing.T) {
+	t.Parallel()
+
+	const orgID = "org-nxdomain-txt"
+	const domain = "nxdomain-txt.example.com"
+	ctx, ti := newTestInstance(t, orgID, domain)
+
+	txtName := "_gram." + domain
+	nxdomain := &net.DNSError{Err: "no such host", Name: txtName, IsNotFound: true}
+	cfg := newPassingDNSResolverConfig(testTargetCNAME, domain, orgID)
+	cfg.LookupTXTFunc = func(context.Context, string) ([]string, error) { return nil, nxdomain }
+	ti.resolver = dns.NewMockResolver(cfg)
+
+	activity := newActivity(t, ti)
+
+	err := activity.Do(ctx, activities.VerifyCustomDomainArgs{
+		OrgID:     orgID,
+		Domain:    domain,
+		CreatedBy: urn.NewPrincipal(urn.PrincipalTypeUser, "test-user"),
+	})
+	require.Error(t, err)
+
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, activities.ErrTypeDNSNotFound, appErr.Type())
+	require.True(t, appErr.NonRetryable(), "DNS-not-found should be non-retryable")
+	require.Contains(t, err.Error(), txtName)
 }
 
 // Verify ErrNoRows is what sqlc returns for missing rows (sanity check).

--- a/server/internal/background/interceptors/log.go
+++ b/server/internal/background/interceptors/log.go
@@ -6,6 +6,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/interceptor"
+	sdklog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -43,11 +45,7 @@ func (w *workflowLogExecution) ExecuteWorkflow(ctx workflow.Context, in *interce
 	logger.Debug("workflow started")
 
 	result, err := w.Next.ExecuteWorkflow(ctx, in)
-	if err == nil {
-		logger.Info("workflow finished")
-	} else {
-		logger.Error("workflow failed", "error", err.Error())
-	}
+	logWorkflowResult(logger, err)
 
 	return result, err
 }
@@ -67,11 +65,35 @@ func (a *activityLogExecution) ExecuteActivity(ctx context.Context, in *intercep
 	logger.Debug("activity started")
 
 	result, err := a.Next.ExecuteActivity(ctx, in)
-	if err == nil {
-		logger.Info("activity finished")
-	} else {
-		logger.Error("activity failed", "error", err.Error())
-	}
+	logActivityResult(logger, err)
 
 	return result, err
+}
+
+// logWorkflowResult downgrades benign Temporal sentinels (ContinueAsNew,
+// Canceled) to Info so they stay out of failure alerts and log noise.
+func logWorkflowResult(logger sdklog.Logger, err error) {
+	switch {
+	case err == nil:
+		logger.Info("workflow finished")
+	case workflow.IsContinueAsNewError(err):
+		logger.Info("workflow continuing as new")
+	case temporal.IsCanceledError(err):
+		logger.Info("workflow canceled")
+	default:
+		logger.Error("workflow failed", "error", err.Error())
+	}
+}
+
+// logActivityResult downgrades the Canceled sentinel (worker shutdown,
+// workflow timeout, caller cancel) to Info so it stays out of failure alerts.
+func logActivityResult(logger sdklog.Logger, err error) {
+	switch {
+	case err == nil:
+		logger.Info("activity finished")
+	case temporal.IsCanceledError(err):
+		logger.Info("activity canceled")
+	default:
+		logger.Error("activity failed", "error", err.Error())
+	}
 }

--- a/server/internal/background/interceptors/log_test.go
+++ b/server/internal/background/interceptors/log_test.go
@@ -1,0 +1,101 @@
+package interceptors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdklog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+type capturedLog struct {
+	level   string
+	message string
+}
+
+type captureLogger struct {
+	calls []capturedLog
+}
+
+var _ sdklog.Logger = (*captureLogger)(nil)
+
+func (l *captureLogger) Debug(msg string, _ ...any) {
+	l.calls = append(l.calls, capturedLog{level: "debug", message: msg})
+}
+
+func (l *captureLogger) Info(msg string, _ ...any) {
+	l.calls = append(l.calls, capturedLog{level: "info", message: msg})
+}
+
+func (l *captureLogger) Warn(msg string, _ ...any) {
+	l.calls = append(l.calls, capturedLog{level: "warn", message: msg})
+}
+
+func (l *captureLogger) Error(msg string, _ ...any) {
+	l.calls = append(l.calls, capturedLog{level: "error", message: msg})
+}
+
+func TestLogWorkflowResult_Success(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, nil)
+
+	require.Equal(t, []capturedLog{{level: "info", message: "workflow finished"}}, logger.calls)
+}
+
+func TestLogWorkflowResult_GenericError(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, errors.New("boom"))
+
+	require.Equal(t, []capturedLog{{level: "error", message: "workflow failed"}}, logger.calls)
+}
+
+func TestLogWorkflowResult_ContinueAsNew(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, &workflow.ContinueAsNewError{})
+
+	require.Equal(t, []capturedLog{{level: "info", message: "workflow continuing as new"}}, logger.calls)
+}
+
+func TestLogWorkflowResult_Canceled(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logWorkflowResult(logger, temporal.NewCanceledError())
+
+	require.Equal(t, []capturedLog{{level: "info", message: "workflow canceled"}}, logger.calls)
+}
+
+func TestLogActivityResult_Success(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logActivityResult(logger, nil)
+
+	require.Equal(t, []capturedLog{{level: "info", message: "activity finished"}}, logger.calls)
+}
+
+func TestLogActivityResult_GenericError(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logActivityResult(logger, errors.New("boom"))
+
+	require.Equal(t, []capturedLog{{level: "error", message: "activity failed"}}, logger.calls)
+}
+
+func TestLogActivityResult_Canceled(t *testing.T) {
+	t.Parallel()
+
+	logger := &captureLogger{}
+	logActivityResult(logger, temporal.NewCanceledError())
+
+	require.Equal(t, []capturedLog{{level: "info", message: "activity canceled"}}, logger.calls)
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2285/quiet-false-positive-temporal-workflow-failure-signals

Two unrelated false-positive sources were paging oncall and drowning real failures in log noise.

**1. Workflow/activity log interceptors logged benign Temporal sentinels as failures.**

`ContinueAsNewError` (the documented way to iterate a long-running workflow like `DrainRiskAnalysisWorkflow`) and `CanceledError` (worker shutdown, workflow timeout, caller cancel) are control flow, not failures. The interceptors at `server/internal/background/interceptors/log.go` logged every one as `workflow failed` / `activity failed`, producing ~757 spurious log lines per 30 min on `gram-worker` and flipping APM spans to `status: error`. They now log at **Info**, keeping them out of the Datadog `Elevated temporal workflow failures in Gram` monitor.

**2. `VerifyCustomDomain` retried NXDOMAIN.**

Customer-side DNS gaps consumed three retries before the workflow gave up — long enough for the monitor to page oncall. NXDOMAIN (`*net.DNSError` with `IsNotFound == true`) at the CNAME-no-A-record site and the TXT site is now wrapped as a non-retryable `temporal.ApplicationError` with type `CustomDomainDNSNotFound`, so the activity terminates after one attempt. Users re-trigger via the existing dashboard "Reverify" button (idempotent `POST /rpc/domain.register` with `ALLOW_DUPLICATE` workflow ID reuse). Other DNS errors (timeouts, SERVFAIL, NS errors) stay retryable.