### PR TITLE
mig: add retry_after column to outbox_svix_relays table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2557,6 +2557,7 @@ CREATE TABLE IF NOT EXISTS outbox_svix_relays (
   svix_message_id TEXT,
   attempts INT NOT NULL DEFAULT 0,
   last_error TEXT,
+  retry_after timestamptz,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -884,6 +884,7 @@ type OutboxSvixRelay struct {
 	SvixMessageID pgtype.Text
 	Attempts      int32
 	LastError     pgtype.Text
+	RetryAfter    pgtype.Timestamptz
 	CreatedAt     pgtype.Timestamptz
 	UpdatedAt     pgtype.Timestamptz
 }

--- a/server/migrations/20260512215317_add-retry-after-to-outbox-svix-relays.sql
+++ b/server/migrations/20260512215317_add-retry-after-to-outbox-svix-relays.sql
@@ -1,0 +1,2 @@
+-- Modify "outbox_svix_relays" table
+ALTER TABLE "outbox_svix_relays" ADD COLUMN "retry_after" timestamptz NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8NU89Qb3H36IRgE+FeMB0MGjzbIiBaT0Fu21f1BQZSc=
+h1:EyZ+2ueONbctvK4TNKdjqs6I2erHqPk+6849vqzyvuI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -169,3 +169,4 @@ h1:8NU89Qb3H36IRgE+FeMB0MGjzbIiBaT0Fu21f1BQZSc=
 20260512103400_add-prompt-injection-rules.sql h1:X5zqk2CoHY9IrOJemHa+UvmRsmrHNcBO01wFfo2+H2U=
 20260512155737_add_workos_user_sync_metadata.sql h1:4VI2g6/r9x2TJyj3A9KRooa6pUi6zMUhrYNyaiKs/IQ=
 20260512175020_otel-forwarding-configs.sql h1:xmDFO0MH0Eyzrym5R1lV+0KTZeQwqMYzByhtmqUZSkM=
+20260512215317_add-retry-after-to-outbox-svix-relays.sql h1:o/1Y3Gh/+rXEdTFyLijpPsNLgXpNyhzNgIVeku/SKYU=


### PR DESCRIPTION
This change introduces a new column to the outbox_svix_relays that allows us to implement backoff with jitter logic for outbox events that failed to be sent to svix. The retry_after column will store the timestamp until which we should wait before attempting to resend events.