### PR TITLE
mig: remotesessions tables

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.761.5
 sources:
     Gram-Internal:
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:250a7b47f37580af2a66feb9444d05620495c53bcf9ec728b7f26a163fca8ed8
-        sourceBlobDigest: sha256:76297143ab1d783cd6ef4c59b9d6e202f9a74d527140649704b13dd5bad03fbe
+        sourceRevisionDigest: sha256:4f5d0ec1263cc5417617a7cee7786490592d78f7f02371310ef59fe4a224f01f
+        sourceBlobDigest: sha256:16a89de83ab7c177db0d5f4bf86f6f3fbcad0a7b69c026c8bb9dc71377230dd2
         tags:
             - latest
             - 0.0.1
@@ -11,8 +11,10 @@ targets:
     gram-internal:
         source: Gram-Internal
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:250a7b47f37580af2a66feb9444d05620495c53bcf9ec728b7f26a163fca8ed8
-        sourceBlobDigest: sha256:76297143ab1d783cd6ef4c59b9d6e202f9a74d527140649704b13dd5bad03fbe
+        sourceRevisionDigest: sha256:4f5d0ec1263cc5417617a7cee7786490592d78f7f02371310ef59fe4a224f01f
+        sourceBlobDigest: sha256:16a89de83ab7c177db0d5f4bf86f6f3fbcad0a7b69c026c8bb9dc71377230dd2
+        codeSamplesNamespace: gram-api-description-typescript-code-samples
+        codeSamplesRevisionDigest: sha256:3747cd18ce1e232221db54566d7825e04bf975f558d02bb9e3d0728b8de47ed2
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: pinned

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -810,6 +810,93 @@ CREATE INDEX IF NOT EXISTS user_sessions_subject_idx
 ON user_sessions (subject_urn, user_session_issuer_id)
 WHERE deleted IS FALSE;
 
