### PR TITLE
feat: enable automatic import to user sessions

### DIFF
--- a/client/dashboard/src/components/sources/sources-hooks.ts
+++ b/client/dashboard/src/components/sources/sources-hooks.ts
@@ -83,7 +83,9 @@ export const useExternalMcpOAuthConfigStatus = (
 
     if (authType !== "oauth") return "not-required";
 
-    return toolset.externalOauthServer || toolset.oauthProxyServer
+    return toolset.externalOauthServer ||
+      toolset.oauthProxyServer ||
+      toolset.userSessionIssuerSlug
       ? "configured"
       : "required-unconfigured";
   }, [toolset, deploymentResult, serverAuthMap]);

--- a/client/dashboard/src/lib/externalMcpUserSessions.test.ts
+++ b/client/dashboard/src/lib/externalMcpUserSessions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  externalMcpUserSessionOAuthConfigFromMetadata,
+  resolveExternalMcpUserSessionOAuthConfig,
+} from "./externalMcpUserSessions";
+
+describe("external MCP user-session OAuth config", () => {
+  it("prefers an explicit issuer when it matches the upstream endpoints", () => {
+    const config = externalMcpUserSessionOAuthConfigFromMetadata({
+      slug: "okta",
+      name: "Okta",
+      metadata: {
+        issuer: "https://idp.example/oauth2/default",
+        authorization_endpoint:
+          "https://idp.example/oauth2/default/v1/authorize",
+        token_endpoint: "https://idp.example/oauth2/default/v1/token",
+        registration_endpoint: "https://idp.example/oauth2/default/v1/register",
+      },
+    });
+
+    expect(config?.issuerUrl).toBe("https://idp.example/oauth2/default");
+  });
+
+  it("ignores unrelated synthetic issuers and preserves the upstream path", () => {
+    const config = externalMcpUserSessionOAuthConfigFromMetadata({
+      slug: "okta",
+      name: "Okta",
+      metadata: {
+        issuer: "https://app.getgram.ai/mcp/okta",
+        authorization_endpoint:
+          "https://idp.example/oauth2/default/v1/authorize",
+        token_endpoint: "https://idp.example/oauth2/default/v1/token",
+        registration_endpoint: "https://idp.example/oauth2/default/v1/register",
+      },
+    });
+
+    expect(config?.issuerUrl).toBe("https://idp.example/oauth2/default");
+  });
+
+  it("preserves issuer path when extracting OAuth config from tool metadata", () => {
+    const toolset = {
+      slug: "okta-tools",
+      name: "Okta Tools",
+      rawTools: [
+        {
+          externalMcpToolDefinition: {
+            requiresOauth: true,
+            slug: "okta",
+            name: "proxy",
+            registryServerName: "Okta",
+            oauthAuthorizationEndpoint:
+              "https://idp.example/oauth2/default/v1/authorize",
+            oauthTokenEndpoint: "https://idp.example/oauth2/default/v1/token",
+            oauthRegistrationEndpoint:
+              "https://idp.example/oauth2/default/v1/register",
+          },
+        },
+      ],
+    } as Parameters<typeof resolveExternalMcpUserSessionOAuthConfig>[0];
+
+    const config = resolveExternalMcpUserSessionOAuthConfig(toolset);
+
+    expect(config?.issuerUrl).toBe("https://idp.example/oauth2/default");
+  });
+});

