### PR TITLE
mig: add unique index on organization_metadata slug

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -73,6 +73,9 @@ CREATE TABLE IF NOT EXISTS organization_metadata (
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_workos_id_key
 ON organization_metadata (workos_id);
 
+CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_slug_key
+ON organization_metadata (slug);
+
 CREATE UNIQUE INDEX IF NOT EXISTS projects_organization_id_slug_key
 ON projects (organization_id, slug)
 WHERE deleted IS FALSE;

--- a/server/migrations/20260514141917_org-metadata-add-slug-unique-index.sql
+++ b/server/migrations/20260514141917_org-metadata-add-slug-unique-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "organization_metadata_slug_key" to table: "organization_metadata"
+CREATE UNIQUE INDEX CONCURRENTLY "organization_metadata_slug_key" ON "organization_metadata" ("slug");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Fr2EzuEGUaao2MrJenXR95Mj/LoeZ/9ngf0b/pfpkr4=
+h1:SsofrDEE2APE3hATdXPKar00jXe5UHjfAo3D3rw2D9Y=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -176,3 +176,4 @@ h1:Fr2EzuEGUaao2MrJenXR95Mj/LoeZ/9ngf0b/pfpkr4=
 20260513120106_unique-org-workos-id.sql h1:whhKfMZ6Xf0zN4tOUbKxbyTmNU7mLmCtkZUOIG7HX2E=
 20260513143640_add-organization-invitations.sql h1:ullg5rI+Zo173EOQ56n2B6UFQB5mGLljO2FqLTeJXiQ=
 20260513152016_alter-user-id-membership-to-be-nullable.sql h1:WXg7B2CQFX4uuXTJYiaNkMtjDhSrBsZqNl4rWR09d5U=
+20260514141917_org-metadata-add-slug-unique-index.sql h1:8snzreqjc8R39UL9bJGKeXl4WlnVaE9YOo8o8RV5GTk=


### PR DESCRIPTION
## Summary

- Adds a unique index on `organization_metadata.slug` to enforce slug uniqueness at the database level
- Migration uses `CREATE UNIQUE INDEX CONCURRENTLY` (non-blocking)

## Validation

```sql
SELECT slug, COUNT(*) AS cnt FROM organization_metadata GROUP BY slug HAVING COUNT(*) > 1;
```

Run this against production before applying the migration to confirm no duplicate slugs exist.

## Test plan

- [ ] Run `mise run db:reset && mise run db:migrate` locally — migration applies cleanly
- [ ] Run duplicate-check query against staging/prod to verify no conflicts
- [ ] Confirm `INSERT` with a duplicate slug is rejected after migration
