### PR TITLE
feat(dashboard): split onboarding name and personality

### DIFF
--- a/.changeset/age-2257-split-name-personality.md
+++ b/.changeset/age-2257-split-name-personality.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Onboarding now asks for the assistant's name and personality as two separate steps instead of one combined card. When the user has already named the assistant in chat ("call it X"), the agent skips the name picker and goes straight to the personality step.

--- a/client/dashboard/src/pages/assistants/onboarding/docs/slack.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/docs/slack.ts
@@ -37,7 +37,7 @@ Required keys for the default flow:
 7. **Show the tokens card.** Once the install card resolves with \`installed: true\`, call \`request_environment_secrets\` for \`SLACK_BOT_TOKEN\` (OAuth & Permissions → Bot User OAuth Token), \`SLACK_USER_TOKEN\` (OAuth & Permissions → User OAuth Token), and \`SLACK_SIGNING_SECRET\` (Basic Information → App Credentials). This is a separate card, not part of the install card. If the install card resolved with \`cancelled: true\`, do not call \`request_environment_secrets\` — they have nothing to paste.
 8. **Self-handshake.** Single short burst, no confirmation:
    - **a.** Ask for the user's Slack handle.
-   - **b.** DM the user a greeting in the assistant's voice (the persona picked via \`propose_identity\`). Do not template.
+   - **b.** DM the user a greeting in the assistant's voice (the persona picked via \`propose_personality\`). Do not template.
    - **c.** Search your own messages for the greeting; read \`bot_id\` off the bot-authored message. Do not substitute a user id.
    - **d.** \`update_trigger(id, config)\` adding \`event.bot_id != "<bot_id>"\` to \`config.filter\` (AND with any existing filter). Required to break reply loops.
 

--- a/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
@@ -25,7 +25,7 @@ Two panes: this chat (left), Draft Assistant panel (right, live state). Sections
 
 # System prompt sections
 Three top-level H1 sections, each replaced independently:
-- \`# Personality\` — voice, tone, addressing style, formatting habits, uncertainty handling. Written by \`set_personality\` (and by \`propose_identity\` for filled presets / pasted instructions).
+- \`# Personality\` — voice, tone, addressing style, formatting habits, uncertainty handling. Written by \`set_personality\` (and by \`propose_personality\` for filled presets / pasted instructions).
 - \`# Behavior\` — operational rules derived from attached tools. Recomputed on \`attach_toolset\`/\`detach_toolset\`/\`add_tools_to_toolset\`. Don't restate behavior-style rules inside Personality or Tasks.
 - \`# Tasks\` — what the Assistant does on each run: how it interprets incoming events, which tools to use, what output looks like, when to stay silent. Written by \`set_tasks\`. This is where role/goal-specific guidance lives.
 Pass section bodies WITHOUT a leading heading — the tool adds it. Inside a section body, use H2 (\`##\`) or lower for any sub-structure; never H1 (\`# Foo\`) — H1 inside a body can collide with the section parser. Other sections and any free-form text between them are preserved.
@@ -69,15 +69,18 @@ Recommend:
 - Where to paste webhook URL → \`show_webhook_url\` with instructions. Slack: Event Subscriptions → Request URL.
 
 # Standard flow ("I want an assistant that does X")
-1. Extract trigger (\`cron\`/\`slack\`), actions, destination — just enough to propose an identity. Don't interrogate.
-2. \`propose_identity\` — generate name suggestions and let the user pick a name + personality. This is the first interactive step. Do it before tools/triggers. The tool itself saves the name and (for filled presets / pasted instructions) the \`# Personality\` section. The assistant + its env are created on this step.
-3. \`set_personality\` — only when the result note tells you to (description-based, random, or stub-preset modes).
-4. \`set_tasks\` — write the role/goal guidance derived from the user's stated goal.
-5. 3rd-party integration? \`list_docs\` → \`read_docs\`.
-6. Toolsets: \`list_toolsets\`/\`list_integrations\`/\`list_available_tools\` → \`create_toolset\` if needed → \`attach_toolset\` (no env arg — defaults to the assistant env). \`# Behavior\` auto-recomputes.
-7. Credentials: \`add_environment_keys\` to declare every required var up front (even if values come later), then \`request_environment_secrets\` to have the user enter values. Both target the assistant env automatically.
-8. \`create_trigger\` (no env arg — defaults to the assistant env). Webhook-kind → \`show_webhook_url\` after.
-9. User confirms done → \`finish_onboarding\` with a summary.
+1. Extract trigger (\`cron\`/\`slack\`), actions, destination — just enough to propose a name. Don't interrogate.
+2. Name the assistant:
+   - If the user has NOT given a name in chat: \`propose_name\` — generate 4–6 unique first-name suggestions. The assistant + its env are created when the user picks.
+   - If the user has ALREADY given a name in chat (any phrasing where they specify what to call it): SKIP \`propose_name\` and call \`update_assistant({ name })\` directly to create the assistant. Don't re-prompt for a name.
+3. \`propose_personality\` — let the user pick a preset / describe in their own words / paste instructions / random. For filled presets and pasted text the tool writes \`# Personality\` itself.
+4. \`set_personality\` — only when the propose_personality result note tells you to (description-based, random, or stub-preset modes).
+5. \`set_tasks\` — write the role/goal guidance derived from the user's stated goal.
+6. 3rd-party integration? \`list_docs\` → \`read_docs\`.
+7. Toolsets: \`list_toolsets\`/\`list_integrations\`/\`list_available_tools\` → \`create_toolset\` if needed → \`attach_toolset\` (no env arg — defaults to the assistant env). \`# Behavior\` auto-recomputes.
+8. Credentials: \`add_environment_keys\` to declare every required var up front (even if values come later), then \`request_environment_secrets\` to have the user enter values. Both target the assistant env automatically.
+9. \`create_trigger\` (no env arg — defaults to the assistant env). Webhook-kind → \`show_webhook_url\` after.
+10. User confirms done → \`finish_onboarding\` with a summary.
 
 # Naming
 - Treat the Assistant as a coworker, not a product. First names only.
@@ -86,8 +89,8 @@ Recommend:
 - Suggestions should feel like real people. Think employee directory, not mascot.
 
 # Rules
-- One Assistant per session. \`propose_identity\` (creation flow) is what creates it; subsequent calls update.
-- Creation flow only: \`propose_identity\` first. Edit flow: skip \`propose_identity\` — the Assistant already has a name; use \`set_personality\`/\`set_tasks\`/\`update_assistant\` directly.
+- One Assistant per session. Creation happens when the assistant first gets a name — either via \`propose_name\` (user picks from suggestions) or via a direct \`update_assistant({ name })\` (when the user supplied a name in chat).
+- Creation flow only: name first (\`propose_name\` OR direct \`update_assistant\` when the user already named it), then \`propose_personality\`. Edit flow: skip both — the Assistant already has a name and personality; use \`set_personality\`/\`set_tasks\`/\`update_assistant\` directly.
 - One environment per Assistant by default. Don't pass \`environment_slug\`/\`environment_id\` on \`attach_toolset\`/\`create_trigger\` in the happy path — the assistant's shared env is used automatically. If a tool response includes a \`notes\` entry about env adoption/recreation, relay it to the user and consider re-attaching any older toolsets/triggers that still reference the old slug.
 - Fallback only (never first choice): \`create_environment\` and explicit env overrides exist for when the shared env was deleted mid-session and a retry still fails, or when the user explicitly asks for a separate env.
 - Declare required credentials as soon as you know them: \`add_environment_keys\` with the full list (e.g. \`["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"]\`). Stub-first is fine — empty values are allowed and make the env self-documenting.
@@ -150,11 +153,11 @@ ${snapshot.instructions.trim().length > 0 ? snapshot.instructions : "(empty — 
 
   const modeBlock = isEdit
     ? `# Mode
