### PR TITLE
fix(auth): skip WorkOS reads when org already linked locally

### DIFF
--- a/.changeset/age-2324-skip-workos-reads-linked-orgs.md
+++ b/.changeset/age-2324-skip-workos-reads-linked-orgs.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+skip WorkOS reads when org already linked locally

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -38,6 +38,11 @@ type mockWorkOSFetcher struct {
 	// Track calls to CreateOrganization / CreateOrganizationMembership.
 	createdOrgs        []createdOrgRecord
 	createdMemberships []createdMembershipRecord
+
+	// Counters for reads. Steady-state logins (org already linked locally)
+	// must not hit either path; see TestE2E_Callback_LinkedOrgsSkipWorkOSReads.
+	getOrgCalls           int
+	ensureExternalIDCalls int
 }
 
 type createdOrgRecord struct {
@@ -53,6 +58,7 @@ func (m *mockWorkOSFetcher) ListUserMemberships(_ context.Context, userID string
 }
 
 func (m *mockWorkOSFetcher) GetOrganization(_ context.Context, orgID string) (*workos.Organization, error) {
+	m.getOrgCalls++
 	if org, ok := m.orgs[orgID]; ok {
 		return org, nil
 	}
@@ -64,6 +70,7 @@ func (m *mockWorkOSFetcher) EnsureUserExternalID(_ context.Context, _, _ string)
 }
 
 func (m *mockWorkOSFetcher) EnsureOrgExternalID(_ context.Context, _, _ string) error {
+	m.ensureExternalIDCalls++
 	return nil
 }
 
@@ -379,6 +386,76 @@ func TestE2E_Callback_ExistingUserWithDBOrgs(t *testing.T) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	assert.Equal(t, orgEntry.ID, authCtx.ActiveOrganizationID, "should use DB org, not WorkOS ghost org")
+}
+
+// TestE2E_Callback_LinkedOrgsSkipWorkOSReads verifies the AGE-2324 fix:
+// when every WorkOS membership maps to a local org row already linked by
+// workos_id, the per-membership loop must skip both GetOrganization and
+// EnsureOrgExternalID. Each retained call is one cross-region round-trip per
+// org per login, so this is the load-bearing assertion for the latency win.
+func TestE2E_Callback_LinkedOrgsSkipWorkOSReads(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workosUserID = "user_01LINKED_STEADY"
+		orgID1       = "org_01LINKED_A"
+		orgID2       = "org_01LINKED_B"
+		orgID3       = "org_01LINKED_C"
+	)
+	gramUserID := users.UserIDFromWorkOSID(workosUserID)
+
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{
+			workosUserID: {
+				{ID: "om_LA", UserID: workosUserID, OrganizationID: orgID1, Organization: "Linked A", RoleSlug: "admin"},
+				{ID: "om_LB", UserID: workosUserID, OrganizationID: orgID2, Organization: "Linked B", RoleSlug: "member"},
+				{ID: "om_LC", UserID: workosUserID, OrganizationID: orgID3, Organization: "Linked C", RoleSlug: "member"},
+			},
+		},
+		// Populate orgs so any errant GetOrganization would succeed — we want
+		// the assertion to fail on call count, not on a 404 masquerading as
+		// the fix.
+		orgs: map[string]*workos.Organization{
+			orgID1: {ID: orgID1, Name: "Linked A"},
+			orgID2: {ID: orgID2, Name: "Linked B"},
+			orgID3: {ID: orgID3, Name: "Linked C"},
+		},
+	}
+
+	userInfo := &MockUserInfo{
+		UserID:         workosUserID,
+		Email:          "linked@example.com",
+		OrganizationID: orgID1, // triggers inline SyncMembershipsFromWorkOS in Callback
+		Organizations:  []MockOrganizationEntry{},
+	}
+
+	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
+
+	require.NoError(t, inst.createTestUser(ctx, userInfo))
+	inst.setUserWorkosID(ctx, t, gramUserID, workosUserID)
+
+	wid1, wid2, wid3 := orgID1, orgID2, orgID3
+	for _, entry := range []MockOrganizationEntry{
+		{ID: orgid.FromWorkOSID(orgID1), Name: "Linked A", Slug: "linked-a", WorkosID: &wid1, UserWorkspaceSlugs: []string{"linked-a"}},
+		{ID: orgid.FromWorkOSID(orgID2), Name: "Linked B", Slug: "linked-b", WorkosID: &wid2, UserWorkspaceSlugs: []string{"linked-b"}},
+		{ID: orgid.FromWorkOSID(orgID3), Name: "Linked C", Slug: "linked-c", WorkosID: &wid3, UserWorkspaceSlugs: []string{"linked-c"}},
+	} {
+		require.NoError(t, inst.createTestOrganization(ctx, entry, gramUserID))
+	}
+
+	result, err := inst.callbackWithNonce(ctx, t)
+	require.NoError(t, err)
+	require.NotContains(t, result.Location, "signin_error=")
+	require.NotEmpty(t, result.SessionToken)
+
+	require.Equal(t, 0, fetcher.getOrgCalls, "linked-org steady-state must not call WorkOS GetOrganization")
+	require.Equal(t, 0, fetcher.ensureExternalIDCalls, "linked-org steady-state must not call WorkOS EnsureOrgExternalID")
+
+	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, orgid.FromWorkOSID(orgID1), authCtx.ActiveOrganizationID)
 }
 
 func TestE2E_Callback_IDPOrgSelectionSyncsMissingMembershipForExistingUser(t *testing.T) {

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -332,59 +332,8 @@ func (r *Resolver) syncMembershipsFromWorkOS(ctx context.Context, gramUserID, wo
 	}
 
 	for _, m := range members {
-		org, err := r.workosClient.GetOrganization(ctx, m.OrganizationID)
-		if err != nil {
-			return nil, fmt.Errorf("get workos organization %q: %w", m.OrganizationID, err)
-		}
-
-		gramOrgID := r.resolveGramOrgID(ctx, m.OrganizationID, org.ExternalID)
-
-		slug := orgslug.Slugify(org.Name)
-		if slug == "" {
-			slug = m.OrganizationID
-		}
-		shouldCreateOrg := false
-		existingOrg, err := r.orgRepo.GetOrganizationMetadata(ctx, gramOrgID)
-		switch {
-		case err == nil:
-			if !existingOrg.WorkosID.Valid {
-				if _, err := r.orgRepo.SetOrgWorkosID(ctx, orgRepo.SetOrgWorkosIDParams{
-					WorkosID:       pgtype.Text{String: m.OrganizationID, Valid: true},
-					OrganizationID: gramOrgID,
-				}); err != nil {
-					return nil, fmt.Errorf("set workos id for organization %q: %w", gramOrgID, err)
-				}
-			} else if existingOrg.WorkosID.String != m.OrganizationID {
-				return nil, fmt.Errorf("workos organization %q resolved to gram organization %q with different workos_id %q", m.OrganizationID, gramOrgID, existingOrg.WorkosID.String)
-			}
-		case errors.Is(err, pgx.ErrNoRows):
-			slug, err = orgslug.FindUnique(ctx, r.orgRepo, slug)
-			if err != nil {
-				return nil, fmt.Errorf("find unique slug for workos organization %q: %w", m.OrganizationID, err)
-			}
-			shouldCreateOrg = true
-		default:
-			return nil, fmt.Errorf("get org metadata for workos organization %q: %w", m.OrganizationID, err)
-		}
-
-		if shouldCreateOrg {
-			if _, err := r.orgRepo.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
-				ID:          gramOrgID,
-				Name:        org.Name,
-				Slug:        slug,
-				WorkosID:    pgtype.Text{String: m.OrganizationID, Valid: true},
-				Whitelisted: pgtype.Bool{Bool: false, Valid: false},
-			}); err != nil {
-				return nil, fmt.Errorf("upsert org metadata from workos %q: %w", m.OrganizationID, err)
-			}
-		}
-
-		if err := r.workosClient.EnsureOrgExternalID(ctx, m.OrganizationID, gramOrgID); err != nil {
-			r.logger.ErrorContext(ctx, "failed to sync org external_id to workos",
-				attr.SlogError(err),
-				attr.SlogWorkOSOrganizationID(m.OrganizationID),
-				attr.SlogOrganizationID(gramOrgID),
-			)
+		if err := r.upsertOrgFromMembership(ctx, m); err != nil {
+			return nil, err
 		}
 	}
 
