### PR TITLE
feat(assistants): self-heal corrupt chat history

### DIFF
--- a/.changeset/age-2094-self-heal-history-corruption.md
+++ b/.changeset/age-2094-self-heal-history-corruption.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+assistants now self-heal when the inference provider rejects a chat as malformed: the runtime trims history to the last 5 user messages, prepends a recovery notice that nudges the agent to recover lost context via its tools, and retries — instead of leaving the thread stuck.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -792,6 +792,7 @@ func newStartCommand() *cli.Command {
 			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo)
 			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver)
 			assistantsCore.SetWakeCanceller(triggerApp)
+			assistantsCore.SetChatMessageWriter(chatWriter)
 			assistantsSvc := assistants.NewService(logger, tracerProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv})
 			triggerApp.RegisterDispatcher(assistantsSvc)
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -640,6 +640,7 @@ func newWorkerCommand() *cli.Command {
 			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
 			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, db, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemetryLogger, contextWindowResolver)
 			assistantsCore.SetWakeCanceller(triggerApp)
+			assistantsCore.SetChatMessageWriter(chatWriter)
 			assistantsSvc := assistants.NewService(logger, tracerProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv})
 			triggerApp.RegisterDispatcher(assistantsSvc)
 

--- a/server/internal/assistants/classify_turn_error_test.go
+++ b/server/internal/assistants/classify_turn_error_test.go
@@ -1,0 +1,77 @@
+package assistants
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/chat"
+)
+
+func TestClassifyTurnError(t *testing.T) {
+	t.Parallel()
+
+	// Verbatim copy of the marker stamped by chat.HandleCompletion on upstream
+	// 4xx responses; chat keeps it package-private so the cross-package
+	// contract here is the matched substring, not the symbol.
+	const corruptionMarker = "history corrupted: upstream provider rejected the replayed transcript"
+	require.True(t, chat.IsHistoryCorrupted(errors.New(corruptionMarker)),
+		"corruptionMarker must stay in sync with chat package; chat.IsHistoryCorrupted is the source of truth")
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: nil,
+		},
+		{
+			name: "network drop",
+			err:  errors.New("send assistant fly runtime request: dial tcp: connection refused"),
+			want: ErrRuntimeUnhealthy,
+		},
+		{
+			name: "runner crash",
+			err:  errors.New("status=502 body=upstream connect failure"),
+			want: ErrRuntimeUnhealthy,
+		},
+		{
+			name: "generic provider failure",
+			err:  errors.New("status=500 body=provider error: model unavailable"),
+			want: ErrCompletionFailed,
+		},
+		{
+			name: "gateway-stamped generic failure",
+			err:  errors.New("loop error: completion failed: rate limit exceeded"),
+			want: ErrCompletionFailed,
+		},
+		{
+			name: "marker stamped by /chat/completions on upstream 4xx",
+			err:  fmt.Errorf("execute fly turn request: status=422 body=provider error: {\"message\":%q}", corruptionMarker),
+			want: ErrHistoryCorrupted,
+		},
+		{
+			name: "marker wrapped through assistant runtime error chain",
+			err: fmt.Errorf("run assistant turn: %w",
+				errors.New("execute fly turn request: status=422 body=provider error: "+corruptionMarker)),
+			want: ErrHistoryCorrupted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyTurnError(tt.err)
+			if tt.want == nil {
+				require.NoError(t, got)
+				return
+			}
+			require.ErrorIs(t, got, tt.want)
+		})
+	}
+}

--- a/server/internal/assistants/runtime.go
+++ b/server/internal/assistants/runtime.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
@@ -317,6 +318,31 @@ var ErrRuntimeUnhealthy = errors.New("assistant runtime unhealthy")
 // fail the event and leave the VM warm to handle subsequent events.
 var ErrCompletionFailed = errors.New("assistant completion failed")
 
+// ErrHistoryCorrupted signals the upstream provider rejected the replayed
+// transcript as malformed or oversize. Distinct from ErrCompletionFailed:
+// trimming history and retrying typically clears it, so callers self-heal
+// once per event before giving up.
+var ErrHistoryCorrupted = errors.New("assistant chat history corrupted")
+
+// classifyTurnError buckets a /turn error into runtime-unhealthy (tear
+// down), completion-failed (terminal), or history-corrupted (self-heal).
+// "provider error" is agentkit-provider-openrouter's prefix; "completion
+// failed" is Gram's gateway-stamped variant. chat.IsHistoryCorrupted
+// detects the Gram-owned marker stamped on upstream 400/422 responses.
+func classifyTurnError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if chat.IsHistoryCorrupted(err) {
+		return ErrHistoryCorrupted
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "provider error") || strings.Contains(msg, "completion failed") {
+		return ErrCompletionFailed
+	}
+	return ErrRuntimeUnhealthy
+}
+
 func (m *RuntimeManager) Backend() string {
 	return runtimeBackendLocal
 }
