### PR TITLE
fix(risk): harden AnalyzeBatch against Presidio degradation

### DIFF
--- a/.changeset/age-2286-harden-analyzebatch-presidio.md
+++ b/.changeset/age-2286-harden-analyzebatch-presidio.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+harden AnalyzeBatch against Presidio degradation

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -196,6 +196,7 @@ func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages
 
 	var wg sync.WaitGroup
 	var gitleaksErr error
+	var presidioErr error
 
 	if slices.Contains(args.Sources, "gitleaks") {
 		wg.Go(func() {
@@ -210,17 +211,22 @@ func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages
 
 	if slices.Contains(args.Sources, "presidio") {
 		wg.Go(func() {
+			// PIIScanner may return partial results alongside an error;
+			// always consume results so successful per-text findings are
+			// preserved even when some HTTP calls failed.
 			results, err := a.piiScanner.AnalyzeBatch(ctx, contents, args.PresidioEntities, func() {
 				activity.RecordHeartbeat(ctx, "presidio")
 			})
+			if results != nil {
+				presidioFindings = results
+			}
 			if err != nil {
-				a.logger.WarnContext(ctx, "presidio scan failed, continuing with gitleaks only", attr.SlogError(err))
+				presidioErr = err
+				a.logger.WarnContext(ctx, "presidio scan returned errors, using partial results", attr.SlogError(err))
 				if a.metrics.presidioScanSkipped != nil {
 					a.metrics.presidioScanSkipped.Add(ctx, 1)
 				}
-				return
 			}
-			presidioFindings = results
 		})
 	}
 
@@ -243,6 +249,26 @@ func (a *AnalyzeBatch) scan(ctx context.Context, args AnalyzeBatchArgs, messages
 	if gitleaksErr != nil {
 		scanSpan.SetStatus(codes.Error, gitleaksErr.Error())
 		return nil, fmt.Errorf("gitleaks scan batch: %w", gitleaksErr)
+	}
+
+	// When the activity ctx was canceled (heartbeat timeout, parent
+	// workflow stop, etc.) report it as a scan-layer failure instead of
+	// letting control fall through to writeResults where db.Begin would
+	// surface a misleading "begin transaction: context canceled". Join
+	// the underlying Presidio error so the chain reflects the actual
+	// cause when Presidio degradation triggered the cancellation.
+	//
+	// Partial findings from gitleaks/promptInjection/presidio captured
+	// so far are intentionally discarded — Temporal will retry the
+	// activity (RetryPolicy.MaximumAttempts), and any partial write to
+	// the DB here would race the cancellation anyway.
+	if ctx.Err() != nil {
+		err := fmt.Errorf("scan canceled: %w", ctx.Err())
+		if presidioErr != nil {
+			err = errors.Join(err, fmt.Errorf("presidio: %w", presidioErr))
+		}
+		scanSpan.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 
 	if slices.Contains(args.Sources, shadowmcp.SourceShadowMCP) {

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
@@ -27,6 +28,13 @@ type PIIScanner interface {
 	// AnalyzeBatch sends multiple texts to the PII analyzer and returns
 	// findings for each. The outer slice is indexed by input position.
 	// When entities is non-empty, only those entity types are detected.
+	//
+	// Implementations may return partial results alongside a non-nil error
+	// when some inputs were analyzed successfully but others failed —
+	// callers MUST consume results regardless of error so successful
+	// findings are not discarded. The returned error reflects the most
+	// diagnostic failure observed (cancellation errors are de-prioritized
+	// in favor of underlying causes).
 	AnalyzeBatch(ctx context.Context, texts []string, entities []string, onProgress func()) ([][]Finding, error)
 }
 
@@ -57,6 +65,14 @@ const presidioRetryBackoff = 100 * time.Millisecond
 
 const presidioRetryBackoffCap = 1 * time.Second
 
+// Per-request timeout for /analyze. Tuned 2026-05-12 from production
+// risk.presidio.request_duration data: healthy avg <1s, healthy max 5s typical
+// (occasional 40-75s tail), degraded calls observed at 60-180s. 30s detects
+// degradation aggressively while clearing healthy traffic with ~6x margin.
+// Must stay <= AnalyzeBatch HeartbeatTimeout in drain_risk_analysis.go (60s),
+// otherwise a single stalled call can starve the activity heartbeat.
+const analyzeRequestTimeout = 30 * time.Second
+
 // PresidioClient calls the Presidio Analyzer HTTP API.
 // Presidio is a trusted cluster-internal service, so the client uses an
 // unsafe guardian policy with an empty blocklist. The default policy blocks
@@ -68,6 +84,7 @@ type PresidioClient struct {
 	logger             *slog.Logger
 	requestConcurrency int
 	retryBackoff       time.Duration
+	requestTimeout     time.Duration
 	requestDuration    metric.Float64Histogram
 	requestFailures    metric.Int64Counter
 }
@@ -100,6 +117,7 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 		logger:             logger,
 		requestConcurrency: perBatchRequestConcurrency,
 		retryBackoff:       presidioRetryBackoff,
+		requestTimeout:     analyzeRequestTimeout,
 		requestDuration:    requestDuration,
 		requestFailures:    requestFailures,
 	}
@@ -183,32 +201,41 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	}
 	close(ch)
 
+	var firstErrMu sync.Mutex
+	var firstErr error
+	captureErr := func(e error) {
+		firstErrMu.Lock()
+		defer firstErrMu.Unlock()
+		firstErr = mergeFirstErr(firstErr, e)
+	}
+
 	var wg sync.WaitGroup
 	for range workers {
 		wg.Go(func() {
 			for batch := range ch {
-				p.analyzeRange(ctx, texts, entities, batch, results, onProgress)
+				p.analyzeRange(ctx, texts, entities, batch, results, onProgress, captureErr)
 			}
 		})
 	}
 
 	wg.Wait()
-	return results, nil
+	return results, firstErr
 }
 
-func (p *PresidioClient) analyzeRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func()) {
-	if ok, err := p.tryAnalyzeRange(ctx, texts, entities, batch, results, onProgress); !ok {
-		p.splitFailedRange(ctx, texts, entities, batch, results, onProgress, err, 0)
+func (p *PresidioClient) analyzeRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func(), captureErr func(error)) {
+	if ok, err := p.tryAnalyzeRange(ctx, texts, entities, batch, results, onProgress, captureErr); !ok {
+		p.splitFailedRange(ctx, texts, entities, batch, results, onProgress, captureErr, err, 0)
 	}
 }
 
-func (p *PresidioClient) tryAnalyzeRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func()) (bool, error) {
+func (p *PresidioClient) tryAnalyzeRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func(), captureErr func(error)) (bool, error) {
 	if onProgress != nil {
 		onProgress()
 	}
 
 	findings, err := p.analyze(ctx, texts[batch.start:batch.end], entities)
 	if err != nil {
+		captureErr(err)
 		return false, err
 	}
 
@@ -221,7 +248,7 @@ func (p *PresidioClient) tryAnalyzeRange(ctx context.Context, texts []string, en
 	return true, nil
 }
 
-func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func(), cause error, depth int) {
+func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, entities []string, batch indexRange, results [][]Finding, onProgress func(), captureErr func(error), cause error, depth int) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -247,13 +274,35 @@ func (p *PresidioClient) splitFailedRange(ctx context.Context, texts []string, e
 	left := indexRange{start: batch.start, end: mid}
 	right := indexRange{start: mid, end: batch.end}
 
-	leftOK, leftErr := p.tryAnalyzeRange(ctx, texts, entities, left, results, onProgress)
-	rightOK, rightErr := p.tryAnalyzeRange(ctx, texts, entities, right, results, onProgress)
+	leftOK, leftErr := p.tryAnalyzeRange(ctx, texts, entities, left, results, onProgress, captureErr)
+	rightOK, rightErr := p.tryAnalyzeRange(ctx, texts, entities, right, results, onProgress, captureErr)
 	if !leftOK {
-		p.splitFailedRange(ctx, texts, entities, left, results, onProgress, leftErr, depth+1)
+		p.splitFailedRange(ctx, texts, entities, left, results, onProgress, captureErr, leftErr, depth+1)
 	}
 	if !rightOK {
-		p.splitFailedRange(ctx, texts, entities, right, results, onProgress, rightErr, depth+1)
+		p.splitFailedRange(ctx, texts, entities, right, results, onProgress, captureErr, rightErr, depth+1)
+	}
+}
+
+func isCancelErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+// mergeFirstErr returns the better of two errors for surfacing in the
+// activity-level error chain. Prefers non-cancel errors: cancellation is a
+// downstream consequence (parent ctx canceled, sibling's timeout elapsed) —
+// the underlying Presidio failure that triggered it is what the caller needs
+// to see.
+func mergeFirstErr(existing, candidate error) error {
+	switch {
+	case candidate == nil:
+		return existing
+	case existing == nil:
+		return candidate
+	case isCancelErr(existing) && !isCancelErr(candidate):
+		return candidate
+	default:
+		return existing
 	}
 }
 
@@ -340,7 +389,10 @@ func (p *PresidioClient) analyze(ctx context.Context, texts []string, entities [
 		return nil, fmt.Errorf("marshal presidio request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/analyze", bytes.NewReader(body))
+	reqCtx, cancel := context.WithTimeout(ctx, p.requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, p.baseURL+"/analyze", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create presidio request: %w", err)
 	}

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -86,6 +86,7 @@ type PresidioClient struct {
 	retryBackoff       time.Duration
 	requestTimeout     time.Duration
 	requestDuration    metric.Float64Histogram
+	requestSize        metric.Int64Histogram
 	requestFailures    metric.Int64Counter
 }
 
@@ -98,6 +99,16 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 		metric.WithDescription("Duration of individual Presidio /analyze HTTP requests in seconds"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+	)
+
+	// Bucket boundaries span 1 KiB to 4 MiB on powers of 4 to cover both
+	// typical chat-message batches and tail payloads dominated by
+	// oversized tool-call JSON.
+	requestSize, _ := meter.Int64Histogram(
+		"risk.presidio.request_size",
+		metric.WithDescription("Size of Presidio /analyze HTTP request bodies in bytes"),
+		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(1024, 4096, 16384, 65536, 262144, 1048576, 4194304),
 	)
 
 	requestFailures, _ := meter.Int64Counter(
@@ -119,6 +130,7 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 		retryBackoff:       presidioRetryBackoff,
 		requestTimeout:     analyzeRequestTimeout,
 		requestDuration:    requestDuration,
+		requestSize:        requestSize,
 		requestFailures:    requestFailures,
 	}
 }
@@ -387,6 +399,10 @@ func (p *PresidioClient) analyze(ctx context.Context, texts []string, entities [
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal presidio request: %w", err)
+	}
+
+	if p.requestSize != nil {
+		p.requestSize.Record(ctx, int64(len(body)))
 	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, p.requestTimeout)

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -1,7 +1,10 @@
 package risk_analysis
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,7 +125,10 @@ func TestPresidioAnalyzeBatchSplitsPoisonedBatch(t *testing.T) {
 		"poison",
 		"backup alice@example.com",
 	}, nil, nil)
-	require.NoError(t, err)
+	// AnalyzeBatch surfaces the first observed Presidio HTTP failure
+	// alongside partial results; callers must consume results regardless.
+	require.Error(t, err)
+	require.ErrorContains(t, err, "presidio returned status 500")
 	require.Len(t, results, 4)
 
 	assert.Empty(t, results[0])
@@ -178,7 +185,8 @@ func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
 		"three",
 		"four",
 	}, nil, nil)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "presidio returned status 503")
 	require.Len(t, results, 4)
 	for _, findings := range results {
 		assert.Empty(t, findings)
@@ -200,4 +208,79 @@ func TestPresidioAnalyzeBatchSplitsUntilSingleTexts(t *testing.T) {
 func testLogger(t *testing.T) *slog.Logger {
 	t.Helper()
 	return slog.New(slog.NewTextHandler(t.Output(), nil))
+}
+
+func TestPresidioAnalyzeTimesOutPerRequest(t *testing.T) {
+	t.Parallel()
+
+	// Server blocks until the test's deadline ctx fires so the only way
+	// out is the client's per-request timeout. Without a per-request
+	// timeout the test would hang for the full t.Context() budget.
+	released := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-released:
+		}
+	}))
+	// LIFO cleanup: release in-flight handlers before srv.Close blocks on
+	// them. Keep-alive connection reuse means a client-side reqCtx timeout
+	// does not always propagate to r.Context() Done.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(released) })
+
+	client := NewPresidioClientWithConcurrency(
+		srv.URL,
+		otel.GetTracerProvider(),
+		otel.GetMeterProvider(),
+		testLogger(t),
+		1,
+	)
+	client.requestTimeout = 100 * time.Millisecond
+
+	start := time.Now()
+	results, err := client.AnalyzeBatch(t.Context(), []string{"hang"}, nil, nil)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0])
+	// Single text bisects to depth 0 immediately, so total time is one
+	// request timeout + bounded retry sleep. Generous upper bound to
+	// avoid flakes under CI load.
+	assert.Less(t, elapsed, 5*time.Second, "per-request timeout did not bound elapsed time: %s", elapsed)
+}
+
+func TestIsCancelErrClassifiesContextErrors(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isCancelErr(context.Canceled))
+	assert.True(t, isCancelErr(context.DeadlineExceeded))
+	assert.True(t, isCancelErr(fmt.Errorf("wrapped: %w", context.Canceled)))
+	assert.True(t, isCancelErr(fmt.Errorf("wrapped: %w", context.DeadlineExceeded)))
+	assert.False(t, isCancelErr(nil))
+	assert.False(t, isCancelErr(errors.New("presidio returned status 500")))
+}
+
+func TestMergeFirstErrPrefersNonCancel(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("presidio returned status 500")
+	wrappedCancel := fmt.Errorf("http request: %w", context.Canceled)
+
+	require.NoError(t, mergeFirstErr(nil, nil))
+	assert.Equal(t, boom, mergeFirstErr(nil, boom))
+	assert.Equal(t, boom, mergeFirstErr(boom, nil))
+	// First-write wins when both are equally diagnostic.
+	assert.Equal(t, boom, mergeFirstErr(boom, errors.New("other 500")))
+	// Cancel-then-non-cancel: prefer the non-cancel cause.
+	assert.Equal(t, boom, mergeFirstErr(context.Canceled, boom))
+	assert.Equal(t, boom, mergeFirstErr(wrappedCancel, boom))
+	assert.Equal(t, boom, mergeFirstErr(context.DeadlineExceeded, boom))
+	// Non-cancel-then-cancel: keep the non-cancel cause.
+	assert.Equal(t, boom, mergeFirstErr(boom, context.Canceled))
+	assert.Equal(t, boom, mergeFirstErr(boom, wrappedCancel))
+	// Two cancel errors: first wins (no useful diagnostic to swap to).
+	assert.Equal(t, context.Canceled, mergeFirstErr(context.Canceled, context.DeadlineExceeded))
 }

