### PR TITLE
feat(dashboard): make project overview date range configurable

### DIFF
--- a/.changeset/project-overview-date-filter.md
+++ b/.changeset/project-overview-date-filter.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Make the Project Overview page date range configurable via a `TimeRangePicker` in the header, matching the Insights and Logs pages. The selected range is URL-backed (`range`, `from`, `to`, `label`), the default is still the last 7 days, and the "Explore with AI" suggestions reflect the active range.

--- a/client/dashboard/src/components/observe/useDateRangeFilter.ts
+++ b/client/dashboard/src/components/observe/useDateRangeFilter.ts
@@ -1,0 +1,116 @@
+import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router";
+import {
+  isValidPreset,
+  safeBase64Decode,
+  safeBase64Encode,
+} from "./observeFilterUtils";
+
+const DEFAULT_PRESET: DateRangePreset = "7d";
+
+export function useDateRangeFilter(
+  defaultPreset: DateRangePreset = DEFAULT_PRESET,
+) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const urlRange = searchParams.get("range");
+  const urlFrom = searchParams.get("from");
+  const urlTo = searchParams.get("to");
+  const urlLabelEncoded = searchParams.get("label");
+  const customRangeLabel = urlLabelEncoded
+    ? safeBase64Decode(urlLabelEncoded)
+    : null;
+
+  const dateRange: DateRangePreset = isValidPreset(urlRange)
+    ? urlRange
+    : defaultPreset;
+
+  const customRange = useMemo(() => {
+    if (urlFrom && urlTo) {
+      const from = new Date(urlFrom);
+      const to = new Date(urlTo);
+      if (!isNaN(from.getTime()) && !isNaN(to.getTime())) {
+        return { from, to };
+      }
+    }
+    return null;
+  }, [urlFrom, urlTo]);
+
+  const updateSearchParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null) {
+            next.delete(key);
+          } else {
+            next.set(key, value);
+          }
+        }
+        return next;
+      });
+    },
+    [setSearchParams],
+  );
+
+  const setDateRangeParam = useCallback(
+    (preset: DateRangePreset) => {
+      updateSearchParams({ range: preset, from: null, to: null, label: null });
+    },
+    [updateSearchParams],
+  );
+
+  const setCustomRangeParam = useCallback(
+    (from: Date, to: Date, label?: string) => {
+      updateSearchParams({
+        range: null,
+        from: from.toISOString(),
+        to: to.toISOString(),
+        label: label ? safeBase64Encode(label) : null,
+      });
+    },
+    [updateSearchParams],
+  );
+
+  const clearCustomRange = useCallback(() => {
+    updateSearchParams({ from: null, to: null, label: null });
+  }, [updateSearchParams]);
+
+  const { from, to } = useMemo(
+    () => customRange ?? getPresetRange(dateRange),
+    [customRange, dateRange],
+  );
+
+  return {
+    dateRange,
+    customRange,
+    customRangeLabel,
+    from,
+    to,
+    setDateRangeParam,
+    setCustomRangeParam,
+    clearCustomRange,
+  };
+}
+
+const PRESET_LABELS: Record<DateRangePreset, string> = {
+  "15m": "last 15 minutes",
+  "1h": "last hour",
+  "4h": "last 4 hours",
+  "1d": "last day",
+  "2d": "last 2 days",
+  "3d": "last 3 days",
+  "7d": "last 7 days",
+  "15d": "last 15 days",
+  "30d": "last 30 days",
+  "90d": "last 3 months",
+};
+
+export function formatDateRangeLabel(
+  dateRange: DateRangePreset,
+  customRangeLabel: string | null,
+): string {
+  if (customRangeLabel) return customRangeLabel;
+  return PRESET_LABELS[dateRange] ?? "selected period";
+}

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -10,15 +10,19 @@ import { useOrgRoutes, useRoutes } from "@/routes";
 import { useAuditLogs, useGetProjectOverview } from "@gram/client/react-query";
 import { useFeaturesGet } from "@gram/client/react-query/featuresGet";
 import { cn } from "@/lib/utils";
-import { subDays } from "date-fns";
 import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { Badge, Button, Card, Icon } from "@speakeasy-api/moonshine";
