### PR TITLE
feat: monitor OpenRouter credits usage for enterprise orgs

### DIFF
--- a/.changeset/age-2325-openrouter-credits-monitoring.md
+++ b/.changeset/age-2325-openrouter-credits-monitoring.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+monitor OpenRouter credits usage for enterprise organizations

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -41,9 +41,11 @@ import (
 )
 
 type Activities struct {
+	collectOpenRouterCreditsMetrics *activities.CollectOpenRouterCreditsMetrics
 	collectPlatformUsageMetrics     *activities.CollectPlatformUsageMetrics
 	customDomainIngress             *activities.CustomDomainIngress
 	fallbackModelUsageTracking      *activities.FallbackModelUsageTracking
+	fireOpenRouterCreditsMetrics    *activities.FireOpenRouterCreditsMetrics
 	firePlatformUsageMetrics        *activities.FirePlatformUsageMetrics
 	freeTierReportingUsageMetrics   *activities.FreeTierReportingUsageMetrics
 	generateChatTitle               *activities.GenerateChatTitle
@@ -126,9 +128,11 @@ func NewActivities(
 	usageTrackingStrategy := chat.NewDefaultUsageTrackingStrategy(db, logger, openrouterProvisioner, billingTracker, nil)
 
 	return &Activities{
+		collectOpenRouterCreditsMetrics: activities.NewCollectOpenRouterCreditsMetrics(logger, db, openrouterProvisioner),
 		collectPlatformUsageMetrics:     activities.NewCollectPlatformUsageMetrics(logger, db),
 		customDomainIngress:             activities.NewCustomDomainIngress(logger, db, k8sClient),
 		fallbackModelUsageTracking:      activities.NewFallbackModelUsageTracking(usageTrackingStrategy),
+		fireOpenRouterCreditsMetrics:    activities.NewFireOpenRouterCreditsMetrics(logger, meterProvider),
 		firePlatformUsageMetrics:        activities.NewFirePlatformUsageMetrics(logger, billingTracker),
 		freeTierReportingUsageMetrics:   activities.NewFreeTierReportingMetrics(logger, db, billingRepo, posthogClient),
 		generateChatTitle:               activities.NewGenerateChatTitle(logger, db, chatClient),
@@ -237,6 +241,14 @@ func (a *Activities) CollectPlatformUsageMetrics(ctx context.Context) ([]activit
 
 func (a *Activities) FirePlatformUsageMetrics(ctx context.Context, metrics []activities.PlatformUsageMetrics) error {
 	return a.firePlatformUsageMetrics.Do(ctx, metrics)
+}
+
+func (a *Activities) CollectOpenRouterCreditsMetrics(ctx context.Context, args activities.CollectOpenRouterCreditsMetricsArgs) ([]activities.OpenRouterCreditsMetric, error) {
+	return a.collectOpenRouterCreditsMetrics.Do(ctx, args)
+}
+
+func (a *Activities) FireOpenRouterCreditsMetrics(ctx context.Context, metrics []activities.OpenRouterCreditsMetric) error {
+	return a.fireOpenRouterCreditsMetrics.Do(ctx, metrics)
 }
 
 func (a *Activities) FreeTierReportingUsageMetrics(ctx context.Context, orgIDs []string) error {

--- a/server/internal/background/activities/openrouter_credits_metrics.go
+++ b/server/internal/background/activities/openrouter_credits_metrics.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	meterOpenRouterCreditsRemaining = "openrouter.credits.remaining"
-	meterOpenRouterCreditsUsedRatio = "openrouter.credits.used_ratio"
+	meterOpenRouterCreditsRemaining = "gram.openrouter.credits_remaining"
+	meterOpenRouterCreditsUsedRatio = "gram.openrouter.credits_used_ratio"
 
 	openRouterCreditsPollConcurrency = 10
 )

--- a/server/internal/background/activities/openrouter_credits_metrics.go
+++ b/server/internal/background/activities/openrouter_credits_metrics.go
@@ -1,0 +1,169 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	repo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+const (
+	meterOpenRouterCreditsRemaining = "openrouter.credits.remaining"
+	meterOpenRouterCreditsUsedRatio = "openrouter.credits.used_ratio"
+
+	openRouterCreditsPollConcurrency = 10
+)
+
+type CollectOpenRouterCreditsMetrics struct {
+	logger     *slog.Logger
+	db         *pgxpool.Pool
+	repo       *repo.Queries
+	openRouter openrouter.Provisioner
+}
+
+func NewCollectOpenRouterCreditsMetrics(
+	logger *slog.Logger,
+	db *pgxpool.Pool,
+	openRouterProvisioner openrouter.Provisioner,
+) *CollectOpenRouterCreditsMetrics {
+	return &CollectOpenRouterCreditsMetrics{
+		logger:     logger.With(attr.SlogComponent("collect_openrouter_credits_metrics")),
+		db:         db,
+		repo:       repo.New(db),
+		openRouter: openRouterProvisioner,
+	}
+}
+
+type OpenRouterCreditsMetric struct {
+	OrganizationID   string
+	OrganizationSlug string
+	AccountType      string
+	CreditsUsed      float64
+	CreditLimit      int64
+}
+
+type CollectOpenRouterCreditsMetricsArgs struct {
+	// AccountTypes is the allow-list of `organization_metadata.gram_account_type`
+	// values whose OpenRouter keys should be polled. Expand here (e.g. add
+	// "pro") to grow coverage without code changes elsewhere.
+	AccountTypes []string
+}
+
+func (c *CollectOpenRouterCreditsMetrics) Do(ctx context.Context, args CollectOpenRouterCreditsMetricsArgs) ([]OpenRouterCreditsMetric, error) {
+	rows, err := c.repo.GetOpenRouterCreditsMonitoringTargets(ctx, args.AccountTypes)
+	if err != nil {
+		return nil, fmt.Errorf("list openrouter credits monitoring targets: %w", err)
+	}
+
+	// Pre-allocate and write to a disjoint index per goroutine — no mutex
+	// needed. Failed polls leave their slot zero-valued and are filtered out
+	// of the final result.
+	results := make([]OpenRouterCreditsMetric, len(rows))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(openRouterCreditsPollConcurrency)
+	for i, row := range rows {
+		g.Go(func() error {
+			used, err := c.openRouter.GetKeyUsage(gctx, row.ApiKey)
+			if err != nil {
+				// Skip on a per-org failure so one bad key does not blank the
+				// whole batch. The error is logged for diagnosis and swallowed
+				// so the errgroup does not cancel sibling polls.
+				c.logger.ErrorContext(gctx, "fetch openrouter key usage",
+					attr.SlogOrganizationID(row.OrganizationID),
+					attr.SlogOrganizationSlug(row.OrganizationSlug),
+					attr.SlogError(err),
+				)
+				return nil
+			}
+
+			results[i] = OpenRouterCreditsMetric{
+				OrganizationID:   row.OrganizationID,
+				OrganizationSlug: row.OrganizationSlug,
+				AccountType:      row.GramAccountType,
+				CreditsUsed:      used,
+				CreditLimit:      row.MonthlyCredits,
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("wait for openrouter credits polls: %w", err)
+	}
+
+	collected := results[:0]
+	for _, r := range results {
+		if r.OrganizationID != "" {
+			collected = append(collected, r)
+		}
+	}
+	return collected, nil
+}
+
+type FireOpenRouterCreditsMetrics struct {
+	logger           *slog.Logger
+	creditsRemaining metric.Float64Gauge
+	creditsUsedRatio metric.Float64Gauge
+}
+
+func NewFireOpenRouterCreditsMetrics(logger *slog.Logger, meterProvider metric.MeterProvider) *FireOpenRouterCreditsMetrics {
+	ctx := context.Background()
+	componentLogger := logger.With(attr.SlogComponent("fire_openrouter_credits_metrics"))
+
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/background/activities/openrouter_credits")
+
+	remaining, err := meter.Float64Gauge(
+		meterOpenRouterCreditsRemaining,
+		metric.WithDescription("Remaining OpenRouter monthly credits per org (limit minus usage)."),
+		metric.WithUnit("{credit}"),
+	)
+	if err != nil {
+		componentLogger.ErrorContext(ctx, "create metric",
+			attr.SlogMetricName(meterOpenRouterCreditsRemaining), attr.SlogError(err))
+	}
+
+	usedRatio, err := meter.Float64Gauge(
+		meterOpenRouterCreditsUsedRatio,
+		metric.WithDescription("Fraction of monthly OpenRouter credits used per org (0.0–1.0)."),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		componentLogger.ErrorContext(ctx, "create metric",
+			attr.SlogMetricName(meterOpenRouterCreditsUsedRatio), attr.SlogError(err))
+	}
+
+	return &FireOpenRouterCreditsMetrics{
+		logger:           componentLogger,
+		creditsRemaining: remaining,
+		creditsUsedRatio: usedRatio,
+	}
+}
+
+func (f *FireOpenRouterCreditsMetrics) Do(ctx context.Context, metrics []OpenRouterCreditsMetric) error {
+	for _, m := range metrics {
+		attrs := metric.WithAttributes(
+			attr.OrganizationID(m.OrganizationID),
+			attr.OrganizationSlug(m.OrganizationSlug),
+			attr.OrganizationAccountType(m.AccountType),
+		)
+
+		if f.creditsRemaining != nil {
+			f.creditsRemaining.Record(ctx, float64(m.CreditLimit)-m.CreditsUsed, attrs)
+		}
+
+		// Skip ratio when limit is zero — gives no useful signal and would
+		// divide by zero. Disabled/unprovisioned keys are already filtered
+		// at the SQL layer; this guards against a 0-limit edge case.
+		if f.creditsUsedRatio != nil && m.CreditLimit > 0 {
+			f.creditsUsedRatio.Record(ctx, m.CreditsUsed/float64(m.CreditLimit), attrs)
+		}
+	}
+	return nil
+}

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -49,6 +49,29 @@ WHERE toolsets.deleted = false
 GROUP BY organization_metadata.id
 HAVING COUNT(toolsets.id) > 0;
 
+-- name: GetOpenRouterCreditsMonitoringTargets :many
+-- Targets for periodic OpenRouter credit usage polling. Filters out disabled
+-- orgs and disabled/deleted keys, and restricts to the caller-supplied
+-- account-type allowlist so coverage can expand (e.g. add 'pro') without a
+-- code change. monthly_credits is the canonical limit last written by
+-- RefreshAPIKeyLimit and reflects any per-org overrides applied via the
+-- OpenrouterKeyRefreshWorkflow. The api_key is included so the caller can
+-- issue the upstream usage HTTP call in a single round-trip — keep it inside
+-- the activity boundary and never return it to the workflow.
+SELECT
+    om.id AS organization_id,
+    om.slug AS organization_slug,
+    om.gram_account_type,
+    k.monthly_credits,
+    k.key AS api_key
+FROM organization_metadata om
+JOIN openrouter_api_keys k ON k.organization_id = om.id
+WHERE om.disabled_at IS NULL
+  AND k.disabled = FALSE
+  AND k.deleted = FALSE
+  AND om.gram_account_type = ANY(@account_types::text[])
+ORDER BY om.slug;
+
 -- name: GetUserEmailsByOrgIDs :many
 -- Get user emails for organization IDs by looking up the latest deployment for each org
 SELECT DISTINCT

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -186,6 +186,64 @@ func (q *Queries) GetAllOrganizationsWithToolsets(ctx context.Context) ([]GetAll
 	return items, nil
 }
 
+const getOpenRouterCreditsMonitoringTargets = `-- name: GetOpenRouterCreditsMonitoringTargets :many
+SELECT
+    om.id AS organization_id,
+    om.slug AS organization_slug,
+    om.gram_account_type,
+    k.monthly_credits,
+    k.key AS api_key
+FROM organization_metadata om
+JOIN openrouter_api_keys k ON k.organization_id = om.id
+WHERE om.disabled_at IS NULL
+  AND k.disabled = FALSE
+  AND k.deleted = FALSE
+  AND om.gram_account_type = ANY($1::text[])
+ORDER BY om.slug
+`
+
+type GetOpenRouterCreditsMonitoringTargetsRow struct {
+	OrganizationID   string
+	OrganizationSlug string
+	GramAccountType  string
+	MonthlyCredits   int64
+	ApiKey           string
+}
+
+// Targets for periodic OpenRouter credit usage polling. Filters out disabled
+// orgs and disabled/deleted keys, and restricts to the caller-supplied
+// account-type allowlist so coverage can expand (e.g. add 'pro') without a
+// code change. monthly_credits is the canonical limit last written by
+// RefreshAPIKeyLimit and reflects any per-org overrides applied via the
+// OpenrouterKeyRefreshWorkflow. The api_key is included so the caller can
+// issue the upstream usage HTTP call in a single round-trip — keep it inside
+// the activity boundary and never return it to the workflow.
+func (q *Queries) GetOpenRouterCreditsMonitoringTargets(ctx context.Context, accountTypes []string) ([]GetOpenRouterCreditsMonitoringTargetsRow, error) {
+	rows, err := q.db.Query(ctx, getOpenRouterCreditsMonitoringTargets, accountTypes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetOpenRouterCreditsMonitoringTargetsRow
+	for rows.Next() {
+		var i GetOpenRouterCreditsMonitoringTargetsRow
+		if err := rows.Scan(
+			&i.OrganizationID,
+			&i.OrganizationSlug,
+			&i.GramAccountType,
+			&i.MonthlyCredits,
+			&i.ApiKey,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getPlatformUsageMetrics = `-- name: GetPlatformUsageMetrics :many
 WITH latest_deployments AS (
   SELECT DISTINCT ON (project_id) project_id, d.id as deployment_id

--- a/server/internal/background/openrouter_credits_metrics.go
+++ b/server/internal/background/openrouter_credits_metrics.go
@@ -1,0 +1,99 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	openRouterCreditsMetricsWorkflowID          = "v1:collect-openrouter-credits-metrics"
+	openRouterCreditsMetricsScheduleID          = "v1:collect-openrouter-credits-metrics-schedule"
+	openRouterCreditsMetricsScheduledWorkflowID = "v1:collect-openrouter-credits-metrics/scheduled"
+
+	// Activity budget: timeout (30s) × max attempts (2) × activities (2) = 2min,
+	// which fits comfortably under WorkflowRunTimeout (3min). OpenRouter
+	// `/v1/key` is sub-second in practice; 30s is a generous ceiling that
+	// surfaces stalls quickly rather than masking them through retry loops.
+	openRouterCreditsMetricsActivityMaxRetries = 2
+	openRouterCreditsMetricsActivityTimeout    = 30 * time.Second
+	openRouterCreditsMetricsScheduleInterval   = 5 * time.Minute
+	openRouterCreditsMetricsWorkflowRunTimeout = 3 * time.Minute
+)
+
+// openRouterCreditsMetricsAccountTypes is the allowlist of organization
+// account types whose OpenRouter keys are polled for usage. Add a tier here
+// (e.g. "pro") to expand coverage — no schema, infra, or Datadog change
+// required as long as the per-org monitor selector matches.
+var openRouterCreditsMetricsAccountTypes = []string{"enterprise"}
+
+type OpenRouterCreditsMetricsClient struct {
+	TemporalEnv *tenv.Environment
+}
+
+func (c *OpenRouterCreditsMetricsClient) StartCollectOpenRouterCreditsMetrics(ctx context.Context) (client.WorkflowRun, error) {
+	run, err := c.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    openRouterCreditsMetricsWorkflowID,
+		TaskQueue:             string(c.TemporalEnv.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+	}, CollectOpenRouterCreditsMetricsWorkflow)
+	if err != nil {
+		return nil, fmt.Errorf("execute collect openrouter credits metrics workflow: %w", err)
+	}
+	return run, nil
+}
+
+func CollectOpenRouterCreditsMetricsWorkflow(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: openRouterCreditsMetricsActivityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: openRouterCreditsMetricsActivityMaxRetries,
+		},
+	})
+
+	var a *Activities
+	var metrics []activities.OpenRouterCreditsMetric
+	if err := workflow.ExecuteActivity(
+		ctx,
+		a.CollectOpenRouterCreditsMetrics,
+		activities.CollectOpenRouterCreditsMetricsArgs{AccountTypes: openRouterCreditsMetricsAccountTypes},
+	).Get(ctx, &metrics); err != nil {
+		return fmt.Errorf("collect openrouter credits metrics: %w", err)
+	}
+
+	if err := workflow.ExecuteActivity(ctx, a.FireOpenRouterCreditsMetrics, metrics).Get(ctx, nil); err != nil {
+		return fmt.Errorf("fire openrouter credits metrics: %w", err)
+	}
+
+	return nil
+}
+
+func AddOpenRouterCreditsMetricsSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	_, err := temporalEnv.Client().ScheduleClient().Create(ctx, client.ScheduleOptions{
+		ID: openRouterCreditsMetricsScheduleID,
+		Spec: client.ScheduleSpec{
+			Intervals: []client.ScheduleIntervalSpec{
+				{Every: openRouterCreditsMetricsScheduleInterval},
+			},
+		},
+		Action: &client.ScheduleWorkflowAction{
+			ID:                 openRouterCreditsMetricsScheduledWorkflowID,
+			Workflow:           CollectOpenRouterCreditsMetricsWorkflow,
+			TaskQueue:          string(temporalEnv.Queue()),
+			WorkflowRunTimeout: openRouterCreditsMetricsWorkflowRunTimeout,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create openrouter credits metrics schedule: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -257,6 +257,8 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.RefreshOpenRouterKey)
 	temporalWorker.RegisterActivity(activities.VerifyCustomDomain)
 	temporalWorker.RegisterActivity(activities.CustomDomainIngress)
+	temporalWorker.RegisterActivity(activities.CollectOpenRouterCreditsMetrics)
+	temporalWorker.RegisterActivity(activities.FireOpenRouterCreditsMetrics)
 	temporalWorker.RegisterActivity(activities.CollectPlatformUsageMetrics)
 	temporalWorker.RegisterActivity(activities.FirePlatformUsageMetrics)
 	temporalWorker.RegisterActivity(activities.FreeTierReportingUsageMetrics)
@@ -306,6 +308,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(OpenrouterKeyRefreshWorkflow)
 	temporalWorker.RegisterWorkflow(CustomDomainRegistrationWorkflow)
 	temporalWorker.RegisterWorkflow(CustomDomainDeletionWorkflow)
+	temporalWorker.RegisterWorkflow(CollectOpenRouterCreditsMetricsWorkflow)
 	temporalWorker.RegisterWorkflow(CollectPlatformUsageMetricsWorkflow)
 	temporalWorker.RegisterWorkflow(RefreshBillingUsageWorkflow)
 	temporalWorker.RegisterWorkflow(IndexToolsetWorkflow)
@@ -341,6 +344,12 @@ func NewTemporalWorker(
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
 			logger.ErrorContext(context.Background(), "failed to add platform usage metrics schedule", attr.SlogError(err))
+		}
+	}
+
+	if err := AddOpenRouterCreditsMetricsSchedule(context.Background(), env); err != nil {
+		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+			logger.ErrorContext(context.Background(), "failed to add openrouter credits metrics schedule", attr.SlogError(err))
 		}
 	}
 

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -24,6 +24,10 @@ func (o *Development) GetCreditsUsed(ctx context.Context, orgID string) (float64
 	return 12.5, 10, nil // arbitrary local numbers
 }
 
+func (o *Development) GetKeyUsage(ctx context.Context, apiKey string) (float64, error) {
+	return 12.5, nil // arbitrary local number
+}
+
 func (o *Development) GetModelUsage(ctx context.Context, generationID string, orgID string) (*ModelUsage, error) {
 	// Development mode doesn't track model usage
 	totalCost := 12.5

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -124,6 +124,7 @@ type Provisioner interface {
 	ProvisionAPIKey(ctx context.Context, orgID string) (string, error)
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, limit *int) (int, error)
 	GetCreditsUsed(ctx context.Context, orgID string) (float64, int, error)
+	GetKeyUsage(ctx context.Context, apiKey string) (float64, error)
 	GetModelUsage(ctx context.Context, generationID string, orgID string) (*ModelUsage, error)
 }
 
@@ -283,19 +284,32 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string) (float64,
 		return 0, limit, nil // the key doesn't exist yet
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", OpenRouterBaseURL+"/v1/key", nil)
+	used, err := o.GetKeyUsage(ctx, key.Key)
 	if err != nil {
-		o.logger.ErrorContext(ctx, "failed to get openrouter key HTTP request", attr.SlogError(err))
-		return 0, limit, fmt.Errorf("failed to get key request: %w", err)
+		return 0, limit, err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+key.Key)
+	return used, limit, nil
+}
+
+// GetKeyUsage issues the upstream `/v1/key` call with the given API key and
+// returns the rounded monthly usage. Callers that already have the key (e.g.
+// the credits monitoring activity, which joins openrouter_api_keys in a
+// single SQL query) can skip the org/key DB lookups in GetCreditsUsed.
+func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", OpenRouterBaseURL+"/v1/key", nil)
+	if err != nil {
+		o.logger.ErrorContext(ctx, "failed to build openrouter key usage request", attr.SlogError(err))
+		return 0, fmt.Errorf("build key usage request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := o.orClient.Do(req)
 	if err != nil {
-		o.logger.ErrorContext(ctx, "failed to send HTTP request", attr.SlogError(err))
-		return 0, limit, fmt.Errorf("failed to send update key request: %w", err)
+		o.logger.ErrorContext(ctx, "failed to send openrouter key usage request", attr.SlogError(err))
+		return 0, fmt.Errorf("send key usage request: %w", err)
 	}
 
 	defer o11y.NoLogDefer(func() error {
@@ -303,13 +317,13 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string) (float64,
 	})
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, limit, errors.New("failed to update OpenRouter API key: " + resp.Status)
+		return 0, errors.New("fetch OpenRouter key usage: " + resp.Status)
 	}
 
 	var usageResp keyUsageResponse
 	if err := json.NewDecoder(resp.Body).Decode(&usageResp); err != nil {
 		o.logger.ErrorContext(ctx, "failed to decode key usage response", attr.SlogError(err))
-		return 0, limit, fmt.Errorf("failed to decode key usage response: %w", err)
+		return 0, fmt.Errorf("decode key usage response: %w", err)
 	}
 
 	var creditsUsed float64
@@ -317,7 +331,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string) (float64,
 		creditsUsed = math.Round(*usageResp.Data.UsageMonthly*100) / 100
 	}
 
-	return creditsUsed, limit, nil
+	return creditsUsed, nil
 }
 
 func (o *OpenRouter) getLimitForOrg(org orgRepo.OrganizationMetadatum) int {

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -45,6 +45,10 @@ func (m *mockProvisioner) GetCreditsUsed(ctx context.Context, orgID string) (flo
 	return 0, 0, nil
 }
 
+func (m *mockProvisioner) GetKeyUsage(ctx context.Context, apiKey string) (float64, error) {
+	return 0, nil
+}
+
 func (m *mockProvisioner) GetModelUsage(ctx context.Context, generationID string, orgID string) (*ModelUsage, error) {
 	return nil, nil
 }


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2325/feat-set-up-openrouter-usage-limit-monitoring-and-alerts

Adds a 5-minute scheduled Temporal workflow that polls OpenRouter's `/v1/key` for every enterprise org with a non-disabled API key and emits `gram.openrouter.credits_remaining` and `gram.openrouter.credits_used_ratio` OTel gauges tagged by org. Polling is concurrency-capped at 10; per-org failures are logged and swallowed so one bad key does not blank the batch.

The new SQL query is parameterized by `gram_account_type`, so expanding coverage (e.g. to `pro`) is a one-line constant change in the workflow file.

Refactors `openrouter.GetCreditsUsed` to delegate its upstream HTTP call to a new `GetKeyUsage` method on the `Provisioner` interface. This lets the monitoring activity issue the credit check using a key it already holds from the SQL query — eliminating two DB reads per polled org per cycle. Existing callers (the Billing UI's `chat.creditUsage` endpoint) keep their original semantics.