### PR TITLE
fix(plugins): bump manifest version on every publish so clients refresh

### DIFF
--- a/.changeset/plugin-publish-version-bump.md
+++ b/.changeset/plugin-publish-version-bump.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix plugin re-publish so Claude Code, Cursor, and Codex marketplace clients refresh installed copies. Every plugin manifest now ships with a per-publish version (`0.1.<unix_ts>`) instead of a hardcoded `0.1.0`, so platform clients see a newer version on republish and pull the updated content.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -53,6 +53,19 @@ type GenerateConfig struct {
 	// ProjectSlug is the publishing project's slug. The Cursor hooks endpoint
 	// requires it via the Gram-Project header (Claude's does not).
 	ProjectSlug string
+	// Version is stamped into every plugin.json. Callers should bump this on
+	// every publish so platform marketplaces (Claude Code, Cursor, Codex) treat
+	// the manifest as new and refresh installed copies. Empty falls back to
+	// the static default, preserving test ergonomics.
+	Version string
+}
+
+// pluginManifestVersion returns the version to stamp into generated
+// plugin.json files. Callers set cfg.Version to a per-publish value; the
+// "0.1.0" fallback exists so package tests don't need to construct a version
+// just to exercise unrelated assertions.
+func pluginManifestVersion(cfg GenerateConfig) string {
+	return conv.Default(cfg.Version, "0.1.0")
 }
 
 // claudeHookAsyncFlag returns the async flag for a Claude hook event.
