### PR TITLE
mig: add dead_letter_reason to risk_results

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2560,8 +2560,7 @@ CREATE TABLE IF NOT EXISTS risk_results (
   tags TEXT[],
 
   -- Populated on rows that represent a message the scanner could not analyze
-  -- after exhausting its retry budget (currently only Presidio). NULL on all
-  -- other rows, including normal findings and "no findings" markers.
+  -- after exhausting its retry budget
   dead_letter_reason TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2559,6 +2559,11 @@ CREATE TABLE IF NOT EXISTS risk_results (
   confidence DOUBLE PRECISION,
   tags TEXT[],
 
+  -- Populated on rows that represent a message the scanner could not analyze
+  -- after exhausting its retry budget (currently only Presidio). NULL on all
+  -- other rows, including normal findings and "no findings" markers.
+  dead_letter_reason TEXT,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   CONSTRAINT risk_results_pkey PRIMARY KEY (id),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1153,6 +1153,7 @@ type RiskResult struct {
 	EndPos            pgtype.Int4
 	Confidence        pgtype.Float8
 	Tags              []string
+	DeadLetterReason  pgtype.Text
 	CreatedAt         pgtype.Timestamptz
 }
 

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -624,7 +624,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.created_at, cm.chat_id, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.created_at, cm.chat_id, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -660,6 +660,7 @@ type ListRiskResultsByChatFoundRow struct {
 	EndPos            pgtype.Int4
 	Confidence        pgtype.Float8
 	Tags              []string
+	DeadLetterReason  pgtype.Text
 	CreatedAt         pgtype.Timestamptz
 	ChatID            uuid.UUID
 	ChatTitle         pgtype.Text
@@ -696,6 +697,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.DeadLetterReason,
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.ChatTitle,
@@ -712,7 +714,7 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 }
 
 const listRiskResultsByProjectAndPolicy = `-- name: ListRiskResultsByProjectAndPolicy :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.created_at, cm.chat_id, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.created_at, cm.chat_id, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -748,6 +750,7 @@ type ListRiskResultsByProjectAndPolicyRow struct {
 	EndPos            pgtype.Int4
 	Confidence        pgtype.Float8
 	Tags              []string
+	DeadLetterReason  pgtype.Text
 	CreatedAt         pgtype.Timestamptz
 	ChatID            uuid.UUID
 	ChatTitle         pgtype.Text
@@ -784,6 +787,7 @@ func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg Lis
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.DeadLetterReason,
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.ChatTitle,
@@ -800,7 +804,7 @@ func (q *Queries) ListRiskResultsByProjectAndPolicy(ctx context.Context, arg Lis
 }
 
 const listRiskResultsByProjectFound = `-- name: ListRiskResultsByProjectFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.created_at, cm.chat_id, c.title AS chat_title, c.external_user_id AS chat_user_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.dead_letter_reason, rr.created_at, cm.chat_id, c.title AS chat_title, c.external_user_id AS chat_user_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -834,6 +838,7 @@ type ListRiskResultsByProjectFoundRow struct {
 	EndPos            pgtype.Int4
 	Confidence        pgtype.Float8
 	Tags              []string
+	DeadLetterReason  pgtype.Text
 	CreatedAt         pgtype.Timestamptz
 	ChatID            uuid.UUID
 	ChatTitle         pgtype.Text
@@ -865,6 +870,7 @@ func (q *Queries) ListRiskResultsByProjectFound(ctx context.Context, arg ListRis
 			&i.EndPos,
 			&i.Confidence,
 			&i.Tags,
+			&i.DeadLetterReason,
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.ChatTitle,

--- a/server/migrations/20260513113209_add_risk_results_dead_letter_reason.sql
+++ b/server/migrations/20260513113209_add_risk_results_dead_letter_reason.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_results" table
+ALTER TABLE "risk_results" ADD COLUMN "dead_letter_reason" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QNGkpxihIcP5obsHuRYviJE4qXw1GS4tQRxJTPBp0PI=
+h1:/hKB4c9RhQ1NJ+fl0TMy3u/KqyWonZ5BK3JFm4RPZa0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -172,3 +172,4 @@ h1:QNGkpxihIcP5obsHuRYviJE4qXw1GS4tQRxJTPBp0PI=
 20260512215317_add-retry-after-to-outbox-svix-relays.sql h1:o/1Y3Gh/+rXEdTFyLijpPsNLgXpNyhzNgIVeku/SKYU=
 20260513000047_rename-outbox-relay-table.sql h1:AGyRYZsUpxHNZZj8Ziq1CgY1mu2xaWCWaR9HuRJE47c=
 20260513005837_remotesession_tables.sql h1:5DUSVR2+u/G7JO8BIWqcIpGvcc6KosOs/CmwPR/QA6g=
+20260513113209_add_risk_results_dead_letter_reason.sql h1:BUudDtten6ipXzo+TKfESVxc2UUyCKykq0v4dKXwi+g=


### PR DESCRIPTION
## Summary
- Adds a nullable `dead_letter_reason TEXT` column to `risk_results`.
- Lets the risk-analysis pipeline persist per-row context when a message is permanently un-analyzable (e.g. Presidio exhausting its retry budget). NULL on every existing row and on normal scanned/finding rows; non-NULL only on dead-letter markers.
- Migration ships on its own per project rules; the application changes that write to the column follow in a separate PR.

## Test plan
- [x] \`mise run db:diff add_risk_results_dead_letter_reason\` generated the migration.
- [x] \`mise run lint:migrations --no-atlas\` passes (CI runs \`atlas migrate lint\` via the dedicated action job).
- [ ] CI green on the atlas-action lint step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)