### PR TITLE
fix(assistants): drop trigger dispatch when target assistant is gone

### DIFF
--- a/.changeset/age-2301-skip-missing-assistant-dispatch.md
+++ b/.changeset/age-2301-skip-missing-assistant-dispatch.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Drop trigger dispatches whose target assistant has been deleted instead of failing the activity; retrying can't recover a missing row.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1098,7 +1098,18 @@ func (s *ServiceCore) EnqueueTriggerTask(ctx context.Context, task bgtriggers.Ta
 		return EnqueueResult{}, fmt.Errorf("parse assistant id: %w", err)
 	}
 	assistant, err := s.getAssistantForDispatch(ctx, assistantID)
-	if err != nil {
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// Trigger targets an assistant that no longer exists (deleted, or the
+		// trigger was created against the wrong id). Retrying won't help —
+		// drop the dispatch so the activity succeeds and Temporal doesn't
+		// hammer the same row through three attempts.
+		s.logger.WarnContext(ctx, "skipping trigger dispatch: assistant not found",
+			attr.SlogAssistantID(assistantID.String()),
+			attr.SlogTriggerInstanceID(task.TriggerInstanceID),
+		)
+		return EnqueueResult{AssistantID: uuid.Nil, ThreadID: uuid.Nil, EventCreated: false}, nil
+	case err != nil:
 		return EnqueueResult{}, err
 	}
 	if assistant.Status != StatusActive {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -18,6 +18,7 @@ import (
 
 	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
+	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -1247,4 +1248,29 @@ func mustParseURLForServiceTest(t *testing.T, raw string) *url.URL {
 	parsed, err := url.Parse(raw)
 	require.NoError(t, err)
 	return parsed
+}
+
+func TestServiceCoreEnqueueTriggerTaskSkipsMissingAssistant(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_enqueue_missing")
+	require.NoError(t, err)
+
+	logger := testenv.NewLogger(t)
+	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, testRuntimeBackend{backend: runtimeBackendFlyIO}, nil, tokens, nil, telemetry.NewStub(logger), nil)
+
+	missing := uuid.New()
+	result, err := core.EnqueueTriggerTask(t.Context(), bgtriggers.Task{
+		TriggerInstanceID: uuid.New().String(),
+		DefinitionSlug:    sourceKindSlack,
+		TargetKind:        bgtriggers.TargetKindAssistant,
+		TargetRef:         missing.String(),
+		EventID:           "evt-missing",
+		CorrelationID:     "corr-missing",
+		EventJSON:         []byte(`{}`),
+	})
+	require.NoError(t, err)
+	require.False(t, result.EventCreated)
+	require.Equal(t, uuid.Nil, result.AssistantID)
 }


### PR DESCRIPTION
## Summary

- `EnqueueTriggerTask` propagated `pgx.ErrNoRows` from `getAssistantForDispatch` as an activity-level failure, so any trigger whose `target_ref` points at a deleted assistant burned three DispatchTrigger retries and fired the Temporal failure alert (54 errors / 188 ok over the last 2d in prod, all with the same message).
- Treat the missing-row case the same as paused: log + return an empty result so the dispatcher no-ops and the activity succeeds.
- Adds a regression test asserting the missing-assistant path is non-fatal.

Re-scoped from the original "MCP startup" framing after verifying in Datadog that the Datadog alert is `select assistant for dispatch: no rows in result set`, not an MCP-related failure.

Closes [AGE-2301](https://linear.app/speakeasy/issue/AGE-2301/bug-tolerate-mcp-startup-failures-during-initial-3s-window)

✻ Clauded...