### PR TITLE
feat(mcp): introduce remote session challenge coordination to auth flow

### DIFF
--- a/dev-idp/internal/database/queries.sql
+++ b/dev-idp/internal/database/queries.sql
@@ -365,6 +365,22 @@ RETURNING *;
 DELETE FROM current_users WHERE mode = @mode;
 
 -- =============================================================================
+-- oauth_clients (dynamic client registration for oauth2-1)
+-- =============================================================================
+
+-- name: CreateOAuthClient :one
+INSERT INTO oauth_clients (
+  client_id, mode, client_secret, redirect_uris
+)
+VALUES (
+  @client_id, @mode, @client_secret, @redirect_uris
+)
+RETURNING *;
+
+-- name: GetOAuthClient :one
+SELECT * FROM oauth_clients WHERE client_id = @client_id AND mode = @mode;
+
+-- =============================================================================
 -- auth_codes / tokens (shared by every OAuth-shaped mode)
 -- =============================================================================
 

--- a/dev-idp/internal/database/repo/models.go
+++ b/dev-idp/internal/database/repo/models.go
@@ -53,6 +53,14 @@ type Membership struct {
 	UpdatedAt      time.Time
 }
 
+type OauthClient struct {
+	ClientID     string
+	Mode         string
+	ClientSecret string
+	RedirectUris string
+	CreatedAt    time.Time
+}
+
 type Organization struct {
 	ID          uuid.UUID
 	Name        string

--- a/dev-idp/internal/database/repo/queries.sql.go
+++ b/dev-idp/internal/database/repo/queries.sql.go
@@ -259,6 +259,45 @@ func (q *Queries) CreateMembership(ctx context.Context, arg CreateMembershipPara
 	return i, err
 }
 
+const createOAuthClient = `-- name: CreateOAuthClient :one
+
+INSERT INTO oauth_clients (
+  client_id, mode, client_secret, redirect_uris
+)
+VALUES (
+  ?1, ?2, ?3, ?4
+)
+RETURNING client_id, mode, client_secret, redirect_uris, created_at
+`
+
+type CreateOAuthClientParams struct {
+	ClientID     string
+	Mode         string
+	ClientSecret string
+	RedirectUris string
+}
+
+// =============================================================================
+// oauth_clients (dynamic client registration for oauth2-1)
+// =============================================================================
+func (q *Queries) CreateOAuthClient(ctx context.Context, arg CreateOAuthClientParams) (OauthClient, error) {
+	row := q.db.QueryRowContext(ctx, createOAuthClient,
+		arg.ClientID,
+		arg.Mode,
+		arg.ClientSecret,
+		arg.RedirectUris,
+	)
+	var i OauthClient
+	err := row.Scan(
+		&i.ClientID,
+		&i.Mode,
+		&i.ClientSecret,
+		&i.RedirectUris,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const createOrganization = `-- name: CreateOrganization :one
 
 INSERT INTO organizations (id, name, slug, account_type, workos_id)
@@ -666,6 +705,28 @@ func (q *Queries) GetMembershipWithOrgName(ctx context.Context, id uuid.UUID) (G
 		&i.Role,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getOAuthClient = `-- name: GetOAuthClient :one
+SELECT client_id, mode, client_secret, redirect_uris, created_at FROM oauth_clients WHERE client_id = ?1 AND mode = ?2
+`
+
+type GetOAuthClientParams struct {
+	ClientID string
+	Mode     string
+}
+
+func (q *Queries) GetOAuthClient(ctx context.Context, arg GetOAuthClientParams) (OauthClient, error) {
+	row := q.db.QueryRowContext(ctx, getOAuthClient, arg.ClientID, arg.Mode)
+	var i OauthClient
+	err := row.Scan(
+		&i.ClientID,
+		&i.Mode,
+		&i.ClientSecret,
+		&i.RedirectUris,
+		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/dev-idp/internal/database/schema.sql
+++ b/dev-idp/internal/database/schema.sql
@@ -56,8 +56,20 @@ CREATE TABLE IF NOT EXISTS current_users (
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- Short-TTL `/authorize` codes. `client_id` is recorded for inspection only —
--- never validated against any registered list.
+-- Dynamically registered OAuth 2.1 clients. The dev-idp only needs enough
+-- state to reject /authorize redirect_uri values that were not registered.
+CREATE TABLE IF NOT EXISTS oauth_clients (
+  client_id TEXT NOT NULL PRIMARY KEY,
+  mode TEXT NOT NULL,
+  client_secret TEXT NOT NULL,
+  redirect_uris TEXT NOT NULL DEFAULT '[]',
+
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS oauth_clients_mode_idx ON oauth_clients (mode);
+
+-- Short-TTL `/authorize` codes.
 CREATE TABLE IF NOT EXISTS auth_codes (
   code TEXT NOT NULL PRIMARY KEY,
   mode TEXT NOT NULL,

--- a/dev-idp/internal/modes/oauth21/handler.go
+++ b/dev-idp/internal/modes/oauth21/handler.go
@@ -5,9 +5,8 @@
 //
 // Identity resolution is non-interactive (idp-design.md §3) — every
 // /authorize call resolves the per-mode currentUser and
-// immediately redirects with the issued code. Client authentication is
-// permissive (idp-design.md §5.2) — every client_id / client_secret /
-// redirect_uri is accepted as-is.
+// immediately redirects with the issued code. Dynamic client registration
+// persists redirect_uris so tests can catch unregistered callback URLs.
 package oauth21
 
 import (
@@ -192,7 +191,7 @@ type dcrResponse struct {
 
 func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Decode whatever the caller sent so we can echo redirect_uris /
-	// grant_types / response_types back. None of it is persisted (§5.2).
+	// grant_types / response_types back.
 	var body struct {
 		RedirectURIs            []string `json:"redirect_uris"`
 		GrantTypes              []string `json:"grant_types"`
@@ -201,12 +200,35 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
 
+	clientID := "client_" + randomHex(16)
+	clientSecret := "secret_" + randomHex(32)
+	redirectURIs := body.RedirectURIs
+	if redirectURIs == nil {
+		redirectURIs = []string{}
+	}
+	rawRedirectURIs, err := json.Marshal(redirectURIs)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "marshal registered redirect uris", slog.Any("error", err))
+		oauthError(w, http.StatusInternalServerError, "server_error", "failed to register client")
+		return
+	}
+	if _, err := repo.New(h.db).CreateOAuthClient(r.Context(), repo.CreateOAuthClientParams{
+		ClientID:     clientID,
+		Mode:         Mode,
+		ClientSecret: clientSecret,
+		RedirectUris: string(rawRedirectURIs),
+	}); err != nil {
+		h.logger.ErrorContext(r.Context(), "create oauth client", slog.Any("error", err))
+		oauthError(w, http.StatusInternalServerError, "server_error", "failed to register client")
+		return
+	}
+
 	writeJSON(w, http.StatusCreated, dcrResponse{
-		ClientID:                "client_" + randomHex(16),
-		ClientSecret:            "secret_" + randomHex(32),
+		ClientID:                clientID,
+		ClientSecret:            clientSecret,
 		ClientIDIssuedAt:        time.Now().Unix(),
 		ClientSecretExpiresAt:   0, // 0 = never expires (RFC 7591)
-		RedirectURIs:            body.RedirectURIs,
+		RedirectURIs:            redirectURIs,
 		GrantTypes:              body.GrantTypes,
 		ResponseTypes:           body.ResponseTypes,
 		TokenEndpointAuthMethod: body.TokenEndpointAuthMethod,
@@ -254,6 +276,30 @@ func (h *Handler) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	target, err := url.Parse(redirectURI)
 	if err != nil {
 		oauthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri is not a valid URL")
+		return
+	}
+
+	client, err := repo.New(h.db).GetOAuthClient(ctx, repo.GetOAuthClientParams{
+		ClientID: clientID,
+		Mode:     Mode,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			oauthError(w, http.StatusBadRequest, "invalid_client", "client_id is not registered")
+			return
+		}
+		h.logger.ErrorContext(ctx, "load oauth client", slog.Any("error", err))
+		oauthError(w, http.StatusInternalServerError, "server_error", "failed to load client")
+		return
+	}
+	var registeredRedirectURIs []string
+	if err := json.Unmarshal([]byte(client.RedirectUris), &registeredRedirectURIs); err != nil {
+		h.logger.ErrorContext(ctx, "decode registered redirect uris", slog.Any("error", err))
+		oauthError(w, http.StatusInternalServerError, "server_error", "failed to load client")
+		return
+	}
+	if !slices.Contains(registeredRedirectURIs, redirectURI) {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri is not registered for this client")
 		return
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/getkin/kin-openapi v0.133.0 h1:pJdmNohVIJ97r4AUFtEXRXwESr8b0bD721u/Tz6k8PQ=
+github.com/getkin/kin-openapi v0.133.0/go.mod h1:boAciF6cXk5FhPqe/NQeBTeenbjqU4LhWBf09ILVvWE=
 github.com/gitleaks/go-gitdiff v0.9.1 h1:ni6z6/3i9ODT685OLCTf+s/ERlWUNWQF4x1pvoNICw0=
 github.com/gitleaks/go-gitdiff v0.9.1/go.mod h1:pKz0X4YzCKZs30BL+weqBIG7mx0jl4tF1uXV9ZyNvrA=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
@@ -559,6 +561,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
@@ -573,6 +577,10 @@ github.com/nwaples/rardecode/v2 v2.1.0/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsR
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
+github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
@@ -607,6 +615,8 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2D
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
+github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
+github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pganalyze/pg_query_go/v6 v6.1.0 h1:jG5ZLhcVgL1FAw4C/0VNQaVmX1SUJx71wBGdtTtBvls=
 github.com/pganalyze/pg_query_go/v6 v6.1.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/pgvector/pgvector-go v0.3.0 h1:Ij+Yt78R//uYqs3Zk35evZFvr+G0blW0OUN+Q2D1RWc=
@@ -794,6 +804,8 @@ github.com/wasilibs/go-re2 v1.9.0 h1:kjAd8qbNvV4Ve2Uf+zrpTCrDHtqH4dlsRXktywo73JQ
 github.com/wasilibs/go-re2 v1.9.0/go.mod h1:0sRtscWgpUdNA137bmr1IUgrRX0Su4dcn9AEe61y+yI=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
+github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
+github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 github.com/workos/workos-go/v6 v6.5.0 h1:buh8Qj2SpffRAXROs789EnEWQPTvnOqjN4GBb272l9g=
 github.com/workos/workos-go/v6 v6.5.0/go.mod h1:s2UWX2+JxAjTJ7Gr8B+iiAzs8CbHXPUd/ilqd7t0Ayc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,6 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/getkin/kin-openapi v0.133.0 h1:pJdmNohVIJ97r4AUFtEXRXwESr8b0bD721u/Tz6k8PQ=
-github.com/getkin/kin-openapi v0.133.0/go.mod h1:boAciF6cXk5FhPqe/NQeBTeenbjqU4LhWBf09ILVvWE=
 github.com/gitleaks/go-gitdiff v0.9.1 h1:ni6z6/3i9ODT685OLCTf+s/ERlWUNWQF4x1pvoNICw0=
 github.com/gitleaks/go-gitdiff v0.9.1/go.mod h1:pKz0X4YzCKZs30BL+weqBIG7mx0jl4tF1uXV9ZyNvrA=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
@@ -561,8 +559,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
@@ -577,10 +573,6 @@ github.com/nwaples/rardecode/v2 v2.1.0/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsR
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
-github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
@@ -615,8 +607,6 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2D
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
-github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
-github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pganalyze/pg_query_go/v6 v6.1.0 h1:jG5ZLhcVgL1FAw4C/0VNQaVmX1SUJx71wBGdtTtBvls=
 github.com/pganalyze/pg_query_go/v6 v6.1.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/pgvector/pgvector-go v0.3.0 h1:Ij+Yt78R//uYqs3Zk35evZFvr+G0blW0OUN+Q2D1RWc=
@@ -804,8 +794,6 @@ github.com/wasilibs/go-re2 v1.9.0 h1:kjAd8qbNvV4Ve2Uf+zrpTCrDHtqH4dlsRXktywo73JQ
 github.com/wasilibs/go-re2 v1.9.0/go.mod h1:0sRtscWgpUdNA137bmr1IUgrRX0Su4dcn9AEe61y+yI=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
-github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
-github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 github.com/workos/workos-go/v6 v6.5.0 h1:buh8Qj2SpffRAXROs789EnEWQPTvnOqjN4GBb272l9g=
 github.com/workos/workos-go/v6 v6.5.0/go.mod h1:s2UWX2+JxAjTJ7Gr8B+iiAzs8CbHXPUd/ilqd7t0Ayc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -766,6 +766,15 @@ func newStartCommand() *cli.Command {
 				platformtoolsruntime.WithExternalTools(memoryTools),
 			)
 
+			remoteChallengeManager := remotesessions.NewChallengeManager(
+				logger,
+				db,
+				encryptionClient,
+				guardianPolicy,
+				cache.NewRedisCacheAdapter(redisClient),
+				serverURL,
+			)
+
 			mcpService := mcp.NewService(
 				logger,
 				tracerProvider,
@@ -797,6 +806,7 @@ func newStartCommand() *cli.Command {
 				platformToolsets,
 				identityResolver,
 				usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)),
+				remoteChallengeManager,
 			)
 
 			chatClient := chat.NewAgenticChatClient(

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -45,6 +45,7 @@ import (
 	platformtoolsruntime "github.com/speakeasy-api/gram/server/internal/platformtools/runtime"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -623,6 +624,15 @@ func newWorkerCommand() *cli.Command {
 			memoryTools := platformtoolsruntime.MemoryExternalTools(memorySvc)
 			platformFeatureChecker := productFeatures.PlatformFeatureCheck
 
+			remoteChallengeManager := remotesessions.NewChallengeManager(
+				logger,
+				db,
+				encryptionClient,
+				guardianPolicy,
+				cache.NewRedisCacheAdapter(redisClient),
+				serverURL,
+			)
+
 			mcpService := mcp.NewService(
 				logger,
 				tracerProvider,
@@ -654,6 +664,7 @@ func newWorkerCommand() *cli.Command {
 				nil,
 				identityResolver,
 				usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)),
+				remoteChallengeManager,
 			)
 
 			chatClient := chat.NewAgenticChatClient(

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -32,12 +32,27 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
+
+// LegacyMcpEndpointRef identifies an MCP endpoint by (mcp_slug,
+// custom_domain_id) — the tuple of toolset columns that addresses a
+// served MCP server outside of any project context. Structurally
+// similar to the new MCP Endpoint concept
+// (mcpendpointsrepo.McpEndpoint) but distinct: this reference points
+// into the legacy toolsets-driven MCP surface, where each toolset row
+// exposes one (slug, optional domain) pair, not a separate
+// mcp_endpoints row. Resolved to a *toolsets_repo.Toolset by
+// (*Service).resolveMcp.
+type LegacyMcpEndpointRef struct {
+	McpSlug        string        `json:"mcp_slug"`
+	CustomDomainID uuid.NullUUID `json:"custom_domain_id"`
+}
 
 // AuthnChallengeState is the in-flight context of a single Gram-as-AS authn
 // challenge — the OAuth client's request, the issuer it's against, and the
@@ -46,14 +61,14 @@ import (
 // round-trip through the IDP and land on /connect, short enough that
 // abandoned flows don't pile up.
 type AuthnChallengeState struct {
-	ID                  string    `json:"id"`
-	UserSessionIssuerID uuid.UUID `json:"user_session_issuer_id"`
-	ToolsetID           uuid.UUID `json:"toolset_id"`
-	ClientID            string    `json:"client_id"`
-	RedirectURI         string    `json:"redirect_uri"`
-	State               string    `json:"state,omitempty"`
-	CodeChallenge       string    `json:"code_challenge"`
-	CodeChallengeMethod string    `json:"code_challenge_method"`
+	ID                  string               `json:"id"`
+	UserSessionIssuerID uuid.UUID            `json:"user_session_issuer_id"`
+	Endpoint            LegacyMcpEndpointRef `json:"endpoint"`
+	ClientID            string               `json:"client_id"`
+	RedirectURI         string               `json:"redirect_uri"`
+	State               string               `json:"state,omitempty"`
+	CodeChallenge       string               `json:"code_challenge"`
+	CodeChallengeMethod string               `json:"code_challenge_method"`
 	// Subject is nil on creation; HandleIDPCallback (private path)
 	// stamps `user:<id>`, HandleConsent's POST mints a fresh
 	// `anonymous:<uuid>` on the public path. Pointer so the Redis JSON
@@ -191,6 +206,52 @@ func WriteAuthenticateChallenge(w http.ResponseWriter, baseURL, mcpSlug, message
 		return oops.C(oops.CodeUnauthorized)
 	}
 	return oops.E(oops.CodeUnauthorized, nil, "%s", message)
+}
+
+var errToolsetEndpointMismatch = errors.New("authn challenge endpoint does not match toolset")
+
+// resolveMcp loads the Toolset addressed by a LegacyMcpEndpointRef. The
+// single source of truth for endpoint → toolset across both
+// path-driven handlers (via loadToolsetFromMcpSlug) and stored-state
+// callbacks (HandleIDPCallback). Strict semantics: an unset
+// CustomDomainID matches ONLY toolsets with custom_domain_id IS NULL —
+// no prefer-platform-with-fallback. Returns errToolsetNotFound on
+// pgx.ErrNoRows.
+func (s *Service) resolveMcp(ctx context.Context, endpoint LegacyMcpEndpointRef) (*toolsets_repo.Toolset, error) {
+	var toolset toolsets_repo.Toolset
+	var err error
+	if endpoint.CustomDomainID.Valid {
+		toolset, err = s.toolsetsRepo.GetToolsetByMcpSlugAndCustomDomain(ctx, toolsets_repo.GetToolsetByMcpSlugAndCustomDomainParams{
+			McpSlug:        conv.ToPGText(endpoint.McpSlug),
+			CustomDomainID: endpoint.CustomDomainID,
+		})
+	} else {
+		toolset, err = s.toolsetsRepo.GetToolsetByPlatformMcpSlug(ctx, conv.ToPGText(endpoint.McpSlug))
+	}
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, errToolsetNotFound
+	case err != nil:
+		return nil, fmt.Errorf("lookup toolset: %w", err)
+	}
+	return &toolset, nil
+}
+
+// compareToolsetEndpoint asserts the stored endpoint reference matches
+// the toolset's (mcp_slug, custom_domain_id) tuple. Replaces the
+// historical ToolsetID-equality state-confusion guard. Today there is
+// one endpoint per toolset and the comparison is direct; the helper
+// centralises it so a future model with multiple mcp_endpoints rows
+// per toolset can expand the check to "endpoint is in the toolset's
+// endpoint set" without churning callers.
+func compareToolsetEndpoint(toolset *toolsets_repo.Toolset, endpoint LegacyMcpEndpointRef) error {
+	if conv.PtrValOr(conv.FromPGText[string](toolset.McpSlug), "") != endpoint.McpSlug {
+		return errToolsetEndpointMismatch
+	}
+	if toolset.CustomDomainID != endpoint.CustomDomainID {
+		return errToolsetEndpointMismatch
+	}
+	return nil
 }
 
 // requireUserSessionIssuer verifies the toolset's user_session_issuer_id FK

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -56,7 +56,7 @@ type LegacyMcpEndpointRef struct {
 
 // AuthnChallengeState is the in-flight context of a single Gram-as-AS authn
 // challenge — the OAuth client's request, the issuer it's against, and the
-// resolved subject (stamped later in the flow). Stored in Redis under
+// subject once it has been resolved. Stored in Redis under
 // `authnChallenge:{ID}` for ~10 minutes — long enough for the user to
 // round-trip through the IDP and land on /connect, short enough that
 // abandoned flows don't pile up.
@@ -69,11 +69,12 @@ type AuthnChallengeState struct {
 	State               string               `json:"state,omitempty"`
 	CodeChallenge       string               `json:"code_challenge"`
 	CodeChallengeMethod string               `json:"code_challenge_method"`
-	// Subject is nil on creation; HandleIDPCallback (private path)
-	// stamps `user:<id>`, HandleConsent's POST mints a fresh
-	// `anonymous:<uuid>` on the public path. Pointer so the Redis JSON
-	// can round-trip an unstamped state (the URN's MarshalJSON refuses
-	// to serialise a zero-value SessionSubject).
+	CSRFToken           string               `json:"csrf_token"`
+	// Subject is stamped exactly once before consent is rendered:
+	// HandleAuthorize stamps `anonymous:<uuid>` for public toolsets, and
+	// HandleIDPCallback stamps `user:<id>` for private toolsets. Pointer so
+	// the Redis JSON can round-trip the private pre-IDP state (the URN's
+	// MarshalJSON refuses to serialise a zero-value SessionSubject).
 	Subject   *urn.SessionSubject `json:"subject,omitempty"`
 	CreatedAt time.Time           `json:"created_at"`
 }
@@ -210,13 +211,11 @@ func WriteAuthenticateChallenge(w http.ResponseWriter, baseURL, mcpSlug, message
 
 var errToolsetEndpointMismatch = errors.New("authn challenge endpoint does not match toolset")
 
-// resolveMcp loads the Toolset addressed by a LegacyMcpEndpointRef. The
-// single source of truth for endpoint → toolset across both
-// path-driven handlers (via loadToolsetFromMcpSlug) and stored-state
-// callbacks (HandleIDPCallback). Strict semantics: an unset
-// CustomDomainID matches ONLY toolsets with custom_domain_id IS NULL —
-// no prefer-platform-with-fallback. Returns errToolsetNotFound on
-// pgx.ErrNoRows.
+// resolveMcp loads the Toolset addressed by a LegacyMcpEndpointRef. Note
+// that this resolution differs from other places where we resolve MCPs in
+// the legacy MCP pathway. It pins the MCP to only be resolved through a
+// single context rather than allowing it to be resolved willy-nilly by
+// platform slug. Returns errToolsetNotFound on pgx.ErrNoRows.
 func (s *Service) resolveMcp(ctx context.Context, endpoint LegacyMcpEndpointRef) (*toolsets_repo.Toolset, error) {
 	var toolset toolsets_repo.Toolset
 	var err error

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -129,7 +129,7 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	if !toolset.McpIsPublic {
-		callbackURL := fmt.Sprintf("%s/mcp/%s/idp_callback", baseURL, mcpSlug)
+		callbackURL := fmt.Sprintf("%s/mcp/%s/idp_callback", s.serverURL.String(), mcpSlug)
 		idpURL, err := s.identityResolver.BuildAuthorizationURL(ctx, sessions.AuthURLParams{
 			CallbackURL:     callbackURL,
 			Scope:           "",

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -23,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -38,8 +39,8 @@ import (
 //   - branch on the toolset's privacy:
 //   - private (`!McpIsPublic`): 302 to the Speakeasy IDP login page; on
 //     return HandleIDPCallback stamps `user:<id>` onto the state
-//   - public (`McpIsPublic`): 302 directly to /connect; HandleConsent's
-//     POST stamps `anonymous:<prospective_mcp_session_id>`
+//   - public (`McpIsPublic`): stamp an anonymous subject, then 302 directly
+//     to /connect
 func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	mcpSlug := chi.URLParam(r, "mcpSlug")
@@ -103,9 +104,18 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	challengeID := uuid.NewString()
+	csrfToken, err := generateOpaqueToken()
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "generate consent csrf token").Log(ctx, logger)
+	}
 	customDomainID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 	if customDomainCtx != nil {
 		customDomainID = uuid.NullUUID{UUID: customDomainCtx.DomainID, Valid: true}
+	}
+	var subject *urn.SessionSubject
+	if toolset.McpIsPublic {
+		sub := urn.NewAnonymousSubject(uuid.NewString())
+		subject = &sub
 	}
 
 	challengeState := AuthnChallengeState{
@@ -115,15 +125,14 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 			McpSlug:        mcpSlug,
 			CustomDomainID: customDomainID,
 		},
-		ClientID: req.ClientID,
+		ClientID:            req.ClientID,
 		RedirectURI:         req.RedirectURI,
 		State:               req.State,
 		CodeChallenge:       req.CodeChallenge,
 		CodeChallengeMethod: req.CodeChallengeMethod,
-		// Subject is left nil — HandleIDPCallback (private path) and
-		// HandleConsent (public path) stamp it later in the flow.
-		Subject:   nil,
-		CreatedAt: time.Now(),
+		CSRFToken:           csrfToken,
+		Subject:             subject,
+		CreatedAt:           time.Now(),
 	}
 
 	if err := s.authnChallengeCache.Store(ctx, challengeState); err != nil {
@@ -136,7 +145,10 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	if !toolset.McpIsPublic {
-		callbackURL := fmt.Sprintf("%s/mcp/idp_callback", s.serverURL.String())
+		callbackURL, err := url.JoinPath(s.serverURL.String(), "mcp", "idp_callback")
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "build IDP callback URL").Log(ctx, logger)
+		}
 		idpURL, err := s.identityResolver.BuildAuthorizationURL(ctx, sessions.AuthURLParams{
 			CallbackURL:     callbackURL,
 			Scope:           "",
@@ -151,9 +163,11 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 		return nil
 	}
 
-	// Public toolset: skip IDP, route straight to consent. The anonymous sub
-	// is minted on the consent POST (per plan).
-	consentURL := fmt.Sprintf("%s/mcp/%s/connect?state=%s", baseURL, mcpSlug, url.QueryEscape(challengeID))
+	// Public toolset: skip IDP and route straight to consent.
+	consentURL, err := buildConsentURL(baseURL, mcpSlug, challengeID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build consent URL").Log(ctx, logger)
+	}
 	http.Redirect(w, r, consentURL, http.StatusFound)
 	return nil
 }

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -103,12 +103,19 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	challengeID := uuid.NewString()
+	customDomainID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
+	if customDomainCtx != nil {
+		customDomainID = uuid.NullUUID{UUID: customDomainCtx.DomainID, Valid: true}
+	}
 
 	challengeState := AuthnChallengeState{
 		ID:                  challengeID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ToolsetID:           toolset.ID,
-		ClientID:            req.ClientID,
+		Endpoint: LegacyMcpEndpointRef{
+			McpSlug:        mcpSlug,
+			CustomDomainID: customDomainID,
+		},
+		ClientID: req.ClientID,
 		RedirectURI:         req.RedirectURI,
 		State:               req.State,
 		CodeChallenge:       req.CodeChallenge,
@@ -129,7 +136,7 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	}
 
 	if !toolset.McpIsPublic {
-		callbackURL := fmt.Sprintf("%s/mcp/%s/idp_callback", s.serverURL.String(), mcpSlug)
+		callbackURL := fmt.Sprintf("%s/mcp/idp_callback", s.serverURL.String())
 		idpURL, err := s.identityResolver.BuildAuthorizationURL(ctx, sessions.AuthURLParams{
 			CallbackURL:     callbackURL,
 			Scope:           "",

--- a/server/internal/mcp/authnchallenge_authorize_test.go
+++ b/server/internal/mcp/authnchallenge_authorize_test.go
@@ -24,7 +24,7 @@ import (
 func TestAuthorize_CustomDomainPrivateChallengeUsesGramIDPCallback(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestMCPService(t)
+	ctx, ti, _ := newTestMCPServiceWithDevIDP(t)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -62,12 +62,12 @@ func TestAuthorize_CustomDomainPrivateChallengeUsesGramIDPCallback(t *testing.T)
 
 	loc, err := url.Parse(w.Header().Get("Location"))
 	require.NoError(t, err)
-	returnURL, err := url.Parse(loc.Query().Get("return_url"))
+	redirectURI, err := url.Parse(loc.Query().Get("redirect_uri"))
 	require.NoError(t, err)
-	require.Equal(t, ti.serverURL.Scheme, returnURL.Scheme)
-	require.Equal(t, ti.serverURL.Host, returnURL.Host)
-	require.Equal(t, "/mcp/idp_callback", returnURL.Path)
-	require.NotEqual(t, domain.Domain, returnURL.Host)
+	require.Equal(t, ti.serverURL.Scheme, redirectURI.Scheme)
+	require.Equal(t, ti.serverURL.Host, redirectURI.Host)
+	require.Equal(t, "/mcp/idp_callback", redirectURI.Path)
+	require.NotEqual(t, domain.Domain, redirectURI.Host)
 
 	_, authnCache := buildChallengeManagerForTest(t, ti)
 	stored, err := authnCache.Get(ctx, "authnChallenge:"+loc.Query().Get("state"))

--- a/server/internal/mcp/authnchallenge_authorize_test.go
+++ b/server/internal/mcp/authnchallenge_authorize_test.go
@@ -1,0 +1,116 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+func TestAuthorize_CustomDomainPrivateChallengeUsesGramIDPCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "auth-callback-cd-" + uuid.New().String()[:8]
+	toolset, issuer := createPrivateIssuerGatedToolset(t, ctx, ti, authCtx, slug)
+	toolset, domain := attachCustomDomainToToolset(t, ctx, ti, authCtx, toolset, "auth-callback.example.com")
+	clientID := "custom-domain-client"
+	clientRedirectURI := "http://example.com/cb"
+	insertUserSessionClient(t, ctx, ti.conn, issuer.ID, clientID)
+
+	customCtx := customdomains.WithContext(context.Background(), &customdomains.Context{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domain.Domain,
+		DomainID:       domain.ID,
+	})
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", clientRedirectURI)
+	q.Set("state", "state-123")
+	q.Set("code_challenge", "challenge")
+	q.Set("code_challenge_method", "S256")
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+slug+"/authorize?"+q.Encode(), nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", slug)
+	req = req.WithContext(context.WithValue(customCtx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleAuthorize(w, req))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	returnURL, err := url.Parse(loc.Query().Get("return_url"))
+	require.NoError(t, err)
+	require.Equal(t, ti.serverURL.Scheme, returnURL.Scheme)
+	require.Equal(t, ti.serverURL.Host, returnURL.Host)
+	require.Equal(t, "/mcp/"+toolset.McpSlug.String+"/idp_callback", returnURL.Path)
+	require.NotEqual(t, domain.Domain, returnURL.Host)
+}
+
+func createPrivateIssuerGatedToolset(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	authCtx *contextvalues.AuthContext,
+	slug string,
+) (toolsets_repo.Toolset, usersessions_repo.UserSessionIssuer) {
+	t.Helper()
+
+	usersRepo := usersessions_repo.New(ti.conn)
+	issuer, err := usersRepo.CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
+		ProjectID:          *authCtx.ProjectID,
+		Slug:               "usi-" + uuid.New().String()[:8],
+		AuthnChallengeMode: "interactive",
+		SessionDuration: pgtype.Interval{
+			Microseconds: int64(time.Hour / time.Microsecond),
+			Days:         0,
+			Months:       0,
+			Valid:        true,
+		},
+	})
+	require.NoError(t, err)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Private Issuer MCP " + slug,
+		Slug:                   slug,
+		Description:            conv.ToPGText("A private issuer-gated MCP for auth testing"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText(slug),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	toolset, err = toolsetsRepo.UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
+		Slug:                toolset.Slug,
+		ProjectID:           toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	return toolset, issuer
+}

--- a/server/internal/mcp/authnchallenge_authorize_test.go
+++ b/server/internal/mcp/authnchallenge_authorize_test.go
@@ -105,6 +105,7 @@ func TestIDPCallback_StaticRouteResolvesToolsetFromChallengeState(t *testing.T) 
 		State:               "client-state",
 		CodeChallenge:       "",
 		CodeChallengeMethod: "",
+		CSRFToken:           "csrf-token",
 		Subject:             nil,
 		CreatedAt:           time.Now(),
 	}))

--- a/server/internal/mcp/authnchallenge_authorize_test.go
+++ b/server/internal/mcp/authnchallenge_authorize_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -65,8 +66,59 @@ func TestAuthorize_CustomDomainPrivateChallengeUsesGramIDPCallback(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, ti.serverURL.Scheme, returnURL.Scheme)
 	require.Equal(t, ti.serverURL.Host, returnURL.Host)
-	require.Equal(t, "/mcp/"+toolset.McpSlug.String+"/idp_callback", returnURL.Path)
+	require.Equal(t, "/mcp/idp_callback", returnURL.Path)
 	require.NotEqual(t, domain.Domain, returnURL.Host)
+
+	_, authnCache := buildChallengeManagerForTest(t, ti)
+	stored, err := authnCache.Get(ctx, "authnChallenge:"+loc.Query().Get("state"))
+	require.NoError(t, err)
+	require.Equal(t, toolset.McpSlug.String, stored.Endpoint.McpSlug)
+	require.True(t, stored.Endpoint.CustomDomainID.Valid)
+	require.Equal(t, domain.ID, stored.Endpoint.CustomDomainID.UUID)
+}
+
+func TestIDPCallback_StaticRouteResolvesToolsetFromChallengeState(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "idp-static-callback-" + uuid.New().String()[:8]
+	toolset, issuer := createPrivateIssuerGatedToolset(t, ctx, ti, authCtx, slug)
+	toolset, domain := attachCustomDomainToToolset(t, ctx, ti, authCtx, toolset, "idp-static-callback.example.com")
+
+	_, authnCache := buildChallengeManagerForTest(t, ti)
+	stateID := uuid.NewString()
+	clientRedirectURI := "http://example.com/cb"
+	require.NoError(t, authnCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		UserSessionIssuerID: issuer.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: uuid.NullUUID{UUID: domain.ID, Valid: true},
+		},
+		ClientID:            "test-mcp-client",
+		RedirectURI:         clientRedirectURI,
+		State:               "client-state",
+		CodeChallenge:       "",
+		CodeChallengeMethod: "",
+		Subject:             nil,
+		CreatedAt:           time.Now(),
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp/idp_callback?state="+stateID+"&error=access_denied", nil)
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleIDPCallback(w, req))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, clientRedirectURI, loc.Scheme+"://"+loc.Host+loc.Path)
+	require.Equal(t, "access_denied", loc.Query().Get("error"))
+	require.Equal(t, "client-state", loc.Query().Get("state"))
 }
 
 func createPrivateIssuerGatedToolset(

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -7,6 +7,7 @@ package mcp
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	_ "embed"
 	"encoding/base64"
 	"errors"
@@ -25,7 +26,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -49,6 +49,7 @@ type consentTemplateData struct {
 	ClientName         string
 	MCPSlug            string
 	State              string
+	CSRFToken          string
 	SubjectDisplay     string
 	RedirectURI        string
 	RemoteSessionCards []remoteSessionCard
@@ -70,8 +71,8 @@ type remoteSessionCard struct {
 //
 // On POST + Give Access:
 //
-//   - If the AuthnChallengeState's Subject is still empty (public-toolset
-//     path that bypassed the IDP), mint a fresh anonymous URN here.
+//   - Verify the consent CSRF token stored on AuthnChallengeState.
+//   - Use the subject that was already resolved into AuthnChallengeState.
 //   - Persist a user_session_consents row binding (principal, client,
 //     remote_set_hash). Even the empty-remote-set case is bound to a
 //     specific hash so consent can't be CSRF'd past on a future issuer
@@ -141,26 +142,11 @@ func (s *Service) handleConsentGet(w http.ResponseWriter, r *http.Request) error
 		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
 	}
 
-	// Public-toolset late-bind: the IDP path stamps Subject on a private
-	// toolset, but on the public path the user reaches /connect with no
-	// stamped subject. Interactive-mode remote-login cards minted below
-	// need a stable subject so the /remote_login_callback handler can
-	// attribute the resulting remote_sessions row. Stamp an anonymous URN
-	// now and persist it back to Redis; handleConsentPost's existing
-	// public-path branch will skip its own mint when it finds Subject
-	// already set.
-	if (challengeState.Subject == nil || challengeState.Subject.IsZero()) && toolset.McpIsPublic {
-		sub := urn.NewAnonymousSubject(uuid.NewString())
-		challengeState.Subject = &sub
-		if err := s.authnChallengeCache.Store(ctx, challengeState); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "stamp anonymous subject").Log(ctx, logger)
-		}
+	if challengeState.Subject == nil || challengeState.Subject.IsZero() {
+		return oops.E(oops.CodeUnauthorized, nil, "authn challenge subject is not resolved").Log(ctx, logger)
 	}
 
-	subjectDisplay := "An anonymous session for this MCP server"
-	if challengeState.Subject != nil && !challengeState.Subject.IsZero() {
-		subjectDisplay = challengeState.Subject.String()
-	}
+	subjectDisplay := challengeState.Subject.String()
 
 	cards, err := s.buildRemoteSessionCards(ctx, toolset, challengeState, mcpSlug)
 	if err != nil {
@@ -171,6 +157,7 @@ func (s *Service) handleConsentGet(w http.ResponseWriter, r *http.Request) error
 		ClientName:         client.ClientName,
 		MCPSlug:            mcpSlug,
 		State:              stateID,
+		CSRFToken:          challengeState.CSRFToken,
 		SubjectDisplay:     subjectDisplay,
 		RedirectURI:        challengeState.RedirectURI,
 		RemoteSessionCards: cards,
@@ -234,6 +221,10 @@ func (s *Service) handleConsentPost(w http.ResponseWriter, r *http.Request) erro
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}
 
+	if challengeState.CSRFToken == "" || subtle.ConstantTimeCompare([]byte(r.PostForm.Get("csrf_token")), []byte(challengeState.CSRFToken)) != 1 {
+		return oops.E(oops.CodeUnauthorized, nil, "invalid consent csrf token").Log(ctx, logger)
+	}
+
 	// Explicit action required: fail closed on missing / unknown values so
 	// a malformed form post can't trigger the approval path.
 	action := r.PostForm.Get("action")
@@ -251,22 +242,10 @@ func (s *Service) handleConsentPost(w http.ResponseWriter, r *http.Request) erro
 		return oops.E(oops.CodeBadRequest, nil, `action must be "approve" or "deny"`).Log(ctx, logger)
 	}
 
-	// Subject binding by toolset privacy:
-	//   - Public toolset: late-bind a fresh anonymous URN. The user came
-	//     straight to /connect bypassing the IDP, so there's no upstream
-	//     identity to attach.
-	//   - Private toolset: Subject MUST have been stamped by
-	//     HandleIDPCallback. If it isn't, the user reached /connect
-	//     without authenticating — refuse rather than mint an anonymous
-	//     session that bypasses the IDP login requirement.
-	var subject urn.SessionSubject
-	if challengeState.Subject != nil && !challengeState.Subject.IsZero() {
-		subject = *challengeState.Subject
-	} else if toolset.McpIsPublic {
-		subject = urn.NewAnonymousSubject(uuid.NewString())
-	} else {
-		return oops.E(oops.CodeUnauthorized, nil, "private toolset requires IDP authentication before consent").Log(ctx, logger)
+	if challengeState.Subject == nil || challengeState.Subject.IsZero() {
+		return oops.E(oops.CodeUnauthorized, nil, "authn challenge subject is not resolved").Log(ctx, logger)
 	}
+	subject := *challengeState.Subject
 
 	// Resolve the user_session_clients row id for the consent FK.
 	clientRow, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
@@ -317,6 +296,21 @@ func (s *Service) handleConsentPost(w http.ResponseWriter, r *http.Request) erro
 	// the user agent to GET the redirect target with NO body re-submission.
 	http.Redirect(w, r, clientRedirect, http.StatusSeeOther)
 	return nil
+}
+
+func buildConsentURL(baseURL, mcpSlug, stateID string) (string, error) {
+	consentURL, err := url.JoinPath(baseURL, "mcp", mcpSlug, "connect")
+	if err != nil {
+		return "", fmt.Errorf("join consent path: %w", err)
+	}
+	u, err := url.Parse(consentURL)
+	if err != nil {
+		return "", fmt.Errorf("parse consent URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("state", stateID)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 // buildClientRedirect produces the URL to redirect the MCP client to,

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -141,6 +141,22 @@ func (s *Service) handleConsentGet(w http.ResponseWriter, r *http.Request) error
 		return oops.E(oops.CodeUnexpected, err, "lookup user session client").Log(ctx, logger)
 	}
 
+	// Public-toolset late-bind: the IDP path stamps Subject on a private
+	// toolset, but on the public path the user reaches /connect with no
+	// stamped subject. Interactive-mode remote-login cards minted below
+	// need a stable subject so the /remote_login_callback handler can
+	// attribute the resulting remote_sessions row. Stamp an anonymous URN
+	// now and persist it back to Redis; handleConsentPost's existing
+	// public-path branch will skip its own mint when it finds Subject
+	// already set.
+	if (challengeState.Subject == nil || challengeState.Subject.IsZero()) && toolset.McpIsPublic {
+		sub := urn.NewAnonymousSubject(uuid.NewString())
+		challengeState.Subject = &sub
+		if err := s.authnChallengeCache.Store(ctx, challengeState); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "stamp anonymous subject").Log(ctx, logger)
+		}
+	}
+
 	subjectDisplay := "An anonymous session for this MCP server"
 	if challengeState.Subject != nil && !challengeState.Subject.IsZero() {
 		subjectDisplay = challengeState.Subject.String()

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -5,10 +5,12 @@
 package mcp
 
 import (
+	"context"
 	"crypto/sha256"
 	_ "embed"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -21,6 +23,8 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -42,11 +46,22 @@ var remoteSetHashEmpty = func() string {
 
 // consentTemplateData is the field set the consent template renders against.
 type consentTemplateData struct {
-	ClientName     string
-	MCPSlug        string
-	State          string
-	SubjectDisplay string
-	RedirectURI    string
+	ClientName         string
+	MCPSlug            string
+	State              string
+	SubjectDisplay     string
+	RedirectURI        string
+	RemoteSessionCards []remoteSessionCard
+}
+
+// remoteSessionCard is the per-remote view rendered by the {{range}} block
+// in the consent template. ChallengeURL is the upstream provider's
+// authorize URL with PKCE + state bound for this consent session.
+type remoteSessionCard struct {
+	ClientID     string
+	IssuerSlug   string
+	Connected    bool
+	ChallengeURL string
 }
 
 // HandleConsent serves the GET (consent UI) and POST (Give Access /
@@ -131,12 +146,18 @@ func (s *Service) handleConsentGet(w http.ResponseWriter, r *http.Request) error
 		subjectDisplay = challengeState.Subject.String()
 	}
 
+	cards, err := s.buildRemoteSessionCards(ctx, toolset, challengeState, mcpSlug)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build remote session cards").Log(ctx, logger)
+	}
+
 	data := consentTemplateData{
-		ClientName:     client.ClientName,
-		MCPSlug:        mcpSlug,
-		State:          stateID,
-		SubjectDisplay: subjectDisplay,
-		RedirectURI:    challengeState.RedirectURI,
+		ClientName:         client.ClientName,
+		MCPSlug:            mcpSlug,
+		State:              stateID,
+		SubjectDisplay:     subjectDisplay,
+		RedirectURI:        challengeState.RedirectURI,
+		RemoteSessionCards: cards,
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -314,4 +335,60 @@ func buildClientRedirect(redirectURI, code, originalState, errCode, errDescripti
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// buildRemoteSessionCards loads every remote_session_client linked to the
+// toolset's user_session_issuer and materialises a card per client. Each
+// card carries a connected/disconnected state (read from remote_sessions
+// for the stamped subject) plus the upstream authorize URL minted by the
+// ChallengeManager. Mints fresh per-card Redis state on every render —
+// the 10-min TTL keeps abandoned states from piling up.
+func (s *Service) buildRemoteSessionCards(
+	ctx context.Context,
+	toolset *toolsets_repo.Toolset,
+	challengeState AuthnChallengeState,
+	mcpSlug string,
+) ([]remoteSessionCard, error) {
+	clients, err := s.remoteChallengeMgr.ListClients(ctx, toolset.ProjectID, toolset.UserSessionIssuerID.UUID)
+	if err != nil {
+		return nil, fmt.Errorf("list remote session clients: %w", err)
+	}
+	if len(clients) == 0 {
+		return nil, nil
+	}
+
+	// Single round-trip for connected-state across all cards. Empty when
+	// the subject hasn't been stamped yet (early render before IDP /
+	// anonymous late-bind); the per-card check below then resolves false.
+	var connectedIDs map[uuid.UUID]struct{}
+	if challengeState.Subject != nil && !challengeState.Subject.IsZero() {
+		connectedIDs, err = s.remoteChallengeMgr.ConnectedClientIDs(ctx, *challengeState.Subject, toolset.UserSessionIssuerID.UUID)
+		if err != nil {
+			return nil, fmt.Errorf("connected client ids: %w", err)
+		}
+	}
+
+	parent := remotesessions.ParentChallenge{
+		ID:                  challengeState.ID,
+		ProjectID:           toolset.ProjectID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Subject:             challengeState.Subject,
+		McpSlug:             mcpSlug,
+	}
+
+	cards := make([]remoteSessionCard, 0, len(clients))
+	for _, c := range clients {
+		challengeURL, berr := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, parent, c)
+		if berr != nil {
+			return nil, fmt.Errorf("build authorization url for %s: %w", c.IssuerSlug, berr)
+		}
+		_, connected := connectedIDs[c.ID]
+		cards = append(cards, remoteSessionCard{
+			ClientID:     c.ID.String(),
+			IssuerSlug:   c.IssuerSlug,
+			Connected:    connected,
+			ChallengeURL: challengeURL,
+		})
+	}
+	return cards, nil
 }

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -126,8 +126,8 @@ func (s *Service) handleConsentGet(w http.ResponseWriter, r *http.Request) error
 	if err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
 	}
-	if challengeState.ToolsetID != toolset.ID {
-		return oops.E(oops.CodeUnauthorized, nil, "authn challenge state does not match this MCP server").Log(ctx, logger)
+	if err := compareToolsetEndpoint(toolset, challengeState.Endpoint); err != nil {
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}
 
 	client, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
@@ -230,8 +230,8 @@ func (s *Service) handleConsentPost(w http.ResponseWriter, r *http.Request) erro
 	if err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
 	}
-	if challengeState.ToolsetID != toolset.ID {
-		return oops.E(oops.CodeUnauthorized, nil, "authn challenge state does not match this MCP server").Log(ctx, logger)
+	if err := compareToolsetEndpoint(toolset, challengeState.Endpoint); err != nil {
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}
 
 	// Explicit action required: fail closed on missing / unknown values so

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -144,7 +143,10 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 			return oops.E(oops.CodeUnexpected, derr, "failed to load custom domain").Log(ctx, logger)
 		}
 	}
-	consentURL := fmt.Sprintf("%s/mcp/%s/connect?state=%s", baseURL, mcpSlug, url.QueryEscape(challengeState.ID))
+	consentURL, err := buildConsentURL(baseURL, mcpSlug, challengeState.ID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build consent URL").Log(ctx, logger)
+	}
 	http.Redirect(w, r, consentURL, http.StatusFound)
 	return nil
 }

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -14,15 +14,19 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 // HandleIDPCallback is the GET endpoint the IDP redirects back to after the
 // user authenticates on the private-toolset path. Mounted at
-// `GET /mcp/{mcpSlug}/idp_callback`.
+// `GET /mcp/idp_callback`; the legacy `GET /mcp/{mcpSlug}/idp_callback`
+// route is still accepted, but the toolset is resolved from the stored
+// AuthnChallengeState.
 //
 // It drives the IDP wire calls through s.identityResolver (WorkOS-backed)
 // and runs the standard user bootstrap (UpsertUser, posthog signup, WorkOS
@@ -33,29 +37,8 @@ import (
 // persists.
 func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	mcpSlug := chi.URLParam(r, "mcpSlug")
-	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, s.logger)
-	}
-
-	toolset, customDomainCtx, err := s.loadToolsetFromMcpSlug(ctx, mcpSlug)
-	switch {
-	case errors.Is(err, errToolsetNotFound):
-		return oops.E(oops.CodeNotFound, err, "mcp server not found")
-	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, s.logger)
-	}
-	if !toolset.UserSessionIssuerID.Valid {
-		return oops.E(oops.CodeNotFound, nil, "not found")
-	}
-	if err := s.requireUserSessionIssuer(ctx, toolset); err != nil {
-		return err
-	}
-
-	logger := s.logger.With(
-		attr.SlogToolsetID(toolset.ID.String()),
-		attr.SlogProjectID(toolset.ProjectID.String()),
-	)
+	routeMcpSlug := chi.URLParam(r, "mcpSlug")
+	logger := s.logger
 
 	q := r.URL.Query()
 	stateID := q.Get("state")
@@ -73,10 +56,32 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").Log(ctx, logger)
 	}
 
-	// State-confusion guard: the state must belong to this toolset.
-	if challengeState.ToolsetID != toolset.ID {
+	mcpSlug := challengeState.Endpoint.McpSlug
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from authn challenge state").Log(ctx, logger)
+	}
+	if routeMcpSlug != "" && routeMcpSlug != mcpSlug {
 		return oops.E(oops.CodeUnauthorized, nil, "authn challenge state does not match this MCP server").Log(ctx, logger)
 	}
+
+	toolset, err := s.resolveMcp(ctx, challengeState.Endpoint)
+	switch {
+	case errors.Is(err, errToolsetNotFound):
+		return oops.E(oops.CodeNotFound, err, "mcp server not found")
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").Log(ctx, logger)
+	}
+	if !toolset.UserSessionIssuerID.Valid {
+		return oops.E(oops.CodeNotFound, nil, "not found")
+	}
+	if err := s.requireUserSessionIssuer(ctx, toolset); err != nil {
+		return err
+	}
+
+	logger = s.logger.With(
+		attr.SlogToolsetID(toolset.ID.String()),
+		attr.SlogProjectID(toolset.ProjectID.String()),
+	)
 
 	// If the IDP returned an error (user cancelled at the IDP, IDP refused
 	// to authenticate, etc.) per OAuth 2.0, forward it back to the MCP
@@ -127,8 +132,17 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	}
 
 	baseURL := s.serverURL.String()
-	if customDomainCtx != nil {
-		baseURL = fmt.Sprintf("https://%s", customDomainCtx.Domain)
+	if challengeState.Endpoint.CustomDomainID.Valid {
+		domain, derr := customdomains_repo.New(s.db).GetCustomDomainByIDAndOrganization(ctx, customdomains_repo.GetCustomDomainByIDAndOrganizationParams{
+			ID:             challengeState.Endpoint.CustomDomainID.UUID,
+			OrganizationID: toolset.OrganizationID,
+		})
+		switch {
+		case derr == nil:
+			baseURL = fmt.Sprintf("https://%s", domain.Domain)
+		case !errors.Is(derr, pgx.ErrNoRows):
+			return oops.E(oops.CodeUnexpected, derr, "failed to load custom domain").Log(ctx, logger)
+		}
 	}
 	consentURL := fmt.Sprintf("%s/mcp/%s/connect?state=%s", baseURL, mcpSlug, url.QueryEscape(challengeState.ID))
 	http.Redirect(w, r, consentURL, http.StatusFound)

--- a/server/internal/mcp/authnchallenge_test.go
+++ b/server/internal/mcp/authnchallenge_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -186,6 +188,14 @@ func TestHandleAuthorize_PublicToolset_RedirectsToConsent(t *testing.T) {
 	loc := w.Header().Get("Location")
 	require.Contains(t, loc, "/connect", "public toolset should redirect to consent page")
 	require.Contains(t, loc, "state=", "consent redirect should carry challenge state")
+
+	parsedLoc, err := url.Parse(loc)
+	require.NoError(t, err)
+	stored, err := ti.authnChallengeCache.Get(ctx, "authnChallenge:"+parsedLoc.Query().Get("state"))
+	require.NoError(t, err)
+	require.NotEmpty(t, stored.CSRFToken)
+	require.NotNil(t, stored.Subject)
+	require.Equal(t, urn.SessionSubjectKindAnonymous, stored.Subject.Kind)
 }
 
 func TestHandleAuthorize_InvalidClientID_ReturnsError(t *testing.T) {
@@ -216,6 +226,134 @@ func TestHandleAuthorize_InvalidClientID_ReturnsError(t *testing.T) {
 	var body map[string]string
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	require.Equal(t, "invalid_client", body["error"])
+}
+
+func TestHandleConsentGet_RendersCSRFToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	subject := urn.NewUserSubject("consent-user-" + uuid.NewString())
+	stateID := uuid.NewString()
+	csrfToken := "csrf-" + uuid.NewString()
+
+	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
+		ClientID:            client.ClientID,
+		RedirectURI:         client.RedirectUris[0],
+		State:               "client-state",
+		CodeChallenge:       "abc",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           csrfToken,
+		Subject:             &subject,
+		CreatedAt:           time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+toolset.McpSlug.String+"/connect?state="+stateID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", toolset.McpSlug.String)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	err = ti.service.HandleConsent(w, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `name="csrf_token" value="`+csrfToken+`"`)
+}
+
+func TestHandleConsentPost_RejectsInvalidCSRFToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	subject := urn.NewUserSubject("consent-user-" + uuid.NewString())
+	stateID := uuid.NewString()
+
+	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
+		ClientID:            client.ClientID,
+		RedirectURI:         client.RedirectUris[0],
+		State:               "client-state",
+		CodeChallenge:       "abc",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           "expected-csrf",
+		Subject:             &subject,
+		CreatedAt:           time.Now(),
+	})
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("state", stateID)
+	form.Set("csrf_token", "wrong-csrf")
+	form.Set("action", "approve")
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+toolset.McpSlug.String+"/connect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", toolset.McpSlug.String)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	err = ti.service.HandleConsent(w, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid consent csrf token")
+}
+
+func TestHandleConsentPost_ApproveWithCSRFRedirectsWithCode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	subject := urn.NewUserSubject("consent-user-" + uuid.NewString())
+	stateID := uuid.NewString()
+	csrfToken := "csrf-" + uuid.NewString()
+
+	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
+		ClientID:            client.ClientID,
+		RedirectURI:         client.RedirectUris[0],
+		State:               "client-state",
+		CodeChallenge:       "abc",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           csrfToken,
+		Subject:             &subject,
+		CreatedAt:           time.Now(),
+	})
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("state", stateID)
+	form.Set("csrf_token", csrfToken)
+	form.Set("action", "approve")
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+toolset.McpSlug.String+"/connect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", toolset.McpSlug.String)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	err = ti.service.HandleConsent(w, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSeeOther, w.Code)
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "client-state", loc.Query().Get("state"))
+	require.NotEmpty(t, loc.Query().Get("code"))
 }
 
 func TestHandleIDPCallback_ExchangesCodeAndRedirectsToConsent(t *testing.T) {
@@ -254,6 +392,7 @@ func TestHandleIDPCallback_ExchangesCodeAndRedirectsToConsent(t *testing.T) {
 		State:               "client-state",
 		CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
 		CreatedAt:           time.Now(),
 	})
 	require.NoError(t, err)
@@ -310,6 +449,7 @@ func TestHandleIDPCallback_UserNotInOrg_ReturnsForbidden(t *testing.T) {
 		State:               "client-state",
 		CodeChallenge:       "abc",
 		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
 		CreatedAt:           time.Now(),
 	})
 	require.NoError(t, err)
@@ -369,6 +509,7 @@ func TestHandleIDPCallback_IDPError_ForwardsToClient(t *testing.T) {
 		State:               "client-state",
 		CodeChallenge:       "abc",
 		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
 		CreatedAt:           time.Now(),
 	})
 	require.NoError(t, err)
@@ -438,6 +579,7 @@ func TestHandleIDPCallback_ToolsetMismatch_ReturnsUnauthorized(t *testing.T) {
 		RedirectURI:         "http://localhost:3000/callback",
 		CodeChallenge:       "abc",
 		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
 		CreatedAt:           time.Now(),
 	})
 	require.NoError(t, err)
@@ -477,6 +619,7 @@ func TestHandleIDPCallback_MissingCode_ReturnsError(t *testing.T) {
 		RedirectURI:         "http://localhost:3000/callback",
 		CodeChallenge:       "abc",
 		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
 		CreatedAt:           time.Now(),
 	})
 	require.NoError(t, err)
@@ -520,6 +663,7 @@ func TestHandleIDPCallback_ExchangeFailure_ReturnsUnauthorized(t *testing.T) {
 		RedirectURI:         "http://localhost:3000/callback",
 		CodeChallenge:       "abc",
 		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
 		CreatedAt:           time.Now(),
 	})
 	require.NoError(t, err)

--- a/server/internal/mcp/authnchallenge_test.go
+++ b/server/internal/mcp/authnchallenge_test.go
@@ -245,7 +245,10 @@ func TestHandleIDPCallback_ExchangesCodeAndRedirectsToConsent(t *testing.T) {
 	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  challengeID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ToolsetID:           toolset.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
 		ClientID:            "test-client",
 		RedirectURI:         "http://localhost:3000/callback",
 		State:               "client-state",
@@ -298,7 +301,10 @@ func TestHandleIDPCallback_UserNotInOrg_ReturnsForbidden(t *testing.T) {
 	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  challengeID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ToolsetID:           toolset.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
 		ClientID:            "test-client",
 		RedirectURI:         "http://localhost:3000/callback",
 		State:               "client-state",
@@ -354,7 +360,10 @@ func TestHandleIDPCallback_IDPError_ForwardsToClient(t *testing.T) {
 	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  challengeID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ToolsetID:           toolset.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
 		ClientID:            "test-client",
 		RedirectURI:         "http://localhost:3000/callback",
 		State:               "client-state",
@@ -421,7 +430,10 @@ func TestHandleIDPCallback_ToolsetMismatch_ReturnsUnauthorized(t *testing.T) {
 	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  challengeID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ToolsetID:           uuid.New(), // wrong toolset
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        "wrong-toolset-slug",
+			CustomDomainID: uuid.NullUUID{Valid: false},
+		},
 		ClientID:            "test-client",
 		RedirectURI:         "http://localhost:3000/callback",
 		CodeChallenge:       "abc",
@@ -457,7 +469,10 @@ func TestHandleIDPCallback_MissingCode_ReturnsError(t *testing.T) {
 	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  challengeID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ToolsetID:           toolset.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
 		ClientID:            "test-client",
 		RedirectURI:         "http://localhost:3000/callback",
 		CodeChallenge:       "abc",
@@ -497,7 +512,10 @@ func TestHandleIDPCallback_ExchangeFailure_ReturnsUnauthorized(t *testing.T) {
 	err := ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  challengeID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
-		ToolsetID:           toolset.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        toolset.McpSlug.String,
+			CustomDomainID: toolset.CustomDomainID,
+		},
 		ClientID:            "test-client",
 		RedirectURI:         "http://localhost:3000/callback",
 		CodeChallenge:       "abc",

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -79,6 +79,62 @@
         font-weight: bold;
         margin-right: 10px;
       }
+      .remotes {
+        margin-bottom: 24px;
+      }
+      .remotes h3 {
+        margin: 0 0 12px 0;
+        color: #333;
+        font-size: 15px;
+      }
+      .remote-card {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 12px 14px;
+        border: 1px solid #e2e2e2;
+        border-radius: 6px;
+        margin-bottom: 8px;
+        background: #fff;
+      }
+      .remote-card .meta {
+        font-size: 14px;
+        color: #333;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .remote-card .meta .issuer {
+        font-weight: 600;
+      }
+      .remote-card .meta .state {
+        font-size: 12px;
+        color: #666;
+        margin-top: 2px;
+      }
+      .remote-card .state.connected {
+        color: #28a745;
+      }
+      .remote-card .state.disconnected {
+        color: #b95f00;
+      }
+      .remote-card a.btn-link {
+        padding: 8px 14px;
+        font-size: 14px;
+        font-weight: 600;
+        border-radius: 6px;
+        text-decoration: none;
+        background-color: #007bff;
+        color: white;
+      }
+      .remote-card a.btn-link:hover {
+        background-color: #0056b3;
+      }
+      .remote-card a.btn-link.connected {
+        background-color: #f3f4f6;
+        color: #333;
+        border: 1px solid #e2e2e2;
+      }
       .actions {
         display: flex;
         gap: 10px;
@@ -132,6 +188,25 @@
         <dd>{{.RedirectURI}}</dd>
         {{end}}
       </dl>
+
+      {{if .RemoteSessionCards}}
+      <div class="remotes">
+        <h3>Connect required services</h3>
+        {{range .RemoteSessionCards}}
+        <div class="remote-card">
+          <div class="meta">
+            <div class="issuer">{{.IssuerSlug}}</div>
+            {{if .Connected}}
+            <div class="state connected">✓ Connected</div>
+            {{else}}
+            <div class="state disconnected">Not connected</div>
+            {{end}}
+          </div>
+          <a class="btn-link {{if .Connected}}connected{{end}}" href="{{.ChallengeURL}}">{{if .Connected}}Reconnect{{else}}Connect{{end}}</a>
+        </div>
+        {{end}}
+      </div>
+      {{end}}
 
       <div class="actions">
         <form method="POST" action="/mcp/{{.MCPSlug}}/connect">

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -211,6 +211,7 @@
       <div class="actions">
         <form method="POST" action="/mcp/{{.MCPSlug}}/connect">
           <input type="hidden" name="state" value="{{.State}}" />
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
           <button
             type="submit"
             name="action"
@@ -222,6 +223,7 @@
         </form>
         <form method="POST" action="/mcp/{{.MCPSlug}}/connect">
           <input type="hidden" name="state" value="{{.State}}" />
+          <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
           <button
             type="submit"
             name="action"

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -63,6 +63,7 @@ import (
 	organizations_repo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	platformtoolsruntime "github.com/speakeasy-api/gram/server/internal/platformtools/runtime"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
@@ -121,6 +122,9 @@ type Service struct {
 	// uses, intentionally separate signer code so each path is removable
 	// in isolation.
 	userSessionSigner *usersessions.Signer
+	// remoteChallengeMgr drives the per-remote OAuth authn leg used by the
+	// interactive /connect cards and the /remote_login_callback handler.
+	remoteChallengeMgr *remotesessions.ChallengeManager
 }
 
 type oauthTokenInputs struct {
@@ -174,6 +178,7 @@ func NewService(
 	platformToolsets map[string]platformtools.Toolset,
 	identityResolver IdentityResolver,
 	userSessionSigner *usersessions.Signer,
+	remoteChallengeMgr *remotesessions.ChallengeManager,
 ) *Service {
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcp")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcp")
@@ -244,8 +249,9 @@ func NewService(
 			cacheImpl,
 			cache.SuffixNone,
 		),
-		identityResolver:  identityResolver,
-		userSessionSigner: userSessionSigner,
+		identityResolver:   identityResolver,
+		userSessionSigner:  userSessionSigner,
+		remoteChallengeMgr: remoteChallengeMgr,
 	}
 }
 
@@ -271,6 +277,7 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/connect", oops.ErrHandle(service.logger, service.HandleConsent).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/token", oops.ErrHandle(service.logger, service.HandleToken).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/revoke", oops.ErrHandle(service.logger, service.HandleRevoke).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/remote_login_callback", oops.ErrHandle(service.logger, service.remoteChallengeMgr.HandleRemoteLoginCallback).ServeHTTP)
 }
 
 // HandleGetServer handles GET requests to /mcp/{mcpSlug}, checking for HTML requests

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -257,6 +257,8 @@ func NewService(
 
 func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Service) {
 	o11y.AttachHandler(mux, "POST", PlatformToolsetRoute, oops.ErrHandle(service.logger, service.ServePlatformToolset).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", "/mcp/idp_callback", oops.ErrHandle(service.logger, service.HandleIDPCallback).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", "/mcp/remote_login_callback", oops.ErrHandle(service.logger, service.remoteChallengeMgr.HandleRemoteLoginCallback).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.ServePublic).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}", oops.ErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
 		return service.HandleGetServer(w, r, metadataService)
@@ -749,28 +751,39 @@ func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_re
 	return anySchemeSatisfied(schemes, mergedEnv, oauthToken), nil
 }
 
+// loadToolsetFromMcpSlug resolves the toolset for a route-driven request
+// (path mcpSlug + optional customdomains.Context). Distinct from
+// resolveMcp: when there is no customdomain context, it falls back to
+// GetToolsetByMcpSlug — which prefers a platform-domain toolset but
+// accepts a custom-domain toolset when no platform-only row exists. The
+// fallback is load-bearing (TestServePublic_CustomDomain_PlatformDomainStillWorks)
+// because customers attach custom domains to existing toolsets without
+// retiring the platform URL.
+//
+// resolveMcp, used by stored-state callbacks, is strict-platform on an
+// unset CustomDomainID — there the value is an explicit assertion
+// rather than a route inference.
 func (s *Service) loadToolsetFromMcpSlug(ctx context.Context, mcpSlug string) (*toolsets_repo.Toolset, *customdomains.Context, error) {
-	var toolset toolsets_repo.Toolset
-	var toolsetErr error
-	var customDomainCtx *customdomains.Context
-	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
-		toolset, toolsetErr = s.toolsetsRepo.GetToolsetByMcpSlugAndCustomDomain(ctx, toolsets_repo.GetToolsetByMcpSlugAndCustomDomainParams{
-			McpSlug:        conv.ToPGText(mcpSlug),
-			CustomDomainID: uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true},
+	customDomainCtx := customdomains.FromContext(ctx)
+	if customDomainCtx != nil {
+		toolset, err := s.resolveMcp(ctx, LegacyMcpEndpointRef{
+			McpSlug:        mcpSlug,
+			CustomDomainID: uuid.NullUUID{UUID: customDomainCtx.DomainID, Valid: true},
 		})
-		customDomainCtx = domainCtx
-	} else {
-		toolset, toolsetErr = s.toolsetsRepo.GetToolsetByMcpSlug(ctx, conv.ToPGText(mcpSlug))
+		if err != nil {
+			return nil, nil, err
+		}
+		return toolset, customDomainCtx, nil
 	}
 
+	toolset, err := s.toolsetsRepo.GetToolsetByMcpSlug(ctx, conv.ToPGText(mcpSlug))
 	switch {
-	case errors.Is(toolsetErr, pgx.ErrNoRows):
+	case errors.Is(err, pgx.ErrNoRows):
 		return nil, nil, errToolsetNotFound
-	case toolsetErr != nil:
-		return nil, nil, fmt.Errorf("lookup toolset: %w", toolsetErr)
+	case err != nil:
+		return nil, nil, fmt.Errorf("lookup toolset: %w", err)
 	}
-
-	return &toolset, customDomainCtx, nil
+	return &toolset, nil, nil
 }
 
 // loadHeaderDisplayNames loads the header display names mapping from MCP metadata.

--- a/server/internal/mcp/remotelogin_integration_test.go
+++ b/server/internal/mcp/remotelogin_integration_test.go
@@ -67,7 +67,10 @@ func TestRemoteLoginCallback_AuthenticatedSubject(t *testing.T) {
 	require.NoError(t, authnCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  parentID,
 		UserSessionIssuerID: result.UserSessionIssuer.ID,
-		ToolsetID:           result.Toolset.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        result.Toolset.McpSlug.String,
+			CustomDomainID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		},
 		ClientID:            "test-mcp-client",
 		RedirectURI:         "http://example.com/cb",
 		CodeChallenge:       "",
@@ -107,7 +110,10 @@ func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 	require.NoError(t, authnCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  parentID,
 		UserSessionIssuerID: result.UserSessionIssuer.ID,
-		ToolsetID:           result.Toolset.ID,
+		Endpoint: mcp.LegacyMcpEndpointRef{
+			McpSlug:        result.Toolset.McpSlug.String,
+			CustomDomainID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		},
 		ClientID:            "test-mcp-client",
 		RedirectURI:         "http://example.com/cb",
 		CodeChallenge:       "",
@@ -173,8 +179,8 @@ func TestRemoteLoginChallenge_CustomDomainRegistersGramCallback(t *testing.T) {
 
 	parsed, err := url.Parse(authURL)
 	require.NoError(t, err)
-	gramCallback := ti.serverURL.String() + "/mcp/" + result.Toolset.McpSlug.String + "/remote_login_callback"
-	customCallback := "https://remote-login-custom.example.com/mcp/" + result.Toolset.McpSlug.String + "/remote_login_callback"
+	gramCallback := ti.serverURL.String() + "/mcp/remote_login_callback"
+	customCallback := "https://remote-login-custom.example.com/mcp/remote_login_callback"
 	require.Equal(t, gramCallback, parsed.Query().Get("redirect_uri"))
 
 	upstreamResp := httpGetNoFollow(t, authURL)
@@ -231,10 +237,7 @@ func runRemoteLoginRoundTrip(
 	require.NotEmpty(t, state, "upstream redirect must carry ?state")
 
 	cbReq := httptest.NewRequest(http.MethodGet,
-		"/mcp/"+result.Toolset.McpSlug.String+"/remote_login_callback?code="+url.QueryEscape(code)+"&state="+url.QueryEscape(state), nil)
-	cbCtx := chi.NewRouteContext()
-	cbCtx.URLParams.Add("mcpSlug", result.Toolset.McpSlug.String)
-	cbReq = cbReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, cbCtx))
+		"/mcp/remote_login_callback?code="+url.QueryEscape(code)+"&state="+url.QueryEscape(state), nil)
 
 	cbW := httptest.NewRecorder()
 	require.NoError(t, mgr.HandleRemoteLoginCallback(cbW, cbReq))

--- a/server/internal/mcp/remotelogin_integration_test.go
+++ b/server/internal/mcp/remotelogin_integration_test.go
@@ -5,9 +5,8 @@
 //
 //   - authenticated: AuthnChallengeState pre-stamped with a user:<id> URN
 //     (what HandleIDPCallback does on the private-toolset path).
-//   - anonymous: public toolset, no subject on the parent challenge at
-//     /authorize time — handleConsentGet late-binds an anonymous URN and
-//     persists it back to Redis before rendering the per-remote cards.
+//   - anonymous: AuthnChallengeState pre-stamped with an anonymous:<id> URN
+//     (what HandleAuthorize does on the public-toolset path).
 package mcp_test
 
 import (
@@ -75,6 +74,7 @@ func TestRemoteLoginCallback_AuthenticatedSubject(t *testing.T) {
 		RedirectURI:         "http://example.com/cb",
 		CodeChallenge:       "",
 		CodeChallengeMethod: "",
+		CSRFToken:           "csrf-token",
 		Subject:             &userSubject,
 		CreatedAt:           time.Now(),
 	}))
@@ -83,10 +83,9 @@ func TestRemoteLoginCallback_AuthenticatedSubject(t *testing.T) {
 }
 
 // TestRemoteLoginCallback_AnonymousSubject covers the public-toolset
-// path. The parent AuthnChallengeState is created with no subject; the
-// /mcp/{slug}/connect GET handler late-binds an anonymous URN and
-// persists it. The remote-login callback then attributes the
-// remote_sessions row to that anonymous URN.
+// path. The parent AuthnChallengeState is created with an anonymous subject;
+// the remote-login callback then attributes the remote_sessions row to that
+// anonymous URN.
 func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 	t.Parallel()
 
@@ -107,6 +106,7 @@ func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 	mgr, authnCache := buildChallengeManagerForTest(t, ti)
 
 	parentID := uuid.NewString()
+	anonymousSubject := urn.NewAnonymousSubject(uuid.NewString())
 	require.NoError(t, authnCache.Store(ctx, mcp.AuthnChallengeState{
 		ID:                  parentID,
 		UserSessionIssuerID: result.UserSessionIssuer.ID,
@@ -118,15 +118,15 @@ func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 		RedirectURI:         "http://example.com/cb",
 		CodeChallenge:       "",
 		CodeChallengeMethod: "",
-		Subject:             nil,
+		CSRFToken:           "csrf-token",
+		Subject:             &anonymousSubject,
 		CreatedAt:           time.Now(),
 	}))
 
 	insertUserSessionClient(t, ctx, ti.conn, result.UserSessionIssuer.ID, "test-mcp-client")
 
-	// HandleConsent (GET) must stamp an anonymous URN onto the parent
-	// AuthnChallengeState. Hitting it via the service exercises the real
-	// path (loadToolset → requireUserSessionIssuer → late-bind branch).
+	// Hitting HandleConsent GET through the service exercises the real
+	// card-render path (loadToolset → requireUserSessionIssuer → card build).
 	req := httptest.NewRequest(http.MethodGet, "/mcp/"+result.Toolset.McpSlug.String+"/connect?state="+parentID, nil)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("mcpSlug", result.Toolset.McpSlug.String)
@@ -138,8 +138,8 @@ func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 
 	stamped, err := authnCache.Get(ctx, "authnChallenge:"+parentID)
 	require.NoError(t, err)
-	require.NotNil(t, stamped.Subject, "consent GET must stamp anonymous subject on public toolset")
-	require.Equal(t, urn.SessionSubjectKindAnonymous, stamped.Subject.Kind)
+	require.NotNil(t, stamped.Subject)
+	require.Equal(t, anonymousSubject, *stamped.Subject)
 
 	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, stamped.Subject)
 }

--- a/server/internal/mcp/remotelogin_integration_test.go
+++ b/server/internal/mcp/remotelogin_integration_test.go
@@ -28,11 +28,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -52,9 +54,10 @@ func TestRemoteLoginCallback_AuthenticatedSubject(t *testing.T) {
 	require.NotNil(t, authCtx.ProjectID)
 
 	result := oauthtest.CreateIssuerGatedToolset(t, ctx, ti.conn, ti.enc, authCtx, oauthtest.IssuerGatedToolsetOpts{
-		Slug:             "issuer-auth",
-		IsPublic:         false,
-		UpstreamMetadata: idp.OAuth21Metadata(t),
+		Slug:                         "issuer-auth",
+		IsPublic:                     false,
+		UpstreamMetadata:             idp.OAuth21Metadata(t),
+		RemoteSessionCallbackBaseURL: ti.serverURL.String(),
 	})
 
 	mgr, authnCache := buildChallengeManagerForTest(t, ti)
@@ -92,9 +95,10 @@ func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 	require.NotNil(t, authCtx.ProjectID)
 
 	result := oauthtest.CreateIssuerGatedToolset(t, ctx, ti.conn, ti.enc, authCtx, oauthtest.IssuerGatedToolsetOpts{
-		Slug:             "issuer-anon",
-		IsPublic:         true,
-		UpstreamMetadata: idp.OAuth21Metadata(t),
+		Slug:                         "issuer-anon",
+		IsPublic:                     true,
+		UpstreamMetadata:             idp.OAuth21Metadata(t),
+		RemoteSessionCallbackBaseURL: ti.serverURL.String(),
 	})
 
 	mgr, authnCache := buildChallengeManagerForTest(t, ti)
@@ -132,6 +136,58 @@ func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 	require.Equal(t, urn.SessionSubjectKindAnonymous, stamped.Subject.Kind)
 
 	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, stamped.Subject)
+}
+
+func TestRemoteLoginChallenge_CustomDomainRegistersGramCallback(t *testing.T) {
+	t.Parallel()
+
+	idp := devidptest.Launch(t, devidptest.LaunchOpts{})
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	result := oauthtest.CreateIssuerGatedToolset(t, ctx, ti.conn, ti.enc, authCtx, oauthtest.IssuerGatedToolsetOpts{
+		Slug:                         "issuer-custom-domain",
+		IsPublic:                     false,
+		UpstreamMetadata:             idp.OAuth21Metadata(t),
+		RemoteSessionCallbackBaseURL: ti.serverURL.String(),
+	})
+	result.Toolset, _ = attachCustomDomainToToolset(t, ctx, ti, authCtx, result.Toolset, "remote-login-custom.example.com")
+
+	mgr, _ := buildChallengeManagerForTest(t, ti)
+	clients, err := mgr.ListClients(ctx, result.Toolset.ProjectID, result.UserSessionIssuer.ID)
+	require.NoError(t, err)
+	require.Len(t, clients, 1)
+
+	userSubject := urn.NewUserSubject(uuid.NewString())
+	authURL, err := mgr.BuildAuthorizationUrl(ctx, remotesessions.ParentChallenge{
+		ID:                  uuid.NewString(),
+		ProjectID:           result.Toolset.ProjectID,
+		UserSessionIssuerID: result.UserSessionIssuer.ID,
+		Subject:             &userSubject,
+		McpSlug:             result.Toolset.McpSlug.String,
+	}, clients[0])
+	require.NoError(t, err)
+
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+	gramCallback := ti.serverURL.String() + "/mcp/" + result.Toolset.McpSlug.String + "/remote_login_callback"
+	customCallback := "https://remote-login-custom.example.com/mcp/" + result.Toolset.McpSlug.String + "/remote_login_callback"
+	require.Equal(t, gramCallback, parsed.Query().Get("redirect_uri"))
+
+	upstreamResp := httpGetNoFollow(t, authURL)
+	defer func() { _ = upstreamResp.Body.Close() }()
+	require.Equal(t, http.StatusFound, upstreamResp.StatusCode, "registered Gram callback should be accepted by dev-idp")
+
+	badURL := *parsed
+	badQuery := badURL.Query()
+	badQuery.Set("redirect_uri", customCallback)
+	badURL.RawQuery = badQuery.Encode()
+	badResp := httpGetNoFollow(t, badURL.String())
+	defer func() { _ = badResp.Body.Close() }()
+	require.Equal(t, http.StatusBadRequest, badResp.StatusCode, "unregistered custom-domain callback should be rejected by dev-idp")
 }
 
 // runRemoteLoginRoundTrip drives BuildAuthorizationUrl → upstream
@@ -212,6 +268,51 @@ func insertUserSessionClient(t *testing.T, ctx context.Context, conn *pgxpool.Po
 		ClientSecretExpiresAt: pgtype.Timestamptz{Valid: false},
 	})
 	require.NoError(t, err)
+}
+
+func attachCustomDomainToToolset(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	authCtx *contextvalues.AuthContext,
+	toolset toolsets_repo.Toolset,
+	domainName string,
+) (toolsets_repo.Toolset, customdomains_repo.CustomDomain) {
+	t.Helper()
+
+	domainsRepo := customdomains_repo.New(ti.conn)
+	domain, err := domainsRepo.CreateCustomDomain(ctx, customdomains_repo.CreateCustomDomainParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domainName,
+		IngressName:    pgtype.Text{String: "", Valid: false},
+		CertSecretName: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	domain, err = domainsRepo.UpdateCustomDomain(ctx, customdomains_repo.UpdateCustomDomainParams{
+		ID:             domain.ID,
+		Verified:       true,
+		Activated:      true,
+		IngressName:    pgtype.Text{String: "", Valid: false},
+		CertSecretName: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	toolset, err = toolsets_repo.New(ti.conn).UpdateToolset(ctx, toolsets_repo.UpdateToolsetParams{
+		Name:                   toolset.Name,
+		Description:            toolset.Description,
+		DefaultEnvironmentSlug: toolset.DefaultEnvironmentSlug,
+		McpSlug:                toolset.McpSlug,
+		McpIsPublic:            toolset.McpIsPublic,
+		CustomDomainID:         uuid.NullUUID{UUID: domain.ID, Valid: true},
+		McpEnabled:             toolset.McpEnabled,
+		ToolSelectionMode:      toolset.ToolSelectionMode,
+		Slug:                   toolset.Slug,
+		ProjectID:              toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	return toolset, domain
 }
 
 // buildChallengeManagerForTest constructs a ChallengeManager wired to the

--- a/server/internal/mcp/remotelogin_integration_test.go
+++ b/server/internal/mcp/remotelogin_integration_test.go
@@ -1,0 +1,237 @@
+// remotelogin_integration_test.go drives the /mcp/{slug}/remote_login_callback
+// handler against a live dev-idp instance acting as the upstream OAuth
+// authorization server. Covers the two subject shapes the callback must
+// attribute remote_sessions rows to:
+//
+//   - authenticated: AuthnChallengeState pre-stamped with a user:<id> URN
+//     (what HandleIDPCallback does on the private-toolset path).
+//   - anonymous: public toolset, no subject on the parent challenge at
+//     /authorize time — handleConsentGet late-binds an anonymous URN and
+//     persists it back to Redis before rendering the per-remote cards.
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/dev-idp/pkg/devidptest"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// TestRemoteLoginCallback_AuthenticatedSubject covers the private-toolset
+// path where HandleIDPCallback has already stamped a user:<id> URN onto the
+// parent AuthnChallengeState. The callback must persist a remote_sessions
+// row keyed to that user.
+func TestRemoteLoginCallback_AuthenticatedSubject(t *testing.T) {
+	t.Parallel()
+
+	idp := devidptest.Launch(t, devidptest.LaunchOpts{})
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	result := oauthtest.CreateIssuerGatedToolset(t, ctx, ti.conn, ti.enc, authCtx, oauthtest.IssuerGatedToolsetOpts{
+		Slug:             "issuer-auth",
+		IsPublic:         false,
+		UpstreamMetadata: idp.OAuth21Metadata(t),
+	})
+
+	mgr, authnCache := buildChallengeManagerForTest(t, ti)
+
+	userSubject := urn.NewUserSubject(uuid.NewString())
+	parentID := uuid.NewString()
+	require.NoError(t, authnCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  parentID,
+		UserSessionIssuerID: result.UserSessionIssuer.ID,
+		ToolsetID:           result.Toolset.ID,
+		ClientID:            "test-mcp-client",
+		RedirectURI:         "http://example.com/cb",
+		CodeChallenge:       "",
+		CodeChallengeMethod: "",
+		Subject:             &userSubject,
+		CreatedAt:           time.Now(),
+	}))
+
+	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, &userSubject)
+}
+
+// TestRemoteLoginCallback_AnonymousSubject covers the public-toolset
+// path. The parent AuthnChallengeState is created with no subject; the
+// /mcp/{slug}/connect GET handler late-binds an anonymous URN and
+// persists it. The remote-login callback then attributes the
+// remote_sessions row to that anonymous URN.
+func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
+	t.Parallel()
+
+	idp := devidptest.Launch(t, devidptest.LaunchOpts{})
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	result := oauthtest.CreateIssuerGatedToolset(t, ctx, ti.conn, ti.enc, authCtx, oauthtest.IssuerGatedToolsetOpts{
+		Slug:             "issuer-anon",
+		IsPublic:         true,
+		UpstreamMetadata: idp.OAuth21Metadata(t),
+	})
+
+	mgr, authnCache := buildChallengeManagerForTest(t, ti)
+
+	parentID := uuid.NewString()
+	require.NoError(t, authnCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  parentID,
+		UserSessionIssuerID: result.UserSessionIssuer.ID,
+		ToolsetID:           result.Toolset.ID,
+		ClientID:            "test-mcp-client",
+		RedirectURI:         "http://example.com/cb",
+		CodeChallenge:       "",
+		CodeChallengeMethod: "",
+		Subject:             nil,
+		CreatedAt:           time.Now(),
+	}))
+
+	insertUserSessionClient(t, ctx, ti.conn, result.UserSessionIssuer.ID, "test-mcp-client")
+
+	// HandleConsent (GET) must stamp an anonymous URN onto the parent
+	// AuthnChallengeState. Hitting it via the service exercises the real
+	// path (loadToolset → requireUserSessionIssuer → late-bind branch).
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+result.Toolset.McpSlug.String+"/connect?state="+parentID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", result.Toolset.McpSlug.String)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleConsent(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	stamped, err := authnCache.Get(ctx, "authnChallenge:"+parentID)
+	require.NoError(t, err)
+	require.NotNil(t, stamped.Subject, "consent GET must stamp anonymous subject on public toolset")
+	require.Equal(t, urn.SessionSubjectKindAnonymous, stamped.Subject.Kind)
+
+	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, stamped.Subject)
+}
+
+// runRemoteLoginRoundTrip drives BuildAuthorizationUrl → upstream
+// /authorize (no-follow) → HandleRemoteLoginCallback against a freshly
+// stamped parent challenge, then asserts the resulting redirect and the
+// remote_sessions row's subject_urn. Shared by both subject-shape tests.
+func runRemoteLoginRoundTrip(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	mgr *remotesessions.ChallengeManager,
+	result oauthtest.IssuerGatedToolsetResult,
+	parentChallengeID string,
+	expectedSubject *urn.SessionSubject,
+) {
+	t.Helper()
+
+	clients, err := mgr.ListClients(ctx, result.Toolset.ProjectID, result.UserSessionIssuer.ID)
+	require.NoError(t, err)
+	require.Len(t, clients, 1)
+
+	parent := remotesessions.ParentChallenge{
+		ID:                  parentChallengeID,
+		ProjectID:           result.Toolset.ProjectID,
+		UserSessionIssuerID: result.UserSessionIssuer.ID,
+		Subject:             expectedSubject,
+		McpSlug:             result.Toolset.McpSlug.String,
+	}
+	authURL, err := mgr.BuildAuthorizationUrl(ctx, parent, clients[0])
+	require.NoError(t, err)
+
+	upstreamResp := httpGetNoFollow(t, authURL)
+	defer func() { _ = upstreamResp.Body.Close() }()
+	require.Equal(t, http.StatusFound, upstreamResp.StatusCode, "upstream /authorize should redirect")
+
+	loc, err := url.Parse(upstreamResp.Header.Get("Location"))
+	require.NoError(t, err)
+	code := loc.Query().Get("code")
+	state := loc.Query().Get("state")
+	require.NotEmpty(t, code, "upstream redirect must carry ?code")
+	require.NotEmpty(t, state, "upstream redirect must carry ?state")
+
+	cbReq := httptest.NewRequest(http.MethodGet,
+		"/mcp/"+result.Toolset.McpSlug.String+"/remote_login_callback?code="+url.QueryEscape(code)+"&state="+url.QueryEscape(state), nil)
+	cbCtx := chi.NewRouteContext()
+	cbCtx.URLParams.Add("mcpSlug", result.Toolset.McpSlug.String)
+	cbReq = cbReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, cbCtx))
+
+	cbW := httptest.NewRecorder()
+	require.NoError(t, mgr.HandleRemoteLoginCallback(cbW, cbReq))
+	require.Equal(t, http.StatusSeeOther, cbW.Code, "callback should redirect back to /connect")
+	require.Contains(t, cbW.Header().Get("Location"), "/mcp/"+result.Toolset.McpSlug.String+"/connect")
+	require.Contains(t, cbW.Header().Get("Location"), parentChallengeID)
+
+	sessions, err := remotesessions_repo.New(ti.conn).ListRemoteSessionsByProjectID(ctx, remotesessions_repo.ListRemoteSessionsByProjectIDParams{
+		ProjectID:  result.Toolset.ProjectID,
+		LimitValue: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, sessions, 1, "exactly one remote_sessions row should exist")
+	require.Equal(t, expectedSubject.String(), sessions[0].SubjectUrn.String())
+	require.Equal(t, result.RemoteSessionClient.ID, sessions[0].RemoteSessionClientID)
+	require.True(t, sessions[0].AccessExpiresAt.Valid)
+	require.True(t, sessions[0].AccessExpiresAt.Time.After(time.Now()), "access_expires_at must be in the future")
+}
+
+// insertUserSessionClient creates a user_session_clients row so
+// HandleConsent's lookup by ClientID succeeds. The real flow would mint
+// this in HandleRegister; tests skip that hop.
+func insertUserSessionClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, issuerID uuid.UUID, clientID string) {
+	t.Helper()
+	_, err := usersessions_repo.New(conn).CreateUserSessionClient(ctx, usersessions_repo.CreateUserSessionClientParams{
+		UserSessionIssuerID:   issuerID,
+		ClientID:              clientID,
+		ClientSecretHash:      pgtype.Text{Valid: false},
+		ClientName:            "test-mcp-client",
+		RedirectUris:          []string{"http://example.com/cb"},
+		ClientSecretExpiresAt: pgtype.Timestamptz{Valid: false},
+	})
+	require.NoError(t, err)
+}
+
+// buildChallengeManagerForTest constructs a ChallengeManager wired to the
+// same Redis + DB as the service under test, so RemoteLoginStates written
+// by one are readable by the other. Also returns a TypedCacheObject for
+// AuthnChallengeState keyed identically to the service's internal cache.
+func buildChallengeManagerForTest(
+	t *testing.T,
+	ti *testInstance,
+) (*remotesessions.ChallengeManager, cache.TypedCacheObject[mcp.AuthnChallengeState]) {
+	t.Helper()
+
+	policy, err := guardian.NewUnsafePolicy(ti.tracerProvider, []string{})
+	require.NoError(t, err)
+
+	mgr := remotesessions.NewChallengeManager(ti.logger, ti.conn, ti.enc, policy, ti.cacheAdapter, ti.serverURL)
+	authnCache := cache.NewTypedObjectCache[mcp.AuthnChallengeState](
+		ti.logger.With(attr.SlogCacheNamespace("authn_challenge")),
+		ti.cacheAdapter,
+		cache.SuffixNone,
+	)
+	return mgr, authnCache
+}

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/dev-idp/pkg/devidptest"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
@@ -90,6 +92,27 @@ type testInstance struct {
 func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 	return newTestMCPServiceWithIdentityResolver(t, nil)
+}
+
+// newTestMCPServiceWithDevIDP launches an in-process dev-idp instance and
+// wires the service with a real *identity.Resolver pointing at it. Use this
+// for tests exercising HandleAuthorize / HandleIDPCallback that need a real
+// BuildAuthorizationURL (redirect_uri shape, oauth21 authorize endpoint)
+// rather than the static-return mockIdentityResolver.
+func newTestMCPServiceWithDevIDP(t *testing.T) (context.Context, *testInstance, *devidptest.Instance) {
+	t.Helper()
+	idp := devidptest.Launch(t, devidptest.LaunchOpts{})
+	resolver := identity.NewResolver(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		cache.NoopCache,
+		idp.OAuth21URL,
+		"devidp-test-client", // non-"client_" prefix routes through idpBaseURL
+		nil,                  // idpClient — BuildAuthorizationURL doesn't touch it
+		nil, nil, nil, nil, nil,
+	)
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, resolver)
+	return ctx, ti, idp
 }
 
 func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.IdentityResolver) (context.Context, *testInstance) {

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/stretchr/testify/require"
@@ -164,7 +165,8 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter)
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
-	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, identityResolver, userSessionSigner)
+	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
+	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, identityResolver, userSessionSigner, remoteChallengeMgr)
 
 	authnCache := cache.NewTypedObjectCache[mcp.AuthnChallengeState](logger, cacheAdapter, cache.SuffixNone)
 

--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -34,6 +34,10 @@ type IssuerGatedToolsetOpts struct {
 	// issuer / authorization_endpoint / token_endpoint / registration_endpoint
 	// out of this document and DCR-registers a remote_session_client.
 	UpstreamMetadata []byte
+	// RemoteSessionCallbackBaseURL, when set, registers the Gram
+	// /remote_login_callback URL for the generated MCP slug. Tests that drive
+	// a real upstream authorize flow should set this to the Gram server URL.
+	RemoteSessionCallbackBaseURL string
 	// AuthnChallengeMode is "chain" or "interactive". Default "interactive".
 	AuthnChallengeMode string
 }
@@ -118,7 +122,11 @@ func CreateIssuerGatedToolset(
 	})
 	require.NoError(t, err)
 
-	clientID, clientSecret := dcrRegister(t, ctx, meta.RegistrationEndpoint, "test-issuer-gated-"+suffix)
+	redirectURIs := []string{"http://localhost/unused"}
+	if opts.RemoteSessionCallbackBaseURL != "" {
+		redirectURIs = []string{strings.TrimRight(opts.RemoteSessionCallbackBaseURL, "/") + "/mcp/" + slug + "/remote_login_callback"}
+	}
+	clientID, clientSecret := dcrRegister(t, ctx, meta.RegistrationEndpoint, "test-issuer-gated-"+suffix, redirectURIs)
 	encSecret, err := enc.Encrypt([]byte(clientSecret))
 	require.NoError(t, err)
 
@@ -178,12 +186,12 @@ func CreateIssuerGatedToolset(
 
 // dcrRegister POSTs an RFC 7591 client registration to the given endpoint
 // and returns the issued (client_id, client_secret).
-func dcrRegister(t *testing.T, ctx context.Context, endpoint, clientName string) (string, string) {
+func dcrRegister(t *testing.T, ctx context.Context, endpoint, clientName string, redirectURIs []string) (string, string) {
 	t.Helper()
 
 	body, err := json.Marshal(map[string]any{
 		"client_name":                clientName,
-		"redirect_uris":              []string{"http://localhost/unused"},
+		"redirect_uris":              redirectURIs,
 		"grant_types":                []string{"authorization_code", "refresh_token"},
 		"response_types":             []string{"code"},
 		"token_endpoint_auth_method": "client_secret_basic",

--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -1,0 +1,214 @@
+package oauthtest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// IssuerGatedToolsetOpts configures CreateIssuerGatedToolset.
+type IssuerGatedToolsetOpts struct {
+	// Slug prefix for the toolset. A UUID suffix is appended automatically.
+	Slug string
+	// IsPublic sets McpIsPublic on the toolset. Default false (private).
+	IsPublic bool
+	// UpstreamMetadata is RFC 8414 JSON describing the remote authorization
+	// server (e.g. devidptest.Instance.OAuth21Metadata(t)). The helper reads
+	// issuer / authorization_endpoint / token_endpoint / registration_endpoint
+	// out of this document and DCR-registers a remote_session_client.
+	UpstreamMetadata []byte
+	// AuthnChallengeMode is "chain" or "interactive". Default "interactive".
+	AuthnChallengeMode string
+}
+
+// IssuerGatedToolsetResult holds the rows created by CreateIssuerGatedToolset.
+type IssuerGatedToolsetResult struct {
+	Toolset             toolsets_repo.Toolset
+	UserSessionIssuer   usersessions_repo.UserSessionIssuer
+	RemoteSessionIssuer remotesessions_repo.RemoteSessionIssuer
+	RemoteSessionClient remotesessions_repo.RemoteSessionClient
+}
+
+// CreateIssuerGatedToolset provisions a user_session_issuer + one
+// remote_session_issuer + one DCR-registered remote_session_client wired to
+// the provided upstream AS metadata, then creates a toolset bound to the
+// user_session_issuer. Used by integration tests that exercise the
+// /mcp/{slug}/connect + /mcp/{slug}/remote_login_callback handlers against
+// a live dev-idp instance.
+func CreateIssuerGatedToolset(
+	t *testing.T,
+	ctx context.Context,
+	conn *pgxpool.Pool,
+	enc *encryption.Client,
+	authCtx *contextvalues.AuthContext,
+	opts IssuerGatedToolsetOpts,
+) IssuerGatedToolsetResult {
+	t.Helper()
+
+	require.NotNil(t, opts.UpstreamMetadata, "UpstreamMetadata is required")
+
+	var meta struct {
+		Issuer                string `json:"issuer"`
+		AuthorizationEndpoint string `json:"authorization_endpoint"`
+		TokenEndpoint         string `json:"token_endpoint"`
+		RegistrationEndpoint  string `json:"registration_endpoint"`
+		JwksURI               string `json:"jwks_uri"`
+	}
+	require.NoError(t, json.Unmarshal(opts.UpstreamMetadata, &meta))
+	require.NotEmpty(t, meta.RegistrationEndpoint, "upstream must support DCR for issuer-gated tests")
+
+	suffix := uuid.New().String()[:8]
+	if opts.Slug == "" {
+		opts.Slug = "issuer-gated"
+	}
+	slug := opts.Slug + "-" + suffix
+	mode := opts.AuthnChallengeMode
+	if mode == "" {
+		mode = "interactive"
+	}
+
+	usersRepo := usersessions_repo.New(conn)
+	remoteRepo := remotesessions_repo.New(conn)
+	toolsetsRepo := toolsets_repo.New(conn)
+
+	usi, err := usersRepo.CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
+		ProjectID:          *authCtx.ProjectID,
+		Slug:               "usi-" + suffix,
+		AuthnChallengeMode: mode,
+		SessionDuration: pgtype.Interval{
+			Microseconds: int64(time.Hour / time.Microsecond),
+			Days:         0,
+			Months:       0,
+			Valid:        true,
+		},
+	})
+	require.NoError(t, err)
+
+	rsi, err := remoteRepo.CreateRemoteSessionIssuer(ctx, remotesessions_repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         *authCtx.ProjectID,
+		Slug:                              "rsi-" + suffix,
+		Issuer:                            meta.Issuer,
+		AuthorizationEndpoint:             conv.ToPGText(meta.AuthorizationEndpoint),
+		TokenEndpoint:                     conv.ToPGText(meta.TokenEndpoint),
+		RegistrationEndpoint:              conv.ToPGText(meta.RegistrationEndpoint),
+		JwksUri:                           conv.PtrToPGTextEmpty(conv.PtrEmpty(meta.JwksURI)),
+		ScopesSupported:                   []string{},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+		Oidc:                              false,
+		Passthrough:                       false,
+	})
+	require.NoError(t, err)
+
+	clientID, clientSecret := dcrRegister(t, ctx, meta.RegistrationEndpoint, "test-issuer-gated-"+suffix)
+	encSecret, err := enc.Encrypt([]byte(clientSecret))
+	require.NoError(t, err)
+
+	rsc, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
+		ProjectID:             *authCtx.ProjectID,
+		RemoteSessionIssuerID: rsi.ID,
+		UserSessionIssuerID:   usi.ID,
+		ClientID:              clientID,
+		ClientSecretEncrypted: conv.ToPGText(encSecret),
+		ClientIDIssuedAt:      pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		ClientSecretExpiresAt: pgtype.Timestamptz{Valid: false},
+	})
+	require.NoError(t, err)
+
+	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Issuer-Gated MCP " + suffix,
+		Slug:                   slug,
+		Description:            conv.ToPGText("Test toolset bound to user_session_issuer"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText(slug),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	if opts.IsPublic {
+		toolset, err = toolsetsRepo.UpdateToolset(ctx, toolsets_repo.UpdateToolsetParams{
+			Name:                   toolset.Name,
+			Description:            toolset.Description,
+			DefaultEnvironmentSlug: toolset.DefaultEnvironmentSlug,
+			McpSlug:                toolset.McpSlug,
+			McpIsPublic:            true,
+			McpEnabled:             toolset.McpEnabled,
+			CustomDomainID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+			ToolSelectionMode:      "",
+			Slug:                   toolset.Slug,
+			ProjectID:              toolset.ProjectID,
+		})
+		require.NoError(t, err)
+	}
+
+	toolset, err = toolsetsRepo.UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: usi.ID, Valid: true},
+		Slug:                toolset.Slug,
+		ProjectID:           toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	return IssuerGatedToolsetResult{
+		Toolset:             toolset,
+		UserSessionIssuer:   usi,
+		RemoteSessionIssuer: rsi,
+		RemoteSessionClient: rsc,
+	}
+}
+
+// dcrRegister POSTs an RFC 7591 client registration to the given endpoint
+// and returns the issued (client_id, client_secret).
+func dcrRegister(t *testing.T, ctx context.Context, endpoint, clientName string) (string, string) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"client_name":                clientName,
+		"redirect_uris":              []string{"http://localhost/unused"},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "client_secret_basic",
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, 2, resp.StatusCode/100, "DCR %s: %s", resp.Status, strings.TrimSpace(string(raw)))
+
+	var out struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &out))
+	require.NotEmpty(t, out.ClientID)
+	require.NotEmpty(t, out.ClientSecret)
+	return out.ClientID, out.ClientSecret
+}

--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -34,9 +34,9 @@ type IssuerGatedToolsetOpts struct {
 	// issuer / authorization_endpoint / token_endpoint / registration_endpoint
 	// out of this document and DCR-registers a remote_session_client.
 	UpstreamMetadata []byte
-	// RemoteSessionCallbackBaseURL, when set, registers the Gram
-	// /remote_login_callback URL for the generated MCP slug. Tests that drive
-	// a real upstream authorize flow should set this to the Gram server URL.
+	// RemoteSessionCallbackBaseURL, when set, registers the static Gram
+	// /mcp/remote_login_callback URL. Tests that drive a real upstream
+	// authorize flow should set this to the Gram server URL.
 	RemoteSessionCallbackBaseURL string
 	// AuthnChallengeMode is "chain" or "interactive". Default "interactive".
 	AuthnChallengeMode string
@@ -54,8 +54,8 @@ type IssuerGatedToolsetResult struct {
 // remote_session_issuer + one DCR-registered remote_session_client wired to
 // the provided upstream AS metadata, then creates a toolset bound to the
 // user_session_issuer. Used by integration tests that exercise the
-// /mcp/{slug}/connect + /mcp/{slug}/remote_login_callback handlers against
-// a live dev-idp instance.
+// /mcp/{slug}/connect + /mcp/remote_login_callback handlers against a live
+// dev-idp instance.
 func CreateIssuerGatedToolset(
 	t *testing.T,
 	ctx context.Context,
@@ -124,7 +124,7 @@ func CreateIssuerGatedToolset(
 
 	redirectURIs := []string{"http://localhost/unused"}
 	if opts.RemoteSessionCallbackBaseURL != "" {
-		redirectURIs = []string{strings.TrimRight(opts.RemoteSessionCallbackBaseURL, "/") + "/mcp/" + slug + "/remote_login_callback"}
+		redirectURIs = []string{strings.TrimRight(opts.RemoteSessionCallbackBaseURL, "/") + "/mcp/remote_login_callback"}
 	}
 	clientID, clientSecret := dcrRegister(t, ctx, meta.RegistrationEndpoint, "test-issuer-gated-"+suffix, redirectURIs)
 	encSecret, err := enc.Encrypt([]byte(clientSecret))

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -6,7 +6,7 @@
 //     and the picked remote_session_client, it mints a RemoteLoginState in
 //     Redis (carrying PKCE + parent binding) and returns the authorize URL
 //     to redirect the user to.
-//   - HandleRemoteLoginCallback is bound to `GET /mcp/{slug}/remote_login_callback`.
+//   - HandleRemoteLoginCallback is bound to `GET /mcp/remote_login_callback`.
 //     Reads ?code+?state, validates state, exchanges code for tokens at the
 //     upstream token endpoint, encrypts and persists the remote_sessions
 //     row, then redirects back to /mcp/{slug}/connect with the parent
@@ -218,7 +218,7 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 		return "", fmt.Errorf("generate code verifier: %w", err)
 	}
 	codeChallenge := s256Challenge(verifier)
-	redirectURI := m.callbackURL(parent.McpSlug)
+	redirectURI := m.callbackURL()
 
 	// Parse the upstream authorize URL before the cache write so a malformed
 	// endpoint can't leave an orphaned RemoteLoginState in Redis (its key is
@@ -261,17 +261,16 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 }
 
 // HandleRemoteLoginCallback is the GET handler for
-// /mcp/{mcpSlug}/remote_login_callback. Bound by mcp/ at route-mount time.
+// /mcp/remote_login_callback. Bound by mcp/ at route-mount time. The legacy
+// /mcp/{mcpSlug}/remote_login_callback route is still accepted, but the MCP
+// slug is resolved from the stored RemoteLoginState.
 // Coordinates code → token exchange at the upstream token endpoint and
 // persists the result in remote_sessions; on success redirects back to
 // /mcp/{slug}/connect?state={parent_challenge_id}.
 func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	mcpSlug := chi.URLParam(r, "mcpSlug")
-	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, m.logger)
-	}
-	logger := m.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+	routeMcpSlug := chi.URLParam(r, "mcpSlug")
+	logger := m.logger
 
 	q := r.URL.Query()
 	if errCode := q.Get("error"); errCode != "" {
@@ -297,11 +296,24 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	if err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "remote login state not found or expired").Log(ctx, logger)
 	}
-	if state.McpSlug != mcpSlug {
+	mcpSlug := state.McpSlug
+	if mcpSlug == "" {
+		mcpSlug = routeMcpSlug
+	}
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from remote login state").Log(ctx, logger)
+	}
+	if routeMcpSlug != "" && routeMcpSlug != mcpSlug {
+		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").Log(ctx, logger)
+	}
+	if state.McpSlug != "" && state.McpSlug != mcpSlug {
 		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").Log(ctx, logger)
 	}
 
-	logger = logger.With(attr.SlogProjectID(state.ProjectID.String()))
+	logger = logger.With(
+		attr.SlogToolsetMCPSlug(mcpSlug),
+		attr.SlogProjectID(state.ProjectID.String()),
+	)
 
 	// Hoisted above the DB lookup + upstream code exchange so a state with a
 	// missing/zero Subject fails fast — otherwise we burn the single-use
@@ -383,8 +395,8 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	return nil
 }
 
-func (m *ChallengeManager) callbackURL(mcpSlug string) string {
-	return strings.TrimRight(m.serverURL.String(), "/") + "/mcp/" + mcpSlug + "/remote_login_callback"
+func (m *ChallengeManager) callbackURL() string {
+	return strings.TrimRight(m.serverURL.String(), "/") + "/mcp/remote_login_callback"
 }
 
 // tokenResponse is the slice of the upstream /token reply we care about.

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -1,0 +1,470 @@
+// ChallengeManager drives the per-remote OAuth authn-challenge leg of the
+// MCP user-session flow. Two entry points split by direction:
+//
+//   - BuildAuthorizationUrl is called by the user-session consent renderer
+//     (mcp/authnchallenge_consent.go). Given the in-flight parent challenge
+//     and the picked remote_session_client, it mints a RemoteLoginState in
+//     Redis (carrying PKCE + parent binding) and returns the authorize URL
+//     to redirect the user to.
+//   - HandleRemoteLoginCallback is bound to `GET /mcp/{slug}/remote_login_callback`.
+//     Reads ?code+?state, validates state, exchanges code for tokens at the
+//     upstream token endpoint, encrypts and persists the remote_sessions
+//     row, then redirects back to /mcp/{slug}/connect with the parent
+//     challenge id so the consent page re-renders with this remote ✓.
+//
+// AuthnChallengeState reuse: the parent challenge passed to
+// BuildAuthorizationUrl is the same Redis-backed state minted at
+// /authorize — its ID is the unambiguous binding back to the right /connect
+// render after a user round-trips through the upstream provider. mcp/
+// builds a ParentChallenge value from its AuthnChallengeState; this package
+// never imports mcp/.
+
+package remotesessions
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// ParentChallenge projects the in-flight user-session AuthnChallengeState
+// into the fields the remote leg needs. mcp/ builds this from its
+// AuthnChallengeState; remotesessions/ never imports mcp/.
+type ParentChallenge struct {
+	ID                  string
+	ProjectID           uuid.UUID
+	UserSessionIssuerID uuid.UUID
+	Subject             *urn.SessionSubject
+	McpSlug             string
+}
+
+// RemoteLoginState is the per-remote-leg Redis state, keyed by the opaque
+// `state` parameter sent to the upstream provider. ~10 minute TTL — same
+// budget as the parent AuthnChallengeState.
+type RemoteLoginState struct {
+	ID                    string              `json:"id"`
+	ParentChallengeID     string              `json:"parent_challenge_id"`
+	ProjectID             uuid.UUID           `json:"project_id"`
+	UserSessionIssuerID   uuid.UUID           `json:"user_session_issuer_id"`
+	RemoteSessionClientID uuid.UUID           `json:"remote_session_client_id"`
+	TokenEndpoint         string              `json:"token_endpoint"`
+	RedirectURI           string              `json:"redirect_uri"`
+	CodeVerifier          string              `json:"code_verifier"`
+	Subject               *urn.SessionSubject `json:"subject,omitempty"`
+	McpSlug               string              `json:"mcp_slug"`
+	CreatedAt             time.Time           `json:"created_at"`
+}
+
+var _ cache.CacheableObject[RemoteLoginState] = (*RemoteLoginState)(nil)
+
+func (s RemoteLoginState) CacheKey() string              { return "remoteLogin:" + s.ID }
+func (s RemoteLoginState) AdditionalCacheKeys() []string { return []string{} }
+func (s RemoteLoginState) TTL() time.Duration            { return 10 * time.Minute }
+
+// ChallengeManager drives the per-remote OAuth authn-challenge leg.
+type ChallengeManager struct {
+	logger    *slog.Logger
+	db        *pgxpool.Pool
+	enc       *encryption.Client
+	policy    *guardian.Policy
+	cache     cache.TypedCacheObject[RemoteLoginState]
+	serverURL *url.URL
+}
+
+func NewChallengeManager(
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+	enc *encryption.Client,
+	policy *guardian.Policy,
+	cacheImpl cache.Cache,
+	serverURL *url.URL,
+) *ChallengeManager {
+	logger = logger.With(attr.SlogComponent("remotesessions_challenge"))
+	return &ChallengeManager{
+		logger: logger,
+		db:     db,
+		enc:    enc,
+		policy: policy,
+		cache: cache.NewTypedObjectCache[RemoteLoginState](
+			logger.With(attr.SlogCacheNamespace("remote_login")),
+			cacheImpl,
+			cache.SuffixNone,
+		),
+		serverURL: serverURL,
+	}
+}
+
+// Client is the joined view of a remote_session_client + its
+// remote_session_issuer used by BuildAuthorizationUrl and the consent
+// renderer. Kept as a package value type so mcp/ can pass it back to us
+// without re-querying.
+type Client struct {
+	ID                    uuid.UUID
+	ExternalClientID      string
+	ClientSecretEncrypted *string
+	IssuerSlug            string
+	IssuerURL             string
+	AuthorizationEndpoint string
+	TokenEndpoint         string
+	Scopes                []string
+	Passthrough           bool
+}
+
+// ListClients returns the joined client + issuer rows linked to a user
+// session issuer. Used by the consent renderer to materialise the
+// per-remote cards.
+func (m *ChallengeManager) ListClients(
+	ctx context.Context,
+	projectID uuid.UUID,
+	userSessionIssuerID uuid.UUID,
+) ([]Client, error) {
+	rows, err := remotesessions_repo.New(m.db).ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessions_repo.ListRemoteSessionClientsForUserSessionIssuerParams{
+		UserSessionIssuerID: userSessionIssuerID,
+		ProjectID:           projectID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list remote session clients: %w", err)
+	}
+	out := make([]Client, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, Client{
+			ID:                    r.ClientID,
+			ExternalClientID:      r.ExternalClientID,
+			ClientSecretEncrypted: conv.FromPGText[string](r.ClientSecretEncrypted),
+			IssuerSlug:            r.IssuerSlug,
+			IssuerURL:             r.IssuerUrl,
+			AuthorizationEndpoint: conv.PtrValOr(conv.FromPGText[string](r.AuthorizationEndpoint), ""),
+			TokenEndpoint:         conv.PtrValOr(conv.FromPGText[string](r.TokenEndpoint), ""),
+			Scopes:                r.ScopesSupported,
+			Passthrough:           r.Passthrough,
+		})
+	}
+	return out, nil
+}
+
+// ConnectedClientIDs returns the set of remote_session_client_ids that
+// have an active remote_sessions row for `subject` under the given
+// `userSessionIssuerID`. Single round-trip; the caller (consent
+// renderer) then does O(1) membership checks per card. Returns an empty
+// set for zero subjects so anonymous-pre-stamp renders are no-ops.
+func (m *ChallengeManager) ConnectedClientIDs(
+	ctx context.Context,
+	subject urn.SessionSubject,
+	userSessionIssuerID uuid.UUID,
+) (map[uuid.UUID]struct{}, error) {
+	if subject.IsZero() {
+		return map[uuid.UUID]struct{}{}, nil
+	}
+	ids, err := remotesessions_repo.New(m.db).ListConnectedClientIDsForSubject(ctx, remotesessions_repo.ListConnectedClientIDsForSubjectParams{
+		SubjectUrn:          subject,
+		UserSessionIssuerID: userSessionIssuerID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list connected client ids: %w", err)
+	}
+	set := make(map[uuid.UUID]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, nil
+}
+
+// BuildAuthorizationUrl mints a RemoteLoginState (with PKCE S256) for the
+// (parent, client) pair, stores it in Redis, and returns the upstream
+// authorize URL with bound `state` + `code_challenge` query params. The
+// caller is the consent renderer; this is called once per visible card.
+func (m *ChallengeManager) BuildAuthorizationUrl(
+	ctx context.Context,
+	parent ParentChallenge,
+	client Client,
+) (string, error) {
+	if client.AuthorizationEndpoint == "" {
+		return "", fmt.Errorf("remote_session_issuer %s missing authorization_endpoint", client.IssuerSlug)
+	}
+	if client.TokenEndpoint == "" {
+		return "", fmt.Errorf("remote_session_issuer %s missing token_endpoint", client.IssuerSlug)
+	}
+
+	stateID, err := randomToken(32)
+	if err != nil {
+		return "", fmt.Errorf("generate state: %w", err)
+	}
+	verifier, err := randomToken(32)
+	if err != nil {
+		return "", fmt.Errorf("generate code verifier: %w", err)
+	}
+	codeChallenge := s256Challenge(verifier)
+	redirectURI := m.callbackURL(parent.McpSlug)
+
+	// Parse the upstream authorize URL before the cache write so a malformed
+	// endpoint can't leave an orphaned RemoteLoginState in Redis (its key is
+	// keyed on the random stateID — nothing else can reach it to clean up,
+	// it just expires after TTL).
+	u, err := url.Parse(client.AuthorizationEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse authorization_endpoint: %w", err)
+	}
+
+	state := RemoteLoginState{
+		ID:                    stateID,
+		ParentChallengeID:     parent.ID,
+		ProjectID:             parent.ProjectID,
+		UserSessionIssuerID:   parent.UserSessionIssuerID,
+		RemoteSessionClientID: client.ID,
+		TokenEndpoint:         client.TokenEndpoint,
+		RedirectURI:           redirectURI,
+		CodeVerifier:          verifier,
+		Subject:               parent.Subject,
+		McpSlug:               parent.McpSlug,
+		CreatedAt:             time.Now(),
+	}
+	if err := m.cache.Store(ctx, state); err != nil {
+		return "", fmt.Errorf("store remote login state: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", client.ExternalClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("state", stateID)
+	q.Set("code_challenge", codeChallenge)
+	q.Set("code_challenge_method", "S256")
+	if len(client.Scopes) > 0 {
+		q.Set("scope", strings.Join(client.Scopes, " "))
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// HandleRemoteLoginCallback is the GET handler for
+// /mcp/{mcpSlug}/remote_login_callback. Bound by mcp/ at route-mount time.
+// Coordinates code → token exchange at the upstream token endpoint and
+// persists the result in remote_sessions; on success redirects back to
+// /mcp/{slug}/connect?state={parent_challenge_id}.
+func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	mcpSlug := chi.URLParam(r, "mcpSlug")
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").Log(ctx, m.logger)
+	}
+	logger := m.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+
+	q := r.URL.Query()
+	if errCode := q.Get("error"); errCode != "" {
+		logger.WarnContext(ctx, "remote authn challenge returned error",
+			attr.SlogOAuthError(errCode),
+			attr.SlogOAuthErrorDescription(q.Get("error_description")),
+		)
+		return oops.E(oops.CodeUnauthorized, nil, "remote authn challenge denied: %s", errCode)
+	}
+	stateID := q.Get("state")
+	if stateID == "" {
+		return oops.E(oops.CodeBadRequest, nil, "state is required").Log(ctx, logger)
+	}
+	code := q.Get("code")
+	if code == "" {
+		return oops.E(oops.CodeBadRequest, nil, "code is required").Log(ctx, logger)
+	}
+
+	// Single-use state: GETDEL so a duplicate callback can't double-exchange
+	// the code. The upstream code itself is also single-use, but defense in
+	// depth keeps the failure mode obvious.
+	state, err := m.cache.GetAndDelete(ctx, "remoteLogin:"+stateID)
+	if err != nil {
+		return oops.E(oops.CodeUnauthorized, err, "remote login state not found or expired").Log(ctx, logger)
+	}
+	if state.McpSlug != mcpSlug {
+		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").Log(ctx, logger)
+	}
+
+	logger = logger.With(attr.SlogProjectID(state.ProjectID.String()))
+
+	// Hoisted above the DB lookup + upstream code exchange so a state with a
+	// missing/zero Subject fails fast — otherwise we burn the single-use
+	// upstream authorization code on a request that can't produce a
+	// remote_sessions row anyway.
+	if state.Subject == nil || state.Subject.IsZero() {
+		return oops.E(oops.CodeUnauthorized, nil, "remote login requires a stamped subject on the parent challenge").Log(ctx, logger)
+	}
+
+	queries := remotesessions_repo.New(m.db)
+	clientRow, err := queries.GetRemoteSessionClientByID(ctx, remotesessions_repo.GetRemoteSessionClientByIDParams{
+		ID:        state.RemoteSessionClientID,
+		ProjectID: state.ProjectID,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "load remote session client").Log(ctx, logger)
+	}
+
+	var clientSecret string
+	if clientRow.ClientSecretEncrypted.Valid {
+		decoded, derr := m.enc.Decrypt(clientRow.ClientSecretEncrypted.String)
+		if derr != nil {
+			return oops.E(oops.CodeUnexpected, derr, "decrypt client secret").Log(ctx, logger)
+		}
+		clientSecret = decoded
+	}
+
+	tok, err := m.exchangeCode(ctx, state, clientRow.ClientID, clientSecret, code)
+	if err != nil {
+		return oops.E(oops.CodeUnauthorized, err, "upstream token exchange failed").Log(ctx, logger)
+	}
+
+	accessEnc, err := m.enc.Encrypt([]byte(tok.AccessToken))
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "encrypt access token").Log(ctx, logger)
+	}
+	var refreshEnc *string
+	if tok.RefreshToken != "" {
+		v, eerr := m.enc.Encrypt([]byte(tok.RefreshToken))
+		if eerr != nil {
+			return oops.E(oops.CodeUnexpected, eerr, "encrypt refresh token").Log(ctx, logger)
+		}
+		refreshEnc = &v
+	}
+
+	// expires_in is OPTIONAL per RFC 6749 §5.1. Fall back to a 1h default
+	// so we always have a positive access_expires_at to compare against —
+	// silent-refresh logic in a later milestone will treat the row as
+	// "needs refresh" if the upstream didn't tell us.
+	accessExpires := time.Now().Add(1 * time.Hour)
+	if tok.ExpiresIn > 0 {
+		accessExpires = time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+	}
+	var refreshExpires *time.Time
+	if tok.RefreshExpiresIn > 0 {
+		v := time.Now().Add(time.Duration(tok.RefreshExpiresIn) * time.Second)
+		refreshExpires = &v
+	}
+
+	scopes := tok.Scopes()
+	if scopes == nil {
+		scopes = []string{}
+	}
+	if _, err := queries.UpsertRemoteSession(ctx, remotesessions_repo.UpsertRemoteSessionParams{
+		SubjectUrn:            *state.Subject,
+		UserSessionIssuerID:   state.UserSessionIssuerID,
+		RemoteSessionClientID: state.RemoteSessionClientID,
+		AccessTokenEncrypted:  accessEnc,
+		AccessExpiresAt:       conv.ToPGTimestamptz(accessExpires),
+		RefreshTokenEncrypted: conv.PtrToPGText(refreshEnc),
+		RefreshExpiresAt:      conv.PtrToPGTimestamptz(refreshExpires),
+		Scopes:                scopes,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "store remote session").Log(ctx, logger)
+	}
+
+	redirect := fmt.Sprintf("%s/mcp/%s/connect?state=%s", strings.TrimRight(m.serverURL.String(), "/"), mcpSlug, url.QueryEscape(state.ParentChallengeID))
+	http.Redirect(w, r, redirect, http.StatusSeeOther)
+	return nil
+}
+
+func (m *ChallengeManager) callbackURL(mcpSlug string) string {
+	return strings.TrimRight(m.serverURL.String(), "/") + "/mcp/" + mcpSlug + "/remote_login_callback"
+}
+
+// tokenResponse is the slice of the upstream /token reply we care about.
+// RFC 6749 fields plus the optional refresh_expires_in some providers
+// (e.g. Keycloak) include.
+type tokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	TokenType        string `json:"token_type"`
+	ExpiresIn        int    `json:"expires_in"`
+	RefreshExpiresIn int    `json:"refresh_expires_in"`
+	Scope            string `json:"scope"`
+}
+
+func (t tokenResponse) Scopes() []string {
+	if t.Scope == "" {
+		return nil
+	}
+	return strings.Split(t.Scope, " ")
+}
+
+// exchangeCode POSTs application/x-www-form-urlencoded to the upstream
+// token endpoint per RFC 6749 §4.1.3. Auth methods: client_secret_basic
+// when a secret is set, otherwise public-client (PKCE-only).
+func (m *ChallengeManager) exchangeCode(
+	ctx context.Context,
+	state RemoteLoginState,
+	externalClientID string,
+	clientSecret string,
+	code string,
+) (tokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", state.RedirectURI)
+	form.Set("client_id", externalClientID)
+	form.Set("code_verifier", state.CodeVerifier)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, state.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return tokenResponse{}, fmt.Errorf("new token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if clientSecret != "" {
+		req.SetBasicAuth(externalClientID, clientSecret)
+	}
+
+	resp, err := m.policy.PooledClient().Do(req)
+	if err != nil {
+		return tokenResponse{}, fmt.Errorf("post token: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return tokenResponse{}, fmt.Errorf("read token response body: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return tokenResponse{}, fmt.Errorf("token endpoint %s: %s", resp.Status, string(body))
+	}
+	var tok tokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return tokenResponse{}, fmt.Errorf("decode token response: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return tokenResponse{}, errors.New("token endpoint returned no access_token")
+	}
+	return tok, nil
+}
+
+func randomToken(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("read random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func s256Challenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -167,6 +167,92 @@ VALUES (
 )
 RETURNING *;
 
+-- name: UpsertRemoteSession :one
+-- Used by /mcp/{slug}/remote_login_callback to materialise (or refresh) the
+-- remote_session for a (subject, client) pair. Conflict target matches the
+-- partial unique index on (subject_urn, remote_session_client_id) WHERE
+-- deleted IS FALSE; on conflict we overwrite every token field. A
+-- soft-deleted row falls outside the partial index, so a re-auth after
+-- revocation inserts a fresh active row alongside the tombstone.
+INSERT INTO remote_sessions (
+    subject_urn,
+    user_session_issuer_id,
+    remote_session_client_id,
+    access_token_encrypted,
+    access_expires_at,
+    refresh_token_encrypted,
+    refresh_expires_at,
+    scopes
+)
+VALUES (
+    @subject_urn,
+    @user_session_issuer_id,
+    @remote_session_client_id,
+    @access_token_encrypted,
+    @access_expires_at,
+    @refresh_token_encrypted,
+    @refresh_expires_at,
+    @scopes
+)
+ON CONFLICT (subject_urn, remote_session_client_id) WHERE deleted IS FALSE
+DO UPDATE SET
+    access_token_encrypted = EXCLUDED.access_token_encrypted,
+    access_expires_at = EXCLUDED.access_expires_at,
+    refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
+    refresh_expires_at = EXCLUDED.refresh_expires_at,
+    scopes = EXCLUDED.scopes,
+    updated_at = clock_timestamp()
+RETURNING *;
+
+-- name: GetActiveRemoteSession :one
+-- Look up the active remote_session for a (subject, client) binding.
+-- Single-row exact lookup; uniqueness enforced by the partial unique
+-- index on (subject_urn, remote_session_client_id) WHERE deleted IS FALSE.
+SELECT *
+FROM remote_sessions
+WHERE subject_urn = @subject_urn
+  AND remote_session_client_id = @remote_session_client_id
+  AND deleted IS FALSE;
+
+-- name: ListConnectedClientIDsForSubject :many
+-- Bulk lookup for the consent renderer: returns the set of
+-- remote_session_client_ids that have an active remote_sessions row for
+-- the given subject under a single user_session_issuer. Folds the N
+-- per-card IsConnected lookups into one round-trip. The partial unique
+-- index on (subject_urn, remote_session_client_id) WHERE deleted IS
+-- FALSE means at most one row per (subject, client), so the result set
+-- doubles as a membership set without DISTINCT.
+SELECT remote_session_client_id
+FROM remote_sessions
+WHERE subject_urn = @subject_urn
+  AND user_session_issuer_id = @user_session_issuer_id
+  AND deleted IS FALSE;
+
+-- name: ListRemoteSessionClientsForUserSessionIssuer :many
+-- Joined client + issuer view used by the consent renderer and the
+-- ChallengeManager. Returns one row per remote_session_client linked to
+-- the given user_session_issuer.
+SELECT
+    c.id                                   AS client_id,
+    c.client_id                            AS external_client_id,
+    c.client_secret_encrypted              AS client_secret_encrypted,
+    c.remote_session_issuer_id             AS remote_session_issuer_id,
+    c.user_session_issuer_id               AS user_session_issuer_id,
+    i.slug                                 AS issuer_slug,
+    i.issuer                               AS issuer_url,
+    i.authorization_endpoint               AS authorization_endpoint,
+    i.token_endpoint                       AS token_endpoint,
+    i.scopes_supported                     AS scopes_supported,
+    i.passthrough                          AS passthrough,
+    i.oidc                                 AS oidc
+FROM remote_session_clients AS c
+JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
+WHERE c.user_session_issuer_id = @user_session_issuer_id
+  AND c.project_id              = @project_id
+  AND c.deleted IS FALSE
+  AND i.deleted IS FALSE
+ORDER BY c.id ASC;
+
 -- name: ListRemoteSessionsByProjectID :many
 SELECT s.*
 FROM remote_sessions AS s

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -168,7 +168,7 @@ VALUES (
 RETURNING *;
 
 -- name: UpsertRemoteSession :one
--- Used by /mcp/{slug}/remote_login_callback to materialise (or refresh) the
+-- Used by /mcp/remote_login_callback to materialise (or refresh) the
 -- remote_session for a (subject, client) pair. Conflict target matches the
 -- partial unique index on (subject_urn, remote_session_client_id) WHERE
 -- deleted IS FALSE; on conflict we overwrite every token field. A

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -1007,7 +1007,7 @@ type UpsertRemoteSessionParams struct {
 	Scopes                []string
 }
 
-// Used by /mcp/{slug}/remote_login_callback to materialise (or refresh) the
+// Used by /mcp/remote_login_callback to materialise (or refresh) the
 // remote_session for a (subject, client) pair. Conflict target matches the
 // partial unique index on (subject_urn, remote_session_client_id) WHERE
 // deleted IS FALSE; on conflict we overwrite every token field. A

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -266,6 +266,43 @@ func (q *Queries) DeleteRemoteSessionIssuer(ctx context.Context, arg DeleteRemot
 	return i, err
 }
 
+const getActiveRemoteSession = `-- name: GetActiveRemoteSession :one
+SELECT id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, access_expires_at, refresh_token_encrypted, refresh_expires_at, scopes, created_at, updated_at, deleted_at, deleted
+FROM remote_sessions
+WHERE subject_urn = $1
+  AND remote_session_client_id = $2
+  AND deleted IS FALSE
+`
+
+type GetActiveRemoteSessionParams struct {
+	SubjectUrn            urn.SessionSubject
+	RemoteSessionClientID uuid.UUID
+}
+
+// Look up the active remote_session for a (subject, client) binding.
+// Single-row exact lookup; uniqueness enforced by the partial unique
+// index on (subject_urn, remote_session_client_id) WHERE deleted IS FALSE.
+func (q *Queries) GetActiveRemoteSession(ctx context.Context, arg GetActiveRemoteSessionParams) (RemoteSession, error) {
+	row := q.db.QueryRow(ctx, getActiveRemoteSession, arg.SubjectUrn, arg.RemoteSessionClientID)
+	var i RemoteSession
+	err := row.Scan(
+		&i.ID,
+		&i.SubjectUrn,
+		&i.UserSessionIssuerID,
+		&i.RemoteSessionClientID,
+		&i.AccessTokenEncrypted,
+		&i.AccessExpiresAt,
+		&i.RefreshTokenEncrypted,
+		&i.RefreshExpiresAt,
+		&i.Scopes,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getRemoteSessionByID = `-- name: GetRemoteSessionByID :one
 SELECT s.id, s.subject_urn, s.user_session_issuer_id, s.remote_session_client_id, s.access_token_encrypted, s.access_expires_at, s.refresh_token_encrypted, s.refresh_expires_at, s.scopes, s.created_at, s.updated_at, s.deleted_at, s.deleted
 FROM remote_sessions AS s
@@ -457,6 +494,46 @@ func (q *Queries) InsertRemoteSession(ctx context.Context, arg InsertRemoteSessi
 	return i, err
 }
 
+const listConnectedClientIDsForSubject = `-- name: ListConnectedClientIDsForSubject :many
+SELECT remote_session_client_id
+FROM remote_sessions
+WHERE subject_urn = $1
+  AND user_session_issuer_id = $2
+  AND deleted IS FALSE
+`
+
+type ListConnectedClientIDsForSubjectParams struct {
+	SubjectUrn          urn.SessionSubject
+	UserSessionIssuerID uuid.UUID
+}
+
+// Bulk lookup for the consent renderer: returns the set of
+// remote_session_client_ids that have an active remote_sessions row for
+// the given subject under a single user_session_issuer. Folds the N
+// per-card IsConnected lookups into one round-trip. The partial unique
+// index on (subject_urn, remote_session_client_id) WHERE deleted IS
+// FALSE means at most one row per (subject, client), so the result set
+// doubles as a membership set without DISTINCT.
+func (q *Queries) ListConnectedClientIDsForSubject(ctx context.Context, arg ListConnectedClientIDsForSubjectParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listConnectedClientIDsForSubject, arg.SubjectUrn, arg.UserSessionIssuerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var remote_session_client_id uuid.UUID
+		if err := rows.Scan(&remote_session_client_id); err != nil {
+			return nil, err
+		}
+		items = append(items, remote_session_client_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRemoteSessionClientsByProjectID = `-- name: ListRemoteSessionClientsByProjectID :many
 SELECT id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, created_at, updated_at, deleted_at, deleted
 FROM remote_session_clients
@@ -505,6 +582,85 @@ func (q *Queries) ListRemoteSessionClientsByProjectID(ctx context.Context, arg L
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRemoteSessionClientsForUserSessionIssuer = `-- name: ListRemoteSessionClientsForUserSessionIssuer :many
+SELECT
+    c.id                                   AS client_id,
+    c.client_id                            AS external_client_id,
+    c.client_secret_encrypted              AS client_secret_encrypted,
+    c.remote_session_issuer_id             AS remote_session_issuer_id,
+    c.user_session_issuer_id               AS user_session_issuer_id,
+    i.slug                                 AS issuer_slug,
+    i.issuer                               AS issuer_url,
+    i.authorization_endpoint               AS authorization_endpoint,
+    i.token_endpoint                       AS token_endpoint,
+    i.scopes_supported                     AS scopes_supported,
+    i.passthrough                          AS passthrough,
+    i.oidc                                 AS oidc
+FROM remote_session_clients AS c
+JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
+WHERE c.user_session_issuer_id = $1
+  AND c.project_id              = $2
+  AND c.deleted IS FALSE
+  AND i.deleted IS FALSE
+ORDER BY c.id ASC
+`
+
+type ListRemoteSessionClientsForUserSessionIssuerParams struct {
+	UserSessionIssuerID uuid.UUID
+	ProjectID           uuid.UUID
+}
+
+type ListRemoteSessionClientsForUserSessionIssuerRow struct {
+	ClientID              uuid.UUID
+	ExternalClientID      string
+	ClientSecretEncrypted pgtype.Text
+	RemoteSessionIssuerID uuid.UUID
+	UserSessionIssuerID   uuid.UUID
+	IssuerSlug            string
+	IssuerUrl             string
+	AuthorizationEndpoint pgtype.Text
+	TokenEndpoint         pgtype.Text
+	ScopesSupported       []string
+	Passthrough           bool
+	Oidc                  bool
+}
+
+// Joined client + issuer view used by the consent renderer and the
+// ChallengeManager. Returns one row per remote_session_client linked to
+// the given user_session_issuer.
+func (q *Queries) ListRemoteSessionClientsForUserSessionIssuer(ctx context.Context, arg ListRemoteSessionClientsForUserSessionIssuerParams) ([]ListRemoteSessionClientsForUserSessionIssuerRow, error) {
+	rows, err := q.db.Query(ctx, listRemoteSessionClientsForUserSessionIssuer, arg.UserSessionIssuerID, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRemoteSessionClientsForUserSessionIssuerRow
+	for rows.Next() {
+		var i ListRemoteSessionClientsForUserSessionIssuerRow
+		if err := rows.Scan(
+			&i.ClientID,
+			&i.ExternalClientID,
+			&i.ClientSecretEncrypted,
+			&i.RemoteSessionIssuerID,
+			&i.UserSessionIssuerID,
+			&i.IssuerSlug,
+			&i.IssuerUrl,
+			&i.AuthorizationEndpoint,
+			&i.TokenEndpoint,
+			&i.ScopesSupported,
+			&i.Passthrough,
+			&i.Oidc,
 		); err != nil {
 			return nil, err
 		}
@@ -800,6 +956,85 @@ func (q *Queries) UpdateRemoteSessionIssuer(ctx context.Context, arg UpdateRemot
 		&i.TokenEndpointAuthMethodsSupported,
 		&i.Oidc,
 		&i.Passthrough,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
+const upsertRemoteSession = `-- name: UpsertRemoteSession :one
+INSERT INTO remote_sessions (
+    subject_urn,
+    user_session_issuer_id,
+    remote_session_client_id,
+    access_token_encrypted,
+    access_expires_at,
+    refresh_token_encrypted,
+    refresh_expires_at,
+    scopes
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8
+)
+ON CONFLICT (subject_urn, remote_session_client_id) WHERE deleted IS FALSE
+DO UPDATE SET
+    access_token_encrypted = EXCLUDED.access_token_encrypted,
+    access_expires_at = EXCLUDED.access_expires_at,
+    refresh_token_encrypted = EXCLUDED.refresh_token_encrypted,
+    refresh_expires_at = EXCLUDED.refresh_expires_at,
+    scopes = EXCLUDED.scopes,
+    updated_at = clock_timestamp()
+RETURNING id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, access_expires_at, refresh_token_encrypted, refresh_expires_at, scopes, created_at, updated_at, deleted_at, deleted
+`
+
+type UpsertRemoteSessionParams struct {
+	SubjectUrn            urn.SessionSubject
+	UserSessionIssuerID   uuid.UUID
+	RemoteSessionClientID uuid.UUID
+	AccessTokenEncrypted  string
+	AccessExpiresAt       pgtype.Timestamptz
+	RefreshTokenEncrypted pgtype.Text
+	RefreshExpiresAt      pgtype.Timestamptz
+	Scopes                []string
+}
+
+// Used by /mcp/{slug}/remote_login_callback to materialise (or refresh) the
+// remote_session for a (subject, client) pair. Conflict target matches the
+// partial unique index on (subject_urn, remote_session_client_id) WHERE
+// deleted IS FALSE; on conflict we overwrite every token field. A
+// soft-deleted row falls outside the partial index, so a re-auth after
+// revocation inserts a fresh active row alongside the tombstone.
+func (q *Queries) UpsertRemoteSession(ctx context.Context, arg UpsertRemoteSessionParams) (RemoteSession, error) {
+	row := q.db.QueryRow(ctx, upsertRemoteSession,
+		arg.SubjectUrn,
+		arg.UserSessionIssuerID,
+		arg.RemoteSessionClientID,
+		arg.AccessTokenEncrypted,
+		arg.AccessExpiresAt,
+		arg.RefreshTokenEncrypted,
+		arg.RefreshExpiresAt,
+		arg.Scopes,
+	)
+	var i RemoteSession
+	err := row.Scan(
+		&i.ID,
+		&i.SubjectUrn,
+		&i.UserSessionIssuerID,
+		&i.RemoteSessionClientID,
+		&i.AccessTokenEncrypted,
+		&i.AccessExpiresAt,
+		&i.RefreshTokenEncrypted,
+		&i.RefreshExpiresAt,
+		&i.Scopes,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -141,7 +142,8 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter)
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
-	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner)
+	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
+	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr)
 
 	svc := xmcp.NewService(logger, tracerProvider, meterProvider, conn, enc, authzEngine, guardianPolicy, posthogClient, billingClient, billingClient, mcpService, serverURL)
 


### PR DESCRIPTION
## Summary

Adds the runtime layer that turns the remote-session management API into a working OAuth client leg, plus the issuer-gated authn-challenge surface (`HandleAuthorize` → IDP / consent → callback). Rebased onto main now that `private-rbac/remote-sessions-management` (#2778) has merged.

### Challenge manager — per-remote OAuth leg

- `remotesessions.ChallengeManager` (`server/internal/remotesessions/challenge.go`)
  - `BuildAuthorizationUrl(ctx, parent, client)` — mints a per-leg `RemoteLoginState` in Redis (PKCE S256) and returns the upstream authorize URL.
  - `HandleRemoteLoginCallback` — validates state, exchanges code → tokens at the upstream `token_endpoint`, encrypts and upserts the `remote_sessions` row, redirects back to `/mcp/{slug}/connect?state={parent}`.
  - `ListClients` / `IsConnected` helpers used by the consent renderer.
- `consent_template.html` + `authnchallenge_consent.go`: per-remote cards rendered for the toolset's `user_session_issuer`, one Connect card per `remote_session_client` with connected/disconnected state and a `BuildAuthorizationUrl`-minted link.
- SQL: `ListRemoteSessionClientsForUserSessionIssuer`, `UpsertRemoteSession` (ON CONFLICT on the partial unique index), `GetActiveRemoteSession`.

### Issuer-gated authn-challenge entry points

- `HandleAuthorize` (`GET /mcp/{slug}/authorize`) — validates the OAuth 2.1 authorize request, mints an `AuthnChallengeState` in Redis, then branches:
  - Private (`!McpIsPublic`): 302 to the Speakeasy IDP login; `HandleIDPCallback` stamps `user:<id>` onto the state.
  - Public: 302 straight to `/connect`; `HandleConsent`'s POST stamps `anonymous:<session_id>`.
- **Public-toolset anonymous late-bind:** `handleConsentGet` stamps an anonymous URN onto the parent state if the toolset is public and Subject is still nil, so the remote-login callback has a stable subject to attribute the `remote_sessions` row to.

### Static MCP callbacks

- `/mcp/idp_callback` and `/mcp/remote_login_callback` are now **static** routes; the toolset is resolved from the stored challenge state. The legacy `/mcp/{slug}/idp_callback` and `/mcp/{slug}/remote_login_callback` routes are still accepted as aliases so existing IDPs/proxies don't break.
- IDP callback URL is pinned to the Gram serverURL even on custom-domain toolsets, so the IDP only has to trust a single redirect set.
- `AuthnChallengeState` now carries `LegacyMcpEndpointRef { McpSlug, CustomDomainID }` instead of the historical `ToolsetID`. Same single-toolset semantics today; the helper centralises the comparison so a future model with multiple endpoints per toolset can expand it without churning callers.

### Wiring

- `mcp.Service` gets a `*remotesessions.ChallengeManager` field; routes mounted in `Attach`; threaded through `cmd/gram/start.go` and `cmd/gram/worker.go`.
- New `oauthtest.CreateIssuerGatedToolset` helper provisions `user_session_issuer` + `remote_session_issuer` + DCR-registered `remote_session_client` against a live dev-idp.
- New `newTestMCPServiceWithDevIDP` helper in `mcp/setup_test.go` wires a real `*identity.Resolver` pointing at devidp so tests can exercise `HandleAuthorize` end-to-end against the real `BuildAuthorizationURL` (oauth21 `/authorize`, `redirect_uri` query shape) instead of a static-return mock.

### Tests

- `TestRemoteLoginCallback_AuthenticatedSubject` — private toolset, pre-stamped `user:<id>` subject; asserts `remote_sessions.subject_urn == user:<id>`.
- `TestRemoteLoginCallback_AnonymousSubject` — public toolset; `HandleConsent(GET)` stamps anonymous URN; asserts `remote_sessions.subject_urn == anonymous:<id>`.
- `TestAuthorize_CustomDomainPrivateChallengeUsesGramIDPCallback` — confirms the IDP `redirect_uri` stays pinned to Gram serverURL even when the request comes through a custom domain.
- `TestIDPCallback_StaticRouteResolvesToolsetFromChallengeState` — confirms the static `/mcp/idp_callback` route resolves the toolset from `AuthnChallengeState`.

Token-resolution work (the MCP-runtime side that reads back the upstream tokens this PR persists) is in stacked PR #2849.

## Test plan

- [x] `go build ./server/...`
- [x] `mise lint:server`
- [x] `go test ./server/internal/mcp/... ./server/internal/remotesessions/... ./server/internal/xmcp/...`
- [ ] Manual: hit `POST /mcp/<slug>` with no auth on a private issuer-gated toolset → 401 → `/authorize` → IDP login → `/idp_callback` → `/connect` with per-remote Connect cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
