### PR TITLE
chore: finalize WorkOS membership sync

### DIFF
--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -268,9 +268,10 @@ func backfillOrganizationMember(ctx context.Context, dbtx pgx.Tx, organizationID
 	}
 
 	if gramUserID != "" {
-		if err := orgQueries.UpsertOrganizationUserRelationshipFromWorkOS(ctx, orgrepo.UpsertOrganizationUserRelationshipFromWorkOSParams{
+		if err := orgQueries.UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
 			OrganizationID:     organizationID,
 			UserID:             conv.ToPGText(gramUserID),
+			WorkosUserID:       conv.ToPGText(member.UserID),
 			WorkosMembershipID: conv.ToPGText(member.ID),
 			WorkosUpdatedAt:    conv.ToPGTimestamptz(parsed.updatedAt),
 			WorkosLastEventID:  conv.ToPGText(""),

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -267,17 +267,15 @@ func backfillOrganizationMember(ctx context.Context, dbtx pgx.Tx, organizationID
 		return nil
 	}
 
-	if gramUserID != "" {
-		if err := orgQueries.UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
-			OrganizationID:     organizationID,
-			UserID:             conv.ToPGText(gramUserID),
-			WorkosUserID:       conv.ToPGText(member.UserID),
-			WorkosMembershipID: conv.ToPGText(member.ID),
-			WorkosUpdatedAt:    conv.ToPGTimestamptz(parsed.updatedAt),
-			WorkosLastEventID:  conv.ToPGText(""),
-		}); err != nil {
-			return fmt.Errorf("upsert organization membership %q: %w", member.ID, err)
-		}
+	if err := orgQueries.UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     organizationID,
+		UserID:             conv.ToPGTextEmpty(gramUserID),
+		WorkosUserID:       conv.ToPGText(member.UserID),
+		WorkosMembershipID: conv.ToPGText(member.ID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(parsed.updatedAt),
+		WorkosLastEventID:  conv.ToPGText(""),
+	}); err != nil {
+		return fmt.Errorf("upsert organization membership %q: %w", member.ID, err)
 	}
 
 	roleSlugs := []string{}

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -156,6 +156,11 @@ func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *test
 	require.False(t, assignments[0].UserID.Valid)
 	require.Equal(t, membershipID, assignments[0].WorkosMembershipID.String)
 	require.Empty(t, assignments[0].WorkosLastEventID.String)
+
+	relationship, err := orgrepo.New(conn).GetRelationshipByMembershipID(ctx, conv.ToPGText(membershipID))
+	require.NoError(t, err)
+	require.False(t, relationship.UserID.Valid)
+	require.Equal(t, workosUserID, relationship.WorkosUserID.String)
 }
 
 func TestBackfillWorkOSOrganization_MembershipWithNewerEventSkipsRoleSnapshot(t *testing.T) {

--- a/server/internal/background/activities/handle_workos_membership_event.go
+++ b/server/internal/background/activities/handle_workos_membership_event.go
@@ -59,36 +59,22 @@ func handleOrganizationMembershipUpsert(ctx context.Context, logger *slog.Logger
 		return fmt.Errorf("get user by workos id %q: %w", payload.UserID, err)
 	}
 
-	if gramUserID != "" {
-		existing, err := orgrepo.New(dbtx).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
-			OrganizationID: org.ID,
-			UserID:         conv.ToPGText(gramUserID),
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-		case err != nil:
-			return fmt.Errorf("get organization membership %q: %w", payload.ID, err)
-		}
-		var lastEventID *string
-		if existing.WorkosLastEventID.Valid {
-			lastEventID = &existing.WorkosLastEventID.String
-		}
-		var rowUpdatedAt *time.Time
-		if existing.WorkosUpdatedAt.Valid {
-			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
-		}
-		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
-			return nil
-		}
-		if err := orgrepo.New(dbtx).UpsertOrganizationUserRelationshipFromWorkOS(ctx, orgrepo.UpsertOrganizationUserRelationshipFromWorkOSParams{
-			OrganizationID:     org.ID,
-			UserID:             conv.ToPGText(gramUserID),
-			WorkosMembershipID: conv.ToPGText(payload.ID),
-			WorkosUpdatedAt:    conv.ToPGTimestamptz(payload.UpdatedAt),
-			WorkosLastEventID:  conv.ToPGText(event.ID),
-		}); err != nil {
-			return fmt.Errorf("upsert organization membership %q: %w", payload.ID, err)
-		}
+	lastEventID, rowUpdatedAt, err := getMembershipRelationshipCursor(ctx, orgrepo.New(dbtx), org.ID, gramUserID, payload.ID)
+	if err != nil {
+		return err
+	}
+	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
+		return nil
+	}
+	if err := orgrepo.New(dbtx).UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     org.ID,
+		UserID:             conv.ToPGTextEmpty(gramUserID),
+		WorkosUserID:       conv.ToPGText(payload.UserID),
+		WorkosMembershipID: conv.ToPGText(payload.ID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID:  conv.ToPGText(event.ID),
+	}); err != nil {
+		return fmt.Errorf("upsert organization membership %q: %w", payload.ID, err)
 	}
 
 	if err := orgrepo.New(dbtx).SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
@@ -130,46 +116,61 @@ func handleOrganizationMembershipDeleted(ctx context.Context, logger *slog.Logge
 		return fmt.Errorf("get user by workos id %q: %w", payload.UserID, err)
 	}
 
