### PR TITLE
fix: get stop hook working in cowork again

### DIFF
--- a/.changeset/wet-lamps-repeat.md
+++ b/.changeset/wet-lamps-repeat.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+fix: get stop hook working in cowork again

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -379,6 +379,11 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 		return
 	}
 
+	// Persistence outlives the request: Claude Code may close the connection
+	// the instant the hook returns (Stop especially), which would otherwise
+	// cancel the in-flight INSERT and drop the chat message.
+	ctx = context.WithoutCancel(ctx)
+
 	sessionID := *payload.SessionID
 
 	// Both plugin-authenticated and OTEL-only requests go through the same
@@ -390,7 +395,12 @@ func (s *Service) recordHook(ctx context.Context, payload *gen.ClaudePayload) {
 	// avoids this because its payload includes UserEmail directly.
 	metadata, err := s.getSessionMetadata(ctx, sessionID)
 	if err == nil {
-		s.persistHook(ctx, payload, &metadata)
+		// Persistence does DB writes plus a Temporal workflow start, which
+		// can take longer than Claude Code is willing to wait for a hook
+		// response (Stop especially — the client closes the connection
+		// immediately on the response). Run it detached so the response
+		// returns promptly and the work completes in the background.
+		go s.persistHook(ctx, payload, &metadata)
 	} else {
 		if err := s.bufferHook(ctx, sessionID, payload); err != nil {
 			s.logger.ErrorContext(ctx, "Failed to buffer hook", attr.SlogError(err))

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -138,6 +138,11 @@ func (s *Service) recordCursorHook(ctx context.Context, payload *gen.CursorPaylo
 		return
 	}
 
+	// Persistence outlives the request: the client may close the connection
+	// the instant the hook returns, which would otherwise cancel in-flight
+	// INSERTs and drop the chat message.
+	ctx = context.WithoutCancel(ctx)
+
 	userEmail := conv.PtrValOr(payload.UserEmail, "")
 	userID := s.resolveUserByEmail(ctx, userEmail, orgID)
 
@@ -151,7 +156,12 @@ func (s *Service) recordCursorHook(ctx context.Context, payload *gen.CursorPaylo
 		ProjectID:   projectID,
 	}
 
-	s.persistCursorHook(ctx, payload, metadata, blockReason)
+	// Persistence does DB + ClickHouse writes that can take longer than the
+	// client is willing to wait for a hook response (`stop` especially —
+	// curl in send_hook.sh has a 10s --max-time and the client closes the
+	// connection the moment the response lands). Run detached so the
+	// response returns promptly and the work completes in the background.
+	go s.persistCursorHook(ctx, payload, metadata, blockReason)
 }
 
 func (s *Service) persistCursorHook(ctx context.Context, payload *gen.CursorPayload, metadata *SessionMetadata, blockReason string) {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -69,12 +69,15 @@ func pluginManifestVersion(cfg GenerateConfig) string {
 }
 
 // claudeHookAsyncFlag returns the async flag for a Claude hook event.
-// Blocking events (PreToolUse, UserPromptSubmit) return false so Claude
-// waits for the deny/allow decision. All others return true for
-// fire-and-forget telemetry so Claude is not held up.
+// PreToolUse and UserPromptSubmit are blocking so Claude waits for the
+// deny/allow decision. Stop must also be blocking: when async=true,
+// Cowork (Claude Code) appears to skip dispatching the Stop hook entirely
+// — an apparent bug on the client side. Marking it synchronous is the
+// only reliable way to get Stop events to fire. All other events return
+// true for fire-and-forget telemetry so Claude is not held up.
 func claudeHookAsyncFlag(event string) *bool {
 	switch event {
-	case "UserPromptSubmit", "PreToolUse":
+	case "UserPromptSubmit", "PreToolUse", "Stop":
 		f := false
 		return &f
 	default:


### PR DESCRIPTION
It appears Cowork will not fire the stop hook consistently unless it is set to synchronous...