### PR TITLE
feat(catalog): expose MCP catalog to assistants as platform tools

### DIFF
--- a/.changeset/age-2296-catalog-platform-tools.md
+++ b/.changeset/age-2296-catalog-platform-tools.md
@@ -2,4 +2,4 @@
 "server": minor
 ---
 
-Assistants can now search and install MCP catalog servers from a chat. `platform_search_catalog` queries the configured MCP registries and returns each result's registry_id + registry_specifier alongside tool previews; `platform_install_catalog_server` installs a server into the caller's project, creating a new toolset wired to the server's tools and enabling it for MCP — the same effect as the "Add to Project" dialog in the catalog UI.
+Assistants can now search and install MCP catalog servers from a chat. `platform_search_catalog` queries the configured MCP registries and returns each result's registry_id + registry_specifier alongside tool and remote previews; `platform_install_catalog_server` registers the selected catalog server as a remote MCP server in the caller's project, resolving the upstream URL (with variable substitution) and required headers from the catalog entry.

--- a/.changeset/age-2296-catalog-platform-tools.md
+++ b/.changeset/age-2296-catalog-platform-tools.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Assistants can now search and install MCP catalog servers from a chat. `platform_search_catalog` queries the configured MCP registries and returns each result's registry_id + registry_specifier alongside tool previews; `platform_install_catalog_server` installs a server into the caller's project, creating a new toolset wired to the server's tools and enabling it for MCP — the same effect as the "Add to Project" dialog in the catalog UI.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -55,6 +55,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
@@ -77,6 +78,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/otelforwarding"
 	"github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	platformcatalog "github.com/speakeasy-api/gram/server/internal/platformtools/catalog"
 	platformtoolsruntime "github.com/speakeasy-api/gram/server/internal/platformtools/runtime"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	"github.com/speakeasy-api/gram/server/internal/projects"
@@ -736,6 +738,25 @@ func newStartCommand() *cli.Command {
 				AssistantMemoryTools: memoryTools,
 			})
 
+			// deploymentsSvc and toolsetsSvc are constructed up here (rather
+			// than inline with their Attach call below) so the catalog platform
+			// tools can hand off to them for install — the install tool maps to
+			// the same evolveDeployment + createToolset + enable MCP flow as
+			// the dashboard catalog dialog.
+			deploymentsSvc := deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger)
+			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
+			catalogTools := platformtoolsruntime.CatalogExternalTools(
+				&platformcatalog.FuncInstaller{
+					EvolveFn:        deploymentsSvc.Evolve,
+					CreateToolsetFn: toolsetsSvc.CreateToolset,
+					UpdateToolsetFn: toolsetsSvc.UpdateToolset,
+				},
+				mcpRegistryClient,
+				externalmcprepo.New(db),
+			)
+			platformExtras := append([]platformtools.ExternalTool{}, memoryTools...)
+			platformExtras = append(platformExtras, catalogTools...)
+
 			platformSvc := platformtoolsruntime.NewService(
 				logger,
 				db,
@@ -744,7 +765,7 @@ func newStartCommand() *cli.Command {
 				platformtoolsruntime.WithTriggerTools(triggerApp),
 				platformtoolsruntime.WithSlackHTTPClient(guardianPolicy.PooledClient()),
 				platformtoolsruntime.WithFeatureChecker(platformFeatureChecker),
-				platformtoolsruntime.WithExternalTools(memoryTools),
+				platformtoolsruntime.WithExternalTools(platformExtras),
 			)
 
 			mcpService := mcp.NewService(
@@ -773,7 +794,7 @@ func newStartCommand() *cli.Command {
 				assistantTokenManager,
 				shadowMCPClient,
 				auditLogger,
-				memoryTools,
+				platformExtras,
 				platformFeatureChecker,
 				platformToolsets,
 				speakeasyIDPClient,
@@ -796,7 +817,6 @@ func newStartCommand() *cli.Command {
 			assistantsSvc := assistants.NewService(logger, tracerProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv})
 			triggerApp.RegisterDispatcher(assistantsSvc)
 
-			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
 			mcpMetadataService := mcpmetadata.NewService(logger, tracerProvider, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
 
 			otelForwardClient := otelforwarding.NewClient(logger, db, encryptionClient, cache.NewRedisCacheAdapter(redisClient))
@@ -960,7 +980,7 @@ func newStartCommand() *cli.Command {
 			integrations.Attach(mux, integrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			templates.Attach(mux, templates.NewService(logger, tracerProvider, db, sessionManager, toolsetsSvc, authzEngine, auditLogger))
 			assets.Attach(mux, assets.NewService(logger, tracerProvider, guardianPolicy, db, sessionManager, chatSessionsManager, assetStorage, c.String(usersessions.JWTSigningKeyFlag), authzEngine, auditLogger))
-			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger))
+			deployments.Attach(mux, deploymentsSvc)
 			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), authzEngine, auditLogger))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
@@ -970,7 +990,7 @@ func newStartCommand() *cli.Command {
 			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger))
 			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, encryptionClient, authzEngine, guardianPolicy, posthogClient, billingRepo, billingTracker, mcpService, serverURL), mcpMetadataService)
 			triggers.Attach(mux, triggers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, triggerApp, auditLogger))
-			tools.Attach(mux, tools.NewService(logger, tracerProvider, db, sessionManager, authzEngine, platformFeatureChecker, memoryTools))
+			tools.Attach(mux, tools.NewService(logger, tracerProvider, db, sessionManager, authzEngine, platformFeatureChecker, platformExtras))
 			resources.Attach(mux, resources.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			oauth.AttachExternalOAuth(mux, externalOAuthService)
 			oauth.Attach(mux, oauthService)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -52,6 +52,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
+	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
@@ -750,6 +751,7 @@ func newStartCommand() *cli.Command {
 				},
 				mcpRegistryClient,
 				externalmcprepo.New(db),
+				deploymentsrepo.New(db),
 			)
 			platformExtras := append([]platformtools.ExternalTool{}, memoryTools...)
 			platformExtras = append(platformExtras, catalogTools...)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -734,9 +734,6 @@ func newStartCommand() *cli.Command {
 			platformFeatureChecker := productFeatures.PlatformFeatureCheck
 
 			memoryTools := platformtoolsruntime.MemoryExternalTools(memorySvc)
-			platformToolsets := platformtools.BuildToolsets(platformtools.ToolsetDependencies{
-				AssistantMemoryTools: memoryTools,
-			})
 
 			// deploymentsSvc and toolsetsSvc are constructed up here (rather
 			// than inline with their Attach call below) so the catalog platform
@@ -756,6 +753,11 @@ func newStartCommand() *cli.Command {
 			)
 			platformExtras := append([]platformtools.ExternalTool{}, memoryTools...)
 			platformExtras = append(platformExtras, catalogTools...)
+
+			platformToolsets := platformtools.BuildToolsets(platformtools.ToolsetDependencies{
+				AssistantMemoryTools:  memoryTools,
+				AssistantCatalogTools: catalogTools,
+			})
 
 			platformSvc := platformtoolsruntime.NewService(
 				logger,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -743,11 +743,13 @@ func newStartCommand() *cli.Command {
 			// the dashboard catalog dialog.
 			deploymentsSvc := deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger)
 			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
+			externalMcpSvc := externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine)
 			catalogTools := platformtoolsruntime.CatalogExternalTools(
 				&platformcatalog.FuncInstaller{
-					EvolveFn:        deploymentsSvc.Evolve,
-					CreateToolsetFn: toolsetsSvc.CreateToolset,
-					UpdateToolsetFn: toolsetsSvc.UpdateToolset,
+					EvolveFn:                  deploymentsSvc.Evolve,
+					CreateToolsetFn:           toolsetsSvc.CreateToolset,
+					UpdateToolsetFn:           toolsetsSvc.UpdateToolset,
+					GetCatalogServerDetailsFn: externalMcpSvc.GetServerDetails,
 				},
 				mcpRegistryClient,
 				externalmcprepo.New(db),
@@ -1000,7 +1002,7 @@ func newStartCommand() *cli.Command {
 			oauth.Attach(mux, oauthService)
 			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, platformSvc, billingTracker, telemLogger, productFeatures, serverURL, authzEngine))
 			mcpmetadata.Attach(mux, mcpMetadataService)
-			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine))
+			externalmcp.Attach(mux, externalMcpSvc)
 			collections.Attach(mux, collections.NewService(logger, tracerProvider, db, sessionManager, authzEngine, serverURL))
 			mcp.Attach(mux, mcpService, mcpMetadataService)
 			chat.Attach(mux, chatService)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -52,7 +52,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/deployments"
-	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
@@ -736,24 +735,17 @@ func newStartCommand() *cli.Command {
 
 			memoryTools := platformtoolsruntime.MemoryExternalTools(memorySvc)
 
-			// deploymentsSvc and toolsetsSvc are constructed up here (rather
-			// than inline with their Attach call below) so the catalog platform
-			// tools can hand off to them for install — the install tool maps to
-			// the same evolveDeployment + createToolset + enable MCP flow as
-			// the dashboard catalog dialog.
-			deploymentsSvc := deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger)
-			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
+			// Hoisted so catalogTools can hand off to GetServerDetails /
+			// CreateServer; the *.Attach calls below reuse the same instances.
 			externalMcpSvc := externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine)
+			remoteMcpSvc := remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger)
 			catalogTools := platformtoolsruntime.CatalogExternalTools(
-				&platformcatalog.FuncInstaller{
-					EvolveFn:                  deploymentsSvc.Evolve,
-					CreateToolsetFn:           toolsetsSvc.CreateToolset,
-					UpdateToolsetFn:           toolsetsSvc.UpdateToolset,
-					GetCatalogServerDetailsFn: externalMcpSvc.GetServerDetails,
+				&platformcatalog.FuncCatalog{
+					GetServerDetailsFn:   externalMcpSvc.GetServerDetails,
+					CreateRemoteServerFn: remoteMcpSvc.CreateServer,
 				},
 				mcpRegistryClient,
 				externalmcprepo.New(db),
-				deploymentsrepo.New(db),
 			)
 			platformExtras := append([]platformtools.ExternalTool{}, memoryTools...)
 			platformExtras = append(platformExtras, catalogTools...)
@@ -982,18 +974,19 @@ func newStartCommand() *cli.Command {
 			}
 			plugins.Attach(mux, plugins.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url")))
 			productfeatures.Attach(mux, productfeatures.NewService(logger, tracerProvider, db, sessionManager, redisClient, authzEngine))
+			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
 			toolsets.Attach(mux, toolsetsSvc)
 			integrations.Attach(mux, integrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			templates.Attach(mux, templates.NewService(logger, tracerProvider, db, sessionManager, toolsetsSvc, authzEngine, auditLogger))
 			assets.Attach(mux, assets.NewService(logger, tracerProvider, guardianPolicy, db, sessionManager, chatSessionsManager, assetStorage, c.String(usersessions.JWTSigningKeyFlag), authzEngine, auditLogger))
-			deployments.Attach(mux, deploymentsSvc)
+			deployments.Attach(mux, deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger))
 			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), authzEngine, auditLogger))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
 			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger))
-			remotemcp.Attach(mux, remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger))
+			remotemcp.Attach(mux, remoteMcpSvc)
 			xmcp.Attach(mux, xmcp.NewService(logger, tracerProvider, meterProvider, db, encryptionClient, authzEngine, guardianPolicy, posthogClient, billingRepo, billingTracker, mcpService, serverURL), mcpMetadataService)
 			triggers.Attach(mux, triggers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, triggerApp, auditLogger))
 			tools.Attach(mux, tools.NewService(logger, tracerProvider, db, sessionManager, authzEngine, platformFeatureChecker, platformExtras))

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -736,13 +736,17 @@ func newStartCommand() *cli.Command {
 			memoryTools := platformtoolsruntime.MemoryExternalTools(memorySvc)
 
 			// Hoisted so catalogTools can hand off to GetServerDetails /
-			// CreateServer; the *.Attach calls below reuse the same instances.
+			// CreateServer / link + rollback; the *.Attach calls below
+			// reuse the same instances.
 			externalMcpSvc := externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine)
 			remoteMcpSvc := remotemcp.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, guardianPolicy, auditLogger)
+			mcpServersSvc := mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger)
 			catalogTools := platformtoolsruntime.CatalogExternalTools(
 				&platformcatalog.FuncCatalog{
 					GetServerDetailsFn:   externalMcpSvc.GetServerDetails,
 					CreateRemoteServerFn: remoteMcpSvc.CreateServer,
+					DeleteRemoteServerFn: remoteMcpSvc.DeleteServer,
+					CreateMCPServerFn:    mcpServersSvc.CreateMcpServer,
 				},
 				mcpRegistryClient,
 				externalmcprepo.New(db),
@@ -983,7 +987,7 @@ func newStartCommand() *cli.Command {
 			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), authzEngine, auditLogger))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
-			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
+			mcpservers.Attach(mux, mcpServersSvc)
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger))
 			remotemcp.Attach(mux, remoteMcpSvc)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -55,7 +55,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