-	if gramUserID != "" {
-		existing, err := orgrepo.New(dbtx).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
-			OrganizationID: org.ID,
-			UserID:         conv.ToPGText(gramUserID),
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-		case err != nil:
-			return fmt.Errorf("get organization membership %q: %w", payload.ID, err)
-		}
-		var lastEventID *string
-		if existing.WorkosLastEventID.Valid {
-			lastEventID = &existing.WorkosLastEventID.String
-		}
-		var rowUpdatedAt *time.Time
-		if existing.WorkosUpdatedAt.Valid {
-			rowUpdatedAt = &existing.WorkosUpdatedAt.Time
-		}
-		if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
-			return nil
-		}
-		if err := orgrepo.New(dbtx).MarkOrganizationUserRelationshipAsDeleted(ctx, orgrepo.MarkOrganizationUserRelationshipAsDeletedParams{
-			OrganizationID:     org.ID,
-			UserID:             conv.ToPGText(gramUserID),
-			WorkosMembershipID: conv.ToPGText(payload.ID),
-			WorkosUpdatedAt:    conv.ToPGTimestamptz(payload.UpdatedAt),
-			WorkosLastEventID:  conv.ToPGText(event.ID),
-		}); err != nil {
-			return fmt.Errorf("mark organization membership %q deleted: %w", payload.ID, err)
-		}
+	lastEventID, rowUpdatedAt, err := getMembershipRelationshipCursor(ctx, orgrepo.New(dbtx), org.ID, gramUserID, payload.ID)
+	if err != nil {
+		return err
+	}
+	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
+		return nil
+	}
+	if err := orgrepo.New(dbtx).MarkWorkOSMembershipDeleted(ctx, orgrepo.MarkWorkOSMembershipDeletedParams{
+		OrganizationID:     org.ID,
+		UserID:             conv.ToPGTextEmpty(gramUserID),
+		WorkosUserID:       conv.ToPGText(payload.UserID),
+		WorkosMembershipID: conv.ToPGText(payload.ID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID:  conv.ToPGText(event.ID),
+	}); err != nil {
+		return fmt.Errorf("mark organization membership %q deleted: %w", payload.ID, err)
 	}
 
-	if err := orgrepo.New(dbtx).DeleteOrganizationRoleAssignmentsByWorkosUser(ctx, orgrepo.DeleteOrganizationRoleAssignmentsByWorkosUserParams{
-		OrganizationID: org.ID,
-		WorkosUserID:   payload.UserID,
+	if err := orgrepo.New(dbtx).MarkRoleAssignmentsDeleted(ctx, orgrepo.MarkRoleAssignmentsDeletedParams{
+		OrganizationID:    org.ID,
+		WorkosUserID:      payload.UserID,
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID: conv.ToPGText(event.ID),
 	}); err != nil {
-		return fmt.Errorf("delete role assignments for workos user %q: %w", payload.UserID, err)
+		return fmt.Errorf("mark role assignments for workos user %q deleted: %w", payload.UserID, err)
 	}
 
 	return nil
+}
+
+func getMembershipRelationshipCursor(ctx context.Context, repo *orgrepo.Queries, organizationID, gramUserID, workosMembershipID string) (*string, *time.Time, error) {
+	existing, err := repo.GetRelationshipByMembershipID(ctx, conv.ToPGText(workosMembershipID))
+	if errors.Is(err, pgx.ErrNoRows) && gramUserID != "" {
+		existing, err = repo.GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+			OrganizationID: organizationID,
+			UserID:         conv.ToPGText(gramUserID),
+		})
+	}
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, nil, nil
+	case err != nil:
+		return nil, nil, fmt.Errorf("get organization membership %q: %w", workosMembershipID, err)
+	}
+
+	var lastEventID *string
+	if existing.WorkosLastEventID.Valid {
+		lastEventID = &existing.WorkosLastEventID.String
+	}
+	var rowUpdatedAt *time.Time
+	if existing.WorkosUpdatedAt.Valid {
+		rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+	}
+
+	return lastEventID, rowUpdatedAt, nil
 }
 
 func decodeWorkOSMembershipPayload(event events.Event) (workosMembershipEventPayload, error) {

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -737,7 +737,9 @@ func TestProcessWorkOSOrganizationEvents_MembershipDeleteSoftDeletesAndClearsAss
 		WorkosUserID:   workosUserID,
 	})
 	require.NoError(t, err)
-	require.Empty(t, assignments)
+	require.Len(t, assignments, 1)
+	require.True(t, assignments[0].DeletedAt.Valid)
+	require.Equal(t, "event_01HZDEL2", assignments[0].WorkosLastEventID.String)
 }
 
 func TestProcessWorkOSOrganizationEvents_MembershipUnknownOrganizationSkips(t *testing.T) {

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -742,6 +742,46 @@ func TestProcessWorkOSOrganizationEvents_MembershipDeleteSoftDeletesAndClearsAss
 	require.Equal(t, "event_01HZDEL2", assignments[0].WorkosLastEventID.String)
 }
 
