### PR TITLE
chore(auth): skip WorkOS AuthKit org selector when org is known

### DIFF
--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -454,6 +454,9 @@ func (r *Resolver) BuildAuthorizationURL(ctx context.Context, params sessions.Au
 	q.Set("state", params.State)
 	q.Set("scope", "openid email profile")
 	q.Set("provider", "authkit")
+	if params.OrganizationID != "" {
+		q.Set("organization_id", params.OrganizationID)
+	}
 
 	authorizeBase := workosAuthorizeEndpoint
 	if !strings.HasPrefix(r.idpClientID, "client_") {

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -407,33 +407,33 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 // /login with no context), which leaves the organization_id param unset and
 // lets AuthKit show the org selector as normal.
 func (s *Service) resolveWorkOSOrgIDForLogin(ctx context.Context, payload *gen.LoginPayload) string {
-	var slug string
-
 	// Admin override header takes priority.
 	if adminOverride, _ := contextvalues.GetAdminOverrideFromContext(ctx); adminOverride != "" {
-		slug = adminOverride
+		return s.workosOrgIDFromSlug(ctx, adminOverride)
 	}
 
 	// Fall back to the org slug embedded in the redirect URL.
-	if slug == "" && payload != nil && payload.Redirect != nil {
-		slug = organizationSlugFromDestinationURL(*payload.Redirect)
+	if payload != nil && payload.Redirect != nil {
+		if slug := organizationSlugFromDestinationURL(*payload.Redirect); slug != "" {
+			return s.workosOrgIDFromSlug(ctx, slug)
+		}
 	}
 
 	// Default: no admin override and no org slug in the redirect URL.
 	// Return "" so AuthKit shows the org selector as normal.
-	if slug == "" {
-		return ""
-	}
+	return ""
+}
 
+// workosOrgIDFromSlug looks up an org by slug and returns its WorkOS ID.
+// Returns "" if the org doesn't exist or has no WorkOS ID.
+func (s *Service) workosOrgIDFromSlug(ctx context.Context, slug string) string {
 	orgMeta, err := s.orgRepo.GetOrganizationMetadataBySlug(ctx, slug)
 	if err != nil {
 		return ""
 	}
-
 	if !orgMeta.WorkosID.Valid {
 		return ""
 	}
-
 	return orgMeta.WorkosID.String
 }
 

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -379,12 +379,17 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 
 	state := encodeStateParam(payload, nonce)
 
+	// When we already know the target org, pass its WorkOS ID so AuthKit
+	// skips the org-selector screen.
+	workosOrgID := s.resolveWorkOSOrgIDForLogin(ctx, payload)
+
 	authURL, err := s.identity.BuildAuthorizationURL(ctx, sessions.AuthURLParams{
 		CallbackURL:     callbackURL,
 		State:           state,
 		Scope:           "",
 		ClientID:        "",
 		ScopesSupported: nil,
+		OrganizationID:  workosOrgID,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error building authorization URL").Log(ctx, s.logger)
@@ -393,6 +398,43 @@ func (s *Service) Login(ctx context.Context, payload *gen.LoginPayload) (res *ge
 	return &gen.LoginResult{
 		Location: authURL.String(),
 	}, nil
+}
+
+// resolveWorkOSOrgIDForLogin attempts to determine the target WorkOS org ID
+// at login time so AuthKit can skip the org-selector screen. Checks the admin
+// override header first, then falls back to extracting the org slug from the
+// redirect destination URL. Returns "" when neither is present (e.g. a bare
+// /login with no context), which leaves the organization_id param unset and
+// lets AuthKit show the org selector as normal.
+func (s *Service) resolveWorkOSOrgIDForLogin(ctx context.Context, payload *gen.LoginPayload) string {
+	var slug string
+
+	// Admin override header takes priority.
+	if adminOverride, _ := contextvalues.GetAdminOverrideFromContext(ctx); adminOverride != "" {
+		slug = adminOverride
+	}
+
+	// Fall back to the org slug embedded in the redirect URL.
+	if slug == "" && payload != nil && payload.Redirect != nil {
+		slug = organizationSlugFromDestinationURL(*payload.Redirect)
+	}
+
+	// Default: no admin override and no org slug in the redirect URL.
+	// Return "" so AuthKit shows the org selector as normal.
+	if slug == "" {
+		return ""
+	}
+
+	orgMeta, err := s.orgRepo.GetOrganizationMetadataBySlug(ctx, slug)
+	if err != nil {
+		return ""
+	}
+
+	if !orgMeta.WorkosID.Valid {
+		return ""
+	}
+
+	return orgMeta.WorkosID.String
 }
 
 // organizationSlugFromState extracts the org slug from the state param's

--- a/server/internal/auth/login_test.go
+++ b/server/internal/auth/login_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
+	"github.com/speakeasy-api/gram/server/internal/auth"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 )
 
 func TestService_Login(t *testing.T) {
@@ -139,5 +141,104 @@ func TestService_Login(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, redirectURL, state["final_destination_url"])
 		require.NotEmpty(t, state["nonce"], "state should contain a nonce")
+	})
+
+	t.Run("login with redirect containing org slug sets organization_id", func(t *testing.T) {
+		t.Parallel()
+
+		workosOrgID := "org_workos_skip_selector"
+		userInfo := defaultMockUserInfo()
+		userInfo.Organizations[0].WorkosID = &workosOrgID
+		ctx, instance := newTestAuthService(t, userInfo)
+
+		// Seed org in DB so resolveWorkOSOrgIDForLogin can find it.
+		for _, org := range userInfo.Organizations {
+			require.NoError(t, instance.createTestOrganization(ctx, org, userInfo.UserID))
+		}
+
+		redirectURL := "/test-org/projects/default"
+		ctx = auth.TestNonceBindingContext(ctx, testNonceBinding)
+		result, err := instance.service.Login(ctx, &gen.LoginPayload{Redirect: &redirectURL})
+		require.NoError(t, err)
+
+		parsedURL, err := url.Parse(result.Location)
+		require.NoError(t, err)
+		require.Equal(t, workosOrgID, parsedURL.Query().Get("organization_id"),
+			"authorize URL should include organization_id when redirect contains a known org slug")
+	})
+
+	t.Run("login with admin override sets organization_id", func(t *testing.T) {
+		t.Parallel()
+
+		workosOrgID := "org_workos_admin_override"
+		userInfo := defaultMockUserInfo()
+		ctx, instance := newTestAuthService(t, userInfo)
+
+		// Create the target org in DB (admin may not be a member).
+		require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
+			ID:       "admin-target-org",
+			Name:     "Admin Target Org",
+			Slug:     "admin-target",
+			WorkosID: &workosOrgID,
+		}, ""))
+
+		ctx = contextvalues.SetAdminOverrideInContext(ctx, "admin-target")
+		ctx = auth.TestNonceBindingContext(ctx, testNonceBinding)
+		result, err := instance.service.Login(ctx, &gen.LoginPayload{})
+		require.NoError(t, err)
+
+		parsedURL, err := url.Parse(result.Location)
+		require.NoError(t, err)
+		require.Equal(t, workosOrgID, parsedURL.Query().Get("organization_id"),
+			"authorize URL should include organization_id from admin override")
+	})
+
+	t.Run("login without redirect or admin override omits organization_id", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		ctx, instance := newTestAuthService(t, userInfo)
+		_ = instance
+
+		ctx = auth.TestNonceBindingContext(ctx, testNonceBinding)
+		result, err := instance.service.Login(ctx, &gen.LoginPayload{})
+		require.NoError(t, err)
+
+		parsedURL, err := url.Parse(result.Location)
+		require.NoError(t, err)
+		require.Empty(t, parsedURL.Query().Get("organization_id"),
+			"authorize URL should not include organization_id when no org context is available")
+	})
+
+	t.Run("login admin override takes priority over redirect URL", func(t *testing.T) {
+		t.Parallel()
+
+		workosAdminOrg := "org_workos_admin_prio"
+		workosRedirectOrg := "org_workos_redirect_prio"
+		userInfo := defaultMockUserInfo()
+		userInfo.Organizations[0].WorkosID = &workosRedirectOrg
+		ctx, instance := newTestAuthService(t, userInfo)
+
+		// Seed both orgs in DB.
+		for _, org := range userInfo.Organizations {
+			require.NoError(t, instance.createTestOrganization(ctx, org, userInfo.UserID))
+		}
+		require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
+			ID:       "admin-prio-org",
+			Name:     "Admin Priority Org",
+			Slug:     "admin-prio",
+			WorkosID: &workosAdminOrg,
+		}, ""))
+
+		redirectURL := "/test-org/projects/default"
+		ctx = contextvalues.SetAdminOverrideInContext(ctx, "admin-prio")
+		ctx = auth.TestNonceBindingContext(ctx, testNonceBinding)
+		result, err := instance.service.Login(ctx, &gen.LoginPayload{Redirect: &redirectURL})
+		require.NoError(t, err)
+
+		parsedURL, err := url.Parse(result.Location)
+		require.NoError(t, err)
+		require.Equal(t, workosAdminOrg, parsedURL.Query().Get("organization_id"),
+			"admin override should take priority over redirect URL org slug")
 	})
 }

