### PR TITLE
feat(dashboard): auto-sync sources card on MCP detail page

### DIFF
--- a/client/dashboard/src/pages/mcp/AutoSyncSourcesCard.test.ts
+++ b/client/dashboard/src/pages/mcp/AutoSyncSourcesCard.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FUNCTION_PREFIX,
+  applyFunctionToggle,
+  extractFunctionSubscriptions,
+} from "./autoSyncSources";
+
+describe("extractFunctionSubscriptions", () => {
+  it("returns an empty set for an empty input", () => {
+    expect(extractFunctionSubscriptions([])).toEqual(new Set());
+  });
+
+  it("strips the function: prefix from each entry", () => {
+    expect(
+      extractFunctionSubscriptions(["function:billing", "function:catalog"]),
+    ).toEqual(new Set(["billing", "catalog"]));
+  });
+
+  it("ignores entries that don't start with function:", () => {
+    expect(
+      extractFunctionSubscriptions(["http:stripe", "function:billing"]),
+    ).toEqual(new Set(["billing"]));
+  });
+
+  it("dedupes identical entries", () => {
+    expect(
+      extractFunctionSubscriptions(["function:foo", "function:foo"]),
+    ).toEqual(new Set(["foo"]));
+  });
+
+  it("treats the prefix constant as a single source of truth", () => {
+    expect(FUNCTION_PREFIX).toBe("function:");
+  });
+});
+
+describe("applyFunctionToggle", () => {
+  it("adds a new entry when toggling on", () => {
+    expect(applyFunctionToggle([], "billing", true)).toEqual([
+      "function:billing",
+    ]);
+  });
+
+  it("removes an entry when toggling off", () => {
+    expect(applyFunctionToggle(["function:billing"], "billing", false)).toEqual(
+      [],
+    );
+  });
+
+  it("is idempotent on repeated toggling-on", () => {
+    expect(applyFunctionToggle(["function:billing"], "billing", true)).toEqual([
+      "function:billing",
+    ]);
+  });
+
+  it("preserves non-function entries through a toggle", () => {
+    const result = applyFunctionToggle(
+      ["http:stripe", "function:billing"],
+      "catalog",
+      true,
+    );
+    expect(result).toContain("http:stripe");
+    expect(result).toContain("function:billing");
+    expect(result).toContain("function:catalog");
+  });
+
+  it("does not touch other function entries when toggling one off", () => {
+    expect(
+      applyFunctionToggle(
+        ["function:billing", "function:catalog"],
+        "billing",
+        false,
+      ),
+    ).toEqual(["function:catalog"]);
+  });
+});

