### PR TITLE
fix(dashboard): prevent transient 404 after deleting MCP toolset

### DIFF
--- a/.changeset/age-2312-prevent-immediate-404-deleting-mcp.md
+++ b/.changeset/age-2312-prevent-immediate-404-deleting-mcp.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Prevent a transient "toolset not found" error from appearing immediately after deleting an MCP server's toolset.

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -100,6 +100,7 @@ import { toast } from "sonner";
 import { useModel } from "../playground/Openrouter";
 import { AddToolsDialog } from "../toolsets/AddToolsDialog";
 import { ToolsetEmptyState } from "../toolsets/ToolsetEmptyState";
+import { useToolsets } from "../toolsets/useToolsets";
 import { getSystemProvidedVariables } from "./environmentVariableUtils";
 import { useMcpConfigs, useMcpSlugValidation } from "./mcp-details-utils";
 import { MCPAuthenticationTab } from "./MCPEnvironmentSettings";
@@ -1252,6 +1253,7 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
   const { domain } = useCustomDomain();
   const routes = useRoutes();
   const client = useSdkClient();
+  const toolsets = useToolsets();
   const { data: deploymentResult, refetch: refetchDeployment } =
     useLatestDeployment();
   const deployment = deploymentResult?.deployment;
@@ -1341,9 +1343,13 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
         slug: toolset.slug,
       });
 
-      invalidateAllToolset(queryClient);
+      invalidateAllToolset(queryClient, { refetchType: "none" });
       invalidateAllGetPeriodUsage(queryClient);
       refetchDeployment();
+      // Wait for the toolset list to refresh before navigating so the
+      // listing page never renders a card for the deleted toolset (which
+      // would trigger a per-card getBySlug refetch that 404s).
+      await toolsets.refetch();
 
       toast.success(`MCP server "${toolset.slug}" deleted`);
       setIsDeleteDialogOpen(false);


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2312/deleting-toolset-mcp-immediately-errors

After deleting an MCP server's toolset from its Settings tab, the page would call `/rpc/toolsets.get` immediately on the slug that was just deleted, which would either render a route-level "toolset not found" error that took over the page or have that request cancelled if there was just enough roundtrip latency, before redirecting to the MCP listing. Two changes in `MCPSettingsTab`'s `handleDeleteMcpServer`:

- `invalidateAllToolset(queryClient)` → `invalidateAllToolset(queryClient, { refetchType: "none" })`. The default `refetchType` of `"active"` triggered an immediate refetch on the active `useToolset(toolsetSlug)` observer; the refetch 404'd and propagated through child `useToolset(toolset.slug)` calls (default `throwOnError: true`), throwing to the route error boundary before navigation committed.
- Await a fresh `toolsets.list` refetch before navigating. Without it, the listing page renders cards from the stale cached list while it background-refetches, and each card calls `useExternalMcpOAuthConfigStatus(slug)` → `useToolset(slug)`. For the just-deleted slug this 404s and throws.

## Alternatives considered

- `queryClient.removeQueries({ queryKey: queryKeyToolset(...) })` to evict the deleted toolset's cached entry. *Caused* the refetch we were trying to avoid: active observers see the cache go away and immediately re-fetch.
- Optimistic `setQueryData` on the list query to drop the deleted entry before navigation. Slightly snappier UX, but requires writing the list query key (with auth params) by hand and is more brittle to SDK regen than `refetch()`.
- Eliminate the N+1: change `useExternalMcpOAuthConfigStatus` to take a toolset object rather than a slug, so listing cards don't need a per-card `useToolset` call at all. The cleanest long-term shape and would remove this bug class outright. Blocked: `ToolsetEntry` (the list response element) lacks `externalOauthServer` / `oauthProxyServer`, which are load-bearing for the `"required-unconfigured"` status that drives the click-to-`#authentication` handler in `MCPCard` / `MCPTableRow`. Needs a server-side addition to the list response first. Worth a follow-up.
- `throwOnError: false` on the per-card `useToolset` inside `useExternalMcpOAuthConfigStatus`. Would defuse the crash class for future variants of this bug but leaves the brief flash of a deleted-toolset card on the listing. Worth doing alongside the server-side N+1 fix.