### PR TITLE
fix(dashboard): respect server name overrides in tool logs filter dropdown

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -446,6 +446,7 @@ function HooksInnerContent({
             onCustomRangeChange={onCustomRangeChange}
             onClearCustomRange={onClearCustomRange}
             projectSlug={projectSlug}
+            serverNameMappings={serverNameMappings}
           />
 
           <div className="flex min-h-0 flex-1 overflow-hidden">

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -322,6 +322,7 @@ function HooksInnerContent({
   serverNameMappings: ReturnType<typeof useServerNameMappings>;
 }) {
   const orgRoutes = useOrgRoutes();
+
   return (
     <>
       <div className="flex min-h-0 w-full flex-1 flex-col">
@@ -359,6 +360,7 @@ function HooksInnerContent({
             onCustomRangeChange={onCustomRangeChange}
             onClearCustomRange={onClearCustomRange}
             projectSlug={projectSlug}
+            serverNameMappings={serverNameMappings}
           />
 
           <div className="flex min-h-0 flex-1 overflow-hidden">

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -18,6 +18,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import type { useServerNameMappings } from "@/hooks/useServerNameMappings";
 
 export interface FilterChip {
   display: string;
@@ -47,6 +48,7 @@ export function ObserveFilterBar({
   onClearCustomRange,
   projectSlug,
   className,
+  serverNameMappings,
 }: {
   serverOptions: string[];
   onServerSelectionChange: (values: string[]) => void;
@@ -63,6 +65,7 @@ export function ObserveFilterBar({
   onClearCustomRange: () => void;
   projectSlug?: string;
   className?: string;
+  serverNameMappings?: ReturnType<typeof useServerNameMappings>;
 }) {
   const selectedServers = useMemo(
     () =>
@@ -82,12 +85,20 @@ export function ObserveFilterBar({
     [activeFilters],
   );
 
+  const serverOptionsWithDisplayNames = useMemo(() => {
+    const rawToDisplay = serverNameMappings?.rawToDisplay;
+    return serverOptions.map((rawName) => ({
+      label: rawToDisplay?.get(rawName) ?? rawName,
+      value: rawName,
+    }));
+  }, [serverOptions, serverNameMappings?.rawToDisplay]);
+
   return (
     <div
       className={cn("flex shrink-0 flex-wrap items-center gap-2", className)}
     >
       <MultiSelect
-        options={serverOptions.map((s) => ({ label: s, value: s }))}
+        options={serverOptionsWithDisplayNames}
         defaultValue={selectedServers}
         onValueChange={onServerSelectionChange}
         placeholder="Filter by server name"


### PR DESCRIPTION
The server name filter on the tool logs page now displays the user-configured display names instead of raw server names.

Slack: https://speakeasyapi.slack.com/archives/C0ARJG28X29/p1778706761691629?thread_ts=1778705577.476469&cid=C0ARJG28X29

https://claude.ai/code/session_01Vowhso9XtK5qb6iS8s1vPy