### PR TITLE
mig: add shadow mcp access rule tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2687,6 +2687,114 @@ CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
 WHERE found IS TRUE;
 
+-- Access approval requests are created when a user requests access after a
+-- policy blocks a resource. Repeated blocked attempts increment this mutable
+-- workflow row.
+CREATE TABLE IF NOT EXISTS access_approval_requests (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid NOT NULL,
+  resource_type TEXT NOT NULL CHECK (resource_type <> ''),
+
+  requester_user_id TEXT,
+  requester_email TEXT,
+  requester_display_name TEXT,
+
+  status TEXT NOT NULL CHECK (status IN ('requested', 'approved', 'denied')),
+  request_fingerprint TEXT CHECK (request_fingerprint IS NULL OR request_fingerprint <> ''),
+
+  display_name TEXT CHECK (display_name IS NULL OR display_name <> ''),
+  observed_summary jsonb NOT NULL DEFAULT '{}' CHECK (jsonb_typeof(observed_summary) = 'object'),
+
+  blocked_count INT NOT NULL DEFAULT 1 CHECK (blocked_count > 0),
+  first_blocked_at timestamptz,
+  last_blocked_at timestamptz,
+  requested_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  decided_at timestamptz,
+  decided_by TEXT,
+  decision_note TEXT,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT access_approval_requests_pkey PRIMARY KEY (id),
+  CONSTRAINT access_approval_requests_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+  CONSTRAINT access_approval_requests_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE,
+  CONSTRAINT access_approval_requests_decision_check CHECK (
+    (status = 'requested' AND decided_at IS NULL) OR
+    (status IN ('approved', 'denied') AND decided_at IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS access_approval_requests_project_resource_status_requested_idx
+ON access_approval_requests (project_id, resource_type, status, requested_at DESC)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS access_approval_requests_organization_resource_status_requested_idx
+ON access_approval_requests (organization_id, resource_type, status, requested_at DESC)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS access_approval_requests_active_requester_fingerprint_key
+ON access_approval_requests (organization_id, project_id, resource_type, requester_user_id, request_fingerprint)
+WHERE deleted IS FALSE AND status = 'requested' AND requester_user_id IS NOT NULL AND request_fingerprint IS NOT NULL;
+
+-- Access rules are managed allow/deny policy used by runtime enforcement.
+CREATE TABLE IF NOT EXISTS access_rules (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid,
+  access_scope TEXT NOT NULL DEFAULT 'organization' CHECK (access_scope IN ('organization', 'project')),
+  resource_type TEXT NOT NULL CHECK (resource_type <> ''),
+
+  disposition TEXT NOT NULL CHECK (disposition IN ('allowed', 'denied')),
+  match_kind TEXT NOT NULL CHECK (match_kind <> ''),
+  match_value TEXT NOT NULL CHECK (match_value <> ''),
+
+  display_name TEXT NOT NULL CHECK (display_name <> ''),
+  observed_summary jsonb NOT NULL DEFAULT '{}' CHECK (jsonb_typeof(observed_summary) = 'object'),
+  source_request_id uuid,
+
+  created_by TEXT,
+  updated_by TEXT,
+  reason TEXT,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT access_rules_pkey PRIMARY KEY (id),
+  CONSTRAINT access_rules_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE,
+  CONSTRAINT access_rules_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+  CONSTRAINT access_rules_scope_project_check CHECK (
+    (access_scope = 'organization' AND project_id IS NULL) OR
+    (access_scope = 'project' AND project_id IS NOT NULL)
+  ),
+  CONSTRAINT access_rules_source_request_id_fkey FOREIGN KEY (source_request_id) REFERENCES access_approval_requests(id) ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS access_rules_organization_scope_match_value_key
+ON access_rules (organization_id, resource_type, match_kind, match_value)
+WHERE deleted IS FALSE AND access_scope = 'organization';
+
+CREATE UNIQUE INDEX IF NOT EXISTS access_rules_project_scope_match_value_key
+ON access_rules (organization_id, project_id, resource_type, match_kind, match_value)
+WHERE deleted IS FALSE AND access_scope = 'project';
+
+CREATE INDEX IF NOT EXISTS access_rules_project_scope_created_idx
+ON access_rules (organization_id, project_id, resource_type, disposition, created_at DESC)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS access_rules_organization_disposition_created_idx
+ON access_rules (organization_id, resource_type, disposition, created_at DESC)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS access_rules_source_request_id_idx
+ON access_rules (source_request_id)
+WHERE source_request_id IS NOT NULL AND deleted IS FALSE;
+
 CREATE TABLE IF NOT EXISTS authz_challenge_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -14,6 +14,52 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+type AccessApprovalRequest struct {
+	ID                   uuid.UUID
+	OrganizationID       string
+	ProjectID            uuid.UUID
+	ResourceType         string
+	RequesterUserID      pgtype.Text
+	RequesterEmail       pgtype.Text
+	RequesterDisplayName pgtype.Text
+	Status               string
+	RequestFingerprint   pgtype.Text
+	DisplayName          pgtype.Text
+	ObservedSummary      []byte
+	BlockedCount         int32
+	FirstBlockedAt       pgtype.Timestamptz
+	LastBlockedAt        pgtype.Timestamptz
+	RequestedAt          pgtype.Timestamptz
+	DecidedAt            pgtype.Timestamptz
+	DecidedBy            pgtype.Text
+	DecisionNote         pgtype.Text
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	DeletedAt            pgtype.Timestamptz
+	Deleted              bool
+}
+
+type AccessRule struct {
+	ID              uuid.UUID
+	OrganizationID  string
+	ProjectID       uuid.NullUUID
+	AccessScope     string
+	ResourceType    string
+	Disposition     string
+	MatchKind       string
+	MatchValue      string
+	DisplayName     string
+	ObservedSummary []byte
+	SourceRequestID uuid.NullUUID
+	CreatedBy       pgtype.Text
+	UpdatedBy       pgtype.Text
+	Reason          pgtype.Text
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+	DeletedAt       pgtype.Timestamptz
+	Deleted         bool
+}
+
 type AgentExecution struct {
 	ID           string
 	ProjectID    uuid.UUID

--- a/server/migrations/20260521033529_access-controls.sql
+++ b/server/migrations/20260521033529_access-controls.sql
@@ -1,0 +1,84 @@
+-- Create "access_approval_requests" table
+CREATE TABLE "access_approval_requests" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NOT NULL,
+  "resource_type" text NOT NULL,
+  "requester_user_id" text NULL,
+  "requester_email" text NULL,
+  "requester_display_name" text NULL,
+  "status" text NOT NULL,
+  "request_fingerprint" text NULL,
+  "display_name" text NULL,
+  "observed_summary" jsonb NOT NULL DEFAULT '{}',
+  "blocked_count" integer NOT NULL DEFAULT 1,
+  "first_blocked_at" timestamptz NULL,
+  "last_blocked_at" timestamptz NULL,
+  "requested_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "decided_at" timestamptz NULL,
+  "decided_by" text NULL,
+  "decision_note" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "access_approval_requests_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "access_approval_requests_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "access_approval_requests_blocked_count_check" CHECK (blocked_count > 0),
+  CONSTRAINT "access_approval_requests_decision_check" CHECK (((status = 'requested'::text) AND (decided_at IS NULL)) OR ((status = ANY (ARRAY['approved'::text, 'denied'::text])) AND (decided_at IS NOT NULL))),
+  CONSTRAINT "access_approval_requests_display_name_check" CHECK ((display_name IS NULL) OR (display_name <> ''::text)),
+  CONSTRAINT "access_approval_requests_observed_summary_check" CHECK (jsonb_typeof(observed_summary) = 'object'::text),
+  CONSTRAINT "access_approval_requests_request_fingerprint_check" CHECK ((request_fingerprint IS NULL) OR (request_fingerprint <> ''::text)),
+  CONSTRAINT "access_approval_requests_resource_type_check" CHECK (resource_type <> ''::text),
+  CONSTRAINT "access_approval_requests_status_check" CHECK (status = ANY (ARRAY['requested'::text, 'approved'::text, 'denied'::text]))
+);
+-- Create index "access_approval_requests_active_requester_fingerprint_key" to table: "access_approval_requests"
+CREATE UNIQUE INDEX "access_approval_requests_active_requester_fingerprint_key" ON "access_approval_requests" ("organization_id", "project_id", "resource_type", "requester_user_id", "request_fingerprint") WHERE ((deleted IS FALSE) AND (status = 'requested'::text) AND (requester_user_id IS NOT NULL) AND (request_fingerprint IS NOT NULL));
+-- Create index "access_approval_requests_organization_resource_status_requested" to table: "access_approval_requests"
+CREATE INDEX "access_approval_requests_organization_resource_status_requested" ON "access_approval_requests" ("organization_id", "resource_type", "status", "requested_at" DESC) WHERE (deleted IS FALSE);
+-- Create index "access_approval_requests_project_resource_status_requested_idx" to table: "access_approval_requests"
+CREATE INDEX "access_approval_requests_project_resource_status_requested_idx" ON "access_approval_requests" ("project_id", "resource_type", "status", "requested_at" DESC) WHERE (deleted IS FALSE);
+-- Create "access_rules" table
+CREATE TABLE "access_rules" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NULL,
+  "access_scope" text NOT NULL DEFAULT 'organization',
+  "resource_type" text NOT NULL,
+  "disposition" text NOT NULL,
+  "match_kind" text NOT NULL,
+  "match_value" text NOT NULL,
+  "display_name" text NOT NULL,
+  "observed_summary" jsonb NOT NULL DEFAULT '{}',
+  "source_request_id" uuid NULL,
+  "created_by" text NULL,
+  "updated_by" text NULL,
+  "reason" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "access_rules_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "access_rules_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "access_rules_source_request_id_fkey" FOREIGN KEY ("source_request_id") REFERENCES "access_approval_requests" ("id") ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT "access_rules_access_scope_check" CHECK (access_scope = ANY (ARRAY['organization'::text, 'project'::text])),
+  CONSTRAINT "access_rules_display_name_check" CHECK (display_name <> ''::text),
+  CONSTRAINT "access_rules_disposition_check" CHECK (disposition = ANY (ARRAY['allowed'::text, 'denied'::text])),
+  CONSTRAINT "access_rules_match_kind_check" CHECK (match_kind <> ''::text),
+  CONSTRAINT "access_rules_match_value_check" CHECK (match_value <> ''::text),
+  CONSTRAINT "access_rules_observed_summary_check" CHECK (jsonb_typeof(observed_summary) = 'object'::text),
+  CONSTRAINT "access_rules_resource_type_check" CHECK (resource_type <> ''::text),
+  CONSTRAINT "access_rules_scope_project_check" CHECK (((access_scope = 'organization'::text) AND (project_id IS NULL)) OR ((access_scope = 'project'::text) AND (project_id IS NOT NULL)))
+);
+-- Create index "access_rules_organization_disposition_created_idx" to table: "access_rules"
+CREATE INDEX "access_rules_organization_disposition_created_idx" ON "access_rules" ("organization_id", "resource_type", "disposition", "created_at" DESC) WHERE (deleted IS FALSE);
+-- Create index "access_rules_organization_scope_match_value_key" to table: "access_rules"
+CREATE UNIQUE INDEX "access_rules_organization_scope_match_value_key" ON "access_rules" ("organization_id", "resource_type", "match_kind", "match_value") WHERE ((deleted IS FALSE) AND (access_scope = 'organization'::text));
+-- Create index "access_rules_project_scope_created_idx" to table: "access_rules"
+CREATE INDEX "access_rules_project_scope_created_idx" ON "access_rules" ("organization_id", "project_id", "resource_type", "disposition", "created_at" DESC) WHERE (deleted IS FALSE);
+-- Create index "access_rules_project_scope_match_value_key" to table: "access_rules"
+CREATE UNIQUE INDEX "access_rules_project_scope_match_value_key" ON "access_rules" ("organization_id", "project_id", "resource_type", "match_kind", "match_value") WHERE ((deleted IS FALSE) AND (access_scope = 'project'::text));
+-- Create index "access_rules_source_request_id_idx" to table: "access_rules"
+CREATE INDEX "access_rules_source_request_id_idx" ON "access_rules" ("source_request_id") WHERE ((source_request_id IS NOT NULL) AND (deleted IS FALSE));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:3YYIANnXGi+LTuyY/z4/FmgtWqzaGyUBcpKebX6mSvY=
+h1:uYJgIGRjaFmcfWZZ18RdozSSr5vCh00yw1LVRxP/qbU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -185,3 +185,4 @@ h1:3YYIANnXGi+LTuyY/z4/FmgtWqzaGyUBcpKebX6mSvY=
 20260518213910_add-remote-session-client-token-endpoint-auth-method.sql h1:JuOMsaREjEdVpN5V9su1Gi7al06kmYwZw6LGLyYqq3o=
 20260520030115_add_audience_and_scope_to_remote_session_clients.sql h1:61DiqJmzoI4CR7F8oyNtDzs0hGFtsXliB4LVsHA+b5E=
 20260520182725_project-marketplace-settings.sql h1:4RMTKbJZG0ft/SUEnGR737b3iTY1SOmIp6NnisqTYO8=
+20260521033529_access-controls.sql h1:JOOANBN6oA6LKMk6hSTfDqZDW8UTqqgLdyYUjSehJEA=


### PR DESCRIPTION
### Summary

Adds the Postgres schema for the Shadow MCP request workflow and managed Access Rules.

Includes:
- `access_approval_requests` for signed request-access submissions after a Shadow MCP Risk Policy block
- `access_rules` for project/org scoped allow and deny decisions
- request dedupe by active requester fingerprint
- mutable blocked-count/request-state tracking in Postgres
- project-scoped and organization-scoped rule schema support
- URL, host, and server-identity match fields through `match_kind` / `match_value`
- generated SQLC database models

This PR intentionally does not add runtime/API/dashboard behavior. It also does not add a ClickHouse event stream for this v1 request workflow.

### Verification

- `atlas migrate validate --dir file://server/migrations`
- `atlas migrate validate --dir file://server/clickhouse/migrations`
- `atlas migrate validate --dir file://server/clickhouse/local/golang_migrate --dir-format golang-migrate`

Note: `mise run lint:migrations` reached Atlas lint locally but could not complete because the connected local database was dirty (`agent_executions` already existed).

### Related PRs
- #2763
- #2771
- #2796
- #2831
- #2761