--- a/server/internal/auth/sessions/types.go
+++ b/server/internal/auth/sessions/types.go
@@ -81,4 +81,5 @@ type AuthURLParams struct {
 	State           string
 	ClientID        string
 	ScopesSupported []string
+	OrganizationID  string // WorkOS org ID — when set, AuthKit skips the org selector
 }

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -136,6 +136,7 @@ func (s *Service) HandleAuthorize(w http.ResponseWriter, r *http.Request) error 
 			State:           challengeID,
 			ClientID:        "",
 			ScopesSupported: nil,
+			OrganizationID:  "",
 		})
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "build IDP authorization URL").Log(ctx, logger)

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -385,6 +385,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 			State:           string(oauthReqInfoJSON),
 			ScopesSupported: provider.ScopesSupported,
 			ClientID:        "",
+			OrganizationID:  "",
 		})
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to build gram OAuth URL").Log(ctx, s.logger)


### PR DESCRIPTION
## Summary

- When we already know the target org at login time, pass `organization_id` to the WorkOS authorize URL so AuthKit skips the org-selector screen
- Two cases handled: **admin override** (header/cookie) and **redirect URL** containing an org slug (e.g. `/my-org/projects/default`)
- Falls back gracefully — bare `/login` with no context shows the org selector as before

## Changes

- `sessions/types.go` — added `OrganizationID` field to `AuthURLParams`
- `identity/identity.go` — `BuildAuthorizationURL` sets `organization_id` query param when provided
- `auth/impl.go` — new `resolveWorkOSOrgIDForLogin` method: admin override → redirect URL slug → DB lookup → WorkOS ID
- `login_test.go` — 4 new tests covering redirect org, admin override, no-context default, and priority ordering

## Test plan

- [x] Existing auth tests pass (109 tests)
- [x] New Login tests pass (4 tests covering all org resolution paths)
- [ ] Manual: login with redirect URL containing org slug → no org picker
- [ ] Manual: admin override login → no org picker
- [ ] Manual: bare login → org picker shown as before