### PR TITLE
fix(elements): one failed MCP server nukes tools from all others

### DIFF
--- a/.changeset/elements-mcp-partial-failures.md
+++ b/.changeset/elements-mcp-partial-failures.md
@@ -1,0 +1,5 @@
+---
+"@gram-ai/elements": patch
+---
+
+Stop one failing MCP server from dropping tools from healthy ones. When a chat is configured with multiple MCP servers, a rejection on any single `tools/list` call (e.g. a 401 on one toolset) used to wipe out the merged tool map and trigger React Query retries against every server. Healthy servers are now merged in normally; only when every server fails does the query reject and retry.

--- a/elements/src/hooks/useMCPTools.ts
+++ b/elements/src/hooks/useMCPTools.ts
@@ -4,6 +4,7 @@ import { ToolsFilter } from "@/types";
 import { experimental_createMCPClient as createMCPClient } from "@ai-sdk/mcp";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { useMemo, useRef } from "react";
+import { trackError } from "@/lib/errorTracking";
 import { Auth } from "./useAuth";
 
 type MCPToolsResult = Awaited<
@@ -98,7 +99,7 @@ export function useMCPTools({
       }));
       perServerHeadersRef.current = serverEntries.map((s) => s.headers);
 
-      const perServerTools = await Promise.all(
+      const settled = await Promise.allSettled(
         serverEntries.map(async ({ server, headers }) => {
           const client = await createMCPClient({
             name: "gram-elements-mcp-client",
@@ -110,14 +111,38 @@ export function useMCPTools({
 
       const merged: MCPToolsResult = {};
       const namespaced = servers.length > 1;
-      for (const { server, tools } of perServerTools) {
+      let rejected = 0;
+      for (const [i, { server }] of serverEntries.entries()) {
+        const result = settled[i]!;
+        if (result.status === "rejected") {
+          rejected++;
+          trackError(result.reason, {
+            source: "custom",
+            scope: "mcp-tools",
+            serverName: server.name ?? deriveNameFromUrl(server.url),
+            serverUrl: server.url,
+          });
+          continue;
+        }
         const prefix = namespaced
           ? (server.name ?? deriveNameFromUrl(server.url))
           : null;
-        for (const [toolName, tool] of Object.entries(tools)) {
+        for (const [toolName, tool] of Object.entries(result.value.tools)) {
           const key = prefix ? `${prefix}__${toolName}` : toolName;
           merged[key] = tool;
         }
+      }
+
+      // Surface as a query rejection only when every server failed, so React
+      // Query's retry/backoff still recovers from total outages (e.g. expired
+      // auth hitting every server). Partial failures resolve normally.
+      if (rejected > 0 && rejected === serverEntries.length) {
+        const first = settled.find(
+          (r): r is PromiseRejectedResult => r.status === "rejected",
+        );
+        throw first?.reason instanceof Error
+          ? first.reason
+          : new Error("All MCP servers failed to list tools");
       }
 
       return merged;

--- a/elements/src/hooks/useMCPTools.ts
+++ b/elements/src/hooks/useMCPTools.ts
@@ -56,6 +56,11 @@ export function useMCPTools({
   // requests. `mcpHeaders` is a write-only proxy that fans cross-cutting
   // header writes (e.g. Gram-Chat-ID) out to every per-server record.
   const perServerHeadersRef = useRef<Record<string, string>[]>([]);
+  // When some servers fail and some succeed we still resolve with the partial
+  // tool map, but flip this so the query is treated as stale — natural refetch
+  // triggers (window focus, reconnect) can then recover the missing servers
+  // instead of the partial result being cached for the session.
+  const partialFailureRef = useRef(false);
   const headersProxyRef = useRef<Record<string, string> | null>(null);
   if (!headersProxyRef.current) {
     headersProxyRef.current = new Proxy<Record<string, string>>(
@@ -133,6 +138,9 @@ export function useMCPTools({
         }
       }
 
+      partialFailureRef.current =
+        rejected > 0 && rejected < serverEntries.length;
+
       // Surface as a query rejection only when every server failed, so React
       // Query's retry/backoff still recovers from total outages (e.g. expired
       // auth hitting every server). Partial failures resolve normally.
@@ -148,7 +156,7 @@ export function useMCPTools({
       return merged;
     },
     enabled: !auth.isLoading && servers.length > 0,
-    staleTime: Infinity,
+    staleTime: () => (partialFailureRef.current ? 0 : Infinity),
     gcTime: Infinity,
   });
 


### PR DESCRIPTION
## Summary

- `elements/src/hooks/useMCPTools.ts` fanned out per-server `client.tools()` through `Promise.all`, so a single rejection (e.g. a 401 on an issuer-gated toolset) dropped the entire merged tool map. React Query then retried the whole batch ~3×, hammering every server.
- Switched to `Promise.allSettled`: healthy servers merge in normally, and rejected servers go to `trackError` with their name + URL so the failure is visible in RUM.
- Preserved retry semantics for total outages — when every server rejects, the query itself rejects so React Query's retry/backoff still kicks in (e.g. expired auth hitting all servers identically).

Closes [AGE-2299](https://linear.app/speakeasy/issue/AGE-2299/fixelements-one-failed-mcp-server-nukes-tools-from-all-others).

✻ Clauded...