### PR TITLE
fix(hooks): authCtx fallback for UserPromptSubmit risk scan

### DIFF
--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -8,13 +8,22 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 )
 
 // scanClaudeForEnforcement extracts the scannable text from a Claude hook
-// payload, resolves the project from session metadata, and runs the risk
-// scanner. Returns nil when the scanner is unavailable, the session is not
-// yet validated, or no enforcing policy matches.
+// payload, resolves the project (session metadata wins; falls back to the
+// plugin-auth context populated by Gram-Key + Gram-Project headers), and
+// runs the risk scanner. Returns nil when the scanner is unavailable, the
+// project cannot be resolved, or no enforcing policy matches.
+//
+// The authCtx fallback is critical for UserPromptSubmit on the very first
+// hook of a session: Claude Code's OTEL Logs exporter is async, so the
+// `/rpc/hooks.otel/v1/logs` request that seeds session metadata in Redis
+// can land after the first UserPromptSubmit. Without this fallback, the
+// first prompt of every session slips through unscanned even when the
+// plugin authenticated the request.
 func (s *Service) scanClaudeForEnforcement(ctx context.Context, payload *gen.ClaudePayload) *risk.ScanResult {
 	if s.riskScanner == nil || payload.SessionID == nil {
 		return nil
@@ -25,13 +34,17 @@ func (s *Service) scanClaudeForEnforcement(ctx context.Context, payload *gen.Cla
 		return nil
 	}
 
-	metadata, err := s.getSessionMetadata(ctx, *payload.SessionID)
-	if err != nil {
-		// Session not yet validated; cannot determine project.
-		return nil
-	}
-	projectID, err := uuid.Parse(metadata.ProjectID)
-	if err != nil {
+	var projectID uuid.UUID
+	if metadata, err := s.getSessionMetadata(ctx, *payload.SessionID); err == nil {
+		pid, perr := uuid.Parse(metadata.ProjectID)
+		if perr != nil {
+			return nil
+		}
+		projectID = pid
+	} else if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil {
+		projectID = *authCtx.ProjectID
+	} else {
+		// No session metadata and no plugin auth; project unresolvable.
 		return nil
 	}
 

--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -34,17 +34,8 @@ func (s *Service) scanClaudeForEnforcement(ctx context.Context, payload *gen.Cla
 		return nil
 	}
 
-	var projectID uuid.UUID
-	if metadata, err := s.getSessionMetadata(ctx, *payload.SessionID); err == nil {
-		pid, perr := uuid.Parse(metadata.ProjectID)
-		if perr != nil {
-			return nil
-		}
-		projectID = pid
-	} else if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil {
-		projectID = *authCtx.ProjectID
-	} else {
-		// No session metadata and no plugin auth; project unresolvable.
+	projectID, ok := s.resolveClaudeScanProjectID(ctx, *payload.SessionID)
+	if !ok {
 		return nil
 	}
 
@@ -58,6 +49,26 @@ func (s *Service) scanClaudeForEnforcement(ctx context.Context, payload *gen.Cla
 	}
 
 	return result
+}
+
+// resolveClaudeScanProjectID resolves the project_id used to scope a Claude
+// hook risk scan. Session metadata cached by the OTEL Logs endpoint wins;
+// the plugin-auth context populated by Gram-Key + Gram-Project headers is
+// the fallback. Returns ok=false when neither source yields a project_id.
+func (s *Service) resolveClaudeScanProjectID(ctx context.Context, sessionID string) (uuid.UUID, bool) {
+	metadata, err := s.getSessionMetadata(ctx, sessionID)
+	if err == nil {
+		pid, perr := uuid.Parse(metadata.ProjectID)
+		if perr == nil {
+			return pid, true
+		}
+		return uuid.Nil, false
+	}
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		return uuid.Nil, false
+	}
+	return *authCtx.ProjectID, true
 }
 
 // scanCursorForEnforcement runs the risk scanner for a Cursor hook payload.


### PR DESCRIPTION
## Why

`handleUserPromptSubmit` only blocks when `scanClaudeForEnforcement` can resolve the project_id, and the only source it consulted was the Redis-cached session metadata seeded by Claude Code's OTEL Logs exporter (`/rpc/hooks.otel/v1/logs`).

That exporter is asynchronous. The very first `UserPromptSubmit` of a session routinely races ahead of the OTEL log, so the scan hits an empty cache, returns nil silently, and the prompt slips through unscanned. There is no log line on cache miss either, so the failure is invisible.

`handlePreToolUse` already side-steps this by reading `authCtx.ProjectID` populated from the `Gram-Key` + `Gram-Project` headers (see `claude_hooks.go:489-505`). `UserPromptSubmit` did not.

### Repro before the fix

- Curl `/rpc/hooks.claude` with `Gram-Key` + `Gram-Project` headers and a never-seen session_id + a PII prompt: returns HTTP 200, no block. Trace shows the handler ran, the SQL spans queried `risk_policies` would have been issued, but only on a session-metadata path.
- Same curl, preceded by a `/rpc/hooks.otel/v1/logs` POST registering the session: returns HTTP 403 as expected.

The race exists for every authenticated plugin user; published Claude plugin happens to win the race most of the time, but nothing guarantees it.

### How `authCtx.ProjectID` actually gets populated (important nuance)

The fallback only works when the request carries **both** `Gram-Key` AND `Gram-Project` headers, because:

- `Gram-Key` resolves the org via the `apikey` security scheme but leaves `authCtx.ProjectID = nil`.
- `authCtx.ProjectID` is only set inside `checkProjectAccess` (`server/internal/auth/auth.go:75-115`), which runs as part of the `project_slug` security scheme (driven by the `Gram-Project` header).

The `Claude` endpoint already enforces this pairing in `hasOptionalPluginAuth` (`claude_hooks.go:349-352`) before invoking `authorizePluginRequest`, so by the time `scanClaudeForEnforcement` reads `authCtx.ProjectID`, it is guaranteed non-nil. PreToolUse's existing fallback relies on the exact same precondition, so no new behavioral assumption is introduced.

Implication: unauthenticated hook requests (no `Gram-Key` / `Gram-Project` headers) still depend on OTEL session metadata. The published `hooks/plugin-claude/hooks/send_hook.sh` currently does NOT forward these headers, so it remains on the OTEL-only path until that script is updated to inject `Gram-Key` and `Gram-Project` from env. That follow-up is intentionally out of scope for this PR; this change unblocks any plugin-authenticated path (e.g. tests, custom plugins, mise hooks:test) immediately and unblocks the published plugin as soon as the script is updated.

We deliberately did NOT add a heuristic like "default to the org's `default` project" when only `Gram-Key` is present:

- "default" is a project-slug convention, not enforced; not every org uses it.
- Picking a project by name across orgs is a cross-tenant footgun and would silently scope scans to the wrong project.
- A future improvement could pull `api_keys.project_id` directly off the resolved key inside the `apikey` scheme so the `Gram-Project` header becomes optional. That's a larger auth-scheme change and belongs in its own PR.

## What changed

`scanClaudeForEnforcement` now resolves the project with a two-tier lookup, extracted into a small helper so the scan function stays a single flat path:

### Before

```go
metadata, err := s.getSessionMetadata(ctx, *payload.SessionID)
if err != nil {
    // Session not yet validated; cannot determine project.
    return nil
}
projectID, err := uuid.Parse(metadata.ProjectID)
```

### After

```go
projectID, ok := s.resolveClaudeScanProjectID(ctx, *payload.SessionID)
if !ok {
    return nil
}
```

```go
func (s *Service) resolveClaudeScanProjectID(ctx context.Context, sessionID string) (uuid.UUID, bool) {
    metadata, err := s.getSessionMetadata(ctx, sessionID)
    if err == nil {
        pid, perr := uuid.Parse(metadata.ProjectID)
        if perr == nil {
            return pid, true
        }
        return uuid.Nil, false
    }
    authCtx, ok := contextvalues.GetAuthContext(ctx)
    if !ok || authCtx == nil || authCtx.ProjectID == nil {
        return uuid.Nil, false
    }
    return *authCtx.ProjectID, true
}
```

Behavior matrix:

| Request | Session in cache | Plugin auth headers (`Gram-Key` + `Gram-Project`) | Before | After |
| --- | --- | --- | --- | --- |
| Plugin-authenticated, cache cold | no | yes | allow (silent miss) | scan + block when matched |
| Plugin-authenticated, cache warm | yes | yes | scan | scan (cache wins) |
| Unauthenticated, cache cold | no | no | allow (silent miss) | allow (unchanged) |
| Unauthenticated, cache warm | yes | no | scan | scan (unchanged) |

PreToolUse, Cursor, and Codex paths are untouched (already authenticated path or already had the fallback).

## Follow-ups (not in this PR)

- `hooks/plugin-claude/hooks/send_hook.sh` does not currently forward `Gram-Key` / `Gram-Project` headers; published plugin users would only benefit from this fix once the script propagates the env-supplied credentials. Worth a separate PR in the plugin repo.
- Optional auth-scheme change: pull `api_keys.project_id` off the resolved key inside the `apikey` scheme so `authCtx.ProjectID` is populated by `Gram-Key` alone and `Gram-Project` becomes optional.
- Add a server test covering: `UserPromptSubmit` with `Gram-Key`+`Gram-Project` headers and a session_id NOT in cache, against a project with an enforcing policy, returns 403.
- Consider logging a warn or emitting a metric when project resolution fails for an authenticated session, so silent allow-throughs are observable.
