### PR TITLE
feat(hooks): structured org/project attrs on all hook routes

### DIFF
--- a/.changeset/hooks-logging-attrs.md
+++ b/.changeset/hooks-logging-attrs.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Make hook routes (Claude / Cursor / Codex / OTEL Logs / OTEL Metrics) filterable in Datadog by `gram.org.id`, `gram.project.id`, `gram.hook.source`, and `gram.hook.event`. Replace nested `value` payloads with top-level slog attrs attached via `slog.With`, and log on every early-return path — including unauthorized requests and missing-session-id branches — so a silent 401 or no-session request is still visible when debugging hook setup for a given org/project.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -222,6 +222,7 @@ const (
 	ProjectSlugKey                  = attribute.Key("gram.project.slug")
 	RiskPolicyCountKey              = attribute.Key("gram.risk.policy_count")
 	RiskPolicyIDKey                 = attribute.Key("gram.risk.policy_id")
+	RiskPolicyNameKey               = attribute.Key("gram.risk.policy_name")
 	RiskRuleIDKey                   = attribute.Key("gram.risk.rule_id")
 	RiskScanAttemptKey              = attribute.Key("gram.risk.scan.attempt")
 	RiskScanMaxAttemptsKey          = attribute.Key("gram.risk.scan.max_attempts")
@@ -259,6 +260,7 @@ const (
 	HookIsInterruptKey          = attribute.Key("gram.hook.is_interrupt")
 	HookSourceKey               = attribute.Key("gram.hook.source")
 	HookServerNameOverrideIDKey = attribute.Key("gram.hook.server_name_override_id")
+	HookHasPluginAuthKey        = attribute.Key("gram.hook.has_plugin_auth")
 	// HookBlockReasonKey is set on hook telemetry entries when the Gram hook
 	// denied the tool call (e.g. shadow-MCP guard). Its presence (non-empty)
 	// signals the trace should render as "blocked" in dashboards.
@@ -448,6 +450,18 @@ func HookServerNameOverrideID(v string) attribute.KeyValue {
 func SlogHookServerNameOverrideID(v string) slog.Attr {
 	return slog.String(string(HookServerNameOverrideIDKey), v)
 }
+
+func HookEvent(v string) attribute.KeyValue { return HookEventKey.String(v) }
+func SlogHookEvent(v string) slog.Attr      { return slog.String(string(HookEventKey), v) }
+
+func HookSource(v string) attribute.KeyValue { return HookSourceKey.String(v) }
+func SlogHookSource(v string) slog.Attr      { return slog.String(string(HookSourceKey), v) }
+
+func HookBlockReason(v string) attribute.KeyValue { return HookBlockReasonKey.String(v) }
+func SlogHookBlockReason(v string) slog.Attr      { return slog.String(string(HookBlockReasonKey), v) }
+
+func HookHasPluginAuth(v bool) attribute.KeyValue { return HookHasPluginAuthKey.Bool(v) }
+func SlogHookHasPluginAuth(v bool) slog.Attr      { return slog.Bool(string(HookHasPluginAuthKey), v) }
 
 func ServerAddress(v string) attribute.KeyValue { return ServerAddressKey.String(v) }
 func SlogServerAddress(v string) slog.Attr      { return slog.String(string(ServerAddressKey), v) }
@@ -988,6 +1002,9 @@ func SlogRiskPolicyCount(v int) slog.Attr      { return slog.Int(string(RiskPoli
 
 func RiskPolicyID(v string) attribute.KeyValue { return RiskPolicyIDKey.String(v) }
 func SlogRiskPolicyID(v string) slog.Attr      { return slog.String(string(RiskPolicyIDKey), v) }
+
+func RiskPolicyName(v string) attribute.KeyValue { return RiskPolicyNameKey.String(v) }
+func SlogRiskPolicyName(v string) slog.Attr      { return slog.String(string(RiskPolicyNameKey), v) }
 
 func RiskRuleID(v string) attribute.KeyValue { return RiskRuleIDKey.String(v) }
 func SlogRiskRuleID(v string) slog.Attr      { return slog.String(string(RiskRuleIDKey), v) }

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -171,33 +171,35 @@ func (d *formDecoder) Decode(v any) error {
 func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 	claudeMetadata := extractSessionMetadata(payload)
 
+	logger := s.logger.With(
+		attr.SlogHookSource("claude"),
+		attr.SlogHookEvent("Logs"),
+		attr.SlogServiceName(claudeMetadata.ServiceName),
+		attr.SlogGenAIConversationID(claudeMetadata.SessionID),
+		attr.SlogAuthUserEmail(claudeMetadata.UserEmail),
+	)
+
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		// Auth middleware should have rejected this already; log here so a
 		// stray unauthenticated request is still visible per source/event
 		// when filtering hook traffic in Datadog.
-		s.logger.WarnContext(ctx, "rejected unauthorized claude OTEL logs request",
+		logger.WarnContext(ctx, "rejected unauthorized claude OTEL logs request",
 			attr.SlogEvent("claude_logs_unauthorized"),
-			attr.SlogHookSource("claude"),
-			attr.SlogHookEvent("Logs"),
-			attr.SlogGenAIConversationID(claudeMetadata.SessionID),
-			attr.SlogServiceName(claudeMetadata.ServiceName),
 		)
 		return oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
 
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
+	logger = logger.With(
+		attr.SlogOrganizationID(orgID),
+		attr.SlogProjectID(projectID),
+	)
 
 	if claudeMetadata.SessionID == "" {
-		s.logger.WarnContext(ctx, "claude OTEL logs payload contained no session ID",
+		logger.WarnContext(ctx, "claude OTEL logs payload contained no session ID",
 			attr.SlogEvent("claude_logs_no_session"),
-			attr.SlogHookSource("claude"),
-			attr.SlogHookEvent("Logs"),
-			attr.SlogOrganizationID(orgID),
-			attr.SlogProjectID(projectID),
-			attr.SlogServiceName(claudeMetadata.ServiceName),
-			attr.SlogAuthUserEmail(claudeMetadata.UserEmail),
 		)
 		return nil
 	}
@@ -215,28 +217,16 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 	}
 
 	if err := s.cache.Set(ctx, sessionCacheKey(completeMetadata.SessionID), completeMetadata, 24*time.Hour); err != nil {
-		s.logger.ErrorContext(ctx, "Failed to store session metadata",
+		logger.ErrorContext(ctx, "Failed to store session metadata",
 			attr.SlogEvent("claude_logs_cache_set_failed"),
-			attr.SlogHookSource("claude"),
-			attr.SlogHookEvent("Logs"),
-			attr.SlogOrganizationID(orgID),
-			attr.SlogProjectID(projectID),
-			attr.SlogGenAIConversationID(completeMetadata.SessionID),
 			attr.SlogError(err),
 		)
 	}
 
 	s.flushPendingHooks(ctx, completeMetadata.SessionID, &completeMetadata)
 
-	s.logger.InfoContext(ctx, "Stored session metadata",
+	logger.InfoContext(ctx, "Stored session metadata",
 		attr.SlogEvent("session_validated"),
-		attr.SlogHookSource("claude"),
-		attr.SlogHookEvent("Logs"),
-		attr.SlogOrganizationID(orgID),
-		attr.SlogProjectID(projectID),
-		attr.SlogGenAIConversationID(completeMetadata.SessionID),
-		attr.SlogServiceName(completeMetadata.ServiceName),
-		attr.SlogAuthUserEmail(completeMetadata.UserEmail),
 	)
 
 	return nil
@@ -244,12 +234,15 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 
 // Metrics handles authenticated OTEL metrics data from Claude Code
 func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) error {
+	logger := s.logger.With(
+		attr.SlogHookSource("claude"),
+		attr.SlogHookEvent("Metrics"),
+	)
+
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		s.logger.WarnContext(ctx, "rejected unauthorized claude OTEL metrics request",
+		logger.WarnContext(ctx, "rejected unauthorized claude OTEL metrics request",
 			attr.SlogEvent("claude_metrics_unauthorized"),
-			attr.SlogHookSource("claude"),
-			attr.SlogHookEvent("Metrics"),
 		)
 		return oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
@@ -257,10 +250,8 @@ func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) erro
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
 
-	s.logger.InfoContext(ctx, "Received Claude token metrics",
+	logger.InfoContext(ctx, "Received Claude token metrics",
 		attr.SlogEvent("claude_metrics"),
-		attr.SlogHookSource("claude"),
-		attr.SlogHookEvent("Metrics"),
 		attr.SlogOrganizationID(orgID),
 		attr.SlogProjectID(projectID),
 	)
@@ -327,10 +318,11 @@ func extractSessionMetadata(payload *gen.LogsPayload) claudeLogMetadata {
 
 // Claude is the unified endpoint for all Claude Code hook events.
 func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.ClaudeHookResult, error) {
-	// Log entry with top-level org/project/source/event attrs so the request
-	// is filterable in Datadog even before auth resolves. Auth on this
-	// endpoint is optional; the project_slug header may be present even
-	// when the API key isn't validated yet, so include it as a hint.
+	// Build a request-scoped logger so org/project/source/event are
+	// attached to every log line in this handler — including the
+	// pre-auth entry log. Auth on this endpoint is optional; the
+	// project_slug header may be present even when the API key isn't
+	// validated yet, so include it as a hint up front.
 	toolName := ""
 	if payload.ToolName != nil {
 		toolName = *payload.ToolName
@@ -344,14 +336,18 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 		projectSlugHint = *payload.ProjectSlugInput
 	}
 	hasPluginAuth := hasOptionalPluginAuth(payload)
-	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Claude: %s", payload.HookEventName),
-		attr.SlogEvent("claude_hook"),
+
+	logger := s.logger.With(
 		attr.SlogHookSource("claude"),
 		attr.SlogHookEvent(payload.HookEventName),
 		attr.SlogToolName(toolName),
 		attr.SlogGenAIConversationID(sessionID),
 		attr.SlogProjectSlug(projectSlugHint),
 		attr.SlogHookHasPluginAuth(hasPluginAuth),
+	)
+
+	logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Claude: %s", payload.HookEventName),
+		attr.SlogEvent("claude_hook"),
 	)
 
 	if hasPluginAuth {
@@ -363,29 +359,20 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 		// in Redis, and the OTEL Logs endpoint flushes it once the session is
 		// validated. Policies that need auth context degrade gracefully.
 		if authedCtx, err := s.authorizePluginRequest(ctx, *payload.ApikeyToken, *payload.ProjectSlugInput); err != nil {
-			s.logger.WarnContext(ctx, "plugin auth failed on claude hook; falling back to OTEL-buffered path",
+			logger.WarnContext(ctx, "plugin auth failed on claude hook; falling back to OTEL-buffered path",
 				attr.SlogEvent("claude_hook_auth_failed"),
-				attr.SlogHookSource("claude"),
-				attr.SlogHookEvent(payload.HookEventName),
-				attr.SlogProjectSlug(projectSlugHint),
 				attr.SlogError(err),
 			)
 		} else {
 			ctx = authedCtx
 			if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
-				attrs := []any{
-					attr.SlogEvent("claude_hook_auth_ok"),
-					attr.SlogHookSource("claude"),
-					attr.SlogHookEvent(payload.HookEventName),
-					attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
-				}
+				logger = logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 				if authCtx.ProjectID != nil {
-					attrs = append(attrs, attr.SlogProjectID(authCtx.ProjectID.String()))
+					logger = logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 				}
-				if authCtx.ProjectSlug != nil {
-					attrs = append(attrs, attr.SlogProjectSlug(*authCtx.ProjectSlug))
-				}
-				s.logger.InfoContext(ctx, "plugin auth ok on claude hook", attrs...)
+				logger.InfoContext(ctx, "plugin auth ok on claude hook",
+					attr.SlogEvent("claude_hook_auth_ok"),
+				)
 			}
 		}
 	}
@@ -411,7 +398,7 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 	case "Notification":
 		return s.handleNotification(ctx, payload)
 	default:
-		s.logger.ErrorContext(ctx, fmt.Sprintf("Unknown hook event: %s", payload.HookEventName))
+		logger.ErrorContext(ctx, fmt.Sprintf("Unknown hook event: %s", payload.HookEventName))
 		return makeHookResult(payload.HookEventName), nil
 	}
 }
@@ -455,23 +442,26 @@ func (s *Service) authorizePluginRequest(ctx context.Context, key, projectSlug s
 }
 
 func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
+	logger := s.logger.With(
+		attr.SlogHookSource("claude"),
+		attr.SlogHookEvent(payload.HookEventName),
+	)
+	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
+		logger = logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		if authCtx.ProjectID != nil {
+			logger = logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
+		}
+	}
+
 	if payload.SessionID == nil || *payload.SessionID == "" {
-		attrs := []any{
+		logger.WarnContext(ctx, "Tool event called without session ID",
 			attr.SlogEvent("claude_hook_no_session"),
-			attr.SlogHookSource("claude"),
-			attr.SlogHookEvent(payload.HookEventName),
-		}
-		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
-			attrs = append(attrs, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
-			if authCtx.ProjectID != nil {
-				attrs = append(attrs, attr.SlogProjectID(authCtx.ProjectID.String()))
-			}
-		}
-		s.logger.WarnContext(ctx, "Tool event called without session ID", attrs...)
+		)
 		return
 	}
 
 	sessionID := *payload.SessionID
+	logger = logger.With(attr.SlogGenAIConversationID(sessionID))
 
 	// Both plugin-authenticated and OTEL-only requests go through the same
 	// Redis-buffered flow: persist when session metadata is in the cache,
@@ -485,20 +475,10 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 		s.persistHook(ctx, payload, &metadata)
 	} else {
 		if err := s.bufferHook(ctx, sessionID, payload); err != nil {
-			attrs := []any{
+			logger.ErrorContext(ctx, "Failed to buffer hook",
 				attr.SlogEvent("claude_hook_buffer_failed"),
-				attr.SlogHookSource("claude"),
-				attr.SlogHookEvent(payload.HookEventName),
-				attr.SlogGenAIConversationID(sessionID),
 				attr.SlogError(err),
-			}
-			if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
-				attrs = append(attrs, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
-				if authCtx.ProjectID != nil {
-					attrs = append(attrs, attr.SlogProjectID(authCtx.ProjectID.String()))
-				}
-			}
-			s.logger.ErrorContext(ctx, "Failed to buffer hook", attrs...)
+			)
 		}
 	}
 }
@@ -639,14 +619,15 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 
 	detail, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, payload.ToolInput, mcpToolName, metadata.GramOrgID)
 	if denied {
-		s.logger.InfoContext(ctx, "denying claude tool call: failed gram toolset validation",
-			attr.SlogEvent("claude_hook_denied"),
+		s.logger.With(
 			attr.SlogHookSource("claude"),
 			attr.SlogHookEvent(payload.HookEventName),
 			attr.SlogOrganizationID(metadata.GramOrgID),
 			attr.SlogProjectID(metadata.ProjectID),
 			attr.SlogGenAIConversationID(sessionID),
 			attr.SlogToolName(rawToolName),
+		).InfoContext(ctx, "denying claude tool call: failed gram toolset validation",
+			attr.SlogEvent("claude_hook_denied"),
 			attr.SlogHookBlockReason(detail),
 			attr.SlogRiskPolicyID(policy.ID),
 			attr.SlogRiskPolicyName(policy.Name),

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
@@ -318,35 +319,21 @@ func extractSessionMetadata(payload *gen.LogsPayload) claudeLogMetadata {
 
 // Claude is the unified endpoint for all Claude Code hook events.
 func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.ClaudeHookResult, error) {
-	// Build a request-scoped logger so org/project/source/event are
-	// attached to every log line in this handler — including the
-	// pre-auth entry log. Auth on this endpoint is optional; the
-	// project_slug header may be present even when the API key isn't
-	// validated yet, so include it as a hint up front.
-	toolName := ""
-	if payload.ToolName != nil {
-		toolName = *payload.ToolName
-	}
-	sessionID := ""
-	if payload.SessionID != nil {
-		sessionID = *payload.SessionID
-	}
-	projectSlugHint := ""
-	if payload.ProjectSlugInput != nil {
-		projectSlugHint = *payload.ProjectSlugInput
-	}
+	// project_slug header may be set even when the API key isn't validated
+	// yet on this optional-auth endpoint — log it as a hint up front.
+	projectSlugHint := conv.PtrValOr(payload.ProjectSlugInput, "")
 	hasPluginAuth := hasOptionalPluginAuth(payload)
 
 	logger := s.logger.With(
 		attr.SlogHookSource("claude"),
 		attr.SlogHookEvent(payload.HookEventName),
-		attr.SlogToolName(toolName),
-		attr.SlogGenAIConversationID(sessionID),
+		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+		attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
 		attr.SlogProjectSlug(projectSlugHint),
 		attr.SlogHookHasPluginAuth(hasPluginAuth),
 	)
 
-	logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Claude: %s", payload.HookEventName),
+	logger.InfoContext(ctx, "claude hook received",
 		attr.SlogEvent("claude_hook"),
 	)
 
@@ -358,22 +345,17 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 		// same path a no-headers request takes — recordHook buffers the event
 		// in Redis, and the OTEL Logs endpoint flushes it once the session is
 		// validated. Policies that need auth context degrade gracefully.
-		if authedCtx, err := s.authorizePluginRequest(ctx, *payload.ApikeyToken, *payload.ProjectSlugInput); err != nil {
+		if authedCtx, err := s.authorizePluginRequest(ctx, conv.PtrValOr(payload.ApikeyToken, ""), projectSlugHint); err != nil {
 			logger.WarnContext(ctx, "plugin auth failed on claude hook; falling back to OTEL-buffered path",
 				attr.SlogEvent("claude_hook_auth_failed"),
 				attr.SlogError(err),
 			)
 		} else {
 			ctx = authedCtx
-			if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
-				logger = logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
-				if authCtx.ProjectID != nil {
-					logger = logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
-				}
-				logger.InfoContext(ctx, "plugin auth ok on claude hook",
-					attr.SlogEvent("claude_hook_auth_ok"),
-				)
-			}
+			logger = s.withAuthContext(ctx, logger)
+			logger.InfoContext(ctx, "plugin auth ok on claude hook",
+				attr.SlogEvent("claude_hook_auth_ok"),
+			)
 		}
 	}
 
@@ -442,16 +424,10 @@ func (s *Service) authorizePluginRequest(ctx context.Context, key, projectSlug s
 }
 
 func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
-	logger := s.logger.With(
+	logger := s.withAuthContext(ctx, s.logger.With(
 		attr.SlogHookSource("claude"),
 		attr.SlogHookEvent(payload.HookEventName),
-	)
-	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
-		logger = logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
-		if authCtx.ProjectID != nil {
-			logger = logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
-		}
-	}
+	))
 
 	if payload.SessionID == nil || *payload.SessionID == "" {
 		logger.WarnContext(ctx, "Tool event called without session ID",

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -169,18 +169,40 @@ func (d *formDecoder) Decode(v any) error {
 
 // Logs handles authenticated OTEL logs data from Claude Code
 func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
+	claudeMetadata := extractSessionMetadata(payload)
+
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		// Auth middleware should have rejected this already; log here so a
+		// stray unauthenticated request is still visible per source/event
+		// when filtering hook traffic in Datadog.
+		s.logger.WarnContext(ctx, "rejected unauthorized claude OTEL logs request",
+			attr.SlogEvent("claude_logs_unauthorized"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent("Logs"),
+			attr.SlogGenAIConversationID(claudeMetadata.SessionID),
+			attr.SlogServiceName(claudeMetadata.ServiceName),
+		)
 		return oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
 
-	claudeMetadata := extractSessionMetadata(payload)
+	orgID := authCtx.ActiveOrganizationID
+	projectID := authCtx.ProjectID.String()
+
 	if claudeMetadata.SessionID == "" {
-		s.logger.WarnContext(ctx, "Logs payload contained no session ID")
+		s.logger.WarnContext(ctx, "claude OTEL logs payload contained no session ID",
+			attr.SlogEvent("claude_logs_no_session"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent("Logs"),
+			attr.SlogOrganizationID(orgID),
+			attr.SlogProjectID(projectID),
+			attr.SlogServiceName(claudeMetadata.ServiceName),
+			attr.SlogAuthUserEmail(claudeMetadata.UserEmail),
+		)
 		return nil
 	}
 
-	userID := s.resolveUserByEmail(ctx, claudeMetadata.UserEmail, authCtx.ActiveOrganizationID)
+	userID := s.resolveUserByEmail(ctx, claudeMetadata.UserEmail, orgID)
 
 	completeMetadata := SessionMetadata{
 		SessionID:   claudeMetadata.SessionID,
@@ -188,18 +210,33 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		UserEmail:   claudeMetadata.UserEmail,
 		UserID:      userID,
 		ClaudeOrgID: claudeMetadata.ClaudeOrgID,
-		GramOrgID:   authCtx.ActiveOrganizationID,
-		ProjectID:   authCtx.ProjectID.String(),
+		GramOrgID:   orgID,
+		ProjectID:   projectID,
 	}
 
 	if err := s.cache.Set(ctx, sessionCacheKey(completeMetadata.SessionID), completeMetadata, 24*time.Hour); err != nil {
-		s.logger.ErrorContext(ctx, "Failed to store session metadata", attr.SlogError(err))
+		s.logger.ErrorContext(ctx, "Failed to store session metadata",
+			attr.SlogEvent("claude_logs_cache_set_failed"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent("Logs"),
+			attr.SlogOrganizationID(orgID),
+			attr.SlogProjectID(projectID),
+			attr.SlogGenAIConversationID(completeMetadata.SessionID),
+			attr.SlogError(err),
+		)
 	}
 
 	s.flushPendingHooks(ctx, completeMetadata.SessionID, &completeMetadata)
 
 	s.logger.InfoContext(ctx, "Stored session metadata",
 		attr.SlogEvent("session_validated"),
+		attr.SlogHookSource("claude"),
+		attr.SlogHookEvent("Logs"),
+		attr.SlogOrganizationID(orgID),
+		attr.SlogProjectID(projectID),
+		attr.SlogGenAIConversationID(completeMetadata.SessionID),
+		attr.SlogServiceName(completeMetadata.ServiceName),
+		attr.SlogAuthUserEmail(completeMetadata.UserEmail),
 	)
 
 	return nil
@@ -209,19 +246,27 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) error {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		s.logger.WarnContext(ctx, "rejected unauthorized claude OTEL metrics request",
+			attr.SlogEvent("claude_metrics_unauthorized"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent("Metrics"),
+		)
 		return oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
 
+	orgID := authCtx.ActiveOrganizationID
+	projectID := authCtx.ProjectID.String()
+
 	s.logger.InfoContext(ctx, "Received Claude token metrics",
 		attr.SlogEvent("claude_metrics"),
-		attr.SlogValueAny(map[string]any{
-			"organization_id": authCtx.ActiveOrganizationID,
-			"project_id":      authCtx.ProjectID.String(),
-		}),
+		attr.SlogHookSource("claude"),
+		attr.SlogHookEvent("Metrics"),
+		attr.SlogOrganizationID(orgID),
+		attr.SlogProjectID(projectID),
 	)
 
 	// Write metrics to ClickHouse
-	s.writeMetricsToClickHouse(ctx, payload, authCtx.ActiveOrganizationID, authCtx.ProjectID.String())
+	s.writeMetricsToClickHouse(ctx, payload, orgID, projectID)
 
 	return nil
 }
@@ -282,16 +327,34 @@ func extractSessionMetadata(payload *gen.LogsPayload) claudeLogMetadata {
 
 // Claude is the unified endpoint for all Claude Code hook events.
 func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.ClaudeHookResult, error) {
+	// Log entry with top-level org/project/source/event attrs so the request
+	// is filterable in Datadog even before auth resolves. Auth on this
+	// endpoint is optional; the project_slug header may be present even
+	// when the API key isn't validated yet, so include it as a hint.
+	toolName := ""
+	if payload.ToolName != nil {
+		toolName = *payload.ToolName
+	}
+	sessionID := ""
+	if payload.SessionID != nil {
+		sessionID = *payload.SessionID
+	}
+	projectSlugHint := ""
+	if payload.ProjectSlugInput != nil {
+		projectSlugHint = *payload.ProjectSlugInput
+	}
+	hasPluginAuth := hasOptionalPluginAuth(payload)
 	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Claude: %s", payload.HookEventName),
 		attr.SlogEvent("claude_hook"),
-		attr.SlogValueAny(map[string]any{
-			"hookEventName": payload.HookEventName,
-			"toolName":      payload.ToolName,
-			"sessionID":     payload.SessionID,
-		}),
+		attr.SlogHookSource("claude"),
+		attr.SlogHookEvent(payload.HookEventName),
+		attr.SlogToolName(toolName),
+		attr.SlogGenAIConversationID(sessionID),
+		attr.SlogProjectSlug(projectSlugHint),
+		attr.SlogHookHasPluginAuth(hasPluginAuth),
 	)
 
-	if hasOptionalPluginAuth(payload) {
+	if hasPluginAuth {
 		// Auth is optional. Returning a 401 on failure deadlocks the client:
 		// send_hook.sh maps any non-2xx to "block all tool calls", but
 		// recovering (e.g. `gram login`) requires Bash, which the hook just
@@ -302,10 +365,28 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (*gen.
 		if authedCtx, err := s.authorizePluginRequest(ctx, *payload.ApikeyToken, *payload.ProjectSlugInput); err != nil {
 			s.logger.WarnContext(ctx, "plugin auth failed on claude hook; falling back to OTEL-buffered path",
 				attr.SlogEvent("claude_hook_auth_failed"),
+				attr.SlogHookSource("claude"),
+				attr.SlogHookEvent(payload.HookEventName),
+				attr.SlogProjectSlug(projectSlugHint),
 				attr.SlogError(err),
 			)
 		} else {
 			ctx = authedCtx
+			if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
+				attrs := []any{
+					attr.SlogEvent("claude_hook_auth_ok"),
+					attr.SlogHookSource("claude"),
+					attr.SlogHookEvent(payload.HookEventName),
+					attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
+				}
+				if authCtx.ProjectID != nil {
+					attrs = append(attrs, attr.SlogProjectID(authCtx.ProjectID.String()))
+				}
+				if authCtx.ProjectSlug != nil {
+					attrs = append(attrs, attr.SlogProjectSlug(*authCtx.ProjectSlug))
+				}
+				s.logger.InfoContext(ctx, "plugin auth ok on claude hook", attrs...)
+			}
 		}
 	}
 
@@ -375,7 +456,18 @@ func (s *Service) authorizePluginRequest(ctx context.Context, key, projectSlug s
 
 func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 	if payload.SessionID == nil || *payload.SessionID == "" {
-		s.logger.WarnContext(ctx, "Tool event called without session ID")
+		attrs := []any{
+			attr.SlogEvent("claude_hook_no_session"),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent(payload.HookEventName),
+		}
+		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
+			attrs = append(attrs, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+			if authCtx.ProjectID != nil {
+				attrs = append(attrs, attr.SlogProjectID(authCtx.ProjectID.String()))
+			}
+		}
+		s.logger.WarnContext(ctx, "Tool event called without session ID", attrs...)
 		return
 	}
 
@@ -393,7 +485,20 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 		s.persistHook(ctx, payload, &metadata)
 	} else {
 		if err := s.bufferHook(ctx, sessionID, payload); err != nil {
-			s.logger.ErrorContext(ctx, "Failed to buffer hook", attr.SlogError(err))
+			attrs := []any{
+				attr.SlogEvent("claude_hook_buffer_failed"),
+				attr.SlogHookSource("claude"),
+				attr.SlogHookEvent(payload.HookEventName),
+				attr.SlogGenAIConversationID(sessionID),
+				attr.SlogError(err),
+			}
+			if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
+				attrs = append(attrs, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+				if authCtx.ProjectID != nil {
+					attrs = append(attrs, attr.SlogProjectID(authCtx.ProjectID.String()))
+				}
+			}
+			s.logger.ErrorContext(ctx, "Failed to buffer hook", attrs...)
 		}
 	}
 }
@@ -511,6 +616,10 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 			// buffered hook will be re-persisted once metadata arrives.
 			s.logger.WarnContext(ctx, "claude PreToolUse fired before session metadata available; allowing tool call",
 				attr.SlogEvent("claude_hook_pretooluse_no_metadata"),
+				attr.SlogHookSource("claude"),
+				attr.SlogHookEvent(payload.HookEventName),
+				attr.SlogGenAIConversationID(sessionID),
+				attr.SlogToolName(rawToolName),
 				attr.SlogError(err),
 			)
 			if output != nil {
@@ -532,13 +641,15 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	if denied {
 		s.logger.InfoContext(ctx, "denying claude tool call: failed gram toolset validation",
 			attr.SlogEvent("claude_hook_denied"),
-			attr.SlogValueAny(map[string]any{
-				"hookEventName": payload.HookEventName,
-				"toolName":      rawToolName,
-				"reason":        detail,
-				"policyID":      policy.ID,
-				"policyName":    policy.Name,
-			}),
+			attr.SlogHookSource("claude"),
+			attr.SlogHookEvent(payload.HookEventName),
+			attr.SlogOrganizationID(metadata.GramOrgID),
+			attr.SlogProjectID(metadata.ProjectID),
+			attr.SlogGenAIConversationID(sessionID),
+			attr.SlogToolName(rawToolName),
+			attr.SlogHookBlockReason(detail),
+			attr.SlogRiskPolicyID(policy.ID),
+			attr.SlogRiskPolicyName(policy.Name),
 		)
 		auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
 		userReason := renderUserBlockReason(policy.UserMessage, auditReason)

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -20,29 +20,30 @@ import (
 )
 
 func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.CodexHookResult, error) {
+	logger := s.logger.With(
+		attr.SlogHookSource("codex"),
+		attr.SlogHookEvent(payload.HookEventName),
+		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+		attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
+	)
+
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		s.logger.WarnContext(ctx, "rejected unauthorized codex hook request",
+		logger.WarnContext(ctx, "rejected unauthorized codex hook request",
 			attr.SlogEvent("codex_hook_unauthorized"),
-			attr.SlogHookSource("codex"),
-			attr.SlogHookEvent(payload.HookEventName),
-			attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
-			attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
 		)
 		return nil, oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
 
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
-
-	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Codex: %s", payload.HookEventName),
-		attr.SlogEvent("codex_hook"),
-		attr.SlogHookSource("codex"),
-		attr.SlogHookEvent(payload.HookEventName),
+	logger = logger.With(
 		attr.SlogOrganizationID(orgID),
 		attr.SlogProjectID(projectID),
-		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
-		attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
+	)
+
+	logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Codex: %s", payload.HookEventName),
+		attr.SlogEvent("codex_hook"),
 	)
 
 	var blockReason, userReason string
@@ -58,13 +59,8 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 		if policy != nil {
 			toolName := conv.PtrValOr(payload.ToolName, "")
 			if detail, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, payload.ToolInput, toolName, orgID); denied {
-				s.logger.InfoContext(ctx, "denying codex tool call: failed gram toolset validation",
+				logger.InfoContext(ctx, "denying codex tool call: failed gram toolset validation",
 					attr.SlogEvent("codex_hook_denied"),
-					attr.SlogHookSource("codex"),
-					attr.SlogHookEvent(payload.HookEventName),
-					attr.SlogOrganizationID(orgID),
-					attr.SlogProjectID(projectID),
-					attr.SlogToolName(toolName),
 					attr.SlogHookBlockReason(detail),
 					attr.SlogRiskPolicyID(policy.ID),
 					attr.SlogRiskPolicyName(policy.Name),

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -22,19 +22,28 @@ import (
 func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.CodexHookResult, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		s.logger.WarnContext(ctx, "rejected unauthorized codex hook request",
+			attr.SlogEvent("codex_hook_unauthorized"),
+			attr.SlogHookSource("codex"),
+			attr.SlogHookEvent(payload.HookEventName),
+			attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+			attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
+		)
 		return nil, oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
 
-	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Codex: %s", payload.HookEventName),
-		attr.SlogEvent("codex_hook"),
-		attr.SlogValueAny(map[string]any{
-			"hookEventName": payload.HookEventName,
-			"toolName":      payload.ToolName,
-		}),
-	)
-
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
+
+	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Codex: %s", payload.HookEventName),
+		attr.SlogEvent("codex_hook"),
+		attr.SlogHookSource("codex"),
+		attr.SlogHookEvent(payload.HookEventName),
+		attr.SlogOrganizationID(orgID),
+		attr.SlogProjectID(projectID),
+		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+		attr.SlogGenAIConversationID(conv.PtrValOr(payload.SessionID, "")),
+	)
 
 	var blockReason, userReason string
 
@@ -51,13 +60,14 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 			if detail, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, payload.ToolInput, toolName, orgID); denied {
 				s.logger.InfoContext(ctx, "denying codex tool call: failed gram toolset validation",
 					attr.SlogEvent("codex_hook_denied"),
-					attr.SlogValueAny(map[string]any{
-						"hookEventName": payload.HookEventName,
-						"toolName":      toolName,
-						"reason":        detail,
-						"policyID":      policy.ID,
-						"policyName":    policy.Name,
-					}),
+					attr.SlogHookSource("codex"),
+					attr.SlogHookEvent(payload.HookEventName),
+					attr.SlogOrganizationID(orgID),
+					attr.SlogProjectID(projectID),
+					attr.SlogToolName(toolName),
+					attr.SlogHookBlockReason(detail),
+					attr.SlogRiskPolicyID(policy.ID),
+					attr.SlogRiskPolicyName(policy.Name),
 				)
 				blockReason = fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
 				userReason = renderUserBlockReason(policy.UserMessage, blockReason)

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -42,7 +42,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (*gen.Co
 		attr.SlogProjectID(projectID),
 	)
 
-	logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Codex: %s", payload.HookEventName),
+	logger.InfoContext(ctx, "codex hook received",
 		attr.SlogEvent("codex_hook"),
 	)
 

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -47,7 +47,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 		attr.SlogProjectID(projectID),
 	)
 
-	logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Cursor: %s", payload.HookEventName),
+	logger.InfoContext(ctx, "cursor hook received",
 		attr.SlogEvent("cursor_hook"),
 	)
 

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -26,19 +26,30 @@ import (
 func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.CursorHookResult, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		s.logger.WarnContext(ctx, "rejected unauthorized cursor hook request",
+			attr.SlogEvent("cursor_hook_unauthorized"),
+			attr.SlogHookSource("cursor"),
+			attr.SlogHookEvent(payload.HookEventName),
+			attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+			attr.SlogGenAIConversationID(conv.PtrValOr(payload.ConversationID, "")),
+			attr.SlogAuthUserEmail(conv.PtrValOr(payload.UserEmail, "")),
+		)
 		return nil, oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
 
-	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Cursor: %s", payload.HookEventName),
-		attr.SlogEvent("cursor_hook"),
-		attr.SlogValueAny(map[string]any{
-			"hookEventName": payload.HookEventName,
-			"toolName":      payload.ToolName,
-		}),
-	)
-
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
+
+	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Cursor: %s", payload.HookEventName),
+		attr.SlogEvent("cursor_hook"),
+		attr.SlogHookSource("cursor"),
+		attr.SlogHookEvent(payload.HookEventName),
+		attr.SlogOrganizationID(orgID),
+		attr.SlogProjectID(projectID),
+		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+		attr.SlogGenAIConversationID(conv.PtrValOr(payload.ConversationID, "")),
+		attr.SlogAuthUserEmail(conv.PtrValOr(payload.UserEmail, "")),
+	)
 
 	result := &gen.CursorHookResult{
 		Permission:        nil,
@@ -74,13 +85,14 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 		if detail, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, payload.ToolInput, toolName, orgID); denied {
 			s.logger.InfoContext(ctx, "denying cursor tool call: failed gram toolset validation",
 				attr.SlogEvent("cursor_hook_denied"),
-				attr.SlogValueAny(map[string]any{
-					"hookEventName": payload.HookEventName,
-					"toolName":      conv.PtrValOr(payload.ToolName, ""),
-					"reason":        detail,
-					"policyID":      policy.ID,
-					"policyName":    policy.Name,
-				}),
+				attr.SlogHookSource("cursor"),
+				attr.SlogHookEvent(payload.HookEventName),
+				attr.SlogOrganizationID(orgID),
+				attr.SlogProjectID(projectID),
+				attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+				attr.SlogHookBlockReason(detail),
+				attr.SlogRiskPolicyID(policy.ID),
+				attr.SlogRiskPolicyName(policy.Name),
 			)
 			auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
 			userReason := renderUserBlockReason(policy.UserMessage, auditReason)

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -24,31 +24,31 @@ import (
 
 // Cursor is the endpoint for Cursor hook events
 func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.CursorHookResult, error) {
+	logger := s.logger.With(
+		attr.SlogHookSource("cursor"),
+		attr.SlogHookEvent(payload.HookEventName),
+		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
+		attr.SlogGenAIConversationID(conv.PtrValOr(payload.ConversationID, "")),
+		attr.SlogAuthUserEmail(conv.PtrValOr(payload.UserEmail, "")),
+	)
+
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
-		s.logger.WarnContext(ctx, "rejected unauthorized cursor hook request",
+		logger.WarnContext(ctx, "rejected unauthorized cursor hook request",
 			attr.SlogEvent("cursor_hook_unauthorized"),
-			attr.SlogHookSource("cursor"),
-			attr.SlogHookEvent(payload.HookEventName),
-			attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
-			attr.SlogGenAIConversationID(conv.PtrValOr(payload.ConversationID, "")),
-			attr.SlogAuthUserEmail(conv.PtrValOr(payload.UserEmail, "")),
 		)
 		return nil, oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
 
 	orgID := authCtx.ActiveOrganizationID
 	projectID := authCtx.ProjectID.String()
-
-	s.logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Cursor: %s", payload.HookEventName),
-		attr.SlogEvent("cursor_hook"),
-		attr.SlogHookSource("cursor"),
-		attr.SlogHookEvent(payload.HookEventName),
+	logger = logger.With(
 		attr.SlogOrganizationID(orgID),
 		attr.SlogProjectID(projectID),
-		attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
-		attr.SlogGenAIConversationID(conv.PtrValOr(payload.ConversationID, "")),
-		attr.SlogAuthUserEmail(conv.PtrValOr(payload.UserEmail, "")),
+	)
+
+	logger.InfoContext(ctx, fmt.Sprintf("🪝 HOOK Cursor: %s", payload.HookEventName),
+		attr.SlogEvent("cursor_hook"),
 	)
 
 	result := &gen.CursorHookResult{
@@ -83,13 +83,8 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (*gen.
 		}
 		toolName := strings.TrimPrefix(conv.PtrValOr(payload.ToolName, ""), "MCP:")
 		if detail, denied := s.shadowMCPClient.ValidateToolsetCall(ctx, payload.ToolInput, toolName, orgID); denied {
-			s.logger.InfoContext(ctx, "denying cursor tool call: failed gram toolset validation",
+			logger.InfoContext(ctx, "denying cursor tool call: failed gram toolset validation",
 				attr.SlogEvent("cursor_hook_denied"),
-				attr.SlogHookSource("cursor"),
-				attr.SlogHookEvent(payload.HookEventName),
-				attr.SlogOrganizationID(orgID),
-				attr.SlogProjectID(projectID),
-				attr.SlogToolName(conv.PtrValOr(payload.ToolName, "")),
 				attr.SlogHookBlockReason(detail),
 				attr.SlogRiskPolicyID(policy.ID),
 				attr.SlogRiskPolicyName(policy.Name),

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
@@ -150,6 +151,23 @@ func generateSpanID() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// withAuthContext returns a child logger with gram.org.id and gram.project.id
+// attached when an AuthContext is present on ctx. Falls through to logger
+// unchanged when there's no auth context — callers can use the result
+// regardless and the unauthenticated path still emits a (less attributed)
+// log line.
+func (s *Service) withAuthContext(ctx context.Context, logger *slog.Logger) *slog.Logger {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil {
+		return logger
+	}
+	logger = logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+	if authCtx.ProjectID != nil {
+		logger = logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
+	}
+	return logger
 }
 
 // lookupShadowMCPBlockingPolicy returns the first enabled shadow_mcp policy


### PR DESCRIPTION
## Summary
- Make Claude / Cursor / Codex / OTEL Logs / OTEL Metrics hook routes filterable in Datadog by `gram.org.id`, `gram.project.id`, `gram.hook.source`, and `gram.hook.event`.
- Replace nested `SlogValueAny(map[...])` payloads — which Datadog cannot facet on — with top-level slog attrs.
- Log on every early-return path that previously returned silently: unauthorized requests on Cursor / Codex / Logs / Metrics, missing-session-id branches on Claude / Logs, cache-set failures, buffer failures, and plugin-auth success/failure on Claude. This makes a silent 401 or no-session request visible when debugging hook setup for a given org/project.
- Add `attr.Slog*` helpers for `gram.hook.event`, `gram.hook.source`, `gram.hook.block_reason`, `gram.hook.has_plugin_auth`, and `gram.risk.policy_name` (lint enforces `attr.Slog*` over raw `slog.*`).

## Datadog query examples (after deploy)
- All hook traffic for an org: `@gram.org.id:<ORG_ID> @gram.hook.source:*`
- Just OTEL Logs ingest for a project: `@gram.project.id:<PROJECT_ID> @gram.hook.event:Logs`
- Unauthorized hits per source: `@event:*_unauthorized`
- Denied tool calls: `@event:*_hook_denied @gram.org.id:<ORG_ID>`

## Test plan
- [x] `mise build:server`
- [x] `mise lint:server`
- [x] `go test ./internal/hooks/...`
- [ ] Smoke against dev: send a Claude hook with bad creds and verify `claude_hook_auth_failed` log carries `gram.hook.source` + `gram.project.slug`
- [ ] Smoke against dev: send a Cursor hook with no creds and verify the `cursor_hook_unauthorized` log appears (previously silent 401)
- [ ] Smoke against dev: send a Claude OTEL `Logs` request with a payload lacking `session.id` and verify `claude_logs_no_session` log appears with `gram.org.id` / `gram.project.id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)