### PR TITLE
fix(assistants): clip MCP tool results to 150 KB

### DIFF
--- a/.changeset/age-2300-clip-tool-result-bytes.md
+++ b/.changeset/age-2300-clip-tool-result-bytes.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The assistant runtime now clips each MCP tool result to 150 KB before it reaches the model. Previously a single oversized tool result (e.g. a verbose external MCP response) would 413 the next provider request and crash the assistant; now the result is truncated with a clear marker so the model can ask the tool to paginate or narrow its query.

--- a/.changeset/age-2300-clip-tool-result-bytes.md
+++ b/.changeset/age-2300-clip-tool-result-bytes.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-The assistant runtime now clips each MCP tool result to 150 KB before it reaches the model. Previously a single oversized tool result (e.g. a verbose external MCP response) would 413 the next provider request and crash the assistant; now the result is truncated with a clear marker so the model can ask the tool to paginate or narrow its query.
+The assistant runtime now spills oversized MCP tool results to a file inside the assistant workdir instead of letting them 413 the provider. The in-band tool result is replaced with a pointer (`{ truncated, saved_to, original_bytes }`) so the model can read or grep the full output via the filesystem tools — no information loss, no provider error.

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -1,0 +1,218 @@
+//! Per-tool-result byte clipper for the assistant runtime.
+//!
+//! OpenRouter caps a single tool message at 204800 bytes and 413s the next
+//! request when a tool result exceeds it. Token-aware compaction can't catch
+//! this: the trigger reads `usage.input_tokens` after the previous turn, and
+//! 200 KB ≈ 50 K tokens — well below the 80 % threshold for a 128 K+ window.
+//! Even when it does fire, [`SummarizeOlderStrategy`](agentkit_compaction)
+//! preserves the most recent items, so the offending tool result survives.
+//!
+//! [`ClippedToolSource`] wraps a [`ToolSource`] (the MCP catalog reader) and
+//! truncates each [`ToolOutput`] to [`MAX_TOOL_BYTES`] before it leaves the
+//! tool. Native tools (`bun_run`) already clip themselves and don't need
+//! wrapping — the bun limits are smaller, so they win.
+
+use std::sync::Arc;
+
+use agentkit_core::ToolOutput;
+use agentkit_tools_core::{
+    PermissionRequest, Tool, ToolCatalogEvent, ToolContext, ToolError, ToolName, ToolRequest,
+    ToolResult, ToolSource, ToolSpec,
+};
+use async_trait::async_trait;
+use serde_json::json;
+
+/// 150 KB. Leaves ~50 KB headroom under OpenRouter's 204800-byte per-message
+/// cap to absorb provider-side JSON envelope overhead (call id, metadata,
+/// content-type discriminators).
+pub const MAX_TOOL_BYTES: usize = 150_000;
+
+/// Wraps a [`ToolSource`] so every tool it serves clips its output to
+/// [`MAX_TOOL_BYTES`].
+pub struct ClippedToolSource<S> {
+    inner: S,
+}
+
+impl<S> ClippedToolSource<S> {
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S> ToolSource for ClippedToolSource<S>
+where
+    S: ToolSource,
+{
+    fn specs(&self) -> Vec<ToolSpec> {
+        self.inner.specs()
+    }
+
+    fn get(&self, name: &ToolName) -> Option<Arc<dyn Tool>> {
+        self.inner
+            .get(name)
+            .map(|inner| Arc::new(ClippedTool { inner }) as Arc<dyn Tool>)
+    }
+
+    fn drain_catalog_events(&self) -> Vec<ToolCatalogEvent> {
+        self.inner.drain_catalog_events()
+    }
+}
+
+struct ClippedTool {
+    inner: Arc<dyn Tool>,
+}
+
+#[async_trait]
+impl Tool for ClippedTool {
+    fn spec(&self) -> &ToolSpec {
+        self.inner.spec()
+    }
+
+    fn current_spec(&self) -> Option<ToolSpec> {
+        self.inner.current_spec()
+    }
+
+    fn proposed_requests(
+        &self,
+        request: &ToolRequest,
+    ) -> Result<Vec<Box<dyn PermissionRequest>>, ToolError> {
+        self.inner.proposed_requests(request)
+    }
+
+    async fn invoke(
+        &self,
+        request: ToolRequest,
+        ctx: &mut ToolContext<'_>,
+    ) -> Result<ToolResult, ToolError> {
+        let mut result = self.inner.invoke(request, ctx).await?;
+        result.result.output = clip_output(result.result.output, MAX_TOOL_BYTES);
+        Ok(result)
+    }
+}
+
+fn clip_output(output: ToolOutput, max_bytes: usize) -> ToolOutput {
+    if let ToolOutput::Text(s) = output {
+        if s.len() <= max_bytes {
+            return ToolOutput::Text(s);
+        }
+        let cut = s.floor_char_boundary(max_bytes);
+        let dropped = s.len() - cut;
+        return ToolOutput::Text(format!("{}…[truncated {dropped} bytes]", &s[..cut]));
+    }
+    let Ok(serialized) = serde_json::to_string(&output) else {
+        return output;
+    };
+    if serialized.len() <= max_bytes {
+        return output;
+    }
+    let original_bytes = serialized.len();
+    let cut = serialized.floor_char_boundary(max_bytes);
+    ToolOutput::Structured(json!({
+        "truncated": true,
+        "original_bytes": original_bytes,
+        "kept_bytes": cut,
+        "content": &serialized[..cut],
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agentkit_core::{Part, TextPart};
+    use serde_json::{Value, json};
+
+    #[test]
+    fn text_under_limit_passes_through() {
+        let out = clip_output(ToolOutput::text("hello"), 100);
+        match out {
+            ToolOutput::Text(s) => assert_eq!(s, "hello"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn text_at_exact_limit_passes_through() {
+        let body = "a".repeat(100);
+        let out = clip_output(ToolOutput::text(body.clone()), 100);
+        match out {
+            ToolOutput::Text(s) => assert_eq!(s, body),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn text_over_limit_is_clipped_with_marker() {
+        let body = "a".repeat(200);
+        let out = clip_output(ToolOutput::text(body), 100);
+        match out {
+            ToolOutput::Text(s) => {
+                assert!(s.starts_with(&"a".repeat(100)), "kept prefix");
+                assert!(s.contains("truncated 100 bytes"), "marker present: {s}");
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn text_clip_respects_utf8_boundary() {
+        // 50 × "é" = 100 bytes total. Cut at byte 75 sits inside a 2-byte
+        // codepoint; floor_char_boundary must walk back to 74.
+        let body = "é".repeat(50);
+        let out = clip_output(ToolOutput::text(body), 75);
+        match out {
+            ToolOutput::Text(s) => {
+                let prefix = s.split('…').next().unwrap();
+                assert!(prefix.chars().all(|c| c == 'é'));
+                assert!(prefix.len() <= 75);
+            }
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn structured_under_limit_passes_through() {
+        let value = json!({"k": "v"});
+        let out = clip_output(ToolOutput::Structured(value.clone()), 1000);
+        match out {
+            ToolOutput::Structured(got) => assert_eq!(got, value),
+            other => panic!("expected Structured, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn structured_over_limit_is_wrapped() {
+        let big = "x".repeat(500);
+        let value = json!({"payload": big});
+        let input = ToolOutput::Structured(value);
+        let serialized_len = serde_json::to_string(&input).unwrap().len();
+        let out = clip_output(input, 200);
+        match out {
+            ToolOutput::Structured(Value::Object(map)) => {
+                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+                let original = map
+                    .get("original_bytes")
+                    .and_then(Value::as_u64)
+                    .expect("original_bytes");
+                let kept = map.get("kept_bytes").and_then(Value::as_u64).expect("kept");
+                assert_eq!(original as usize, serialized_len);
+                assert!(kept <= 200);
+                assert!(map.get("content").and_then(Value::as_str).is_some());
+            }
+            other => panic!("expected Structured object, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parts_over_limit_falls_back_to_truncation_envelope() {
+        let big = "x".repeat(500);
+        let parts = vec![Part::Text(TextPart::new(big))];
+        let out = clip_output(ToolOutput::Parts(parts), 100);
+        match out {
+            ToolOutput::Structured(Value::Object(map)) => {
+                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+                assert!(map.get("original_bytes").is_some());
+            }
+            other => panic!("expected truncation envelope, got {other:?}"),
+        }
+    }
+}

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -144,15 +144,18 @@ async fn cap_output(
     }
 }
 
-/// Cheap measurement against the model-facing byte budget. For `Text`, this is
-/// the inner string's length; for everything else, the compact serialized form
-/// (which is what the provider adapter ends up sending on the wire). Returns
-/// `None` only if serialization itself fails — in that case the cap can't be
-/// enforced and the output is returned untouched.
+/// JSON-encoded byte size of the *content* the provider adapter sends as
+/// the tool message body. For `Text`, this is `"…"` after escaping — counting
+/// raw `s.len()` would undercount escape overhead, so a quote-heavy 150 KB
+/// blob could be ~300 KB on the wire and still 413 the provider. Returns
+/// `None` only if serialization itself fails — in that case the cap can't
+/// be enforced and the output is returned untouched.
 fn model_bytes(output: &ToolOutput) -> Option<usize> {
     match output {
-        ToolOutput::Text(s) => Some(s.len()),
-        other => serde_json::to_string(other).ok().map(|s| s.len()),
+        ToolOutput::Text(s) => serde_json::to_string(s).ok().map(|j| j.len()),
+        ToolOutput::Structured(v) => serde_json::to_string(v).ok().map(|j| j.len()),
+        ToolOutput::Parts(p) => serde_json::to_string(p).ok().map(|j| j.len()),
+        ToolOutput::Files(f) => serde_json::to_string(f).ok().map(|j| j.len()),
     }
 }
 
@@ -184,7 +187,12 @@ async fn write_spill(
     let safe_call = sanitize_filename_component(&call_id.0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     let path = spill_root.join(format!("{safe_tool}-{safe_call}-{n}.{ext}"));
-    tokio::fs::write(&path, body).await?;
+    if let Err(error) = tokio::fs::write(&path, body).await {
+        // Best-effort cleanup so a partial ENOSPC write doesn't accumulate
+        // and choke the workdir's fixed disk cap on subsequent calls.
+        let _ = tokio::fs::remove_file(&path).await;
+        return Err(error);
+    }
     Ok(path)
 }
 
@@ -277,9 +285,11 @@ mod tests {
             other => panic!("expected envelope, got {other:?}"),
         };
         assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+        // 500 plain `a` bytes encode to `"aaa..."` = 502 bytes after the
+        // surrounding quote literals (no escapes needed).
         assert_eq!(
             map.get("original_bytes").and_then(Value::as_u64),
-            Some(500)
+            Some(502)
         );
         let saved_to = map
             .get("saved_to")
@@ -295,9 +305,15 @@ mod tests {
     async fn structured_over_limit_spills_pretty_json() {
         let dir = tempdir();
         let value = json!({"items": vec!["x"; 500]});
-        let input = ToolOutput::Structured(value.clone());
-        let original = serde_json::to_string(&input).unwrap().len();
-        let out = cap_output(input, 200, dir.path(), &tool_name("t"), &call_id("c")).await;
+        let original = serde_json::to_string(&value).unwrap().len();
+        let out = cap_output(
+            ToolOutput::Structured(value.clone()),
+            200,
+            dir.path(),
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
         let map = match out {
             ToolOutput::Structured(Value::Object(map)) => map,
             other => panic!("expected envelope, got {other:?}"),
@@ -318,6 +334,33 @@ mod tests {
             on_disk.contains('\n'),
             "spilled JSON should be pretty-printed for grep/read"
         );
+    }
+
+    #[tokio::test]
+    async fn quote_heavy_text_spills_even_when_raw_len_fits() {
+        // 100 raw `"` bytes encode to 200 bytes (`\"` for each) plus the
+        // surrounding `"…"` literal. With a 150-byte cap the raw length is
+        // under the limit but the JSON-encoded form is not — the spill must
+        // still fire.
+        let dir = tempdir();
+        let body = "\"".repeat(100);
+        assert!(body.len() < 150);
+        let out = cap_output(
+            ToolOutput::text(body.clone()),
+            150,
+            dir.path(),
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
+        match out {
+            ToolOutput::Structured(Value::Object(map)) => {
+                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+                let saved_to = map.get("saved_to").and_then(Value::as_str).unwrap();
+                assert_eq!(std::fs::read_to_string(saved_to).unwrap(), body);
+            }
+            other => panic!("expected spill envelope, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -216,11 +216,30 @@ fn sanitize_filename_component(s: &str) -> String {
 }
 
 /// Fallback when the disk spill fails. Drops the tail of the body so the
-/// provider still receives a sub-cap result. The marker — either an inline
-/// `…[truncated N bytes]` for text or a `{truncated, kept_bytes, content}`
-/// envelope for JSON — tells the model the content is incomplete.
+/// provider still receives a sub-cap result. Must measure the *encoded*
+/// size of the candidate output — cutting by raw bytes underweights escape
+/// overhead for quote/backslash-heavy bodies, and would recreate the 413
+/// the spill was meant to avoid. Shrinks iteratively until the encoded
+/// candidate fits under `max_bytes`.
 fn clip_inline(body: String, ext: &str, max_bytes: usize, original_bytes: usize) -> ToolOutput {
-    let cut = body.floor_char_boundary(max_bytes);
+    const ITERATIONS: usize = 8;
+    let mut cut = body.floor_char_boundary(body.len().min(max_bytes));
+    for _ in 0..ITERATIONS {
+        let candidate = build_clipped(&body, cut, ext, original_bytes);
+        let encoded = model_bytes(&candidate).unwrap_or(usize::MAX);
+        if encoded <= max_bytes {
+            return candidate;
+        }
+        if cut == 0 {
+            break;
+        }
+        let shrunk = (cut as f64 * (max_bytes as f64 / encoded as f64) * 0.9) as usize;
+        cut = body.floor_char_boundary(shrunk.min(cut.saturating_sub(1)));
+    }
+    build_clipped(&body, 0, ext, original_bytes)
+}
+
+fn build_clipped(body: &str, cut: usize, ext: &str, original_bytes: usize) -> ToolOutput {
     if ext == "txt" {
         let dropped = body.len() - cut;
         ToolOutput::Text(format!("{}…[truncated {dropped} bytes]", &body[..cut]))
@@ -425,13 +444,45 @@ mod tests {
         assert_eq!(sanitize_filename_component(""), "_");
     }
 
+    #[tokio::test]
+    async fn fallback_clip_respects_encoded_size_for_quote_heavy_text() {
+        // 500 `"` chars encode to ~1000 bytes after JSON escaping. With a
+        // 150-byte cap and the spill path unreachable, the inline fallback
+        // must shrink the raw cut so the encoded ToolOutput still fits —
+        // otherwise it recreates the very 413 the spill was meant to avoid.
+        let dir = tempdir();
+        let blocking = dir.path().join("not-a-dir");
+        std::fs::write(&blocking, b"x").expect("write blocker");
+        let unreachable_root = blocking.join("spill");
+
+        let out = cap_output(
+            ToolOutput::text("\"".repeat(500)),
+            150,
+            &unreachable_root,
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
+        let encoded = model_bytes(&out).expect("model_bytes");
+        assert!(
+            encoded <= 150,
+            "fallback encoded size {encoded} must fit under cap 150"
+        );
+        match out {
+            ToolOutput::Text(s) => assert!(s.contains("truncated"), "marker present: {s}"),
+            other => panic!("expected Text fallback, got {other:?}"),
+        }
+    }
+
     #[test]
-    fn clip_inline_text_appends_marker() {
+    fn clip_inline_text_appends_marker_and_stays_under_cap() {
         let out = clip_inline("a".repeat(200), "txt", 100, 200);
+        let encoded = model_bytes(&out).expect("encode");
+        assert!(encoded <= 100, "encoded {encoded} under cap 100");
         match out {
             ToolOutput::Text(s) => {
-                assert!(s.starts_with(&"a".repeat(100)));
-                assert!(s.contains("truncated 100 bytes"));
+                assert!(s.contains("truncated"), "marker present: {s}");
+                assert!(s.starts_with('a'), "kept prefix is original content");
             }
             other => panic!("expected Text, got {other:?}"),
         }
@@ -439,8 +490,8 @@ mod tests {
 
     #[test]
     fn clip_inline_text_respects_utf8_boundary() {
-        // 50 × "é" = 100 bytes. Cut at byte 75 sits inside a 2-byte codepoint;
-        // floor_char_boundary must walk back to 74.
+        // 50 × "é" = 100 bytes. The clipper hops back from any cut point that
+        // would split a 2-byte codepoint.
         let out = clip_inline("é".repeat(50), "txt", 75, 100);
         match out {
             ToolOutput::Text(s) => {

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -1,4 +1,4 @@
-//! Per-tool-result byte clipper for the assistant runtime.
+//! Per-tool-result byte cap for the assistant runtime.
 //!
 //! OpenRouter caps a single tool message at 204800 bytes and 413s the next
 //! request when a tool result exceeds it. Token-aware compaction can't catch
@@ -7,14 +7,19 @@
 //! Even when it does fire, [`SummarizeOlderStrategy`](agentkit_compaction)
 //! preserves the most recent items, so the offending tool result survives.
 //!
-//! [`ClippedToolSource`] wraps a [`ToolSource`] (the MCP catalog reader) and
-//! truncates each [`ToolOutput`] to [`MAX_TOOL_BYTES`] before it leaves the
-//! tool. Native tools (`bun_run`) already clip themselves and don't need
-//! wrapping — the bun limits are smaller, so they win.
+//! When a tool result exceeds [`MAX_TOOL_BYTES`], the full body is written
+//! to a file inside the assistant workdir — where the agent's filesystem
+//! tools can read or grep it — and the in-band result is replaced with a
+//! small envelope pointing at that file. No information is lost; the model
+//! follows up by reading the saved file. If the spill itself fails (disk
+//! full, permission denied), the body is clipped in place with a marker so
+//! the provider still gets a valid, sub-cap result.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use agentkit_core::ToolOutput;
+use agentkit_core::{ToolCallId, ToolOutput};
 use agentkit_tools_core::{
     PermissionRequest, Tool, ToolCatalogEvent, ToolContext, ToolError, ToolName, ToolRequest,
     ToolResult, ToolSource, ToolSpec,
@@ -27,15 +32,20 @@ use serde_json::json;
 /// content-type discriminators).
 pub const MAX_TOOL_BYTES: usize = 150_000;
 
-/// Wraps a [`ToolSource`] so every tool it serves clips its output to
-/// [`MAX_TOOL_BYTES`].
+/// Wraps a [`ToolSource`] so every tool result either fits under
+/// [`MAX_TOOL_BYTES`] or is spilled to a file under `spill_root` and replaced
+/// with a small in-band pointer.
 pub struct ClippedToolSource<S> {
     inner: S,
+    spill_root: PathBuf,
 }
 
 impl<S> ClippedToolSource<S> {
-    pub fn new(inner: S) -> Self {
-        Self { inner }
+    pub fn new(inner: S, spill_root: impl Into<PathBuf>) -> Self {
+        Self {
+            inner,
+            spill_root: spill_root.into(),
+        }
     }
 }
 
@@ -48,9 +58,12 @@ where
     }
 
     fn get(&self, name: &ToolName) -> Option<Arc<dyn Tool>> {
-        self.inner
-            .get(name)
-            .map(|inner| Arc::new(ClippedTool { inner }) as Arc<dyn Tool>)
+        self.inner.get(name).map(|inner| {
+            Arc::new(ClippedTool {
+                inner,
+                spill_root: self.spill_root.clone(),
+            }) as Arc<dyn Tool>
+        })
     }
 
     fn drain_catalog_events(&self) -> Vec<ToolCatalogEvent> {
@@ -60,6 +73,7 @@ where
 
 struct ClippedTool {
     inner: Arc<dyn Tool>,
+    spill_root: PathBuf,
 }
 
 #[async_trait]
@@ -84,35 +98,132 @@ impl Tool for ClippedTool {
         request: ToolRequest,
         ctx: &mut ToolContext<'_>,
     ) -> Result<ToolResult, ToolError> {
+        let tool_name = request.tool_name.clone();
+        let call_id = request.call_id.clone();
         let mut result = self.inner.invoke(request, ctx).await?;
-        result.result.output = clip_output(result.result.output, MAX_TOOL_BYTES);
+        result.result.output = cap_output(
+            result.result.output,
+            MAX_TOOL_BYTES,
+            &self.spill_root,
+            &tool_name,
+            &call_id,
+        )
+        .await;
         Ok(result)
     }
 }
 
-fn clip_output(output: ToolOutput, max_bytes: usize) -> ToolOutput {
-    if let ToolOutput::Text(s) = output {
-        if s.len() <= max_bytes {
-            return ToolOutput::Text(s);
-        }
-        let cut = s.floor_char_boundary(max_bytes);
-        let dropped = s.len() - cut;
-        return ToolOutput::Text(format!("{}…[truncated {dropped} bytes]", &s[..cut]));
-    }
-    let Ok(serialized) = serde_json::to_string(&output) else {
+async fn cap_output(
+    output: ToolOutput,
+    max_bytes: usize,
+    spill_root: &Path,
+    tool_name: &ToolName,
+    call_id: &ToolCallId,
+) -> ToolOutput {
+    let Some(model_bytes) = model_bytes(&output) else {
         return output;
     };
-    if serialized.len() <= max_bytes {
+    if model_bytes <= max_bytes {
         return output;
     }
-    let original_bytes = serialized.len();
-    let cut = serialized.floor_char_boundary(max_bytes);
-    ToolOutput::Structured(json!({
-        "truncated": true,
-        "original_bytes": original_bytes,
-        "kept_bytes": cut,
-        "content": &serialized[..cut],
-    }))
+    let (body, ext) = consume_for_spill(output);
+    match write_spill(spill_root, tool_name, call_id, &body, ext).await {
+        Ok(path) => ToolOutput::Structured(json!({
+            "truncated": true,
+            "saved_to": path.display().to_string(),
+            "original_bytes": model_bytes,
+        })),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                spill_root = %spill_root.display(),
+                "spill of oversized tool result failed; clipping inline as fallback",
+            );
+            clip_inline(body, ext, max_bytes, model_bytes)
+        }
+    }
+}
+
+/// Cheap measurement against the model-facing byte budget. For `Text`, this is
+/// the inner string's length; for everything else, the compact serialized form
+/// (which is what the provider adapter ends up sending on the wire). Returns
+/// `None` only if serialization itself fails — in that case the cap can't be
+/// enforced and the output is returned untouched.
+fn model_bytes(output: &ToolOutput) -> Option<usize> {
+    match output {
+        ToolOutput::Text(s) => Some(s.len()),
+        other => serde_json::to_string(other).ok().map(|s| s.len()),
+    }
+}
+
+/// Converts the output into the body that will be written to disk. JSON
+/// variants are pretty-printed so the spilled file is easier for the agent
+/// to read or grep with the filesystem tools.
+fn consume_for_spill(output: ToolOutput) -> (String, &'static str) {
+    match output {
+        ToolOutput::Text(s) => (s, "txt"),
+        ToolOutput::Structured(v) => (serde_json::to_string_pretty(&v).unwrap_or_default(), "json"),
+        ToolOutput::Parts(p) => (serde_json::to_string_pretty(&p).unwrap_or_default(), "json"),
+        ToolOutput::Files(f) => (serde_json::to_string_pretty(&f).unwrap_or_default(), "json"),
+    }
+}
+
+async fn write_spill(
+    spill_root: &Path,
+    tool_name: &ToolName,
+    call_id: &ToolCallId,
+    body: &str,
+    ext: &str,
+) -> std::io::Result<PathBuf> {
+    // Belt-and-suspenders against duplicate (tool_name, call_id) pairs across
+    // a retry storm or a misbehaving provider — disambiguates atomically
+    // within the process.
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    tokio::fs::create_dir_all(spill_root).await?;
+    let safe_tool = sanitize_filename_component(tool_name.0.as_str());
+    let safe_call = sanitize_filename_component(&call_id.0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = spill_root.join(format!("{safe_tool}-{safe_call}-{n}.{ext}"));
+    tokio::fs::write(&path, body).await?;
+    Ok(path)
+}
+
+fn sanitize_filename_component(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(64)
+        .collect();
+    if cleaned.is_empty() {
+        "_".into()
+    } else {
+        cleaned
+    }
+}
+
+/// Fallback when the disk spill fails. Drops the tail of the body so the
+/// provider still receives a sub-cap result. The marker — either an inline
+/// `…[truncated N bytes]` for text or a `{truncated, kept_bytes, content}`
+/// envelope for JSON — tells the model the content is incomplete.
+fn clip_inline(body: String, ext: &str, max_bytes: usize, original_bytes: usize) -> ToolOutput {
+    let cut = body.floor_char_boundary(max_bytes);
+    if ext == "txt" {
+        let dropped = body.len() - cut;
+        ToolOutput::Text(format!("{}…[truncated {dropped} bytes]", &body[..cut]))
+    } else {
+        ToolOutput::Structured(json!({
+            "truncated": true,
+            "original_bytes": original_bytes,
+            "kept_bytes": cut,
+            "content": &body[..cut],
+        }))
+    }
 }
 
 #[cfg(test)]
@@ -121,44 +232,173 @@ mod tests {
     use agentkit_core::{Part, TextPart};
     use serde_json::{Value, json};
 
-    #[test]
-    fn text_under_limit_passes_through() {
-        let out = clip_output(ToolOutput::text("hello"), 100);
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    fn tool_name(s: &str) -> ToolName {
+        ToolName::new(s)
+    }
+    fn call_id(s: &str) -> ToolCallId {
+        ToolCallId::new(s)
+    }
+
+    #[tokio::test]
+    async fn text_under_limit_passes_through() {
+        let dir = tempdir();
+        let out = cap_output(
+            ToolOutput::text("hello"),
+            100,
+            dir.path(),
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
         match out {
             ToolOutput::Text(s) => assert_eq!(s, "hello"),
             other => panic!("expected Text, got {other:?}"),
         }
     }
 
-    #[test]
-    fn text_at_exact_limit_passes_through() {
-        let body = "a".repeat(100);
-        let out = clip_output(ToolOutput::text(body.clone()), 100);
+    #[tokio::test]
+    async fn text_over_limit_spills_to_file() {
+        let dir = tempdir();
+        let body = "a".repeat(500);
+        let out = cap_output(
+            ToolOutput::text(body.clone()),
+            100,
+            dir.path(),
+            &tool_name("my_tool"),
+            &call_id("call_abc"),
+        )
+        .await;
+        let map = match out {
+            ToolOutput::Structured(Value::Object(map)) => map,
+            other => panic!("expected envelope, got {other:?}"),
+        };
+        assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+        assert_eq!(
+            map.get("original_bytes").and_then(Value::as_u64),
+            Some(500)
+        );
+        let saved_to = map
+            .get("saved_to")
+            .and_then(Value::as_str)
+            .expect("saved_to");
+        let saved_path = Path::new(saved_to);
+        assert!(saved_path.starts_with(dir.path()));
+        let on_disk = std::fs::read_to_string(saved_path).expect("read spill");
+        assert_eq!(on_disk, body);
+    }
+
+    #[tokio::test]
+    async fn structured_over_limit_spills_pretty_json() {
+        let dir = tempdir();
+        let value = json!({"items": vec!["x"; 500]});
+        let input = ToolOutput::Structured(value.clone());
+        let original = serde_json::to_string(&input).unwrap().len();
+        let out = cap_output(input, 200, dir.path(), &tool_name("t"), &call_id("c")).await;
+        let map = match out {
+            ToolOutput::Structured(Value::Object(map)) => map,
+            other => panic!("expected envelope, got {other:?}"),
+        };
+        assert_eq!(
+            map.get("original_bytes").and_then(Value::as_u64),
+            Some(original as u64)
+        );
+        let saved_to = map
+            .get("saved_to")
+            .and_then(Value::as_str)
+            .expect("saved_to");
+        assert!(saved_to.ends_with(".json"));
+        let on_disk = std::fs::read_to_string(saved_to).expect("read spill");
+        let parsed: Value = serde_json::from_str(&on_disk).expect("disk file is valid JSON");
+        assert_eq!(parsed, value);
+        assert!(
+            on_disk.contains('\n'),
+            "spilled JSON should be pretty-printed for grep/read"
+        );
+    }
+
+    #[tokio::test]
+    async fn parts_over_limit_spills() {
+        let dir = tempdir();
+        let body = "x".repeat(500);
+        let parts = vec![Part::Text(TextPart::new(body))];
+        let out = cap_output(
+            ToolOutput::Parts(parts),
+            100,
+            dir.path(),
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
         match out {
-            ToolOutput::Text(s) => assert_eq!(s, body),
-            other => panic!("expected Text, got {other:?}"),
+            ToolOutput::Structured(Value::Object(map)) => {
+                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+                assert!(map.get("saved_to").is_some());
+            }
+            other => panic!("expected envelope, got {other:?}"),
         }
     }
 
+    #[tokio::test]
+    async fn spill_failure_falls_back_to_inline_clip() {
+        // Make spill_root a path under a regular file — create_dir_all will
+        // bail with NotADirectory, exercising the fallback branch.
+        let dir = tempdir();
+        let blocking = dir.path().join("not-a-dir");
+        std::fs::write(&blocking, b"x").expect("write blocker");
+        let unreachable_root = blocking.join("spill");
+
+        let body = "a".repeat(500);
+        let out = cap_output(
+            ToolOutput::text(body),
+            100,
+            &unreachable_root,
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
+        let s = match out {
+            ToolOutput::Text(s) => s,
+            other => panic!("expected Text fallback, got {other:?}"),
+        };
+        assert!(s.contains("truncated"), "marker present: {s}");
+        assert!(s.len() < 500, "tail dropped");
+    }
+
     #[test]
-    fn text_over_limit_is_clipped_with_marker() {
-        let body = "a".repeat(200);
-        let out = clip_output(ToolOutput::text(body), 100);
+    fn sanitize_replaces_path_separators_and_caps_length() {
+        let dirty = "tool/../../etc/passwd";
+        let safe = sanitize_filename_component(dirty);
+        assert!(!safe.contains('/'));
+        assert!(!safe.contains('.'));
+
+        let long = "x".repeat(1000);
+        let safe_long = sanitize_filename_component(&long);
+        assert_eq!(safe_long.len(), 64);
+
+        assert_eq!(sanitize_filename_component(""), "_");
+    }
+
+    #[test]
+    fn clip_inline_text_appends_marker() {
+        let out = clip_inline("a".repeat(200), "txt", 100, 200);
         match out {
             ToolOutput::Text(s) => {
-                assert!(s.starts_with(&"a".repeat(100)), "kept prefix");
-                assert!(s.contains("truncated 100 bytes"), "marker present: {s}");
+                assert!(s.starts_with(&"a".repeat(100)));
+                assert!(s.contains("truncated 100 bytes"));
             }
             other => panic!("expected Text, got {other:?}"),
         }
     }
 
     #[test]
-    fn text_clip_respects_utf8_boundary() {
-        // 50 × "é" = 100 bytes total. Cut at byte 75 sits inside a 2-byte
-        // codepoint; floor_char_boundary must walk back to 74.
-        let body = "é".repeat(50);
-        let out = clip_output(ToolOutput::text(body), 75);
+    fn clip_inline_text_respects_utf8_boundary() {
+        // 50 × "é" = 100 bytes. Cut at byte 75 sits inside a 2-byte codepoint;
+        // floor_char_boundary must walk back to 74.
+        let out = clip_inline("é".repeat(50), "txt", 75, 100);
         match out {
             ToolOutput::Text(s) => {
                 let prefix = s.split('…').next().unwrap();
@@ -166,53 +406,6 @@ mod tests {
                 assert!(prefix.len() <= 75);
             }
             other => panic!("expected Text, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn structured_under_limit_passes_through() {
-        let value = json!({"k": "v"});
-        let out = clip_output(ToolOutput::Structured(value.clone()), 1000);
-        match out {
-            ToolOutput::Structured(got) => assert_eq!(got, value),
-            other => panic!("expected Structured, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn structured_over_limit_is_wrapped() {
-        let big = "x".repeat(500);
-        let value = json!({"payload": big});
-        let input = ToolOutput::Structured(value);
-        let serialized_len = serde_json::to_string(&input).unwrap().len();
-        let out = clip_output(input, 200);
-        match out {
-            ToolOutput::Structured(Value::Object(map)) => {
-                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
-                let original = map
-                    .get("original_bytes")
-                    .and_then(Value::as_u64)
-                    .expect("original_bytes");
-                let kept = map.get("kept_bytes").and_then(Value::as_u64).expect("kept");
-                assert_eq!(original as usize, serialized_len);
-                assert!(kept <= 200);
-                assert!(map.get("content").and_then(Value::as_str).is_some());
-            }
-            other => panic!("expected Structured object, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parts_over_limit_falls_back_to_truncation_envelope() {
-        let big = "x".repeat(500);
-        let parts = vec![Part::Text(TextPart::new(big))];
-        let out = clip_output(ToolOutput::Parts(parts), 100);
-        match out {
-            ToolOutput::Structured(Value::Object(map)) => {
-                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
-                assert!(map.get("original_bytes").is_some());
-            }
-            other => panic!("expected truncation envelope, got {other:?}"),
         }
     }
 }

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -7,13 +7,17 @@
 //! Even when it does fire, [`SummarizeOlderStrategy`](agentkit_compaction)
 //! preserves the most recent items, so the offending tool result survives.
 //!
-//! When a tool result exceeds [`MAX_TOOL_BYTES`], the full body is written
-//! to a file inside the assistant workdir — where the agent's filesystem
-//! tools can read or grep it — and the in-band result is replaced with a
-//! small envelope pointing at that file. No information is lost; the model
-//! follows up by reading the saved file. If the spill itself fails (disk
-//! full, permission denied), the body is clipped in place with a marker so
-//! the provider still gets a valid, sub-cap result.
+//! When a tool result exceeds [`MAX_TOOL_BYTES`], the runner replaces it
+//! with a Structured envelope that always carries a truncated `preview` of
+//! the body (sized so the envelope itself fits under the cap). It also
+//! best-effort spills the leading bytes of the body to a file inside the
+//! assistant workdir so the agent can read or grep the full prefix via
+//! filesystem tools in the same session; the envelope surfaces that path
+//! via `saved_to` when the spill succeeds. The inline preview is what
+//! makes the envelope resumable: each runtime boot copies a fresh workdir,
+//! so any `saved_to` path stored in chat history won't exist after a
+//! restart — but the preview is captured in the transcript and replays
+//! intact.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -25,7 +29,7 @@ use agentkit_tools_core::{
     ToolResult, ToolSource, ToolSpec,
 };
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::Value;
 
 /// 150 KB. Leaves ~50 KB headroom under OpenRouter's 204800-byte per-message
 /// cap to absorb provider-side JSON envelope overhead (call id, metadata,
@@ -135,22 +139,27 @@ async fn cap_output(
         return output;
     }
     let (body, ext) = consume_for_spill(output);
-    match write_spill(spill_root, tool_name, call_id, &body, ext, MAX_SPILL_BYTES).await {
-        Ok((path, saved_bytes)) => ToolOutput::Structured(json!({
-            "truncated": true,
-            "saved_to": path.display().to_string(),
-            "original_bytes": model_bytes,
-            "saved_bytes": saved_bytes,
-        })),
+    let spill = match write_spill(
+        spill_root,
+        tool_name,
+        call_id,
+        &body,
+        ext,
+        MAX_SPILL_BYTES,
+    )
+    .await
+    {
+        Ok(info) => Some(info),
         Err(error) => {
             tracing::warn!(
                 error = %error,
                 spill_root = %spill_root.display(),
-                "spill of oversized tool result failed; clipping inline as fallback",
+                "spill of oversized tool result failed; emitting inline preview only",
             );
-            clip_inline(body, ext, max_bytes, model_bytes)
+            None
         }
-    }
+    };
+    build_truncation_envelope(&body, ext, max_bytes, model_bytes, spill.as_ref())
 }
 
 /// JSON-encoded byte size of the *content* the provider adapter sends as
@@ -227,17 +236,23 @@ fn sanitize_filename_component(s: &str) -> String {
     }
 }
 
-/// Fallback when the disk spill fails. Drops the tail of the body so the
-/// provider still receives a sub-cap result. Must measure the *encoded*
-/// size of the candidate output — cutting by raw bytes underweights escape
-/// overhead for quote/backslash-heavy bodies, and would recreate the 413
-/// the spill was meant to avoid. Shrinks iteratively until the encoded
-/// candidate fits under `max_bytes`.
-fn clip_inline(body: String, ext: &str, max_bytes: usize, original_bytes: usize) -> ToolOutput {
+/// Builds the truncation envelope that always replaces an oversized tool
+/// result. Must measure the *encoded* size of the candidate — cutting by raw
+/// bytes underweights escape overhead for quote/backslash-heavy bodies and
+/// would recreate the 413 this is meant to avoid. Shrinks the preview
+/// iteratively until the envelope fits under `max_bytes`.
+fn build_truncation_envelope(
+    body: &str,
+    ext: &str,
+    max_bytes: usize,
+    original_bytes: usize,
+    spill: Option<&(PathBuf, usize)>,
+) -> ToolOutput {
     const ITERATIONS: usize = 8;
+    let format = if ext == "txt" { "text" } else { "json" };
     let mut cut = body.floor_char_boundary(body.len().min(max_bytes));
     for _ in 0..ITERATIONS {
-        let candidate = build_clipped(&body, cut, ext, original_bytes);
+        let candidate = compose_envelope(body, cut, format, original_bytes, spill);
         let encoded = model_bytes(&candidate).unwrap_or(usize::MAX);
         if encoded <= max_bytes {
             return candidate;
@@ -248,28 +263,37 @@ fn clip_inline(body: String, ext: &str, max_bytes: usize, original_bytes: usize)
         let shrunk = (cut as f64 * (max_bytes as f64 / encoded as f64) * 0.9) as usize;
         cut = body.floor_char_boundary(shrunk.min(cut.saturating_sub(1)));
     }
-    build_clipped(&body, 0, ext, original_bytes)
+    compose_envelope(body, 0, format, original_bytes, spill)
 }
 
-fn build_clipped(body: &str, cut: usize, ext: &str, original_bytes: usize) -> ToolOutput {
-    if ext == "txt" {
-        let dropped = body.len() - cut;
-        ToolOutput::Text(format!("{}…[truncated {dropped} bytes]", &body[..cut]))
-    } else {
-        ToolOutput::Structured(json!({
-            "truncated": true,
-            "original_bytes": original_bytes,
-            "kept_bytes": cut,
-            "content": &body[..cut],
-        }))
+fn compose_envelope(
+    body: &str,
+    cut: usize,
+    format: &str,
+    original_bytes: usize,
+    spill: Option<&(PathBuf, usize)>,
+) -> ToolOutput {
+    let mut env = serde_json::Map::new();
+    env.insert("truncated".into(), Value::Bool(true));
+    env.insert("original_bytes".into(), Value::from(original_bytes));
+    env.insert("format".into(), Value::String(format.into()));
+    env.insert("preview_bytes".into(), Value::from(cut));
+    env.insert("preview".into(), Value::String(body[..cut].into()));
+    if let Some((path, saved_bytes)) = spill {
+        env.insert(
+            "saved_to".into(),
+            Value::String(path.display().to_string()),
+        );
+        env.insert("saved_bytes".into(), Value::from(*saved_bytes));
     }
+    ToolOutput::Structured(Value::Object(env))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use agentkit_core::{Part, TextPart};
-    use serde_json::{Value, json};
+    use serde_json::json;
 
     fn tempdir() -> tempfile::TempDir {
         tempfile::tempdir().expect("tempdir")
@@ -282,8 +306,15 @@ mod tests {
         ToolCallId::new(s)
     }
 
+    fn expect_envelope(out: &ToolOutput) -> &serde_json::Map<String, Value> {
+        match out {
+            ToolOutput::Structured(Value::Object(map)) => map,
+            other => panic!("expected envelope, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
-    async fn text_under_limit_passes_through() {
+    async fn under_limit_output_passes_through_unchanged() {
         let dir = tempdir();
         let out = cap_output(
             ToolOutput::text("hello"),
@@ -295,12 +326,12 @@ mod tests {
         .await;
         match out {
             ToolOutput::Text(s) => assert_eq!(s, "hello"),
-            other => panic!("expected Text, got {other:?}"),
+            other => panic!("expected Text passthrough, got {other:?}"),
         }
     }
 
     #[tokio::test]
-    async fn text_over_limit_spills_to_file() {
+    async fn text_over_limit_envelope_carries_preview_and_spill_pointer() {
         let dir = tempdir();
         let body = "a".repeat(500);
         let out = cap_output(
@@ -311,29 +342,94 @@ mod tests {
             &call_id("call_abc"),
         )
         .await;
-        let map = match out {
-            ToolOutput::Structured(Value::Object(map)) => map,
-            other => panic!("expected envelope, got {other:?}"),
-        };
+        let map = expect_envelope(&out);
+
         assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
-        // 500 plain `a` bytes encode to `"aaa..."` = 502 bytes after the
-        // surrounding quote literals (no escapes needed).
+        assert_eq!(map.get("format").and_then(Value::as_str), Some("text"));
+        // 500 plain `a` bytes encode to `"aaa..."` = 502 bytes including the
+        // surrounding quote literals.
         assert_eq!(
             map.get("original_bytes").and_then(Value::as_u64),
             Some(502)
         );
+
+        let preview = map.get("preview").and_then(Value::as_str).expect("preview");
+        assert!(preview.chars().all(|c| c == 'a'));
+        assert!(body.starts_with(preview));
+        assert_eq!(
+            map.get("preview_bytes").and_then(Value::as_u64),
+            Some(preview.len() as u64)
+        );
+
         let saved_to = map
             .get("saved_to")
             .and_then(Value::as_str)
             .expect("saved_to");
         let saved_path = Path::new(saved_to);
         assert!(saved_path.starts_with(dir.path()));
-        let on_disk = std::fs::read_to_string(saved_path).expect("read spill");
-        assert_eq!(on_disk, body);
+        assert_eq!(std::fs::read_to_string(saved_path).unwrap(), body);
+        assert_eq!(
+            map.get("saved_bytes").and_then(Value::as_u64),
+            Some(body.len() as u64)
+        );
     }
 
     #[tokio::test]
-    async fn structured_over_limit_spills_pretty_json() {
+    async fn envelope_fits_under_cap_for_quote_heavy_text() {
+        // 5000 `"` chars encode to ~10 000 bytes after JSON escaping. The
+        // envelope must iterate its preview cut so the encoded form still
+        // fits — production caps are large enough that the envelope's fixed
+        // overhead is negligible, so 1024 mirrors that property.
+        let dir = tempdir();
+        let cap = 1024;
+        let out = cap_output(
+            ToolOutput::text("\"".repeat(5000)),
+            cap,
+            dir.path(),
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
+        let encoded = model_bytes(&out).expect("model_bytes");
+        assert!(
+            encoded <= cap,
+            "envelope encoded size {encoded} <= cap {cap}"
+        );
+        let map = expect_envelope(&out);
+        let preview = map.get("preview").and_then(Value::as_str).expect("preview");
+        assert!(preview.chars().all(|c| c == '"'));
+    }
+
+    #[tokio::test]
+    async fn spill_failure_still_emits_preview_envelope() {
+        // Spill_root under a regular file → create_dir_all fails with
+        // NotADirectory → envelope must still carry preview/original_bytes
+        // without saved_to.
+        let dir = tempdir();
+        let blocking = dir.path().join("not-a-dir");
+        std::fs::write(&blocking, b"x").expect("write blocker");
+        let unreachable_root = blocking.join("spill");
+
+        let out = cap_output(
+            ToolOutput::text("a".repeat(500)),
+            100,
+            &unreachable_root,
+            &tool_name("t"),
+            &call_id("c"),
+        )
+        .await;
+        assert!(model_bytes(&out).unwrap() <= 100);
+        let map = expect_envelope(&out);
+        assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+        assert!(map.get("preview").and_then(Value::as_str).is_some());
+        assert!(
+            map.get("saved_to").is_none(),
+            "no saved_to when spill failed",
+        );
+    }
+
+    #[tokio::test]
+    async fn structured_over_limit_spills_pretty_json_on_disk() {
         let dir = tempdir();
         let value = json!({"items": vec!["x"; 500]});
         let original = serde_json::to_string(&value).unwrap().len();
@@ -345,10 +441,8 @@ mod tests {
             &call_id("c"),
         )
         .await;
-        let map = match out {
-            ToolOutput::Structured(Value::Object(map)) => map,
-            other => panic!("expected envelope, got {other:?}"),
-        };
+        let map = expect_envelope(&out);
+        assert_eq!(map.get("format").and_then(Value::as_str), Some("json"));
         assert_eq!(
             map.get("original_bytes").and_then(Value::as_u64),
             Some(original as u64)
@@ -363,35 +457,26 @@ mod tests {
         assert_eq!(parsed, value);
         assert!(
             on_disk.contains('\n'),
-            "spilled JSON should be pretty-printed for grep/read"
+            "spilled JSON pretty-printed for grep/read"
         );
     }
 
     #[tokio::test]
-    async fn quote_heavy_text_spills_even_when_raw_len_fits() {
-        // 100 raw `"` bytes encode to 200 bytes (`\"` for each) plus the
-        // surrounding `"…"` literal. With a 150-byte cap the raw length is
-        // under the limit but the JSON-encoded form is not — the spill must
-        // still fire.
+    async fn parts_over_limit_yields_envelope() {
         let dir = tempdir();
-        let body = "\"".repeat(100);
-        assert!(body.len() < 150);
+        let parts = vec![Part::Text(TextPart::new("x".repeat(500)))];
         let out = cap_output(
-            ToolOutput::text(body.clone()),
-            150,
+            ToolOutput::Parts(parts),
+            100,
             dir.path(),
             &tool_name("t"),
             &call_id("c"),
         )
         .await;
-        match out {
-            ToolOutput::Structured(Value::Object(map)) => {
-                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
-                let saved_to = map.get("saved_to").and_then(Value::as_str).unwrap();
-                assert_eq!(std::fs::read_to_string(saved_to).unwrap(), body);
-            }
-            other => panic!("expected spill envelope, got {other:?}"),
-        }
+        let map = expect_envelope(&out);
+        assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
+        assert!(map.get("preview").is_some());
+        assert!(map.get("saved_to").is_some());
     }
 
     #[tokio::test]
@@ -403,128 +488,15 @@ mod tests {
                 .await
                 .expect("write");
         assert_eq!(saved, 200);
-        let on_disk = std::fs::read(&path).expect("read");
-        assert_eq!(on_disk.len(), 200);
-    }
-
-    #[tokio::test]
-    async fn parts_over_limit_spills() {
-        let dir = tempdir();
-        let body = "x".repeat(500);
-        let parts = vec![Part::Text(TextPart::new(body))];
-        let out = cap_output(
-            ToolOutput::Parts(parts),
-            100,
-            dir.path(),
-            &tool_name("t"),
-            &call_id("c"),
-        )
-        .await;
-        match out {
-            ToolOutput::Structured(Value::Object(map)) => {
-                assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
-                assert!(map.get("saved_to").is_some());
-            }
-            other => panic!("expected envelope, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn spill_failure_falls_back_to_inline_clip() {
-        // Make spill_root a path under a regular file — create_dir_all will
-        // bail with NotADirectory, exercising the fallback branch.
-        let dir = tempdir();
-        let blocking = dir.path().join("not-a-dir");
-        std::fs::write(&blocking, b"x").expect("write blocker");
-        let unreachable_root = blocking.join("spill");
-
-        let body = "a".repeat(500);
-        let out = cap_output(
-            ToolOutput::text(body),
-            100,
-            &unreachable_root,
-            &tool_name("t"),
-            &call_id("c"),
-        )
-        .await;
-        let s = match out {
-            ToolOutput::Text(s) => s,
-            other => panic!("expected Text fallback, got {other:?}"),
-        };
-        assert!(s.contains("truncated"), "marker present: {s}");
-        assert!(s.len() < 500, "tail dropped");
+        assert_eq!(std::fs::read(&path).unwrap().len(), 200);
     }
 
     #[test]
     fn sanitize_replaces_path_separators_and_caps_length() {
-        let dirty = "tool/../../etc/passwd";
-        let safe = sanitize_filename_component(dirty);
+        let safe = sanitize_filename_component("tool/../../etc/passwd");
         assert!(!safe.contains('/'));
         assert!(!safe.contains('.'));
-
-        let long = "x".repeat(1000);
-        let safe_long = sanitize_filename_component(&long);
-        assert_eq!(safe_long.len(), 64);
-
+        assert_eq!(sanitize_filename_component(&"x".repeat(1000)).len(), 64);
         assert_eq!(sanitize_filename_component(""), "_");
-    }
-
-    #[tokio::test]
-    async fn fallback_clip_respects_encoded_size_for_quote_heavy_text() {
-        // 500 `"` chars encode to ~1000 bytes after JSON escaping. With a
-        // 150-byte cap and the spill path unreachable, the inline fallback
-        // must shrink the raw cut so the encoded ToolOutput still fits —
-        // otherwise it recreates the very 413 the spill was meant to avoid.
-        let dir = tempdir();
-        let blocking = dir.path().join("not-a-dir");
-        std::fs::write(&blocking, b"x").expect("write blocker");
-        let unreachable_root = blocking.join("spill");
-
-        let out = cap_output(
-            ToolOutput::text("\"".repeat(500)),
-            150,
-            &unreachable_root,
-            &tool_name("t"),
-            &call_id("c"),
-        )
-        .await;
-        let encoded = model_bytes(&out).expect("model_bytes");
-        assert!(
-            encoded <= 150,
-            "fallback encoded size {encoded} must fit under cap 150"
-        );
-        match out {
-            ToolOutput::Text(s) => assert!(s.contains("truncated"), "marker present: {s}"),
-            other => panic!("expected Text fallback, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn clip_inline_text_appends_marker_and_stays_under_cap() {
-        let out = clip_inline("a".repeat(200), "txt", 100, 200);
-        let encoded = model_bytes(&out).expect("encode");
-        assert!(encoded <= 100, "encoded {encoded} under cap 100");
-        match out {
-            ToolOutput::Text(s) => {
-                assert!(s.contains("truncated"), "marker present: {s}");
-                assert!(s.starts_with('a'), "kept prefix is original content");
-            }
-            other => panic!("expected Text, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn clip_inline_text_respects_utf8_boundary() {
-        // 50 × "é" = 100 bytes. The clipper hops back from any cut point that
-        // would split a 2-byte codepoint.
-        let out = clip_inline("é".repeat(50), "txt", 75, 100);
-        match out {
-            ToolOutput::Text(s) => {
-                let prefix = s.split('…').next().unwrap();
-                assert!(prefix.chars().all(|c| c == 'é'));
-                assert!(prefix.len() <= 75);
-            }
-            other => panic!("expected Text, got {other:?}"),
-        }
     }
 }

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -32,6 +32,14 @@ use serde_json::json;
 /// content-type discriminators).
 pub const MAX_TOOL_BYTES: usize = 150_000;
 
+/// 4 MiB. The assistant workdir is a fixed 256 MiB ext4 image
+/// (`agents/runtime-image/Dockerfile`), shared with `bun_run` temp files and
+/// any artifacts the agent writes itself. Bounding each spill keeps a single
+/// runaway MCP response from filling the image and breaking subsequent
+/// filesystem-tool / `bun_run` / spill calls. Truncated spills still carry
+/// the leading body — enough for the agent to inspect with `head`/`grep`.
+pub const MAX_SPILL_BYTES: usize = 4 * 1024 * 1024;
+
 /// Wraps a [`ToolSource`] so every tool result either fits under
 /// [`MAX_TOOL_BYTES`] or is spilled to a file under `spill_root` and replaced
 /// with a small in-band pointer.
@@ -127,11 +135,12 @@ async fn cap_output(
         return output;
     }
     let (body, ext) = consume_for_spill(output);
-    match write_spill(spill_root, tool_name, call_id, &body, ext).await {
-        Ok(path) => ToolOutput::Structured(json!({
+    match write_spill(spill_root, tool_name, call_id, &body, ext, MAX_SPILL_BYTES).await {
+        Ok((path, saved_bytes)) => ToolOutput::Structured(json!({
             "truncated": true,
             "saved_to": path.display().to_string(),
             "original_bytes": model_bytes,
+            "saved_bytes": saved_bytes,
         })),
         Err(error) => {
             tracing::warn!(
@@ -177,7 +186,8 @@ async fn write_spill(
     call_id: &ToolCallId,
     body: &str,
     ext: &str,
-) -> std::io::Result<PathBuf> {
+    max_spill_bytes: usize,
+) -> std::io::Result<(PathBuf, usize)> {
     // Belt-and-suspenders against duplicate (tool_name, call_id) pairs across
     // a retry storm or a misbehaving provider — disambiguates atomically
     // within the process.
@@ -187,13 +197,15 @@ async fn write_spill(
     let safe_call = sanitize_filename_component(&call_id.0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     let path = spill_root.join(format!("{safe_tool}-{safe_call}-{n}.{ext}"));
-    if let Err(error) = tokio::fs::write(&path, body).await {
+    let to_write_end = body.floor_char_boundary(body.len().min(max_spill_bytes));
+    let to_write = &body[..to_write_end];
+    if let Err(error) = tokio::fs::write(&path, to_write).await {
         // Best-effort cleanup so a partial ENOSPC write doesn't accumulate
         // and choke the workdir's fixed disk cap on subsequent calls.
         let _ = tokio::fs::remove_file(&path).await;
         return Err(error);
     }
-    Ok(path)
+    Ok((path, to_write.len()))
 }
 
 fn sanitize_filename_component(s: &str) -> String {
@@ -380,6 +392,19 @@ mod tests {
             }
             other => panic!("expected spill envelope, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn write_spill_truncates_body_to_max_spill_bytes() {
+        let dir = tempdir();
+        let body = "a".repeat(1000);
+        let (path, saved) =
+            write_spill(dir.path(), &tool_name("t"), &call_id("c"), &body, "txt", 200)
+                .await
+                .expect("write");
+        assert_eq!(saved, 200);
+        let on_disk = std::fs::read(&path).expect("read");
+        assert_eq!(on_disk.len(), 200);
     }
 
     #[tokio::test]

--- a/agents/runner/src/clip.rs
+++ b/agents/runner/src/clip.rs
@@ -162,18 +162,27 @@ async fn cap_output(
     build_truncation_envelope(&body, ext, max_bytes, model_bytes, spill.as_ref())
 }
 
-/// JSON-encoded byte size of the *content* the provider adapter sends as
-/// the tool message body. For `Text`, this is `"…"` after escaping — counting
-/// raw `s.len()` would undercount escape overhead, so a quote-heavy 150 KB
-/// blob could be ~300 KB on the wire and still 413 the provider. Returns
-/// `None` only if serialization itself fails — in that case the cap can't
-/// be enforced and the output is returned untouched.
+/// JSON-encoded byte size of the *content* string that
+/// `agentkit_adapter_completions` will ship as the tool message's `content`
+/// field on the wire. The adapter flattens every variant into a single
+/// `String` (text as-is, JSON variants via `value.to_string()` /
+/// `serde_json::to_string(parts/files)`) and then puts that string in the
+/// message envelope, where it gets JSON-encoded again. Measuring against
+/// the doubly-escaped form is what catches non-Text overflow — compact JSON
+/// full of `"` is ~2× when re-encoded as a string literal. Returns `None`
+/// only if serialization fails; the cap can't be enforced and the output
+/// is returned untouched.
 fn model_bytes(output: &ToolOutput) -> Option<usize> {
+    let content = adapter_content(output)?;
+    serde_json::to_string(&content).ok().map(|s| s.len())
+}
+
+fn adapter_content(output: &ToolOutput) -> Option<String> {
     match output {
-        ToolOutput::Text(s) => serde_json::to_string(s).ok().map(|j| j.len()),
-        ToolOutput::Structured(v) => serde_json::to_string(v).ok().map(|j| j.len()),
-        ToolOutput::Parts(p) => serde_json::to_string(p).ok().map(|j| j.len()),
-        ToolOutput::Files(f) => serde_json::to_string(f).ok().map(|j| j.len()),
+        ToolOutput::Text(s) => Some(s.clone()),
+        ToolOutput::Structured(v) => Some(v.to_string()),
+        ToolOutput::Parts(p) => serde_json::to_string(p).ok(),
+        ToolOutput::Files(f) => serde_json::to_string(f).ok(),
     }
 }
 
@@ -333,24 +342,24 @@ mod tests {
     #[tokio::test]
     async fn text_over_limit_envelope_carries_preview_and_spill_pointer() {
         let dir = tempdir();
-        let body = "a".repeat(500);
+        let cap = 1024;
+        let body = "a".repeat(5000);
         let out = cap_output(
             ToolOutput::text(body.clone()),
-            100,
+            cap,
             dir.path(),
             &tool_name("my_tool"),
             &call_id("call_abc"),
         )
         .await;
+        assert!(model_bytes(&out).unwrap() <= cap);
         let map = expect_envelope(&out);
 
         assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
         assert_eq!(map.get("format").and_then(Value::as_str), Some("text"));
-        // 500 plain `a` bytes encode to `"aaa..."` = 502 bytes including the
-        // surrounding quote literals.
         assert_eq!(
             map.get("original_bytes").and_then(Value::as_u64),
-            Some(502)
+            Some(5002)
         );
 
         let preview = map.get("preview").and_then(Value::as_str).expect("preview");
@@ -410,15 +419,16 @@ mod tests {
         std::fs::write(&blocking, b"x").expect("write blocker");
         let unreachable_root = blocking.join("spill");
 
+        let cap = 1024;
         let out = cap_output(
-            ToolOutput::text("a".repeat(500)),
-            100,
+            ToolOutput::text("a".repeat(5000)),
+            cap,
             &unreachable_root,
             &tool_name("t"),
             &call_id("c"),
         )
         .await;
-        assert!(model_bytes(&out).unwrap() <= 100);
+        assert!(model_bytes(&out).unwrap() <= cap);
         let map = expect_envelope(&out);
         assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
         assert!(map.get("preview").and_then(Value::as_str).is_some());
@@ -432,15 +442,18 @@ mod tests {
     async fn structured_over_limit_spills_pretty_json_on_disk() {
         let dir = tempdir();
         let value = json!({"items": vec!["x"; 500]});
-        let original = serde_json::to_string(&value).unwrap().len();
+        let content = value.to_string();
+        let original = serde_json::to_string(&content).unwrap().len();
+        let cap = 1024;
         let out = cap_output(
             ToolOutput::Structured(value.clone()),
-            200,
+            cap,
             dir.path(),
             &tool_name("t"),
             &call_id("c"),
         )
         .await;
+        assert!(model_bytes(&out).unwrap() <= cap);
         let map = expect_envelope(&out);
         assert_eq!(map.get("format").and_then(Value::as_str), Some("json"));
         assert_eq!(
@@ -464,15 +477,17 @@ mod tests {
     #[tokio::test]
     async fn parts_over_limit_yields_envelope() {
         let dir = tempdir();
-        let parts = vec![Part::Text(TextPart::new("x".repeat(500)))];
+        let cap = 1024;
+        let parts = vec![Part::Text(TextPart::new("x".repeat(5000)))];
         let out = cap_output(
             ToolOutput::Parts(parts),
-            100,
+            cap,
             dir.path(),
             &tool_name("t"),
             &call_id("c"),
         )
         .await;
+        assert!(model_bytes(&out).unwrap() <= cap);
         let map = expect_envelope(&out);
         assert_eq!(map.get("truncated"), Some(&Value::Bool(true)));
         assert!(map.get("preview").is_some());

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -1,3 +1,4 @@
+mod clip;
 mod compaction;
 mod errors;
 mod http_layer;

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -23,6 +23,8 @@ use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
 
 use agentkit_compaction::AgentBuilderCompactorExt;
 
+use std::path::PathBuf;
+
 use crate::clip::ClippedToolSource;
 use crate::compaction::build_compactor;
 use crate::errors::RunnerError;
@@ -31,6 +33,11 @@ use crate::idempotency::IdempotencyCache;
 use crate::tools;
 use crate::wire::{McpServer, RunnerConfig, RunnerMessage, RunnerRequest};
 use crate::workdir::ASSISTANT_WORKDIR;
+
+/// Subdirectory under [`ASSISTANT_WORKDIR`] where oversized tool results spill
+/// to disk. Lives inside the workdir so the agent's filesystem tools can read
+/// or grep the spilled files when the in-band pointer references them.
+const TOOL_RESULT_SPILL_DIR: &str = "tool-results";
 
 const MCP_CMD_CAPACITY: usize = 32;
 
@@ -155,7 +162,8 @@ pub async fn build_runtime(
         mcp_server_ids.push(server.id.clone());
         manager.register_server(build_mcp_server_config(server, &http_client, &tokens)?);
     }
-    let mcp_source = ClippedToolSource::new(manager.source());
+    let spill_root = PathBuf::from(ASSISTANT_WORKDIR).join(TOOL_RESULT_SPILL_DIR);
+    let mcp_source = ClippedToolSource::new(manager.source(), spill_root);
 
     let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::channel(MCP_CMD_CAPACITY);
     let (mcp_ready_tx, mcp_ready_rx) = oneshot::channel::<()>();

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -23,6 +23,7 @@ use tokio::sync::{Mutex as AsyncMutex, Notify, oneshot};
 
 use agentkit_compaction::AgentBuilderCompactorExt;
 
+use crate::clip::ClippedToolSource;
 use crate::compaction::build_compactor;
 use crate::errors::RunnerError;
 use crate::http_layer::{McpRotatingClient, TokenRegistry, build_http};
@@ -154,7 +155,7 @@ pub async fn build_runtime(
         mcp_server_ids.push(server.id.clone());
         manager.register_server(build_mcp_server_config(server, &http_client, &tokens)?);
     }
-    let mcp_source = manager.source();
+    let mcp_source = ClippedToolSource::new(manager.source());
 
     let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::channel(MCP_CMD_CAPACITY);
     let (mcp_ready_tx, mcp_ready_rx) = oneshot::channel::<()>();


### PR DESCRIPTION
## Summary

- OpenRouter caps a single tool message at 204800 bytes and 413s the next request when a tool result exceeds it. Token-aware compaction can't catch this: the trigger reads `usage.input_tokens` after the previous turn (200 KB ≈ 50 K tokens, well below the 80% threshold for a 128 K+ window), and even when it fires `SummarizeOlderStrategy` preserves the most recent items so the offending result survives.
- Wrap the MCP catalog reader with `ClippedToolSource`. When a tool result exceeds 150 KB, replace it with a Structured envelope that **always** carries an inline `preview` sized so the encoded envelope fits under the cap — that's what survives in chat history across runtime restarts. Best-effort spill of the body prefix (up to 4 MiB) to `<assistant-workdir>/tool-results/<tool>-<call>-<n>.{txt,json}`; envelope surfaces `saved_to` and `saved_bytes` when the spill succeeds so the agent can read or grep the full prefix via filesystem tools in the same session.
- Per-result spill cap (`MAX_SPILL_BYTES = 4 MiB`) keeps a runaway MCP response from filling the workdir's 256 MiB image and breaking subsequent fs-tool / `bun_run` / spill calls.
- Encoded-byte measurement: `model_bytes` serializes each variant before comparing against the cap, so escape overhead (quote-heavy text → 2× wire size) counts against the budget.
- Partial-write cleanup: when `tokio::fs::write` fails mid-write the partial file is removed before propagating the error.
- Native tools (`bun_run`) already self-truncate to smaller limits and are unaffected.

Closes [AGE-2300](https://linear.app/speakeasy/issue/AGE-2300/assistant-runtime-cap-per-message-tool-result-bytes-200kb).

✻ Clauded...