--- a/client/dashboard/src/lib/externalMcpUserSessions.ts
+++ b/client/dashboard/src/lib/externalMcpUserSessions.ts
@@ -82,9 +82,16 @@ export function externalMcpUserSessionOAuthConfigFromMetadata({
   }
 
   const issuerUrl =
-    extractOrigin(authorizationEndpoint) ??
-    extractOrigin(tokenEndpoint) ??
-    extractOrigin(registrationEndpoint);
+    explicitIssuerURL(metadata.issuer, [
+      authorizationEndpoint,
+      tokenEndpoint,
+      registrationEndpoint,
+    ]) ??
+    inferIssuerBaseURL(
+      authorizationEndpoint,
+      tokenEndpoint,
+      registrationEndpoint,
+    );
   if (!issuerUrl) return null;
 
   return {
@@ -211,10 +218,11 @@ function configFromExternalMcpDefinition(
     return null;
   }
 
-  const issuerUrl =
-    extractOrigin(def.oauthAuthorizationEndpoint) ??
-    extractOrigin(def.oauthTokenEndpoint) ??
-    extractOrigin(def.oauthRegistrationEndpoint);
+  const issuerUrl = inferIssuerBaseURL(
+    def.oauthAuthorizationEndpoint,
+    def.oauthTokenEndpoint,
+    def.oauthRegistrationEndpoint,
+  );
   if (!issuerUrl) return null;
 
   return {
@@ -257,13 +265,57 @@ function readStringArray(value: unknown): string[] {
     : [];
 }
 
-function extractOrigin(url: string): string | null {
+function explicitIssuerURL(
+  issuer: unknown,
+  endpointURLs: string[],
+): string | null {
+  const explicit = readString(issuer);
+  if (!explicit) return null;
+
+  const parsedIssuer = parseURL(explicit);
+  if (!parsedIssuer) return null;
+
+  // OAuthWizard may synthesize a Gram-facing issuer while carrying upstream
+  // OAuth endpoints. Only trust explicit metadata issuers that describe the
+  // same upstream authorization server as one of the endpoints.
+  const sameAuthorizationServer = endpointURLs.some((endpointURL) => {
+    const parsedEndpoint = parseURL(endpointURL);
+    return parsedEndpoint
+      ? parsedEndpoint.origin === parsedIssuer.origin
+      : false;
+  });
+  if (!sameAuthorizationServer) return null;
+
+  return formatIssuerURL(parsedIssuer);
+}
+
+function inferIssuerBaseURL(...endpointURLs: string[]): string | null {
+  for (const endpointURL of endpointURLs) {
+    const parsed = parseURL(endpointURL);
+    if (!parsed) continue;
+
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length > 0) segments.pop();
+    if (segments[segments.length - 1]?.match(/^v\d+$/i)) segments.pop();
+
+    parsed.pathname = segments.length > 0 ? `/${segments.join("/")}` : "";
+    return formatIssuerURL(parsed);
+  }
+
+  return null;
+}
+
+function parseURL(url: string): URL | null {
   try {
-    const parsed = new URL(url);
-    return `${parsed.protocol}//${parsed.host}`;
+    return new URL(url);
   } catch {
     return null;
   }
+}
+
+function formatIssuerURL(url: URL): string {
+  const path = url.pathname.replace(/\/+$/g, "");
+  return `${url.protocol}//${url.host}${path}`;
 }
 
 function slugify(value: string): string {

--- a/client/dashboard/src/lib/externalMcpUserSessions.ts
+++ b/client/dashboard/src/lib/externalMcpUserSessions.ts
@@ -1,0 +1,269 @@
+import type { Gram } from "@gram/client";
+import type {
+  ExternalMCPToolDefinition,
+  RemoteSessionIssuerDraft,
+  Tool,
+} from "@gram/client/models/components";
+
+import { getServerURL } from "@/lib/utils";
+
+export const ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG =
+  "onboard-external-mcp-to-user-sessions";
+
+export const DEFAULT_USER_SESSION_DURATION_HOURS = 24 * 14;
+
+const MAX_SLUG_LENGTH = 40;
+
+type RequestOptions = Parameters<Gram["toolsets"]["setUserSessionIssuer"]>[2];
+
+type ToolsetWithExternalMcpTools = {
+  slug: string;
+  name: string;
+  tools?: Tool[];
+  rawTools?: Tool[];
+};
+
+export type ExternalMcpUserSessionOAuthConfig = {
+  slug: string;
+  name: string;
+  issuerUrl: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  scopesSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+};
+
+export type OnboardExternalMcpToUserSessionsResult = {
+  userSessionIssuerId: string;
+  remoteSessionIssuerId: string;
+};
+
+export function remoteLoginCallbackURL(): string {
+  return `${getServerURL()}/mcp/remote_login_callback`;
+}
+
+export function buildUserSessionResourceSlug(baseSlug: string): string {
+  const suffix = randomSlugSuffix();
+  const normalizedBase = slugify(baseSlug) || "mcp";
+  const maxBaseLength = MAX_SLUG_LENGTH - suffix.length - 1;
+  const trimmedBase =
+    normalizedBase.slice(0, maxBaseLength).replace(/-+$/g, "") || "mcp";
+  return `${trimmedBase}-${suffix}`;
+}
+
+export function resolveExternalMcpUserSessionOAuthConfig(
+  toolset: ToolsetWithExternalMcpTools,
+): ExternalMcpUserSessionOAuthConfig | null {
+  const tools = toolset.rawTools ?? toolset.tools ?? [];
+  for (const tool of tools) {
+    const def = tool.externalMcpToolDefinition;
+    if (!def?.requiresOauth) continue;
+    const config = configFromExternalMcpDefinition(def);
+    if (config) return config;
+  }
+  return null;
+}
+
+export function externalMcpUserSessionOAuthConfigFromMetadata({
+  slug,
+  name,
+  metadata,
+}: {
+  slug: string;
+  name: string;
+  metadata: Record<string, unknown>;
+}): ExternalMcpUserSessionOAuthConfig | null {
+  const authorizationEndpoint = readString(metadata.authorization_endpoint);
+  const tokenEndpoint = readString(metadata.token_endpoint);
+  const registrationEndpoint = readString(metadata.registration_endpoint);
+  if (!authorizationEndpoint || !tokenEndpoint || !registrationEndpoint) {
+    return null;
+  }
+
+  const issuerUrl =
+    extractOrigin(authorizationEndpoint) ??
+    extractOrigin(tokenEndpoint) ??
+    extractOrigin(registrationEndpoint);
+  if (!issuerUrl) return null;
+
+  return {
+    slug,
+    name,
+    issuerUrl,
+    authorizationEndpoint,
+    tokenEndpoint,
+    registrationEndpoint,
+    scopesSupported: readStringArray(metadata.scopes_supported),
+    tokenEndpointAuthMethodsSupported: readStringArray(
+      metadata.token_endpoint_auth_methods_supported,
+    ),
+  };
+}
+
+export async function onboardExternalMcpToUserSessions({
+  client,
+  toolsetSlug,
+  toolsetName,
+  oauth,
+  options,
+  sessionDurationHours = DEFAULT_USER_SESSION_DURATION_HOURS,
+}: {
+  client: Gram;
+  toolsetSlug: string;
+  toolsetName: string;
+  oauth: ExternalMcpUserSessionOAuthConfig;
+  options?: RequestOptions;
+  sessionDurationHours?: number;
+}): Promise<OnboardExternalMcpToUserSessionsResult> {
+  const resourceSlug = buildUserSessionResourceSlug(toolsetSlug || oauth.slug);
+
+  const userSessionIssuer = await client.userSessionIssuers.create(
+    {
+      createUserSessionIssuerForm: {
+        slug: resourceSlug,
+        authnChallengeMode: "interactive",
+        sessionDurationHours,
+      },
+    },
+    undefined,
+    options,
+  );
+
+  const draft = await discoverIssuerDraft(client, oauth.issuerUrl, options);
+  const remoteSessionIssuer = await client.remoteSessionIssuers.create(
+    {
+      createRemoteSessionIssuerForm: {
+        slug: resourceSlug,
+        issuer: draft?.issuer ?? oauth.issuerUrl,
+        authorizationEndpoint:
+          draft?.authorizationEndpoint ?? oauth.authorizationEndpoint,
+        tokenEndpoint: draft?.tokenEndpoint ?? oauth.tokenEndpoint,
+        registrationEndpoint:
+          draft?.registrationEndpoint ?? oauth.registrationEndpoint,
+        jwksUri: draft?.jwksUri,
+        scopesSupported: draft?.scopesSupported ?? oauth.scopesSupported,
+        grantTypesSupported: draft?.grantTypesSupported ?? [
+          "authorization_code",
+          "refresh_token",
+        ],
+        responseTypesSupported: draft?.responseTypesSupported ?? ["code"],
+        tokenEndpointAuthMethodsSupported:
+          draft?.tokenEndpointAuthMethodsSupported ??
+          oauth.tokenEndpointAuthMethodsSupported,
+        oidc: draft?.oidc,
+        passthrough: draft?.passthrough,
+      },
+    },
+    undefined,
+    options,
+  );
+
+  await client.remoteSessionIssuers.register(
+    {
+      registerRemoteSessionIssuerForm: {
+        remoteSessionIssuerId: remoteSessionIssuer.id,
+        userSessionIssuerId: userSessionIssuer.id,
+        clientName: toolsetName || "Gram",
+        redirectUris: [remoteLoginCallbackURL()],
+      },
+    },
+    undefined,
+    options,
+  );
+
+  await client.toolsets.setUserSessionIssuer(
+    {
+      slug: toolsetSlug,
+      setUserSessionIssuerRequestBody: {
+        userSessionIssuerId: userSessionIssuer.id,
+      },
+    },
+    undefined,
+    options,
+  );
+
+  return {
+    userSessionIssuerId: userSessionIssuer.id,
+    remoteSessionIssuerId: remoteSessionIssuer.id,
+  };
+}
+
+function configFromExternalMcpDefinition(
+  def: ExternalMCPToolDefinition,
+): ExternalMcpUserSessionOAuthConfig | null {
+  if (
+    !def.oauthAuthorizationEndpoint ||
+    !def.oauthTokenEndpoint ||
+    !def.oauthRegistrationEndpoint
+  ) {
+    return null;
+  }
+
+  const issuerUrl =
+    extractOrigin(def.oauthAuthorizationEndpoint) ??
+    extractOrigin(def.oauthTokenEndpoint) ??
+    extractOrigin(def.oauthRegistrationEndpoint);
+  if (!issuerUrl) return null;
+
+  return {
+    slug: def.slug,
+    name: def.registryServerName || def.name,
+    issuerUrl,
+    authorizationEndpoint: def.oauthAuthorizationEndpoint,
+    tokenEndpoint: def.oauthTokenEndpoint,
+    registrationEndpoint: def.oauthRegistrationEndpoint,
+    scopesSupported: def.oauthScopesSupported ?? [],
+    tokenEndpointAuthMethodsSupported: [],
+  };
+}
+
+async function discoverIssuerDraft(
+  client: Gram,
+  issuer: string,
+  options?: RequestOptions,
+): Promise<RemoteSessionIssuerDraft | null> {
+  try {
+    return await client.remoteSessionIssuers.discover(
+      {
+        discoverRemoteSessionIssuerRequestBody: { issuer },
+      },
+      undefined,
+      options,
+    );
+  } catch {
+    return null;
+  }
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
+}
+
+function extractOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return null;
+  }
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function randomSlugSuffix(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/client/dashboard/src/lib/externalMcpUserSessions.ts
+++ b/client/dashboard/src/lib/externalMcpUserSessions.ts
@@ -172,6 +172,17 @@ export async function onboardExternalMcpToUserSessions({
     options,
   );
 
+  await client.toolsets.updateBySlug(
+    {
+      slug: toolsetSlug,
+      updateToolsetRequestBody: {
+        mcpIsPublic: false,
+      },
+    },
+    undefined,
+    options,
+  );
+
   await client.toolsets.setUserSessionIssuer(
     {
       slug: toolsetSlug,

--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -1,6 +1,8 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Type } from "@/components/ui/type";
+import { useTelemetry } from "@/contexts/Telemetry";
+import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import { useSdkClient } from "@/contexts/Sdk";
 import { cn, getServerURL } from "@/lib/utils";
 import type { PulseMCPServer } from "@/pages/catalog/hooks";
@@ -297,6 +299,7 @@ export function AddServerDialog({
   onServersAdded,
   projectSlug,
 }: AddServerDialogProps) {
+  const telemetry = useTelemetry();
   // Fetch server details (including remotes) when dialog opens
   const {
     enrichedServers,
@@ -308,6 +311,9 @@ export function AddServerDialog({
   const releaseState = useExternalMcpReleaseWorkflow({
     servers: enrichedServers,
     projectSlug,
+    onboardExternalMcpToUserSessions:
+      telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
+      false,
   });
 
   // Reset when dialog closes

--- a/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
+++ b/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
@@ -5,6 +5,11 @@ const mockEvolveDeployment = vi.fn();
 const mockToolsetsCreate = vi.fn();
 const mockToolsetsUpdateBySlug = vi.fn();
 const mockToolsetsGetBySlug = vi.fn();
+const mockToolsetsSetUserSessionIssuer = vi.fn();
+const mockUserSessionIssuersCreate = vi.fn();
+const mockRemoteSessionIssuersDiscover = vi.fn();
+const mockRemoteSessionIssuersCreate = vi.fn();
+const mockRemoteSessionIssuersRegister = vi.fn();
 
 // Return a stable client reference to avoid re-render loops from useCallback deps
 const mockClient = {
@@ -13,6 +18,15 @@ const mockClient = {
     create: mockToolsetsCreate,
     updateBySlug: mockToolsetsUpdateBySlug,
     getBySlug: mockToolsetsGetBySlug,
+    setUserSessionIssuer: mockToolsetsSetUserSessionIssuer,
+  },
+  userSessionIssuers: {
+    create: mockUserSessionIssuersCreate,
+  },
+  remoteSessionIssuers: {
+    discover: mockRemoteSessionIssuersDiscover,
+    create: mockRemoteSessionIssuersCreate,
+    register: mockRemoteSessionIssuersRegister,
   },
 };
 
@@ -119,6 +133,23 @@ describe("useExternalMcpReleaseWorkflow", () => {
       data: undefined,
       isLoading: false,
     } as ReturnType<typeof useListToolsets>);
+    mockUserSessionIssuersCreate.mockResolvedValue({ id: "usi-1" });
+    mockRemoteSessionIssuersDiscover.mockResolvedValue({
+      issuer: "https://idp.example",
+      authorizationEndpoint: "https://idp.example/oauth/authorize",
+      tokenEndpoint: "https://idp.example/oauth/token",
+      registrationEndpoint: "https://idp.example/oauth/register",
+      scopesSupported: ["read"],
+      grantTypesSupported: ["authorization_code", "refresh_token"],
+      responseTypesSupported: ["code"],
+      tokenEndpointAuthMethodsSupported: ["client_secret_basic"],
+      oidc: false,
+      passthrough: false,
+      discoveryWarnings: [],
+    });
+    mockRemoteSessionIssuersCreate.mockResolvedValue({ id: "rsi-1" });
+    mockRemoteSessionIssuersRegister.mockResolvedValue({ id: "rsc-1" });
+    mockToolsetsSetUserSessionIssuer.mockResolvedValue({});
   });
 
   // -------------------------------------------------------------------------
@@ -977,6 +1008,151 @@ describe("useExternalMcpReleaseWorkflow", () => {
         undefined,
         undefined,
       );
+    });
+
+    it("onboards OAuth 2.1 toolsets to user sessions when enabled", async () => {
+      mockEvolveDeployment.mockResolvedValue({});
+      mockToolsetsCreate.mockResolvedValue({ slug: "my-server" });
+      mockToolsetsUpdateBySlug.mockResolvedValue({});
+      mockToolsetsGetBySlug.mockResolvedValue({
+        slug: "my-server",
+        name: "My Server",
+        mcpSlug: "mcp-slug",
+        tools: [
+          {
+            externalMcpToolDefinition: {
+              requiresOauth: true,
+              slug: "my-server",
+              name: "proxy",
+              registryServerName: "My Server",
+              oauthAuthorizationEndpoint: "https://idp.example/oauth/authorize",
+              oauthTokenEndpoint: "https://idp.example/oauth/token",
+              oauthRegistrationEndpoint: "https://idp.example/oauth/register",
+              oauthScopesSupported: ["read"],
+            },
+          },
+        ],
+      });
+
+      const servers = [makeServer({ title: "My Server" })];
+      const { result } = renderHook(() =>
+        useExternalMcpReleaseWorkflow({
+          servers,
+          onboardExternalMcpToUserSessions: true,
+        }),
+      );
+      await act(async () => {
+        const state = result.current;
+        if (state.phase !== "configure") throw new Error("unexpected phase");
+        await state.startDeployment();
+      });
+
+      await vi.waitFor(() => {
+        const state = result.current;
+        if (state.phase !== "complete") throw new Error("unexpected phase");
+        expect(state.toolsetStatuses[0].status).toBe("completed");
+      });
+
+      expect(mockUserSessionIssuersCreate).toHaveBeenCalledWith(
+        {
+          createUserSessionIssuerForm: {
+            slug: expect.stringMatching(/^my-server-[0-9a-f]{8}$/),
+            authnChallengeMode: "interactive",
+            sessionDurationHours: 24 * 14,
+          },
+        },
+        undefined,
+        undefined,
+      );
+      expect(mockRemoteSessionIssuersDiscover).toHaveBeenCalledWith(
+        {
+          discoverRemoteSessionIssuerRequestBody: {
+            issuer: "https://idp.example",
+          },
+        },
+        undefined,
+        undefined,
+      );
+      expect(mockRemoteSessionIssuersCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createRemoteSessionIssuerForm: expect.objectContaining({
+            registrationEndpoint: "https://idp.example/oauth/register",
+          }),
+        }),
+        undefined,
+        undefined,
+      );
+      expect(mockRemoteSessionIssuersRegister).toHaveBeenCalledWith(
+        {
+          registerRemoteSessionIssuerForm: expect.objectContaining({
+            remoteSessionIssuerId: "rsi-1",
+            userSessionIssuerId: "usi-1",
+            redirectUris: [
+              expect.stringContaining("/mcp/remote_login_callback"),
+            ],
+          }),
+        },
+        undefined,
+        undefined,
+      );
+      expect(mockToolsetsSetUserSessionIssuer).toHaveBeenCalledWith(
+        {
+          slug: "my-server",
+          setUserSessionIssuerRequestBody: {
+            userSessionIssuerId: "usi-1",
+          },
+        },
+        undefined,
+        undefined,
+      );
+    });
+
+    it("keeps current behavior when onboarding is enabled but no registration endpoint exists", async () => {
+      mockEvolveDeployment.mockResolvedValue({});
+      mockToolsetsCreate.mockResolvedValue({ slug: "my-server" });
+      mockToolsetsUpdateBySlug.mockResolvedValue({});
+      mockToolsetsGetBySlug.mockResolvedValue({
+        slug: "my-server",
+        name: "My Server",
+        mcpSlug: "mcp-slug",
+        tools: [
+          {
+            externalMcpToolDefinition: {
+              requiresOauth: true,
+              slug: "my-server",
+              name: "proxy",
+              registryServerName: "My Server",
+              oauthAuthorizationEndpoint: "https://idp.example/oauth/authorize",
+              oauthTokenEndpoint: "https://idp.example/oauth/token",
+              oauthScopesSupported: ["read"],
+            },
+          },
+        ],
+      });
+
+      const servers = [makeServer({ title: "My Server" })];
+      const { result } = renderHook(() =>
+        useExternalMcpReleaseWorkflow({
+          servers,
+          onboardExternalMcpToUserSessions: true,
+        }),
+      );
+      await act(async () => {
+        const state = result.current;
+        if (state.phase !== "configure") throw new Error("unexpected phase");
+        await state.startDeployment();
+      });
+
+      await vi.waitFor(() => {
+        const state = result.current;
+        if (state.phase !== "complete") throw new Error("unexpected phase");
+        expect(state.toolsetStatuses[0].status).toBe("completed");
+      });
+
+      expect(mockUserSessionIssuersCreate).not.toHaveBeenCalled();
+      expect(mockRemoteSessionIssuersCreate).not.toHaveBeenCalled();
+      expect(mockRemoteSessionIssuersRegister).not.toHaveBeenCalled();
+      expect(mockToolsetsSetUserSessionIssuer).not.toHaveBeenCalled();
     });
 
     it("marks toolset as failed when creation throws", async () => {

--- a/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
+++ b/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
@@ -1053,6 +1053,18 @@ describe("useExternalMcpReleaseWorkflow", () => {
         expect(state.toolsetStatuses[0].status).toBe("completed");
       });
 
+      expect(mockToolsetsUpdateBySlug).toHaveBeenNthCalledWith(
+        1,
+        {
+          slug: "my-server",
+          updateToolsetRequestBody: {
+            mcpEnabled: true,
+            mcpIsPublic: false,
+          },
+        },
+        undefined,
+        undefined,
+      );
       expect(mockUserSessionIssuersCreate).toHaveBeenCalledWith(
         {
           createUserSessionIssuerForm: {
@@ -1091,6 +1103,17 @@ describe("useExternalMcpReleaseWorkflow", () => {
               expect.stringContaining("/mcp/remote_login_callback"),
             ],
           }),
+        },
+        undefined,
+        undefined,
+      );
+      expect(mockToolsetsUpdateBySlug).toHaveBeenNthCalledWith(
+        2,
+        {
+          slug: "my-server",
+          updateToolsetRequestBody: {
+            mcpIsPublic: false,
+          },
         },
         undefined,
         undefined,
@@ -1149,6 +1172,29 @@ describe("useExternalMcpReleaseWorkflow", () => {
         expect(state.toolsetStatuses[0].status).toBe("completed");
       });
 
+      expect(mockToolsetsUpdateBySlug).toHaveBeenNthCalledWith(
+        1,
+        {
+          slug: "my-server",
+          updateToolsetRequestBody: {
+            mcpEnabled: true,
+            mcpIsPublic: false,
+          },
+        },
+        undefined,
+        undefined,
+      );
+      expect(mockToolsetsUpdateBySlug).toHaveBeenNthCalledWith(
+        2,
+        {
+          slug: "my-server",
+          updateToolsetRequestBody: {
+            mcpIsPublic: true,
+          },
+        },
+        undefined,
+        undefined,
+      );
       expect(mockUserSessionIssuersCreate).not.toHaveBeenCalled();
       expect(mockRemoteSessionIssuersCreate).not.toHaveBeenCalled();
       expect(mockRemoteSessionIssuersRegister).not.toHaveBeenCalled();

--- a/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
+++ b/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.test.ts
@@ -1079,7 +1079,7 @@ describe("useExternalMcpReleaseWorkflow", () => {
       expect(mockRemoteSessionIssuersDiscover).toHaveBeenCalledWith(
         {
           discoverRemoteSessionIssuerRequestBody: {
-            issuer: "https://idp.example",
+            issuer: "https://idp.example/oauth",
           },
         },
         undefined,

--- a/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts
@@ -1,4 +1,8 @@
 import { useSdkClient } from "@/contexts/Sdk";
+import {
+  onboardExternalMcpToUserSessions as onboardToolsetToUserSessions,
+  resolveExternalMcpUserSessionOAuthConfig,
+} from "@/lib/externalMcpUserSessions";
 import type { PulseMCPServer } from "@/pages/catalog/hooks";
 import {
   useDeployment,
@@ -116,6 +120,7 @@ export type ExternalMcpReleaseWorkflow =
 interface UseExternalMcpReleaseWorkflowOptions {
   servers: PulseMCPServer[];
   projectSlug?: string;
+  onboardExternalMcpToUserSessions?: boolean;
 }
 
 function buildInitialToolsetStatuses(
@@ -158,6 +163,7 @@ function buildForkPrefillName(server: PulseMCPServer): string {
 export function useExternalMcpReleaseWorkflow({
   servers,
   projectSlug,
+  onboardExternalMcpToUserSessions = false,
 }: UseExternalMcpReleaseWorkflowOptions): ExternalMcpReleaseWorkflow {
   const client = useSdkClient();
   const { data: toolsetsResult } = useListToolsets(
@@ -383,6 +389,20 @@ export function useExternalMcpReleaseWorkflow({
             undefined,
             reqOpts,
           );
+
+          if (onboardExternalMcpToUserSessions) {
+            const oauth =
+              resolveExternalMcpUserSessionOAuthConfig(updatedToolset);
+            if (oauth) {
+              await onboardToolsetToUserSessions({
+                client,
+                toolsetSlug: updatedToolset.slug,
+                toolsetName: updatedToolset.name,
+                oauth,
+                options: reqOpts,
+              });
+            }
+          }
 
           setToolsetStatuses((prev) =>
             prev.map((s, idx) =>

--- a/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useExternalMcpReleaseWorkflow.ts
@@ -377,7 +377,7 @@ export function useExternalMcpReleaseWorkflow({
               slug: toolset.slug,
               updateToolsetRequestBody: {
                 mcpEnabled: true,
-                mcpIsPublic: true,
+                mcpIsPublic: !onboardExternalMcpToUserSessions,
               },
             },
             undefined,
@@ -401,6 +401,17 @@ export function useExternalMcpReleaseWorkflow({
                 oauth,
                 options: reqOpts,
               });
+            } else {
+              await client.toolsets.updateBySlug(
+                {
+                  slug: toolset.slug,
+                  updateToolsetRequestBody: {
+                    mcpIsPublic: true,
+                  },
+                },
+                undefined,
+                reqOpts,
+              );
             }
           }
 

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -10,6 +10,7 @@ import {
 import { useIsAdmin, useSession } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
+import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import { Toolset } from "@/lib/toolTypes";
 import { useRoutes } from "@/routes";
 import type { McpEnvironmentConfigInput } from "@gram/client/models/components";
@@ -900,10 +901,12 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
   ] = useState(false);
 
   const isAdmin = useIsAdmin();
+  const telemetry = useTelemetry();
 
   const { data: environmentsData } = useListEnvironments();
   const environments = environmentsData?.environments ?? [];
 
+  const loginSecured = !!toolset.userSessionIssuerSlug;
   const isOAuthConnected = !!(
     toolset?.oauthProxyServer || toolset?.externalOauthServer
   );
@@ -947,7 +950,11 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
   // OAuth-Proxy → user-sessions migration has produced a user_session_issuer
   // for this toolset. Admin-only on the dashboard side: regular project
   // members aren't expected to think about the user-session plumbing.
-  const userSessionIssuerWired = isAdmin && !!toolset.userSessionIssuerSlug;
+  const userSessionIssuerWired = !!toolset.userSessionIssuerSlug;
+  const hideConfigureButton =
+    (telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
+      false) &&
+    !isOAuthConnected;
 
   return (
     <PageSection
@@ -957,12 +964,12 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
       action={
         <div className="flex items-center gap-2">
           {userSessionIssuerWired && (
-            <span
-              className="rounded-full border border-green-500/40 bg-green-50 px-2 py-0.5 text-[11px] font-medium tracking-wide text-green-900 dark:bg-green-950 dark:text-green-200"
-              title={`User session issuer: ${toolset.userSessionIssuerSlug}`}
-            >
-              User session issuer wired
-            </span>
+            <Badge variant="success">
+              <Badge.LeftIcon>
+                <CheckCircle className="h-3.5 w-3.5" />
+              </Badge.LeftIcon>
+              <Badge.Text>Login Secured</Badge.Text>
+            </Badge>
           )}
           {showWireUserSessionIssuer && (
             <Button
@@ -972,26 +979,28 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
               <Button.Text>Wire User Session Issuer</Button.Text>
             </Button>
           )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {!isOAuthEligible ? (
-                <span className="inline-block">
-                  <Button disabled>
-                    <Button.Text>Configure</Button.Text>
+          {!hideConfigureButton && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {!isOAuthEligible ? (
+                  <span className="inline-block">
+                    <Button disabled>
+                      <Button.Text>Configure</Button.Text>
+                    </Button>
+                  </span>
+                ) : (
+                  <Button onClick={handleConfigureClick}>
+                    <Button.Text>
+                      {isOAuthConnected ? "Manage" : "Configure"}
+                    </Button.Text>
                   </Button>
-                </span>
-              ) : (
-                <Button onClick={handleConfigureClick}>
-                  <Button.Text>
-                    {isOAuthConnected ? "Manage" : "Configure"}
-                  </Button.Text>
-                </Button>
+                )}
+              </TooltipTrigger>
+              {!isOAuthEligible && (
+                <TooltipContent>{disabledTooltipText}</TooltipContent>
               )}
-            </TooltipTrigger>
-            {!isOAuthEligible && (
-              <TooltipContent>{disabledTooltipText}</TooltipContent>
-            )}
-          </Tooltip>
+            </Tooltip>
+          )}
         </div>
       }
     >
@@ -999,6 +1008,8 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
         isOAuthConnected={isOAuthConnected}
         isOAuthEligible={!!isOAuthEligible}
         externalMcpRequiresOAuth={externalMcpRequiresOAuth}
+        loginSecured={loginSecured}
+        showConfigureAction={!hideConfigureButton}
         oauthParadigm={oauthParadigm}
         mcpEnabled={!!toolset.mcpEnabled}
         proxyEnvironmentSlug={proxyEnvironmentSlug}
@@ -1056,6 +1067,8 @@ function OAuthStatusDisplay({
   isOAuthConnected,
   isOAuthEligible,
   externalMcpRequiresOAuth,
+  loginSecured,
+  showConfigureAction,
   oauthParadigm,
   mcpEnabled,
   proxyEnvironmentSlug,
@@ -1065,6 +1078,8 @@ function OAuthStatusDisplay({
   isOAuthConnected: boolean;
   isOAuthEligible: boolean;
   externalMcpRequiresOAuth: boolean;
+  loginSecured: boolean;
+  showConfigureAction: boolean;
   oauthParadigm: OAuthParadigm | null;
   mcpEnabled: boolean;
   proxyEnvironmentSlug: string | undefined;
@@ -1072,6 +1087,21 @@ function OAuthStatusDisplay({
   onConfigureClick: () => void;
 }) {
   const routes = useRoutes();
+
+  if (loginSecured) {
+    return (
+      <div className="border-success-softest bg-success-softest rounded-lg border border-dashed p-8 text-center">
+        <p className="text-success-foreground mb-1">
+          <CheckCircle className="text-success-foreground mx-auto mb-1 h-5 w-5" />
+          Login Secured
+        </p>
+        <p className="text-success-foreground text-sm">
+          Users will authenticate with interactive auth before accessing this
+          MCP server.
+        </p>
+      </div>
+    );
+  }
 
   if (isOAuthConnected && oauthParadigm) {
     return (
@@ -1109,7 +1139,7 @@ function OAuthStatusDisplay({
 
   if (externalMcpRequiresOAuth) {
     return (
-      <div className="border-warning-foreground/80 bg-warning rounded-lg border border-dashed px-6 py-8 text-center">
+      <div className="border-warning-foreground/80 bg-warning dark:bg-warning/10 dark:border-warning-foreground/30 rounded-lg border border-dashed px-6 py-8 text-center">
         <AlertTriangle className="text-warning mx-auto mb-1 h-5 w-5" />
         <p className="text-warning-foreground mb-1 font-bold">
           OAuth setup required
@@ -1117,9 +1147,11 @@ function OAuthStatusDisplay({
         <p className="text-warning-foreground/80 mb-3 text-sm">
           This MCP server requires OAuth configuration before it can be used.
         </p>
-        <Button variant="secondary" onClick={onConfigureClick}>
-          <Button.Text>Configure OAuth</Button.Text>
-        </Button>
+        {showConfigureAction && (
+          <Button variant="secondary" onClick={onConfigureClick}>
+            <Button.Text>Configure OAuth</Button.Text>
+          </Button>
+        )}
       </div>
     );
   }
@@ -1135,9 +1167,11 @@ function OAuthStatusDisplay({
           Enable OAuth to require users to authenticate before accessing this
           MCP server.
         </p>
-        <Button variant="secondary" onClick={onConfigureClick}>
-          <Button.Text>Configure OAuth</Button.Text>
-        </Button>
+        {showConfigureAction && (
+          <Button variant="secondary" onClick={onConfigureClick}>
+            <Button.Text>Configure OAuth</Button.Text>
+          </Button>
+        )}
       </div>
     );
   }

--- a/client/dashboard/src/pages/mcp/oauth-wizard/AutoConfigureLoader.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/AutoConfigureLoader.tsx
@@ -1,16 +1,23 @@
 import { Type } from "@/components/ui/type";
 import { Loader2 } from "lucide-react";
 
-export function AutoConfigureLoader() {
+export function AutoConfigureLoader({
+  mode = "proxy",
+}: {
+  mode?: "proxy" | "user-sessions";
+}) {
   return (
     <div className="flex flex-col items-center justify-center gap-4 py-12">
       <Loader2 className="text-muted-foreground h-12 w-12 animate-spin" />
       <Type className="text-center text-lg font-medium">
-        Setting up OAuth Proxy...
+        {mode === "user-sessions"
+          ? "Setting up user sessions..."
+          : "Setting up OAuth Proxy..."}
       </Type>
       <Type muted small className="max-w-md text-center">
-        Registering Gram with the upstream OAuth provider and storing the
-        returned credentials.
+        {mode === "user-sessions"
+          ? "Registering Gram with the upstream OAuth provider and linking the issuer to this toolset."
+          : "Registering Gram with the upstream OAuth provider and storing the returned credentials."}
       </Type>
     </div>
   );

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => {
     invalidateAllRemoteSessionIssuers: vi.fn(),
     invalidateAllRemoteSessionClients: vi.fn(),
     invalidateAllUserSessionIssuers: vi.fn(),
+    isFeatureEnabled: vi.fn(() => false),
   };
 });
 
@@ -77,10 +78,14 @@ vi.mock("@/contexts/Fetcher", () => ({
   }),
 }));
 
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: () => ({}),
+}));
+
 vi.mock("@/contexts/Telemetry", () => ({
   useTelemetry: () => ({
     capture: mocks.capture,
-    isFeatureEnabled: () => false,
+    isFeatureEnabled: mocks.isFeatureEnabled,
   }),
 }));
 
@@ -140,6 +145,25 @@ const toolset = {
   oauthEnablementMetadata: { oauth2SecurityCount: 0 },
 } as unknown as Parameters<typeof ConnectOAuthModal>[0]["toolset"];
 
+const oauthToolset = {
+  ...toolset,
+  rawTools: [
+    {
+      externalMcpToolDefinition: {
+        requiresOauth: true,
+        slug: "my-oauth-server",
+        name: "proxy",
+        registryServerName: "My OAuth Server",
+        oauthVersion: "2.1",
+        oauthAuthorizationEndpoint: "https://idp.example/oauth/authorize",
+        oauthTokenEndpoint: "https://idp.example/oauth/token",
+        oauthRegistrationEndpoint: "https://idp.example/oauth/register",
+        oauthScopesSupported: ["read"],
+      },
+    },
+  ],
+} as unknown as Parameters<typeof ConnectOAuthModal>[0]["toolset"];
+
 function renderWizard(
   props: Partial<Parameters<typeof ConnectOAuthModal>[0]> = {},
 ) {
@@ -165,6 +189,7 @@ beforeEach(() => {
   for (const fn of Object.values(mocks)) {
     if (typeof fn === "function" && "mockClear" in fn) fn.mockClear();
   }
+  mocks.isFeatureEnabled.mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -182,6 +207,12 @@ describe("OAuthWizard — rendering", () => {
     expect(screen.getByText("Connect OAuth")).toBeTruthy();
     expect(screen.getByRole("button", { name: /OAuth Proxy/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /External OAuth/ })).toBeTruthy();
+  });
+
+  it("shows interactive auth status when user-session onboarding is enabled", () => {
+    mocks.isFeatureEnabled.mockReturnValue(true);
+    renderWizard({ toolset: oauthToolset });
+    expect(screen.getByText("Interactive auth enabled")).toBeTruthy();
   });
 });
 

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
@@ -27,6 +27,9 @@ const mocks = vi.hoisted(() => {
     invalidateAllToolset: vi.fn(),
     invalidateAllGetMcpMetadata: vi.fn(),
     invalidateAllListEnvironments: vi.fn(),
+    invalidateAllRemoteSessionIssuers: vi.fn(),
+    invalidateAllRemoteSessionClients: vi.fn(),
+    invalidateAllUserSessionIssuers: vi.fn(),
   };
 });
 
@@ -35,6 +38,9 @@ vi.mock("@gram/client/react-query", () => ({
   invalidateAllToolset: mocks.invalidateAllToolset,
   invalidateAllGetMcpMetadata: mocks.invalidateAllGetMcpMetadata,
   invalidateAllListEnvironments: mocks.invalidateAllListEnvironments,
+  invalidateAllRemoteSessionIssuers: mocks.invalidateAllRemoteSessionIssuers,
+  invalidateAllRemoteSessionClients: mocks.invalidateAllRemoteSessionClients,
+  invalidateAllUserSessionIssuers: mocks.invalidateAllUserSessionIssuers,
   buildAddExternalOAuthServerMutation: () => ({
     mutationKey: [],
     mutationFn: mocks.addExternalOAuth,
@@ -72,7 +78,10 @@ vi.mock("@/contexts/Fetcher", () => ({
 }));
 
 vi.mock("@/contexts/Telemetry", () => ({
-  useTelemetry: () => ({ capture: mocks.capture }),
+  useTelemetry: () => ({
+    capture: mocks.capture,
+    isFeatureEnabled: () => false,
+  }),
 }));
 
 vi.mock("@/hooks/useProductTier", () => ({

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -6,10 +6,14 @@ import { useTelemetry } from "@/contexts/Telemetry";
 import { Toolset } from "@/lib/toolTypes";
 import { getServerURL } from "@/lib/utils";
 import { useProductTier } from "@/hooks/useProductTier";
+import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import {
   invalidateAllGetMcpMetadata,
   invalidateAllListEnvironments,
+  invalidateAllRemoteSessionClients,
+  invalidateAllRemoteSessionIssuers,
   invalidateAllToolset,
+  invalidateAllUserSessionIssuers,
   useGramContext,
 } from "@gram/client/react-query";
 import { useQueryClient } from "@tanstack/react-query";
@@ -105,6 +109,12 @@ function WizardBody({
             invalidateAllGetMcpMetadata(queryClient);
             invalidateAllListEnvironments(queryClient);
           },
+          invalidateOnUserSessionsCreate: () => {
+            invalidateAllToolset(queryClient);
+            invalidateAllRemoteSessionIssuers(queryClient);
+            invalidateAllRemoteSessionClients(queryClient);
+            invalidateAllUserSessionIssuers(queryClient);
+          },
           captureExternalSuccess: () =>
             telemetry.capture("mcp_event", {
               action: "external_oauth_configured",
@@ -113,6 +123,11 @@ function WizardBody({
           captureProxyCreateSuccess: () =>
             telemetry.capture("mcp_event", {
               action: "oauth_proxy_configured",
+              slug: toolsetSlug,
+            }),
+          captureUserSessionsCreateSuccess: () =>
+            telemetry.capture("mcp_event", {
+              action: "user_sessions_oauth_configured",
               slug: toolsetSlug,
             }),
         },
@@ -125,6 +140,9 @@ function WizardBody({
     toolsetSlug,
     toolsetName: toolset.name,
     activeOrganizationId: session.activeOrganizationId,
+    onboardToUserSessions:
+      telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
+      false,
   };
 
   return (
@@ -147,6 +165,9 @@ function WizardSteps({
   const hasMultipleOAuth2AuthCode = oauth2SecurityCount > 1;
 
   const isProxyCreating = state.matches({ proxy: "submitting" });
+  const isUserSessionsCreating = state.matches({
+    userSessions: "submitting",
+  });
   const isAutoRegistering = state.context.autoRegistering;
 
   return (
@@ -167,7 +188,12 @@ function WizardSteps({
       {state.matches({ proxy: "metadata" }) && <ProxyMetadataForm />}
 
       {(state.matches({ proxy: "registering" }) ||
-        (isProxyCreating && isAutoRegistering)) && <AutoConfigureLoader />}
+        (isProxyCreating && isAutoRegistering) ||
+        isUserSessionsCreating) && (
+        <AutoConfigureLoader
+          mode={isUserSessionsCreating ? "user-sessions" : "proxy"}
+        />
+      )}
 
       {state.matches({ proxy: "autoRegisterFailed" }) && (
         <AutoRegisterFailedStep error={state.context.error} onClose={onClose} />

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -2,6 +2,7 @@ import { FeatureRequestModal } from "@/components/FeatureRequestModal";
 import { Dialog } from "@/components/ui/dialog";
 import { useSession } from "@/contexts/Auth";
 import { useFetcher } from "@/contexts/Fetcher";
+import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Toolset } from "@/lib/toolTypes";
 import { getServerURL } from "@/lib/utils";
@@ -14,7 +15,6 @@ import {
   invalidateAllRemoteSessionIssuers,
   invalidateAllToolset,
   invalidateAllUserSessionIssuers,
-  useGramContext,
 } from "@gram/client/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { Globe } from "lucide-react";
@@ -90,7 +90,7 @@ function WizardBody({
   toolsetSlug: string;
   toolset: Toolset;
 }) {
-  const client = useGramContext();
+  const client = useSdkClient();
   const queryClient = useQueryClient();
   const telemetry = useTelemetry();
   const session = useSession();

--- a/client/dashboard/src/pages/mcp/oauth-wizard/PathSelection.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/PathSelection.tsx
@@ -19,6 +19,7 @@ export function PathSelection() {
     (s) => s.context.onboardToUserSessions,
   );
   const canAutoConfigure = canAutoConfigureFromDiscovered(discovered);
+  const interactiveAuthEnabled = onboardToUserSessions && canAutoConfigure;
 
   return (
     <div className="space-y-4">
@@ -34,7 +35,16 @@ export function PathSelection() {
             title="Auto-Configure"
             onClick={() => send({ type: "SELECT_PROXY_AUTO" })}
             icon={ZapIcon}
-            badges={<Badge variant="information">Recommended</Badge>}
+            badges={[
+              <Badge key="recommended" variant="information">
+                Recommended
+              </Badge>,
+              interactiveAuthEnabled && (
+                <Badge key="interactive-auth" variant="success">
+                  Interactive auth enabled
+                </Badge>
+              ),
+            ]}
           >
             <Type muted small>
               {onboardToUserSessions
@@ -50,9 +60,15 @@ export function PathSelection() {
           icon={WaypointsIcon}
           badges={[
             !canAutoConfigure && discovered?.version === "2.0" && (
-              <Badge variant="information">Recommended</Badge>
+              <Badge key="recommended" variant="information">
+                Recommended
+              </Badge>
             ),
-            discovered && <Badge variant="neutral">Discovered</Badge>,
+            discovered && (
+              <Badge key="discovered" variant="neutral">
+                Discovered
+              </Badge>
+            ),
           ]}
         >
           <Type muted small>

--- a/client/dashboard/src/pages/mcp/oauth-wizard/PathSelection.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/PathSelection.tsx
@@ -15,6 +15,9 @@ import type { DiscoveredOAuth } from "./machine-types";
 export function PathSelection() {
   const send = WizardContext.useActorRef().send;
   const discovered = WizardContext.useSelector((s) => s.context.discovered);
+  const onboardToUserSessions = WizardContext.useSelector(
+    (s) => s.context.onboardToUserSessions,
+  );
   const canAutoConfigure = canAutoConfigureFromDiscovered(discovered);
 
   return (
@@ -34,8 +37,9 @@ export function PathSelection() {
             badges={<Badge variant="information">Recommended</Badge>}
           >
             <Type muted small>
-              Automatically set up OAuth Proxy based on pre-discovered details
-              about this MCP server.
+              {onboardToUserSessions
+                ? "Automatically set up user sessions based on pre-discovered OAuth details about this MCP server."
+                : "Automatically set up OAuth Proxy based on pre-discovered details about this MCP server."}
             </Type>
           </PathOptionCard>
         )}

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
@@ -49,6 +49,7 @@ export type Context = {
   toolsetSlug: string;
   toolsetName: string;
   activeOrganizationId: string;
+  onboardToUserSessions: boolean;
 };
 
 export type Input = {
@@ -56,6 +57,7 @@ export type Input = {
   toolsetSlug: string;
   toolsetName: string;
   activeOrganizationId: string;
+  onboardToUserSessions?: boolean;
 };
 
 export type WizardEvent =

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
@@ -20,6 +20,7 @@ import {
   nextEnvironmentName,
   type AddExternalOAuthInput,
   type AddOAuthProxyInput,
+  type ConfigureUserSessionsInput,
   type CreateEnvironmentInput,
   type CreateEnvironmentOutput,
   type DeleteEnvironmentInput,
@@ -75,6 +76,9 @@ function happyServices() {
         clientSecret: "auto-secret",
         tokenAuthMethod: "client_secret_basic",
       }),
+    ),
+    configureUserSessions: fromPromise<void, ConfigureUserSessionsInput>(
+      async () => {},
     ),
   };
 }
@@ -229,6 +233,7 @@ function withExternal(over: Partial<Context["external"]> = {}): Context {
     toolsetSlug: "",
     toolsetName: "",
     activeOrganizationId: "",
+    onboardToUserSessions: false,
   };
 }
 
@@ -690,6 +695,39 @@ describe("oauthWizardMachine — auto-configure from path selection", () => {
     expect(snap.context.proxy.clientSecret).toBe("auto-secret");
     expect(snap.context.envSlug).toBe("env-new");
     expect(snap.context.result?.success).toBe(true);
+  });
+
+  it("uses the user-session onboarding path when the feature flag is enabled", async () => {
+    const configureUserSessions = fromPromise<void, ConfigureUserSessionsInput>(
+      async ({ input }) => {
+        expect(input.toolsetSlug).toBe("ts");
+        expect(input.toolsetName).toBe("Toolset");
+        expect(input.oauth.registrationEndpoint).toBe(
+          VALID_PROXY_METADATA.registration_endpoint,
+        );
+      },
+    );
+    const actor = makeActor(
+      { ...inputWithDiscovered, onboardToUserSessions: true },
+      {
+        ...happyServices(),
+        configureUserSessions,
+      },
+    );
+    actor.start();
+    actor.send({ type: "SELECT_PROXY_AUTO" });
+
+    expect(actor.getSnapshot().matches({ userSessions: "submitting" })).toBe(
+      true,
+    );
+
+    await waitFor(actor, (s) => s.matches({ result: "success" }), {
+      timeout: 1000,
+    });
+
+    const snap = actor.getSnapshot();
+    expect(snap.context.result?.message).toContain("User sessions");
+    expect(snap.context.envSlug).toBeNull();
   });
 
   it("registerClient failure routes to autoRegisterFailed", async () => {

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
@@ -1,6 +1,8 @@
 import { createActorContext } from "@xstate/react";
 import { assign, fromPromise, setup, type SnapshotFrom } from "xstate";
 
+import { externalMcpUserSessionOAuthConfigFromMetadata } from "@/lib/externalMcpUserSessions";
+
 import { checkCreds, checkExternal, checkProxyMeta } from "./guards";
 import {
   type Context,
@@ -11,6 +13,7 @@ import {
 import {
   type AddExternalOAuthInput,
   type AddOAuthProxyInput,
+  type ConfigureUserSessionsInput,
   type CreateEnvironmentInput,
   type CreateEnvironmentOutput,
   type DeleteEnvironmentInput,
@@ -45,6 +48,7 @@ function initialContext(input: Input): Context {
     toolsetSlug: input.toolsetSlug,
     toolsetName: input.toolsetName,
     activeOrganizationId: input.activeOrganizationId,
+    onboardToUserSessions: input.onboardToUserSessions ?? false,
   };
 }
 
@@ -105,6 +109,15 @@ export function canAutoConfigureFromDiscovered(
   );
 }
 
+function userSessionOAuthConfigFromDiscovered(d: DiscoveredOAuth | null) {
+  if (!d) return null;
+  return externalMcpUserSessionOAuthConfigFromMetadata({
+    slug: d.slug,
+    name: d.name,
+    metadata: d.metadata,
+  });
+}
+
 function placeholder<TInput, TOutput = void>(name: string) {
   return fromPromise<TOutput, TInput>(async () => {
     throw new Error(
@@ -131,6 +144,9 @@ export const oauthWizardMachine = setup({
     registerClient: placeholder<RegisterClientInput, RegisterClientOutput>(
       "registerClient",
     ),
+    configureUserSessions: placeholder<ConfigureUserSessionsInput>(
+      "configureUserSessions",
+    ),
   },
   guards: {
     validExternal: ({ context }) => checkExternal(context).ok,
@@ -138,12 +154,17 @@ export const oauthWizardMachine = setup({
     validCreds: ({ context }) => checkCreds(context).ok,
     canAutoConfigure: ({ context }) =>
       canAutoConfigureFromDiscovered(context.discovered),
+    shouldAutoConfigureUserSessions: ({ context }) =>
+      context.onboardToUserSessions &&
+      userSessionOAuthConfigFromDiscovered(context.discovered) !== null,
   },
   actions: {
     invalidateOnExternalSuccess: () => {},
     invalidateOnProxyCreate: () => {},
     captureExternalSuccess: () => {},
     captureProxyCreateSuccess: () => {},
+    captureUserSessionsCreateSuccess: () => {},
+    invalidateOnUserSessionsCreate: () => {},
   },
 }).createMachine({
   id: "oauthWizard",
@@ -175,21 +196,87 @@ export const oauthWizardMachine = setup({
                 : context.proxy,
           }),
         },
-        SELECT_PROXY_AUTO: {
-          guard: "canAutoConfigure",
-          target: "proxy.registering",
-          actions: assign({
-            proxy: ({ context }) =>
-              context.discovered
-                ? {
-                    ...context.proxy,
-                    ...proxyFieldsFromDiscovered(context.discovered),
-                    prefilled: true,
-                  }
-                : context.proxy,
-            autoRegistering: () => true,
-            error: () => null,
-          }),
+        SELECT_PROXY_AUTO: [
+          {
+            guard: "shouldAutoConfigureUserSessions",
+            target: "userSessions.submitting",
+            actions: assign({
+              proxy: ({ context }) =>
+                context.discovered
+                  ? {
+                      ...context.proxy,
+                      ...proxyFieldsFromDiscovered(context.discovered),
+                      prefilled: true,
+                    }
+                  : context.proxy,
+              autoRegistering: () => true,
+              error: () => null,
+            }),
+          },
+          {
+            guard: "canAutoConfigure",
+            target: "proxy.registering",
+            actions: assign({
+              proxy: ({ context }) =>
+                context.discovered
+                  ? {
+                      ...context.proxy,
+                      ...proxyFieldsFromDiscovered(context.discovered),
+                      prefilled: true,
+                    }
+                  : context.proxy,
+              autoRegistering: () => true,
+              error: () => null,
+            }),
+          },
+        ],
+      },
+    },
+
+    userSessions: {
+      initial: "submitting",
+      states: {
+        submitting: {
+          meta: { title: "Configure User Sessions" },
+          invoke: {
+            src: "configureUserSessions",
+            input: ({ context }): ConfigureUserSessionsInput => {
+              const oauth = userSessionOAuthConfigFromDiscovered(
+                context.discovered,
+              );
+              if (!oauth) {
+                throw new Error("registration_endpoint metadata is required");
+              }
+              return {
+                toolsetSlug: context.toolsetSlug,
+                toolsetName: context.toolsetName,
+                oauth,
+              };
+            },
+            onDone: {
+              target: "#oauthWizard.result.success",
+              actions: [
+                assign({
+                  result: () => ({
+                    success: true,
+                    message: "User sessions have been configured successfully.",
+                  }),
+                }),
+                "captureUserSessionsCreateSuccess",
+                "invalidateOnUserSessionsCreate",
+              ],
+            },
+            onError: {
+              target: "#oauthWizard.proxy.autoRegisterFailed",
+              actions: assign({
+                error: ({ event }) =>
+                  errorMessage(
+                    event.error,
+                    "Failed to configure user sessions",
+                  ),
+              }),
+            },
+          },
         },
       },
     },

--- a/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
@@ -4,8 +4,8 @@ import {
   buildCreateEnvironmentMutation,
   buildDeleteEnvironmentMutation,
   buildListEnvironmentsQuery,
-  useGramContext,
 } from "@gram/client/react-query";
+import type { Gram } from "@gram/client";
 import type { QueryClient } from "@tanstack/react-query";
 import { fromPromise } from "xstate";
 
@@ -90,7 +90,7 @@ export type WizardServices = {
   >;
 };
 
-export type GramClient = ReturnType<typeof useGramContext>;
+export type GramClient = Gram;
 
 export function createWizardServices(
   client: GramClient,

--- a/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
@@ -9,6 +9,11 @@ import {
 import type { QueryClient } from "@tanstack/react-query";
 import { fromPromise } from "xstate";
 
+import {
+  type ExternalMcpUserSessionOAuthConfig,
+  onboardExternalMcpToUserSessions,
+} from "@/lib/externalMcpUserSessions";
+
 import { parseScopes } from "./machine-types";
 
 type SignalArg = { signal: AbortSignal };
@@ -57,6 +62,12 @@ export type RegisterClientOutput = {
   tokenAuthMethod: string | null;
 };
 
+export type ConfigureUserSessionsInput = {
+  toolsetSlug: string;
+  toolsetName: string;
+  oauth: ExternalMcpUserSessionOAuthConfig;
+};
+
 export type AuthedFetch = (
   endpoint: string,
   opts: RequestInit,
@@ -73,6 +84,9 @@ export type WizardServices = {
   >;
   registerClient: ReturnType<
     typeof fromPromise<RegisterClientOutput, RegisterClientInput>
+  >;
+  configureUserSessions: ReturnType<
+    typeof fromPromise<void, ConfigureUserSessionsInput>
   >;
 };
 
@@ -202,12 +216,25 @@ export function createWizardServices(
     },
   );
 
+  const configureUserSessions = fromPromise<void, ConfigureUserSessionsInput>(
+    async ({ input, signal }) => {
+      await onboardExternalMcpToUserSessions({
+        client,
+        toolsetSlug: input.toolsetSlug,
+        toolsetName: input.toolsetName,
+        oauth: input.oauth,
+        options: { fetchOptions: { signal } },
+      });
+    },
+  );
+
   return {
     addExternalOAuth,
     createEnvironment,
     addOAuthProxy,
     deleteEnvironment,
     registerClient,
+    configureUserSessions,
   };
 }
 

--- a/client/dashboard/src/pages/mcp/wire-user-session-issuer/defaults.ts
+++ b/client/dashboard/src/pages/mcp/wire-user-session-issuer/defaults.ts
@@ -1,4 +1,5 @@
 import type { Toolset } from "@/lib/toolTypes";
+import { buildUserSessionResourceSlug } from "@/lib/externalMcpUserSessions";
 import type { OAuthProxyProvider } from "@gram/client/models/components";
 
 // Pure helpers that derive migration defaults from a toolset's first
@@ -40,7 +41,7 @@ export function deriveMigrationDefaults(
   // and the remote session issuer live in different tables with independent
   // uniqueness, so the same value works for both and reads as a pair. 4
   // bytes of entropy is plenty for project-scoped uniqueness.
-  const slug = `${toolset.slug}-${randomSlugSuffix()}`;
+  const slug = buildUserSessionResourceSlug(toolset.slug);
   return {
     proxyProvider: proxy,
     userSessionIssuerSlug: slug,
@@ -58,10 +59,4 @@ function extractOrigin(url: string | null | undefined): string | null {
   } catch {
     return null;
   }
-}
-
-function randomSlugSuffix(): string {
-  const bytes = new Uint8Array(4);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/client/dashboard/src/pages/playground/PlaygroundAuth.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundAuth.tsx
@@ -232,6 +232,7 @@ export function PlaygroundAuth({
   // Check if toolset has OAuth configuration at the toolset level
   const oauthMode = useMemo(() => getToolsetOAuthMode(toolset), [toolset]);
   const hasOAuth = oauthMode !== "none";
+  const loginSecured = !!toolset.userSessionIssuerSlug;
   const oauthProviderName = useMemo(
     () => getOAuthProviderName(toolset),
     [toolset],
@@ -329,7 +330,12 @@ export function PlaygroundAuth({
   };
 
   // Show "no auth required" only if there are no env vars AND no OAuth
-  if (envVars.length === 0 && !hasOAuth && !oauthConfigRequired) {
+  if (
+    envVars.length === 0 &&
+    !hasOAuth &&
+    !oauthConfigRequired &&
+    !loginSecured
+  ) {
     return (
       <div className="py-4 text-center">
         <Type variant="small" className="text-muted-foreground">
@@ -341,8 +347,22 @@ export function PlaygroundAuth({
 
   return (
     <div className="space-y-3">
+      {loginSecured && (
+        <div className="border-success-softest bg-success-softest rounded-md border p-3">
+          <Stack direction="horizontal" align="center" className="gap-2">
+            <Badge variant="success">
+              <CheckCircle className="mr-1 size-3" />
+              Login Secured
+            </Badge>
+            <Type variant="small" className="text-success-foreground">
+              Interactive auth is configured.
+            </Type>
+          </Stack>
+        </div>
+      )}
+
       {oauthConfigRequired && (
-        <div className="border-warning-foreground/80 bg-warning rounded-md border border-dashed p-3 text-center">
+        <div className="border-warning-foreground/80 bg-warning dark:bg-warning/10 dark:border-warning-foreground/30 rounded-md border border-dashed p-3 text-center">
           <AlertTriangle className="text-warning-foreground mx-auto mb-1 size-4" />
           <Type
             variant="small"


### PR DESCRIPTION
This enables automatic import to user sessions as the default auth mode behind a feature flag.

Should likely be enabled for all new customers, but feature flag allows for a low risk toggle