--- a/server/internal/background/drain_risk_analysis.go
+++ b/server/internal/background/drain_risk_analysis.go
@@ -64,6 +64,16 @@ func DrainRiskAnalysisWorkflow(ctx workflow.Context, params DrainRiskAnalysisPar
 	// workflow's own queue so each environment stays isolated.
 	analyzeBatchOpts := activityOpts
 	analyzeBatchOpts.TaskQueue = RiskAnalysisTaskQueue(tenv.TaskQueueName(workflow.GetInfo(ctx).TaskQueueName))
+	// HeartbeatTimeout overrides activityOpts (30s). AnalyzeBatch's
+	// presidio scanner runs perBatchRequestConcurrency workers in
+	// parallel; onProgress() (which emits the heartbeat) fires before
+	// each /analyze call, then the worker blocks for up to
+	// analyzeRequestTimeout per call. Worst case under a fully-degraded
+	// Presidio: every worker stalls in parallel for the full per-request
+	// timeout before the next onProgress() can fire. 60s gives a 2x
+	// buffer over the 30s per-request timeout so the heartbeat budget
+	// holds even in that worst case.
+	analyzeBatchOpts.HeartbeatTimeout = 60 * time.Second
 	analyzeBatchCtx := workflow.WithActivityOptions(ctx, analyzeBatchOpts)
 
 	var a *Activities


### PR DESCRIPTION
[AGE-2286](https://linear.app/speakeasy/issue/AGE-2286/harden-analyzebatch-against-presidio-degradation)

When Presidio degrades, `AnalyzeBatch` previously surfaced one of three misleading errors (`Heartbeat timeout`, `analyze batch failed`, `begin transaction: context canceled`), none of which named Presidio — slowing oncall investigation. Three coupled changes fix the root cause:

- Bound `/analyze` HTTP calls at 30s (was unbounded). Sized from production `risk.presidio.request_duration`: healthy max ~5s, degraded calls run 60-180s.
- Surface the first non-cancel Presidio error from `AnalyzeBatch` and `errors.Join` it onto a scan-canceled error when ctx fires, so the activity-level chain reflects the actual cause instead of the downstream `db.Begin` failure.
- Bump `AnalyzeBatch` `HeartbeatTimeout` from 30s to 60s (scoped to `analyzeBatchOpts` only), giving 2x margin over the per-request timeout for the worst case of parallel worker stalls.