+func TestProcessWorkOSOrganizationEvents_MembershipRejoinReusesTombstone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_membership_rejoin")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_mem_rejoin"
+	const workosOrgID = "org_01HZMEMREJOIN"
+	const userID = "user_mem_rejoin"
+	const workosUserID = "user_01HZMEMREJOIN"
+	const firstMembershipID = "mem_01HZREJOIN1"
+	const secondMembershipID = "mem_01HZREJOIN2"
+
+	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZREJOIN1", firstMembershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)),
+			newWorkOSMembershipEvent(t, "organization_membership.deleted", "event_01HZREJOIN2", firstMembershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 13, 0, 0, 0, time.UTC)),
+			newWorkOSMembershipEvent(t, "organization_membership.created", "event_01HZREJOIN3", secondMembershipID, workosOrgID, workosUserID, time.Date(2026, 5, 6, 14, 0, 0, 0, time.UTC)),
+		},
+	})
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZREJOIN3", res.LastEventID)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	require.False(t, relationship.Deleted)
+	require.Equal(t, secondMembershipID, relationship.WorkosMembershipID.String)
+	require.Equal(t, "event_01HZREJOIN3", relationship.WorkosLastEventID.String)
+}
+
 func TestProcessWorkOSOrganizationEvents_MembershipUnknownOrganizationSkips(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/activities/process_workos_user_events.go
+++ b/server/internal/background/activities/process_workos_user_events.go
@@ -215,6 +215,12 @@ func (p *ProcessWorkOSUserEvents) handleUserUpsert(ctx context.Context, logger *
 	}); err != nil {
 		return nil, fmt.Errorf("link role assignments to user: %w", err)
 	}
+	if err := organizationQueries.LinkRelationshipsToUser(ctx, organizationsrepo.LinkRelationshipsToUserParams{
+		UserID:       conv.ToPGText(gramUserID),
+		WorkosUserID: conv.ToPGText(payload.ID),
+	}); err != nil {
+		return nil, fmt.Errorf("link organization relationships to user: %w", err)
+	}
 	if err := logRoleAssignmentLinkedToDifferentWorkOSUser(ctx, logger, organizationQueries, gramUserID, payload.ID); err != nil {
 		return nil, err
 	}

--- a/server/internal/background/activities/process_workos_user_events_test.go
+++ b/server/internal/background/activities/process_workos_user_events_test.go
@@ -183,6 +183,80 @@ func TestProcessWorkOSUserEvents_LinksOptimisticRoleAssignments(t *testing.T) {
 	require.Equal(t, gramID, assignments[0].UserID.String)
 }
 