@@ -578,7 +604,7 @@ func (m *RuntimeManager) RunTurn(
 		MaxTimeSeconds: 30 * 60,
 		IdempotencyKey: idempotencyKey,
 	}); err != nil {
-		return fmt.Errorf("%w: execute turn request: %w", ErrRuntimeUnhealthy, err)
+		return fmt.Errorf("%w: execute turn request: %w", classifyTurnError(err), err)
 	}
 	return nil
 }

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -801,25 +801,6 @@ func (f *FlyRuntimeBackend) RunTurn(ctx context.Context, runtime assistantRuntim
 	return nil
 }
 
-// classifyTurnError distinguishes upstream completion failures (provider
-// rejected the request — replaying it won't help) from real runtime
-// problems (VM gone, connection refused, runner crashed). Only the latter
-// should churn the Fly app; surfacing every provider 4xx as
-// ErrRuntimeUnhealthy nukes-and-respawns the VM on each retry, producing
-// thousands of dead assistant_runtimes rows on a single bad input.
-//
-// Match is body-substring based because the runner wraps the upstream error
-// before returning it; agentkit-provider-openrouter prefixes failed Gram
-// completion calls with "provider error", and Gram's own gateway path
-// stamps "completion failed" with oops.CodeGatewayError.
-func classifyTurnError(err error) error {
-	msg := err.Error()
-	if strings.Contains(msg, "provider error") || strings.Contains(msg, "completion failed") {
-		return ErrCompletionFailed
-	}
-	return ErrRuntimeUnhealthy
-}
-
 func (f *FlyRuntimeBackend) ServerURL(_ context.Context, runtime assistantRuntimeRecord, raw *url.URL) (*url.URL, error) {
 	if err := validateRuntimeBackend(f, runtime.Backend); err != nil {
 		return nil, err

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
+	"github.com/speakeasy-api/gram/server/internal/chat"
 	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
@@ -283,6 +284,7 @@ type ServiceCore struct {
 	telemetryLogger *telemetry.Logger
 	contextWindow   *openrouter.ContextWindowResolver
 	wakeCanceller   WakeCanceller
+	chatWriter      *chat.ChatMessageWriter
 }
 
 func NewServiceCore(
@@ -307,6 +309,7 @@ func NewServiceCore(
 		telemetryLogger: telemetryLogger,
 		contextWindow:   contextWindow,
 		wakeCanceller:   nil,
+		chatWriter:      nil,
 	}
 }
 
@@ -314,6 +317,14 @@ func NewServiceCore(
 // assistants must not import triggers.
 func (s *ServiceCore) SetWakeCanceller(c WakeCanceller) {
 	s.wakeCanceller = c
+}
+
+// SetChatMessageWriter wires the chat writer used by self-heal. Set after
+// construction (rather than via NewServiceCore) to match the existing
+// post-construction injection pattern and avoid churning every test call
+// site. Self-heal is skipped if the writer was never set.
+func (s *ServiceCore) SetChatMessageWriter(w *chat.ChatMessageWriter) {
+	s.chatWriter = w
 }
 
 // resolveAssistantContextWindow returns the smallest context_length the gram
@@ -1455,12 +1466,56 @@ func (s *ServiceCore) ProcessThreadEvents(ctx context.Context, projectID, thread
 				}, nil
 			}
 
+			// First-attempt history corruption: write a trimmed generation,
+			// tear the runtime down so the next admit /configures with it,
+			// and re-pend the event. Further attempts fall through to the
+			// terminal-fail branch so persistent corruption can't loop.
+			if errors.Is(runErr, ErrHistoryCorrupted) && event.Attempts <= 1 {
+				if healErr := s.selfHealCorruptHistory(ctx, thread.ChatID, thread.ProjectID); healErr != nil {
+					s.logger.ErrorContext(ctx, "assistant self-heal failed",
+						attr.SlogAssistantThreadID(thread.ID.String()),
+						attr.SlogAssistantEventID(event.ID.String()),
+						attr.SlogError(healErr),
+					)
+					s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant self-heal failed", "ERROR", healErr)
+					if err := s.failEvent(ctx, thread.ProjectID, event.ID, fmt.Errorf("self-heal failed: %w", healErr)); err != nil {
+						return ProcessThreadEventsResult{}, err
+					}
+					warmUntil := time.Now().UTC().Add(time.Duration(assistant.WarmTTLSeconds) * time.Second)
+					if err := s.setRuntimeActive(ctx, thread.ProjectID, runtimeRecord.ID, warmUntil); err != nil {
+						return ProcessThreadEventsResult{}, err
+					}
+					return ProcessThreadEventsResult{
+						AssistantID:       assistant.ID,
+						WarmUntil:         warmUntil,
+						WarmTTLSeconds:    assistant.WarmTTLSeconds,
+						RuntimeActive:     true,
+						RetryAdmission:    false,
+						ProcessedAnyEvent: processedAny,
+					}, nil
+				}
+				s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_self_heal", "assistant history self-heal applied", "WARN", runErr)
+				_ = s.runtime.Stop(ctx, runtimeRecord)
+				_ = s.stopRuntimeRecord(ctx, thread.ProjectID, thread.ID, runtimeStateStopped)
+				if err := s.resetEventToPending(ctx, thread.ProjectID, event.ID, runErr); err != nil {
+					return ProcessThreadEventsResult{}, err
+				}
+				return ProcessThreadEventsResult{
+					AssistantID:       assistant.ID,
+					WarmUntil:         time.Time{},
+					WarmTTLSeconds:    assistant.WarmTTLSeconds,
+					RuntimeActive:     false,
+					RetryAdmission:    true,
+					ProcessedAnyEvent: processedAny,
+				}, nil
+			}
+
 			// Upstream completion provider rejected the request (Anthropic 400
 			// on a malformed message, OpenRouter rate limit, etc). The runtime
 			// is fine — replaying the same input would just produce the same
 			// failure, so terminally fail the event and keep the VM warm for
 			// subsequent ones rather than churning Fly on every retry.
-			if errors.Is(runErr, ErrCompletionFailed) {
+			if errors.Is(runErr, ErrCompletionFailed) || errors.Is(runErr, ErrHistoryCorrupted) {
 				s.emitAssistantTelemetry(turnCtx, assistant, thread, &runtimeRecord, &event, "event_terminal", "assistant event failed at completion provider", "ERROR", runErr)
 				if err := s.failEvent(ctx, thread.ProjectID, event.ID, runErr); err != nil {
 					return ProcessThreadEventsResult{}, err
@@ -1933,6 +1988,100 @@ func (s *ServiceCore) loadThreadContext(ctx context.Context, projectID, threadID
 	}
 	assistant.Toolsets = refs[assistant.ID]
 	return thread, assistant, runtime, nil
+}
+
+const (
+	selfHealUserMessageCap    = 5
+	selfHealUserMessageMaxLen = 1000
+)
+
+// selfHealRecoveryNoticeTemplate prefixes the trimmed generation when the
+// upstream provider rejects the replayed transcript. The "%d" slot is the
+// number of user messages retained; the second is the per-message rune cap.
+// Sent as a user-role row because loadChatHistory drops system rows.
+const selfHealRecoveryNoticeTemplate = "[gram self-heal] Earlier conversation history was rejected by the inference provider as malformed and has been discarded. " +
+	"The %d user message(s) that follow are the most recent ones, each truncated to %d characters. " +
+	"Prior context (including any tool calls and their results) is not available. " +
+	"Before asking the user to repeat themselves, try to recover the lost context using your available tools — " +
+	"e.g. search prior messages or threads in whichever channel this conversation lives in, look up referenced records, " +
+	"or re-fetch any IDs that appear in the surviving messages. Only ask the user to restate context if your tools can't recover it."
+
+// selfHealCorruptHistory writes a fresh generation containing a leading
+// recovery notice followed by the last selfHealUserMessageCap user-role
+// messages (each truncated to selfHealUserMessageMaxLen runes). The next
+// /configure pulls this generation as the live history; assistant/tool
+// turns are dropped — they're the most likely source of the rejection.
+func (s *ServiceCore) selfHealCorruptHistory(ctx context.Context, chatID uuid.UUID, projectID uuid.UUID) error {
+	if s.chatWriter == nil {
+		return fmt.Errorf("self-heal: chat writer not configured")
+	}
+
+	messages, err := chatrepo.New(s.db).ListLatestGenerationChatMessages(ctx, chatrepo.ListLatestGenerationChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: projectID,
+	})
+	if err != nil {
+		return fmt.Errorf("self-heal: list chat messages: %w", err)
+	}
+
+	var currentGen int32
+	userMessages := make([]chatrepo.ChatMessage, 0, len(messages))
+	for _, m := range messages {
+		if m.Generation > currentGen {
+			currentGen = m.Generation
+		}
+		if m.Role == "user" {
+			userMessages = append(userMessages, m)
+		}
+	}
+	if len(userMessages) > selfHealUserMessageCap {
+		userMessages = userMessages[len(userMessages)-selfHealUserMessageCap:]
+	}
+
+	nextGen := currentGen + 1
+	empty := conv.ToPGTextEmpty("")
+	base := chatrepo.CreateChatMessageParams{
+		ChatID:           chatID,
+		ProjectID:        projectID,
+		Role:             "user",
+		Content:          "",
+		ContentRaw:       nil,
+		ContentAssetUrl:  empty,
+		StorageError:     empty,
+		Model:            empty,
+		MessageID:        empty,
+		ToolCallID:       empty,
+		UserID:           empty,
+		ExternalUserID:   empty,
+		FinishReason:     empty,
+		ToolCalls:        nil,
+		PromptTokens:     0,
+		CompletionTokens: 0,
+		TotalTokens:      0,
+		Origin:           empty,
+		UserAgent:        empty,
+		IpAddress:        empty,
+		Source:           empty,
+		ContentHash:      nil,
+		Generation:       nextGen,
+	}
+
+	rows := make([]chatrepo.CreateChatMessageParams, 0, len(userMessages)+1)
+	notice := base
+	notice.Content = fmt.Sprintf(selfHealRecoveryNoticeTemplate, len(userMessages), selfHealUserMessageMaxLen)
+	rows = append(rows, notice)
+	for _, m := range userMessages {
+		row := base
+		row.Content = conv.TruncateString(m.Content, selfHealUserMessageMaxLen)
+		row.UserID = m.UserID
+		row.ExternalUserID = m.ExternalUserID
+		rows = append(rows, row)
+	}
+
+	if _, err := s.chatWriter.Write(ctx, projectID, rows); err != nil {
+		return fmt.Errorf("self-heal: write recovery generation: %w", err)
+	}
+	return nil
 }
 
 func (s *ServiceCore) loadChatHistory(ctx context.Context, chatID uuid.UUID, projectID uuid.UUID) ([]runtimeMessage, error) {

--- a/server/internal/assistants/service_self_heal_test.go
+++ b/server/internal/assistants/service_self_heal_test.go
@@ -1,0 +1,194 @@
+package assistants
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
+	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestServiceCoreSelfHealsHistoryCorruptionOnFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_self_heal_first")
+	require.NoError(t, err)
+
+	projectID, assistantID, chatID, threadID := insertAssistantFixture(t, conn)
+
+	ctx := t.Context()
+
+	// Seed eight chronological user messages plus some assistant/tool noise
+	// that should NOT carry over after self-heal trims to user-only.
+	seedRows := []struct {
+		role       string
+		content    string
+		toolCallID pgtype.Text
+		toolCalls  []byte
+	}{
+		{role: "user", content: "first"},
+		{role: "assistant", content: "ack first"},
+		{role: "user", content: "second"},
+		{role: "assistant", content: "", toolCalls: []byte(`[{"id":"call_a","type":"function","function":{"name":"x","arguments":"{}"}}]`)},
+		{role: "tool", content: `{"r":1}`, toolCallID: pgtype.Text{String: "call_a", Valid: true}},
+		{role: "user", content: "third"},
+		{role: "user", content: "fourth"},
+		{role: "user", content: "fifth"},
+		{role: "user", content: "sixth"},
+		{role: "user", content: strings.Repeat("x", selfHealUserMessageMaxLen+500)},
+		{role: "user", content: "eighth"},
+	}
+	q := chatrepo.New(conn)
+	for _, r := range seedRows {
+		require.NoError(t, q.CreateChatMessageWithToolCalls(ctx, chatrepo.CreateChatMessageWithToolCallsParams{
+			ChatID:     chatID,
+			ProjectID:  uuid.NullUUID{UUID: projectID, Valid: true},
+			Role:       r.role,
+			Content:    r.content,
+			ToolCalls:  r.toolCalls,
+			ToolCallID: r.toolCallID,
+		}))
+	}
+
+	var stopCalls atomic.Int64
+	logger := testenv.NewLogger(t)
+	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
+	corruption := fmt.Errorf("%w: execute fly turn request: status=400 body=provider error: messages: tool_use_id has no corresponding tool_use block", ErrHistoryCorrupted)
+	backend := testRuntimeBackend{
+		backend:    runtimeBackendFlyIO,
+		runTurnErr: corruption,
+		stopCalls:  &stopCalls,
+	}
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
+	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
+	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
+	core.SetChatMessageWriter(chatWriter)
+
+	admitted, err := core.AdmitPendingThreads(ctx, assistantID)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{threadID}, admitted.ThreadIDs)
+
+	result, err := core.ProcessThreadEvents(ctx, projectID, threadID)
+	require.NoError(t, err)
+	require.True(t, result.RetryAdmission, "self-heal must request re-admission")
+	require.False(t, result.RuntimeActive, "self-heal must tear the runtime down so /configure replays with trimmed history")
+	require.False(t, result.ProcessedAnyEvent)
+	require.Equal(t, int64(1), stopCalls.Load(), "self-heal must Stop the runtime so the next admit cold-starts with trimmed history")
+
+	// Event is back to pending with the corruption error stamped on it; the
+	// next claim will bump attempts to 2 which gates self-heal off.
+	event, err := assistantsrepo.New(conn).GetLatestAssistantThreadEventByThreadID(ctx, assistantsrepo.GetLatestAssistantThreadEventByThreadIDParams{AssistantThreadID: threadID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.Equal(t, eventStatusPending, event.Status)
+	require.EqualValues(t, 1, event.Attempts)
+	require.True(t, event.LastError.Valid)
+	require.Contains(t, event.LastError.String, "tool_use_id has no corresponding tool_use block")
+
+	history, err := core.loadChatHistory(ctx, chatID, projectID)
+	require.NoError(t, err)
+	require.Len(t, history, selfHealUserMessageCap+1, "trimmed generation should contain the recovery notice + last 5 user messages")
+
+	require.Equal(t, "user", history[0].Role)
+	require.Contains(t, history[0].Content, "[gram self-heal]", "leading row must be the recovery notice")
+	require.Contains(t, history[0].Content, "tools", "notice should nudge the agent to recover via tools before bothering the user")
+
+	wantTail := []string{"fourth", "fifth", "sixth", "", "eighth"}
+	for i, want := range wantTail {
+		row := history[i+1]
+		require.Equal(t, "user", row.Role, "trimmed row %d", i)
+		require.Empty(t, row.ToolCalls)
+		require.Empty(t, row.ToolCallID)
+		if want == "" {
+			// The oversize message must be truncated to the rune cap.
+			require.Lenf(t, []rune(row.Content), selfHealUserMessageMaxLen,
+				"oversized user message must be truncated to %d runes", selfHealUserMessageMaxLen)
+		} else {
+			require.Equal(t, want, row.Content, "trimmed tail must preserve recent user prompts verbatim")
+		}
+	}
+}
+
+func TestServiceCoreSkipsSelfHealAfterFirstRetry(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_self_heal_skip")
+	require.NoError(t, err)
+
+	projectID, assistantID, chatID, threadID := insertAssistantFixture(t, conn)
+
+	ctx := t.Context()
+
+	// Bump attempts past the self-heal threshold so the corruption hits the
+	// terminal-fail branch instead.
+	require.NoError(t, chatrepo.New(conn).CreateChatMessageWithToolCalls(ctx, chatrepo.CreateChatMessageWithToolCallsParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: projectID, Valid: true},
+		Role:      "user",
+		Content:   "hello",
+	}))
+	// Simulate a prior attempt by claiming + resetting the event once so
+	// attempts == 1 going in; the upcoming ClaimNextPendingEvent will bump
+	// to 2 before processEventTurn fires.
+	q := assistantsrepo.New(conn)
+	_, err = q.ClaimNextPendingEvent(ctx, assistantsrepo.ClaimNextPendingEventParams{
+		ProcessingStatus: eventStatusProcessing,
+		ProjectID:        projectID,
+		ThreadID:         threadID,
+		PendingStatus:    eventStatusPending,
+	})
+	require.NoError(t, err)
+
+	// Reset to pending without resetting attempts.
+	eventRow, err := q.GetLatestAssistantThreadEventByThreadID(ctx, assistantsrepo.GetLatestAssistantThreadEventByThreadIDParams{AssistantThreadID: threadID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.NoError(t, q.ResetAssistantThreadEventToPending(ctx, assistantsrepo.ResetAssistantThreadEventToPendingParams{
+		PendingStatus: eventStatusPending,
+		LastError:     pgtype.Text{String: "prior corruption", Valid: true},
+		EventID:       eventRow.ID,
+		ProjectID:     projectID,
+	}))
+
+	var stopCalls atomic.Int64
+	logger := testenv.NewLogger(t)
+	tokens := assistanttokens.New("test-jwt-secret", conn, nil)
+	corruption := fmt.Errorf("%w: provider error: messages: tool_use_id has no corresponding tool_use block", ErrHistoryCorrupted)
+	backend := testRuntimeBackend{
+		backend:    runtimeBackendFlyIO,
+		runTurnErr: corruption,
+		stopCalls:  &stopCalls,
+	}
+	core := NewServiceCore(logger, testenv.NewTracerProvider(t), conn, backend, nil, tokens, mustParseURLForServiceTest(t, "https://gram.example.com"), telemetry.NewStub(logger), nil)
+	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, assetstest.NewTestBlobStore(t))
+	t.Cleanup(func() { _ = chatWriterShutdown(ctx) })
+	core.SetChatMessageWriter(chatWriter)
+
+	admitted, err := core.AdmitPendingThreads(ctx, assistantID)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{threadID}, admitted.ThreadIDs)
+
+	result, err := core.ProcessThreadEvents(ctx, projectID, threadID)
+	require.NoError(t, err)
+	require.False(t, result.RetryAdmission, "second corruption must NOT retry — self-heal already ran")
+	require.True(t, result.RuntimeActive, "completion-fail path keeps the runtime warm")
+	require.Equal(t, int64(0), stopCalls.Load(), "second corruption must not Stop the runtime")
+
+	event, err := q.GetLatestAssistantThreadEventByThreadID(ctx, assistantsrepo.GetLatestAssistantThreadEventByThreadIDParams{AssistantThreadID: threadID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.Equal(t, eventStatusFailed, event.Status, "second corruption must terminally fail")
+
+	// Only the seeded gen 0 should exist — no second self-heal generation was written.
+	gen, err := chatrepo.New(conn).GetMaxGenerationForChat(ctx, chatID)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, gen, "self-heal must not run on retry attempts")
+}

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -662,6 +662,33 @@ func (s *Service) checkCreditBalance(ctx context.Context, orgID, accountType str
 	return nil
 }
 
+// historyCorruptedMarker rides on /chat/completions 4xx response bodies and
+// survives the runner's "provider error: <body>" wrap so the assistant
+// runtime can detect upstream history rejection without sniffing each
+// provider's evolving wording. Detection is exposed via IsHistoryCorrupted.
+const historyCorruptedMarker = "history corrupted: upstream provider rejected the replayed transcript"
+
+// IsHistoryCorrupted reports whether err carries the upstream-history-rejected
+// marker stamped by HandleCompletion on a 400/422 from OpenRouter. Callers
+// (assistant runtime) self-heal by trimming history and retrying.
+func IsHistoryCorrupted(err error) bool {
+	return err != nil && strings.Contains(err.Error(), historyCorruptedMarker)
+}
+
+// classifyCompletionError maps an upstream OpenRouter error returned by the
+// completion client into the oops code that should flow back to the caller
+// (and through the runner to the assistant runtime).
+func (s *Service) classifyCompletionError(ctx context.Context, label string, err error) error {
+	switch {
+	case openrouter.IsInsufficientCredits(err):
+		return oops.C(oops.CodeInsufficientCredits).Log(ctx, s.logger)
+	case openrouter.IsHistoryCorruptionCandidate(err):
+		return oops.E(oops.CodeInvalid, err, historyCorruptedMarker).Log(ctx, s.logger)
+	default:
+		return oops.E(oops.CodeGatewayError, err, "%s", label).Log(ctx, s.logger)
+	}
+}
+
 // HandleCompletion is a proxy to the OpenAI API that logs request and response data.
 func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error {
 	ctx, authCtx, err := s.directAuthorize(r.Context(), r)
@@ -828,10 +855,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	if isStreaming {
 		streamBody, err := s.completionClient.GetCompletionStream(ctx, completionReq)
 		if err != nil {
-			if openrouter.IsInsufficientCredits(err) {
-				return oops.C(oops.CodeInsufficientCredits).Log(ctx, s.logger)
-			}
-			return oops.E(oops.CodeGatewayError, err, "get completion stream").Log(ctx, s.logger)
+			return s.classifyCompletionError(ctx, "get completion stream", err)
 		}
 		defer o11y.NoLogDefer(func() error { return streamBody.Close() })
 
@@ -852,10 +876,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	 */
 	response, err := s.completionClient.GetCompletion(ctx, completionReq)
 	if err != nil {
-		if openrouter.IsInsufficientCredits(err) {
-			return oops.C(oops.CodeInsufficientCredits).Log(ctx, s.logger)
-		}
-		return oops.E(oops.CodeGatewayError, err, "completion failed").Log(ctx, s.logger)
+		return s.classifyCompletionError(ctx, "completion failed", err)
 	}
 
 	var gramMetadata *openrouter.GramMetadata

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -18,10 +18,28 @@ func IsInsufficientCredits(err error) bool {
 	return errors.Is(err, ErrInsufficientCredits)
 }
 
+// ErrHistoryCorruptionCandidate signals OpenRouter (or the upstream provider
+// it proxies for) rejected the request with a 4xx consistent with a
+// malformed or oversize transcript. Callers self-heal by trimming history
+// and retrying.
+var ErrHistoryCorruptionCandidate = errors.New("openrouter: history corruption candidate")
+
+// IsHistoryCorruptionCandidate reports whether err originated from an
+// OpenRouter 400/422 response anywhere in the error chain.
+func IsHistoryCorruptionCandidate(err error) bool {
+	return errors.Is(err, ErrHistoryCorruptionCandidate)
+}
+
 func classifyHTTPError(status int, body []byte) error {
 	msg := strings.TrimSpace(string(body))
-	if status == http.StatusPaymentRequired {
+	switch status {
+	case http.StatusPaymentRequired:
 		return fmt.Errorf("OpenRouter API error (status %d): %s: %w", status, msg, ErrInsufficientCredits)
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		// Other 4xx (401 auth, 403 moderation, 404 model, 408 timeout, 429
+		// rate limit) aren't fixable by trimming and are excluded here.
+		return fmt.Errorf("OpenRouter API error (status %d): %s: %w", status, msg, ErrHistoryCorruptionCandidate)
+	default:
+		return fmt.Errorf("OpenRouter API error (status %d): %s", status, msg)
 	}
-	return fmt.Errorf("OpenRouter API error (status %d): %s", status, msg)
 }

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -36,10 +36,47 @@ func classifyHTTPError(status int, body []byte) error {
 	case http.StatusPaymentRequired:
 		return fmt.Errorf("OpenRouter API error (status %d): %s: %w", status, msg, ErrInsufficientCredits)
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:
-		// Other 4xx (401 auth, 403 moderation, 404 model, 408 timeout, 429
-		// rate limit) aren't fixable by trimming and are excluded here.
-		return fmt.Errorf("OpenRouter API error (status %d): %s: %w", status, msg, ErrHistoryCorruptionCandidate)
+		// 400/422 is the strongest "request body is the problem" signal, but
+		// it also covers non-history bad params (invalid model, malformed
+		// JSON, etc). Self-heal trims the live transcript and persists it,
+		// so misclassifying a one-off param error as corruption would lose
+		// real history. Require BOTH the status code and a corruption-shaped
+		// body before opting into self-heal.
+		if looksLikeHistoryCorruption(msg) {
+			return fmt.Errorf("OpenRouter API error (status %d): %s: %w", status, msg, ErrHistoryCorruptionCandidate)
+		}
+		return fmt.Errorf("OpenRouter API error (status %d): %s", status, msg)
 	default:
 		return fmt.Errorf("OpenRouter API error (status %d): %s", status, msg)
 	}
+}
+
+// historyCorruptionBodyMarkers are fragments inference providers emit when
+// they refuse a transcript for shape reasons (tool pairing, role
+// alternation, oversize context). Kept narrow; widen only as new patterns
+// are observed in production. Body comes from the upstream verbatim so
+// matching here — at the OpenRouter boundary — is the only place the
+// fragments aren't already mangled by intermediate wrappers.
+var historyCorruptionBodyMarkers = []string{
+	// Anthropic
+	"tool_use",
+	"tool_result",
+	// Anthropic + others
+	"must alternate",
+	// OpenAI
+	"tool_calls",
+	// Context overflow
+	"maximum context length",
+	"context_length_exceeded",
+	"prompt is too long",
+}
+
+func looksLikeHistoryCorruption(body string) bool {
+	lower := strings.ToLower(body)
+	for _, marker := range historyCorruptionBodyMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -94,8 +94,12 @@ func TestChatClient_GetCompletion_WrapsHistoryCorruptionForBadRequest(t *testing
 		body           string
 		wantCorruption bool
 	}{
-		{"400 invalid_request", http.StatusBadRequest, `{"error":{"type":"invalid_request_error","message":"messages: tool_use_ids were found without corresponding tool_use blocks"}}`, true},
-		{"422 unprocessable", http.StatusUnprocessableEntity, `{"error":{"message":"messages must alternate"}}`, true},
+		{"400 anthropic orphaned tool_use", http.StatusBadRequest, `{"error":{"type":"invalid_request_error","message":"messages: tool_use_ids were found without corresponding tool_use blocks"}}`, true},
+		{"422 role alternation", http.StatusUnprocessableEntity, `{"error":{"message":"messages must alternate between user and assistant"}}`, true},
+		{"400 openai tool_calls pairing", http.StatusBadRequest, `{"error":{"message":"messages with role 'tool' must be a response to a preceeding message with 'tool_calls'"}}`, true},
+		{"400 context overflow", http.StatusBadRequest, `{"error":{"message":"prompt is too long: 250000 tokens > 200000 maximum"}}`, true},
+		{"400 invalid model param is NOT corruption", http.StatusBadRequest, `{"error":{"type":"invalid_request_error","message":"model 'gpt-7' does not exist"}}`, false},
+		{"400 malformed json is NOT corruption", http.StatusBadRequest, `{"error":{"message":"invalid JSON in request body"}}`, false},
 		{"403 moderation is NOT corruption", http.StatusForbidden, `{"error":{"type":"content_policy_violation"}}`, false},
 		{"429 rate limit is NOT corruption", http.StatusTooManyRequests, `{"error":{"message":"rate_limit_exceeded"}}`, false},
 		{"500 upstream blip is NOT corruption", http.StatusInternalServerError, `{"error":{"message":"upstream"}}`, false},

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -85,6 +85,44 @@ func TestChatClient_GetCompletion_Non402_DoesNotWrapInsufficientCredits(t *testi
 	assert.False(t, IsInsufficientCredits(err), "non-402 must not be classified as insufficient credits")
 }
 
+func TestChatClient_GetCompletion_WrapsHistoryCorruptionForBadRequest(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		status         int
+		body           string
+		wantCorruption bool
+	}{
+		{"400 invalid_request", http.StatusBadRequest, `{"error":{"type":"invalid_request_error","message":"messages: tool_use_ids were found without corresponding tool_use blocks"}}`, true},
+		{"422 unprocessable", http.StatusUnprocessableEntity, `{"error":{"message":"messages must alternate"}}`, true},
+		{"403 moderation is NOT corruption", http.StatusForbidden, `{"error":{"type":"content_policy_violation"}}`, false},
+		{"429 rate limit is NOT corruption", http.StatusTooManyRequests, `{"error":{"message":"rate_limit_exceeded"}}`, false},
+		{"500 upstream blip is NOT corruption", http.StatusInternalServerError, `{"error":{"message":"upstream"}}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(server.Close)
+
+			client := newTestClientForServer(t, server)
+			_, err := client.GetCompletion(context.Background(), CompletionRequest{
+				OrgID:       "test-org",
+				ProjectID:   uuid.New().String(),
+				Messages:    []or.ChatMessages{CreateMessageUser("hi")},
+				ChatID:      uuid.New(),
+				UsageSource: billing.ModelUsageSourcePlayground,
+			})
+			require.Error(t, err)
+			require.Equal(t, tc.wantCorruption, IsHistoryCorruptionCandidate(err))
+		})
+	}
+}
+
 func newTestClientForServer(t *testing.T, server *httptest.Server) *ChatClient {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Detect upstream provider 4xx (400/422) at the OpenRouter boundary in `openrouter/errors.go`; chat `/chat/completions` stamps a Gram-owned marker so the signal survives the runner's `provider error: <body>` wrap.
- Assistant runtime classifies the marker as `ErrHistoryCorrupted` (distinct from `ErrCompletionFailed`/`ErrRuntimeUnhealthy`) and self-heals on the first attempt: writes a new chat generation containing a recovery user-role notice + the last 5 user messages (each truncated to 1000 runes), tears the runtime down so the next admit `/configure`s with the trimmed history, and re-pends the event.
- Recovery notice nudges the agent to recover lost context via its own tools (search prior thread, look up referenced records) before bothering the user.
- Beyond the first attempt the corruption path falls through to terminal-fail so a persistent rejection can't loop.

Closes [AGE-2094](https://linear.app/speakeasy/issue/AGE-2094/self-heal-discard-corrupt-history).

✻ Clauded...