### PR TITLE
feat(dashboard): add search bar to MCP servers listing page

### DIFF
--- a/.changeset/age-2310-mcp-search-bar.md
+++ b/.changeset/age-2310-mcp-search-bar.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+add search bar to MCP servers listing page

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -5,13 +5,15 @@ import { MCPCard, MCPCardSkeleton } from "@/components/mcp/MCPCard";
 import { MCPTableRow, MCPTableRowSkeleton } from "@/components/mcp/MCPTableRow";
 import { Page } from "@/components/page-layout";
 import { DotTable } from "@/components/ui/dot-table";
+import { SearchBar } from "@/components/ui/search-bar";
+import { Type } from "@/components/ui/type";
 import { ViewToggle } from "@/components/ui/view-toggle";
 import { useViewMode } from "@/components/ui/use-view-mode";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useRoutes } from "@/routes";
 import { Button } from "@speakeasy-api/moonshine";
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useToolsets } from "../toolsets/useToolsets";
@@ -56,6 +58,24 @@ export function MCPOverview() {
   const [viewMode, setViewMode] = useViewMode();
   const [newMcpDialogOpen, setNewMcpDialogOpen] = useState(false);
   const [newMcpServerName, setNewMcpServerName] = useState("");
+  const [search, setSearch] = useState("");
+
+  const filteredToolsets = useMemo(() => {
+    const query = search.toLowerCase();
+    return [...toolsets]
+      .filter((toolset) => {
+        if (!query) return true;
+        return (
+          toolset.name.toLowerCase().includes(query) ||
+          toolset.slug.toLowerCase().includes(query)
+        );
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [toolsets, search]);
+
+  const showSearch = !isLoading && toolsets.length > 6;
+  const showNoMatches =
+    !isLoading && search !== "" && filteredToolsets.length === 0;
 
   const handleCreateMcpServerSubmit = async () => {
     const result = await client.toolsets.create({
@@ -147,7 +167,19 @@ export function MCPOverview() {
           servers are public.
         </Page.Section.Description>
         <Page.Section.Body>
-          {viewMode === "grid" ? (
+          {showSearch && (
+            <SearchBar
+              value={search}
+              onChange={setSearch}
+              placeholder="Search MCP servers..."
+              className="mb-4"
+            />
+          )}
+          {showNoMatches ? (
+            <Type muted className="py-8 text-center">
+              No MCP servers matching &ldquo;{search}&rdquo;
+            </Type>
+          ) : viewMode === "grid" ? (
             <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
               {isLoading ? (
                 <>
@@ -155,7 +187,7 @@ export function MCPOverview() {
                   <MCPCardSkeleton />
                 </>
               ) : (
-                toolsets.map((toolset) => (
+                filteredToolsets.map((toolset) => (
                   <MCPCard key={toolset.id} toolset={toolset} />
                 ))
               )}
@@ -175,7 +207,7 @@ export function MCPOverview() {
                   <MCPTableRowSkeleton />
                 </>
               ) : (
-                toolsets.map((toolset) => (
+                filteredToolsets.map((toolset) => (
                   <MCPTableRow key={toolset.id} toolset={toolset} />
                 ))
               )}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2310/add-search-bar-to-mcp-servers-listing-page

Mirrors the client-side search pattern from `OrgProjects`. Filters toolsets case-insensitively against `name` and `slug` and sorts results alphabetically. The bar only renders when a project has more than 6 hosted MCP servers, and the filter/sort is memoized. A distinct empty state shows when a search yields no matches.