+func TestProcessWorkOSUserEvents_LinksPendingRelationshipOverTombstone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newUserEventsTestConn(t, "workos_user_events_link_relationship_tombstone")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "org_relationship_tombstone"
+	const workosOrgID = "org_workos_relationship_tombstone"
+	const workosUserID = "user_relationship_tombstone"
+	const gramUserID = "gram_user_relationship_tombstone"
+	const firstMembershipID = "mem_relationship_tombstone_1"
+	const secondMembershipID = "mem_relationship_tombstone_2"
+	seedTime := time.Date(2026, 5, 10, 10, 0, 0, 0, time.UTC)
+
+	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+		ID:                organizationID,
+		Name:              "Relationship Tombstone Org",
+		Slug:              "relationship-tombstone-org",
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(seedTime),
+		WorkosLastEventID: conv.ToPGText("event_org_relationship_tombstone"),
+	})
+	require.NoError(t, err)
+	_, err = usersrepo.New(conn).UpsertSyncedUser(ctx, syncedUserParams(gramUserID, workosUserID, "old@example.com", "Existing User"))
+	require.NoError(t, err)
+	err = orgrepo.New(conn).UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     organizationID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosUserID:       conv.ToPGText(workosUserID),
+		WorkosMembershipID: conv.ToPGText(firstMembershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(seedTime),
+		WorkosLastEventID:  conv.ToPGText("event_relationship_tombstone_1"),
+	})
+	require.NoError(t, err)
+	err = orgrepo.New(conn).MarkWorkOSMembershipDeleted(ctx, orgrepo.MarkWorkOSMembershipDeletedParams{
+		OrganizationID:     organizationID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosUserID:       conv.ToPGText(workosUserID),
+		WorkosMembershipID: conv.ToPGText(firstMembershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(seedTime.Add(time.Hour)),
+		WorkosLastEventID:  conv.ToPGText("event_relationship_tombstone_2"),
+	})
+	require.NoError(t, err)
+	err = orgrepo.New(conn).UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     organizationID,
+		UserID:             conv.ToPGTextEmpty(""),
+		WorkosUserID:       conv.ToPGText(workosUserID),
+		WorkosMembershipID: conv.ToPGText(secondMembershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(seedTime.Add(2 * time.Hour)),
+		WorkosLastEventID:  conv.ToPGText("event_relationship_tombstone_3"),
+	})
+	require.NoError(t, err)
+
+	workosClient := workos.NewStubClient()
+	workosClient.SetEventPages([][]events.Event{{
+		{ID: "event_user_relationship_tombstone", Event: "user.updated", CreatedAt: time.Now(), Data: userEventDataWithExternalID(workosUserID, gramUserID, "new@example.com", "Existing", "User", "")},
+	}})
+
+	activity := activities.NewProcessWorkOSUserEvents(logger, conn, workosClient)
+	res, err := activity.Do(ctx, processWorkOSUserEventsParams(workosUserID))
+	require.NoError(t, err)
+	require.Equal(t, "event_user_relationship_tombstone", res.LastEventID)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	require.NoError(t, err)
+	require.False(t, relationship.Deleted)
+	require.Equal(t, secondMembershipID, relationship.WorkosMembershipID.String)
+	require.Equal(t, "event_relationship_tombstone_3", relationship.WorkosLastEventID.String)
+}
+
 func TestProcessWorkOSUserEvents_UsesExistingUserIDWhenExternalIDMissing(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -193,7 +193,6 @@ WITH updated_existing_user_relationship AS (
     WHERE organization_id = @organization_id
       AND user_id = @user_id
       AND @user_id::text IS NOT NULL
-      AND deleted_at IS NULL
     RETURNING id
 )
 INSERT INTO organization_user_relationships (
@@ -340,6 +339,52 @@ WHERE workos_user_id = @workos_user_id
   AND deleted_at IS NULL;
 
 -- name: LinkRelationshipsToUser :exec
+WITH pending_relationships AS (
+    SELECT
+        id,
+        organization_id,
+        workos_user_id,
+        workos_membership_id,
+        workos_updated_at,
+        workos_last_event_id
+    FROM organization_user_relationships
+    WHERE workos_user_id = @workos_user_id
+      AND user_id IS NULL
+      AND deleted_at IS NULL
+),
+deleted_pending_for_tombstones AS (
+    UPDATE organization_user_relationships pending
+    SET deleted_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+    FROM pending_relationships
+    WHERE pending.id = pending_relationships.id
+      AND EXISTS (
+          SELECT 1
+          FROM organization_user_relationships existing
+          WHERE existing.organization_id = pending_relationships.organization_id
+            AND existing.user_id = @user_id
+            AND existing.deleted_at IS NOT NULL
+      )
+    RETURNING
+        pending_relationships.organization_id,
+        pending_relationships.workos_user_id,
+        pending_relationships.workos_membership_id,
+        pending_relationships.workos_updated_at,
+        pending_relationships.workos_last_event_id
+),
+relinked_tombstones AS (
+    UPDATE organization_user_relationships existing
+    SET workos_user_id = deleted_pending_for_tombstones.workos_user_id,
+        workos_membership_id = deleted_pending_for_tombstones.workos_membership_id,
+        workos_updated_at = deleted_pending_for_tombstones.workos_updated_at,
+        workos_last_event_id = deleted_pending_for_tombstones.workos_last_event_id,
+        deleted_at = NULL,
+        updated_at = clock_timestamp()
+    FROM deleted_pending_for_tombstones
+    WHERE existing.organization_id = deleted_pending_for_tombstones.organization_id
+      AND existing.user_id = @user_id
+      AND existing.deleted_at IS NOT NULL
+)
 UPDATE organization_user_relationships pending
 SET user_id = @user_id,
     updated_at = clock_timestamp()
@@ -351,7 +396,6 @@ WHERE pending.workos_user_id = @workos_user_id
       FROM organization_user_relationships existing
       WHERE existing.organization_id = pending.organization_id
         AND existing.user_id = @user_id
-        AND existing.deleted_at IS NULL
   );
 
 -- name: GetRoleAssignmentLinkedToDifferentWorkOSUser :one

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -172,48 +172,92 @@ FROM organization_user_relationships
 WHERE organization_id = @organization_id
   AND user_id = @user_id;
 
--- name: UpsertOrganizationUserRelationshipFromWorkOS :exec
+-- name: GetRelationshipByMembershipID :one
+SELECT *
+FROM organization_user_relationships
+WHERE workos_membership_id = @workos_membership_id
+ORDER BY updated_at DESC
+LIMIT 1;
+
+-- name: UpsertWorkOSMembership :exec
 -- Upsert a membership row from a WorkOS organization_membership event. Caller
 -- must have already passed the row through ShouldProcessEvent.
+WITH updated_existing_user_relationship AS (
+    UPDATE organization_user_relationships
+    SET workos_user_id = @workos_user_id,
+        workos_membership_id = @workos_membership_id,
+        workos_updated_at = @workos_updated_at,
+        workos_last_event_id = @workos_last_event_id,
+        deleted_at = NULL,
+        updated_at = clock_timestamp()
+    WHERE organization_id = @organization_id
+      AND user_id = @user_id
+      AND @user_id::text IS NOT NULL
+      AND deleted_at IS NULL
+    RETURNING id
+)
 INSERT INTO organization_user_relationships (
     organization_id,
     user_id,
+    workos_user_id,
     workos_membership_id,
     workos_updated_at,
     workos_last_event_id
-) VALUES (
+)
+SELECT
     @organization_id,
     @user_id,
+    @workos_user_id,
     @workos_membership_id,
     @workos_updated_at,
     @workos_last_event_id
-)
-ON CONFLICT (organization_id, user_id) DO UPDATE SET
+WHERE NOT EXISTS (SELECT 1 FROM updated_existing_user_relationship)
+ON CONFLICT (workos_membership_id) WHERE deleted IS FALSE DO UPDATE SET
+    user_id = COALESCE(EXCLUDED.user_id, organization_user_relationships.user_id),
+    workos_user_id = COALESCE(EXCLUDED.workos_user_id, organization_user_relationships.workos_user_id),
     workos_membership_id = EXCLUDED.workos_membership_id,
     workos_updated_at = EXCLUDED.workos_updated_at,
     workos_last_event_id = EXCLUDED.workos_last_event_id,
     deleted_at = NULL,
     updated_at = clock_timestamp();
 
--- name: MarkOrganizationUserRelationshipAsDeleted :exec
+-- name: MarkWorkOSMembershipDeleted :exec
 -- Record a WorkOS membership delete, inserting a tombstone when the local
 -- relationship did not exist so stale replayed creates cannot resurrect it.
+WITH updated_existing_user_relationship AS (
+    UPDATE organization_user_relationships
+    SET workos_user_id = @workos_user_id,
+        workos_membership_id = @workos_membership_id,
+        workos_updated_at = @workos_updated_at,
+        workos_last_event_id = @workos_last_event_id,
+        deleted_at = COALESCE(deleted_at, clock_timestamp()),
+        updated_at = clock_timestamp()
+    WHERE organization_id = @organization_id
+      AND user_id = @user_id
+      AND @user_id::text IS NOT NULL
+    RETURNING id
+)
 INSERT INTO organization_user_relationships (
     organization_id,
     user_id,
+    workos_user_id,
     workos_membership_id,
     workos_updated_at,
     workos_last_event_id,
     deleted_at
-) VALUES (
+)
+SELECT
     @organization_id,
     @user_id,
