### PR TITLE
fix(mcp): serve platform toolsets at /platform/mcp/{slug}

### DIFF
--- a/.changeset/age-2314-platform-mcp-route.md
+++ b/.changeset/age-2314-platform-mcp-route.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistant platform toolsets are now served from `/platform/mcp/{slug}` instead of `/x/platform-mcp/{slug}`, lining up with the dedicated `/platform` ingress prefix so requests reach the server pod instead of falling through to the dashboard.

--- a/.changeset/age-2314-platform-mcp-route.md
+++ b/.changeset/age-2314-platform-mcp-route.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Assistant platform toolsets are now served from `/platform/mcp/{slug}` instead of `/x/platform-mcp/{slug}`, lining up with the dedicated `/platform` ingress prefix so requests reach the server pod instead of falling through to the dashboard.
+Assistant platform toolsets are now served from `/platform/mcp/{slug}` instead of `/x/platform-mcp/{slug}`, in line with `/mcp` prefix for MCP servers.

--- a/server/internal/assistants/resolve_mcp_servers_test.go
+++ b/server/internal/assistants/resolve_mcp_servers_test.go
@@ -22,7 +22,7 @@ func TestResolveAssistantMCPServers_EmptyUserToolsetsStillGetsPlatformServer(t *
 
 	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
 	require.Equal(t,
-		"https://gram.test/x/platform-mcp/"+platformtools.AssistantsPlatformToolsetSlug,
+		"https://gram.test/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug,
 		servers[0].URL,
 	)
 	require.Empty(t, servers[0].Headers)
@@ -53,7 +53,7 @@ func TestResolveAssistantMCPServers_UserToolsetsListedBeforePlatformServer(t *te
 
 	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
 	require.Equal(t,
-		"https://gram.test/x/platform-mcp/"+platformtools.AssistantsPlatformToolsetSlug,
+		"https://gram.test/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug,
 		servers[1].URL,
 	)
 }

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -29,7 +29,7 @@ import (
 // toolsets. The path prefix is distinct from /mcp/{slug} so a platform slug
 // can never collide with a user-toolset slug; keep it in lockstep with
 // platformtools.PlatformToolsetURL.
-const PlatformToolsetRoute = "/x/platform-mcp/{toolsetSlug}"
+const PlatformToolsetRoute = "/platform/mcp/{toolsetSlug}"
 
 // ServePlatformToolset is the runtime-only entrypoint for platform toolsets:
 // only the assistant token is accepted, so user OAuth/API keys/chat sessions

--- a/server/internal/platformtools/toolsets.go
+++ b/server/internal/platformtools/toolsets.go
@@ -59,5 +59,5 @@ func NewAssistantsToolset(tools ...ExternalTool) Toolset {
 // platform toolset. Keep the path segments in lockstep with the chi route
 // registered by the mcp package.
 func PlatformToolsetURL(base *url.URL, slug string) string {
-	return base.JoinPath("x", "platform-mcp", slug).String()
+	return base.JoinPath("platform", "mcp", slug).String()
 }


### PR DESCRIPTION
## Summary
- Rename the platform-toolset MCP route from `/x/platform-mcp/{slug}` to `/platform/mcp/{slug}` (chi route + `PlatformToolsetURL` builder + test expectations).
- `/x/` is reserved for experimental, user-facing MCP runtimes that will graduate to `/mcp/...` (see `xmcp/service.go` doc + AGE-1902). Platform toolsets are a stable internal contract between server and assistant runners, authed only via assistant token — they don't belong under `/x/`.
- The k8s nginx ingress allowlists `/x/mcp`, `/mcp`, etc. `/x/platform-mcp/...` does not match, falls through to the dashboard SPA, and nginx returns 405 on POST. Pairs with [gram-infra#813](https://github.com/speakeasy-api/gram-infra/pull/813), which adds `/platform` to the allowlist.

## Ordering
- Ship the infra PR first (additive, no app behavior change), then this PR.

Closes [AGE-2314](https://linear.app/speakeasy/issue/AGE-2314/move-platform-mcp-route-under-platformmcpslug-add-ingress-allowlist)

✻ Clauded...