### PR TITLE
mig: runtime v2 foundation — bootstrap endpoint, assistant-scoped tokens

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1139,6 +1139,11 @@ WHERE deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS assistant_runtimes (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
+  -- v1 rows pin one VM per thread and stamp the thread's id here. v2 rows
+  -- host every thread under one assistant and use uuid.Nil as a sentinel —
+  -- the foreign key to assistant_threads is intentionally absent so the
+  -- sentinel does not have to back to a real row, and so reaping a thread
+  -- does not cascade-delete the assistant's shared v2 runtime.
   assistant_thread_id uuid NOT NULL,
   assistant_id uuid NOT NULL,
   project_id uuid NOT NULL,
@@ -1149,6 +1154,7 @@ CREATE TABLE IF NOT EXISTS assistant_runtimes (
   last_heartbeat_at timestamptz,
   backend_metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   ended_at timestamptz,
+  runtime_version smallint NOT NULL DEFAULT 1,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -1157,14 +1163,17 @@ CREATE TABLE IF NOT EXISTS assistant_runtimes (
   ended boolean NOT NULL GENERATED ALWAYS AS (ended_at IS NOT NULL) stored,
 
   CONSTRAINT assistant_runtimes_pkey PRIMARY KEY (id),
-  CONSTRAINT assistant_runtimes_assistant_thread_id_fkey FOREIGN KEY (assistant_thread_id) REFERENCES assistant_threads(id) ON DELETE CASCADE,
   CONSTRAINT assistant_runtimes_assistant_id_fkey FOREIGN KEY (assistant_id) REFERENCES assistants(id) ON DELETE CASCADE,
   CONSTRAINT assistant_runtimes_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS assistant_runtimes_assistant_thread_id_active_key
 ON assistant_runtimes (assistant_thread_id)
-WHERE deleted IS FALSE AND ended IS FALSE;
+WHERE deleted IS FALSE AND ended IS FALSE AND runtime_version = 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS assistant_runtimes_v2_one_per_assistant
+ON assistant_runtimes (project_id, assistant_id)
+WHERE runtime_version = 2 AND deleted IS FALSE AND ended IS FALSE;
 
 CREATE INDEX IF NOT EXISTS assistant_runtimes_project_id_assistant_id_state_idx
 ON assistant_runtimes (project_id, assistant_id, state)

--- a/server/internal/assistants/repo/models.go
+++ b/server/internal/assistants/repo/models.go
@@ -21,6 +21,7 @@ type AssistantRuntime struct {
 	LastHeartbeatAt     pgtype.Timestamptz
 	BackendMetadataJson []byte
 	EndedAt             pgtype.Timestamptz
+	RuntimeVersion      int16
 	CreatedAt           pgtype.Timestamptz
 	UpdatedAt           pgtype.Timestamptz
 	DeletedAt           pgtype.Timestamptz

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -460,7 +460,7 @@ func (q *Queries) FailAssistantThreadEvent(ctx context.Context, arg FailAssistan
 }
 
 const getActiveAssistantRuntimeByThreadID = `-- name: GetActiveAssistantRuntimeByThreadID :one
-SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
+SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, runtime_version, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
 WHERE assistant_thread_id = $1
   AND project_id = $2
   AND deleted IS FALSE
@@ -488,6 +488,7 @@ func (q *Queries) GetActiveAssistantRuntimeByThreadID(ctx context.Context, arg G
 		&i.LastHeartbeatAt,
 		&i.BackendMetadataJson,
 		&i.EndedAt,
+		&i.RuntimeVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -641,7 +642,7 @@ func (q *Queries) GetAssistantIgnoringDeleted(ctx context.Context, arg GetAssist
 }
 
 const getAssistantRuntime = `-- name: GetAssistantRuntime :one
-SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
+SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, runtime_version, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
 WHERE id = $1
   AND project_id = $2
 `
@@ -666,6 +667,7 @@ func (q *Queries) GetAssistantRuntime(ctx context.Context, arg GetAssistantRunti
 		&i.LastHeartbeatAt,
 		&i.BackendMetadataJson,
 		&i.EndedAt,
+		&i.RuntimeVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -676,7 +678,7 @@ func (q *Queries) GetAssistantRuntime(ctx context.Context, arg GetAssistantRunti
 }
 
 const getLatestAssistantRuntimeByThreadID = `-- name: GetLatestAssistantRuntimeByThreadID :one
-SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
+SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, runtime_version, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
 WHERE assistant_thread_id = $1
   AND project_id = $2
 ORDER BY created_at DESC
@@ -705,6 +707,7 @@ func (q *Queries) GetLatestAssistantRuntimeByThreadID(ctx context.Context, arg G
 		&i.LastHeartbeatAt,
 		&i.BackendMetadataJson,
 		&i.EndedAt,
+		&i.RuntimeVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -105,6 +105,7 @@ type AssistantRuntime struct {
 	LastHeartbeatAt     pgtype.Timestamptz
 	BackendMetadataJson []byte
 	EndedAt             pgtype.Timestamptz
+	RuntimeVersion      int16
 	CreatedAt           pgtype.Timestamptz
 	UpdatedAt           pgtype.Timestamptz
 	DeletedAt           pgtype.Timestamptz

--- a/server/migrations/20260514200205_age-2320-assistant-runtime-v2.sql
+++ b/server/migrations/20260514200205_age-2320-assistant-runtime-v2.sql
@@ -1,0 +1,10 @@
+-- atlas:txmode none
+
+-- Drop index "assistant_runtimes_assistant_thread_id_active_key" from table: "assistant_runtimes"
+DROP INDEX CONCURRENTLY "assistant_runtimes_assistant_thread_id_active_key";
+-- Modify "assistant_runtimes" table
+ALTER TABLE "assistant_runtimes" DROP CONSTRAINT "assistant_runtimes_assistant_thread_id_fkey", ADD COLUMN "runtime_version" smallint NOT NULL DEFAULT 1;
+-- Create index "assistant_runtimes_assistant_thread_id_active_key" to table: "assistant_runtimes"
+CREATE UNIQUE INDEX CONCURRENTLY "assistant_runtimes_assistant_thread_id_active_key" ON "assistant_runtimes" ("assistant_thread_id") WHERE ((deleted IS FALSE) AND (ended IS FALSE) AND (runtime_version = 1));
+-- Create index "assistant_runtimes_v2_one_per_assistant" to table: "assistant_runtimes"
+CREATE UNIQUE INDEX CONCURRENTLY "assistant_runtimes_v2_one_per_assistant" ON "assistant_runtimes" ("project_id", "assistant_id") WHERE ((runtime_version = 2) AND (deleted IS FALSE) AND (ended IS FALSE));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:SsofrDEE2APE3hATdXPKar00jXe5UHjfAo3D3rw2D9Y=
+h1:UmgzIUYQVlP1ykba7BHuD+Dtic85B2SuDT2MxY+yz9U=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -177,3 +177,4 @@ h1:SsofrDEE2APE3hATdXPKar00jXe5UHjfAo3D3rw2D9Y=
 20260513143640_add-organization-invitations.sql h1:ullg5rI+Zo173EOQ56n2B6UFQB5mGLljO2FqLTeJXiQ=
 20260513152016_alter-user-id-membership-to-be-nullable.sql h1:WXg7B2CQFX4uuXTJYiaNkMtjDhSrBsZqNl4rWR09d5U=
 20260514141917_org-metadata-add-slug-unique-index.sql h1:8snzreqjc8R39UL9bJGKeXl4WlnVaE9YOo8o8RV5GTk=
+20260514200205_age-2320-assistant-runtime-v2.sql h1:gkTPaBGw63rZlYLc2LZvsjlU/jdfZYIq0p6osNzP+5U=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/2835 so the database changes can land independently.