### PR TITLE
feat(dashboard): add filters and search to employees insights tab

### DIFF
--- a/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "@speakeasy-api/moonshine";
 import { ChartCard } from "@/components/chart/ChartCard";
 import { formatChartLabel } from "@/components/chart/chartUtils";
 import { MetricCard } from "@/components/chart/MetricCard";
@@ -184,15 +185,8 @@ export function InsightsEmployeeDetailContent() {
                     : "grid-cols-1 md:grid-cols-3",
                 )}
               >
-                <MetricCard
-                  title="First Activity"
-                  value={0}
-                  icon="calendar"
-                  subtext={
-                    summary
-                      ? formatUnixNano(summary.firstSeenUnixNano)
-                      : "No activity"
-                  }
+                <FirstActivityCard
+                  firstSeenUnixNano={summary?.firstSeenUnixNano}
                 />
                 <MetricCard
                   title="Total Tokens"
@@ -203,7 +197,7 @@ export function InsightsEmployeeDetailContent() {
                   title="Tool Calls"
                   value={summary?.totalToolCalls ?? 0}
                   icon="wrench"
-                  subtext={`${(summary?.toolCallSuccess ?? 0).toLocaleString()} ok / ${(summary?.toolCallFailure ?? 0).toLocaleString()} blocked`}
+                  subtext={`${(summary?.toolCallSuccess ?? 0).toLocaleString()} succeeded / ${(summary?.toolCallFailure ?? 0).toLocaleString()} failed`}
                 />
               </section>
 
@@ -285,6 +279,50 @@ export function InsightsEmployeeDetailContent() {
       </div>
     </>
   );
+}
+
+function FirstActivityCard({
+  firstSeenUnixNano,
+}: {
+  firstSeenUnixNano?: string | null;
+}) {
+  const hasActivity =
+    firstSeenUnixNano != null &&
+    firstSeenUnixNano !== "" &&
+    firstSeenUnixNano !== "0";
+  const date = hasActivity ? unixNanoToDate(firstSeenUnixNano) : null;
+  const primary = date
+    ? date.toLocaleDateString([], {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "No activity";
+  const subtext = date ? `${daysSince(date).toLocaleString()} days ago` : null;
+
+  return (
+    <div className="bg-card border-border rounded-lg border p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-sm font-semibold">First Activity</span>
+        <div className="bg-muted/50 rounded-lg p-2">
+          <Icon name="calendar" className="text-muted-foreground size-4" />
+        </div>
+      </div>
+      <span className="block text-3xl font-semibold tracking-tight">
+        {primary}
+      </span>
+      {subtext && (
+        <span className="text-muted-foreground mt-1 block text-xs">
+          {subtext}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function daysSince(date: Date) {
+  const ms = Date.now() - date.getTime();
+  return Math.max(0, Math.floor(ms / 86_400_000));
 }
 
 function DetailLoadingState({ isInsightsOpen }: { isInsightsOpen: boolean }) {
@@ -561,15 +599,6 @@ function unixNanoToDate(value: string) {
   const nanos = BigInt(value);
   const millis = Number(nanos / 1_000_000n);
   return new Date(millis);
-}
-
-function formatUnixNano(value: string) {
-  const date = unixNanoToDate(value);
-  return date.toLocaleDateString([], {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
 }
 
 function formatPlatform(value: string) {

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -5,6 +5,20 @@ import { ErrorAlert } from "@/components/ui/alert";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { SearchBar } from "@/components/ui/search-bar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import {
@@ -25,14 +39,184 @@ import type {
 } from "@gram/client/models/components";
 import { useGramContext, useMembers, useRoles } from "@gram/client/react-query";
 import { unwrapAsync } from "@gram/client/types/fp";
+import {
+  TimeRangePicker,
+  type DateRangePreset,
+  getPresetRange,
+} from "@gram-ai/elements";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, Info, Sparkles } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Info,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useSlugs } from "@/contexts/Sdk";
 import { slugify } from "@/lib/constants";
 import { Badge } from "@speakeasy-api/moonshine";
 import { HooksSetupDialog } from "@/pages/hooks/HooksSetupDialog";
+
+type EmployeeFilterDimension = "all" | "user" | "role";
+type FilterOption = { id: string; label: string };
+
+const EMPLOYEE_FILTER_DIMENSIONS: EmployeeFilterDimension[] = [
+  "all",
+  "user",
+  "role",
+];
+const EMPLOYEE_FILTER_LABELS: Record<EmployeeFilterDimension, string> = {
+  all: "All",
+  user: "User",
+  role: "Role",
+};
+const EMPLOYEE_FILTER_PLURAL_LABELS: Record<EmployeeFilterDimension, string> = {
+  all: "Items",
+  user: "Users",
+  role: "Roles",
+};
+
+const PRESET_RANGE_LABELS: Record<DateRangePreset, string> = {
+  "15m": "the last 15 minutes",
+  "1h": "the last hour",
+  "4h": "the last 4 hours",
+  "1d": "the last day",
+  "2d": "the last 2 days",
+  "3d": "the last 3 days",
+  "7d": "the last 7 days",
+  "15d": "the last 15 days",
+  "30d": "the last 30 days",
+  "90d": "the last 90 days",
+};
+
+function presetRangeLabel(preset: DateRangePreset): string {
+  return PRESET_RANGE_LABELS[preset] ?? "the selected range";
+}
+
+function EmployeeFilterBar({
+  dimension,
+  onDimensionChange,
+  selectedValue,
+  onValueChange,
+  options,
+  disabled,
+}: {
+  dimension: EmployeeFilterDimension;
+  onDimensionChange: (dimension: EmployeeFilterDimension) => void;
+  selectedValue: string | null;
+  onValueChange: (value: string | null) => void;
+  options: FilterOption[];
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const selectedOption = options.find((o) => o.id === selectedValue);
+  const displayLabel =
+    dimension === "all"
+      ? "All"
+      : selectedOption
+        ? selectedOption.label || selectedOption.id
+        : `All ${EMPLOYEE_FILTER_PLURAL_LABELS[dimension]}`;
+
+  return (
+    <div
+      className={`flex items-center gap-2 ${disabled ? "pointer-events-none opacity-50" : ""}`}
+    >
+      <span className="text-muted-foreground hidden text-sm font-medium 2xl:inline">
+        Filter by
+      </span>
+      <div className="border-border flex h-[42px] items-center rounded-md border p-1">
+        {EMPLOYEE_FILTER_DIMENSIONS.map((value) => {
+          const isSelected = dimension === value;
+          return (
+            <button
+              key={value}
+              onClick={() => onDimensionChange(value)}
+              disabled={disabled}
+              className={`
+                h-8 rounded px-3 text-sm font-medium transition-all duration-150
+                ${
+                  isSelected
+                    ? "text-foreground bg-white shadow-sm dark:bg-gray-900"
+                    : "text-muted-foreground hover:text-foreground"
+                }
+                disabled:cursor-not-allowed
+              `}
+            >
+              {EMPLOYEE_FILTER_LABELS[value]}
+            </button>
+          );
+        })}
+
+        <div className="bg-border/50 mx-1 h-6 w-px" />
+        <Popover
+          open={dimension !== "all" && !disabled && open}
+          onOpenChange={setOpen}
+        >
+          <PopoverTrigger asChild>
+            <button
+              disabled={dimension === "all" || disabled}
+              className={`flex h-8 min-w-[140px] items-center justify-between gap-2 rounded px-2 text-sm transition-colors ${
+                dimension === "all" || disabled
+                  ? "cursor-not-allowed opacity-40"
+                  : "hover:bg-muted/50"
+              }`}
+            >
+              <span className="max-w-[120px] truncate">{displayLabel}</span>
+              <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[220px] p-0" align="end">
+            <Command>
+              <CommandInput
+                placeholder={`Search ${EMPLOYEE_FILTER_PLURAL_LABELS[dimension].toLowerCase()}...`}
+                className="h-9"
+              />
+              <CommandList>
+                <CommandEmpty>No results found.</CommandEmpty>
+                <CommandGroup>
+                  <CommandItem
+                    value="__all__"
+                    onSelect={() => {
+                      onValueChange(null);
+                      setOpen(false);
+                    }}
+                    className="cursor-pointer"
+                  >
+                    <Check
+                      className={`mr-2 size-4 ${selectedValue === null ? "opacity-100" : "opacity-0"}`}
+                    />
+                    <span>All {EMPLOYEE_FILTER_PLURAL_LABELS[dimension]}</span>
+                  </CommandItem>
+                  {options.map((option) => (
+                    <CommandItem
+                      key={option.id}
+                      value={option.label || option.id}
+                      onSelect={() => {
+                        onValueChange(option.id);
+                        setOpen(false);
+                      }}
+                      className="cursor-pointer"
+                    >
+                      <Check
+                        className={`mr-2 size-4 ${selectedValue === option.id ? "opacity-100" : "opacity-0"}`}
+                      />
+                      <span className="truncate">
+                        {option.label || option.id}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  );
+}
 
 type EmployeeStatus = "enrolled" | "not_enrolled";
 
@@ -46,8 +230,6 @@ type Employee = {
   lastActivity: string;
   photoUrl?: string | null;
 };
-
-const LOOKBACK_DAYS = 30;
 
 const statusMeta: Record<
   EmployeeStatus,
@@ -67,11 +249,7 @@ export function InsightsEmployeesContent() {
   const client = useGramContext();
   const { orgSlug, projectSlug } = useSlugs();
   const navigate = useNavigate();
-  const {
-    isExpanded: isInsightsOpen,
-    sendPrompt,
-    setIsExpanded,
-  } = useInsightsState();
+  const { isExpanded: isInsightsOpen } = useInsightsState();
   const mcpConfig = useObservabilityMcpConfig({
     toolsToInclude: ["gram_search_users", "gram_list_organization_users"],
   });
@@ -81,13 +259,28 @@ export function InsightsEmployeesContent() {
     error: membersError,
   } = useMembers();
   const { data: rolesData, isLoading: rolesLoading } = useRoles();
-  const { from, to } = useMemo(() => {
-    const end = new Date();
-    const start = new Date(end);
-    start.setDate(start.getDate() - LOOKBACK_DAYS);
 
-    return { from: start, to: end };
-  }, []);
+  const [dateRange, setDateRange] = useState<DateRangePreset>("30d");
+  const [customRange, setCustomRange] = useState<{
+    from: Date;
+    to: Date;
+  } | null>(null);
+  const [customRangeLabel, setCustomRangeLabel] = useState<string | null>(null);
+  const [filterDimension, setFilterDimension] =
+    useState<EmployeeFilterDimension>("all");
+  const [selectedFilterValue, setSelectedFilterValue] = useState<string | null>(
+    null,
+  );
+
+  const { from, to } = useMemo(
+    () => customRange ?? getPresetRange(dateRange),
+    [customRange, dateRange],
+  );
+  const rangeLabel = useMemo(() => {
+    if (customRange) return customRangeLabel ?? "the selected range";
+    return presetRangeLabel(dateRange);
+  }, [customRange, customRangeLabel, dateRange]);
+
   const members = useMemo(() => membersData?.members ?? [], [membersData]);
   const roles = useMemo(() => rolesData?.roles ?? [], [rolesData]);
   const memberIds = useMemo(
@@ -116,10 +309,39 @@ export function InsightsEmployeesContent() {
     rolesLoading ||
     (memberIds.length > 0 && usageQuery.isLoading);
   const error = membersError ?? usageQuery.error;
-  const employees = useMemo(
+  const allEmployees = useMemo(
     () => buildEmployees(members, roles, usageSummaries),
     [members, roles, usageSummaries],
   );
+  const roleNameById = useMemo(
+    () => new Map(roles.map((role) => [role.id, role.name])),
+    [roles],
+  );
+  const employees = useMemo(() => {
+    if (filterDimension === "all" || !selectedFilterValue) return allEmployees;
+    if (filterDimension === "user") {
+      return allEmployees.filter((item) => item.id === selectedFilterValue);
+    }
+    const roleName = roleNameById.get(selectedFilterValue);
+    return allEmployees.filter((item) =>
+      roleName ? item.role === roleName : false,
+    );
+  }, [allEmployees, filterDimension, roleNameById, selectedFilterValue]);
+  const filterOptions = useMemo<FilterOption[]>(() => {
+    if (filterDimension === "user") {
+      return allEmployees.map((item) => ({
+        id: item.id,
+        label: item.name,
+      }));
+    }
+    if (filterDimension === "role") {
+      return roles.map((role) => ({
+        id: role.id,
+        label: role.name,
+      }));
+    }
+    return [];
+  }, [allEmployees, filterDimension, roles]);
   const totalEmployees = employees.length;
   const enrolledEmployees = employees.filter(
     (item) => item.status === "enrolled",
@@ -138,13 +360,35 @@ export function InsightsEmployeesContent() {
   const prompt =
     "Using the Employees tab context, summarize who is enrolled in this project based on whether they have any Gram token usage.";
 
+  const handleFilterDimensionChange = (next: EmployeeFilterDimension) => {
+    setFilterDimension(next);
+    setSelectedFilterValue(null);
+  };
+  const handlePresetChange = (preset: DateRangePreset) => {
+    setDateRange(preset);
+    setCustomRange(null);
+    setCustomRangeLabel(null);
+  };
+  const handleCustomRangeChange = (
+    rangeFrom: Date,
+    rangeTo: Date,
+    label?: string,
+  ) => {
+    setCustomRange({ from: rangeFrom, to: rangeTo });
+    setCustomRangeLabel(label ?? null);
+  };
+  const handleClearCustomRange = () => {
+    setCustomRange(null);
+    setCustomRangeLabel(null);
+  };
+
   return (
     <>
       <InsightsConfig
         mcpConfig={mcpConfig}
         title="What would you like to know about employee enrollment?"
         subtitle="Ask who is enrolled, who still needs setup, and how Gram adoption is tracking across the team"
-        contextInfo={`Project-scoped Employees tab: ${enrolledEmployees} of ${totalEmployees} employees have Gram Hooks activity in the last ${LOOKBACK_DAYS} days and are enrolled; ${notEnrolledEmployees} employees have no Gram Hooks activity and are not enrolled.`}
+        contextInfo={`Project-scoped Employees tab: ${enrolledEmployees} of ${totalEmployees} employees have Gram Hooks activity in ${rangeLabel} and are enrolled; ${notEnrolledEmployees} employees have no Gram Hooks activity and are not enrolled.`}
         suggestions={[
           {
             title: "Enrollment Coverage",
@@ -184,29 +428,36 @@ export function InsightsEmployeesContent() {
             <div className="flex min-w-0 flex-col gap-1">
               <h1 className="text-xl font-semibold">Employee Enrollment</h1>
               <p className="text-muted-foreground text-sm">
-                Track Gram uptake for organization members in this project over
-                the last {LOOKBACK_DAYS} days. Employees with Gram Hooks
-                activity are marked enrolled; employees without any activity are
-                marked not enrolled.
+                Track Gram uptake for organization members in this project over{" "}
+                {rangeLabel}. Employees with Gram Hooks activity are marked
+                enrolled; employees without any activity are marked not
+                enrolled.
               </p>
             </div>
             <div
               className={cn(
-                "flex items-center gap-3",
+                "flex flex-wrap items-center gap-3",
                 isInsightsOpen ? "justify-start" : "shrink-0",
               )}
             >
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => {
-                  setIsExpanded(true);
-                  sendPrompt(prompt);
-                }}
-              >
-                <Sparkles className="mr-1.5 size-3.5" />
-                Ask AI to summarize
-              </Button>
+              <EmployeeFilterBar
+                dimension={filterDimension}
+                onDimensionChange={handleFilterDimensionChange}
+                selectedValue={selectedFilterValue}
+                onValueChange={setSelectedFilterValue}
+                options={filterOptions}
+                disabled={isLoading}
+              />
+              <TimeRangePicker
+                preset={customRange ? null : dateRange}
+                customRange={customRange}
+                customRangeLabel={customRangeLabel}
+                onPresetChange={handlePresetChange}
+                onCustomRangeChange={handleCustomRangeChange}
+                onClearCustomRange={handleClearCustomRange}
+                disabled={isLoading}
+                projectSlug={projectSlug}
+              />
             </div>
           </div>
 
@@ -267,7 +518,7 @@ export function InsightsEmployeesContent() {
   );
 }
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 10;
 
 function EmployeeTable({
   employees,
@@ -277,126 +528,150 @@ function EmployeeTable({
   onSelectUser: (name: string) => void;
 }) {
   const [page, setPage] = useState(0);
-  const totalPages = Math.ceil(employees.length / PAGE_SIZE);
-  const pageEmployees = employees.slice(
-    page * PAGE_SIZE,
-    (page + 1) * PAGE_SIZE,
+  const [search, setSearch] = useState("");
+  const filteredEmployees = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return employees;
+    return employees.filter(
+      (item) =>
+        item.name.toLowerCase().includes(query) ||
+        item.email.toLowerCase().includes(query),
+    );
+  }, [employees, search]);
+  const totalPages = Math.ceil(filteredEmployees.length / PAGE_SIZE);
+  const safePage = Math.min(page, Math.max(totalPages - 1, 0));
+  const pageEmployees = filteredEmployees.slice(
+    safePage * PAGE_SIZE,
+    (safePage + 1) * PAGE_SIZE,
   );
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setPage(0);
+  };
 
   return (
-    <section className="bg-card rounded-xl border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="pl-6">
-              <span className="flex items-center gap-1">
-                Employee
-                <SimpleTooltip tooltip="Enrollment is inferred by matching the email reported by each AI coding tool to the member's Gram account. Members without a Gram account won't appear as enrolled until they sign up or directory sync is configured.">
-                  <Info className="text-muted-foreground size-3 shrink-0" />
-                </SimpleTooltip>
-              </span>
-            </TableHead>
-            <TableHead>Role</TableHead>
-            <TableHead>Enrollment</TableHead>
-            <TableHead>Token Count</TableHead>
-            <TableHead>Last Activity</TableHead>
-            <TableHead className="pr-6 text-right">Action</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {pageEmployees.length > 0 ? (
-            pageEmployees.map((item) => (
-              <TableRow
-                key={item.id}
-                className="cursor-pointer"
-                onClick={() => onSelectUser(item.name)}
-              >
-                <TableCell className="pl-6">
-                  <div className="flex items-center gap-3">
-                    <Avatar className="size-9">
-                      {item.photoUrl && (
-                        <AvatarImage src={item.photoUrl} alt={item.name} />
-                      )}
-                      <AvatarFallback className="text-sm font-semibold">
-                        {getInitials(item.name)}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div>
-                      <p className="font-medium">{item.name}</p>
-                      <p className="text-muted-foreground text-xs">
-                        {item.email}
-                      </p>
+    <section className="bg-card flex flex-col gap-4 rounded-xl border p-4">
+      <SearchBar
+        value={search}
+        onChange={handleSearchChange}
+        placeholder="Search by name or email..."
+      />
+      <div className="overflow-hidden rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-6">
+                <span className="flex items-center gap-1">
+                  Employee
+                  <SimpleTooltip tooltip="Enrollment is inferred by matching the email reported by each AI coding tool to the member's Gram account. Members without a Gram account won't appear as enrolled until they sign up or directory sync is configured.">
+                    <Info className="text-muted-foreground size-3 shrink-0" />
+                  </SimpleTooltip>
+                </span>
+              </TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Enrollment</TableHead>
+              <TableHead>Token Count</TableHead>
+              <TableHead>Last Activity</TableHead>
+              <TableHead className="pr-6 text-right">Action</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {pageEmployees.length > 0 ? (
+              pageEmployees.map((item) => (
+                <TableRow
+                  key={item.id}
+                  className="cursor-pointer"
+                  onClick={() => onSelectUser(item.name)}
+                >
+                  <TableCell className="pl-6">
+                    <div className="flex items-center gap-3">
+                      <Avatar className="size-9">
+                        {item.photoUrl && (
+                          <AvatarImage src={item.photoUrl} alt={item.name} />
+                        )}
+                        <AvatarFallback className="text-sm font-semibold">
+                          {getInitials(item.name)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <p className="font-medium">{item.name}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {item.email}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <p className="text-sm">{item.role}</p>
-                </TableCell>
-                <TableCell>
-                  <StatusPill status={item.status} />
-                </TableCell>
-                <TableCell>
-                  <span className="font-mono text-sm">
-                    {item.tokenCount.toLocaleString()}
-                  </span>
-                </TableCell>
-                <TableCell className="text-muted-foreground text-sm">
-                  {item.lastActivity}
-                </TableCell>
-                <TableCell className="pr-6 text-right">
-                  <button
-                    type="button"
-                    className="text-primary hover:text-primary/80 text-sm font-medium underline underline-offset-4"
-                    aria-label={`View ${item.name}`}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onSelectUser(item.name);
-                    }}
-                  >
-                    View
-                  </button>
+                  </TableCell>
+                  <TableCell>
+                    <p className="text-sm">{item.role}</p>
+                  </TableCell>
+                  <TableCell>
+                    <StatusPill status={item.status} />
+                  </TableCell>
+                  <TableCell>
+                    <span className="font-mono text-sm">
+                      {item.tokenCount.toLocaleString()}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {item.lastActivity}
+                  </TableCell>
+                  <TableCell className="pr-6 text-right">
+                    <button
+                      type="button"
+                      className="text-primary hover:text-primary/80 text-sm font-medium underline underline-offset-4"
+                      aria-label={`View ${item.name}`}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSelectUser(item.name);
+                      }}
+                    >
+                      View
+                    </button>
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-muted-foreground py-10 text-center text-sm"
+                >
+                  {search
+                    ? `No employees matching "${search}".`
+                    : "No organization members found."}
                 </TableCell>
               </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell
-                colSpan={6}
-                className="text-muted-foreground py-10 text-center text-sm"
+            )}
+          </TableBody>
+        </Table>
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between border-t px-4 py-3">
+            <p className="text-muted-foreground text-sm">
+              {safePage * PAGE_SIZE + 1}–
+              {Math.min((safePage + 1) * PAGE_SIZE, filteredEmployees.length)}{" "}
+              of {filteredEmployees.length}
+            </p>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setPage((p) => p - 1)}
+                disabled={safePage === 0}
               >
-                No organization members found.
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between border-t px-4 py-3">
-          <p className="text-muted-foreground text-sm">
-            {page * PAGE_SIZE + 1}–
-            {Math.min((page + 1) * PAGE_SIZE, employees.length)} of{" "}
-            {employees.length}
-          </p>
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setPage((p) => p - 1)}
-              disabled={page === 0}
-            >
-              <ChevronLeft className="size-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setPage((p) => p + 1)}
-              disabled={page >= totalPages - 1}
-            >
-              <ChevronRight className="size-4" />
-            </Button>
+                <ChevronLeft className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setPage((p) => p + 1)}
+                disabled={safePage >= totalPages - 1}
+              >
+                <ChevronRight className="size-4" />
+              </Button>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </section>
   );
 }

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -1078,6 +1078,36 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 	return metricsMap, nil
 }
 
+// toolCallExpressions returns the SQL fragments used to count tool calls for a
+// given event source. Hook events (Claude Code, Cursor, Codex) carry a
+// tool_name and a hook event name but no gram_urn; we only count the
+// completion-side event so each call counts once, not once per pre/post pair.
+// Other event sources count Gram MCP tool invocations via gram_urn + HTTP
+// status.
+type toolCallExpressions struct {
+	isCall    string
+	isSuccess string
+	isFailure string
+	key       string
+}
+
+func toolCallExprsFor(eventSource string) toolCallExpressions {
+	if eventSource == "hook" {
+		return toolCallExpressions{
+			isCall:    "tool_name != '' AND toString(attributes.gram.hook.event) IN ('PostToolUse', 'PostToolUseFailure')",
+			isSuccess: "tool_name != '' AND toString(attributes.gram.hook.event) = 'PostToolUse'",
+			isFailure: "tool_name != '' AND toString(attributes.gram.hook.event) = 'PostToolUseFailure'",
+			key:       "tool_name",
+		}
+	}
+	return toolCallExpressions{
+		isCall:    "startsWith(gram_urn, 'tools:')",
+		isSuccess: "startsWith(gram_urn, 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 200 AND toInt32OrZero(toString(attributes.http.response.status_code)) < 300",
+		isFailure: "startsWith(gram_urn, 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 400",
+		key:       "gram_urn",
+	}
+}
+
 // SearchUsersParams contains the parameters for searching users with aggregated metrics.
 type SearchUsersParams struct {
 	GramProjectID    string
@@ -1106,6 +1136,8 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 		groupCol = "external_user_id"
 	}
 
+	tc := toolCallExprsFor(arg.EventSource)
+
 	sb := sq.Select(
 		groupCol+" AS user_id",
 
@@ -1126,15 +1158,15 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 		"avgIf(toFloat64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS avg_tokens_per_request",
 		"sumIf(toFloat64OrZero(toString(attributes.gen_ai.usage.cost)), toString(attributes.gen_ai.usage.cost) != '') AS total_cost",
 
-		// Tool call metrics
-		"countIf(startsWith(toString(attributes.gram.tool.urn), 'tools:')) AS total_tool_calls",
-		"countIf(startsWith(toString(attributes.gram.tool.urn), 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 200 AND toInt32OrZero(toString(attributes.http.response.status_code)) < 300) AS tool_call_success",
-		"countIf(startsWith(toString(attributes.gram.tool.urn), 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 400) AS tool_call_failure",
+		// Tool call metrics (path depends on event source — Gram MCP tools vs AI-coding hook tools)
+		"countIf("+tc.isCall+") AS total_tool_calls",
+		"countIf("+tc.isSuccess+") AS tool_call_success",
+		"countIf("+tc.isFailure+") AS tool_call_failure",
 
-		// Tool breakdowns (maps of tool URN -> count)
-		"sumMapIf(map(gram_urn, toUInt64(1)), startsWith(gram_urn, 'tools:')) AS tool_counts",
-		"sumMapIf(map(gram_urn, toUInt64(1)), startsWith(gram_urn, 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 200 AND toInt32OrZero(toString(attributes.http.response.status_code)) < 300) AS tool_success_counts",
-		"sumMapIf(map(gram_urn, toUInt64(1)), startsWith(gram_urn, 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 400) AS tool_failure_counts",
+		// Tool breakdowns (maps of tool URN or hook tool name -> count)
+		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isCall+") AS tool_counts",
+		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isSuccess+") AS tool_success_counts",
+		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isFailure+") AS tool_failure_counts",
 
 		// Hook source breakdowns (maps of hook source -> count)
 		"sumMapIf(map(hook_source, toUInt64(1)), hook_source != '') AS hook_source_counts",
@@ -1213,6 +1245,8 @@ type GetUserMetricsSummaryParams struct {
 //
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsSummaryParams) (*MetricsSummaryRow, error) {
+	tc := toolCallExprsFor(arg.EventSource)
+
 	sb := sq.Select(
 		// Activity timestamps
 		"min(time_unix_nano) AS first_seen_unix_nano",
@@ -1237,11 +1271,11 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 		"countIf(position(toString(attributes.gen_ai.response.finish_reasons), 'stop') > 0) AS finish_reason_stop",
 		"countIf(position(toString(attributes.gen_ai.response.finish_reasons), 'tool_calls') > 0) AS finish_reason_tool_calls",
 
-		// Tool call metrics
-		"countIf(startsWith(toString(attributes.gram.tool.urn), 'tools:')) AS total_tool_calls",
-		"countIf(startsWith(toString(attributes.gram.tool.urn), 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 200 AND toInt32OrZero(toString(attributes.http.response.status_code)) < 300) AS tool_call_success",
-		"countIf(startsWith(toString(attributes.gram.tool.urn), 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 400) AS tool_call_failure",
-		"avgIf(toFloat64OrZero(toString(attributes.http.server.request.duration)) * 1000, startsWith(toString(attributes.gram.tool.urn), 'tools:')) AS avg_tool_duration_ms",
+		// Tool call metrics (path depends on event source — Gram MCP tools vs AI-coding hook tools)
+		"countIf("+tc.isCall+") AS total_tool_calls",
+		"countIf("+tc.isSuccess+") AS tool_call_success",
+		"countIf("+tc.isFailure+") AS tool_call_failure",
+		"avgIf(toFloat64OrZero(toString(attributes.http.server.request.duration)) * 1000, startsWith(gram_urn, 'tools:')) AS avg_tool_duration_ms",
 
 		// Chat resolution metrics (from AI evaluation of chat outcomes)
 		"countIf(evaluation_score_label = 'success') AS chat_resolution_success",
@@ -1253,10 +1287,10 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 		// Model breakdown (map of model name -> count)
 		"sumMapIf(map(toString(attributes.gen_ai.response.model), toUInt64(1)), toString(attributes.gen_ai.response.model) != '') AS models",
 
-		// Tool breakdowns (maps of tool URN -> count)
-		"sumMapIf(map(gram_urn, toUInt64(1)), startsWith(gram_urn, 'tools:')) AS tool_counts",
-		"sumMapIf(map(gram_urn, toUInt64(1)), startsWith(gram_urn, 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 200 AND toInt32OrZero(toString(attributes.http.response.status_code)) < 300) AS tool_success_counts",
-		"sumMapIf(map(gram_urn, toUInt64(1)), startsWith(gram_urn, 'tools:') AND toInt32OrZero(toString(attributes.http.response.status_code)) >= 400) AS tool_failure_counts",
+		// Tool breakdowns (maps of tool URN or hook tool name -> count)
+		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isCall+") AS tool_counts",
+		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isSuccess+") AS tool_success_counts",
+		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isFailure+") AS tool_failure_counts",
 	).
 		From("telemetry_logs").
 		Where("gram_project_id = ?", arg.GramProjectID).


### PR DESCRIPTION
## Summary

Two improvements to the Employees insights tab + a server change so the detail page actually populates Tool Calls and Top Used Tools for hook-only users.

**Employees list ([InsightsEmployees.tsx](client/dashboard/src/components/observe/InsightsEmployees.tsx))**
- Replaced the *Ask AI to summarize* header button with a `TimeRangePicker` and an MCP-style `All / User / Role` filter dropdown driven by org members and roles. Filter narrows the table and metric cards.
- Added a name/email `SearchBar` above the table and reduced pagination from 25 to 10 per page.

**Employee detail ([InsightsEmployeeDetail.tsx](client/dashboard/src/components/observe/InsightsEmployeeDetail.tsx))**
- Replaced the *First Activity* `MetricCard value={0}` hack with a card that renders the activity date as the primary value and "N days ago" as the subtext.
- Reworded Tool Calls subtext from "ok / blocked" to "succeeded / failed" so it reads correctly for both Gram MCP tool calls and AI-coding hook tool calls.

**Telemetry queries ([queries.sql.go](server/internal/telemetry/repo/queries.sql.go))**
- `SearchUsers` and `GetUserMetricsSummary` previously gated `total_tool_calls` and the `tool_counts` map on `gram_urn` starting with `tools:`, which only fires for Gram MCP tool invocations. AI-coding hook events (Claude Code, Cursor, Codex) carry `tool_name` and a hook event name but no `gram_urn`, so Tool Calls and Top Used Tools were always empty for hook-only users.
- Branch on the `EventSource` param: when `event_source = 'hook'`, count `PostToolUse` (success) / `PostToolUseFailure` (failure) completion events keyed by `tool_name`; otherwise keep the existing Gram-tool path. Counting only the completion side avoids double-counting Pre/Post event pairs.

Resolves [AGE-2236](https://linear.app/speakeasy/issue/AGE-2236/feat-rename-compliance-column-to-status-with-connectedlogged-in-icons).

## Test plan

- [ ] Visit Insights → Employees: confirm the time range picker, the All / User / Role filter, the name/email search bar, and 10/page pagination all work; the *Ask AI to summarize* button is gone (sidebar Ask-AI still works)
- [ ] Open an employee with hook-only activity (e.g. Cursor / Claude Code): confirm Tool Calls is non-zero and Top Used Tools lists the tool names
- [ ] Open an employee with Gram MCP tool activity: confirm Tool Calls and Top Used Tools still show URN-based entries
- [ ] First Activity card shows the date (not "0") and "N days ago" subtext; "No activity" when the user has no events
- [ ] `mise run lint:server` and the telemetry test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)