### PR TITLE
feat: add shadow mcp request links

### DIFF
--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -30,8 +30,9 @@ import { RBACDevToolbar } from "./components/dev-toolbar";
 import { usePageTitle } from "./hooks/use-page-title";
 import { PREFERRED_THEME_STORAGE_KEY } from "./lib/local-storage-keys";
 import CliCallback from "./pages/cli/CliCallback";
-import SlackRegister from "./pages/slackapp/SlackRegister";
+import ShadowMCPRequestAccess from "./pages/shadow-mcp/RequestAccess";
 import SwitchOrg from "./pages/demo/SwitchOrg";
+import SlackRegister from "./pages/slackapp/SlackRegister";
 import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
 
 export default function App() {
@@ -241,6 +242,10 @@ const RouteProvider = () => {
         <Route path="/switch-org" element={<LoginCheck />}>
           <Route index element={<SwitchOrg />} />
         </Route>
+        <Route
+          path="/shadow-mcp/request"
+          element={<ShadowMCPRequestAccess />}
+        />
         <Route path="/" element={<LoginCheck />}>
           <Route path=":orgSlug/projects/:projectSlug">
             {routesWithSubroutes(outsideStructureRoutes)}

--- a/client/dashboard/src/components/access/ShadowMCPRequestAccessContent.test.tsx
+++ b/client/dashboard/src/components/access/ShadowMCPRequestAccessContent.test.tsx
@@ -1,0 +1,237 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { StrictMode, type ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createApprovalRequest: vi.fn(),
+  useSession: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useSession: mocks.useSession,
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/utils")>();
+  return {
+    ...actual,
+    buildLoginRedirectURL: (redirectTo: string | null) =>
+      `/rpc/auth.login${redirectTo ? `?redirect=${encodeURIComponent(redirectTo)}` : ""}`,
+  };
+});
+
+vi.mock("@gram/client/react-query", () => ({
+  useCreateShadowMCPApprovalRequestMutation: () => ({
+    mutateAsync: mocks.createApprovalRequest,
+  }),
+}));
+
+vi.mock("@speakeasy-api/moonshine", () => ({
+  Button: Object.assign(
+    ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+      <button onClick={onClick}>{children}</button>
+    ),
+    {
+      LeftIcon: ({ children }: { children: ReactNode }) => (
+        <span>{children}</span>
+      ),
+      Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+    },
+  ),
+  Icon: ({ name }: { name: string }) => <span data-icon={name} />,
+  Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+import { ShadowMCPRequestAccessContent } from "./ShadowMCPRequestAccessContent";
+
+function renderPage(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <ShadowMCPRequestAccessContent />
+    </MemoryRouter>,
+  );
+}
+
+function renderPageStrict(initialPath: string) {
+  return render(
+    <StrictMode>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <ShadowMCPRequestAccessContent />
+      </MemoryRouter>
+    </StrictMode>,
+  );
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  window.history.replaceState(null, "", "/");
+  mocks.createApprovalRequest.mockReset();
+  mocks.createApprovalRequest.mockResolvedValue({});
+  mocks.useSession.mockReturnValue({ session: "" });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ShadowMCPRequestAccessContent", () => {
+  it("captures fragment token, scrubs the URL, and redirects to login without the token", async () => {
+    const replaceState = vi
+      .spyOn(window.history, "replaceState")
+      .mockImplementation(() => {});
+    const location = window.location;
+    const hrefSetter = vi.fn();
+    // @ts-expect-error jsdom-compatible location replacement for redirect assertion
+    delete window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...location,
+        pathname: "/shadow-mcp/request",
+        hash: "#request_token=smar1.secret-token",
+        set href(value: string) {
+          hrefSetter(value);
+        },
+        get href() {
+          return "https://app.example.test/shadow-mcp/request#request_token=smar1.secret-token";
+        },
+      },
+    });
+
+    renderPage("/shadow-mcp/request#request_token=smar1.secret-token");
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem("shadowMcpApprovalRequestToken")).toBe(
+        "smar1.secret-token",
+      );
+    });
+    expect(replaceState).toHaveBeenCalledWith(null, "", "/shadow-mcp/request");
+    await waitFor(() => {
+      expect(hrefSetter).toHaveBeenCalledWith(
+        "/rpc/auth.login?redirect=%2Fshadow-mcp%2Frequest",
+      );
+    });
+    expect(hrefSetter.mock.calls[0]?.[0]).not.toContain("smar1.secret-token");
+    expect(mocks.createApprovalRequest).not.toHaveBeenCalled();
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: location,
+    });
+  });
+
+  it("ignores query tokens so request tokens are not exposed in referrers", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/shadow-mcp/request?request_token=smar1.query-token",
+    );
+
+    renderPage("/shadow-mcp/request?request_token=smar1.query-token");
+
+    expect(screen.getByText("Link expired")).toBeTruthy();
+    expect(sessionStorage.getItem("shadowMcpApprovalRequestToken")).toBeNull();
+    expect(mocks.createApprovalRequest).not.toHaveBeenCalled();
+  });
+
+  it("submits the stored request token after authentication", async () => {
+    sessionStorage.setItem(
+      "shadowMcpApprovalRequestToken",
+      "smar1.stored-token",
+    );
+    mocks.useSession.mockReturnValue({ session: "session_123" });
+
+    renderPage("/shadow-mcp/request");
+
+    await waitFor(() => {
+      expect(mocks.createApprovalRequest).toHaveBeenCalledWith({
+        request: {
+          createShadowMCPApprovalRequestForm: {
+            requestToken: "smar1.stored-token",
+          },
+        },
+      });
+    });
+  });
+
+  it("shows success after submitting even after clearing the stored token", async () => {
+    sessionStorage.setItem(
+      "shadowMcpApprovalRequestToken",
+      "smar1.stored-token",
+    );
+    mocks.useSession.mockReturnValue({ session: "session_123" });
+
+    renderPage("/shadow-mcp/request");
+
+    await waitFor(() => {
+      expect(mocks.createApprovalRequest).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(
+        sessionStorage.getItem("shadowMcpApprovalRequestToken"),
+      ).toBeNull();
+      expect(screen.getByText("Request sent")).toBeTruthy();
+      expect(screen.getByText("You can close this page.")).toBeTruthy();
+    });
+  });
+
+  it("shows success under StrictMode without double-submitting", async () => {
+    sessionStorage.setItem(
+      "shadowMcpApprovalRequestToken",
+      "smar1.strict-token",
+    );
+    mocks.useSession.mockReturnValue({ session: "session_123" });
+
+    renderPageStrict("/shadow-mcp/request");
+
+    await waitFor(() => {
+      expect(
+        sessionStorage.getItem("shadowMcpApprovalRequestToken"),
+      ).toBeNull();
+      expect(screen.getByText("Request sent")).toBeTruthy();
+    });
+    expect(mocks.createApprovalRequest).toHaveBeenCalledOnce();
+  });
+
+  it("shows submit failure separately and retries the stored token", async () => {
+    sessionStorage.setItem(
+      "shadowMcpApprovalRequestToken",
+      "smar1.retry-token",
+    );
+    mocks.useSession.mockReturnValue({ session: "session_123" });
+    mocks.createApprovalRequest
+      .mockRejectedValueOnce(new Error("network failed"))
+      .mockResolvedValueOnce({});
+
+    renderPage("/shadow-mcp/request");
+
+    await waitFor(() => {
+      expect(screen.getByText("Request failed")).toBeTruthy();
+    });
+    expect(
+      screen.getByText(
+        "We could not send this request. Check your connection and try again.",
+      ),
+    ).toBeTruthy();
+    expect(sessionStorage.getItem("shadowMcpApprovalRequestToken")).toBe(
+      "smar1.retry-token",
+    );
+
+    fireEvent.click(screen.getByText("Try again"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Request sent")).toBeTruthy();
+    });
+    expect(mocks.createApprovalRequest).toHaveBeenCalledTimes(2);
+    expect(sessionStorage.getItem("shadowMcpApprovalRequestToken")).toBeNull();
+  });
+});