-	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
@@ -743,13 +742,12 @@ func newStartCommand() *cli.Command {
 			mcpServersSvc := mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger)
 			catalogTools := platformtoolsruntime.CatalogExternalTools(
 				&platformcatalog.FuncCatalog{
+					ListCatalogFn:        externalMcpSvc.ListCatalog,
 					GetServerDetailsFn:   externalMcpSvc.GetServerDetails,
 					CreateRemoteServerFn: remoteMcpSvc.CreateServer,
 					DeleteRemoteServerFn: remoteMcpSvc.DeleteServer,
 					CreateMCPServerFn:    mcpServersSvc.CreateMcpServer,
 				},
-				mcpRegistryClient,
-				externalmcprepo.New(db),
 			)
 			platformExtras := append([]platformtools.ExternalTool{}, memoryTools...)
 			platformExtras = append(platformExtras, catalogTools...)

--- a/server/internal/platformtools/catalog/catalog.go
+++ b/server/internal/platformtools/catalog/catalog.go
@@ -1,6 +1,6 @@
 // Package catalog implements the platform_search_catalog and
 // platform_install_catalog_server tools that expose the MCP catalog to
-// assistants so they can discover and install external MCP servers on the
+// assistants so they can discover and register external MCP servers on the
 // caller's behalf.
 package catalog
 
@@ -10,9 +10,8 @@ import (
 	"fmt"
 	"io"
 
-	deploymentsgen "github.com/speakeasy-api/gram/server/gen/deployments"
 	registriesgen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
-	toolsetsgen "github.com/speakeasy-api/gram/server/gen/toolsets"
+	remotemcpgen "github.com/speakeasy-api/gram/server/gen/remote_mcp"
 	"github.com/speakeasy-api/gram/server/gen/types"
 )
 
@@ -22,41 +21,29 @@ const (
 	ToolNameInstallCatalogTool = "platform_install_catalog_server"
 )
 
