### PR TITLE
chore: default whitelisted to false for new orgs from existing workos

### DIFF
--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -210,6 +210,7 @@ func TestE2E_Callback_NewUserWithWorkOSOrgMemberships(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, orgName, orgMeta.Name)
 	assert.Equal(t, workosOrgID, orgMeta.WorkosID.String)
+	assert.False(t, orgMeta.Whitelisted, "new org created via login must not be auto-whitelisted")
 }
 
 // TestE2E_Callback_NewUserJoiningExistingOrg verifies that when a new user

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -10,7 +10,7 @@ INSERT INTO organization_metadata (
     @name,
     @slug,
     @workos_id,
-    COALESCE(sqlc.narg('whitelisted')::boolean, TRUE)
+    COALESCE(sqlc.narg('whitelisted')::boolean, FALSE)
 )
 ON CONFLICT (id) DO UPDATE SET
     name = EXCLUDED.name,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -783,7 +783,7 @@ INSERT INTO organization_metadata (
     $2,
     $3,
     $4,
-    COALESCE($5::boolean, TRUE)
+    COALESCE($5::boolean, FALSE)
 )
 ON CONFLICT (id) DO UPDATE SET
     name = EXCLUDED.name,


### PR DESCRIPTION
## Summary

- **Bug**: When a user logs in to an org that exists in WorkOS but not yet in the Gram DB, `UpsertOrganizationMetadata` creates the org with `whitelisted = true` instead of `false`
- **Root cause**: SQL INSERT path uses `COALESCE($5::boolean, TRUE)` — both login call sites pass NULL for whitelisted (intending "use default"), so `COALESCE(NULL, TRUE)` yields `TRUE`
- **Fix**: Change default from `TRUE` to `FALSE` so new orgs are not auto-whitelisted
- The ON CONFLICT (UPDATE) path is unchanged — it preserves the existing `whitelisted` value when NULL is passed

## Test plan

- [ ] Verify existing whitelisted orgs retain `whitelisted = true` on login (ON CONFLICT path)
- [ ] Verify new org created via login gets `whitelisted = false`
- [ ] Verify explicit `whitelisted = true` still works (e.g. org creation flow passing `Valid: true`)