--- a/client/dashboard/src/components/access/ShadowMCPRequestAccessContent.tsx
+++ b/client/dashboard/src/components/access/ShadowMCPRequestAccessContent.tsx
@@ -1,0 +1,234 @@
+import { GramLogo } from "@/components/gram-logo";
+import { Type } from "@/components/ui/type";
+import { useSession } from "@/contexts/Auth";
+import { buildLoginRedirectURL } from "@/lib/utils";
+import { useCreateShadowMCPApprovalRequestMutation } from "@gram/client/react-query";
+import { Button, Icon, Stack } from "@speakeasy-api/moonshine";
+import { useEffect, useState } from "react";
+
+const REQUEST_TOKEN_STORAGE_KEY = "shadowMcpApprovalRequestToken";
+const inFlightSubmissions = new Map<string, Promise<void>>();
+
+type RequestAccessState =
+  | "missing-token"
+  | "authenticating"
+  | "submitting"
+  | "complete"
+  | "error";
+
+type SubmissionResult = "idle" | "complete" | "error";
+
+export function ShadowMCPRequestAccessContent() {
+  const session = useSession();
+  const requestToken = getRequestToken();
+  const [submissionResult, setSubmissionResult] =
+    useState<SubmissionResult>("idle");
+  const [retryCount, setRetryCount] = useState(0);
+  const { mutateAsync: createApprovalRequest } =
+    useCreateShadowMCPApprovalRequestMutation();
+
+  useEffect(() => {
+    const meta = document.createElement("meta");
+    meta.name = "referrer";
+    meta.content = "no-referrer";
+    document.head.appendChild(meta);
+    return () => {
+      document.head.removeChild(meta);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (requestToken) {
+      setSubmissionResult("idle");
+      sessionStorage.setItem(REQUEST_TOKEN_STORAGE_KEY, requestToken);
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+  }, [requestToken]);
+
+  const storedRequestToken =
+    requestToken ?? sessionStorage.getItem(REQUEST_TOKEN_STORAGE_KEY);
+
+  useEffect(() => {
+    if (!storedRequestToken || session.session) return;
+
+    window.location.href = buildLoginRedirectURL("/shadow-mcp/request");
+  }, [session.session, storedRequestToken]);
+
+  useEffect(() => {
+    if (!storedRequestToken || !session.session) return;
+
+    let submission = inFlightSubmissions.get(storedRequestToken);
+    if (!submission) {
+      submission = createApprovalRequest({
+        request: {
+          createShadowMCPApprovalRequestForm: {
+            requestToken: storedRequestToken,
+          },
+        },
+      })
+        .then(() => undefined)
+        .finally(() => {
+          inFlightSubmissions.delete(storedRequestToken);
+        });
+      inFlightSubmissions.set(storedRequestToken, submission);
+    }
+
+    let active = true;
+    submission
+      .then(() => {
+        if (!active) return;
+        setSubmissionResult("complete");
+        sessionStorage.removeItem(REQUEST_TOKEN_STORAGE_KEY);
+      })
+      .catch(() => {
+        if (!active) return;
+        setSubmissionResult("error");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [createApprovalRequest, retryCount, session.session, storedRequestToken]);
+
+  const state = getRequestAccessState({
+    hasSession: !!session.session,
+    hasToken: !!storedRequestToken,
+    submissionResult,
+  });
+
+  return (
+    <div className="bg-background flex min-h-screen w-full flex-col items-center justify-center p-8">
+      <Stack gap={8} align="center" className="w-full max-w-sm">
+        <GramLogo className="w-25" variant="vertical" />
+        <RequestAccessMessage
+          state={state}
+          isPending={state === "submitting"}
+          onRetry={() => {
+            setSubmissionResult("idle");
+            setRetryCount((count) => count + 1);
+          }}
+        />
+      </Stack>
+    </div>
+  );
+}
+
+function getRequestAccessState({
+  hasSession,
+  hasToken,
+  submissionResult,
+}: {
+  hasSession: boolean;
+  hasToken: boolean;
+  submissionResult: SubmissionResult;
+}): RequestAccessState {
+  if (submissionResult === "complete") return "complete";
+  if (submissionResult === "error") return "error";
+  if (!hasToken) return "missing-token";
+  if (!hasSession) return "authenticating";
+  return "submitting";
+}
+
+function getRequestToken(): string | null {
+  const hashParams = new URLSearchParams(
+    window.location.hash.replace(/^#/, ""),
+  );
+  return hashParams.get("request_token") ?? hashParams.get("token");
+}
+
+function RequestAccessMessage({
+  state,
+  isPending,
+  onRetry,
+}: {
+  state: RequestAccessState;
+  isPending: boolean;
+  onRetry: () => void;
+}) {
+  if (state === "complete") {
+    return (
+      <Stack gap={3} align="center">
+        <div className="bg-primary/10 flex h-11 w-11 items-center justify-center rounded-full">
+          <Icon name="check" className="text-primary h-5 w-5" />
+        </div>
+        <Stack gap={1} align="center">
+          <Type variant="subheading" className="text-center">
+            Request sent
+          </Type>
+          <Type muted small className="text-center">
+            You can close this page.
+          </Type>
+        </Stack>
+      </Stack>
+    );
+  }
+
+  if (state === "authenticating") {
+    return (
+      <Stack gap={3} align="center">
+        <Icon
+          name="loader-circle"
+          className="text-muted-foreground h-6 w-6 animate-spin"
+        />
+        <Type muted small className="text-center">
+          Redirecting to sign in...
+        </Type>
+      </Stack>
+    );
+  }
+
+  if (state === "missing-token") {
+    return (
+      <Stack gap={3} align="center">
+        <div className="bg-destructive/10 flex h-11 w-11 items-center justify-center rounded-full">
+          <Icon name="circle-x" className="text-destructive h-5 w-5" />
+        </div>
+        <Stack gap={1} align="center">
+          <Type variant="subheading" className="text-center">
+            Link expired
+          </Type>
+          <Type muted small className="text-center">
+            This request link is no longer valid. Try the blocked MCP action
+            again to generate a new request.
+          </Type>
+        </Stack>
+      </Stack>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <Stack gap={3} align="center">
+        <div className="bg-destructive/10 flex h-11 w-11 items-center justify-center rounded-full">
+          <Icon name="circle-x" className="text-destructive h-5 w-5" />
+        </div>
+        <Stack gap={1} align="center">
+          <Type variant="subheading" className="text-center">
+            Request failed
+          </Type>
+          <Type muted small className="text-center">
+            We could not send this request. Check your connection and try again.
+          </Type>
+        </Stack>
+        <Button variant="secondary" onClick={onRetry}>
+          <Button.LeftIcon>
+            <Icon name="refresh-cw" className="h-4 w-4" />
+          </Button.LeftIcon>
+          <Button.Text>Try again</Button.Text>
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap={3} align="center">
+      <Icon
+        name="loader-circle"
+        className="text-muted-foreground h-6 w-6 animate-spin"
+      />
+      <Type muted small className="text-center">
+        {isPending ? "Submitting request..." : "Preparing request..."}
+      </Type>
+    </Stack>
+  );
+}

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -42,9 +42,19 @@ import type { ProjectEntry } from "@gram/client/models/components";
 
 const PREFERRED_PROJECT_KEY = "preferredProject";
 
-const UNAUTHENTICATED_PATHS = ["/login", "/register", "/book-demo"];
+const UNAUTHENTICATED_PATHS = [
+  "/login",
+  "/register",
+  "/invite",
+  "/book-demo",
+  "/shadow-mcp/request",
+];
 
-const SLUG_EXEMPT_PATHS = ["/slack/register", "/switch-org"];
+const SLUG_EXEMPT_PATHS = [
+  "/slack/register",
+  "/switch-org",
+  "/shadow-mcp/request",
+];
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/client/dashboard/src/pages/shadow-mcp/RequestAccess.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/RequestAccess.tsx
@@ -1,0 +1,5 @@
+import { ShadowMCPRequestAccessContent } from "@/components/access/ShadowMCPRequestAccessContent";
+
+export default function ShadowMCPRequestAccess() {
+  return <ShadowMCPRequestAccessContent />;
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -973,7 +973,7 @@ func newStartCommand() *cli.Command {
 				authzEngine,
 				memorySvc,
 			))
-			hooks.Attach(mux, hooks.NewService(logger, db, tracerProvider, telemLogger, sessionManager, hooksCache, chatClient, temporalEnv, authzEngine, productFeatures, &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}, riskScanner, shadowMCPClient, chatWriter))
+			hooks.Attach(mux, hooks.NewService(logger, db, tracerProvider, telemLogger, sessionManager, hooksCache, chatClient, temporalEnv, authzEngine, productFeatures, &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}, riskScanner, shadowMCPClient, chatWriter, siteURL, c.String("jwt-signing-key")))
 			aiintegrations.Attach(mux, aiintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, &background.TemporalAIUsagePoller{TemporalEnv: temporalEnv}))
 			otelforwarding.Attach(mux, otelforwarding.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, otelForwardClient))
 			auditapi.Attach(mux, auditapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine))

--- a/server/internal/access/shadow_mcp_token.go
+++ b/server/internal/access/shadow_mcp_token.go
@@ -78,7 +78,7 @@ func GenerateShadowMCPApprovalRequestToken(jwtSecret string, input ShadowMCPAppr
 			Subject:   shadowMCPApprovalRequestTokenSubject,
 			Audience:  nil,
 			ExpiresAt: jwt.NewNumericDate(expiry),
-			NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
+			NotBefore: jwt.NewNumericDate(now),
 			IssuedAt:  jwt.NewNumericDate(now),
 			ID:        uuid.NewString(),
 		},

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -764,25 +764,24 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 		// fail closed with a clear reason than silently allow.
 		detail = fmt.Sprintf("MCP server %q has no recognizable target", serverPrefix)
 	}
+	evidence := shadowmcp.AccessEvidence{
+		FullURL:        "",
+		URLHost:        "",
+		ServerIdentity: mcpServerIdentityFromToolName(rawToolName),
+	}
+	if matched != nil {
+		evidence.FullURL = matched.URL
+		evidence.ServerIdentity = serverPrefix
+		if matched.URL == "" && matched.Command != "" {
+			evidence.ServerIdentity = matched.Command
+		}
+	}
 	// Access Rules can explicitly allow a shadow MCP server by URL, command,
 	// or server identity. Deny rules win inside EvaluateAccessRules.
 	if detail != "" && matched != nil {
 		if s.shadowMCPClient == nil {
 			detail = "Shadow MCP validation is unavailable"
 		} else {
-			evidence := shadowmcp.AccessEvidence{
-				FullURL:        "",
-				URLHost:        "",
-				ServerIdentity: mcpServerIdentityFromToolName(rawToolName),
-			}
-			if matched != nil {
-				evidence.FullURL = matched.URL
-				evidence.ServerIdentity = serverPrefix
-				if matched.URL == "" && matched.Command != "" {
-					evidence.ServerIdentity = matched.Command
-				}
-			}
-
 			decision := s.shadowMCPClient.EvaluateAccessRules(ctx, metadata.GramOrgID, metadata.ProjectID, evidence)
 			s.logger.InfoContext(ctx, "evaluated shadow mcp access rules",
 				attr.SlogEvent("shadow_mcp_access_rule_evaluated"),
@@ -819,7 +818,17 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	}
 	if detail != "" {
 		auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
-		userReason := renderUserBlockReason(policy.UserMessage, auditReason)
+		userReason := s.renderShadowMCPUserBlockReason(ctx, shadowMCPRequestLinkParams{
+			OrganizationID:  metadata.GramOrgID,
+			ProjectID:       metadata.ProjectID,
+			RequesterUserID: metadata.UserID,
+			UserMessage:     policy.UserMessage,
+			AuditReason:     auditReason,
+			Evidence:        evidence,
+			ToolName:        mcpToolName,
+			ToolInput:       payload.ToolInput,
+			RiskPolicyID:    policy.ID,
+		})
 		matchedURL := ""
 		if matched != nil {
 			matchedURL = matched.URL

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -60,7 +60,8 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 		policy := s.lookupShadowMCPBlockingPolicy(ctx, projectID)
 		if policy != nil {
 			toolName := conv.PtrValOr(payload.ToolName, "")
-			if detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, authCtx.UserID, payload.ToolInput, toolName, codexShadowMCPEvidence(payload)); denied {
+			evidence := codexShadowMCPEvidence(payload)
+			if detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, authCtx.UserID, payload.ToolInput, toolName, evidence); denied {
 				logger.InfoContext(ctx, "denying codex tool call: failed gram toolset validation",
 					attr.SlogEvent("codex_hook_denied"),
 					attr.SlogHookBlockReason(detail),
@@ -68,7 +69,17 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 					attr.SlogRiskPolicyName(policy.Name),
 				)
 				blockReason = fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
-				userReason = renderUserBlockReason(policy.UserMessage, blockReason)
+				userReason = s.renderShadowMCPUserBlockReason(ctx, shadowMCPRequestLinkParams{
+					OrganizationID:  orgID,
+					ProjectID:       projectID,
+					RequesterUserID: authCtx.UserID,
+					UserMessage:     policy.UserMessage,
+					AuditReason:     blockReason,
+					Evidence:        evidence,
+					ToolName:        toolName,
+					ToolInput:       payload.ToolInput,
+					RiskPolicyID:    policy.ID,
+				})
 			}
 		}
 	case "PermissionRequest":

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -1,0 +1,33 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+)
+
+func TestCodex_PreToolUse_ShadowMCPBlockIncludesRequestLink(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	sessionID := "codex-session-blocked"
+	toolName := "mcp__gram__do_thing"
+
+	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"foo": "bar"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Decision)
+	require.Equal(t, "deny", *result.Decision)
+	require.NotNil(t, result.Reason)
+	require.Contains(t, *result.Reason, "Request access:\nhttps://app.example.test/shadow-mcp/request#request_token=smar1.",
+		"shadow-MCP deny messages should include a signed approval request link")
+	require.Contains(t, *result.Reason, shadowMCPApprovalRequestPrompt)
+}

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -8,7 +8,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 )
 
-func TestCodex_PreToolUse_ShadowMCPBlockIncludesRequestLink(t *testing.T) {
+func TestCodex_PreToolUse_ShadowMCPBlockWithoutURLEvidenceOmitsRequestLink(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
 	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
@@ -27,7 +27,6 @@ func TestCodex_PreToolUse_ShadowMCPBlockIncludesRequestLink(t *testing.T) {
 	require.NotNil(t, result.Decision)
 	require.Equal(t, "deny", *result.Decision)
 	require.NotNil(t, result.Reason)
-	require.Contains(t, *result.Reason, "Request access:\nhttps://app.example.test/shadow-mcp/request#request_token=smar1.",
-		"shadow-MCP deny messages should include a signed approval request link")
-	require.Contains(t, *result.Reason, shadowMCPApprovalRequestPrompt)
+	require.NotContains(t, *result.Reason, "Request access:")
+	require.NotContains(t, *result.Reason, shadowMCPApprovalRequestPrompt)
 }

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -86,7 +86,8 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 			break
 		}
 		toolName := strings.TrimPrefix(conv.PtrValOr(payload.ToolName, ""), "MCP:")
-		if detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, authCtx.UserID, payload.ToolInput, toolName, cursorShadowMCPEvidence(payload)); denied {
+		evidence := cursorShadowMCPEvidence(payload)
+		if detail, denied := s.enforceShadowMCPToolAccess(ctx, orgID, projectID, authCtx.UserID, payload.ToolInput, toolName, evidence); denied {
 			logger.InfoContext(ctx, "denying cursor tool call: failed gram toolset validation",
 				attr.SlogEvent("cursor_hook_denied"),
 				attr.SlogHookBlockReason(detail),
@@ -94,7 +95,21 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 				attr.SlogRiskPolicyName(policy.Name),
 			)
 			auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
-			userReason := renderUserBlockReason(policy.UserMessage, auditReason)
+			requesterUserID := authCtx.UserID
+			if requesterUserID == "" {
+				requesterUserID = s.resolveUserByEmail(ctx, conv.PtrValOr(payload.UserEmail, ""), orgID)
+			}
+			userReason := s.renderShadowMCPUserBlockReason(ctx, shadowMCPRequestLinkParams{
+				OrganizationID:  orgID,
+				ProjectID:       projectID,
+				RequesterUserID: requesterUserID,
+				UserMessage:     policy.UserMessage,
+				AuditReason:     auditReason,
+				Evidence:        evidence,
+				ToolName:        toolName,
+				ToolInput:       payload.ToolInput,
+				RiskPolicyID:    policy.ID,
+			})
 			blockReason = auditReason
 			result.Permission = new("deny")
 			result.UserMessage = &userReason

--- a/server/internal/hooks/cursor_test.go
+++ b/server/internal/hooks/cursor_test.go
@@ -173,6 +173,36 @@ func TestCursor_BeforeMCPExecution_ReturnsAllow(t *testing.T) {
 	assert.Equal(t, "allow", *result.Permission)
 }
 
+func TestCursor_BeforeMCPExecution_ShadowMCPBlockIncludesRequestLink(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	toolName := "list_issues"
+	toolUseID := "toolu_mcp_blocked"
+	conversationID := "conv-mcp-blocked"
+	serverURL := "https://mcp.linear.app/sse"
+
+	result, err := ti.service.Cursor(ctx, &hooks.CursorPayload{
+		HookEventName:  "beforeMCPExecution",
+		ToolName:       &toolName,
+		ToolUseID:      &toolUseID,
+		ConversationID: &conversationID,
+		URL:            &serverURL,
+		ToolInput:      map[string]any{"foo": "bar"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Permission)
+	assert.Equal(t, "deny", *result.Permission)
+	require.NotNil(t, result.UserMessage)
+	assert.Contains(t, *result.UserMessage, "Request access:\nhttps://app.example.test/shadow-mcp/request#request_token=smar1.",
+		"shadow-MCP deny messages should include a signed approval request link")
+	assert.Contains(t, *result.UserMessage, shadowMCPApprovalRequestPrompt)
+	require.NotNil(t, result.AgentMessage)
+	assert.Equal(t, *result.UserMessage, *result.AgentMessage)
+}
+
 func TestBuildCursorTelemetryAttributes_BeforeMCPExecution_ToolSourceFromURL(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"log/slog"
+	"net/url"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -48,6 +49,8 @@ type Service struct {
 	riskScanner        risk.RiskScanner
 	shadowMCPClient    *shadowmcp.Client
 	writer             *chat.ChatMessageWriter
+	siteURL            *url.URL
+	jwtSecret          string
 }
 
 // SessionMetadata contains validated session information from the Logs endpoint
@@ -97,6 +100,8 @@ func NewService(
 	riskScanner risk.RiskScanner,
 	shadowMCPClient *shadowmcp.Client,
 	writer *chat.ChatMessageWriter,
+	siteURL *url.URL,
+	jwtSecret string,
 ) *Service {
 	return &Service{
 		tracer:             tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/hooks"),
@@ -113,6 +118,8 @@ func NewService(
 		riskScanner:        riskScanner,
 		shadowMCPClient:    shadowMCPClient,
 		writer:             writer,
+		siteURL:            siteURL,
+		jwtSecret:          jwtSecret,
 	}
 }
 

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"log"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -90,7 +91,9 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 	t.Cleanup(func() { _ = chatWriterShutdown(t.Context()) })
 	accessStore := accesscontrol.NewRedisStore(cacheAdapter, accesscontrol.AlphaTTL)
 	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore)
-	svc := NewService(logger, conn, tracerProvider, nil, sessionManager, cacheAdapter, nil, nil, authzEngine, nil, nil, nil, shadowMCPClient, chatWriter)
+	siteURL, err := url.Parse("https://app.example.test")
+	require.NoError(t, err)
+	svc := NewService(logger, conn, tracerProvider, nil, sessionManager, cacheAdapter, nil, nil, authzEngine, nil, nil, nil, shadowMCPClient, chatWriter, siteURL, "test-jwt-secret")
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/hooks/shadow_mcp_request_link.go
+++ b/server/internal/hooks/shadow_mcp_request_link.go
@@ -1,0 +1,146 @@
+package hooks
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+const (
+	shadowMCPApprovalRequestTokenTTL = 7 * 24 * time.Hour
+	shadowMCPApprovalRequestPrompt   = "Would you like me to open this link in a browser?"
+)
+
+type shadowMCPRequestLinkParams struct {
+	OrganizationID  string
+	ProjectID       string
+	RequesterUserID string
+	UserMessage     *string
+	AuditReason     string
+	Evidence        shadowmcp.AccessEvidence
+	ToolName        string
+	ToolInput       any
+	RiskPolicyID    string
+}
+
+func (s *Service) renderShadowMCPUserBlockReason(ctx context.Context, params shadowMCPRequestLinkParams) string {
+	message := renderUserBlockReason(params.UserMessage, params.AuditReason)
+	requestURL, ok := s.shadowMCPApprovalRequestURL(ctx, params)
+	if !ok {
+		return message
+	}
+	return strings.TrimSpace(message) + "\n\nRequest access:\n" + requestURL + "\n\n" + shadowMCPApprovalRequestPrompt
+}
+
+func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadowMCPRequestLinkParams) (string, bool) {
+	if s.siteURL == nil || strings.TrimSpace(s.jwtSecret) == "" {
+		return "", false
+	}
+
+	evidence := shadowmcp.NormalizeAccessEvidence(params.Evidence)
+	if evidence.Empty() {
+		return "", false
+	}
+
+	token, _, err := access.GenerateShadowMCPApprovalRequestToken(s.jwtSecret, access.ShadowMCPApprovalRequestTokenInput{
+		OrganizationID:         params.OrganizationID,
+		ProjectID:              params.ProjectID,
+		RequesterUserID:        params.RequesterUserID,
+		ObservedName:           observedShadowMCPName(evidence, params.ToolName),
+		ObservedFullURL:        stringPtrOrNil(evidence.FullURL),
+		ObservedURLHost:        stringPtrOrNil(evidence.URLHost),
+		ObservedServerIdentity: stringPtrOrNil(evidence.ServerIdentity),
+		ToolName:               stringPtrOrNil(params.ToolName),
+		ToolCall:               nil,
+		BlockReason:            stringPtrOrNil(params.AuditReason),
+		RiskPolicyID:           uuidStringPtrOrNil(params.RiskPolicyID),
+		RiskResultID:           nil,
+	}, shadowMCPApprovalRequestTokenTTL)
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to generate shadow mcp approval request link",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(params.OrganizationID),
+			attr.SlogProjectID(params.ProjectID),
+		)
+		return "", false
+	}
+
+	requestURL := s.siteURL.JoinPath("shadow-mcp", "request")
+	query := url.Values{}
+	query.Set("request_token", token)
+	requestURL.Fragment = query.Encode()
+	return requestURL.String(), true
+}
+
+func observedShadowMCPName(evidence shadowmcp.AccessEvidence, toolName string) *string {
+	switch {
+	case evidence.ServerIdentity != "":
+		name := humanizeShadowMCPServerIdentity(evidence.ServerIdentity)
+		return &name
+	case evidence.URLHost != "":
+		return &evidence.URLHost
+	case toolName != "":
+		return &toolName
+	default:
+		return nil
+	}
+}
+
+func humanizeShadowMCPServerIdentity(value string) string {
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '_' || r == '-' || r == '.' || r == ':' || r == ' '
+	})
+	if len(parts) == 0 {
+		return value
+	}
+
+	words := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		words = append(words, humanizeShadowMCPServerIdentityWord(part))
+	}
+	if len(words) == 0 {
+		return value
+	}
+	return strings.Join(words, " ")
+}
+
+func humanizeShadowMCPServerIdentityWord(value string) string {
+	lower := strings.ToLower(value)
+	switch lower {
+	case "ai", "api", "http", "https", "mcp", "oauth", "url":
+		return strings.ToUpper(lower)
+	case "github":
+		return "GitHub"
+	default:
+		return strings.ToUpper(lower[:1]) + lower[1:]
+	}
+}
+
+func stringPtrOrNil(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func uuidStringPtrOrNil(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return nil
+	}
+	return &trimmed
+}