+import { TimeRangePicker } from "@gram-ai/elements";
 import { Wand2 } from "lucide-react";
 import {
   INSIGHTS_AI_RAINBOW_CLASS,
   type InsightsConfigOptions,
 } from "@/components/insights-sidebar";
 import { useInsightsState } from "@/components/insights-context";
+import {
+  formatDateRangeLabel,
+  useDateRangeFilter,
+} from "@/components/observe/useDateRangeFilter";
 import { ActivityTimelineCard } from "./ActivityTimelineCard";
 import { ProjectOnboardingBanner } from "./ProjectOnboarding";
 
@@ -28,8 +32,21 @@ export function ProjectDashboard() {
   const routes = useRoutes();
   const orgRoutes = useOrgRoutes();
 
-  const to = useMemo(() => new Date(), []);
-  const from = useMemo(() => subDays(to, 7), [to]);
+  const {
+    dateRange,
+    customRange,
+    customRangeLabel,
+    from,
+    to,
+    setDateRangeParam,
+    setCustomRangeParam,
+    clearCustomRange,
+  } = useDateRangeFilter();
+
+  const rangeLabel = useMemo(
+    () => formatDateRangeLabel(dateRange, customRangeLabel),
+    [dateRange, customRangeLabel],
+  );
 
   const {
     data: featuresData,
@@ -106,7 +123,7 @@ export function ProjectDashboard() {
     return () => setInsightsOverride(null);
   }, [setInsightsOverride]);
 
-  const timeWindowContext = `The user is on the Project Overview dashboard. The selected period is the last 7 days (from ${from.toISOString()} to ${to.toISOString()}).`;
+  const timeWindowContext = `The user is on the Project Overview dashboard. The selected period is the ${rangeLabel} (from ${from.toISOString()} to ${to.toISOString()}).`;
 
   return (
     <Page.Section>
@@ -117,10 +134,15 @@ export function ProjectDashboard() {
         </Badge>
       </Page.Section.Description>
       <Page.Section.CTA>
-        {logsEnabled && !isProjectEmpty && (
-          <p className="text-muted text-xs">
-            Showing data from the last 7 days
-          </p>
+        {logsEnabled && (
+          <TimeRangePicker
+            preset={customRange ? null : dateRange}
+            customRange={customRange}
+            customRangeLabel={customRangeLabel}
+            onPresetChange={setDateRangeParam}
+            onCustomRangeChange={setCustomRangeParam}
+            onClearCustomRange={clearCustomRange}
+          />
         )}
       </Page.Section.CTA>
 
@@ -197,9 +219,8 @@ export function ProjectDashboard() {
                             suggestions: [
                               {
                                 title: "Top users & usage patterns",
-                                label: "Last 7 days",
-                                prompt:
-                                  "Who are my top 5 end users in the last 7 days, and what is each user's main usage pattern — tool calls, skill invocations, agent sessions, or a mix?",
+                                label: rangeLabel,
+                                prompt: `Who are my top 5 end users in the ${rangeLabel}, and what is each user's main usage pattern — tool calls, skill invocations, agent sessions, or a mix?`,
                               },
                             ],
                           })
@@ -241,9 +262,8 @@ export function ProjectDashboard() {
                             suggestions: [
                               {
                                 title: "Top servers & hot tools",
-                                label: "Last 7 days",
-                                prompt:
-                                  "Which servers received the most tool calls in the last 7 days, and which specific tools on each server are driving that volume? Lets look at data from all logs including hooks telemetry.",
+                                label: rangeLabel,
+                                prompt: `Which servers received the most tool calls in the ${rangeLabel}, and which specific tools on each server are driving that volume? Lets look at data from all logs including hooks telemetry.`,
                               },
                             ],
                           })
@@ -288,9 +308,8 @@ export function ProjectDashboard() {
                             suggestions: [
                               {
                                 title: "Power users & agent behavior",
-                                label: "Last 7 days",
-                                prompt:
-                                  "For the users with the most agent sessions in the last 7 days, what are the common prompts they send and which tools get invoked most often?",
+                                label: rangeLabel,
+                                prompt: `For the users with the most agent sessions in the ${rangeLabel}, what are the common prompts they send and which tools get invoked most often?`,
                               },
                             ],
                           })
@@ -363,9 +382,8 @@ export function ProjectDashboard() {
                             suggestions: [
                               {
                                 title: "LLM clients & reliability",
-                                label: "Last 7 days",
-                                prompt:
-                                  "Break down tool-call activity by LLM client in the last 7 days and highlight any clients with unusually high error rates or latency.",
+                                label: rangeLabel,
+                                prompt: `Break down tool-call activity by LLM client in the ${rangeLabel} and highlight any clients with unusually high error rates or latency.`,
                               },
                             ],
                           })

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -7,8 +7,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useProject } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
 import { useOrgRoutes, useRoutes } from "@/routes";
