### PR TITLE
fix(toolsets): remove public MCP server cap on unpaid plans

### DIFF
--- a/.changeset/age-2267-remove-unpaid-toolset-cap.md
+++ b/.changeset/age-2267-remove-unpaid-toolset-cap.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Removed the 1-public-MCP-server cap on accounts without an active subscription. Users can now enable as many public MCP servers as they want on any plan.

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -517,7 +517,6 @@ export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
     target: ServerStatus;
     sourceStatus: ServerStatus;
   } | null>(null);
-  const [isMaxServersModalOpen, setIsMaxServersModalOpen] = useState(false);
   const updateToolsetMutation = useUpdateToolsetMutation();
   const telemetry = useTelemetry();
 
@@ -601,18 +600,11 @@ export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
           toast.success(label);
         },
         onError: (error) => {
-          if (
-            error instanceof Error &&
-            error.message.includes("maximum number of public MCP servers")
-          ) {
-            setIsMaxServersModalOpen(true);
-          } else {
-            toast.error(
-              error instanceof Error
-                ? error.message
-                : "Failed to update server status",
-            );
-          }
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Failed to update server status",
+          );
         },
       },
     );
@@ -726,16 +718,6 @@ export function MCPStatusDropdown({ toolset }: { toolset: Toolset }) {
         isLoading={updateToolsetMutation.isPending}
         currentlyEnabled={currentStatus !== "disabled"}
         targetIsPublic={pendingStatus === "public"}
-      />
-      <FeatureRequestModal
-        isOpen={isMaxServersModalOpen}
-        onClose={() => setIsMaxServersModalOpen(false)}
-        title="MCP Server Limit Reached"
-        description="You have reached the maximum number of MCP servers for the Base plan. Someone should be in touch shortly, or feel free to book a meeting directly to upgrade."
-        actionType="max_public_mcp_servers"
-        icon={Globe}
-        telemetryData={{ slug: toolset.slug }}
-        accountUpgrade
       />
     </>
   );

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -94,9 +94,8 @@ INSERT INTO assistant_toolsets (
 -- Flips mcp_enabled to TRUE for the listed toolsets in a project. Every
 -- toolset attached to an assistant must be MCP-reachable for the runtime's
 -- startup config to build; we enable on attach so users don't have to do it
--- separately. Bypasses the unpaid-plan public-server cap on purpose: an
--- assistant-attached toolset has no working alternative. mcp_slug is
--- required for an MCP-reachable toolset, so we skip rows that lack one.
+-- separately. mcp_slug is required for an MCP-reachable toolset, so we skip
+-- rows that lack one.
 UPDATE toolsets
 SET mcp_enabled = TRUE,
     updated_at = clock_timestamp()

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -425,9 +425,8 @@ type EnableMCPForToolsetsParams struct {
 // Flips mcp_enabled to TRUE for the listed toolsets in a project. Every
 // toolset attached to an assistant must be MCP-reachable for the runtime's
 // startup config to build; we enable on attach so users don't have to do it
-// separately. Bypasses the unpaid-plan public-server cap on purpose: an
-// assistant-attached toolset has no working alternative. mcp_slug is
-// required for an MCP-reachable toolset, so we skip rows that lack one.
+// separately. mcp_slug is required for an MCP-reachable toolset, so we skip
+// rows that lack one.
 func (q *Queries) EnableMCPForToolsets(ctx context.Context, arg EnableMCPForToolsetsParams) error {
 	_, err := q.db.Exec(ctx, enableMCPForToolsets, arg.ToolsetIds, arg.ProjectID)
 	return err

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -46,8 +46,6 @@ import (
 	usageRepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
-const maxUnpaidEnabledServers = 1
-
 // validOAuthProxyAuthMethods is the allowlist of token_endpoint_auth_methods_supported
 // values accepted by AddOAuthProxyServer and UpdateOAuthProxyServer.
 var validOAuthProxyAuthMethods = map[string]bool{
@@ -428,23 +426,9 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		updateParams.McpIsPublic = *payload.McpIsPublic
 	}
 
-	// Server-side enforcement of limit on # of enabled MCP servers by account type
 	if payload.McpEnabled != nil {
 		if *payload.McpEnabled && !existingToolset.McpSlug.Valid && (payload.McpSlug == nil || *payload.McpSlug == "") {
-			// sanity check this should not be able to happens
 			return nil, oops.E(oops.CodeBadRequest, nil, "mcp slug is required to set mcp is public")
-		}
-
-		isUnpaidAccount := !authCtx.HasActiveSubscription
-		if *payload.McpEnabled && !existingToolset.McpEnabled && isUnpaidAccount {
-			enabledServers, err := tr.ListEnabledToolsetsByOrganization(ctx, authCtx.ActiveOrganizationID)
-			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "error listing enabled toolsets").Log(ctx, logger)
-			}
-
-			if len(enabledServers) >= maxUnpaidEnabledServers {
-				return nil, oops.E(oops.CodeForbidden, nil, "%s", fmt.Sprintf("you have reached the maximum number of public MCP servers for your account type: %d", maxUnpaidEnabledServers)).Log(ctx, logger)
-			}
 		}
 
 		updateParams.McpEnabled = *payload.McpEnabled

--- a/server/internal/toolsets/queries.sql
+++ b/server/internal/toolsets/queries.sql
@@ -196,16 +196,6 @@ SELECT EXISTS (
   AND deleted IS FALSE
 );
 
--- name: ListEnabledToolsetsByOrganization :many
-SELECT t.*
-FROM toolsets t
-JOIN projects p ON t.project_id = p.id
-WHERE p.organization_id = @organization_id
-  AND t.mcp_enabled IS TRUE
-  AND t.deleted IS FALSE
-  AND p.deleted IS FALSE
-ORDER BY t.created_at DESC;
-
 -- name: ListToolsetsByOrganization :many
 SELECT t.*
 FROM toolsets t

--- a/server/internal/toolsets/repo/queries.sql.go
+++ b/server/internal/toolsets/repo/queries.sql.go
@@ -992,57 +992,6 @@ func (q *Queries) GetToolsetsByToolURN(ctx context.Context, arg GetToolsetsByToo
 	return items, nil
 }
 
-const listEnabledToolsetsByOrganization = `-- name: ListEnabledToolsetsByOrganization :many
-SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.created_at, t.updated_at, t.deleted_at, t.deleted
-FROM toolsets t
-JOIN projects p ON t.project_id = p.id
-WHERE p.organization_id = $1
-  AND t.mcp_enabled IS TRUE
-  AND t.deleted IS FALSE
-  AND p.deleted IS FALSE
-ORDER BY t.created_at DESC
-`
-
-func (q *Queries) ListEnabledToolsetsByOrganization(ctx context.Context, organizationID string) ([]Toolset, error) {
-	rows, err := q.db.Query(ctx, listEnabledToolsetsByOrganization, organizationID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []Toolset
-	for rows.Next() {
-		var i Toolset
-		if err := rows.Scan(
-			&i.ID,
-			&i.OrganizationID,
-			&i.ProjectID,
-			&i.Name,
-			&i.Slug,
-			&i.Description,
-			&i.DefaultEnvironmentSlug,
-			&i.McpSlug,
-			&i.McpIsPublic,
-			&i.McpEnabled,
-			&i.ToolSelectionMode,
-			&i.CustomDomainID,
-			&i.ExternalOauthServerID,
-			&i.OauthProxyServerID,
-			&i.UserSessionIssuerID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DeletedAt,
-			&i.Deleted,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listToolsetsByOrganization = `-- name: ListToolsetsByOrganization :many
 SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.created_at, t.updated_at, t.deleted_at, t.deleted
 FROM toolsets t


### PR DESCRIPTION
## Summary

- Removed the 1-public-MCP-server cap that fired in `UpdateToolset` when an org had no active subscription.
- Deleted the now-unused `ListEnabledToolsetsByOrganization` query and the dashboard's error-message-driven "MCP Server Limit Reached" modal.
- Trimmed the stale "Bypasses the unpaid-plan public-server cap" sentence from the `EnableMCPForToolsets` SQL doc comment.

Unpaid plans are an invalid billing state — gating product surface on it traps users instead of routing them to billing.

Closes [AGE-2267](https://linear.app/speakeasy/issue/AGE-2267/remove-cap-on-unpaid-plans-for-toolsets)

✻ Clauded...