--- a/server/internal/hooks/shadow_mcp_request_link.go
+++ b/server/internal/hooks/shadow_mcp_request_link.go
@@ -81,11 +81,11 @@ func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadow
 
 func observedShadowMCPName(evidence shadowmcp.AccessEvidence, toolName string) *string {
 	switch {
+	case evidence.URLHost != "":
+		return &evidence.URLHost
 	case evidence.ServerIdentity != "":
 		name := humanizeShadowMCPServerIdentity(evidence.ServerIdentity)
 		return &name
-	case evidence.URLHost != "":
-		return &evidence.URLHost
 	case toolName != "":
 		return &toolName
 	default:

--- a/server/internal/hooks/shadow_mcp_request_link_test.go
+++ b/server/internal/hooks/shadow_mcp_request_link_test.go
@@ -1,0 +1,88 @@
+package hooks
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestShadowMCPApprovalRequestURLUsesFragmentToken(t *testing.T) {
+	t.Parallel()
+
+	siteURL, err := url.Parse("https://app.example.test")
+	require.NoError(t, err)
+	service := &Service{
+		logger:    testenv.NewLogger(t),
+		siteURL:   siteURL,
+		jwtSecret: "test-jwt-secret",
+	}
+
+	requestURL, ok := service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
+		OrganizationID:  "org_test",
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		RequesterUserID: "user_test",
+		AuditReason:     "blocked",
+		Evidence: shadowmcp.AccessEvidence{
+			FullURL:        "https://MCP.Example.com:443/sse#ignored",
+			URLHost:        "",
+			ServerIdentity: "Example MCP",
+		},
+		ToolName:     "list_issues",
+		ToolInput:    map[string]any{"prompt": strings.Repeat("x", 10_000)},
+		RiskPolicyID: "00000000-0000-0000-0000-000000000002",
+	})
+	require.True(t, ok)
+
+	parsed, err := url.Parse(requestURL)
+	require.NoError(t, err)
+	require.Empty(t, parsed.RawQuery)
+	require.Equal(t, "https", parsed.Scheme)
+	require.Equal(t, "app.example.test", parsed.Host)
+	require.Equal(t, "/shadow-mcp/request", parsed.Path)
+
+	fragment, err := url.ParseQuery(parsed.Fragment)
+	require.NoError(t, err)
+	require.NotContains(t, requestURL, "?request_token=")
+	require.Contains(t, fragment.Get("request_token"), "smar1.")
+	require.Less(t, len(requestURL), 1200, "approval link should not embed full tool input")
+}
+
+func TestShadowMCPApprovalRequestURLRequiresEvidence(t *testing.T) {
+	t.Parallel()
+
+	siteURL, err := url.Parse("https://app.example.test")
+	require.NoError(t, err)
+	service := &Service{
+		logger:    testenv.NewLogger(t),
+		siteURL:   siteURL,
+		jwtSecret: "test-jwt-secret",
+	}
+
+	_, ok := service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
+		OrganizationID:  "org_test",
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		RequesterUserID: "user_test",
+		AuditReason:     "blocked",
+		Evidence:        shadowmcp.AccessEvidence{},
+		ToolName:        "list_issues",
+	})
+	require.False(t, ok)
+}
+
+func TestObservedShadowMCPName_HumanizesServerIdentity(t *testing.T) {
+	t.Parallel()
+
+	name := observedShadowMCPName(shadowmcp.AccessEvidence{
+		FullURL:        "",
+		URLHost:        "",
+		ServerIdentity: "claude_ai_calendly",
+	}, "authenticate")
+
+	require.NotNil(t, name)
+	require.Equal(t, "Claude AI Calendly", *name)
+}

