### PR TITLE
fix(rbac): grant all scopes during admin org impersonation

### DIFF
--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -146,6 +146,16 @@ func (e *Engine) PrepareContext(ctx context.Context) (context.Context, error) {
 		return ctx, nil
 	}
 
+	// Admins impersonating a customer org have no WorkOS membership in that
+	// org, so the normal role-resolution path would yield zero grants and
+	// every Require() call would 403. Grant all scopes — matching the
+	// carve-out in access.ListGrants.
+	if authCtx.IsAdmin {
+		if _, ok := contextvalues.GetAdminOverrideFromContext(ctx); ok {
+			return GrantsToContext(ctx, allScopeGrants()), nil
+		}
+	}
+
 	principals := []urn.Principal{urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)}
 
 	roleSlug, err := e.resolveRoleSlug(ctx, authCtx.UserID, authCtx.ActiveOrganizationID)

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -658,6 +658,49 @@ func scopeOverrideCtx(t *testing.T, isAdmin bool, accountType string) context.Co
 	return contextvalues.SetRBACScopeOverride(ctx, "project:read")
 }
 
+// TestPrepareContext_adminImpersonationGrantsAllScopes verifies that when a
+// Speakeasy admin impersonates a customer org (IsAdmin + AdminOverride), the
+// engine injects wildcard grants for every scope so that Require() calls
+// succeed. Without this, the admin has no WorkOS membership in the target org
+// and every endpoint returns 403.
+func TestPrepareContext_adminImpersonationGrantsAllScopes(t *testing.T) {
+	t.Parallel()
+
+	chConn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(true), staticChallengeLogging(true), workos.NewStubClient(), cache.NoopCache)
+
+	// Build a context that looks like admin impersonation: enterprise account,
+	// IsAdmin flag, and AdminOverride pointing at the target org.
+	sessionID := "session_admin"
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_customer",
+		UserID:               "user_admin",
+		SessionID:            &sessionID,
+		AccountType:          "enterprise",
+		IsAdmin:              true,
+	})
+	ctx = contextvalues.SetAdminOverrideInContext(ctx, "org_customer")
+
+	ctx, err = engine.PrepareContext(ctx)
+	require.NoError(t, err)
+
+	grants, ok := GrantsFromContext(ctx)
+	require.True(t, ok, "grants should be present in context after PrepareContext")
+	require.NotEmpty(t, grants, "admin impersonation should produce non-empty grants")
+
+	// Every scope should be satisfiable via Require.
+	for _, scope := range []Scope{
+		ScopeOrgRead, ScopeOrgAdmin,
+		ScopeProjectRead, ScopeProjectWrite,
+		ScopeMCPRead, ScopeMCPWrite, ScopeMCPConnect,
+		ScopeEnvironmentRead, ScopeEnvironmentWrite,
+	} {
+		err := engine.Require(ctx, Check{Scope: scope, ResourceID: "org_customer"})
+		require.NoError(t, err, "admin impersonation should satisfy scope %s", scope)
+	}
+}
+
 func TestCanUseOverride_devPlusAdmin(t *testing.T) {
 	t.Parallel()
 	chConn, err := newClickhouseClient(t)

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -16,6 +16,22 @@ import (
 
 const WildcardResource = "*"
 
+// allScopeGrants returns wildcard grants for every defined scope. Used to give
+// superadmins (e.g. during org impersonation) unrestricted access.
+func allScopeGrants() []Grant {
+	scopes := []Scope{
+		ScopeOrgRead, ScopeOrgAdmin,
+		ScopeProjectRead, ScopeProjectWrite,
+		ScopeMCPRead, ScopeMCPWrite, ScopeMCPConnect,
+		ScopeEnvironmentRead, ScopeEnvironmentWrite,
+	}
+	grants := make([]Grant, 0, len(scopes))
+	for _, s := range scopes {
+		grants = append(grants, NewGrant(s, WildcardResource))
+	}
+	return grants
+}
+
 const (
 	SystemRoleAdmin  = "admin"
 	SystemRoleMember = "member"


### PR DESCRIPTION
## Summary

- When a Speakeasy admin impersonates a customer org, `PrepareContext` in the authz engine did not detect the impersonation and tried to resolve the admin's WorkOS membership in the target org — which doesn't exist. This yielded zero grants and every `Require()` call returned 403.
- `ListGrants` already had a carve-out for this case (added in 7e1c677ba, Apr 29) but the matching fix was never added to `PrepareContext` when authz was extracted from the access package (b18286627, Apr 23).
- Adds an admin-impersonation check in `PrepareContext` that injects wildcard grants for all scopes, matching `ListGrants` behavior.

## Test plan

- [x] New test `TestPrepareContext_adminImpersonationGrantsAllScopes` — verifies grants are loaded and every scope passes `Require()`
- [x] Full `authz` suite passes (106 tests)
- [x] Full `access` suite passes (109 tests)
- [ ] Manual: impersonate a customer org in the dashboard → Roles & Permissions page loads without 403