-// Installer is the subset of deployments + toolsets + external MCP behavior
-// the install tool depends on. The live wiring constructs an adapter that
-// forwards to the running services; tests substitute a fake.
-type Installer interface {
-	Evolve(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error)
-	CreateToolset(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error)
-	UpdateToolset(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error)
-	GetCatalogServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
+// Catalog is the subset of mcp_registries + remote_mcp behavior the install
+// tool depends on. The live wiring constructs an adapter that forwards to the
+// running services; tests substitute a fake.
+type Catalog interface {
+	GetServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
+	CreateRemoteServer(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error)
 }
 
-// FuncInstaller adapts the deployments.Service, toolsets.Service, and
-// externalmcp.Service method values to the Installer interface without
-// forcing catalog to depend on the concrete service packages (some of them
-// pull platformtools, which would form a cycle).
-type FuncInstaller struct {
-	EvolveFn                  func(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error)
-	CreateToolsetFn           func(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error)
-	UpdateToolsetFn           func(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error)
-	GetCatalogServerDetailsFn func(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
+// FuncCatalog adapts mcp_registries.Service.GetServerDetails and
+// remote_mcp.Service.CreateServer method values to the Catalog interface
+// without forcing this package to depend on the concrete service packages
+// (some of them transitively pull platformtools, which would form a cycle).
+type FuncCatalog struct {
+	GetServerDetailsFn   func(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
+	CreateRemoteServerFn func(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error)
 }
 
-func (f *FuncInstaller) Evolve(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error) {
-	return f.EvolveFn(ctx, payload)
+func (f *FuncCatalog) GetServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error) {
+	return f.GetServerDetailsFn(ctx, payload)
 }
 
-func (f *FuncInstaller) CreateToolset(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error) {
-	return f.CreateToolsetFn(ctx, payload)
-}
-
-func (f *FuncInstaller) UpdateToolset(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error) {
-	return f.UpdateToolsetFn(ctx, payload)
-}
-
-func (f *FuncInstaller) GetCatalogServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error) {
-	return f.GetCatalogServerDetailsFn(ctx, payload)
+func (f *FuncCatalog) CreateRemoteServer(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error) {
+	return f.CreateRemoteServerFn(ctx, payload)
 }
 
 func decodePayload(payload io.Reader, target any) error {

--- a/server/internal/platformtools/catalog/catalog.go
+++ b/server/internal/platformtools/catalog/catalog.go
@@ -31,6 +31,7 @@ const (
 // remote MCP server, then create a disabled mcp_servers row that links to
 // it. Without the link row the dashboard treats the source as orphaned.
 type Catalog interface {
+	ListCatalog(ctx context.Context, payload *registriesgen.ListCatalogPayload) (*registriesgen.ListCatalogResult, error)
 	GetServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
 	CreateRemoteServer(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error)
 	DeleteRemoteServer(ctx context.Context, payload *remotemcpgen.DeleteServerPayload) error
@@ -42,10 +43,15 @@ type Catalog interface {
 // service packages (some transitively pull platformtools, which would
 // form a cycle).
 type FuncCatalog struct {
+	ListCatalogFn        func(ctx context.Context, payload *registriesgen.ListCatalogPayload) (*registriesgen.ListCatalogResult, error)
 	GetServerDetailsFn   func(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
 	CreateRemoteServerFn func(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error)
 	DeleteRemoteServerFn func(ctx context.Context, payload *remotemcpgen.DeleteServerPayload) error
 	CreateMCPServerFn    func(ctx context.Context, payload *mcpserversgen.CreateMcpServerPayload) (*types.McpServer, error)
+}
+
+func (f *FuncCatalog) ListCatalog(ctx context.Context, payload *registriesgen.ListCatalogPayload) (*registriesgen.ListCatalogResult, error) {
+	return f.ListCatalogFn(ctx, payload)
 }
 
 func (f *FuncCatalog) GetServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error) {

--- a/server/internal/platformtools/catalog/catalog.go
+++ b/server/internal/platformtools/catalog/catalog.go
@@ -1,0 +1,84 @@
+// Package catalog implements the platform_search_catalog and
+// platform_install_catalog_server tools that expose the MCP catalog to
+// assistants so they can discover and install external MCP servers on the
+// caller's behalf.
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	deploymentsgen "github.com/speakeasy-api/gram/server/gen/deployments"
+	toolsetsgen "github.com/speakeasy-api/gram/server/gen/toolsets"
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+const (
+	SourceCatalog              = "catalog"
+	ToolNameSearchCatalog      = "platform_search_catalog"
+	ToolNameInstallCatalogTool = "platform_install_catalog_server"
+)
+
+// Installer is the subset of deployments + toolsets behavior the install tool
+// depends on. The live wiring constructs an adapter that forwards to the
+// running deployments.Service and toolsets.Service; tests substitute a fake.
+type Installer interface {
+	Evolve(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error)
+	CreateToolset(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error)
+	UpdateToolset(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error)
+}
+
+// FuncInstaller adapts the deployments.Service and toolsets.Service method
+// values to the Installer interface without forcing catalog to depend on the
+// concrete service packages (those import platformtools, which would form a
+// cycle).
+type FuncInstaller struct {
+	EvolveFn        func(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error)
+	CreateToolsetFn func(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error)
+	UpdateToolsetFn func(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error)
+}
+
+func (f *FuncInstaller) Evolve(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error) {
+	return f.EvolveFn(ctx, payload)
+}
+
+func (f *FuncInstaller) CreateToolset(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error) {
+	return f.CreateToolsetFn(ctx, payload)
+}
+
+func (f *FuncInstaller) UpdateToolset(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error) {
+	return f.UpdateToolsetFn(ctx, payload)
+}
+
+func decodePayload(payload io.Reader, target any) error {
+	body, err := io.ReadAll(payload)
+	if err != nil {
+		return fmt.Errorf("read request body: %w", err)
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		return fmt.Errorf("decode request body: %w", err)
+	}
+	return nil
+}
+
+func writeJSON(wr io.Writer, value any) error {
+	if err := json.NewEncoder(wr).Encode(value); err != nil {
+		return fmt.Errorf("encode response body: %w", err)
+	}
+	return nil
+}
+
+func catalogToolAnnotations(readOnly, destructive, idempotent, openWorld bool) *types.ToolAnnotations {
+	return &types.ToolAnnotations{
+		Title:           nil,
+		ReadOnlyHint:    &readOnly,
+		DestructiveHint: &destructive,
+		IdempotentHint:  &idempotent,
+		OpenWorldHint:   &openWorld,
+	}
+}

--- a/server/internal/platformtools/catalog/catalog.go
+++ b/server/internal/platformtools/catalog/catalog.go
@@ -11,6 +11,7 @@ import (
 	"io"
 
 	deploymentsgen "github.com/speakeasy-api/gram/server/gen/deployments"
+	registriesgen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
 	toolsetsgen "github.com/speakeasy-api/gram/server/gen/toolsets"
 	"github.com/speakeasy-api/gram/server/gen/types"
 )
@@ -21,23 +22,25 @@ const (
 	ToolNameInstallCatalogTool = "platform_install_catalog_server"
 )
 
-// Installer is the subset of deployments + toolsets behavior the install tool
-// depends on. The live wiring constructs an adapter that forwards to the
-// running deployments.Service and toolsets.Service; tests substitute a fake.
+// Installer is the subset of deployments + toolsets + external MCP behavior
+// the install tool depends on. The live wiring constructs an adapter that
+// forwards to the running services; tests substitute a fake.
 type Installer interface {
 	Evolve(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error)
 	CreateToolset(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error)
 	UpdateToolset(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error)
+	GetCatalogServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
 }
 
-// FuncInstaller adapts the deployments.Service and toolsets.Service method
-// values to the Installer interface without forcing catalog to depend on the
-// concrete service packages (those import platformtools, which would form a
-// cycle).
+// FuncInstaller adapts the deployments.Service, toolsets.Service, and
+// externalmcp.Service method values to the Installer interface without
+// forcing catalog to depend on the concrete service packages (some of them
+// pull platformtools, which would form a cycle).
 type FuncInstaller struct {
-	EvolveFn        func(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error)
-	CreateToolsetFn func(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error)
-	UpdateToolsetFn func(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error)
+	EvolveFn                  func(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error)
+	CreateToolsetFn           func(ctx context.Context, payload *toolsetsgen.CreateToolsetPayload) (*types.Toolset, error)
+	UpdateToolsetFn           func(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error)
+	GetCatalogServerDetailsFn func(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
 }
 
 func (f *FuncInstaller) Evolve(ctx context.Context, payload *deploymentsgen.EvolvePayload) (*deploymentsgen.EvolveResult, error) {
@@ -50,6 +53,10 @@ func (f *FuncInstaller) CreateToolset(ctx context.Context, payload *toolsetsgen.
 
 func (f *FuncInstaller) UpdateToolset(ctx context.Context, payload *toolsetsgen.UpdateToolsetPayload) (*types.Toolset, error) {
 	return f.UpdateToolsetFn(ctx, payload)
+}
+
+func (f *FuncInstaller) GetCatalogServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error) {
+	return f.GetCatalogServerDetailsFn(ctx, payload)
 }
 
 func decodePayload(payload io.Reader, target any) error {

--- a/server/internal/platformtools/catalog/catalog.go
+++ b/server/internal/platformtools/catalog/catalog.go
@@ -11,6 +11,7 @@ import (
 	"io"
 
 	registriesgen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
+	mcpserversgen "github.com/speakeasy-api/gram/server/gen/mcp_servers"
 	remotemcpgen "github.com/speakeasy-api/gram/server/gen/remote_mcp"
 	"github.com/speakeasy-api/gram/server/gen/types"
 )
@@ -21,21 +22,30 @@ const (
 	ToolNameInstallCatalogTool = "platform_install_catalog_server"
 )
 
-// Catalog is the subset of mcp_registries + remote_mcp behavior the install
-// tool depends on. The live wiring constructs an adapter that forwards to the
-// running services; tests substitute a fake.
+// Catalog is the subset of mcp_registries + remote_mcp + mcp_servers
+// behavior the install tool depends on. The live wiring constructs an
+// adapter that forwards to the running services; tests substitute a fake.
+//
+// The install flow mirrors the dashboard's "Add remote MCP" path
+// (client/dashboard/src/pages/sources/remote-mcp/hooks.ts): create the
+// remote MCP server, then create a disabled mcp_servers row that links to
+// it. Without the link row the dashboard treats the source as orphaned.
 type Catalog interface {
 	GetServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
 	CreateRemoteServer(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error)
+	DeleteRemoteServer(ctx context.Context, payload *remotemcpgen.DeleteServerPayload) error
+	CreateMCPServer(ctx context.Context, payload *mcpserversgen.CreateMcpServerPayload) (*types.McpServer, error)
 }
 
-// FuncCatalog adapts mcp_registries.Service.GetServerDetails and
-// remote_mcp.Service.CreateServer method values to the Catalog interface
-// without forcing this package to depend on the concrete service packages
-// (some of them transitively pull platformtools, which would form a cycle).
+// FuncCatalog adapts the underlying Goa service method values to the
+// Catalog interface without forcing this package to import the concrete
+// service packages (some transitively pull platformtools, which would
+// form a cycle).
 type FuncCatalog struct {
 	GetServerDetailsFn   func(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error)
 	CreateRemoteServerFn func(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error)
+	DeleteRemoteServerFn func(ctx context.Context, payload *remotemcpgen.DeleteServerPayload) error
+	CreateMCPServerFn    func(ctx context.Context, payload *mcpserversgen.CreateMcpServerPayload) (*types.McpServer, error)
 }
 
 func (f *FuncCatalog) GetServerDetails(ctx context.Context, payload *registriesgen.GetServerDetailsPayload) (*types.ExternalMCPServer, error) {
@@ -44,6 +54,14 @@ func (f *FuncCatalog) GetServerDetails(ctx context.Context, payload *registriesg
 
 func (f *FuncCatalog) CreateRemoteServer(ctx context.Context, payload *remotemcpgen.CreateServerPayload) (*types.RemoteMcpServer, error) {
 	return f.CreateRemoteServerFn(ctx, payload)
+}
+
+func (f *FuncCatalog) DeleteRemoteServer(ctx context.Context, payload *remotemcpgen.DeleteServerPayload) error {
+	return f.DeleteRemoteServerFn(ctx, payload)
+}
+
+func (f *FuncCatalog) CreateMCPServer(ctx context.Context, payload *mcpserversgen.CreateMcpServerPayload) (*types.McpServer, error) {
+	return f.CreateMCPServerFn(ctx, payload)
 }
 
 func decodePayload(payload io.Reader, target any) error {

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -1,0 +1,257 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/google/uuid"
+	deploymentsgen "github.com/speakeasy-api/gram/server/gen/deployments"
+	toolsetsgen "github.com/speakeasy-api/gram/server/gen/toolsets"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+const handlerInstall = "install_catalog_server"
+
+type installInput struct {
+	RegistryID        string  `json:"registry_id" jsonschema:"ID of the registry returned by platform_search_catalog."`
+	RegistrySpecifier string  `json:"registry_specifier" jsonschema:"The server's registry_specifier returned by platform_search_catalog (e.g. 'io.github.user/server')."`
+	Name              *string `json:"name,omitempty" jsonschema:"Optional human-readable name for the resulting toolset. Defaults to the server's title or specifier."`
+}
+
+type installResult struct {
+	ToolsetID    string `json:"toolset_id"`
+	ToolsetSlug  string `json:"toolset_slug"`
+	ToolsetName  string `json:"toolset_name"`
+	MCPSlug      string `json:"mcp_slug,omitempty"`
+	DeploymentID string `json:"deployment_id"`
+	Status       string `json:"status"`
+}
+
+// InstallTool wraps the catalog install flow (evolveDeployment + createToolset
+// + enable MCP) used by the dashboard's AddServerDialog so an assistant can
+// invoke it directly.
+type InstallTool struct {
+	descriptor     core.ToolDescriptor
+	registryClient *externalmcp.RegistryClient
+	repo           *externalmcprepo.Queries
+	installer      Installer
+}
+
+func NewInstallTool(installer Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) *InstallTool {
+	readOnly := false
+	destructive := false
+	idempotent := false
+	openWorld := false
+
+	return &InstallTool{
+		installer:      installer,
+		registryClient: registryClient,
+		repo:           repo,
+		descriptor: core.ToolDescriptor{
+			SourceSlug:  SourceCatalog,
+			HandlerName: handlerInstall,
+			Name:        ToolNameInstallCatalogTool,
+			Description: "Install an MCP catalog server into the caller's project. Creates a new toolset wired to the server's tools and enables the toolset for MCP. Use platform_search_catalog first to discover the registry_id and registry_specifier.",
+			InputSchema: core.BuildInputSchema[installInput](
+				core.WithPropertyFormat("registry_id", "uuid"),
+			),
+			Variables:   nil,
+			Annotations: catalogToolAnnotations(readOnly, destructive, idempotent, openWorld),
+			Managed:     true,
+			OwnerKind:   nil,
+			OwnerID:     nil,
+		},
+	}
+}
+
+func (t *InstallTool) Descriptor() core.ToolDescriptor {
+	return t.descriptor
+}
+
+func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.installer == nil || t.registryClient == nil || t.repo == nil {
+		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
+	}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		return oops.E(oops.CodeUnauthorized, nil, "catalog tools require a project auth context")
+	}
+
+	var input installInput
+	if err := decodePayload(payload, &input); err != nil {
+		return err
+	}
+
+	registryID, err := uuid.Parse(strings.TrimSpace(input.RegistryID))
+	if err != nil {
+		return oops.E(oops.CodeBadRequest, err, "invalid registry_id")
+	}
+	specifier := strings.TrimSpace(input.RegistrySpecifier)
+	if specifier == "" {
+		return oops.E(oops.CodeBadRequest, nil, "registry_specifier is required")
+	}
+
+	registry, err := t.repo.GetMCPRegistryByID(ctx, registryID)
+	if err != nil {
+		return fmt.Errorf("get mcp registry: %w", err)
+	}
+
+	// Fetch tool + remote details so we can build the same tool URN list the
+	// dashboard would build (one URN per tool, falling back to :proxy when
+	// the server's tools are not known yet).
+	details, err := t.registryClient.GetServerDetails(ctx, externalmcp.Registry{
+		ID:  registry.ID,
+		URL: registry.Url,
+	}, specifier, nil)
+	if err != nil {
+		return fmt.Errorf("fetch catalog server details: %w", err)
+	}
+
+	displayName := strings.TrimSpace(conv.PtrValOrEmpty(input.Name, ""))
+	if displayName == "" {
+		displayName = defaultDisplayName(specifier, details.Name)
+	}
+
+	slug := slugFromName(displayName)
+	if slug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "name does not produce a usable slug — pick a name with at least one alphanumeric character")
+	}
+
+	regIDStr := registryID.String()
+	registrySpecifier := specifier
+	evolvePayload := &deploymentsgen.EvolvePayload{
+		ApikeyToken:           nil,
+		SessionToken:          nil,
+		ProjectSlugInput:      nil,
+		DeploymentID:          nil,
+		NonBlocking:           nil,
+		UpsertOpenapiv3Assets: nil,
+		UpsertPackages:        nil,
+		UpsertFunctions:       nil,
+		UpsertExternalMcps: []*deploymentsgen.AddExternalMCPForm{{
+			RegistryID:                          &regIDStr,
+			OrganizationMcpCollectionRegistryID: nil,
+			Name:                                displayName,
+			Slug:                                types.Slug(slug),
+			RegistryServerSpecifier:             registrySpecifier,
+			SelectedRemotes:                     nil,
+		}},
+		ExcludeOpenapiv3Assets: nil,
+		ExcludePackages:        nil,
+		ExcludeFunctions:       nil,
+		ExcludeExternalMcps:    nil,
+	}
+
+	evolveResult, err := t.installer.Evolve(ctx, evolvePayload)
+	if err != nil {
+		return fmt.Errorf("evolve deployment with catalog server: %w", err)
+	}
+	if evolveResult == nil || evolveResult.Deployment == nil {
+		return oops.E(oops.CodeUnexpected, nil, "evolve deployment returned no deployment")
+	}
+
+	toolURNs := make([]string, 0, len(details.Tools))
+	for _, tool := range details.Tools {
+		if tool.Name == "" {
+			continue
+		}
+		toolURNs = append(toolURNs, fmt.Sprintf("tools:externalmcp:%s:%s", slug, tool.Name))
+	}
+	if len(toolURNs) == 0 {
+		toolURNs = []string{fmt.Sprintf("tools:externalmcp:%s:proxy", slug)}
+	}
+	description := details.Description
+	if description == "" {
+		description = fmt.Sprintf("MCP server: %s", specifier)
+	}
+
+	created, err := t.installer.CreateToolset(ctx, &toolsetsgen.CreateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		Name:                   displayName,
+		Description:            &description,
+		ToolUrns:               toolURNs,
+		ResourceUrns:           nil,
+		DefaultEnvironmentSlug: nil,
+		Origin:                 &types.ToolsetOrigin{RegistrySpecifier: specifier},
+		ProjectSlugInput:       nil,
+	})
+	if err != nil {
+		return fmt.Errorf("create toolset for catalog server: %w", err)
+	}
+	if created == nil {
+		return oops.E(oops.CodeUnexpected, nil, "create toolset returned no toolset")
+	}
+
+	mcpEnabled := true
+	mcpPublic := true
+	updated, err := t.installer.UpdateToolset(ctx, &toolsetsgen.UpdateToolsetPayload{
+		SessionToken:           nil,
+		ApikeyToken:            nil,
+		Slug:                   created.Slug,
+		Name:                   nil,
+		Description:            nil,
+		DefaultEnvironmentSlug: nil,
+		PromptTemplateNames:    nil,
+		ToolUrns:               nil,
+		ResourceUrns:           nil,
+		McpEnabled:             &mcpEnabled,
+		McpSlug:                nil,
+		McpIsPublic:            &mcpPublic,
+		CustomDomainID:         nil,
+		ToolSelectionMode:      nil,
+		ProjectSlugInput:       nil,
+	})
+	if err != nil {
+		return fmt.Errorf("enable mcp on toolset: %w", err)
+	}
+
+	mcpSlug := ""
+	if updated != nil && updated.McpSlug != nil {
+		mcpSlug = string(*updated.McpSlug)
+	}
+
+	return writeJSON(wr, installResult{
+		ToolsetID:    created.ID,
+		ToolsetSlug:  string(created.Slug),
+		ToolsetName:  created.Name,
+		MCPSlug:      mcpSlug,
+		DeploymentID: evolveResult.Deployment.ID,
+		Status:       evolveResult.Deployment.Status,
+	})
+}
+
+func defaultDisplayName(specifier string, fallback string) string {
+	specifier = strings.TrimSpace(specifier)
+	if specifier == "" {
+		return strings.TrimSpace(fallback)
+	}
+	if idx := strings.LastIndex(specifier, "/"); idx >= 0 && idx < len(specifier)-1 {
+		return specifier[idx+1:]
+	}
+	return specifier
+}
+
+// slugFromName mirrors the dashboard's generateSlug(name):
+// take the last "/" segment, lowercase, replace non-alphanumeric runs with a
+// single hyphen, trim hyphens. Kept in sync with
+// client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts so the
+// attachment row created here resolves the same tool URNs the UI would have
+// produced.
+func slugFromName(name string) string {
+	lastPart := name
+	if idx := strings.LastIndex(name, "/"); idx >= 0 && idx < len(name)-1 {
+		lastPart = name[idx+1:]
+	}
+	return conv.URLToSlug(lastPart)
+}

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -176,6 +176,17 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 	if evolveResult == nil || evolveResult.Deployment == nil {
 		return oops.E(oops.CodeUnexpected, nil, "evolve deployment returned no deployment")
 	}
+	// Evolve runs the workflow synchronously (NonBlocking is unset), so the
+	// status is terminal here. A "failed" deployment leaves the external MCP
+	// attachment unprocessed; creating a toolset against it would surface
+	// success with non-resolving tool URNs.
+	if evolveResult.Deployment.Status != "completed" {
+		return oops.E(
+			oops.CodeUnexpected, nil,
+			"catalog install deployment did not complete (status=%s); the toolset was not created",
+			evolveResult.Deployment.Status,
+		)
+	}
 
 	toolURNs := make([]string, 0, len(details.Tools))
 	for _, tool := range details.Tools {

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -11,12 +11,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	deploymentsgen "github.com/speakeasy-api/gram/server/gen/deployments"
+	registriesgen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
 	toolsetsgen "github.com/speakeasy-api/gram/server/gen/toolsets"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
-	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
@@ -45,13 +45,12 @@ type installResult struct {
 // invoke it directly.
 type InstallTool struct {
 	descriptor      core.ToolDescriptor
-	registryClient  *externalmcp.RegistryClient
 	repo            *externalmcprepo.Queries
 	deploymentsRepo *deploymentsrepo.Queries
 	installer       Installer
 }
 
-func NewInstallTool(installer Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries, deploymentsRepo *deploymentsrepo.Queries) *InstallTool {
+func NewInstallTool(installer Installer, repo *externalmcprepo.Queries, deploymentsRepo *deploymentsrepo.Queries) *InstallTool {
 	readOnly := false
 	destructive := false
 	idempotent := false
@@ -59,7 +58,6 @@ func NewInstallTool(installer Installer, registryClient *externalmcp.RegistryCli
 
 	return &InstallTool{
 		installer:       installer,
-		registryClient:  registryClient,
 		repo:            repo,
 		deploymentsRepo: deploymentsRepo,
 		descriptor: core.ToolDescriptor{
@@ -84,7 +82,7 @@ func (t *InstallTool) Descriptor() core.ToolDescriptor {
 }
 
 func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
-	if t.installer == nil || t.registryClient == nil || t.repo == nil || t.deploymentsRepo == nil {
+	if t.installer == nil || t.repo == nil || t.deploymentsRepo == nil {
 		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
 	}
 
@@ -107,25 +105,31 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		return oops.E(oops.CodeBadRequest, nil, "registry_specifier is required")
 	}
 
-	registry, err := t.repo.GetMCPRegistryByID(ctx, registryID)
-	if err != nil {
-		return fmt.Errorf("get mcp registry: %w", err)
-	}
-
-	// Fetch tool + remote details so we can build the same tool URN list the
-	// dashboard would build (one URN per tool, falling back to :proxy when
-	// the server's tools are not known yet).
-	details, err := t.registryClient.GetServerDetails(ctx, externalmcp.Registry{
-		ID:  registry.ID,
-		URL: registry.Url,
-	}, specifier, nil)
+	// Fetch full server details (tools + every remote) via the catalog
+	// service. The Goa method runs project-read authz and returns the
+	// full *types.ExternalMCPServer, which is what the dashboard uses to
+	// drive the install dialog.
+	details, err := t.installer.GetCatalogServerDetails(ctx, &registriesgen.GetServerDetailsPayload{
+		RegistryID:       registryID.String(),
+		ServerSpecifier:  specifier,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
 	if err != nil {
 		return fmt.Errorf("fetch catalog server details: %w", err)
+	}
+	if details == nil {
+		return oops.E(oops.CodeUnexpected, nil, "catalog server details returned no server")
 	}
 
 	displayName := strings.TrimSpace(conv.PtrValOrEmpty(input.Name, ""))
 	if displayName == "" {
-		displayName = defaultDisplayName(specifier, details.Name)
+		fallback := ""
+		if details.Title != nil {
+			fallback = *details.Title
+		}
+		displayName = defaultDisplayName(specifier, fallback)
 	}
 
 	slug := slugFromName(displayName)
@@ -144,6 +148,12 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		return err
 	}
 
+	// Pass every streamable-http remote (the dashboard's "Select all"
+	// default after filterToHttpRemotes). When the registry only exposes
+	// SSE remotes, fall back to those; nil leaves the backend to auto-pick
+	// a single remote, which is not "all".
+	selectedRemotes := remoteURLsForInstall(details.Remotes)
+
 	regIDStr := registryID.String()
 	registrySpecifier := specifier
 	evolvePayload := &deploymentsgen.EvolvePayload{
@@ -161,7 +171,7 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 			Name:                                displayName,
 			Slug:                                types.Slug(slug),
 			RegistryServerSpecifier:             registrySpecifier,
-			SelectedRemotes:                     nil,
+			SelectedRemotes:                     selectedRemotes,
 		}},
 		ExcludeOpenapiv3Assets: nil,
 		ExcludePackages:        nil,
@@ -190,10 +200,10 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 
 	toolURNs := make([]string, 0, len(details.Tools))
 	for _, tool := range details.Tools {
-		if tool.Name == "" {
+		if tool == nil || tool.Name == nil || *tool.Name == "" {
 			continue
 		}
-		toolURNs = append(toolURNs, fmt.Sprintf("tools:externalmcp:%s:%s", slug, tool.Name))
+		toolURNs = append(toolURNs, fmt.Sprintf("tools:externalmcp:%s:%s", slug, *tool.Name))
 	}
 	if len(toolURNs) == 0 {
 		toolURNs = []string{fmt.Sprintf("tools:externalmcp:%s:proxy", slug)}
@@ -302,6 +312,36 @@ func (t *InstallTool) ensureNoConflictingSlug(ctx context.Context, projectID uui
 			"a different MCP server (%s) is already installed in this project as %q. Re-run with a name argument to disambiguate.",
 			attachment.RegistryServerSpecifier, slug,
 		)
+	}
+	return nil
+}
+
+// remoteURLsForInstall returns every streamable-http remote URL, falling back
+// to sse URLs only if no streamable-http remote exists. Mirrors the dashboard
+// "filterToHttpRemotes + Select all" path: assistants don't pick a remote, so
+// the install always wires up every endpoint the catalog server offers.
+func remoteURLsForInstall(remotes []*types.ExternalMCPRemote) []string {
+	if len(remotes) == 0 {
+		return nil
+	}
+	streamable := make([]string, 0, len(remotes))
+	sse := make([]string, 0, len(remotes))
+	for _, remote := range remotes {
+		if remote == nil || remote.URL == "" {
+			continue
+		}
+		switch remote.TransportType {
+		case "streamable-http":
+			streamable = append(streamable, remote.URL)
+		case "sse":
+			sse = append(sse, remote.URL)
+		}
+	}
+	if len(streamable) > 0 {
+		return streamable
+	}
+	if len(sse) > 0 {
+		return sse
 	}
 	return nil
 }

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -4,20 +4,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
-	"errors"
-
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
-	deploymentsgen "github.com/speakeasy-api/gram/server/gen/deployments"
 	registriesgen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
-	toolsetsgen "github.com/speakeasy-api/gram/server/gen/toolsets"
+	remotemcpgen "github.com/speakeasy-api/gram/server/gen/remote_mcp"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
-	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
@@ -26,45 +21,44 @@ import (
 const handlerInstall = "install_catalog_server"
 
 type installInput struct {
-	RegistryID        string  `json:"registry_id" jsonschema:"ID of the registry returned by platform_search_catalog."`
-	RegistrySpecifier string  `json:"registry_specifier" jsonschema:"The server's registry_specifier returned by platform_search_catalog (e.g. 'io.github.user/server')."`
-	Name              *string `json:"name,omitempty" jsonschema:"Optional human-readable name for the resulting toolset. Defaults to the server's title or specifier."`
+	RegistryID        string            `json:"registry_id" jsonschema:"ID of the registry returned by platform_search_catalog."`
+	RegistrySpecifier string            `json:"registry_specifier" jsonschema:"The server's registry_specifier returned by platform_search_catalog (e.g. 'io.github.user/server')."`
+	Name              *string           `json:"name,omitempty" jsonschema:"Optional human-readable name for the resulting remote MCP server. Defaults to the catalog title or specifier tail."`
+	RemoteURL         *string           `json:"remote_url,omitempty" jsonschema:"Optional exact URL of the remotes[] entry to install. Omit to let the tool pick: streamable-http first, then sse."`
+	TransportType     *string           `json:"transport_type,omitempty" jsonschema:"Optional transport filter applied when remote_url is not set. One of 'streamable-http' or 'sse'."`
+	Variables         map[string]string `json:"variables,omitempty" jsonschema:"Values for URL template variables declared by the selected remote. Required variables without a default must be supplied here."`
+	Headers           map[string]string `json:"headers,omitempty" jsonschema:"Static values for the headers declared by the selected remote (keyed by header name). Required headers must be supplied here. Secret values are stored encrypted."`
 }
 
 type installResult struct {
-	ToolsetID    string `json:"toolset_id"`
-	ToolsetSlug  string `json:"toolset_slug"`
-	ToolsetName  string `json:"toolset_name"`
-	MCPSlug      string `json:"mcp_slug,omitempty"`
-	DeploymentID string `json:"deployment_id"`
-	Status       string `json:"status"`
+	ServerID      string `json:"server_id"`
+	ServerSlug    string `json:"server_slug,omitempty"`
+	Name          string `json:"name,omitempty"`
+	URL           string `json:"url"`
+	TransportType string `json:"transport_type"`
 }
 
-// InstallTool wraps the catalog install flow (evolveDeployment + createToolset
-// + enable MCP) used by the dashboard's AddServerDialog so an assistant can
-// invoke it directly.
+// InstallTool registers a catalog server as a remote MCP server. It resolves
+// the upstream URL, transport, and required headers/variables from the
+// catalog entry and forwards a single remoteMcp.createServer call.
 type InstallTool struct {
-	descriptor      core.ToolDescriptor
-	repo            *externalmcprepo.Queries
-	deploymentsRepo *deploymentsrepo.Queries
-	installer       Installer
+	descriptor core.ToolDescriptor
+	catalog    Catalog
 }
 
-func NewInstallTool(installer Installer, repo *externalmcprepo.Queries, deploymentsRepo *deploymentsrepo.Queries) *InstallTool {
+func NewInstallTool(catalog Catalog) *InstallTool {
 	readOnly := false
 	destructive := false
 	idempotent := false
 	openWorld := false
 
 	return &InstallTool{
-		installer:       installer,
-		repo:            repo,
-		deploymentsRepo: deploymentsRepo,
+		catalog: catalog,
 		descriptor: core.ToolDescriptor{
 			SourceSlug:  SourceCatalog,
 			HandlerName: handlerInstall,
 			Name:        ToolNameInstallCatalogTool,
-			Description: "Install an MCP catalog server into the caller's project. Creates a new toolset wired to the server's tools and enables the toolset for MCP. Use platform_search_catalog first to discover the registry_id and registry_specifier.",
+			Description: "Register an MCP catalog server as a remote MCP server in the caller's project. Resolves the upstream URL, transport, and required user inputs (URL variables, headers) from the catalog entry. Use platform_search_catalog first to discover the registry_id and registry_specifier.",
 			InputSchema: core.BuildInputSchema[installInput](
 				core.WithPropertyFormat("registry_id", "uuid"),
 			),
@@ -82,7 +76,7 @@ func (t *InstallTool) Descriptor() core.ToolDescriptor {
 }
 
 func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
-	if t.installer == nil || t.repo == nil || t.deploymentsRepo == nil {
+	if t.catalog == nil {
 		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
 	}
 
@@ -108,11 +102,7 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		return oops.E(oops.CodeBadRequest, nil, "registry_specifier is required")
 	}
 
-	// Fetch full server details (tools + every remote) via the catalog
-	// service. The Goa method runs project-read authz and returns the
-	// full *types.ExternalMCPServer, which is what the dashboard uses to
-	// drive the install dialog.
-	details, err := t.installer.GetCatalogServerDetails(ctx, &registriesgen.GetServerDetailsPayload{
+	details, err := t.catalog.GetServerDetails(ctx, &registriesgen.GetServerDetailsPayload{
 		RegistryID:       registryID.String(),
 		ServerSpecifier:  specifier,
 		SessionToken:     nil,
@@ -126,150 +116,161 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		return oops.E(oops.CodeUnexpected, nil, "catalog server details returned no server")
 	}
 
-	displayName := strings.TrimSpace(conv.PtrValOrEmpty(input.Name, ""))
-	if displayName == "" {
-		fallback := ""
-		if details.Title != nil {
-			fallback = *details.Title
-		}
-		displayName = defaultDisplayName(specifier, fallback)
-	}
-
-	slug := slugFromName(displayName)
-	if slug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "name does not produce a usable slug — pick a name with at least one alphanumeric character")
-	}
-
-	// Guard against silently clobbering an unrelated server. The deployments
-	// upsert is keyed by (deployment_id, slug) and updates registry/specifier
-	// on conflict, so installing "io.bar/server" when "io.foo/server" is
-	// already attached under the same trailing-segment slug would replace
-	// the existing attachment in the cloned deployment. The dashboard
-	// equivalent is the slug-collision check in
-	// useExternalMcpReleaseWorkflow.startDeployment.
-	if err := t.ensureNoConflictingSlug(ctx, *authCtx.ProjectID, slug, specifier); err != nil {
+	remote, err := selectRemote(details.Remotes, input.RemoteURL, input.TransportType)
+	if err != nil {
 		return err
 	}
 
-	// Pass every streamable-http remote (the dashboard's "Select all"
-	// default after filterToHttpRemotes). When the registry only exposes
-	// SSE remotes, fall back to those; nil leaves the backend to auto-pick
-	// a single remote, which is not "all".
-	selectedRemotes := remoteURLsForInstall(details.Remotes)
-
-	regIDStr := registryID.String()
-	registrySpecifier := specifier
-	evolvePayload := &deploymentsgen.EvolvePayload{
-		ApikeyToken:           nil,
-		SessionToken:          nil,
-		ProjectSlugInput:      nil,
-		DeploymentID:          nil,
-		NonBlocking:           nil,
-		UpsertOpenapiv3Assets: nil,
-		UpsertPackages:        nil,
-		UpsertFunctions:       nil,
-		UpsertExternalMcps: []*deploymentsgen.AddExternalMCPForm{{
-			RegistryID:                          &regIDStr,
-			OrganizationMcpCollectionRegistryID: nil,
-			Name:                                displayName,
-			Slug:                                types.Slug(slug),
-			RegistryServerSpecifier:             registrySpecifier,
-			SelectedRemotes:                     selectedRemotes,
-		}},
-		ExcludeOpenapiv3Assets: nil,
-		ExcludePackages:        nil,
-		ExcludeFunctions:       nil,
-		ExcludeExternalMcps:    nil,
-	}
-
-	evolveResult, err := t.installer.Evolve(ctx, evolvePayload)
+	resolvedURL, err := resolveRemoteURL(remote.URL, remote.Variables, input.Variables)
 	if err != nil {
-		return fmt.Errorf("evolve deployment with catalog server: %w", err)
-	}
-	if evolveResult == nil || evolveResult.Deployment == nil {
-		return oops.E(oops.CodeUnexpected, nil, "evolve deployment returned no deployment")
-	}
-	// Evolve runs the workflow synchronously (NonBlocking is unset), so the
-	// status is terminal here. A "failed" deployment leaves the external MCP
-	// attachment unprocessed; creating a toolset against it would surface
-	// success with non-resolving tool URNs.
-	if evolveResult.Deployment.Status != "completed" {
-		return oops.E(
-			oops.CodeUnexpected, nil,
-			"catalog install deployment did not complete (status=%s); the toolset was not created",
-			evolveResult.Deployment.Status,
-		)
+		return err
 	}
 
-	toolURNs := make([]string, 0, len(details.Tools))
-	for _, tool := range details.Tools {
-		if tool == nil || tool.Name == nil || *tool.Name == "" {
-			continue
-		}
-		toolURNs = append(toolURNs, fmt.Sprintf("tools:externalmcp:%s:%s", slug, *tool.Name))
-	}
-	if len(toolURNs) == 0 {
-		toolURNs = []string{fmt.Sprintf("tools:externalmcp:%s:proxy", slug)}
-	}
-	description := details.Description
-	if description == "" {
-		description = fmt.Sprintf("MCP server: %s", specifier)
+	headerInputs, err := buildHeaderInputs(remote.Headers, input.Headers)
+	if err != nil {
+		return err
 	}
 
-	created, err := t.installer.CreateToolset(ctx, &toolsetsgen.CreateToolsetPayload{
-		SessionToken:           nil,
-		ApikeyToken:            nil,
-		Name:                   displayName,
-		Description:            &description,
-		ToolUrns:               toolURNs,
-		ResourceUrns:           nil,
-		DefaultEnvironmentSlug: nil,
-		Origin:                 &types.ToolsetOrigin{RegistrySpecifier: specifier},
-		ProjectSlugInput:       nil,
+	displayName := strings.TrimSpace(conv.PtrValOrEmpty(input.Name, ""))
+	if displayName == "" {
+		displayName = defaultDisplayName(specifier, conv.PtrValOrEmpty(details.Title, ""))
+	}
+
+	created, err := t.catalog.CreateRemoteServer(ctx, &remotemcpgen.CreateServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Name:             conv.PtrEmpty(displayName),
+		URL:              resolvedURL,
+		TransportType:    remote.TransportType,
+		Headers:          headerInputs,
 	})
 	if err != nil {
-		return fmt.Errorf("create toolset for catalog server: %w", err)
+		return fmt.Errorf("create remote mcp server: %w", err)
 	}
 	if created == nil {
-		return oops.E(oops.CodeUnexpected, nil, "create toolset returned no toolset")
-	}
-
-	mcpEnabled := true
-	mcpPublic := true
-	updated, err := t.installer.UpdateToolset(ctx, &toolsetsgen.UpdateToolsetPayload{
-		SessionToken:           nil,
-		ApikeyToken:            nil,
-		Slug:                   created.Slug,
-		Name:                   nil,
-		Description:            nil,
-		DefaultEnvironmentSlug: nil,
-		PromptTemplateNames:    nil,
-		ToolUrns:               nil,
-		ResourceUrns:           nil,
-		McpEnabled:             &mcpEnabled,
-		McpSlug:                nil,
-		McpIsPublic:            &mcpPublic,
-		CustomDomainID:         nil,
-		ToolSelectionMode:      nil,
-		ProjectSlugInput:       nil,
-	})
-	if err != nil {
-		return fmt.Errorf("enable mcp on toolset: %w", err)
-	}
-
-	mcpSlug := ""
-	if updated != nil && updated.McpSlug != nil {
-		mcpSlug = string(*updated.McpSlug)
+		return oops.E(oops.CodeUnexpected, nil, "create remote mcp server returned no server")
 	}
 
 	return writeJSON(wr, installResult{
-		ToolsetID:    created.ID,
-		ToolsetSlug:  string(created.Slug),
-		ToolsetName:  created.Name,
-		MCPSlug:      mcpSlug,
-		DeploymentID: evolveResult.Deployment.ID,
-		Status:       evolveResult.Deployment.Status,
+		ServerID:      created.ID,
+		ServerSlug:    conv.PtrValOrEmpty(created.Slug, ""),
+		Name:          conv.PtrValOrEmpty(created.Name, ""),
+		URL:           created.URL,
+		TransportType: created.TransportType,
 	})
+}
+
+// selectRemote picks one entry from remotes following: explicit remote_url
+// match, then explicit transport_type filter (first match), then implicit
+// streamable-http preference, then sse fallback.
+func selectRemote(remotes []*types.ExternalMCPRemote, remoteURL *string, transportType *string) (*types.ExternalMCPRemote, error) {
+	if len(remotes) == 0 {
+		return nil, oops.E(oops.CodeBadRequest, nil, "catalog server exposes no remotes")
+	}
+
+	if remoteURL != nil && strings.TrimSpace(*remoteURL) != "" {
+		want := strings.TrimSpace(*remoteURL)
+		for _, r := range remotes {
+			if r != nil && r.URL == want {
+				return r, nil
+			}
+		}
+		return nil, oops.E(oops.CodeBadRequest, nil, "no remote with url %q on this catalog server", want)
+	}
+
+	if transportType != nil && strings.TrimSpace(*transportType) != "" {
+		want := strings.TrimSpace(*transportType)
+		for _, r := range remotes {
+			if r != nil && r.TransportType == want && r.URL != "" {
+				return r, nil
+			}
+		}
+		return nil, oops.E(oops.CodeBadRequest, nil, "no %s remote on this catalog server", want)
+	}
+
+	for _, transport := range []string{"streamable-http", "sse"} {
+		for _, r := range remotes {
+			if r != nil && r.TransportType == transport && r.URL != "" {
+				return r, nil
+			}
+		}
+	}
+	return nil, oops.E(oops.CodeBadRequest, nil, "catalog server has no streamable-http or sse remote")
+}
+
+// resolveRemoteURL substitutes `{name}` placeholders in rawURL using the
+// supplied variable values (falling back to declared defaults). Returns an
+// error when a required variable has no value, when a supplied value is not
+// in the variable's choices, or when the URL still contains an unresolved
+// placeholder after substitution.
+func resolveRemoteURL(rawURL string, declared map[string]*types.ExternalMCPRemoteVariable, supplied map[string]string) (string, error) {
+	resolved := rawURL
+	for name, variable := range declared {
+		value, ok := supplied[name]
+		if !ok || value == "" {
+			if variable != nil && variable.Default != nil {
+				value = *variable.Default
+			}
+		}
+		if value == "" {
+			required := variable != nil && variable.IsRequired != nil && *variable.IsRequired
+			if required {
+				return "", oops.E(oops.CodeBadRequest, nil, "missing required url variable %q", name)
+			}
+			continue
+		}
+		if variable != nil && len(variable.Choices) > 0 {
+			allowed := slices.Contains(variable.Choices, value)
+			if !allowed {
+				return "", oops.E(oops.CodeBadRequest, nil, "url variable %q value %q is not one of the declared choices", name, value)
+			}
+		}
+		resolved = strings.ReplaceAll(resolved, "{"+name+"}", value)
+	}
+
+	if strings.Contains(resolved, "{") && strings.Contains(resolved, "}") {
+		return "", oops.E(oops.CodeBadRequest, nil, "remote url still contains unresolved placeholders after variable substitution: %s", resolved)
+	}
+
+	return resolved, nil
+}
+
+// buildHeaderInputs maps the catalog-declared headers to remoteMcp header
+// inputs using the supplied static values. Required headers without a value
+// fail the call. is_secret/is_required are preserved from the catalog.
+func buildHeaderInputs(declared []*types.ExternalMCPRemoteHeader, supplied map[string]string) ([]*remotemcpgen.HeaderInput, error) {
+	if len(declared) == 0 {
+		return nil, nil
+	}
+
+	out := make([]*remotemcpgen.HeaderInput, 0, len(declared))
+	for _, header := range declared {
+		if header == nil || header.Name == "" {
+			continue
+		}
+		value := supplied[header.Name]
+		required := header.IsRequired != nil && *header.IsRequired
+		if value == "" {
+			if required {
+				return nil, oops.E(oops.CodeBadRequest, nil, "missing required header %q", header.Name)
+			}
+			continue
+		}
+		isSecret := false
+		if header.IsSecret != nil {
+			isSecret = *header.IsSecret
+		}
+		out = append(out, &remotemcpgen.HeaderInput{
+			Name:                   header.Name,
+			Description:            header.Description,
+			IsRequired:             new(required),
+			IsSecret:               new(isSecret),
+			Value:                  new(value),
+			ValueFromRequestHeader: nil,
+		})
+	}
+	return out, nil
 }
 
 func defaultDisplayName(specifier string, fallback string) string {
@@ -281,84 +282,4 @@ func defaultDisplayName(specifier string, fallback string) string {
 		return specifier[idx+1:]
 	}
 	return specifier
-}
-
-// ensureNoConflictingSlug returns a CodeConflict error when the project's
-// latest deployment already attaches an external MCP under the same slug but
-// for a different registry_server_specifier. Same specifier + same slug is
-// a legitimate idempotent re-install and proceeds silently.
-func (t *InstallTool) ensureNoConflictingSlug(ctx context.Context, projectID uuid.UUID, slug, specifier string) error {
-	latestID, err := t.deploymentsRepo.GetLatestDeploymentID(ctx, projectID)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil
-		}
-		return fmt.Errorf("get latest deployment for slug check: %w", err)
-	}
-	if latestID == uuid.Nil {
-		return nil
-	}
-
-	attachments, err := t.repo.ListExternalMCPAttachments(ctx, latestID)
-	if err != nil {
-		return fmt.Errorf("list external mcp attachments for slug check: %w", err)
-	}
-	for _, attachment := range attachments {
-		if attachment.Slug != slug {
-			continue
-		}
-		if attachment.RegistryServerSpecifier == specifier {
-			return nil
-		}
-		return oops.E(
-			oops.CodeConflict, nil,
-			"a different MCP server (%s) is already installed in this project as %q. Re-run with a name argument to disambiguate.",
-			attachment.RegistryServerSpecifier, slug,
-		)
-	}
-	return nil
-}
-
-// remoteURLsForInstall returns every streamable-http remote URL, falling back
-// to sse URLs only if no streamable-http remote exists. Mirrors the dashboard
-// "filterToHttpRemotes + Select all" path: assistants don't pick a remote, so
-// the install always wires up every endpoint the catalog server offers.
-func remoteURLsForInstall(remotes []*types.ExternalMCPRemote) []string {
-	if len(remotes) == 0 {
-		return nil
-	}
-	streamable := make([]string, 0, len(remotes))
-	sse := make([]string, 0, len(remotes))
-	for _, remote := range remotes {
-		if remote == nil || remote.URL == "" {
-			continue
-		}
-		switch remote.TransportType {
-		case "streamable-http":
-			streamable = append(streamable, remote.URL)
-		case "sse":
-			sse = append(sse, remote.URL)
-		}
-	}
-	if len(streamable) > 0 {
-		return streamable
-	}
-	if len(sse) > 0 {
-		return sse
-	}
-	return nil
-}
-
-// slugFromName mirrors the dashboard's generateSlug(name):
-// take the last "/" segment, lowercase, replace non-alphanumeric runs with a
-// single hyphen, trim hyphens. Kept in sync with
-// client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts so the
-// attachment row created here resolves the same tool URNs the UI would have
-// produced.
-func slugFromName(name string) string {
-	lastPart := name
-	if idx := strings.LastIndex(name, "/"); idx >= 0 && idx < len(name)-1 {
-		lastPart = name[idx+1:]
-	}
-	return conv.URLToSlug(lastPart)
 }

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -207,6 +207,13 @@ func selectRemote(remotes []*types.ExternalMCPRemote, remoteURL *string, transpo
 func resolveRemoteURL(rawURL string, declared map[string]*types.ExternalMCPRemoteVariable, supplied map[string]string) (string, error) {
 	resolved := rawURL
 	for name, variable := range declared {
+		// Secret URL variables can't be safely installed via this tool: the
+		// substituted value would be persisted in the plaintext url column
+		// and surfaced in the install response. Catalog authors should
+		// declare secrets as headers, not URL placeholders.
+		if variable != nil && variable.IsSecret != nil && *variable.IsSecret {
+			return "", oops.E(oops.CodeBadRequest, nil, "url variable %q is declared as secret; secrets in the URL path are not supported — ask the catalog author to declare it as a header instead", name)
+		}
 		value, ok := supplied[name]
 		if !ok || value == "" {
 			if variable != nil && variable.Default != nil {

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	registriesgen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
+	mcpserversgen "github.com/speakeasy-api/gram/server/gen/mcp_servers"
 	remotemcpgen "github.com/speakeasy-api/gram/server/gen/remote_mcp"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -36,7 +37,14 @@ type installResult struct {
 	Name          string `json:"name,omitempty"`
 	URL           string `json:"url"`
 	TransportType string `json:"transport_type"`
+	McpServerID   string `json:"mcp_server_id,omitempty"`
 }
+
+// supportedTransports is the set of remote MCP transports the Gram proxy
+// knows how to dial. Keep in sync with externalmcp.NewClient — installing
+// a catalog remote with any other transport produces a row that fails at
+// proxy time.
+var supportedTransports = []string{"streamable-http", "sse"}
 
 // InstallTool registers a catalog server as a remote MCP server. It resolves
 // the upstream URL, transport, and required headers/variables from the
@@ -152,12 +160,47 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		return oops.E(oops.CodeUnexpected, nil, "create remote mcp server returned no server")
 	}
 
+	// Mirror the dashboard's "Add remote MCP" flow: a remote_mcp_servers
+	// row on its own is not addressable — the dashboard and the xmcp
+	// proxy resolve servers through mcp_servers. Create a disabled link
+	// row so the source shows up in the Sources page; if the link fails,
+	// roll the remote MCP server back so we don't leak orphans.
+	remoteID := created.ID
+	linked, linkErr := t.catalog.CreateMCPServer(ctx, &mcpserversgen.CreateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		EnvironmentID:         nil,
+		ExternalOauthServerID: nil,
+		OauthProxyServerID:    nil,
+		RemoteMcpServerID:     &remoteID,
+		ToolsetID:             nil,
+		Visibility:            types.McpServerVisibility("disabled"),
+	})
+	if linkErr != nil {
+		if rollbackErr := t.catalog.DeleteRemoteServer(ctx, &remotemcpgen.DeleteServerPayload{
+			ID:               remoteID,
+			SessionToken:     nil,
+			ApikeyToken:      nil,
+			ProjectSlugInput: nil,
+		}); rollbackErr != nil {
+			return fmt.Errorf("link mcp server: %w; rollback of remote mcp server %s also failed: %w", linkErr, remoteID, rollbackErr)
+		}
+		return fmt.Errorf("link mcp server: %w", linkErr)
+	}
+
+	mcpServerID := ""
+	if linked != nil {
+		mcpServerID = linked.ID
+	}
+
 	return writeJSON(wr, installResult{
 		ServerID:      created.ID,
 		ServerSlug:    conv.PtrValOrEmpty(created.Slug, ""),
 		Name:          conv.PtrValOrEmpty(created.Name, ""),
 		URL:           created.URL,
 		TransportType: created.TransportType,
+		McpServerID:   mcpServerID,
 	})
 }
 
@@ -173,6 +216,9 @@ func selectRemote(remotes []*types.ExternalMCPRemote, remoteURL *string, transpo
 		want := strings.TrimSpace(*remoteURL)
 		for _, r := range remotes {
 			if r != nil && r.URL == want {
+				if !slices.Contains(supportedTransports, r.TransportType) {
+					return nil, oops.E(oops.CodeBadRequest, nil, "remote %q uses transport %q which is not supported (must be one of %v)", want, r.TransportType, supportedTransports)
+				}
 				return r, nil
 			}
 		}
@@ -181,6 +227,9 @@ func selectRemote(remotes []*types.ExternalMCPRemote, remoteURL *string, transpo
 
 	if transportType != nil && strings.TrimSpace(*transportType) != "" {
 		want := strings.TrimSpace(*transportType)
+		if !slices.Contains(supportedTransports, want) {
+			return nil, oops.E(oops.CodeBadRequest, nil, "transport %q is not supported (must be one of %v)", want, supportedTransports)
+		}
 		for _, r := range remotes {
 			if r != nil && r.TransportType == want && r.URL != "" {
 				return r, nil
@@ -189,7 +238,7 @@ func selectRemote(remotes []*types.ExternalMCPRemote, remoteURL *string, transpo
 		return nil, oops.E(oops.CodeBadRequest, nil, "no %s remote on this catalog server", want)
 	}
 
-	for _, transport := range []string{"streamable-http", "sse"} {
+	for _, transport := range supportedTransports {
 		for _, r := range remotes {
 			if r != nil && r.TransportType == transport && r.URL != "" {
 				return r, nil

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -86,6 +86,9 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
 	}
 
+	if _, ok := contextvalues.GetAssistantPrincipal(ctx); !ok {
+		return oops.E(oops.CodeUnauthorized, nil, "catalog tools require an assistant principal")
+	}
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return oops.E(oops.CodeUnauthorized, nil, "catalog tools require a project auth context")

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -246,6 +246,13 @@ func resolveRemoteURL(rawURL string, declared map[string]*types.ExternalMCPRemot
 // buildHeaderInputs maps the catalog-declared headers to remoteMcp header
 // inputs using the supplied static values. Required headers without a value
 // fail the call. is_secret/is_required are preserved from the catalog.
+//
+// Secret headers are refused outright: the platform MCP path records raw
+// tool-call arguments (serve_platform.go RecordRequestBodyContent) so any
+// secret routed through the supplied headers map would be written to
+// telemetry/log storage in plaintext even though remoteMcp encrypts at
+// rest. Catalog servers that require secret headers must be installed
+// through the dashboard's "Add remote MCP" flow instead.
 func buildHeaderInputs(declared []*types.ExternalMCPRemoteHeader, supplied map[string]string) ([]*remotemcpgen.HeaderInput, error) {
 	if len(declared) == 0 {
 		return nil, nil
@@ -256,6 +263,9 @@ func buildHeaderInputs(declared []*types.ExternalMCPRemoteHeader, supplied map[s
 		if header == nil || header.Name == "" {
 			continue
 		}
+		if header.IsSecret != nil && *header.IsSecret {
+			return nil, oops.E(oops.CodeBadRequest, nil, "header %q is declared as secret; assistants cannot install catalog servers that require secret headers — ask the user to add this server through the dashboard's 'Add remote MCP' flow", header.Name)
+		}
 		value := supplied[header.Name]
 		required := header.IsRequired != nil && *header.IsRequired
 		if value == "" {
@@ -264,15 +274,11 @@ func buildHeaderInputs(declared []*types.ExternalMCPRemoteHeader, supplied map[s
 			}
 			continue
 		}
-		isSecret := false
-		if header.IsSecret != nil {
-			isSecret = *header.IsSecret
-		}
 		out = append(out, &remotemcpgen.HeaderInput{
 			Name:                   header.Name,
 			Description:            header.Description,
 			IsRequired:             new(required),
-			IsSecret:               new(isSecret),
+			IsSecret:               new(false),
 			Value:                  new(value),
 			ValueFromRequestHeader: nil,
 		})

--- a/server/internal/platformtools/catalog/install.go
+++ b/server/internal/platformtools/catalog/install.go
@@ -6,12 +6,16 @@ import (
 	"io"
 	"strings"
 
+	"errors"
+
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	deploymentsgen "github.com/speakeasy-api/gram/server/gen/deployments"
 	toolsetsgen "github.com/speakeasy-api/gram/server/gen/toolsets"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -40,22 +44,24 @@ type installResult struct {
 // + enable MCP) used by the dashboard's AddServerDialog so an assistant can
 // invoke it directly.
 type InstallTool struct {
-	descriptor     core.ToolDescriptor
-	registryClient *externalmcp.RegistryClient
-	repo           *externalmcprepo.Queries
-	installer      Installer
+	descriptor      core.ToolDescriptor
+	registryClient  *externalmcp.RegistryClient
+	repo            *externalmcprepo.Queries
+	deploymentsRepo *deploymentsrepo.Queries
+	installer       Installer
 }
 
-func NewInstallTool(installer Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) *InstallTool {
+func NewInstallTool(installer Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries, deploymentsRepo *deploymentsrepo.Queries) *InstallTool {
 	readOnly := false
 	destructive := false
 	idempotent := false
 	openWorld := false
 
 	return &InstallTool{
-		installer:      installer,
-		registryClient: registryClient,
-		repo:           repo,
+		installer:       installer,
+		registryClient:  registryClient,
+		repo:            repo,
+		deploymentsRepo: deploymentsRepo,
 		descriptor: core.ToolDescriptor{
 			SourceSlug:  SourceCatalog,
 			HandlerName: handlerInstall,
@@ -78,7 +84,7 @@ func (t *InstallTool) Descriptor() core.ToolDescriptor {
 }
 
 func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
-	if t.installer == nil || t.registryClient == nil || t.repo == nil {
+	if t.installer == nil || t.registryClient == nil || t.repo == nil || t.deploymentsRepo == nil {
 		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
 	}
 
@@ -125,6 +131,17 @@ func (t *InstallTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 	slug := slugFromName(displayName)
 	if slug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "name does not produce a usable slug — pick a name with at least one alphanumeric character")
+	}
+
+	// Guard against silently clobbering an unrelated server. The deployments
+	// upsert is keyed by (deployment_id, slug) and updates registry/specifier
+	// on conflict, so installing "io.bar/server" when "io.foo/server" is
+	// already attached under the same trailing-segment slug would replace
+	// the existing attachment in the cloned deployment. The dashboard
+	// equivalent is the slug-collision check in
+	// useExternalMcpReleaseWorkflow.startDeployment.
+	if err := t.ensureNoConflictingSlug(ctx, *authCtx.ProjectID, slug, specifier); err != nil {
+		return err
 	}
 
 	regIDStr := registryID.String()
@@ -240,6 +257,42 @@ func defaultDisplayName(specifier string, fallback string) string {
 		return specifier[idx+1:]
 	}
 	return specifier
+}
+
+// ensureNoConflictingSlug returns a CodeConflict error when the project's
+// latest deployment already attaches an external MCP under the same slug but
+// for a different registry_server_specifier. Same specifier + same slug is
+// a legitimate idempotent re-install and proceeds silently.
+func (t *InstallTool) ensureNoConflictingSlug(ctx context.Context, projectID uuid.UUID, slug, specifier string) error {
+	latestID, err := t.deploymentsRepo.GetLatestDeploymentID(ctx, projectID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("get latest deployment for slug check: %w", err)
+	}
+	if latestID == uuid.Nil {
+		return nil
+	}
+
+	attachments, err := t.repo.ListExternalMCPAttachments(ctx, latestID)
+	if err != nil {
+		return fmt.Errorf("list external mcp attachments for slug check: %w", err)
+	}
+	for _, attachment := range attachments {
+		if attachment.Slug != slug {
+			continue
+		}
+		if attachment.RegistryServerSpecifier == specifier {
+			return nil
+		}
+		return oops.E(
+			oops.CodeConflict, nil,
+			"a different MCP server (%s) is already installed in this project as %q. Re-run with a name argument to disambiguate.",
+			attachment.RegistryServerSpecifier, slug,
+		)
+	}
+	return nil
 }
 
 // slugFromName mirrors the dashboard's generateSlug(name):

--- a/server/internal/platformtools/catalog/install_test.go
+++ b/server/internal/platformtools/catalog/install_test.go
@@ -3,23 +3,9 @@ package catalog
 import (
 	"testing"
 
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/stretchr/testify/require"
 )
-
-func TestSlugFromName_DerivesFromLastSegment(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "exa", slugFromName("io.modelcontextprotocol.anonymous/exa"))
-	require.Equal(t, "my-server", slugFromName("My Server!"))
-	require.Equal(t, "my-server", slugFromName("ai.example/My Server??"))
-}
-
-func TestSlugFromName_RejectsAllSeparators(t *testing.T) {
-	t.Parallel()
-
-	require.Empty(t, slugFromName("---"))
-	require.Empty(t, slugFromName("ai.example/!!!"))
-}
 
 func TestDefaultDisplayName_PrefersSpecifierTail(t *testing.T) {
 	t.Parallel()
@@ -27,4 +13,114 @@ func TestDefaultDisplayName_PrefersSpecifierTail(t *testing.T) {
 	require.Equal(t, "exa", defaultDisplayName("io.modelcontextprotocol.anonymous/exa", "ignored"))
 	require.Equal(t, "server", defaultDisplayName("server", "ignored"))
 	require.Equal(t, "fallback", defaultDisplayName("", "fallback"))
+}
+
+func TestSelectRemote_PrefersStreamableHTTPByDefault(t *testing.T) {
+	t.Parallel()
+
+	sse := &types.ExternalMCPRemote{URL: "https://sse.example/mcp", TransportType: "sse", Headers: nil, Variables: nil}
+	stream := &types.ExternalMCPRemote{URL: "https://stream.example/mcp", TransportType: "streamable-http", Headers: nil, Variables: nil}
+
+	got, err := selectRemote([]*types.ExternalMCPRemote{sse, stream}, nil, nil)
+	require.NoError(t, err)
+	require.Same(t, stream, got)
+}
+
+func TestSelectRemote_FallsBackToSSE(t *testing.T) {
+	t.Parallel()
+
+	sse := &types.ExternalMCPRemote{URL: "https://sse.example/mcp", TransportType: "sse", Headers: nil, Variables: nil}
+
+	got, err := selectRemote([]*types.ExternalMCPRemote{sse}, nil, nil)
+	require.NoError(t, err)
+	require.Same(t, sse, got)
+}
+
+func TestSelectRemote_RemoteURLOverride(t *testing.T) {
+	t.Parallel()
+
+	a := &types.ExternalMCPRemote{URL: "https://a.example/mcp", TransportType: "streamable-http", Headers: nil, Variables: nil}
+	b := &types.ExternalMCPRemote{URL: "https://b.example/mcp", TransportType: "streamable-http", Headers: nil, Variables: nil}
+	wanted := "https://b.example/mcp"
+
+	got, err := selectRemote([]*types.ExternalMCPRemote{a, b}, &wanted, nil)
+	require.NoError(t, err)
+	require.Same(t, b, got)
+}
+
+func TestSelectRemote_TransportFilter(t *testing.T) {
+	t.Parallel()
+
+	sse := &types.ExternalMCPRemote{URL: "https://sse.example/mcp", TransportType: "sse", Headers: nil, Variables: nil}
+	stream := &types.ExternalMCPRemote{URL: "https://stream.example/mcp", TransportType: "streamable-http", Headers: nil, Variables: nil}
+	want := "sse"
+
+	got, err := selectRemote([]*types.ExternalMCPRemote{stream, sse}, nil, &want)
+	require.NoError(t, err)
+	require.Same(t, sse, got)
+}
+
+func TestResolveRemoteURL_SubstitutesAndAppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	required := true
+	defVal := "us-east-1"
+	declared := map[string]*types.ExternalMCPRemoteVariable{
+		"region":  {Description: nil, IsRequired: nil, IsSecret: nil, Default: &defVal, Choices: nil},
+		"account": {Description: nil, IsRequired: &required, IsSecret: nil, Default: nil, Choices: nil},
+	}
+
+	got, err := resolveRemoteURL("https://{region}.example/{account}/mcp", declared, map[string]string{"account": "42"})
+	require.NoError(t, err)
+	require.Equal(t, "https://us-east-1.example/42/mcp", got)
+}
+
+func TestResolveRemoteURL_MissingRequired(t *testing.T) {
+	t.Parallel()
+
+	required := true
+	declared := map[string]*types.ExternalMCPRemoteVariable{
+		"account": {Description: nil, IsRequired: &required, IsSecret: nil, Default: nil, Choices: nil},
+	}
+
+	_, err := resolveRemoteURL("https://example/{account}/mcp", declared, nil)
+	require.Error(t, err)
+}
+
+func TestResolveRemoteURL_RejectsUnknownChoice(t *testing.T) {
+	t.Parallel()
+
+	declared := map[string]*types.ExternalMCPRemoteVariable{
+		"region": {Description: nil, IsRequired: nil, IsSecret: nil, Default: nil, Choices: []string{"us", "eu"}},
+	}
+
+	_, err := resolveRemoteURL("https://{region}.example/mcp", declared, map[string]string{"region": "ap"})
+	require.Error(t, err)
+}
+
+func TestBuildHeaderInputs_SkipsOptionalAndKeepsRequired(t *testing.T) {
+	t.Parallel()
+
+	required := true
+	declared := []*types.ExternalMCPRemoteHeader{
+		{Name: "X-Api-Key", Description: nil, IsSecret: nil, IsRequired: &required, Placeholder: nil},
+		{Name: "X-Optional", Description: nil, IsSecret: nil, IsRequired: nil, Placeholder: nil},
+	}
+
+	out, err := buildHeaderInputs(declared, map[string]string{"X-Api-Key": "abc"})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "X-Api-Key", out[0].Name)
+}
+
+func TestBuildHeaderInputs_MissingRequiredErrors(t *testing.T) {
+	t.Parallel()
+
+	required := true
+	declared := []*types.ExternalMCPRemoteHeader{
+		{Name: "X-Api-Key", Description: nil, IsSecret: nil, IsRequired: &required, Placeholder: nil},
+	}
+
+	_, err := buildHeaderInputs(declared, nil)
+	require.Error(t, err)
 }

--- a/server/internal/platformtools/catalog/install_test.go
+++ b/server/internal/platformtools/catalog/install_test.go
@@ -1,0 +1,30 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlugFromName_DerivesFromLastSegment(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "exa", slugFromName("io.modelcontextprotocol.anonymous/exa"))
+	require.Equal(t, "my-server", slugFromName("My Server!"))
+	require.Equal(t, "my-server", slugFromName("ai.example/My Server??"))
+}
+
+func TestSlugFromName_RejectsAllSeparators(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, slugFromName("---"))
+	require.Empty(t, slugFromName("ai.example/!!!"))
+}
+
+func TestDefaultDisplayName_PrefersSpecifierTail(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "exa", defaultDisplayName("io.modelcontextprotocol.anonymous/exa", "ignored"))
+	require.Equal(t, "server", defaultDisplayName("server", "ignored"))
+	require.Equal(t, "fallback", defaultDisplayName("", "fallback"))
+}

--- a/server/internal/platformtools/catalog/install_test.go
+++ b/server/internal/platformtools/catalog/install_test.go
@@ -48,6 +48,26 @@ func TestSelectRemote_RemoteURLOverride(t *testing.T) {
 	require.Same(t, b, got)
 }
 
+func TestSelectRemote_RejectsUnsupportedTransportOnRemoteURLMatch(t *testing.T) {
+	t.Parallel()
+
+	unsupported := &types.ExternalMCPRemote{URL: "https://ws.example/mcp", TransportType: "websocket", Headers: nil, Variables: nil}
+	wanted := "https://ws.example/mcp"
+
+	_, err := selectRemote([]*types.ExternalMCPRemote{unsupported}, &wanted, nil)
+	require.Error(t, err)
+}
+
+func TestSelectRemote_RejectsUnsupportedTransportInFilter(t *testing.T) {
+	t.Parallel()
+
+	stream := &types.ExternalMCPRemote{URL: "https://stream.example/mcp", TransportType: "streamable-http", Headers: nil, Variables: nil}
+	want := "websocket"
+
+	_, err := selectRemote([]*types.ExternalMCPRemote{stream}, nil, &want)
+	require.Error(t, err)
+}
+
 func TestSelectRemote_TransportFilter(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformtools/catalog/install_test.go
+++ b/server/internal/platformtools/catalog/install_test.go
@@ -136,3 +136,15 @@ func TestBuildHeaderInputs_MissingRequiredErrors(t *testing.T) {
 	_, err := buildHeaderInputs(declared, nil)
 	require.Error(t, err)
 }
+
+func TestBuildHeaderInputs_RejectsSecretHeader(t *testing.T) {
+	t.Parallel()
+
+	secret := true
+	declared := []*types.ExternalMCPRemoteHeader{
+		{Name: "Authorization", Description: nil, IsSecret: &secret, IsRequired: nil, Placeholder: nil},
+	}
+
+	_, err := buildHeaderInputs(declared, map[string]string{"Authorization": "Bearer xyz"})
+	require.Error(t, err)
+}

--- a/server/internal/platformtools/catalog/install_test.go
+++ b/server/internal/platformtools/catalog/install_test.go
@@ -87,6 +87,18 @@ func TestResolveRemoteURL_MissingRequired(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestResolveRemoteURL_RejectsSecretVariable(t *testing.T) {
+	t.Parallel()
+
+	secret := true
+	declared := map[string]*types.ExternalMCPRemoteVariable{
+		"token": {Description: nil, IsRequired: nil, IsSecret: &secret, Default: nil, Choices: nil},
+	}
+
+	_, err := resolveRemoteURL("https://example/{token}/mcp", declared, map[string]string{"token": "shh"})
+	require.Error(t, err)
+}
+
 func TestResolveRemoteURL_RejectsUnknownChoice(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformtools/catalog/search.go
+++ b/server/internal/platformtools/catalog/search.go
@@ -1,0 +1,221 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+const handlerSearch = "search_catalog"
+
+// maxSearchResults caps the aggregated multi-registry response to keep tool
+// output small enough for an LLM to read in one shot. Mirrors the v0 limit
+// applied by externalmcp.ListCatalog.
+const maxSearchResults = 100
+
+type searchInput struct {
+	Query      *string `json:"query,omitempty" jsonschema:"Substring filter passed to the registry."`
+	RegistryID *string `json:"registry_id,omitempty" jsonschema:"Restrict the search to a single registry. Omit to query every configured registry."`
+	Cursor     *string `json:"cursor,omitempty" jsonschema:"Pagination cursor from a previous response. Only honored when registry_id is set."`
+}
+
+type searchToolView struct {
+	Name              string                 `json:"name"`
+	Description       string                 `json:"description"`
+	Version           string                 `json:"version"`
+	Title             *string                `json:"title,omitempty"`
+	IconURL           *string                `json:"icon_url,omitempty"`
+	RegistryID        string                 `json:"registry_id"`
+	RegistrySpecifier string                 `json:"registry_specifier"`
+	Tools             []catalogToolPreview   `json:"tools,omitempty"`
+	Remotes           []catalogRemotePreview `json:"remotes,omitempty"`
+}
+
+type catalogToolPreview struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type catalogRemotePreview struct {
+	URL           string `json:"url"`
+	TransportType string `json:"transport_type"`
+}
+
+type searchResult struct {
+	Servers    []searchToolView `json:"servers"`
+	NextCursor *string          `json:"next_cursor,omitempty"`
+}
+
+// SearchTool wraps the MCP registry list endpoint as a platform tool.
+type SearchTool struct {
+	descriptor     core.ToolDescriptor
+	registryClient *externalmcp.RegistryClient
+	repo           *externalmcprepo.Queries
+}
+
+func NewSearchTool(registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) *SearchTool {
+	readOnly := true
+	destructive := false
+	idempotent := true
+	openWorld := true
+
+	return &SearchTool{
+		registryClient: registryClient,
+		repo:           repo,
+		descriptor: core.ToolDescriptor{
+			SourceSlug:  SourceCatalog,
+			HandlerName: handlerSearch,
+			Name:        ToolNameSearchCatalog,
+			Description: "Search the MCP catalog for installable servers. Each result includes a registry_id and registry_specifier pair that must be passed verbatim to platform_install_catalog_server.",
+			InputSchema: core.BuildInputSchema[searchInput](
+				core.WithPropertyFormat("registry_id", "uuid"),
+			),
+			Variables:   nil,
+			Annotations: catalogToolAnnotations(readOnly, destructive, idempotent, openWorld),
+			Managed:     true,
+			OwnerKind:   nil,
+			OwnerID:     nil,
+		},
+	}
+}
+
+func (t *SearchTool) Descriptor() core.ToolDescriptor {
+	return t.descriptor
+}
+
+func (t *SearchTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.registryClient == nil || t.repo == nil {
+		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
+	}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		return oops.E(oops.CodeUnauthorized, nil, "catalog tools require a project auth context")
+	}
+
+	var input searchInput
+	if err := decodePayload(payload, &input); err != nil {
+		return err
+	}
+
+	registries, err := t.resolveRegistries(ctx, input.RegistryID)
+	if err != nil {
+		return err
+	}
+
+	servers := make([]searchToolView, 0)
+	var nextCursor *string
+	for _, registry := range registries {
+		result, err := t.registryClient.ListServers(ctx, externalmcp.Registry{
+			ID:  registry.ID,
+			URL: registry.URL,
+		}, externalmcp.ListServersParams{
+			Search: input.Query,
+			Cursor: input.Cursor,
+		})
+		if err != nil {
+			// One registry being down should not blank out the rest of the
+			// catalog — externalmcp.ListCatalog applies the same resilience
+			// when aggregating multiple registries.
+			continue
+		}
+		for _, server := range result.Servers {
+			if server == nil {
+				continue
+			}
+			servers = append(servers, toolViewFromServer(server))
+			if len(servers) >= maxSearchResults {
+				break
+			}
+		}
+		if len(registries) == 1 {
+			nextCursor = result.NextCursor
+		}
+		if len(servers) >= maxSearchResults {
+			break
+		}
+	}
+
+	return writeJSON(wr, searchResult{
+		Servers:    servers,
+		NextCursor: nextCursor,
+	})
+}
+
+type registryRow struct {
+	ID  uuid.UUID
+	URL string
+}
+
+func (t *SearchTool) resolveRegistries(ctx context.Context, registryID *string) ([]registryRow, error) {
+	if registryID != nil && *registryID != "" {
+		parsed, err := uuid.Parse(*registryID)
+		if err != nil {
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id")
+		}
+		row, err := t.repo.GetMCPRegistryByID(ctx, parsed)
+		if err != nil {
+			return nil, fmt.Errorf("get mcp registry: %w", err)
+		}
+		return []registryRow{{ID: row.ID, URL: row.Url}}, nil
+	}
+
+	rows, err := t.repo.ListMCPRegistries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list mcp registries: %w", err)
+	}
+	out := make([]registryRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, registryRow{ID: row.ID, URL: row.Url})
+	}
+	return out, nil
+}
+
+func toolViewFromServer(server *types.ExternalMCPServer) searchToolView {
+	view := searchToolView{
+		Name:              server.RegistrySpecifier,
+		Description:       server.Description,
+		Version:           server.Version,
+		Title:             server.Title,
+		IconURL:           server.IconURL,
+		RegistryID:        "",
+		RegistrySpecifier: server.RegistrySpecifier,
+		Tools:             nil,
+		Remotes:           nil,
+	}
+	if server.RegistryID != nil {
+		view.RegistryID = *server.RegistryID
+	}
+	for _, tool := range server.Tools {
+		if tool == nil {
+			continue
+		}
+		preview := catalogToolPreview{Name: "", Description: ""}
+		if tool.Name != nil {
+			preview.Name = *tool.Name
+		}
+		if tool.Description != nil {
+			preview.Description = *tool.Description
+		}
+		view.Tools = append(view.Tools, preview)
+	}
+	for _, remote := range server.Remotes {
+		if remote == nil {
+			continue
+		}
+		view.Remotes = append(view.Remotes, catalogRemotePreview{
+			URL:           remote.URL,
+			TransportType: remote.TransportType,
+		})
+	}
+	return view
+}

--- a/server/internal/platformtools/catalog/search.go
+++ b/server/internal/platformtools/catalog/search.go
@@ -5,22 +5,15 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/uuid"
+	registriesgen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/externalmcp"
-	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
 const handlerSearch = "search_catalog"
-
-// maxSearchResults caps the aggregated multi-registry response to keep tool
-// output small enough for an LLM to read in one shot. Mirrors the v0 limit
-// applied by externalmcp.ListCatalog.
-const maxSearchResults = 100
 
 type searchInput struct {
 	Query      *string `json:"query,omitempty" jsonschema:"Substring filter passed to the registry."`
@@ -55,22 +48,22 @@ type searchResult struct {
 	NextCursor *string          `json:"next_cursor,omitempty"`
 }
 
-// SearchTool wraps the MCP registry list endpoint as a platform tool.
+// SearchTool wraps mcpRegistries.listCatalog as a platform tool so dispatch
+// runs through the same RBAC path (ScopeProjectRead) as the dashboard
+// catalog view.
 type SearchTool struct {
-	descriptor     core.ToolDescriptor
-	registryClient *externalmcp.RegistryClient
-	repo           *externalmcprepo.Queries
+	descriptor core.ToolDescriptor
+	catalog    Catalog
 }
 
-func NewSearchTool(registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) *SearchTool {
+func NewSearchTool(catalog Catalog) *SearchTool {
 	readOnly := true
 	destructive := false
 	idempotent := true
 	openWorld := true
 
 	return &SearchTool{
-		registryClient: registryClient,
-		repo:           repo,
+		catalog: catalog,
 		descriptor: core.ToolDescriptor{
 			SourceSlug:  SourceCatalog,
 			HandlerName: handlerSearch,
@@ -93,7 +86,7 @@ func (t *SearchTool) Descriptor() core.ToolDescriptor {
 }
 
 func (t *SearchTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
-	if t.registryClient == nil || t.repo == nil {
+	if t.catalog == nil {
 		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
 	}
 
@@ -110,77 +103,30 @@ func (t *SearchTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload
 		return err
 	}
 
-	registries, err := t.resolveRegistries(ctx, input.RegistryID)
+	result, err := t.catalog.ListCatalog(ctx, &registriesgen.ListCatalogPayload{
+		RegistryID:       input.RegistryID,
+		Search:           input.Query,
+		Cursor:           input.Cursor,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("list catalog: %w", err)
 	}
 
-	servers := make([]searchToolView, 0)
-	var nextCursor *string
-	for _, registry := range registries {
-		result, err := t.registryClient.ListServers(ctx, externalmcp.Registry{
-			ID:  registry.ID,
-			URL: registry.URL,
-		}, externalmcp.ListServersParams{
-			Search: input.Query,
-			Cursor: input.Cursor,
-		})
-		if err != nil {
-			// One registry being down should not blank out the rest of the
-			// catalog — externalmcp.ListCatalog applies the same resilience
-			// when aggregating multiple registries.
+	views := make([]searchToolView, 0, len(result.Servers))
+	for _, server := range result.Servers {
+		if server == nil {
 			continue
 		}
-		for _, server := range result.Servers {
-			if server == nil {
-				continue
-			}
-			servers = append(servers, toolViewFromServer(server))
-			if len(servers) >= maxSearchResults {
-				break
-			}
-		}
-		if len(registries) == 1 {
-			nextCursor = result.NextCursor
-		}
-		if len(servers) >= maxSearchResults {
-			break
-		}
+		views = append(views, toolViewFromServer(server))
 	}
 
 	return writeJSON(wr, searchResult{
-		Servers:    servers,
-		NextCursor: nextCursor,
+		Servers:    views,
+		NextCursor: result.NextCursor,
 	})
-}
-
-type registryRow struct {
-	ID  uuid.UUID
-	URL string
-}
-
-func (t *SearchTool) resolveRegistries(ctx context.Context, registryID *string) ([]registryRow, error) {
-	if registryID != nil && *registryID != "" {
-		parsed, err := uuid.Parse(*registryID)
-		if err != nil {
-			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id")
-		}
-		row, err := t.repo.GetMCPRegistryByID(ctx, parsed)
-		if err != nil {
-			return nil, fmt.Errorf("get mcp registry: %w", err)
-		}
-		return []registryRow{{ID: row.ID, URL: row.Url}}, nil
-	}
-
-	rows, err := t.repo.ListMCPRegistries(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("list mcp registries: %w", err)
-	}
-	out := make([]registryRow, 0, len(rows))
-	for _, row := range rows {
-		out = append(out, registryRow{ID: row.ID, URL: row.Url})
-	}
-	return out, nil
 }
 
 func toolViewFromServer(server *types.ExternalMCPServer) searchToolView {

--- a/server/internal/platformtools/catalog/search.go
+++ b/server/internal/platformtools/catalog/search.go
@@ -97,6 +97,9 @@ func (t *SearchTool) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload
 		return oops.E(oops.CodeUnexpected, nil, "catalog tools are not configured")
 	}
 
+	if _, ok := contextvalues.GetAssistantPrincipal(ctx); !ok {
+		return oops.E(oops.CodeUnauthorized, nil, "catalog tools require an assistant principal")
+	}
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return oops.E(oops.CodeUnauthorized, nil, "catalog tools require a project auth context")

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -13,11 +13,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/memory"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	platformcatalog "github.com/speakeasy-api/gram/server/internal/platformtools/catalog"
 	platformmemory "github.com/speakeasy-api/gram/server/internal/platformtools/memory"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
@@ -48,6 +51,22 @@ func WithTriggerTools(app *bgtriggers.App) Option {
 func WithSlackHTTPClient(client *guardian.HTTPClient) Option {
 	return func(c *config) {
 		c.deps.SlackHTTPClient = client
+	}
+}
+
+// CatalogExternalTools wires the platform_search_catalog and
+// platform_install_catalog_server tools using the live registry client +
+// repo + installer adapter. Pass the result through WithExternalTools.
+//
+// We surface these as ExternalTools (rather than rolling them into the
+// default registry struct) so callers can choose to omit them in contexts
+// where deployments + toolsets services are not constructed, e.g. the
+// background worker. The runtime catalogs them as platform tools by URN
+// either way.
+func CatalogExternalTools(installer platformcatalog.Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) []platformtools.ExternalTool {
+	return []platformtools.ExternalTool{
+		{Executor: platformcatalog.NewSearchTool(registryClient, repo), RequiredFeature: ""},
+		{Executor: platformcatalog.NewInstallTool(installer, registryClient, repo), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
@@ -57,17 +56,16 @@ func WithSlackHTTPClient(client *guardian.HTTPClient) Option {
 
 // CatalogExternalTools wires the platform_search_catalog and
 // platform_install_catalog_server tools using the live registry client +
-// repo + installer adapter. Pass the result through WithExternalTools.
+// repo + catalog adapter. Pass the result through WithExternalTools.
 //
 // We surface these as ExternalTools (rather than rolling them into the
 // default registry struct) so callers can choose to omit them in contexts
-// where deployments + toolsets services are not constructed, e.g. the
-// background worker. The runtime catalogs them as platform tools by URN
-// either way.
-func CatalogExternalTools(installer platformcatalog.Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries, deploymentsRepo *deploymentsrepo.Queries) []platformtools.ExternalTool {
+// where the remoteMcp service is not constructed, e.g. the background
+// worker. The runtime catalogs them as platform tools by URN either way.
+func CatalogExternalTools(catalog platformcatalog.Catalog, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
 		{Executor: platformcatalog.NewSearchTool(registryClient, repo), RequiredFeature: ""},
-		{Executor: platformcatalog.NewInstallTool(installer, repo, deploymentsRepo), RequiredFeature: ""},
+		{Executor: platformcatalog.NewInstallTool(catalog), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
@@ -63,10 +64,10 @@ func WithSlackHTTPClient(client *guardian.HTTPClient) Option {
 // where deployments + toolsets services are not constructed, e.g. the
 // background worker. The runtime catalogs them as platform tools by URN
 // either way.
-func CatalogExternalTools(installer platformcatalog.Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) []platformtools.ExternalTool {
+func CatalogExternalTools(installer platformcatalog.Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries, deploymentsRepo *deploymentsrepo.Queries) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
 		{Executor: platformcatalog.NewSearchTool(registryClient, repo), RequiredFeature: ""},
-		{Executor: platformcatalog.NewInstallTool(installer, registryClient, repo), RequiredFeature: ""},
+		{Executor: platformcatalog.NewInstallTool(installer, registryClient, repo, deploymentsRepo), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -13,8 +13,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/externalmcp"
-	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/memory"
@@ -55,16 +53,16 @@ func WithSlackHTTPClient(client *guardian.HTTPClient) Option {
 }
 
 // CatalogExternalTools wires the platform_search_catalog and
-// platform_install_catalog_server tools using the live registry client +
-// repo + catalog adapter. Pass the result through WithExternalTools.
+// platform_install_catalog_server tools through the supplied catalog
+// adapter. Pass the result through WithExternalTools.
 //
 // We surface these as ExternalTools (rather than rolling them into the
 // default registry struct) so callers can choose to omit them in contexts
 // where the remoteMcp service is not constructed, e.g. the background
 // worker. The runtime catalogs them as platform tools by URN either way.
-func CatalogExternalTools(catalog platformcatalog.Catalog, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries) []platformtools.ExternalTool {
+func CatalogExternalTools(catalog platformcatalog.Catalog) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
-		{Executor: platformcatalog.NewSearchTool(registryClient, repo), RequiredFeature: ""},
+		{Executor: platformcatalog.NewSearchTool(catalog), RequiredFeature: ""},
 		{Executor: platformcatalog.NewInstallTool(catalog), RequiredFeature: ""},
 	}
 }

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -67,7 +67,7 @@ func WithSlackHTTPClient(client *guardian.HTTPClient) Option {
 func CatalogExternalTools(installer platformcatalog.Installer, registryClient *externalmcp.RegistryClient, repo *externalmcprepo.Queries, deploymentsRepo *deploymentsrepo.Queries) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
 		{Executor: platformcatalog.NewSearchTool(registryClient, repo), RequiredFeature: ""},
-		{Executor: platformcatalog.NewInstallTool(installer, registryClient, repo, deploymentsRepo), RequiredFeature: ""},
+		{Executor: platformcatalog.NewInstallTool(installer, repo, deploymentsRepo), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/toolsets.go
+++ b/server/internal/platformtools/toolsets.go
@@ -18,14 +18,18 @@ type Toolset struct {
 // platform toolset registry. Add a field here when a new toolset needs an
 // external service or pre-built tool slice.
 type ToolsetDependencies struct {
-	AssistantMemoryTools []ExternalTool
+	AssistantMemoryTools  []ExternalTool
+	AssistantCatalogTools []ExternalTool
 }
 
 type toolsetBuilder func(deps ToolsetDependencies) Toolset
 
 var toolsetRegistry = []toolsetBuilder{
 	func(deps ToolsetDependencies) Toolset {
-		return NewAssistantsToolset(deps.AssistantMemoryTools...)
+		tools := make([]ExternalTool, 0, len(deps.AssistantMemoryTools)+len(deps.AssistantCatalogTools))
+		tools = append(tools, deps.AssistantMemoryTools...)
+		tools = append(tools, deps.AssistantCatalogTools...)
+		return NewAssistantsToolset(tools...)
 	},
 }
 


### PR DESCRIPTION
## Summary

- Adds `platform_search_catalog` and `platform_install_catalog_server` so assistants can discover and install MCP catalog servers from a chat.
- `search_catalog` aggregates results across all configured registries (or filters to one); each result hands back the `registry_id` + `registry_specifier` the install tool needs, plus a tool/remote preview the LLM can show the user.
- `install_catalog_server` runs the same flow the dashboard's "Add to Project" dialog runs server-side: `deployments.Evolve` to attach the external MCP, `toolsets.CreateToolset` to create a fresh toolset wired to the server's tools, then `toolsets.UpdateToolset` to flip `mcpEnabled`/`mcpIsPublic` on. Tool URN list and origin metadata match what `AddServerDialog`/`useExternalMcpReleaseWorkflow.buildToolUrns` produces, so a server installed this way is indistinguishable from a UI install.
- Wired as `ExternalTool` extras (catalog package lives under `platformtools/catalog`) to avoid the `platformtools → externalmcp → auth → … → platformtools` import cycle that the default registry route would have triggered.

Closes [AGE-2296](https://linear.app/speakeasy/issue/AGE-2296/add-mcp-catalog-tools-to-assistants-search-and-install)

✻ Clauded...