### PR TITLE
mig: add auto_sync_sources column to toolsets

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -918,6 +918,12 @@ CREATE TABLE IF NOT EXISTS toolsets (
   mcp_is_public BOOLEAN NOT NULL DEFAULT FALSE,
   mcp_enabled BOOLEAN NOT NULL DEFAULT FALSE,
   tool_selection_mode TEXT NOT NULL DEFAULT 'static',
+  -- Subscriptions that auto-extend this toolset's tool_urns when a new
+  -- deployment introduces new tools for the named sources. Entries are
+  -- "<kind>:<source>" (e.g. "function:my-tools"). Empty array = manual mode.
+  -- Only "function:" entries are accepted today; the server-side validator
+  -- rejects other prefixes so OpenAPI support can land additively later.
+  auto_sync_sources TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
   custom_domain_id uuid,
 
   -- OAuth configuration - mutually exclusive

--- a/server/migrations/20260514184707_auto-sync-sources-on-toolsets.sql
+++ b/server/migrations/20260514184707_auto-sync-sources-on-toolsets.sql
@@ -1,0 +1,2 @@
+-- Modify "toolsets" table
+ALTER TABLE "toolsets" ADD COLUMN "auto_sync_sources" text[] NOT NULL DEFAULT ARRAY[]::text[];

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:SsofrDEE2APE3hATdXPKar00jXe5UHjfAo3D3rw2D9Y=
+h1:2Q9joZfl4cCBIHbei5VG4f7nfIPnnobinf0mLe7WWbA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -177,3 +177,4 @@ h1:SsofrDEE2APE3hATdXPKar00jXe5UHjfAo3D3rw2D9Y=
 20260513143640_add-organization-invitations.sql h1:ullg5rI+Zo173EOQ56n2B6UFQB5mGLljO2FqLTeJXiQ=
 20260513152016_alter-user-id-membership-to-be-nullable.sql h1:WXg7B2CQFX4uuXTJYiaNkMtjDhSrBsZqNl4rWR09d5U=
 20260514141917_org-metadata-add-slug-unique-index.sql h1:8snzreqjc8R39UL9bJGKeXl4WlnVaE9YOo8o8RV5GTk=
+20260514184707_auto-sync-sources-on-toolsets.sql h1:+WeVWrMlcnuZofVgkgP+2D9YJMLRNV+qK2JJ0+8bw3Y=


### PR DESCRIPTION
## Summary

- Adds `auto_sync_sources TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[]` to the `toolsets` table.
- Entries will be encoded as `<kind>:<source>` (e.g. `function:my-tools`); only `function:` entries will be accepted by the server-side validator landing in the next PR.
- No Go code references the column yet — this PR ships **alone** per the expand-contract migration rule in `CLAUDE.md`.

Refs [AGE-1377](https://linear.app/speakeasy/issue/AGE-1377).

## Test plan

- [x] `mise build:server` passes
- [x] Migration ordering check passes (timestamp `20260514184707` is fresh; later than the latest on `main`)
- [x] Atlas-generated single-statement `ALTER TABLE ... ADD COLUMN ... NOT NULL DEFAULT ARRAY[]::text[]` — no backfill needed
- [ ] CI's `atlas migrate lint` against a clean dev DB (local run blocked by env: dev DB not empty)
- [ ] Reviewer confirms the column comment in `schema.sql` accurately scopes today's `function:` constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)