+    @workos_user_id,
     @workos_membership_id,
     @workos_updated_at,
     @workos_last_event_id,
     clock_timestamp()
-)
-ON CONFLICT (organization_id, user_id) DO UPDATE SET
+WHERE NOT EXISTS (SELECT 1 FROM updated_existing_user_relationship)
+ON CONFLICT (workos_membership_id) WHERE deleted IS FALSE DO UPDATE SET
+    user_id = COALESCE(EXCLUDED.user_id, organization_user_relationships.user_id),
+    workos_user_id = COALESCE(EXCLUDED.workos_user_id, organization_user_relationships.workos_user_id),
     workos_membership_id = COALESCE(EXCLUDED.workos_membership_id, organization_user_relationships.workos_membership_id),
     workos_updated_at = EXCLUDED.workos_updated_at,
     workos_last_event_id = EXCLUDED.workos_last_event_id,
@@ -263,25 +307,52 @@ upserted AS (
         workos_membership_id = EXCLUDED.workos_membership_id,
         workos_updated_at = EXCLUDED.workos_updated_at,
         workos_last_event_id = EXCLUDED.workos_last_event_id,
+        deleted_at = NULL,
         updated_at = clock_timestamp()
     RETURNING role_urn
 )
-DELETE FROM organization_role_assignments
+UPDATE organization_role_assignments
+SET workos_updated_at = @workos_updated_at,
+    workos_last_event_id = @workos_last_event_id,
+    deleted_at = COALESCE(deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
 WHERE organization_role_assignments.organization_id = @organization_id
   AND organization_role_assignments.workos_user_id = @workos_user_id
+  AND organization_role_assignments.deleted_at IS NULL
   AND organization_role_assignments.role_urn NOT IN (SELECT input_role_urns.role_urn FROM input_role_urns);
 
--- name: DeleteOrganizationRoleAssignmentsByWorkosUser :exec
-DELETE FROM organization_role_assignments
+-- name: MarkRoleAssignmentsDeleted :exec
+UPDATE organization_role_assignments
+SET workos_updated_at = @workos_updated_at,
+    workos_last_event_id = @workos_last_event_id,
+    deleted_at = COALESCE(deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
 WHERE organization_id = @organization_id
-  AND workos_user_id = @workos_user_id;
+  AND workos_user_id = @workos_user_id
+  AND deleted_at IS NULL;
 
 -- name: LinkRoleAssignmentsToUser :exec
 UPDATE organization_role_assignments
 SET user_id = @user_id,
     updated_at = clock_timestamp()
 WHERE workos_user_id = @workos_user_id
-  AND user_id IS NULL;
+  AND user_id IS NULL
+  AND deleted_at IS NULL;
+
+-- name: LinkRelationshipsToUser :exec
+UPDATE organization_user_relationships pending
+SET user_id = @user_id,
+    updated_at = clock_timestamp()
+WHERE pending.workos_user_id = @workos_user_id
+  AND pending.user_id IS NULL
+  AND pending.deleted_at IS NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM organization_user_relationships existing
+      WHERE existing.organization_id = pending.organization_id
+        AND existing.user_id = @user_id
+        AND existing.deleted_at IS NULL
+  );
 
 -- name: GetRoleAssignmentLinkedToDifferentWorkOSUser :one
 SELECT id, workos_user_id

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -365,6 +365,52 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 }
 
 const linkRelationshipsToUser = `-- name: LinkRelationshipsToUser :exec
+WITH pending_relationships AS (
+    SELECT
+        id,
+        organization_id,
+        workos_user_id,
+        workos_membership_id,
+        workos_updated_at,
+        workos_last_event_id
+    FROM organization_user_relationships
+    WHERE workos_user_id = $2
+      AND user_id IS NULL
+      AND deleted_at IS NULL
+),
+deleted_pending_for_tombstones AS (
+    UPDATE organization_user_relationships pending
+    SET deleted_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+    FROM pending_relationships
+    WHERE pending.id = pending_relationships.id
+      AND EXISTS (
+          SELECT 1
+          FROM organization_user_relationships existing
+          WHERE existing.organization_id = pending_relationships.organization_id
+            AND existing.user_id = $1
+            AND existing.deleted_at IS NOT NULL
+      )
+    RETURNING
+        pending_relationships.organization_id,
+        pending_relationships.workos_user_id,
+        pending_relationships.workos_membership_id,
+        pending_relationships.workos_updated_at,
+        pending_relationships.workos_last_event_id
+),
+relinked_tombstones AS (
+    UPDATE organization_user_relationships existing
+    SET workos_user_id = deleted_pending_for_tombstones.workos_user_id,
+        workos_membership_id = deleted_pending_for_tombstones.workos_membership_id,
+        workos_updated_at = deleted_pending_for_tombstones.workos_updated_at,
+        workos_last_event_id = deleted_pending_for_tombstones.workos_last_event_id,
+        deleted_at = NULL,
+        updated_at = clock_timestamp()
+    FROM deleted_pending_for_tombstones
+    WHERE existing.organization_id = deleted_pending_for_tombstones.organization_id
+      AND existing.user_id = $1
+      AND existing.deleted_at IS NOT NULL
+)
 UPDATE organization_user_relationships pending
 SET user_id = $1,
     updated_at = clock_timestamp()
@@ -376,7 +422,6 @@ WHERE pending.workos_user_id = $2
       FROM organization_user_relationships existing
       WHERE existing.organization_id = pending.organization_id
         AND existing.user_id = $1
-        AND existing.deleted_at IS NULL
   )
 `
 