+-- Remote Session Issuers are references to external authorization servers
+-- that will mint tokens that can be passed on behalf of a Gram session to an
+-- MCP backend
+CREATE TABLE IF NOT EXISTS remote_session_issuers (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+
+  slug TEXT NOT NULL,
+  issuer TEXT NOT NULL,
+  authorization_endpoint TEXT,
+  token_endpoint TEXT,
+  registration_endpoint TEXT,
+  jwks_uri TEXT,
+
+  scopes_supported TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  grant_types_supported TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  response_types_supported TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  token_endpoint_auth_methods_supported TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+
+  oidc BOOLEAN NOT NULL DEFAULT FALSE,
+  passthrough BOOLEAN NOT NULL DEFAULT FALSE,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT remote_session_issuers_pkey PRIMARY KEY (id),
+  CONSTRAINT remote_session_issuers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS remote_session_issuers_project_slug_key
+ON remote_session_issuers (project_id, slug)
+WHERE deleted IS FALSE;
+
+-- Remote Session Clients are records of Gram's client registrations with
+-- upstream authorization servers
+CREATE TABLE IF NOT EXISTS remote_session_clients (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  remote_session_issuer_id uuid NOT NULL,
+  user_session_issuer_id uuid NOT NULL,
+
+  client_id TEXT NOT NULL,
+  client_secret_encrypted TEXT,
+  client_id_issued_at timestamptz,
+  client_secret_expires_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT remote_session_clients_pkey PRIMARY KEY (id),
+  CONSTRAINT remote_session_clients_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT remote_session_clients_remote_session_issuer_id_fkey FOREIGN KEY (remote_session_issuer_id) REFERENCES remote_session_issuers (id) ON DELETE CASCADE,
+  CONSTRAINT remote_session_clients_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE CASCADE
+);
+
+-- Remote sessions represent credentials for an external resource that have
+-- been granted to a single Gram subject
+CREATE TABLE IF NOT EXISTS remote_sessions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  subject_urn TEXT NOT NULL,
+  user_session_issuer_id uuid NOT NULL,
+  remote_session_client_id uuid NOT NULL,
+
+  access_token_encrypted TEXT NOT NULL,
+  access_expires_at timestamptz NOT NULL,
+  refresh_token_encrypted TEXT,
+  refresh_expires_at timestamptz,
+  scopes TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT remote_sessions_pkey PRIMARY KEY (id),
+  CONSTRAINT remote_sessions_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE CASCADE,
+  CONSTRAINT remote_sessions_remote_session_client_id_fkey FOREIGN KEY (remote_session_client_id) REFERENCES remote_session_clients (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS remote_sessions_subject_client_key
+ON remote_sessions (subject_urn, remote_session_client_id)
+WHERE deleted IS FALSE;
+
 CREATE TABLE IF NOT EXISTS toolsets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1066,6 +1066,58 @@ type RemoteMcpServerHeader struct {
 	Deleted                bool
 }
 
+type RemoteSession struct {
+	ID                    uuid.UUID
+	SubjectUrn            string
+	UserSessionIssuerID   uuid.UUID
+	RemoteSessionClientID uuid.UUID
+	AccessTokenEncrypted  string
+	AccessExpiresAt       pgtype.Timestamptz
+	RefreshTokenEncrypted pgtype.Text
+	RefreshExpiresAt      pgtype.Timestamptz
+	Scopes                []string
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	Deleted               bool
+}
+
+type RemoteSessionClient struct {
+	ID                    uuid.UUID
+	ProjectID             uuid.UUID
+	RemoteSessionIssuerID uuid.UUID
+	UserSessionIssuerID   uuid.UUID
+	ClientID              string
+	ClientSecretEncrypted pgtype.Text
+	ClientIDIssuedAt      pgtype.Timestamptz
+	ClientSecretExpiresAt pgtype.Timestamptz
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	Deleted               bool
+}
+
+type RemoteSessionIssuer struct {
+	ID                                uuid.UUID
+	ProjectID                         uuid.UUID
+	Slug                              string
+	Issuer                            string
+	AuthorizationEndpoint             pgtype.Text
+	TokenEndpoint                     pgtype.Text
+	RegistrationEndpoint              pgtype.Text
+	JwksUri                           pgtype.Text
+	ScopesSupported                   []string
+	GrantTypesSupported               []string
+	ResponseTypesSupported            []string
+	TokenEndpointAuthMethodsSupported []string
+	Oidc                              bool
+	Passthrough                       bool
+	CreatedAt                         pgtype.Timestamptz
+	UpdatedAt                         pgtype.Timestamptz
+	DeletedAt                         pgtype.Timestamptz
+	Deleted                           bool
+}
+
 type RiskPolicy struct {
 	ID                   uuid.UUID
 	ProjectID            uuid.UUID

--- a/server/migrations/20260513005837_remotesession_tables.sql
+++ b/server/migrations/20260513005837_remotesession_tables.sql
@@ -1,0 +1,65 @@
+-- Create "remote_session_issuers" table
+CREATE TABLE "remote_session_issuers" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "slug" text NOT NULL,
+  "issuer" text NOT NULL,
+  "authorization_endpoint" text NULL,
+  "token_endpoint" text NULL,
+  "registration_endpoint" text NULL,
+  "jwks_uri" text NULL,
+  "scopes_supported" text[] NOT NULL DEFAULT ARRAY[]::text[],
+  "grant_types_supported" text[] NOT NULL DEFAULT ARRAY[]::text[],
+  "response_types_supported" text[] NOT NULL DEFAULT ARRAY[]::text[],
+  "token_endpoint_auth_methods_supported" text[] NOT NULL DEFAULT ARRAY[]::text[],
+  "oidc" boolean NOT NULL DEFAULT false,
+  "passthrough" boolean NOT NULL DEFAULT false,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "remote_session_issuers_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "remote_session_issuers_project_slug_key" to table: "remote_session_issuers"
+CREATE UNIQUE INDEX "remote_session_issuers_project_slug_key" ON "remote_session_issuers" ("project_id", "slug") WHERE (deleted IS FALSE);
+-- Create "remote_session_clients" table
+CREATE TABLE "remote_session_clients" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "remote_session_issuer_id" uuid NOT NULL,
+  "user_session_issuer_id" uuid NOT NULL,
+  "client_id" text NOT NULL,
+  "client_secret_encrypted" text NULL,
+  "client_id_issued_at" timestamptz NULL,
+  "client_secret_expires_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "remote_session_clients_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "remote_session_clients_remote_session_issuer_id_fkey" FOREIGN KEY ("remote_session_issuer_id") REFERENCES "remote_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "remote_session_clients_user_session_issuer_id_fkey" FOREIGN KEY ("user_session_issuer_id") REFERENCES "user_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create "remote_sessions" table
+CREATE TABLE "remote_sessions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "subject_urn" text NOT NULL,
+  "user_session_issuer_id" uuid NOT NULL,
+  "remote_session_client_id" uuid NOT NULL,
+  "access_token_encrypted" text NOT NULL,
+  "access_expires_at" timestamptz NOT NULL,
+  "refresh_token_encrypted" text NULL,
+  "refresh_expires_at" timestamptz NULL,
+  "scopes" text[] NOT NULL DEFAULT ARRAY[]::text[],
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "remote_sessions_remote_session_client_id_fkey" FOREIGN KEY ("remote_session_client_id") REFERENCES "remote_session_clients" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "remote_sessions_user_session_issuer_id_fkey" FOREIGN KEY ("user_session_issuer_id") REFERENCES "user_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "remote_sessions_subject_client_key" to table: "remote_sessions"
+CREATE UNIQUE INDEX "remote_sessions_subject_client_key" ON "remote_sessions" ("subject_urn", "remote_session_client_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:mwpEXLSylGsP200SVFqhzR6pRE9n8YuKI0Mc7aUULUg=
+h1:QNGkpxihIcP5obsHuRYviJE4qXw1GS4tQRxJTPBp0PI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -171,3 +171,4 @@ h1:mwpEXLSylGsP200SVFqhzR6pRE9n8YuKI0Mc7aUULUg=
 20260512175020_otel-forwarding-configs.sql h1:xmDFO0MH0Eyzrym5R1lV+0KTZeQwqMYzByhtmqUZSkM=
 20260512215317_add-retry-after-to-outbox-svix-relays.sql h1:o/1Y3Gh/+rXEdTFyLijpPsNLgXpNyhzNgIVeku/SKYU=
 20260513000047_rename-outbox-relay-table.sql h1:AGyRYZsUpxHNZZj8Ziq1CgY1mu2xaWCWaR9HuRJE47c=
+20260513005837_remotesession_tables.sql h1:5DUSVR2+u/G7JO8BIWqcIpGvcc6KosOs/CmwPR/QA6g=


### PR DESCRIPTION
Adds schemas to support Remote Sessions.

These resources allow Gram to coordinate credential exchange with remote authorization servers during the authentication challenge flow in the MCP Pathway.

There are three related resources included: `remote_sessions_issuers`, `remote_session_clients` and `remote_sessions`

This impacts two flows:

## Server creation
1. when a server is configured the flow will include discovering or creating an issuer for its backend.
2. After an issuer is created, Gram (or the user) will register a client for that issuer
3. The client will be connected to the user_session_issuer for that MCP

## MCP Request
1. When a request for a backend that is secured by an OAuth server is made
2. If a remote session IS NOT yet present, the user will be redirected to do  a challenge mediated by this clinet
3. If it IS present, the credential will be resolved off the remote session and passed along to the underlying server