### PR TITLE
feat(background): auto-sync subscribed toolsets on deployment complete

### DIFF
--- a/server/internal/audit/toolsets.go
+++ b/server/internal/audit/toolsets.go
@@ -21,6 +21,7 @@ const (
 	ActionToolsetAttachOAuthProxy    Action = "toolset:attach_oauth_proxy"
 	ActionToolsetUpdateOAuthProxy    Action = "toolset:update_oauth_proxy"
 	ActionToolsetDetachOAuthProxy    Action = "toolset:detach_oauth_proxy"
+	ActionToolsetToolsAutoAdded      Action = "toolset:tools_auto_added"
 )
 
 type LogToolsetCreateEvent struct {
@@ -460,6 +461,64 @@ func (l *Logger) LogToolsetUpdateOAuthProxy(ctx context.Context, dbtx repo.DBTX,
 		Metadata:       metadata,
 		BeforeSnapshot: beforeSnapshot,
 		AfterSnapshot:  afterSnapshot,
+	}
+
+	return l.log(ctx, dbtx, entry)
+}
+
+type LogToolsetToolsAutoAddedEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	ToolsetURN          urn.Toolset
+	ToolsetName         string
+	ToolsetSlug         string
+	ToolsetVersionAfter int64
+
+	DeploymentID uuid.UUID
+	Sources      []string
+	AddedURNs    []string
+}
+
+// LogToolsetToolsAutoAdded records that the deployment-completed activity
+// extended a toolset with new tool URNs because the toolset is subscribed to
+// the deployment's function sources.
+func (l *Logger) LogToolsetToolsAutoAdded(ctx context.Context, dbtx repo.DBTX, event LogToolsetToolsAutoAddedEvent) error {
+	action := ActionToolsetToolsAutoAdded
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"deployment_id":         event.DeploymentID.String(),
+		"sources":               event.Sources,
+		"added_urns":            event.AddedURNs,
+		"toolset_version_after": event.ToolsetVersionAfter,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.ToolsetURN.ID.String(),
+		SubjectType:        string(subjectTypeToolset),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.ToolsetName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.ToolsetSlug),
+
+		Metadata:       metadata,
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
 	}
 
 	return l.log(ctx, dbtx, entry)

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -53,6 +53,7 @@ type Activities struct {
 	processDeployment               *activities.ProcessDeployment
 	provisionFunctionsAccess        *activities.ProvisionFunctionsAccess
 	deployFunctionRunners           *activities.DeployFunctionRunners
+	autoSyncToolsets                *activities.AutoSyncToolsets
 	reapFlyApps                     *activities.ReapFlyApps
 	refreshBillingUsage             *activities.RefreshBillingUsage
 	refreshOpenRouterKey            *activities.RefreshOpenRouterKey
@@ -138,6 +139,7 @@ func NewActivities(
 		processDeployment:               activities.NewProcessDeployment(logger, tracerProvider, meterProvider, guardianPolicy, db, features, assetStorage, billingRepo, mcpRegistryClient),
 		provisionFunctionsAccess:        activities.NewProvisionFunctionsAccess(logger, db, encryption),
 		deployFunctionRunners:           activities.NewDeployFunctionRunners(logger, db, functionsDeployer, functionsVersion, encryption),
+		autoSyncToolsets:                activities.NewAutoSyncToolsets(logger, db, auditLogger),
 		reapFlyApps:                     activities.NewReapFlyApps(logger, meterProvider, db, functionsDeployer, 1),
 		refreshBillingUsage:             activities.NewRefreshBillingUsage(logger, db, billingRepo),
 		refreshOpenRouterKey:            activities.NewRefreshOpenRouterKey(logger, db, openrouterProvisioner),
@@ -205,6 +207,10 @@ func (a *Activities) TransitionDeployment(ctx context.Context, projectID uuid.UU
 
 func (a *Activities) ProcessDeployment(ctx context.Context, projectID uuid.UUID, deploymentID uuid.UUID) error {
 	return a.processDeployment.Do(ctx, projectID, deploymentID)
+}
+
+func (a *Activities) AutoSyncToolsets(ctx context.Context, req activities.AutoSyncToolsetsRequest) (*activities.AutoSyncToolsetsResult, error) {
+	return a.autoSyncToolsets.Do(ctx, req)
 }
 
 func (a *Activities) GetSlackProjectContext(ctx context.Context, event slacktypes.SlackEvent) (*activities.SlackProjectContextResponse, error) {

--- a/server/internal/background/activities/auto_sync_toolsets.go
+++ b/server/internal/background/activities/auto_sync_toolsets.go
@@ -1,0 +1,273 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	funcrepo "github.com/speakeasy-api/gram/server/internal/functions/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// AutoSyncToolsetsRequest is the input to the AutoSyncToolsets activity. It
+// runs once per completed deployment, against the toolsets whose
+// auto_sync_sources subscription overlaps the deployment's function sources.
+type AutoSyncToolsetsRequest struct {
+	ProjectID    uuid.UUID
+	DeploymentID uuid.UUID
+}
+
+// AutoSyncToolsetsResult reports per-toolset summary information for
+// observability and tests. Empty fields when no toolsets were touched.
+type AutoSyncToolsetsResult struct {
+	ToolsetsExtended int
+	AddedByToolset   map[string][]string // toolset slug -> URNs added
+}
+
+// AutoSyncToolsets is a Temporal activity. It diffs the function tool URNs
+// introduced by a deployment against each toolset subscribed (via
+// auto_sync_sources) to one of the deployment's function sources, and
+// extends those toolsets with the missing URNs by appending a new
+// toolset_versions row. Never removes URNs.
+//
+// Idempotent: a replay against the same deployment becomes a no-op because
+// the second pass finds no new URNs to add.
+type AutoSyncToolsets struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+	audit  *audit.Logger
+}
+
+func NewAutoSyncToolsets(logger *slog.Logger, db *pgxpool.Pool, auditLogger *audit.Logger) *AutoSyncToolsets {
+	return &AutoSyncToolsets{
+		logger: logger.With(attr.SlogComponent("auto_sync_toolsets")),
+		db:     db,
+		audit:  auditLogger,
+	}
+}
+
+// systemActor identifies system-driven audit events. Mirrors the convention
+// established in background/triggers/app.go where Temporal-fired writes use
+// "user:system" as the principal.
+var systemActor = urn.NewPrincipal(urn.PrincipalTypeUser, "system")
+
+func (a *AutoSyncToolsets) Do(ctx context.Context, req AutoSyncToolsetsRequest) (*AutoSyncToolsetsResult, error) {
+	logger := a.logger.With(
+		attr.SlogProjectID(req.ProjectID.String()),
+		attr.SlogDeploymentID(req.DeploymentID.String()),
+	)
+
+	funcRepo := funcrepo.New(a.db)
+	urnRows, err := funcRepo.ListFunctionToolURNsByDeployment(ctx, req.DeploymentID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list function tool URNs for deployment").Log(ctx, logger)
+	}
+
+	if len(urnRows) == 0 {
+		logger.DebugContext(ctx, "no function tools in deployment; auto-sync is a no-op")
+		return &AutoSyncToolsetsResult{}, nil
+	}
+
+	// Bucket URNs by their function-source slug. The prefixed subscription
+	// keys ("function:<slug>") will then drive the toolset lookup.
+	urnsBySource := make(map[string][]string)
+	for _, row := range urnRows {
+		urnsBySource[row.FunctionSlug] = append(urnsBySource[row.FunctionSlug], row.ToolUrn.String())
+	}
+
+	subscriptionKeys := make([]string, 0, len(urnsBySource))
+	for slug := range urnsBySource {
+		subscriptionKeys = append(subscriptionKeys, fmt.Sprintf("%s:%s", urn.ToolKindFunction, slug))
+	}
+	sort.Strings(subscriptionKeys) // deterministic ordering for tests/logs
+
+	tsRepo := toolsetsRepo.New(a.db)
+	candidates, err := tsRepo.ListToolsetsByAutoSyncSource(ctx, toolsetsRepo.ListToolsetsByAutoSyncSourceParams{
+		ProjectID: req.ProjectID,
+		Sources:   subscriptionKeys,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to list subscribed toolsets").Log(ctx, logger)
+	}
+
+	result := &AutoSyncToolsetsResult{
+		AddedByToolset: make(map[string][]string),
+	}
+
+	for _, ts := range candidates {
+		added, err := a.extendOne(ctx, logger, ts, urnsBySource, req.DeploymentID)
+		if err != nil {
+			// One bad toolset doesn't fail the others. The Temporal retry
+			// machinery will pick the activity up again if all errored.
+			logger.ErrorContext(ctx, "failed to extend toolset", attr.SlogError(err), attr.SlogToolsetID(ts.ID.String()))
+			continue
+		}
+		if len(added) > 0 {
+			result.AddedByToolset[ts.Slug] = added
+			result.ToolsetsExtended++
+		}
+	}
+
+	return result, nil
+}
+
+// extendOne handles a single toolset under its own transaction. The toolset
+// row is locked FOR UPDATE so a concurrent run from another deployment
+// completion can't compute a stale "latest version" and collide on the
+// unique (toolset_id, version) constraint.
+func (a *AutoSyncToolsets) extendOne(
+	ctx context.Context,
+	logger *slog.Logger,
+	ts toolsetsRepo.Toolset,
+	urnsBySource map[string][]string,
+	deploymentID uuid.UUID,
+) ([]string, error) {
+	tsLogger := logger.With(
+		attr.SlogToolsetID(ts.ID.String()),
+		attr.SlogToolsetSlug(ts.Slug),
+	)
+
+	// Build the set of URNs the subscription would pull in. Only consider
+	// sources the toolset is actually subscribed to (not every source in the
+	// deployment).
+	subscribed := make(map[string]struct{}, len(ts.AutoSyncSources))
+	for _, entry := range ts.AutoSyncSources {
+		subscribed[entry] = struct{}{}
+	}
+
+	desired := make(map[string]struct{})
+	for slug, urns := range urnsBySource {
+		key := fmt.Sprintf("%s:%s", urn.ToolKindFunction, slug)
+		if _, ok := subscribed[key]; !ok {
+			continue
+		}
+		for _, u := range urns {
+			desired[u] = struct{}{}
+		}
+	}
+	if len(desired) == 0 {
+		return nil, nil
+	}
+
+	tx, err := a.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	txTsRepo := toolsetsRepo.New(tx)
+
+	if _, err := txTsRepo.LockToolsetForAutoSync(ctx, ts.ID); err != nil {
+		return nil, fmt.Errorf("lock toolset: %w", err)
+	}
+
+	latest, err := txTsRepo.GetLatestToolsetVersion(ctx, ts.ID)
+	var (
+		existing      []urn.Tool
+		resourceUrns  = []urn.Resource{} // NOT NULL on toolset_versions; nil would fail the insert
+		predecessorID uuid.NullUUID
+		nextVersion   int64 = 1
+	)
+	switch {
+	case err == nil:
+		existing = latest.ToolUrns
+		resourceUrns = latest.ResourceUrns
+		predecessorID = uuid.NullUUID{UUID: latest.ID, Valid: true}
+		nextVersion = latest.Version + 1
+	case err == pgx.ErrNoRows:
+		// First version for this toolset.
+	default:
+		return nil, fmt.Errorf("read latest toolset version: %w", err)
+	}
+
+	presence := make(map[string]struct{}, len(existing))
+	for _, u := range existing {
+		presence[u.String()] = struct{}{}
+	}
+
+	added := make([]string, 0, len(desired))
+	for u := range desired {
+		if _, already := presence[u]; already {
+			continue
+		}
+		added = append(added, u)
+	}
+	if len(added) == 0 {
+		return nil, nil
+	}
+	sort.Strings(added)
+
+	merged := make([]urn.Tool, 0, len(existing)+len(added))
+	merged = append(merged, existing...)
+	for _, s := range added {
+		parsed, parseErr := urn.ParseTool(s)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse tool urn %q: %w", s, parseErr)
+		}
+		merged = append(merged, parsed)
+	}
+
+	created, err := txTsRepo.CreateToolsetVersion(ctx, toolsetsRepo.CreateToolsetVersionParams{
+		ToolsetID:     ts.ID,
+		Version:       nextVersion,
+		ToolUrns:      merged,
+		ResourceUrns:  resourceUrns,
+		PredecessorID: predecessorID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create toolset version: %w", err)
+	}
+
+	// Subscription keys responsible for these additions.
+	contributingSources := make([]string, 0)
+	for _, key := range sortedKeys(subscribed) {
+		slug := key[len(string(urn.ToolKindFunction))+1:]
+		if _, ok := urnsBySource[slug]; ok {
+			contributingSources = append(contributingSources, key)
+		}
+	}
+
+	tsURN := urn.NewToolset(ts.ID)
+	if err := a.audit.LogToolsetToolsAutoAdded(ctx, tx, audit.LogToolsetToolsAutoAddedEvent{
+		OrganizationID:      ts.OrganizationID,
+		ProjectID:           ts.ProjectID,
+		Actor:               systemActor,
+		ToolsetURN:          tsURN,
+		ToolsetName:         ts.Name,
+		ToolsetSlug:         ts.Slug,
+		ToolsetVersionAfter: created.Version,
+		DeploymentID:        deploymentID,
+		Sources:             contributingSources,
+		AddedURNs:           added,
+	}); err != nil {
+		return nil, fmt.Errorf("emit audit event: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+
+	tsLogger.InfoContext(ctx, "auto-sync extended toolset",
+		slog.Int("added_count", len(added)),
+		slog.Int64("toolset_version", created.Version),
+	)
+	return added, nil
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/server/internal/background/activities/auto_sync_toolsets_test.go
+++ b/server/internal/background/activities/auto_sync_toolsets_test.go
@@ -1,0 +1,259 @@
+package activities_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+// autoSyncFixture is the minimal set of rows needed to exercise the
+// AutoSyncToolsets activity end-to-end. Each helper below performs a single
+// INSERT so failures localise cleanly.
+type autoSyncFixture struct {
+	orgID        string
+	projectID    uuid.UUID
+	deploymentID uuid.UUID
+	functionID   uuid.UUID
+	assetID      uuid.UUID
+	toolsetID    uuid.UUID
+}
+
+func newAutoSyncFixture(t *testing.T, ctx context.Context, conn *pgxpool.Pool, toolsetAutoSyncSources []string, toolURNs []string, functionSlug string) autoSyncFixture {
+	t.Helper()
+	fx := autoSyncFixture{
+		orgID:        "org_" + uuid.NewString(),
+		projectID:    uuid.New(),
+		deploymentID: uuid.New(),
+		functionID:   uuid.New(),
+		assetID:      uuid.New(),
+		toolsetID:    uuid.New(),
+	}
+
+	_, err := conn.Exec(ctx,
+		`INSERT INTO organization_metadata (id, name, slug) VALUES ($1, $2, $3)`,
+		fx.orgID, "Auto-Sync Test Org", "auto-sync-test-"+uuid.NewString()[:8])
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx,
+		`INSERT INTO projects (id, organization_id, name, slug) VALUES ($1, $2, $3, $4)`,
+		fx.projectID, fx.orgID, "auto-sync-project", "auto-sync-project-"+uuid.NewString()[:8])
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx,
+		`INSERT INTO assets (id, project_id, name, kind, content_type, sha256, content_length, url)
+		 VALUES ($1, $2, 'function-asset', 'function', 'application/zip', repeat('a', 64), 0, 'memory://test')`,
+		fx.assetID, fx.projectID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx,
+		`INSERT INTO deployments (id, organization_id, project_id, user_id, idempotency_key)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		fx.deploymentID, fx.orgID, fx.projectID, "test-user", "auto-sync-idempotency-"+uuid.NewString())
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx,
+		`INSERT INTO deployment_statuses (deployment_id, status) VALUES ($1, 'completed')`,
+		fx.deploymentID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx,
+		`INSERT INTO deployments_functions (id, deployment_id, asset_id, name, slug, runtime)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		fx.functionID, fx.deploymentID, fx.assetID, functionSlug, functionSlug, "nodejs:22")
+	require.NoError(t, err)
+
+	for _, u := range toolURNs {
+		_, err = conn.Exec(ctx,
+			`INSERT INTO function_tool_definitions
+			   (id, project_id, deployment_id, function_id, runtime, name, description, tool_urn)
+			 VALUES ($1, $2, $3, $4, 'nodejs:22', $5, '', $6)`,
+			uuid.New(), fx.projectID, fx.deploymentID, fx.functionID, u, u)
+		require.NoError(t, err)
+	}
+
+	if toolsetAutoSyncSources == nil {
+		toolsetAutoSyncSources = []string{}
+	}
+	_, err = conn.Exec(ctx,
+		`INSERT INTO toolsets (id, organization_id, project_id, name, slug, auto_sync_sources)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		fx.toolsetID, fx.orgID, fx.projectID, "auto-sync-toolset", "auto-sync-toolset-"+uuid.NewString()[:8], toolsetAutoSyncSources)
+	require.NoError(t, err)
+
+	return fx
+}
+
+func TestAutoSyncToolsets_EmptyDeployment_NoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn, err := infra.CloneTestDatabase(t, "auto_sync_empty")
+	require.NoError(t, err)
+	logger := testenv.NewLogger(t)
+
+	fx := newAutoSyncFixture(t, ctx, conn,
+		[]string{"function:my-tools"}, // toolset is subscribed
+		nil,                           // but the deployment has no tools
+		"my-tools",
+	)
+
+	act := activities.NewAutoSyncToolsets(logger, conn, audit.NewLogger())
+	res, err := act.Do(ctx, activities.AutoSyncToolsetsRequest{
+		ProjectID:    fx.projectID,
+		DeploymentID: fx.deploymentID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, 0, res.ToolsetsExtended)
+	require.Empty(t, res.AddedByToolset)
+}
+
+func TestAutoSyncToolsets_SubscribedToolsetExtended(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn, err := infra.CloneTestDatabase(t, "auto_sync_extend")
+	require.NoError(t, err)
+	logger := testenv.NewLogger(t)
+
+	fx := newAutoSyncFixture(t, ctx, conn,
+		[]string{"function:billing"},
+		[]string{"tools:function:billing:list_invoices", "tools:function:billing:create_invoice"},
+		"billing",
+	)
+
+	act := activities.NewAutoSyncToolsets(logger, conn, audit.NewLogger())
+	res, err := act.Do(ctx, activities.AutoSyncToolsetsRequest{
+		ProjectID:    fx.projectID,
+		DeploymentID: fx.deploymentID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.ToolsetsExtended)
+	require.Len(t, res.AddedByToolset, 1)
+
+	var firstKey string
+	for k := range res.AddedByToolset {
+		firstKey = k
+	}
+	require.ElementsMatch(t,
+		[]string{"tools:function:billing:list_invoices", "tools:function:billing:create_invoice"},
+		res.AddedByToolset[firstKey],
+	)
+
+	// Toolset version row was created with the added URNs.
+	tsRepo := toolsetsRepo.New(conn)
+	latest, err := tsRepo.GetLatestToolsetVersion(ctx, fx.toolsetID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), latest.Version)
+	require.Len(t, latest.ToolUrns, 2)
+
+	// Audit event was recorded.
+	var auditCount int
+	err = conn.QueryRow(ctx,
+		`SELECT count(*) FROM audit_logs WHERE action = $1 AND subject_id = $2`,
+		string(audit.ActionToolsetToolsAutoAdded), fx.toolsetID,
+	).Scan(&auditCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, auditCount)
+}
+
+func TestAutoSyncToolsets_Idempotent_ReplayIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn, err := infra.CloneTestDatabase(t, "auto_sync_idempotent")
+	require.NoError(t, err)
+	logger := testenv.NewLogger(t)
+
+	fx := newAutoSyncFixture(t, ctx, conn,
+		[]string{"function:catalog"},
+		[]string{"tools:function:catalog:search"},
+		"catalog",
+	)
+
+	act := activities.NewAutoSyncToolsets(logger, conn, audit.NewLogger())
+	req := activities.AutoSyncToolsetsRequest{
+		ProjectID:    fx.projectID,
+		DeploymentID: fx.deploymentID,
+	}
+
+	res1, err := act.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 1, res1.ToolsetsExtended)
+
+	res2, err := act.Do(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 0, res2.ToolsetsExtended, "replay should add nothing")
+
+	// Still exactly one toolset version row.
+	var versionCount int
+	err = conn.QueryRow(ctx,
+		`SELECT count(*) FROM toolset_versions WHERE toolset_id = $1`, fx.toolsetID,
+	).Scan(&versionCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, versionCount)
+
+	// Still exactly one audit event.
+	var auditCount int
+	err = conn.QueryRow(ctx,
+		`SELECT count(*) FROM audit_logs WHERE action = $1 AND subject_id = $2`,
+		string(audit.ActionToolsetToolsAutoAdded), fx.toolsetID,
+	).Scan(&auditCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, auditCount)
+}
+
+func TestAutoSyncToolsets_NoSubscribers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn, err := infra.CloneTestDatabase(t, "auto_sync_no_subs")
+	require.NoError(t, err)
+	logger := testenv.NewLogger(t)
+
+	fx := newAutoSyncFixture(t, ctx, conn,
+		nil, // toolset has no subscriptions
+		[]string{"tools:function:billing:list_invoices"},
+		"billing",
+	)
+
+	act := activities.NewAutoSyncToolsets(logger, conn, audit.NewLogger())
+	res, err := act.Do(ctx, activities.AutoSyncToolsetsRequest{
+		ProjectID:    fx.projectID,
+		DeploymentID: fx.deploymentID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, res.ToolsetsExtended)
+	require.Empty(t, res.AddedByToolset)
+}
+
+func TestAutoSyncToolsets_SubscribedToWrongSource_NoExtension(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn, err := infra.CloneTestDatabase(t, "auto_sync_wrong_source")
+	require.NoError(t, err)
+	logger := testenv.NewLogger(t)
+
+	fx := newAutoSyncFixture(t, ctx, conn,
+		[]string{"function:other-source"}, // subscribed to a source not in this deployment
+		[]string{"tools:function:billing:list_invoices"},
+		"billing",
+	)
+
+	act := activities.NewAutoSyncToolsets(logger, conn, audit.NewLogger())
+	res, err := act.Do(ctx, activities.AutoSyncToolsetsRequest{
+		ProjectID:    fx.projectID,
+		DeploymentID: fx.deploymentID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, res.ToolsetsExtended)
+}

--- a/server/internal/background/deployments.go
+++ b/server/internal/background/deployments.go
@@ -158,6 +158,26 @@ func ProcessDeploymentWorkflow(ctx workflow.Context, params ProcessDeploymentWor
 				string(attr.DeploymentIDKey), params.DeploymentID,
 			)
 		}
+
+		// Auto-sync any toolsets subscribed to this deployment's function
+		// sources. Best-effort: a failure here does NOT fail the deployment;
+		// subscribers can still be reconciled on the next push.
+		autoSyncErr := workflow.ExecuteActivity(
+			ctx,
+			a.AutoSyncToolsets,
+			activities.AutoSyncToolsetsRequest{
+				ProjectID:    params.ProjectID,
+				DeploymentID: params.DeploymentID,
+			},
+		).Get(ctx, nil)
+		if autoSyncErr != nil {
+			logger.Error(
+				"failed to auto-sync subscribed toolsets",
+				"error", autoSyncErr.Error(),
+				string(attr.ProjectIDKey), params.ProjectID,
+				string(attr.DeploymentIDKey), params.DeploymentID,
+			)
+		}
 	}
 
 	var finalTransition activities.TransitionDeploymentResult

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -250,6 +250,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.TransitionDeployment)
 	temporalWorker.RegisterActivity(activities.ProvisionFunctionsAccess)
 	temporalWorker.RegisterActivity(activities.DeployFunctionRunners)
+	temporalWorker.RegisterActivity(activities.AutoSyncToolsets)
 	temporalWorker.RegisterActivity(activities.ReapFlyApps)
 	temporalWorker.RegisterActivity(activities.GetSlackProjectContext)
 	temporalWorker.RegisterActivity(activities.PostSlackMessage)

--- a/server/internal/functions/queries.sql
+++ b/server/internal/functions/queries.sql
@@ -156,3 +156,16 @@ WHERE
   AND df.id = @function_id
   AND a.id = @asset_id
   AND a.deleted IS FALSE;
+
+-- name: ListFunctionToolURNsByDeployment :many
+-- Returns one row per non-deleted function tool definition in a deployment,
+-- with the parent function's slug exposed as the "source" segment to ease
+-- bucketing in callers. Used by the deployment-completed auto-sync activity.
+SELECT
+  ftd.tool_urn AS tool_urn,
+  df.slug AS function_slug
+FROM function_tool_definitions ftd
+JOIN deployments_functions df ON df.id = ftd.function_id
+WHERE ftd.deployment_id = @deployment_id
+  AND ftd.deleted IS FALSE
+ORDER BY df.slug, ftd.tool_urn;

--- a/server/internal/functions/repo/queries.sql.go
+++ b/server/internal/functions/repo/queries.sql.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 const finalizeFlyApp = `-- name: FinalizeFlyApp :one
@@ -358,6 +359,45 @@ func (q *Queries) InitFlyApp(ctx context.Context, arg InitFlyAppParams) (uuid.UU
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err
+}
+
+const listFunctionToolURNsByDeployment = `-- name: ListFunctionToolURNsByDeployment :many
+SELECT
+  ftd.tool_urn AS tool_urn,
+  df.slug AS function_slug
+FROM function_tool_definitions ftd
+JOIN deployments_functions df ON df.id = ftd.function_id
+WHERE ftd.deployment_id = $1
+  AND ftd.deleted IS FALSE
+ORDER BY df.slug, ftd.tool_urn
+`
+
+type ListFunctionToolURNsByDeploymentRow struct {
+	ToolUrn      urn.Tool
+	FunctionSlug string
+}
+
+// Returns one row per non-deleted function tool definition in a deployment,
+// with the parent function's slug exposed as the "source" segment to ease
+// bucketing in callers. Used by the deployment-completed auto-sync activity.
+func (q *Queries) ListFunctionToolURNsByDeployment(ctx context.Context, deploymentID uuid.UUID) ([]ListFunctionToolURNsByDeploymentRow, error) {
+	rows, err := q.db.Query(ctx, listFunctionToolURNsByDeployment, deploymentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListFunctionToolURNsByDeploymentRow
+	for rows.Next() {
+		var i ListFunctionToolURNsByDeploymentRow
+		if err := rows.Scan(&i.ToolUrn, &i.FunctionSlug); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const markFlyAppReaped = `-- name: MarkFlyAppReaped :exec

--- a/server/internal/toolsets/queries.sql
+++ b/server/internal/toolsets/queries.sql
@@ -104,6 +104,18 @@ WHERE project_id = @project_id
   AND auto_sync_sources && @sources::TEXT[]
 ORDER BY id;
 
+-- name: LockToolsetForAutoSync :one
+-- Row-level lock used by the deployment-completed activity to serialize
+-- concurrent auto-sync writers on the same toolset. Pair with a follow-up
+-- CreateToolsetVersion inside the same transaction. Returns the locked
+-- toolset row so the caller can read auto_sync_sources without a second
+-- query.
+SELECT *
+FROM toolsets
+WHERE id = @id
+  AND deleted IS FALSE
+FOR UPDATE;
+
 -- name: DeleteToolset :one
 UPDATE toolsets
 SET deleted_at = clock_timestamp()

--- a/server/internal/toolsets/repo/queries.sql.go
+++ b/server/internal/toolsets/repo/queries.sql.go
@@ -1248,6 +1248,47 @@ func (q *Queries) ListToolsetsWithVersionsByOrganization(ctx context.Context, or
 	return items, nil
 }
 
+const lockToolsetForAutoSync = `-- name: LockToolsetForAutoSync :one
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, auto_sync_sources, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, created_at, updated_at, deleted_at, deleted
+FROM toolsets
+WHERE id = $1
+  AND deleted IS FALSE
+FOR UPDATE
+`
+
+// Row-level lock used by the deployment-completed activity to serialize
+// concurrent auto-sync writers on the same toolset. Pair with a follow-up
+// CreateToolsetVersion inside the same transaction. Returns the locked
+// toolset row so the caller can read auto_sync_sources without a second
+// query.
+func (q *Queries) LockToolsetForAutoSync(ctx context.Context, id uuid.UUID) (Toolset, error) {
+	row := q.db.QueryRow(ctx, lockToolsetForAutoSync, id)
+	var i Toolset
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.ProjectID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.DefaultEnvironmentSlug,
+		&i.McpSlug,
+		&i.McpIsPublic,
+		&i.McpEnabled,
+		&i.ToolSelectionMode,
+		&i.AutoSyncSources,
+		&i.CustomDomainID,
+		&i.ExternalOauthServerID,
+		&i.OauthProxyServerID,
+		&i.UserSessionIssuerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const setToolsetMCPEnabledByID = `-- name: SetToolsetMCPEnabledByID :exec
 UPDATE toolsets
 SET mcp_enabled = $1


### PR DESCRIPTION
## Summary

The engine for [AGE-1377](https://linear.app/speakeasy/issue/AGE-1377). When a deployment finishes processing, the new `AutoSyncToolsets` Temporal activity finds every toolset whose `auto_sync_sources` subscription overlaps the deployment's function sources, and appends any new tool URNs as a new `toolset_versions` row.

Stacks on the RPC PR (#2848); rebases to `main` once #2834 and #2848 land. Design: #2833.

## What's in here

- **`AutoSyncToolsets` activity** (`server/internal/background/activities/auto_sync_toolsets.go`):
  - Lists new function tool URNs for the deployment, buckets by `urn.Source` (the function slug).
  - Looks up subscribed toolsets via `ListToolsetsByAutoSyncSource` (introduced in #2848).
  - For each subscriber: opens its own transaction, locks the toolset row \`FOR UPDATE\`, diffs URNs, inserts a new \`toolset_versions\` row when there are additions, emits an audit event. Never deletes.
  - Per-toolset failures don't block other extensions.
  - Idempotent on replay (a second run finds no new URNs).
- **Workflow wiring** (`server/internal/background/deployments.go`): activity runs after \`DeployFunctionRunners\` succeeds, **best-effort** — a failure logs but does not fail the deployment.
- **Worker registration** + \`Activities\` struct wiring.
- **SQL**:
  - \`toolsets.LockToolsetForAutoSync\` row-lock query.
  - \`functions.ListFunctionToolURNsByDeployment\` join over \`function_tool_definitions\` + \`deployments_functions\`.
- **Audit logging**: \`ActionToolsetToolsAutoAdded\` + \`LogToolsetToolsAutoAdded\`. Actor is the existing \`user:system\` sentinel (mirrors \`background/triggers/app.go\`). Metadata carries \`deployment_id\`, \`sources\`, \`added_urns\`, \`toolset_version_after\`.

## Test plan

- [x] \`go test ./internal/background/activities/ -run TestAutoSyncToolsets\` — 5 scenarios pass:
  - empty deployment → no-op
  - subscribed toolset → extension + audit event
  - replay → idempotent
  - no subscribers → clean no-op
  - subscribed to a source not in this deployment → no-op
- [x] \`mise build:server\` clean
- [x] PR 2's \`UpdateToolset\` integration test still green (no regression)
- [ ] Reviewer: confirm the workflow's "best-effort" semantics are the right call. If we'd rather have auto-sync failures bubble up as \`finalStatus = "failed"\`, that's a 2-line change.
- [ ] Future PR 6 will add the broader E2E scenarios (multi-toolset, multi-source, cross-deployment increment) using full deployment fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)