@@ -1095,7 +1140,6 @@ WITH updated_existing_user_relationship AS (
     WHERE organization_id = $1
       AND user_id = $2
       AND $2::text IS NOT NULL
-      AND deleted_at IS NULL
     RETURNING id
 )
 INSERT INTO organization_user_relationships (

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -68,22 +68,6 @@ func (q *Queries) CreateOrganizationMetadata(ctx context.Context, arg CreateOrga
 	return err
 }
 
-const deleteOrganizationRoleAssignmentsByWorkosUser = `-- name: DeleteOrganizationRoleAssignmentsByWorkosUser :exec
-DELETE FROM organization_role_assignments
-WHERE organization_id = $1
-  AND workos_user_id = $2
-`
-
-type DeleteOrganizationRoleAssignmentsByWorkosUserParams struct {
-	OrganizationID string
-	WorkosUserID   string
-}
-
-func (q *Queries) DeleteOrganizationRoleAssignmentsByWorkosUser(ctx context.Context, arg DeleteOrganizationRoleAssignmentsByWorkosUserParams) error {
-	_, err := q.db.Exec(ctx, deleteOrganizationRoleAssignmentsByWorkosUser, arg.OrganizationID, arg.WorkosUserID)
-	return err
-}
-
 const deleteOrganizationUserRelationship = `-- name: DeleteOrganizationUserRelationship :exec
 UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp()
@@ -292,6 +276,33 @@ func (q *Queries) GetOrganizationUserRelationship(ctx context.Context, arg GetOr
 	return i, err
 }
 
+const getRelationshipByMembershipID = `-- name: GetRelationshipByMembershipID :one
+SELECT id, organization_id, user_id, workos_user_id, workos_membership_id, workos_updated_at, workos_last_event_id, created_at, updated_at, deleted_at, deleted
+FROM organization_user_relationships
+WHERE workos_membership_id = $1
+ORDER BY updated_at DESC
+LIMIT 1
+`
+
+func (q *Queries) GetRelationshipByMembershipID(ctx context.Context, workosMembershipID pgtype.Text) (OrganizationUserRelationship, error) {
+	row := q.db.QueryRow(ctx, getRelationshipByMembershipID, workosMembershipID)
+	var i OrganizationUserRelationship
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.UserID,
+		&i.WorkosUserID,
+		&i.WorkosMembershipID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getRoleAssignmentLinkedToDifferentWorkOSUser = `-- name: GetRoleAssignmentLinkedToDifferentWorkOSUser :one
 SELECT id, workos_user_id
 FROM organization_role_assignments
@@ -353,12 +364,39 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 	return exists, err
 }
 