@@ -369,7 +382,7 @@ func codexAuthPolicy(p PluginInfo, cfg GenerateConfig) string {
 func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p PluginInfo, cfg GenerateConfig) error {
 	pluginJSON, err := marshalJSON(codexPluginMeta{
 		Name:        name,
-		Version:     "0.1.0",
+		Version:     pluginManifestVersion(cfg),
 		Description: p.Description,
 		MCPServers:  "./.mcp.json",
 		Hooks:       "",
@@ -458,7 +471,7 @@ func generateClaudeObservabilityPluginInDir(files map[string][]byte, subdir stri
 	pluginJSON, err := marshalJSON(claudePluginMeta{
 		Name:        name,
 		Description: "Gram observability hooks for " + cfg.OrgName + ". Install this plugin to forward tool events to your team's Gram dashboard.",
-		Version:     "0.1.0",
+		Version:     pluginManifestVersion(cfg),
 		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
 		Homepage:    "https://getgram.ai",
 		UserConfig:  nil,
@@ -511,7 +524,7 @@ func generateCursorObservabilityPluginInDir(files map[string][]byte, subdir stri
 		Name:        name,
 		DisplayName: "Observability (Cursor)",
 		Description: "Gram observability hooks for " + cfg.OrgName + ". Install this plugin to forward tool events to your team's Gram dashboard.",
-		Version:     "0.1.0",
+		Version:     pluginManifestVersion(cfg),
 		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
 		Homepage:    "https://getgram.ai",
 	})
@@ -594,7 +607,7 @@ func generateCodexObservabilityPluginInDir(files map[string][]byte, subdir strin
 	}
 	pluginJSON, err := marshalJSON(codexPluginMeta{
 		Name:        name,
-		Version:     "0.1.0",
+		Version:     pluginManifestVersion(cfg),
 		Description: "Gram observability hooks for " + cfg.OrgName + ". Install this plugin to forward tool events to your team's Gram dashboard.",
 		MCPServers:  "",
 		Hooks:       "./hooks/hooks.json",
@@ -1026,7 +1039,7 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	pluginJSON, err := marshalJSON(claudePluginMeta{
 		Name:        p.Slug,
 		Description: p.Description,
-		Version:     "0.1.0",
+		Version:     pluginManifestVersion(cfg),
 		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
 		Homepage:    "https://getgram.ai",
 		UserConfig:  userConfigPtr,
@@ -1078,7 +1091,7 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 		Name:        name,
 		DisplayName: displayName,
 		Description: p.Description,
-		Version:     "0.1.0",
+		Version:     pluginManifestVersion(cfg),
 		Author:      pluginAuthor{Name: cfg.OrgName, URL: "https://getgram.ai"},
 		Homepage:    "https://getgram.ai",
 	})

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -583,3 +583,102 @@ func TestWritePluginZipMakesShellScriptsExecutable(t *testing.T) {
 	require.Equal(t, uint32(0o644), modes[".claude-plugin/plugin.json"], "non-script files keep default mode")
 	require.Equal(t, uint32(0o644), modes["README.md"], "non-script files keep default mode")
 }
+
+// Each publish must stamp a fresh manifest version into every plugin.json.
+// Claude Code, Cursor, and Codex marketplaces all key cache invalidation off
+// the manifest's version field: if it doesn't change between publishes,
+// previously-installed copies are treated as up-to-date and never refreshed.
+func TestGeneratePluginPackagesStampsConfigVersionIntoEveryManifest(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name:        "Engineering Tools",
+			Slug:        "engineering-tools",
+			Description: "MCP servers",
+			Servers: []PluginServerInfo{
+				{DisplayName: "crm", MCPURL: "https://app.getgram.ai/mcp/crm"},
+			},
+		},
+	}
+
+	cfg := GenerateConfig{
+		OrgName:     "Acme",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "acme-prod",
+		Version:     "0.1.1747087200",
+	}
+
+	files, err := GeneratePluginPackages(plugins, cfg)
+	require.NoError(t, err)
+
+	// Every plugin.json the publisher writes — both per-plugin and the
+	// per-org observability bundle, across all three platforms — must carry
+	// the supplied version.
+	manifestPaths := []string{
+		"engineering-tools/.claude-plugin/plugin.json",
+		"engineering-tools-cursor/.cursor-plugin/plugin.json",
+		"engineering-tools-codex/.codex-plugin/plugin.json",
+		"acme-observability/.claude-plugin/plugin.json",
+		"acme-observability-cursor/.cursor-plugin/plugin.json",
+		"acme-observability-codex/.codex-plugin/plugin.json",
+	}
+	for _, p := range manifestPaths {
+		raw, ok := files[p]
+		require.True(t, ok, "missing manifest: %s", p)
+
+		var meta struct {
+			Version string `json:"version"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &meta), "parse %s", p)
+		require.Equal(t, "0.1.1747087200", meta.Version, "%s did not pick up cfg.Version", p)
+	}
+}
+
+// Successive publishes with bumped versions must produce different manifest
+// bytes so platform clients see a new version and pull. This is the core
+// regression test for the "republish doesn't refresh clients" gap.
+func TestGeneratePluginPackagesRepublishWithBumpedVersionRefreshesManifest(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name:        "Engineering Tools",
+			Slug:        "engineering-tools",
+			Description: "MCP servers",
+			Servers: []PluginServerInfo{
+				{DisplayName: "crm", MCPURL: "https://app.getgram.ai/mcp/crm"},
+			},
+		},
+	}
+
+	base := GenerateConfig{
+		OrgName:   "Acme",
+		ServerURL: "https://app.getgram.ai",
+	}
+
+	first := base
+	first.Version = "0.1.100"
+	firstFiles, err := GeneratePluginPackages(plugins, first)
+	require.NoError(t, err)
+
+	second := base
+	second.Version = "0.1.200"
+	secondFiles, err := GeneratePluginPackages(plugins, second)
+	require.NoError(t, err)
+
+	const manifestPath = "engineering-tools/.claude-plugin/plugin.json"
+	require.NotEqual(t,
+		string(firstFiles[manifestPath]),
+		string(secondFiles[manifestPath]),
+		"manifest bytes must differ between publishes — otherwise Claude's marketplace will not refresh",
+	)
+}
+
+// Empty cfg.Version preserves the legacy "0.1.0" so tests that don't care
+// about versioning don't have to construct one. Production callers always
+// set cfg.Version via Service.generateConfig.
+func TestPluginManifestVersionFallsBackTo010WhenUnset(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "0.1.0", pluginManifestVersion(GenerateConfig{}))
+	require.Equal(t, "0.1.42", pluginManifestVersion(GenerateConfig{Version: "0.1.42"}))
+}

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1439,6 +1439,10 @@ func (s *Service) generateConfig(ctx context.Context, orgID, orgSlug, projectSlu
 		APIKey:      "",
 		HooksAPIKey: "",
 		ProjectSlug: projectSlug,
+		// 0.1.{epoch} stays strictly above the historical 0.1.0 manifests
+		// already in users' Claude/Cursor/Codex caches, so a re-publish is
+		// always seen as a newer version and triggers a refresh.
+		Version: fmt.Sprintf("0.1.%d", time.Now().Unix()),
 	}
 	orgName, err := s.repo.GetOrganizationName(ctx, orgID)
 	switch {


### PR DESCRIPTION
Plugin manifests across Claude Code, Cursor, and Codex marketplaces all shipped with a hardcoded version of "0.1.0". Re-publishing rewrote the GitHub repo content but left every plugin.json identical, so platform clients treated installed copies as up-to-date and never refreshed.

Stamp cfg.Version into every plugin.json (per-plugin and per-org observability bundles) and have Service.generateConfig set it to "0.1.<unix_ts>" at publish time — strictly greater than the historical 0.1.0 already in user caches, and monotonic across republishes.