--- a/client/dashboard/src/pages/mcp/AutoSyncSourcesCard.tsx
+++ b/client/dashboard/src/pages/mcp/AutoSyncSourcesCard.tsx
@@ -1,0 +1,150 @@
+import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Stack } from "@speakeasy-api/moonshine";
+
+import { Heading } from "@/components/ui/heading";
+import { Switch } from "@/components/ui/switch";
+import { Type } from "@/components/ui/type";
+import {
+  invalidateAllToolset,
+  useUpdateToolsetMutation,
+} from "@gram/client/react-query";
+
+import { useTelemetry } from "@/contexts/Telemetry";
+import { useLatestDeployment } from "@/hooks/toolTypes";
+import { useRBAC } from "@/hooks/useRBAC";
+import type { Toolset } from "@/lib/toolTypes";
+
+import {
+  applyFunctionToggle,
+  extractFunctionSubscriptions,
+} from "./autoSyncSources";
+
+interface AutoSyncSourcesCardProps {
+  toolset: Toolset;
+}
+
+export function AutoSyncSourcesCard({ toolset }: AutoSyncSourcesCardProps) {
+  const { hasScope } = useRBAC();
+  const canWrite = hasScope("mcp:write");
+  const queryClient = useQueryClient();
+  const telemetry = useTelemetry();
+
+  const { data: deploymentResult } = useLatestDeployment();
+  const functionSources = deploymentResult?.deployment?.functionsAssets ?? [];
+
+  const subscribed = useMemo(
+    () => extractFunctionSubscriptions(toolset.autoSyncSources ?? []),
+    [toolset.autoSyncSources],
+  );
+
+  const updateToolsetMutation = useUpdateToolsetMutation();
+
+  const toggle = (slug: string, next: boolean) => {
+    const nextSources = applyFunctionToggle(
+      toolset.autoSyncSources ?? [],
+      slug,
+      next,
+    );
+
+    updateToolsetMutation.mutate(
+      {
+        request: {
+          slug: toolset.slug,
+          updateToolsetRequestBody: { autoSyncSources: nextSources },
+        },
+      },
+      {
+        onSuccess: () => {
+          invalidateAllToolset(queryClient);
+          telemetry.capture("mcp_event", {
+            action: next
+              ? "auto_sync_source_added"
+              : "auto_sync_source_removed",
+            slug: toolset.slug,
+            source: slug,
+          });
+        },
+        onError: (error) => {
+          toast.error(
+            `Failed to update auto-sync sources: ${
+              error instanceof Error ? error.message : "unknown error"
+            }`,
+          );
+        },
+      },
+    );
+  };
+
+  return (
+    <Stack gap={2} className="mb-8">
+      <Heading variant="h3">Auto-sync sources</Heading>
+      <Type muted small className="max-w-2xl">
+        Toolsets follow named function sources. When you push a new deployment,
+        new tool URNs from these sources are added to this MCP automatically.
+        Existing tools always update in place.
+      </Type>
+      {functionSources.length === 0 ? (
+        <Type small muted italic>
+          No function sources in this project yet. Push a function deployment to
+          make sources available here.
+        </Type>
+      ) : (
+        <Stack gap={1}>
+          {functionSources.map((source) => (
+            <AutoSyncRow
+              key={source.slug}
+              name={source.name}
+              slug={source.slug}
+              checked={subscribed.has(source.slug)}
+              disabled={!canWrite || updateToolsetMutation.isPending}
+              onToggle={(next) => toggle(source.slug, next)}
+            />
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
+interface AutoSyncRowProps {
+  name: string;
+  slug: string;
+  checked: boolean;
+  disabled: boolean;
+  onToggle: (next: boolean) => void;
+}
+
+function AutoSyncRow({
+  name,
+  slug,
+  checked,
+  disabled,
+  onToggle,
+}: AutoSyncRowProps) {
+  const labelId = `auto-sync-row-${slug}`;
+  return (
+    <Stack
+      direction="horizontal"
+      align="center"
+      gap={2}
+      className="border-border bg-card rounded-md border px-3 py-2"
+    >
+      <Stack gap={0} className="min-w-0 flex-1">
+        <Type variant="small" className="truncate" id={labelId}>
+          {name}
+        </Type>
+        <Type mono variant="small" muted className="truncate">
+          {slug}
+        </Type>
+      </Stack>
+      <Switch
+        checked={checked}
+        onCheckedChange={onToggle}
+        disabled={disabled}
+        aria-labelledby={labelId}
+      />
+    </Stack>
+  );
+}

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1,3 +1,4 @@
+import { AutoSyncSourcesCard } from "@/pages/mcp/AutoSyncSourcesCard";
 import { Block, BlockInner } from "@/components/block";
 import { CodeBlock } from "@/components/code";
 import { DetailHero } from "@/components/detail-hero";
@@ -1535,6 +1536,8 @@ function MCPSettingsTab({ toolset }: { toolset: Toolset }) {
       </PageSection>
 
       <MCPPublishingSection toolset={toolset} />
+
+      <AutoSyncSourcesCard toolset={toolset} />
 
       <PageSection
         heading="Actions"

--- a/client/dashboard/src/pages/mcp/autoSyncSources.ts
+++ b/client/dashboard/src/pages/mcp/autoSyncSources.ts
@@ -1,0 +1,44 @@
+// Pure helpers for the AutoSyncSourcesCard. Kept in a separate module
+// from the React component so unit tests can import them without pulling
+// the design-system / icon dependency chain.
+
+export const FUNCTION_PREFIX = "function:";
+
+// extractFunctionSubscriptions reads the toolset's auto_sync_sources
+// column and returns the unprefixed function slugs the toolset is
+// subscribed to. Non-function: entries are ignored at the UI layer; the
+// server validator rejects them on writes today, so they should never
+// appear here, but the guard keeps the UI honest if/when other kinds
+// are introduced.
+export function extractFunctionSubscriptions(
+  autoSyncSources: string[],
+): Set<string> {
+  return new Set(
+    autoSyncSources
+      .filter((entry) => entry.startsWith(FUNCTION_PREFIX))
+      .map((entry) => entry.slice(FUNCTION_PREFIX.length)),
+  );
+}
+
+// applyFunctionToggle returns the next value for auto_sync_sources after
+// flipping the named slug. Non-function entries are preserved verbatim so
+// future polymorphic subscriptions don't get clobbered.
+export function applyFunctionToggle(
+  current: string[],
+  slug: string,
+  next: boolean,
+): string[] {
+  const nonFunction = current.filter(
+    (entry) => !entry.startsWith(FUNCTION_PREFIX),
+  );
+  const subscribed = extractFunctionSubscriptions(current);
+  if (next) {
+    subscribed.add(slug);
+  } else {
+    subscribed.delete(slug);
+  }
+  return [
+    ...nonFunction,
+    ...Array.from(subscribed).map((s) => `${FUNCTION_PREFIX}${s}`),
+  ];
+}


### PR DESCRIPTION
## Summary

Dashboard surface for [AGE-1377](https://linear.app/speakeasy/issue/AGE-1377). Adds an **Auto-sync sources** section to the MCP server's Settings tab. Each function source in the project gets a row with a toggle bound to the toolset's \`autoSyncSources\` column; toggling on writes \`function:<slug>\` via \`updateToolset\`, after which the auto-sync activity from #2850 extends the toolset on subsequent deployments.

Stacks on **#2852**. Rebases to \`main\` once #2834, #2848, #2850, and #2852 land.

## Files

- \`AutoSyncSourcesCard.tsx\` (new): the component. Reads \`functionsAssets\` from \`useLatestDeployment\`, current subscription from \`toolset.autoSyncSources\`. Uses Moonshine \`Stack\` and the existing \`Switch\` UI primitive. Telemetry events on toggle: \`auto_sync_source_added\` / \`auto_sync_source_removed\`.
- \`autoSyncSources.ts\` (new): pure helpers — \`extractFunctionSubscriptions\`, \`applyFunctionToggle\`, \`FUNCTION_PREFIX\`. Extracted to a standalone module so unit tests don't pull the design-system chain.
- \`AutoSyncSourcesCard.test.ts\` (new): 10 tests covering prefix-strip, dedupe, toggle idempotency, and preservation of forward-compat non-\`function:\` entries.
- \`MCPDetails.tsx\`: 3-line change — import + render the new card between \`MCPPublishingSection\` and the \`Actions\` section so the consequence is visible alongside the public/private toggle.

## Test plan

- [x] \`pnpm vitest run src/pages/mcp/AutoSyncSourcesCard.test.ts\` — 10/10 pass
- [x] \`pnpm tsc -p tsconfig.app.json --noEmit\` — no errors on the new files or \`MCPDetails.tsx\`. Pre-existing \`@gram-ai/elements\` workspace-package errors unchanged.
- [ ] **Manual browser smoke (reviewer / staging)** — the full data path requires #2834 + #2848 + #2850 + #2852 to be live. Suggested flow:
  1. \`gram stage function ./dist/fn.zip --slug billing && gram push --auto-attach my-mcp\`
  2. Open the MCP's Settings tab → see \"billing\" toggled on under Auto-sync sources.
  3. Add a new tool to the function bundle, \`gram push\` (no flag).
  4. Toolset's tool count bumps without dashboard interaction; audit log shows \`toolset:tools_auto_added\`.

## Known follow-ups (for PR 6 / 7)

- \"auto-added <date>\" badge on tool rows that came from auto-sync — needs a \`toolset_versions\` predecessor diff hook; deferred to PR 6's broader testing pass.
- Header pill (\"Auto-syncing N sources\") on the MCP header — kept out of this PR to keep the diff focused on the new card; will lift after the card lands and we see real usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)