-Edit flow. The Assistant already exists (see "Current Assistant state" above). Skip \`propose_identity\` entirely — never call it. Use \`set_personality\` / \`set_tasks\` / \`update_assistant\` / \`attach_toolset\` / \`detach_toolset\` / \`create_trigger\` / \`update_trigger\` / etc. directly to make the changes the user asks for.
+Edit flow. The Assistant already exists (see "Current Assistant state" above). Skip \`propose_name\` and \`propose_personality\` entirely — never call them. Use \`set_personality\` / \`set_tasks\` / \`update_assistant\` / \`attach_toolset\` / \`detach_toolset\` / \`create_trigger\` / \`update_trigger\` / etc. directly to make the changes the user asks for.
 
 Open the conversation with a short, in-persona acknowledgement and ask what they'd like to change. Don't restate your current spec — the user can see it in the panel.`
     : `# Mode
-Creation flow. No Assistant exists yet. Restate the user's goal in one sentence, then call \`propose_identity\` with 4–6 varied first-name candidates. Wait for it to resolve, then follow the \`note\` it returns.
+Creation flow. No Assistant exists yet. Restate the user's goal in one sentence, then name the assistant — call \`propose_name\` with 4–6 varied first-name candidates, OR (if the user already named the assistant in chat) call \`update_assistant({ name })\` directly. Then call \`propose_personality\`. Follow each tool's \`note\` for the next step.
 
 If the user hasn't stated a goal yet, ask. One question, not three.`;
 

--- a/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
@@ -125,7 +125,7 @@ You ARE the Assistant named "${snapshot.name}". Speak in first person as that As
 
 Never restate or re-paste your spec — the user can see it in the live Draft panel.`
     : `# Tone, voice, persona
-A persona has not been chosen yet. Default to: direct, friendly, concise — skip pleasantries, short sentences, bias to action. Once \`propose_identity\` resolves, switch to first person as that Assistant; from then on the persona lives in this conversation's tool-result history (most recent \`propose_identity\` / \`set_personality\` / \`set_tasks\` / \`update_assistant\`). Before a burst of tool calls, one sentence of what you're about to do.
+A persona has not been chosen yet. Default to: direct, friendly, concise — skip pleasantries, short sentences, bias to action. Once \`propose_personality\` resolves (or \`set_personality\` is called), switch to first person as that Assistant; from then on the persona lives in this conversation's tool-result history (most recent \`propose_name\` / \`propose_personality\` / \`set_personality\` / \`set_tasks\` / \`update_assistant\`). Before a burst of tool calls, one sentence of what you're about to do.
 
 Never restate or re-paste the Assistant spec — the user can see the live Draft panel.`;
 

--- a/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/components.tsx
@@ -419,9 +419,15 @@ export function ShowSlackAppGuideComponent({
   );
 }
 
