### PR TITLE
chore: apply gofix and gofmt to otelforwarding

### DIFF
--- a/server/internal/otelforwarding/forwarder.go
+++ b/server/internal/otelforwarding/forwarder.go
@@ -84,7 +84,7 @@ func (f *Forwarder) Start(ctx context.Context) {
 	}
 	f.started = true
 
-	for i := 0; i < defaultWorkers; i++ {
+	for range defaultWorkers {
 		f.wg.Add(1)
 		go f.run(ctx)
 	}

--- a/server/internal/otelforwarding/impl.go
+++ b/server/internal/otelforwarding/impl.go
@@ -13,8 +13,8 @@ import (
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
 
-	gen "github.com/speakeasy-api/gram/server/gen/otel_forwarding"
 	srv "github.com/speakeasy-api/gram/server/gen/http/otel_forwarding/server"
+	gen "github.com/speakeasy-api/gram/server/gen/otel_forwarding"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"


### PR DESCRIPTION
## Summary
- `forwarder.go`: gofix rewrote `for i := 0; i < defaultWorkers; i++` → `for range defaultWorkers` (Go 1.22+ range-over-int idiom)
- `impl.go`: gofmt reordered imports alphabetically

## Test plan
- [x] Pre-commit hooks (gofmt, gofix, gomodtidy) pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)