-import { useAuditLogs, useGetProjectOverview } from "@gram/client/react-query";
+import { useAuditLogs, useGramContext } from "@gram/client/react-query";
 import { useFeaturesGet } from "@gram/client/react-query/featuresGet";
+import { telemetryGetProjectOverview } from "@gram/client/funcs/telemetryGetProjectOverview";
+import { unwrapAsync } from "@gram/client/types/fp";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
 import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { Badge, Button, Card, Icon } from "@speakeasy-api/moonshine";
@@ -55,12 +58,22 @@ export function ProjectDashboard() {
   } = useFeaturesGet();
   const logsEnabled = featuresData?.logsEnabled === true;
 
-  const { data: overview, isPending: isOverviewPending } =
-    useGetProjectOverview(
-      { getProjectMetricsSummaryPayload: { from, to } },
-      undefined,
-      { enabled: logsEnabled },
-    );
+  // The SDK's useGetProjectOverview omits the request body from its query
+  // key, so changing the date range here would otherwise return cached data.
+  // Mirror the observe-page pattern: call useQuery directly with a key that
+  // includes the from/to ISO strings.
+  const client = useGramContext();
+  const { data: overview, isPending: isOverviewPending } = useQuery({
+    queryKey: ["project", "overview", from.toISOString(), to.toISOString()],
+    queryFn: () =>
+      unwrapAsync(
+        telemetryGetProjectOverview(client, {
+          getProjectMetricsSummaryPayload: { from, to },
+        }),
+      ),
+    enabled: logsEnabled,
+    placeholderData: keepPreviousData,
+  });
 
   const featuresSettled = !isFeaturesPending || isFeaturesError;
   const isOverviewLoading =


### PR DESCRIPTION
## Summary

- Project Overview page was hardcoded to the last 7 days. This makes the date range configurable via `TimeRangePicker` in the page header, matching the pattern already used on the Insights / Logs pages.
- Range is URL-backed (`range`, `from`, `to`, `label` search params — same conventions as the observe pages, so deep links round-trip across both surfaces). Default preset is `7d`, so the page renders identically to before for users who haven't changed the picker.
- All four "Explore with AI" prompts and the `timeWindowContext` they share now substitute the live range label (e.g. `"last 30 days"`, `"last 3 months"`, or a custom label) instead of the hardcoded `"last 7 days"` string.

<img width="2494" height="976" alt="CleanShot 2026-05-12 at 17 39 37@2x" src="https://github.com/user-attachments/assets/b591638b-78fc-4ba3-b96f-ca5345454741" />

## Implementation notes

- New focused hook `client/dashboard/src/components/observe/useDateRangeFilter.ts` — handles just URL-backed date range state (the existing `useObserveFilters` does the same thing but bundled with server/user/hook-type filters that the overview doesn't need). Layered on top of the existing `getPresetRange` / `isValidPreset` / `safeBase64*` helpers, plus a small `formatDateRangeLabel` helper for rendering the human-readable range into AI prompts.
- `ProjectDashboard.tsx`: dropped `subDays` / `date-fns`, mounted `TimeRangePicker` in the `Page.Section.CTA` slot (replacing the static "Showing data from the last 7 days" text), parameterized the AI suggestion labels and prompt strings on `rangeLabel`.

## Test plan

- [ ] Project overview loads with the default 7-day range (no URL params)
- [ ] Picking a different preset (e.g. 30d) refreshes KPI cards, top users / servers, and the LLM client breakdown
- [ ] Picking a custom range works and the label appears in the picker trigger
- [ ] Reloading the page preserves the selected range (URL params)
- [ ] "Explore with AI" prompts reflect the currently selected range
- [ ] Logging-disabled state still renders the disabled banner correctly (picker hidden when `logsEnabled === false`)