--- a/server/internal/hooks/shadow_mcp_request_link_test.go
+++ b/server/internal/hooks/shadow_mcp_request_link_test.go
@@ -72,6 +72,20 @@ func TestShadowMCPApprovalRequestURLRequiresEvidence(t *testing.T) {
 		ToolName:        "list_issues",
 	})
 	require.False(t, ok)
+
+	_, ok = service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
+		OrganizationID:  "org_test",
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		RequesterUserID: "user_test",
+		AuditReason:     "blocked",
+		Evidence: shadowmcp.AccessEvidence{
+			FullURL:        "",
+			URLHost:        "",
+			ServerIdentity: "github",
+		},
+		ToolName: "search",
+	})
+	require.False(t, ok)
 }
 
 func TestObservedShadowMCPName_HumanizesServerIdentity(t *testing.T) {
@@ -85,4 +99,17 @@ func TestObservedShadowMCPName_HumanizesServerIdentity(t *testing.T) {
 
 	require.NotNil(t, name)
 	require.Equal(t, "Claude AI Calendly", *name)
+}
+
+func TestObservedShadowMCPName_PrefersURLHostOverServerIdentity(t *testing.T) {
+	t.Parallel()
+
+	name := observedShadowMCPName(shadowmcp.AccessEvidence{
+		FullURL:        "https://mcp.calendly.com/sse",
+		URLHost:        "mcp.calendly.com",
+		ServerIdentity: "claude_ai_calendly",
+	}, "authenticate")
+
+	require.NotNil(t, name)
+	require.Equal(t, "mcp.calendly.com", *name)
 }


### PR DESCRIPTION
### Summary

This PR adds the blocked-hook request-access flow on top of Redis-backed Shadow MCP runtime enforcement.

When a Shadow MCP hook call is blocked, supported clients can receive a request-access link. The link carries a signed request token in the URL fragment, so the token is not sent in normal HTTP request logs. After login, the dashboard request route submits that token to the access API, which records the approval request in Redis through the generic access-control store.

Includes:
- `/shadow-mcp/request` dashboard route
- auth redirect and post-login request submission
- signed request-token creation/validation
- request links in Claude, Cursor, and Codex blocked responses
- request-submission success/error UI
- hook tests for request-link generation and request submission

This PR only creates approval requests. Admin review and rule creation happen through the access API and dashboard UI.

### Verification

- Request-link branch: `mise run test:server ./internal/access ./internal/hooks -run 'TestService_.*ShadowMCPApprovalRequest|Test.*ShadowMCP.*RequestLink' -count=1` passed, 10 tests
- Top of stack: `rg -n "shadow-mcp-allow|AddShadowMCPApproval|RemoveShadowMCPApproval|IsShadowMCPApproved|func CanonicalizeMatch\(" server/internal client/dashboard` returned no matches
- Top of stack: `mise run test:server ./internal/accesscontrol ./internal/access ./internal/risk ./internal/shadowmcp ./internal/hooks -count=1` passed, 458 tests
- Top of stack: `mise run lint:server` passed
- Top of stack: `pnpm --dir client/dashboard type-check` passed
- Top of stack: `pnpm --dir client/dashboard exec vitest run src/components/access/ShadowMCPAccessContent.test.tsx` passed, 3 tests
- Top of stack: `git diff --check` passed

### Stack

- #2763 Redis-backed Shadow MCP access API
- #2771 Shadow MCP runtime enforcement
- #2796 blocked hook request-access links
- #2831 dashboard access rules UI

https://linear.app/speakeasy/issue/AGE-2587/feat-add-shadow-mcp-request-links