@@ -409,14 +358,82 @@ func (r *Resolver) syncMembershipsFromWorkOS(ctx context.Context, gramUserID, wo
 	return rows, nil
 }
 
-func (r *Resolver) resolveGramOrgID(ctx context.Context, workosOrgID, externalID string) string {
-	if existing, err := r.orgRepo.GetOrganizationByWorkosID(ctx, pgtype.Text{String: workosOrgID, Valid: true}); err == nil {
-		return existing.ID
+// upsertOrgFromMembership reconciles the local org row for one WorkOS
+// membership. Steady-state callers (local org already linked to this WorkOS
+// org) make zero WorkOS API calls. WorkOS reads happen only when the local
+// row is missing the link and we need the external_id or org name to create
+// or merge it. After any local mutation we push the gram org ID back to
+// WorkOS as external_id, the only place that link is authored — the
+// background webhook reconcile path sets workos_id locally but never writes
+// external_id remotely.
+func (r *Resolver) upsertOrgFromMembership(ctx context.Context, m workos.Member) error {
+	_, err := r.orgRepo.GetOrganizationByWorkosID(ctx, pgtype.Text{String: m.OrganizationID, Valid: true})
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, pgx.ErrNoRows):
+		// fall through to the create / link path below
+	default:
+		return fmt.Errorf("lookup org by workos id %q: %w", m.OrganizationID, err)
 	}
-	if externalID != "" {
-		return externalID
+
+	org, err := r.workosClient.GetOrganization(ctx, m.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("get workos organization %q: %w", m.OrganizationID, err)
 	}
-	return orgid.FromWorkOSID(workosOrgID)
+
+	gramOrgID := org.ExternalID
+	if gramOrgID == "" {
+		gramOrgID = orgid.FromWorkOSID(m.OrganizationID)
+	}
+
+	slug := orgslug.Slugify(org.Name)
+	if slug == "" {
+		slug = m.OrganizationID
+	}
+
+	existingOrg, err := r.orgRepo.GetOrganizationMetadata(ctx, gramOrgID)
+	switch {
+	case err == nil:
+		if existingOrg.WorkosID.Valid {
+			// The initial lookup by workos_id missed, so the row's workos_id
+			// can only be a different WorkOS org pointing at the same gram ID
+			// — a real conflict.
+			return fmt.Errorf("workos organization %q resolved to gram organization %q with different workos_id %q", m.OrganizationID, gramOrgID, existingOrg.WorkosID.String)
+		}
+		if _, err := r.orgRepo.SetOrgWorkosID(ctx, orgRepo.SetOrgWorkosIDParams{
+			WorkosID:       pgtype.Text{String: m.OrganizationID, Valid: true},
+			OrganizationID: gramOrgID,
+		}); err != nil {
+			return fmt.Errorf("set workos id for organization %q: %w", gramOrgID, err)
+		}
+	case errors.Is(err, pgx.ErrNoRows):
+		uniqueSlug, err := orgslug.FindUnique(ctx, r.orgRepo, slug)
+		if err != nil {
+			return fmt.Errorf("find unique slug for workos organization %q: %w", m.OrganizationID, err)
+		}
+		if _, err := r.orgRepo.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+			ID:          gramOrgID,
+			Name:        org.Name,
+			Slug:        uniqueSlug,
+			WorkosID:    pgtype.Text{String: m.OrganizationID, Valid: true},
+			Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+		}); err != nil {
+			return fmt.Errorf("upsert org metadata from workos %q: %w", m.OrganizationID, err)
+		}
+	default:
+		return fmt.Errorf("get org metadata for workos organization %q: %w", m.OrganizationID, err)
+	}
+
+	if err := r.workosClient.EnsureOrgExternalID(ctx, m.OrganizationID, gramOrgID); err != nil {
+		r.logger.ErrorContext(ctx, "failed to sync org external_id to workos",
+			attr.SlogError(err),
+			attr.SlogWorkOSOrganizationID(m.OrganizationID),
+			attr.SlogOrganizationID(gramOrgID),
+		)
+	}
+
+	return nil
 }
 
 // GetUserInfo returns cached user info, falling back to a DB lookup on cache miss.


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2324/authcallback-latency-n1-workos-getorganization-fan-out-on-every-login

`syncMembershipsFromWorkOS` previously made two WorkOS API reads per membership on every login: one direct `GetOrganization` for the org name/external_id, and one inside `EnsureOrgExternalID`. A user in ten orgs paid ~20 sequential cross-region round-trips on each login, driving 3-5s `auth.callback` latency.

The org name and external_id are only needed when the local row is missing or unlinked. Reorder the per-membership work to look up by workos_id first; on hit, skip both WorkOS calls. The rare new-org / link path still fetches from WorkOS and pushes external_id back so disaster recovery via `resolveGramOrgID`'s external_id fallback keeps working.

The background webhook reconcile path already keeps `workos_id` in sync locally, so steady-state logins after a webhook-only sync now make zero WorkOS reads. Linking external_id remotely is only required when this login is the first to touch the org locally, which is also the only path that still calls `EnsureOrgExternalID`.