-type ProposeIdentityArgs = {
+type ProposeNameArgs = {
   goal?: string;
   name_suggestions: string[];
+};
+
+type NameResult = {
+  success: boolean;
+  cancelled?: boolean;
+  name?: string;
 };
 
 type PersonalityChoice =
@@ -438,23 +444,22 @@ type PersonalityChoice =
   | { kind: "generate"; describe: string }
   | { kind: "random" };
 
-type IdentityResult = {
+type PersonalityResult = {
   success: boolean;
   cancelled?: boolean;
-  name?: string;
   personality?: PersonalityChoice;
 };
 
 type PersonalityMode = "prebuilt" | "generate" | "custom" | "random";
 
-export function ProposeIdentityComponent({
+export function ProposeNameComponent({
   args,
   status,
   result,
   toolCallId,
 }: ToolCallMessagePartProps) {
   const draft = useAssistantDraft();
-  const a = (args ?? {}) as Partial<ProposeIdentityArgs>;
+  const a = (args ?? {}) as Partial<ProposeNameArgs>;
   const suggestions = useMemo(
     () => (Array.isArray(a.name_suggestions) ? a.name_suggestions : []),
     [a.name_suggestions],
@@ -462,12 +467,6 @@ export function ProposeIdentityComponent({
   const goal = a.goal;
 
   const [name, setName] = useState<string>(suggestions[0] ?? "");
-  const [mode, setMode] = useState<PersonalityMode>("prebuilt");
-  const [prebuiltSlug, setPrebuiltSlug] = useState<string>(
-    PERSONALITIES[0]?.slug ?? "",
-  );
-  const [describeText, setDescribeText] = useState<string>("");
-  const [customText, setCustomText] = useState<string>("");
 
   const isPending = isExecuting(status);
   const settled = !isPending;
@@ -479,14 +478,14 @@ export function ProposeIdentityComponent({
       draft.resolvePending(toolCallId, {
         success: false,
         cancelled: true,
-      } satisfies IdentityResult);
+      } satisfies NameResult);
     };
   }, [draft, toolCallId, isPending]);
 
   if (settled && r?.ok) {
     return (
       <ToolCard
-        title="Identity set"
+        title="Name set"
         tone="success"
         icon={<Check className="text-emerald-600" size={16} />}
       >
@@ -499,60 +498,34 @@ export function ProposeIdentityComponent({
 
   if (settled) {
     return (
-      <ToolCard title="Identity — skipped">
+      <ToolCard title="Name — skipped">
         <Type small muted>
-          No identity selected. You can set one from the draft panel anytime.
+          No name selected. You can set one from the draft panel anytime.
         </Type>
       </ToolCard>
     );
   }
 
   const trimmedName = name.trim();
-  const canSubmit =
-    trimmedName.length > 0 &&
-    ((mode === "prebuilt" && prebuiltSlug.length > 0) ||
-      (mode === "generate" && describeText.trim().length > 0) ||
-      (mode === "custom" && customText.trim().length > 0) ||
-      mode === "random");
+  const canSubmit = trimmedName.length > 0;
 
   const submit = () => {
-    let personality: PersonalityChoice | undefined;
-    if (mode === "prebuilt") {
-      const p = getPersonality(prebuiltSlug);
-      if (!p) return;
-      personality = {
-        kind: "prebuilt",
-        prebuilt: {
-          slug: p.slug,
-          title: p.title,
-          summary: p.summary,
-          instructions: p.instructions,
-        },
-      };
-    } else if (mode === "generate") {
-      personality = { kind: "generate", describe: describeText.trim() };
-    } else if (mode === "custom") {
-      personality = { kind: "custom_text", custom_text: customText.trim() };
-    } else {
-      personality = { kind: "random" };
-    }
     draft.resolvePending(toolCallId, {
       success: true,
       name: trimmedName,
-      personality,
-    } satisfies IdentityResult);
+    } satisfies NameResult);
   };
 
   const cancel = () => {
     draft.resolvePending(toolCallId, {
       success: false,
       cancelled: true,
-    } satisfies IdentityResult);
+    } satisfies NameResult);
   };
 
   return (
     <ToolCard
-      title="Name and personality"
+      title="Pick a name"
       icon={<Sparkles className="text-muted-foreground h-4 w-4" />}
     >
       {goal && (
@@ -561,7 +534,7 @@ export function ProposeIdentityComponent({
         </Type>
       )}
 
-      <div className="mb-4">
+      <div>
         <Label className="mb-1 block text-xs font-medium">Name</Label>
         {suggestions.length > 0 && (
           <div className="mb-2 flex flex-wrap gap-1.5">
@@ -588,8 +561,123 @@ export function ProposeIdentityComponent({
         />
       </div>
 
+      <div className="mt-4 flex justify-end gap-2">
+        <Button variant="ghost" onClick={cancel}>
+          Skip
+        </Button>
+        <Button onClick={submit} disabled={!canSubmit}>
+          Save
+        </Button>
+      </div>
+    </ToolCard>
+  );
+}
+
+export function ProposePersonalityComponent({
+  status,
+  result,
+  toolCallId,
+}: ToolCallMessagePartProps) {
+  const draft = useAssistantDraft();
+  const assistantName = draft.assistant?.name ?? "";
+
+  const [mode, setMode] = useState<PersonalityMode>("prebuilt");
+  const [prebuiltSlug, setPrebuiltSlug] = useState<string>(
+    PERSONALITIES[0]?.slug ?? "",
+  );
+  const [describeText, setDescribeText] = useState<string>("");
+  const [customText, setCustomText] = useState<string>("");
+
+  const isPending = isExecuting(status);
+  const settled = !isPending;
+  const r = result as { ok?: boolean } | undefined;
+
+  useEffect(() => {
+    if (!isPending) return;
+    return () => {
+      draft.resolvePending(toolCallId, {
+        success: false,
+        cancelled: true,
+      } satisfies PersonalityResult);
+    };
+  }, [draft, toolCallId, isPending]);
+
+  if (settled && r?.ok) {
+    return (
+      <ToolCard
+        title="Personality set"
+        tone="success"
+        icon={<Check className="text-emerald-600" size={16} />}
+      >
+        <Type small muted>
+          Personality saved.
+        </Type>
+      </ToolCard>
+    );
+  }
+
+  if (settled) {
+    return (
+      <ToolCard title="Personality — skipped">
+        <Type small muted>
+          No personality selected. You can set one from the draft panel anytime.
+        </Type>
+      </ToolCard>
+    );
+  }
+
+  const canSubmit =
+    (mode === "prebuilt" && prebuiltSlug.length > 0) ||
+    (mode === "generate" && describeText.trim().length > 0) ||
+    (mode === "custom" && customText.trim().length > 0) ||
+    mode === "random";
+
+  const submit = () => {
+    let personality: PersonalityChoice | undefined;
+    if (mode === "prebuilt") {
+      const p = getPersonality(prebuiltSlug);
+      if (!p) return;
+      personality = {
+        kind: "prebuilt",
+        prebuilt: {
+          slug: p.slug,
+          title: p.title,
+          summary: p.summary,
+          instructions: p.instructions,
+        },
+      };
+    } else if (mode === "generate") {
+      personality = { kind: "generate", describe: describeText.trim() };
+    } else if (mode === "custom") {
+      personality = { kind: "custom_text", custom_text: customText.trim() };
+    } else {
+      personality = { kind: "random" };
+    }
+    draft.resolvePending(toolCallId, {
+      success: true,
+      personality,
+    } satisfies PersonalityResult);
+  };
+
+  const cancel = () => {
+    draft.resolvePending(toolCallId, {
+      success: false,
+      cancelled: true,
+    } satisfies PersonalityResult);
+  };
+
+  return (
+    <ToolCard
+      title="Pick a personality"
+      icon={<Sparkles className="text-muted-foreground h-4 w-4" />}
+    >
+      {assistantName && (
+        <Type small muted className="mb-3">
+          For: {assistantName}
+        </Type>
+      )}
+
       <div>
-        <Label className="mb-2 block text-xs font-medium">Personality</Label>
         <RadioGroup
           value={mode}
           onValueChange={(v) => setMode(v as PersonalityMode)}
@@ -599,11 +687,11 @@ export function ProposeIdentityComponent({
             <div className="flex items-start gap-2">
               <RadioGroupItem
                 value="prebuilt"
-                id="identity-prebuilt"
+                id="personality-prebuilt"
                 className="mt-1"
               />
               <Label
-                htmlFor="identity-prebuilt"
+                htmlFor="personality-prebuilt"
                 className="flex-1 cursor-pointer flex-col items-start gap-0"
               >
                 <Type small className="font-medium">
@@ -639,11 +727,11 @@ export function ProposeIdentityComponent({
             <div className="flex items-start gap-2">
               <RadioGroupItem
                 value="generate"
-                id="identity-generate"
+                id="personality-generate"
                 className="mt-1"
               />
               <Label
-                htmlFor="identity-generate"
+                htmlFor="personality-generate"
                 className="flex-1 cursor-pointer flex-col items-start gap-0"
               >
                 <Type small className="font-medium">
@@ -669,11 +757,11 @@ export function ProposeIdentityComponent({
             <div className="flex items-start gap-2">
               <RadioGroupItem
                 value="custom"
-                id="identity-custom"
+                id="personality-custom"
                 className="mt-1"
               />
               <Label
-                htmlFor="identity-custom"
+                htmlFor="personality-custom"
                 className="flex-1 cursor-pointer flex-col items-start gap-0"
               >
                 <Type small className="font-medium">
@@ -699,11 +787,11 @@ export function ProposeIdentityComponent({
             <div className="flex items-start gap-2">
               <RadioGroupItem
                 value="random"
-                id="identity-random"
+                id="personality-random"
                 className="mt-1"
               />
               <Label
-                htmlFor="identity-random"
+                htmlFor="personality-random"
                 className="flex-1 cursor-pointer flex-col items-start gap-0"
               >
                 <Type small className="font-medium">

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -395,19 +395,31 @@ function buildAssistantTools(deps: ToolDeps) {
   // and won't pick up draft.setAssistant calls made by earlier tool calls in
   // the same response. Tools that read assistant state across a single
   // response (e.g. propose_name → propose_personality) consult `live` first.
+  type LiveToolset = {
+    toolsetSlug: string;
+    environmentSlug?: string | undefined;
+  };
   const live: {
     id: string | null;
     name: string | undefined;
     instructions: string;
+    toolsets: ReadonlyArray<LiveToolset>;
   } = {
     id: draft.assistantId,
     name: draft.assistant?.name,
     instructions: draft.assistant?.instructions ?? "",
+    toolsets: draft.assistant?.toolsets ?? [],
   };
-  const trackLive = (a: { id: string; name: string; instructions: string }) => {
+  const trackLive = (a: {
+    id: string;
+    name: string;
+    instructions: string;
+    toolsets: ReadonlyArray<LiveToolset>;
+  }) => {
     live.id = a.id;
     live.name = a.name;
     live.instructions = a.instructions;
+    live.toolsets = a.toolsets;
   };
 
   // The LLM may emit multiple mutating tool calls in parallel within one turn.
@@ -754,7 +766,8 @@ function buildAssistantTools(deps: ToolDeps) {
         serialize(async () => {
           const { toolset_slug, environment_slug } = args as AttachToolsetArgs;
           try {
-            const a = await ensureAssistant(deps, {});
+            const a = await ensureAssistant(deps, {}, live.id);
+            trackLive(a);
             const notes: string[] = [];
             let boundSlug = environment_slug;
             if (!boundSlug) {
@@ -774,6 +787,7 @@ function buildAssistantTools(deps: ToolDeps) {
               updateAssistantForm: { id: a.id, toolsets: next },
             });
             draft.setAssistant(updated);
+            trackLive(updated);
             draft.invalidateAll();
             await recomputeBehaviorSection(deps, updated);
             return okResult({
@@ -798,16 +812,17 @@ function buildAssistantTools(deps: ToolDeps) {
         serialize(async () => {
           const { toolset_slug } = args as DetachToolsetArgs;
           try {
-            if (!draft.assistantId || !draft.assistant) {
+            if (!live.id) {
               return errResult("No assistant exists yet. Create one first.");
             }
-            const next = draft.assistant.toolsets.filter(
+            const next = live.toolsets.filter(
               (t) => t.toolsetSlug !== toolset_slug,
             );
             const updated = await sdk.assistants.update({
-              updateAssistantForm: { id: draft.assistantId, toolsets: next },
+              updateAssistantForm: { id: live.id, toolsets: next },
             });
             draft.setAssistant(updated);
+            trackLive(updated);
             draft.invalidateAll();
             await recomputeBehaviorSection(deps, updated);
             return okResult({ toolsets: updated.toolsets });
@@ -1061,7 +1076,8 @@ function buildAssistantTools(deps: ToolDeps) {
             const notes: string[] = [];
             let slug = environment_slug;
             if (!slug) {
-              const a = await ensureAssistant(deps, {});
+              const a = await ensureAssistant(deps, {}, live.id);
+              trackLive(a);
               const envResult = await ensureAssistantEnv(deps, a.name);
               slug = envResult.env.slug;
               if (envResult.note) notes.push(envResult.note);
@@ -1146,7 +1162,8 @@ function buildAssistantTools(deps: ToolDeps) {
             if (environment_slug) {
               slug = environment_slug;
             } else {
-              const a = await ensureAssistant(deps, {});
+              const a = await ensureAssistant(deps, {}, live.id);
+              trackLive(a);
               const envResult = await ensureAssistantEnv(deps, a.name);
               slug = envResult.env.slug;
               if (envResult.note) preNotes.push(envResult.note);
@@ -1260,7 +1277,7 @@ function buildAssistantTools(deps: ToolDeps) {
       execute: async () => {
         try {
           const res = await sdk.triggers.list();
-          const assistantId = draft.assistantId;
+          const assistantId = live.id ?? draft.assistantId;
           const scoped = assistantId
             ? res.triggers.filter(
                 (t) =>
@@ -1315,7 +1332,8 @@ function buildAssistantTools(deps: ToolDeps) {
           args as CreateTriggerArgs;
         const run = async (): Promise<ToolResult> => {
           try {
-            const a = await ensureAssistant(deps, {});
+            const a = await ensureAssistant(deps, {}, live.id);
+            trackLive(a);
             const notes: string[] = [];
             let boundEnvId = environment_id;
             if (!boundEnvId) {
@@ -1374,7 +1392,7 @@ function buildAssistantTools(deps: ToolDeps) {
             );
           }
         };
-        const key = `${draft.assistantId ?? "new"}:${definition_slug}:${name}`;
+        const key = `${live.id ?? draft.assistantId ?? "new"}:${definition_slug}:${name}`;
         const inflight = triggerCreateInFlight.get(key);
         if (inflight) return inflight;
         const p = serialize(run);
@@ -1498,7 +1516,7 @@ function buildAssistantTools(deps: ToolDeps) {
               (t) =>
                 t.definitionSlug === "slack" &&
                 t.targetKind === "assistant" &&
-                t.targetRef === draft.assistantId,
+                t.targetRef === (live.id ?? draft.assistantId),
             );
             if (slackTriggers.length > 0) {
               const first = slackTriggers[0]!;
@@ -1638,11 +1656,12 @@ function buildAssistantTools(deps: ToolDeps) {
       }),
       execute: async (args) => {
         const { message } = args as FinishArgs;
-        if (!draft.assistantId) {
+        const id = live.id ?? draft.assistantId;
+        if (!id) {
           return errResult("No assistant has been created yet.");
         }
         try {
-          const a = await sdk.assistants.get({ id: draft.assistantId });
+          const a = await sdk.assistants.get({ id });
           return okResult({
             assistant: {
               id: a.id,

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -10,7 +10,8 @@ import { computeBehaviorSection } from "../behaviors";
 import { getIntegrationDoc, listIntegrationDocs } from "../docs";
 import { setSection } from "../sections";
 import {
-  ProposeIdentityComponent,
+  ProposeNameComponent,
+  ProposePersonalityComponent,
   RequestEnvironmentSecretsComponent,
   ShowSlackAppGuideComponent,
   ShowWebhookUrlComponent,
@@ -363,7 +364,7 @@ type ShowSlackGuideArgs = {
 type ListIntegrationsArgs = { keywords?: string[] };
 type ReadDocsArgs = { slug: string };
 type FinishArgs = { message?: string };
-type ProposeIdentityArgs = {
+type ProposeNameArgs = {
   goal?: string;
   name_suggestions: string[];
 };
@@ -396,10 +397,10 @@ function buildAssistantTools(deps: ToolDeps) {
 
   const triggerCreateInFlight = new Map<string, Promise<ToolResult>>();
 
-  const propose_identity = defineFrontendTool<ProposeIdentityArgs, ToolResult>(
+  const propose_name = defineFrontendTool<ProposeNameArgs, ToolResult>(
     {
       description:
-        "Present a name + personality picker to the user. Use this as the FIRST step of creation, before any toolsets or triggers. Generate 4-6 unique first-name suggestions that fit the user's stated goal. Treat the assistant like a coworker: pick real first names from a mix of cultures. Never use the phrasing '[Owner]'s assistant', role titles ('Support Bot'), product names, or generic words ('Helper', 'Assistant'). Distinct names only — no duplicates, no variants of the same name. User picks a name (yours or their own) and a personality source (preset, short description, pasted instructions, or random). The tool returns their choice; you then synthesize the final instructions and call update_assistant.",
+        "Present a name picker to the user. Generate 4-6 unique first-name suggestions that fit the user's stated goal. Treat the assistant like a coworker: pick real first names from a mix of cultures. Never use the phrasing '[Owner]'s assistant', role titles ('Support Bot'), product names, or generic words ('Helper', 'Assistant'). Distinct names only — no duplicates, no variants of the same name. The tool creates the assistant + its env when the user picks. See system prompt for when to call this vs. update_assistant directly.",
       parameters: z.object({
         goal: z
           .string()
@@ -417,52 +418,98 @@ function buildAssistantTools(deps: ToolDeps) {
       }),
       execute: async (_args, ctx) => {
         const toolCallId = ctx.toolCallId ?? "";
-        type IdentityResult = {
+        type NameResult = {
           success: boolean;
           cancelled?: boolean;
           name?: string;
+        };
+        const userInput: NameResult = await withTimeout(
+          new Promise<NameResult>((resolve) => {
+            draft.registerPending(toolCallId, (r) => resolve(r as NameResult));
+          }),
+          15 * 60 * 1000,
+          "propose_name",
+        ).catch((): NameResult => ({ success: false, cancelled: true }));
+
+        if (!userInput.success || !userInput.name) {
+          return okResult({
+            cancelled: true,
+            note: "User skipped the name picker. Ask them directly what to name the assistant, then call update_assistant({ name }) followed by propose_personality. Do not re-call propose_name unless they ask.",
+          });
+        }
+
+        const name = userInput.name;
+        return serialize(async () => {
+          try {
+            await ensureAssistant(deps, { name });
+            return okResult({
+              name,
+              note: `Saved name "${name}". Now call propose_personality to let the user pick their personality.`,
+            });
+          } catch (e) {
+            return errResult(e instanceof Error ? e.message : "save failed");
+          }
+        });
+      },
+    },
+    "propose_name",
+  );
+
+  const propose_personality = defineFrontendTool<
+    Record<string, never>,
+    ToolResult
+  >(
+    {
+      description:
+        "Present a personality picker to the user. Call this after the assistant has a name. The user picks one of: preset / short description / pasted instructions / random. For presets with bundled instructions and pasted text, this tool writes # Personality directly. For description-based and random, the result note tells you to call set_personality with synthesized content.",
+      parameters: z.object({}),
+      execute: async (_args, ctx) => {
+        const toolCallId = ctx.toolCallId ?? "";
+        if (!draft.assistant?.name) {
+          return errResult(
+            "propose_personality called before the assistant has a name. Call propose_name (or update_assistant with a name) first.",
+          );
+        }
+        type PersonalityPickResult = {
+          success: boolean;
+          cancelled?: boolean;
           personality?: PersonalityChoice;
         };
-        const userInput: IdentityResult = await withTimeout(
-          new Promise<IdentityResult>((resolve) => {
+        const userInput: PersonalityPickResult = await withTimeout(
+          new Promise<PersonalityPickResult>((resolve) => {
             draft.registerPending(toolCallId, (r) =>
-              resolve(r as IdentityResult),
+              resolve(r as PersonalityPickResult),
             );
           }),
           15 * 60 * 1000,
-          "propose_identity",
+          "propose_personality",
         ).catch(
-          (e): IdentityResult => ({
-            success: false,
-            cancelled: true,
-            name: e instanceof Error ? e.message : "timeout",
-          }),
+          (): PersonalityPickResult => ({ success: false, cancelled: true }),
         );
 
-        if (!userInput.success || !userInput.name || !userInput.personality) {
+        if (!userInput.success || !userInput.personality) {
           return okResult({
             cancelled: true,
-            note: "User skipped the identity picker. Ask them directly for a name and the gist of the personality they want, then call update_assistant with sensible defaults. Do not re-call propose_identity unless they ask.",
+            note: "User skipped the personality picker. Ask them in chat for the gist of the personality they want, then call set_personality with a reasonable expansion. Do not re-call propose_personality unless they ask.",
           });
         }
 
         const p = userInput.personality;
-        const name = userInput.name;
+        const name = draft.assistant.name;
         return serialize(async () => {
           try {
             if (p.kind === "prebuilt") {
               const hasInstructions = p.prebuilt.instructions.trim().length > 0;
-              const current = draft.assistant?.instructions ?? "";
-              const next = hasInstructions
-                ? setSection(current, "Personality", p.prebuilt.instructions)
-                : current;
-              const a = await ensureAssistant(
-                deps,
-                hasInstructions ? { name, instructions: next } : { name },
-              );
-              await recomputeBehaviorSection(deps, a);
+              if (hasInstructions) {
+                const current = draft.assistant?.instructions ?? "";
+                const next = setSection(
+                  current,
+                  "Personality",
+                  p.prebuilt.instructions,
+                );
+                await ensureAssistant(deps, { instructions: next });
+              }
               return okResult({
-                name,
                 personality: {
                   kind: "prebuilt" as const,
                   slug: p.prebuilt.slug,
@@ -471,42 +518,31 @@ function buildAssistantTools(deps: ToolDeps) {
                   body_set: hasInstructions,
                 },
                 note: hasInstructions
-                  ? `Saved name "${name}" and the "${p.prebuilt.title}" personality verbatim under # Personality. Now describe what this assistant does — call set_tasks with role-specific guidance derived from the user's stated goal. Do not call set_personality unless the user explicitly asks to change it.`
-                  : `Saved name "${name}". The "${p.prebuilt.title}" preset has no body — synthesize personality content (voice, tone, formatting habits, uncertainty handling) matching the title "${p.prebuilt.title}" and summary "${p.prebuilt.summary}", then call set_personality with the result. Then call set_tasks with role-specific guidance.`,
+                  ? `Saved the "${p.prebuilt.title}" personality verbatim under # Personality for "${name}". Now describe what this assistant does — call set_tasks with role-specific guidance derived from the user's stated goal. Do not call set_personality unless the user explicitly asks to change it.`
+                  : `The "${p.prebuilt.title}" preset has no body — synthesize personality content (voice, tone, formatting habits, uncertainty handling) matching the title "${p.prebuilt.title}" and summary "${p.prebuilt.summary}", then call set_personality with the result. Then call set_tasks with role-specific guidance.`,
               });
             }
             if (p.kind === "custom_text") {
               const current = draft.assistant?.instructions ?? "";
               const next = setSection(current, "Personality", p.custom_text);
-              const a = await ensureAssistant(deps, {
-                name,
-                instructions: next,
-              });
-              await recomputeBehaviorSection(deps, a);
+              await ensureAssistant(deps, { instructions: next });
               return okResult({
-                name,
                 personality: { kind: "custom_text" as const },
-                note: `Saved name "${name}" and the user's pasted personality verbatim under # Personality. Now call set_tasks with role-specific guidance. Do not modify # Personality.`,
+                note: `Saved the user's pasted personality verbatim under # Personality for "${name}". Now call set_tasks with role-specific guidance. Do not modify # Personality.`,
               });
             }
             if (p.kind === "generate") {
-              const a = await ensureAssistant(deps, { name });
-              await recomputeBehaviorSection(deps, a);
               return okResult({
-                name,
                 personality: {
                   kind: "generate" as const,
                   description: p.describe,
                 },
-                note: `Saved name "${name}". The user described their desired personality: "${p.describe}". Expand that into a full personality (voice, tone, formatting habits, uncertainty handling) and call set_personality with the expanded text. Then call set_tasks with role-specific guidance.`,
+                note: `The user described their desired personality: "${p.describe}". Expand that into a full personality (voice, tone, formatting habits, uncertainty handling) and call set_personality with the expanded text. Then call set_tasks with role-specific guidance.`,
               });
             }
-            const a = await ensureAssistant(deps, { name });
-            await recomputeBehaviorSection(deps, a);
             return okResult({
-              name,
               personality: { kind: "random" as const },
-              note: `Saved name "${name}". Invent a distinctive personality from scratch (voice, formatting habits, sign-off, uncertainty handling). Keep it professional-compatible. Call set_personality with the result, then set_tasks with role-specific guidance.`,
+              note: `Invent a distinctive personality from scratch (voice, formatting habits, sign-off, uncertainty handling). Keep it professional-compatible. Call set_personality with the result, then set_tasks with role-specific guidance.`,
             });
           } catch (e) {
             return errResult(e instanceof Error ? e.message : "save failed");
@@ -514,7 +550,7 @@ function buildAssistantTools(deps: ToolDeps) {
         });
       },
     },
-    "propose_identity",
+    "propose_personality",
   );
 
   const update_assistant = defineFrontendTool<UpdateAssistantArgs, ToolResult>(
@@ -1575,7 +1611,8 @@ function buildAssistantTools(deps: ToolDeps) {
   );
 
   return {
-    propose_identity,
+    propose_name,
+    propose_personality,
     update_assistant,
     set_personality,
     set_tasks,
@@ -1621,7 +1658,8 @@ export function useOnboardingTools(): {
 
   const components = useMemo<Record<string, ToolCallMessagePartComponent>>(
     () => ({
-      propose_identity: ProposeIdentityComponent,
+      propose_name: ProposeNameComponent,
+      propose_personality: ProposePersonalityComponent,
       request_environment_secrets: RequestEnvironmentSecretsComponent,
       show_webhook_url: ShowWebhookUrlComponent,
       show_slack_app_guide: ShowSlackAppGuideComponent,

--- a/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/tools/useOnboardingTools.tsx
@@ -180,13 +180,19 @@ async function ensureAssistant(
     warm_ttl_seconds?: number;
     max_concurrency?: number;
   },
+  idOverride?: string | null,
 ) {
   const { sdk, draft } = deps;
-  if (draft.assistantId) {
+  // streamText captures tool closures at response start, so a tool's `draft`
+  // snapshot is stale for subsequent tool calls in the same response. Callers
+  // can pass `idOverride` to force the update path against an id created
+  // moments earlier in the same response.
+  const currentId = idOverride !== undefined ? idOverride : draft.assistantId;
+  if (currentId) {
     const prevName = draft.assistant?.name;
     const updated = await sdk.assistants.update({
       updateAssistantForm: {
-        id: draft.assistantId,
+        id: currentId,
         ...(payload.name !== undefined ? { name: payload.name } : {}),
         ...(payload.instructions !== undefined
           ? { instructions: payload.instructions }
@@ -385,6 +391,25 @@ type PersonalityChoice =
 function buildAssistantTools(deps: ToolDeps) {
   const { sdk, draft, organizationId } = deps;
 
+  // Live mirror of the assistant — `draft` is closure-captured by streamText
+  // and won't pick up draft.setAssistant calls made by earlier tool calls in
+  // the same response. Tools that read assistant state across a single
+  // response (e.g. propose_name → propose_personality) consult `live` first.
+  const live: {
+    id: string | null;
+    name: string | undefined;
+    instructions: string;
+  } = {
+    id: draft.assistantId,
+    name: draft.assistant?.name,
+    instructions: draft.assistant?.instructions ?? "",
+  };
+  const trackLive = (a: { id: string; name: string; instructions: string }) => {
+    live.id = a.id;
+    live.name = a.name;
+    live.instructions = a.instructions;
+  };
+
   // The LLM may emit multiple mutating tool calls in parallel within one turn.
   // Without this, two attach_toolset calls would each read the same pre-attach
   // toolsets snapshot, compute their own next array, and PUT — last write wins.
@@ -441,7 +466,8 @@ function buildAssistantTools(deps: ToolDeps) {
         const name = userInput.name;
         return serialize(async () => {
           try {
-            await ensureAssistant(deps, { name });
+            const a = await ensureAssistant(deps, { name });
+            trackLive(a);
             return okResult({
               name,
               note: `Saved name "${name}". Now call propose_personality to let the user pick their personality.`,
@@ -465,11 +491,6 @@ function buildAssistantTools(deps: ToolDeps) {
       parameters: z.object({}),
       execute: async (_args, ctx) => {
         const toolCallId = ctx.toolCallId ?? "";
-        if (!draft.assistant?.name) {
-          return errResult(
-            "propose_personality called before the assistant has a name. Call propose_name (or update_assistant with a name) first.",
-          );
-        }
         type PersonalityPickResult = {
           success: boolean;
           cancelled?: boolean;
@@ -495,19 +516,23 @@ function buildAssistantTools(deps: ToolDeps) {
         }
 
         const p = userInput.personality;
-        const name = draft.assistant.name;
+        const name = live.name ?? "the assistant";
         return serialize(async () => {
           try {
             if (p.kind === "prebuilt") {
               const hasInstructions = p.prebuilt.instructions.trim().length > 0;
               if (hasInstructions) {
-                const current = draft.assistant?.instructions ?? "";
                 const next = setSection(
-                  current,
+                  live.instructions,
                   "Personality",
                   p.prebuilt.instructions,
                 );
-                await ensureAssistant(deps, { instructions: next });
+                const a = await ensureAssistant(
+                  deps,
+                  { instructions: next },
+                  live.id,
+                );
+                trackLive(a);
               }
               return okResult({
                 personality: {
@@ -523,9 +548,17 @@ function buildAssistantTools(deps: ToolDeps) {
               });
             }
             if (p.kind === "custom_text") {
-              const current = draft.assistant?.instructions ?? "";
-              const next = setSection(current, "Personality", p.custom_text);
-              await ensureAssistant(deps, { instructions: next });
+              const next = setSection(
+                live.instructions,
+                "Personality",
+                p.custom_text,
+              );
+              const a = await ensureAssistant(
+                deps,
+                { instructions: next },
+                live.id,
+              );
+              trackLive(a);
               return okResult({
                 personality: { kind: "custom_text" as const },
                 note: `Saved the user's pasted personality verbatim under # Personality for "${name}". Now call set_tasks with role-specific guidance. Do not modify # Personality.`,
@@ -589,7 +622,12 @@ function buildAssistantTools(deps: ToolDeps) {
       execute: async (args) =>
         serialize(async () => {
           try {
-            const a = await ensureAssistant(deps, args as UpdateAssistantArgs);
+            const a = await ensureAssistant(
+              deps,
+              args as UpdateAssistantArgs,
+              live.id,
+            );
+            trackLive(a);
             const envResult = a.name
               ? await ensureAssistantEnv(deps, a.name)
               : null;
@@ -631,9 +669,17 @@ function buildAssistantTools(deps: ToolDeps) {
         serialize(async () => {
           const { instructions } = args as SetPersonalityArgs;
           try {
-            const current = draft.assistant?.instructions ?? "";
-            const next = setSection(current, "Personality", instructions);
-            const updated = await ensureAssistant(deps, { instructions: next });
+            const next = setSection(
+              live.instructions,
+              "Personality",
+              instructions,
+            );
+            const updated = await ensureAssistant(
+              deps,
+              { instructions: next },
+              live.id,
+            );
+            trackLive(updated);
             return okResult({
               assistant: {
                 id: updated.id,
@@ -667,9 +713,13 @@ function buildAssistantTools(deps: ToolDeps) {
         serialize(async () => {
           const { tasks } = args as SetTasksArgs;
           try {
-            const current = draft.assistant?.instructions ?? "";
-            const next = setSection(current, "Tasks", tasks);
-            const updated = await ensureAssistant(deps, { instructions: next });
+            const next = setSection(live.instructions, "Tasks", tasks);
+            const updated = await ensureAssistant(
+              deps,
+              { instructions: next },
+              live.id,
+            );
+            trackLive(updated);
             return okResult({
               assistant: {
                 id: updated.id,


### PR DESCRIPTION
## Summary

- Split the onboarding identity picker into two sequential cards: name first, then personality.
- Teach the agent to skip the name picker when the user has already named the assistant in chat — it calls `update_assistant({ name })` directly and proceeds to the personality step.
- Remove redundant `recomputeBehaviorSection` calls in the propose tools (no toolsets are attached yet at this stage), saving an API roundtrip per step.

Closes [AGE-2257](https://linear.app/speakeasy/issue/AGE-2257/onboarding-split-name-and-personality-into-separate-steps).

✻ Clauded...