### PR TITLE
fix(insights): scope Costs tab to insights view, restore Agents on logs

### DIFF
--- a/client/dashboard/src/components/observe/ObserveTabNav.tsx
+++ b/client/dashboard/src/components/observe/ObserveTabNav.tsx
@@ -8,9 +8,14 @@ export function ObserveTabNav({ base }: { base: "insights" | "logs" }) {
 
   const baseSlug = `/${orgSlug}/projects/${projectSlug}/${base}`;
   const tabs = [
-    { label: "Costs", href: `${baseSlug}/costs` },
+    ...(base === "insights"
+      ? [{ label: "Costs", href: `${baseSlug}/costs` }]
+      : []),
     { label: "Tools", href: `${baseSlug}/tools` },
     { label: "MCP Servers", href: `${baseSlug}/mcp` },
+    ...(base === "logs"
+      ? [{ label: "Agents", href: `${baseSlug}/agents` }]
+      : []),
     ...(base === "insights"
       ? [{ label: "Employees", href: `${baseSlug}/employees` }]
       : []),


### PR DESCRIPTION
## Summary

- Fix blank page at `/logs/costs` — Costs tab was rendering on both Insights and Logs views, but only Insights has a `costs` route
- Scope Costs tab to Insights page only
- Restore Agents tab on Logs page (was removed in #2806)

## Context

PR #2806 added the Costs tab unconditionally to the shared `ObserveTabNav` component, which serves both Insights and Logs. Since Logs has no `costs` sub-route, clicking the tab navigated to a dead route → blank page in production.

## Test plan

- [ ] Visit `/insights` — should show: Costs, Tools, MCP Servers, Employees tabs
- [ ] Visit `/logs` — should show: Tools, MCP Servers, Agents tabs
- [ ] Visit `/logs/costs` directly — should redirect to `/logs/tools` (index redirect)