+const linkRelationshipsToUser = `-- name: LinkRelationshipsToUser :exec
+UPDATE organization_user_relationships pending
+SET user_id = $1,
+    updated_at = clock_timestamp()
+WHERE pending.workos_user_id = $2
+  AND pending.user_id IS NULL
+  AND pending.deleted_at IS NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM organization_user_relationships existing
+      WHERE existing.organization_id = pending.organization_id
+        AND existing.user_id = $1
+        AND existing.deleted_at IS NULL
+  )
+`
+
+type LinkRelationshipsToUserParams struct {
+	UserID       pgtype.Text
+	WorkosUserID pgtype.Text
+}
+
+func (q *Queries) LinkRelationshipsToUser(ctx context.Context, arg LinkRelationshipsToUserParams) error {
+	_, err := q.db.Exec(ctx, linkRelationshipsToUser, arg.UserID, arg.WorkosUserID)
+	return err
+}
+
 const linkRoleAssignmentsToUser = `-- name: LinkRoleAssignmentsToUser :exec
 UPDATE organization_role_assignments
 SET user_id = $1,
     updated_at = clock_timestamp()
 WHERE workos_user_id = $2
   AND user_id IS NULL
+  AND deleted_at IS NULL
 `
 
 type LinkRoleAssignmentsToUserParams struct {
@@ -521,23 +559,69 @@ func (q *Queries) ListOrganizationsForUser(ctx context.Context, userID pgtype.Te
 	return items, nil
 }
 
-const markOrganizationUserRelationshipAsDeleted = `-- name: MarkOrganizationUserRelationshipAsDeleted :exec
+const markRoleAssignmentsDeleted = `-- name: MarkRoleAssignmentsDeleted :exec
+UPDATE organization_role_assignments
+SET workos_updated_at = $1,
+    workos_last_event_id = $2,
+    deleted_at = COALESCE(deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+WHERE organization_id = $3
+  AND workos_user_id = $4
+  AND deleted_at IS NULL
+`
+
+type MarkRoleAssignmentsDeletedParams struct {
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+	OrganizationID    string
+	WorkosUserID      string
+}
+
+func (q *Queries) MarkRoleAssignmentsDeleted(ctx context.Context, arg MarkRoleAssignmentsDeletedParams) error {
+	_, err := q.db.Exec(ctx, markRoleAssignmentsDeleted,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+		arg.OrganizationID,
+		arg.WorkosUserID,
+	)
+	return err
+}
+
+const markWorkOSMembershipDeleted = `-- name: MarkWorkOSMembershipDeleted :exec
+WITH updated_existing_user_relationship AS (
+    UPDATE organization_user_relationships
+    SET workos_user_id = $3,
+        workos_membership_id = $4,
+        workos_updated_at = $5,
+        workos_last_event_id = $6,
+        deleted_at = COALESCE(deleted_at, clock_timestamp()),
+        updated_at = clock_timestamp()
+    WHERE organization_id = $1
+      AND user_id = $2
+      AND $2::text IS NOT NULL
+    RETURNING id
+)
 INSERT INTO organization_user_relationships (
     organization_id,
     user_id,
+    workos_user_id,
     workos_membership_id,
     workos_updated_at,
     workos_last_event_id,
     deleted_at
-) VALUES (
+)
+SELECT
     $1,
     $2,
     $3,
     $4,
     $5,
+    $6,
     clock_timestamp()
-)
-ON CONFLICT (organization_id, user_id) DO UPDATE SET
+WHERE NOT EXISTS (SELECT 1 FROM updated_existing_user_relationship)
+ON CONFLICT (workos_membership_id) WHERE deleted IS FALSE DO UPDATE SET
+    user_id = COALESCE(EXCLUDED.user_id, organization_user_relationships.user_id),
+    workos_user_id = COALESCE(EXCLUDED.workos_user_id, organization_user_relationships.workos_user_id),
     workos_membership_id = COALESCE(EXCLUDED.workos_membership_id, organization_user_relationships.workos_membership_id),
     workos_updated_at = EXCLUDED.workos_updated_at,
     workos_last_event_id = EXCLUDED.workos_last_event_id,
@@ -545,9 +629,10 @@ ON CONFLICT (organization_id, user_id) DO UPDATE SET
     updated_at = clock_timestamp()
 `
 
-type MarkOrganizationUserRelationshipAsDeletedParams struct {
+type MarkWorkOSMembershipDeletedParams struct {
 	OrganizationID     string
 	UserID             pgtype.Text
+	WorkosUserID       pgtype.Text
 	WorkosMembershipID pgtype.Text
 	WorkosUpdatedAt    pgtype.Timestamptz
 	WorkosLastEventID  pgtype.Text
@@ -555,10 +640,11 @@ type MarkOrganizationUserRelationshipAsDeletedParams struct {
 
 // Record a WorkOS membership delete, inserting a tombstone when the local
 // relationship did not exist so stale replayed creates cannot resurrect it.
-func (q *Queries) MarkOrganizationUserRelationshipAsDeleted(ctx context.Context, arg MarkOrganizationUserRelationshipAsDeletedParams) error {
-	_, err := q.db.Exec(ctx, markOrganizationUserRelationshipAsDeleted,
+func (q *Queries) MarkWorkOSMembershipDeleted(ctx context.Context, arg MarkWorkOSMembershipDeletedParams) error {
+	_, err := q.db.Exec(ctx, markWorkOSMembershipDeleted,
 		arg.OrganizationID,
 		arg.UserID,
+		arg.WorkosUserID,
 		arg.WorkosMembershipID,
 		arg.WorkosUpdatedAt,
 		arg.WorkosLastEventID,
@@ -701,14 +787,14 @@ const syncUserOrganizationRoleAssignments = `-- name: SyncUserOrganizationRoleAs
 WITH input_role_urns AS (
     SELECT 'role:organization:' || id::text AS role_urn
     FROM organization_roles
-    WHERE organization_id = $1
-      AND workos_slug = ANY($3::text[])
+    WHERE organization_id = $3
+      AND workos_slug = ANY($5::text[])
       AND deleted IS FALSE
       AND workos_deleted IS FALSE
     UNION ALL
     SELECT 'role:global:' || id::text AS role_urn
     FROM global_roles
-    WHERE workos_slug = ANY($3::text[])
+    WHERE workos_slug = ANY($5::text[])
       AND deleted IS FALSE
       AND workos_deleted IS FALSE
 ),
@@ -723,13 +809,13 @@ upserted AS (
         workos_last_event_id
     )
     SELECT
-        $1,
-        $2,
+        $3,
         $4,
-        input_role_urns.role_urn,
-        $5,
         $6,
-        $7
+        input_role_urns.role_urn,
+        $7,
+        $1,
+        $2
     FROM input_role_urns
     ON CONFLICT (organization_id, workos_user_id, role_urn) WHERE deleted_at IS NULL DO UPDATE SET
         -- COALESCE preserves a backfilled user_id if the sync fires before the Gram user exists.
@@ -737,23 +823,29 @@ upserted AS (
         workos_membership_id = EXCLUDED.workos_membership_id,
         workos_updated_at = EXCLUDED.workos_updated_at,
         workos_last_event_id = EXCLUDED.workos_last_event_id,
+        deleted_at = NULL,
         updated_at = clock_timestamp()
     RETURNING role_urn
 )
-DELETE FROM organization_role_assignments
-WHERE organization_role_assignments.organization_id = $1
-  AND organization_role_assignments.workos_user_id = $2
+UPDATE organization_role_assignments
+SET workos_updated_at = $1,
+    workos_last_event_id = $2,
+    deleted_at = COALESCE(deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+WHERE organization_role_assignments.organization_id = $3
+  AND organization_role_assignments.workos_user_id = $4
+  AND organization_role_assignments.deleted_at IS NULL
   AND organization_role_assignments.role_urn NOT IN (SELECT input_role_urns.role_urn FROM input_role_urns)
 `
 
 type SyncUserOrganizationRoleAssignmentsParams struct {
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
 	OrganizationID     string
 	WorkosUserID       string
 	WorkosRoleSlugs    []string
 	UserID             pgtype.Text
 	WorkosMembershipID pgtype.Text
-	WorkosUpdatedAt    pgtype.Timestamptz
-	WorkosLastEventID  pgtype.Text
 }
 
 // Declaratively set all WorkOS role assignments for a known Gram user in an
@@ -761,13 +853,13 @@ type SyncUserOrganizationRoleAssignmentsParams struct {
 // this WorkOS user are removed.
 func (q *Queries) SyncUserOrganizationRoleAssignments(ctx context.Context, arg SyncUserOrganizationRoleAssignmentsParams) error {
 	_, err := q.db.Exec(ctx, syncUserOrganizationRoleAssignments,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
 		arg.OrganizationID,
 		arg.WorkosUserID,
 		arg.WorkosRoleSlugs,
 		arg.UserID,
 		arg.WorkosMembershipID,
-		arg.WorkosUpdatedAt,
-		arg.WorkosLastEventID,
 	)
 	return err
 }
@@ -945,49 +1037,6 @@ func (q *Queries) UpsertOrganizationUserRelationship(ctx context.Context, arg Up
 	return i, err
 }
 
-const upsertOrganizationUserRelationshipFromWorkOS = `-- name: UpsertOrganizationUserRelationshipFromWorkOS :exec
-INSERT INTO organization_user_relationships (
-    organization_id,
-    user_id,
-    workos_membership_id,
-    workos_updated_at,
-    workos_last_event_id
-) VALUES (
-    $1,
-    $2,
-    $3,
-    $4,
-    $5
-)
-ON CONFLICT (organization_id, user_id) DO UPDATE SET
-    workos_membership_id = EXCLUDED.workos_membership_id,
-    workos_updated_at = EXCLUDED.workos_updated_at,
-    workos_last_event_id = EXCLUDED.workos_last_event_id,
-    deleted_at = NULL,
-    updated_at = clock_timestamp()
-`
-
-type UpsertOrganizationUserRelationshipFromWorkOSParams struct {
-	OrganizationID     string
-	UserID             pgtype.Text
-	WorkosMembershipID pgtype.Text
-	WorkosUpdatedAt    pgtype.Timestamptz
-	WorkosLastEventID  pgtype.Text
-}
-
-// Upsert a membership row from a WorkOS organization_membership event. Caller
-// must have already passed the row through ShouldProcessEvent.
-func (q *Queries) UpsertOrganizationUserRelationshipFromWorkOS(ctx context.Context, arg UpsertOrganizationUserRelationshipFromWorkOSParams) error {
-	_, err := q.db.Exec(ctx, upsertOrganizationUserRelationshipFromWorkOS,
-		arg.OrganizationID,
-		arg.UserID,
-		arg.WorkosMembershipID,
-		arg.WorkosUpdatedAt,
-		arg.WorkosLastEventID,
-	)
-	return err
-}
-
 const upsertSvixAppID = `-- name: UpsertSvixAppID :one
 WITH previous AS (
     SELECT prev.svix_app_id
@@ -1032,4 +1081,68 @@ func (q *Queries) UpsertSvixAppID(ctx context.Context, arg UpsertSvixAppIDParams
 		&i.WebhooksEnabled,
 	)
 	return i, err
+}
+
+const upsertWorkOSMembership = `-- name: UpsertWorkOSMembership :exec
+WITH updated_existing_user_relationship AS (
+    UPDATE organization_user_relationships
+    SET workos_user_id = $3,
+        workos_membership_id = $4,
+        workos_updated_at = $5,
+        workos_last_event_id = $6,
+        deleted_at = NULL,
+        updated_at = clock_timestamp()
+    WHERE organization_id = $1
+      AND user_id = $2
+      AND $2::text IS NOT NULL
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO organization_user_relationships (
+    organization_id,
+    user_id,
+    workos_user_id,
+    workos_membership_id,
+    workos_updated_at,
+    workos_last_event_id
+)
+SELECT
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6
+WHERE NOT EXISTS (SELECT 1 FROM updated_existing_user_relationship)
+ON CONFLICT (workos_membership_id) WHERE deleted IS FALSE DO UPDATE SET
+    user_id = COALESCE(EXCLUDED.user_id, organization_user_relationships.user_id),
+    workos_user_id = COALESCE(EXCLUDED.workos_user_id, organization_user_relationships.workos_user_id),
+    workos_membership_id = EXCLUDED.workos_membership_id,
+    workos_updated_at = EXCLUDED.workos_updated_at,
+    workos_last_event_id = EXCLUDED.workos_last_event_id,
+    deleted_at = NULL,
+    updated_at = clock_timestamp()
+`
+
+type UpsertWorkOSMembershipParams struct {
+	OrganizationID     string
+	UserID             pgtype.Text
+	WorkosUserID       pgtype.Text
+	WorkosMembershipID pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WorkosLastEventID  pgtype.Text
+}
+
+// Upsert a membership row from a WorkOS organization_membership event. Caller
+// must have already passed the row through ShouldProcessEvent.
+func (q *Queries) UpsertWorkOSMembership(ctx context.Context, arg UpsertWorkOSMembershipParams) error {
+	_, err := q.db.Exec(ctx, upsertWorkOSMembership,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.WorkosUserID,
+		arg.WorkosMembershipID,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+	)
+	return err
 }


### PR DESCRIPTION
## Summary
- pre-create WorkOS organization relationships by membership ID even before a Gram user exists
- link pre-created organization relationships when the WorkOS user sync creates or updates the Gram user
- tombstone stale WorkOS role assignments instead of deleting them