### PR TITLE
fix: dedupe chat asset writes and idempotently upload to prevent GCS 429s

### DIFF
--- a/.changeset/age-2319-dedupe-chat-asset-writes.md
+++ b/.changeset/age-2319-dedupe-chat-asset-writes.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+dedupe chat asset writes and idempotently upload to prevent GCS 429s

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,8 @@ require (
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
 	golang.org/x/tools v0.44.0
+	google.golang.org/api v0.274.0
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.0
@@ -329,11 +331,9 @@ require (
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	google.golang.org/api v0.274.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/server/internal/assets/store.go
+++ b/server/internal/assets/store.go
@@ -16,6 +16,14 @@ type BlobStore interface {
 	Exists(ctx context.Context, objectURL *url.URL) (bool, error)
 	Read(ctx context.Context, objectURL *url.URL) (rdr io.ReadCloser, err error)
 	ReadAt(ctx context.Context, objectURL *url.URL) (rdr ReaderAtCloser, size int64, err error)
+	// Write writes the object such that retries and concurrent racers cannot
+	// produce duplicate work. Intended for content-addressable callers (path
+	// derived from a hash of the bytes) where overwriting an existing object
+	// is wasted work and, on GCS, hot-keys can hit the per-object 1-write/sec
+	// rate limit. Backends that support server-side preconditions (GCS) attach
+	// a "create only if absent" condition and report "already exists" as
+	// success; backends without native support overwrite, which produces an
+	// identical result for content-addressable payloads.
 	Write(ctx context.Context, objectPath string, contentType string, contentLength int64) (io.WriteCloser, *url.URL, error)
 	PresignRead(ctx context.Context, objectPath string, ttl time.Duration) (*url.URL, error)
 }

--- a/server/internal/assets/store_gcs.go
+++ b/server/internal/assets/store_gcs.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -128,16 +131,61 @@ func (gbs *GCSBlobStore) ReadAt(ctx context.Context, u *url.URL) (ReaderAtCloser
 	}, attrs.Size, nil
 }
 
+// Write attaches a DoesNotExist:true precondition so retries and concurrent
+// racers cannot produce duplicates: a retry after a transient failure can't
+// re-create the object, and concurrent writers racing to the same
+// content-addressable key won't trip GCS's per-object 1-write/sec limit with
+// ResourceExhausted — the loser instead returns FailedPrecondition, which
+// gcsConditionalWriter treats as success since the object is already in the
+// desired state. The precondition also flips the SDK's default
+// RetryIdempotent policy on for this Writer, so transient errors retry
+// automatically.
 func (gbs *GCSBlobStore) Write(ctx context.Context, subpath string, contentType string, contentLength int64) (io.WriteCloser, *url.URL, error) {
 	uri, err := gbs.getBucketURI(subpath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate asset path: %w", err)
 	}
 
-	w := gbs.bucket.Object(strings.TrimPrefix(uri.Path, "/")).NewWriter(ctx)
+	obj := gbs.bucket.Object(strings.TrimPrefix(uri.Path, "/")).If(storage.Conditions{
+		GenerationMatch:        0,
+		GenerationNotMatch:     0,
+		DoesNotExist:           true,
+		MetagenerationMatch:    0,
+		MetagenerationNotMatch: 0,
+	})
+	w := obj.NewWriter(ctx)
 	w.ContentType = contentType
 
-	return w, uri, nil
+	return &gcsConditionalWriter{Writer: w}, uri, nil
+}
+
+// gcsConditionalWriter wraps storage.Writer so a FailedPrecondition on Close
+// (from the DoesNotExist precondition) is reported as success — the object is
+// already in the desired state, which is what the caller wanted.
+type gcsConditionalWriter struct {
+	*storage.Writer
+}
+
+func (g *gcsConditionalWriter) Close() error {
+	err := g.Writer.Close()
+	if err == nil {
+		return nil
+	}
+	if isPreconditionFailed(err) {
+		return nil
+	}
+	return fmt.Errorf("close gcs writer: %w", err)
+}
+
+func isPreconditionFailed(err error) bool {
+	if status.Code(err) == codes.FailedPrecondition {
+		return true
+	}
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusPreconditionFailed {
+		return true
+	}
+	return false
 }
 
 func (gbs *GCSBlobStore) PresignRead(ctx context.Context, subpath string, ttl time.Duration) (*url.URL, error) {

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1277,6 +1277,11 @@ const (
 	// maxAssetReadSize is the maximum size of message content that will be
 	// read from asset storage to prevent memory issues.
 	maxAssetReadSize = 20 * 1024 * 1024 // 20 MiB
+
+	// maxConcurrentChatAssetWork bounds parallelism for the per-batch marshal
+	// and asset-upload phases in storeMessages, capping goroutines, memory,
+	// and outbound connections for arbitrarily large batches.
+	maxConcurrentChatAssetWork = 32
 )
 
 func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, assetStorage assets.BlobStore, rows []chatMessageRow) error {
@@ -1291,57 +1296,110 @@ func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, asset
 		err      error // non-nil if upload failed
 	}
 
-	results := make([]uploadResult, len(rows))
-
-	// Upload all messages to asset storage in parallel.
-	// We don't use errgroup's error propagation here because we want to
-	// continue even if some uploads fail - we'll record the errors and
-	// still insert the messages with their plain text content.
-	var wg errgroup.Group
+	// Phase 1: marshal + hash + path in parallel. Asset paths are
+	// content-addressable (sha256 of jsonData), so the path also serves as
+	// the dedup key in Phase 2.
+	type rowPrep struct {
+		jsonData []byte
+		path     string
+		err      error
+	}
+	preps := make([]rowPrep, len(rows))
+	var marshalWg errgroup.Group
+	marshalWg.SetLimit(maxConcurrentChatAssetWork)
 	for i, row := range rows {
-		wg.Go(func() error {
-			// Marshal the message content to JSON.
+		marshalWg.Go(func() error {
 			jsonData, err := openrouter.GetContentJSON(row.content)
 			if err != nil {
-				results[i] = uploadResult{assetURL: "", jsonData: nil, err: fmt.Errorf("marshal message content: %w", err)}
-				return nil // Don't abort other uploads
+				preps[i] = rowPrep{jsonData: nil, path: "", err: fmt.Errorf("marshal message content: %w", err)}
+				return nil
 			}
-
-			// Compute SHA256 hash for the content-addressable path.
 			hash := sha256.Sum256(jsonData)
 			hashHex := hex.EncodeToString(hash[:])
-
-			// Build asset path: <project_id>/chats/<chat_id>/<sha256_hex>.json
 			assetPath := path.Join(row.projectID.String(), "chats", row.chatID.String(), hashHex+".json")
+			preps[i] = rowPrep{jsonData: jsonData, path: assetPath, err: nil}
+			return nil
+		})
+	}
+	if err := marshalWg.Wait(); err != nil {
+		// Goroutines record per-row failures into preps[i].err and return nil,
+		// so a non-nil error here signals an unexpected future change. Log and
+		// continue with whatever was prepared.
+		logger.ErrorContext(ctx, "chat asset marshal phase reported unexpected error", attr.SlogError(err))
+	}
 
-			// Upload to asset storage.
-			writer, assetURL, err := assetStorage.Write(ctx, assetPath, "application/json", int64(len(jsonData)))
+	// Phase 2: dedup by asset path so duplicate-content rows dispatch a
+	// single upload. Without this, concurrent writers race to the same GCS
+	// object and hit the per-object 1-write/sec rate limit.
+	leaders := make(map[string]int, len(rows)) // assetPath -> first row index that dispatches the upload
+	for i, prep := range preps {
+		if prep.err != nil {
+			continue
+		}
+		if _, ok := leaders[prep.path]; !ok {
+			leaders[prep.path] = i
+		}
+	}
+
+	results := make([]uploadResult, len(rows))
+
+	// Phase 3: upload deduplicated leaders to asset storage in parallel. The
+	// BlobStore.Write contract attaches a "create only if absent" precondition
+	// on GCS so cross-batch races resolve as idempotent no-ops. We don't use
+	// errgroup's error propagation because we want to continue even if some
+	// uploads fail — we'll record the errors and still insert the messages
+	// with their plain text content.
+	var uploadWg errgroup.Group
+	uploadWg.SetLimit(maxConcurrentChatAssetWork)
+	for assetPath, leader := range leaders {
+		uploadWg.Go(func() error {
+			prep := preps[leader]
+
+			writer, assetURL, err := assetStorage.Write(ctx, assetPath, "application/json", int64(len(prep.jsonData)))
 			if err != nil {
-				results[i] = uploadResult{assetURL: "", jsonData: jsonData, err: fmt.Errorf("create asset writer: %w", err)}
+				results[leader] = uploadResult{assetURL: "", jsonData: prep.jsonData, err: fmt.Errorf("create asset writer: %w", err)}
 				return nil
 			}
 
-			if _, err := io.Copy(writer, bytes.NewReader(jsonData)); err != nil {
+			if _, err := io.Copy(writer, bytes.NewReader(prep.jsonData)); err != nil {
 				_ = writer.Close()
-				results[i] = uploadResult{assetURL: "", jsonData: jsonData, err: fmt.Errorf("write asset content: %w", err)}
+				results[leader] = uploadResult{assetURL: "", jsonData: prep.jsonData, err: fmt.Errorf("write asset content: %w", err)}
 				return nil
 			}
 
 			if err := writer.Close(); err != nil {
-				results[i] = uploadResult{assetURL: "", jsonData: jsonData, err: fmt.Errorf("finalize asset upload: %w", err)}
+				results[leader] = uploadResult{assetURL: "", jsonData: prep.jsonData, err: fmt.Errorf("finalize asset upload: %w", err)}
 				return nil
 			}
 
-			results[i] = uploadResult{
+			results[leader] = uploadResult{
 				assetURL: assetURL.String(),
-				jsonData: jsonData,
+				jsonData: prep.jsonData,
 				err:      nil,
 			}
 			return nil
 		})
 	}
 
-	_ = wg.Wait() // Always succeeds since goroutines don't return errors
+	if err := uploadWg.Wait(); err != nil {
+		// Goroutines record per-row failures into results[i].err and return
+		// nil, so a non-nil error here signals an unexpected future change.
+		// Log and continue with whatever was uploaded.
+		logger.ErrorContext(ctx, "chat asset upload phase reported unexpected error", attr.SlogError(err))
+	}
+
+	// Fan leader results back out to follower rows and record marshal errors.
+	for i := range rows {
+		prep := preps[i]
+		if prep.err != nil {
+			results[i] = uploadResult{assetURL: "", jsonData: nil, err: prep.err}
+			continue
+		}
+		if leader, ok := leaders[prep.path]; ok && leader != i {
+			res := results[leader]
+			results[i] = uploadResult{assetURL: res.assetURL, jsonData: prep.jsonData, err: res.err}
+		}
+	}
 
 	// Build database params from upload results.
 	dbrows := make([]repo.CreateChatMessageParams, len(rows))

--- a/server/internal/chat/storage_dedup_test.go
+++ b/server/internal/chat/storage_dedup_test.go
@@ -1,0 +1,126 @@
+package chat_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/assets"
+	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+// countingBlobStore wraps a BlobStore and records every Write call so tests
+// can assert that content-addressable dedup avoids redundant uploads.
+type countingBlobStore struct {
+	inner  assets.BlobStore
+	mu     sync.Mutex
+	writes int
+}
+
+func newCountingBlobStore(t *testing.T) *countingBlobStore {
+	t.Helper()
+	return &countingBlobStore{inner: assetstest.NewTestBlobStore(t)}
+}
+
+func (c *countingBlobStore) writeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writes
+}
+
+func (c *countingBlobStore) Exists(ctx context.Context, u *url.URL) (bool, error) {
+	ok, err := c.inner.Exists(ctx, u)
+	if err != nil {
+		return false, fmt.Errorf("countingBlobStore exists: %w", err)
+	}
+	return ok, nil
+}
+
+func (c *countingBlobStore) Read(ctx context.Context, u *url.URL) (io.ReadCloser, error) {
+	rc, err := c.inner.Read(ctx, u)
+	if err != nil {
+		return nil, fmt.Errorf("countingBlobStore read: %w", err)
+	}
+	return rc, nil
+}
+
+func (c *countingBlobStore) ReadAt(ctx context.Context, u *url.URL) (assets.ReaderAtCloser, int64, error) {
+	r, n, err := c.inner.ReadAt(ctx, u)
+	if err != nil {
+		return nil, 0, fmt.Errorf("countingBlobStore readAt: %w", err)
+	}
+	return r, n, nil
+}
+
+func (c *countingBlobStore) Write(ctx context.Context, p string, ct string, cl int64) (io.WriteCloser, *url.URL, error) {
+	c.mu.Lock()
+	c.writes++
+	c.mu.Unlock()
+	w, u, err := c.inner.Write(ctx, p, ct, cl)
+	if err != nil {
+		return nil, nil, fmt.Errorf("countingBlobStore write: %w", err)
+	}
+	return w, u, nil
+}
+
+func (c *countingBlobStore) PresignRead(ctx context.Context, p string, ttl time.Duration) (*url.URL, error) {
+	u, err := c.inner.PresignRead(ctx, p, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("countingBlobStore presignRead: %w", err)
+	}
+	return u, nil
+}
+
+// Rows with identical content within a single batch hash to the same
+// content-addressable asset path. storeMessages must dispatch a single upload
+// per unique content and fan the resulting asset URL out to every duplicate
+// row — otherwise concurrent writes to the same GCS object trip the per-object
+// 1-write/sec rate limit (AGE-2319).
+func TestStoreMessages_DeduplicatesContentAddressableWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, projectID, orgID := newTestChatContext(t)
+
+	counting := newCountingBlobStore(t)
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, counting)
+	t.Cleanup(func() { _ = shutdown(t.Context()) })
+
+	s := chat.NewChatMessageCaptureStrategy(testenv.NewLogger(t), conn, writer)
+	chatID := uuid.New()
+
+	// Two user messages with identical content + one distinct system message.
+	// Three rows total; two unique contents.
+	req := makeRequest(chatID, projectID, orgID,
+		openrouter.CreateMessageUser("hello"),
+		openrouter.CreateMessageUser("hello"),
+		openrouter.CreateMessageSystem("preamble"),
+	)
+
+	_, err := s.StartOrResumeChat(ctx, req)
+	require.NoError(t, err)
+
+	rows := listAllMessages(t, ctx, conn, chatID, projectID)
+	require.Len(t, rows, 3)
+
+	require.Equal(t, 2, counting.writeCount(), "one Write per unique content, not per row")
+
+	var userURLs []string
+	for _, r := range rows {
+		if r.Role == "user" {
+			userURLs = append(userURLs, r.ContentAssetUrl.String)
+		}
+	}
+	require.Len(t, userURLs, 2)
+	require.NotEmpty(t, userURLs[0])
+	require.Equal(t, userURLs[0], userURLs[1], "duplicate-content rows must share the same content_asset_url")
+}


### PR DESCRIPTION
Datadog showed `gram-server` "failed to upload message to asset storage" errors climbing from 12/day to 7,028/day over a week, all from GCS's per-object 1-write/sec rate limit. Single chat completion requests dispatched hundreds of parallel uploads to the same content-addressable key, racing to write identical bytes.

`storeMessages` now dedupes rows by their content-addressable asset path so duplicate-content messages within a single batch dispatch a single upload, fanning the result to follower rows. Marshal+hash and uploads run as two parallel phases capped at `maxConcurrentChatAssetWork` goroutines.

`BlobStore.Write` is now idempotent across all callers. On GCS it attaches a `DoesNotExist:true` precondition: the upload becomes idempotent (engaging the SDK's default retry on `ResourceExhausted`), and a small wrapper treats `FailedPrecondition` on `Close` as success since the object is already in the desired state. `FSBlobStore`/`S3BlobStore` inherently overwrite, which is safe because every `Write` caller in the codebase uses content-addressable paths.

Linear: [AGE-2319](https://linear.app/speakeasy/issue/AGE-2319/bug-gcs-resourceexhausted-causes-asset-storage-upload-failures)