### PR TITLE
mig: rename outbox_svix_relays to outbox_relays

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2545,9 +2545,9 @@ ON outbox (public_id);
 CREATE INDEX IF NOT EXISTS outbox_organization_id_id_idx
 ON outbox (organization_id, id);
 
--- Per-row Svix relay tracking. One row per outbox entry that has been
+-- Per-row relay tracking. One row per outbox entry that has been
 -- considered by the relay workflow. UPDATE-heavy: each retry rewrites the row.
-CREATE TABLE IF NOT EXISTS outbox_svix_relays (
+CREATE TABLE IF NOT EXISTS outbox_relays (
   outbox_id BIGINT NOT NULL,
 
   processed_at timestamptz,
@@ -2562,13 +2562,14 @@ CREATE TABLE IF NOT EXISTS outbox_svix_relays (
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
-  CONSTRAINT outbox_svix_relays_pkey PRIMARY KEY (outbox_id),
-  CONSTRAINT outbox_svix_relays_outbox_id_fkey FOREIGN KEY (outbox_id) REFERENCES outbox(id) ON DELETE CASCADE
+  CONSTRAINT outbox_relays_pkey PRIMARY KEY (outbox_id),
+  CONSTRAINT outbox_relays_outbox_id_fkey FOREIGN KEY (outbox_id) REFERENCES outbox(id) ON DELETE CASCADE
 ) WITH (
   fillfactor = 80,
   autovacuum_vacuum_scale_factor = 0.05,
   autovacuum_analyze_scale_factor = 0.05
 );
 
-CREATE INDEX IF NOT EXISTS outbox_svix_relays_pending_idx
-ON outbox_svix_relays (outbox_id) WHERE processed_at IS NULL AND dead_lettered IS FALSE;
+CREATE INDEX IF NOT EXISTS outbox_relays_pending_idx
+ON outbox_relays (outbox_id)
+WHERE processed_at IS NULL AND dead_lettered IS FALSE;

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -876,7 +876,7 @@ type Outbox struct {
 	CreatedAt      pgtype.Timestamptz
 }
 
-type OutboxSvixRelay struct {
+type OutboxRelay struct {
 	OutboxID      int64
 	ProcessedAt   pgtype.Timestamptz
 	Noop          bool

--- a/server/migrations/20260513000047_rename-outbox-relay-table.sql
+++ b/server/migrations/20260513000047_rename-outbox-relay-table.sql
@@ -1,3 +1,4 @@
+-- atlas:nolint DS102
 -- Create "outbox_relays" table
 CREATE TABLE "outbox_relays" (
   "outbox_id" bigint NOT NULL,

--- a/server/migrations/20260513000047_rename-outbox-relay-table.sql
+++ b/server/migrations/20260513000047_rename-outbox-relay-table.sql
@@ -1,4 +1,3 @@
--- atlas:nolint DS102
 -- Create "outbox_relays" table
 CREATE TABLE "outbox_relays" (
   "outbox_id" bigint NOT NULL,
@@ -16,5 +15,6 @@ CREATE TABLE "outbox_relays" (
 ) WITH (fillfactor = 80, autovacuum_vacuum_scale_factor = 0.05, autovacuum_analyze_scale_factor = 0.05);
 -- Create index "outbox_relays_pending_idx" to table: "outbox_relays"
 CREATE INDEX "outbox_relays_pending_idx" ON "outbox_relays" ("outbox_id") WHERE ((processed_at IS NULL) AND (dead_lettered IS FALSE));
+-- atlas:nolint DS102
 -- Drop "outbox_svix_relays" table
 DROP TABLE "outbox_svix_relays";

--- a/server/migrations/20260513000047_rename-outbox-relay-table.sql
+++ b/server/migrations/20260513000047_rename-outbox-relay-table.sql
@@ -1,0 +1,19 @@
+-- Create "outbox_relays" table
+CREATE TABLE "outbox_relays" (
+  "outbox_id" bigint NOT NULL,
+  "processed_at" timestamptz NULL,
+  "noop" boolean NOT NULL DEFAULT false,
+  "dead_lettered" boolean NOT NULL DEFAULT false,
+  "svix_message_id" text NULL,
+  "attempts" integer NOT NULL DEFAULT 0,
+  "last_error" text NULL,
+  "retry_after" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("outbox_id"),
+  CONSTRAINT "outbox_relays_outbox_id_fkey" FOREIGN KEY ("outbox_id") REFERENCES "outbox" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+) WITH (fillfactor = 80, autovacuum_vacuum_scale_factor = 0.05, autovacuum_analyze_scale_factor = 0.05);
+-- Create index "outbox_relays_pending_idx" to table: "outbox_relays"
+CREATE INDEX "outbox_relays_pending_idx" ON "outbox_relays" ("outbox_id") WHERE ((processed_at IS NULL) AND (dead_lettered IS FALSE));
+-- Drop "outbox_svix_relays" table
+DROP TABLE "outbox_svix_relays";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:EyZ+2ueONbctvK4TNKdjqs6I2erHqPk+6849vqzyvuI=
+h1:R9ipFUD+TXk3ARl27hq3198bzFMgN+NfGKPfi6gF8u8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -170,3 +170,4 @@ h1:EyZ+2ueONbctvK4TNKdjqs6I2erHqPk+6849vqzyvuI=
 20260512155737_add_workos_user_sync_metadata.sql h1:4VI2g6/r9x2TJyj3A9KRooa6pUi6zMUhrYNyaiKs/IQ=
 20260512175020_otel-forwarding-configs.sql h1:xmDFO0MH0Eyzrym5R1lV+0KTZeQwqMYzByhtmqUZSkM=
 20260512215317_add-retry-after-to-outbox-svix-relays.sql h1:o/1Y3Gh/+rXEdTFyLijpPsNLgXpNyhzNgIVeku/SKYU=
+20260513000047_rename-outbox-relay-table.sql h1:IfNkaOV/iWmSeZnuX87BCtBI01/B1NO1xmERVi/6/Ds=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GQ/Z+RC0/wLBV+V2xgoArcv2E3hIE0YUXzB/ISCuxUQ=
+h1:mwpEXLSylGsP200SVFqhzR6pRE9n8YuKI0Mc7aUULUg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -170,4 +170,4 @@ h1:GQ/Z+RC0/wLBV+V2xgoArcv2E3hIE0YUXzB/ISCuxUQ=
 20260512155737_add_workos_user_sync_metadata.sql h1:4VI2g6/r9x2TJyj3A9KRooa6pUi6zMUhrYNyaiKs/IQ=
 20260512175020_otel-forwarding-configs.sql h1:xmDFO0MH0Eyzrym5R1lV+0KTZeQwqMYzByhtmqUZSkM=
 20260512215317_add-retry-after-to-outbox-svix-relays.sql h1:o/1Y3Gh/+rXEdTFyLijpPsNLgXpNyhzNgIVeku/SKYU=
-20260513000047_rename-outbox-relay-table.sql h1:+6Iwt2fl2NYBhafxVhgacm3mBapuNWtvIP9KUCh5vcA=
+20260513000047_rename-outbox-relay-table.sql h1:AGyRYZsUpxHNZZj8Ziq1CgY1mu2xaWCWaR9HuRJE47c=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:R9ipFUD+TXk3ARl27hq3198bzFMgN+NfGKPfi6gF8u8=
+h1:GQ/Z+RC0/wLBV+V2xgoArcv2E3hIE0YUXzB/ISCuxUQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -170,4 +170,4 @@ h1:R9ipFUD+TXk3ARl27hq3198bzFMgN+NfGKPfi6gF8u8=
 20260512155737_add_workos_user_sync_metadata.sql h1:4VI2g6/r9x2TJyj3A9KRooa6pUi6zMUhrYNyaiKs/IQ=
 20260512175020_otel-forwarding-configs.sql h1:xmDFO0MH0Eyzrym5R1lV+0KTZeQwqMYzByhtmqUZSkM=
 20260512215317_add-retry-after-to-outbox-svix-relays.sql h1:o/1Y3Gh/+rXEdTFyLijpPsNLgXpNyhzNgIVeku/SKYU=
-20260513000047_rename-outbox-relay-table.sql h1:IfNkaOV/iWmSeZnuX87BCtBI01/B1NO1xmERVi/6/Ds=
+20260513000047_rename-outbox-relay-table.sql h1:+6Iwt2fl2NYBhafxVhgacm3mBapuNWtvIP9KUCh5vcA=


### PR DESCRIPTION
This change renames the outbox_svix_relays table to outbox_relays.

> [!CAUTION]
> Normally, this migration would cause data loss because it's implemented as a create-then-drop instead of `ALTER TABLE ...RENAME`. Atlas seems to not support the latter approach. **Nevertheless we consider this particular migration safe because the affected table is empty and no code currently reads from it or writes to it.**