### PR TITLE
chore: fix callback URL, prevent orphaned invites, consolidate env vars

### DIFF
--- a/.mise-tasks/zero/idp.mts
+++ b/.mise-tasks/zero/idp.mts
@@ -16,9 +16,9 @@ async function run() {
 
   if (mode === "mock-workos" && process.env["usage_restart"] !== "true") {
     // Check if the user previously made an explicit choice (not just the default).
-    const apiKey = process.env["WORKOS_API_KEY"];
+    const secret = process.env["GRAM_IDP_CLIENT_SECRET"];
     const hasExplicitChoice =
-      (typeof apiKey === "string" && apiKey !== "" && apiKey !== "unset") ||
+      (typeof secret === "string" && secret !== "" && secret !== "unset") ||
       process.env["GRAM_IDP_SKIPPED"] === "true";
     if (hasExplicitChoice) {
       console.log("✅ IDP mode: mock-workos (already configured).");
@@ -75,7 +75,7 @@ async function setupRealWorkOS() {
 
   await $`touch mise.local.toml`;
   await $`mise set --file mise.local.toml GRAM_IDP_MODE=workos`;
-  await $`mise set --file mise.local.toml WORKOS_API_KEY=${key.trim()}`;
+  await $`mise set --file mise.local.toml GRAM_IDP_CLIENT_SECRET=${key.trim()}`;
   await $`mise set --file mise.local.toml WORKOS_API_URL=${devidpURL}/workos`;
   await $`mise set --file mise.local.toml GRAM_IDP_CLIENT_ID=${clientId.trim()}`;
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For Speakeasy employees testing against real WorkOS data. The `./zero` script pr
 ```toml
 [env]
 GRAM_IDP_MODE = "workos"
-WORKOS_API_KEY = "sk_test_..."
+GRAM_IDP_CLIENT_SECRET = "sk_test_..."
 WORKOS_API_URL = "{{env.GRAM_DEVIDP_EXTERNAL_URL}}/workos"
 GRAM_IDP_CLIENT_ID = "client_..."
 ```

--- a/client/dashboard/src/contexts/TelemetryProvider.tsx
+++ b/client/dashboard/src/contexts/TelemetryProvider.tsx
@@ -14,10 +14,16 @@ import type { Telemetry } from "./Telemetry";
 const AM_TESTING_TELEMETRY = false;
 
 export const TelemetryProvider = (props: { children: ReactNode }) => {
+  const serverURL = getServerURL();
+  const isProd = serverURL.includes("app.getgram.ai");
   const ph = posthog.init(
-    "phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9",
+    isProd
+      ? "phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9"
+      : "phc_5S3YhOs1lONwM2yKa0ytVSAyWOR2GhVhwAebkyi022l",
     {
-      api_host: "https://metrics.speakeasy.com",
+      api_host: isProd
+        ? "https://metrics.speakeasy.com"
+        : "https://metrics.dev.speakeasy.com",
       feature_flag_request_timeout_ms: 1000,
     },
     "speakeasy",

--- a/dev-idp-dashboard/src/components/providers/ActivationCard.tsx
+++ b/dev-idp-dashboard/src/components/providers/ActivationCard.tsx
@@ -49,7 +49,8 @@ function ActiveState() {
 function InactiveState({ mode }: { mode: ActivatableMode }) {
   const { data } = useGramMode();
   const workosKeySet =
-    data?.meta.env.find((v) => v.name === "WORKOS_API_KEY")?.is_set ?? false;
+    data?.meta.env.find((v) => v.name === "GRAM_IDP_CLIENT_SECRET")?.is_set ??
+    false;
 
   return (
     <div className="space-y-3">
@@ -63,7 +64,7 @@ function InactiveState({ mode }: { mode: ActivatableMode }) {
             <CopyableCommand command="mise set --file mise.local.toml WORKOS_API_URL=https://api.workos.com" />
             {!workosKeySet && (
               <div className="space-y-2 pt-3 border-t border-border">
-                <CopyableCommand command="mise set --file mise.local.toml WORKOS_API_KEY=<paste-key>" />
+                <CopyableCommand command="mise set --file mise.local.toml GRAM_IDP_CLIENT_SECRET=<paste-key>" />
                 <p className="text-xs text-muted-foreground">
                   Grab a fresh API key from{" "}
                   <a

--- a/dev-idp-dashboard/src/lib/env-docs.ts
+++ b/dev-idp-dashboard/src/lib/env-docs.ts
@@ -29,9 +29,9 @@ export const ENV_DOCS: readonly EnvDoc[] = [
       "Externally reachable URL of the dev-idp listener. The mode detector compares WORKOS_API_URL against this base.",
   },
   {
-    name: "WORKOS_API_KEY",
+    name: "GRAM_IDP_CLIENT_SECRET",
     description:
-      "API key the dev-idp uses for its live /workos passthrough. The /workos mount is only active when this is set.",
+      "WorkOS API key. In mock-workos mode any value works; in workos mode must be a real sk_test_... key for the live /workos passthrough.",
     sensitive: true,
   },
 ] as const;

--- a/dev-idp-dashboard/src/lib/mode-labels.ts
+++ b/dev-idp-dashboard/src/lib/mode-labels.ts
@@ -12,7 +12,8 @@ export const MODE_SUBTITLES: Record<Mode, string> = {
     "Mock WorkOS REST surface — fully offline user/org/membership lookups.",
   "oauth2-1": "OAuth 2.1 AS — PKCE required, DCR, OIDC.",
   oauth2: "OAuth 2.0 AS — PKCE optional, no DCR, OIDC.",
-  workos: "Live WorkOS REST proxy (mounted only when WORKOS_API_KEY is set).",
+  workos:
+    "Live WorkOS REST proxy (mounted only when GRAM_IDP_CLIENT_SECRET is a real key).",
 };
 
 /** Sidebar grouping for the providers sub-nav. Order here is render order. */

--- a/dev-idp/main.go
+++ b/dev-idp/main.go
@@ -6,7 +6,7 @@
 //   - the mock-workos mode at /mock-workos/ (mock WorkOS REST surface);
 //   - the oauth2 mode at /oauth2/;
 //   - the oauth2-1 mode at /oauth2-1/;
-//   - the workos mode at /workos/ (only when GRAM_IDP_MODE=workos and WORKOS_API_KEY is set).
+//   - the workos mode at /workos/ (only when GRAM_IDP_MODE=workos and GRAM_IDP_CLIENT_SECRET is a real key).
 //
 // A second tiny health server is mounted on GRAM_DEVIDP_CONTROL_ADDRESS.
 //
@@ -61,7 +61,7 @@ func run() error {
 	dbSpec := flag.String("db", os.Getenv("GRAM_DEVIDP_DB"), "SQLite location: 'memory' or 'file:<path>' (default file:local/devidp/devidp.db)")
 	rsaKey := flag.String("rsa-private-key", os.Getenv("GRAM_DEVIDP_RSA_PRIVATE_KEY"), "PEM-encoded RSA private key (omit to generate a fresh ephemeral key)")
 	idpMode := flag.String("idp-mode", envOr("GRAM_IDP_MODE", "mock-workos"), "IDP mode: mock-workos (default) or workos")
-	workosKey := flag.String("workos-api-key", os.Getenv("WORKOS_API_KEY"), "WorkOS API key (required when --idp-mode=workos)")
+	workosKey := flag.String("workos-api-key", os.Getenv("GRAM_IDP_CLIENT_SECRET"), "WorkOS API key (required when --idp-mode=workos)")
 	workosHost := flag.String("workos-host", envOr("WORKOS_API_URL", "https://api.workos.com"), "Base URL of the WorkOS API")
 	flag.Parse()
 
@@ -140,7 +140,7 @@ func run() error {
 
 	if *idpMode == "workos" {
 		if *workosKey == "" {
-			return fmt.Errorf("GRAM_IDP_MODE=workos requires WORKOS_API_KEY to be set")
+			return fmt.Errorf("GRAM_IDP_MODE=workos requires GRAM_IDP_CLIENT_SECRET to be a real WorkOS API key")
 		}
 		wsClient := workos.NewClient(*workosKey, workos.Opts{
 			Endpoint: *workosHost,

--- a/mise.toml
+++ b/mise.toml
@@ -129,9 +129,9 @@ GRAM_DEVIDP_EXTERNAL_URL = "http://{{env.GRAM_DEVIDP_HOST}}:{{env.GRAM_DEVIDP_PO
 GRAM_DEVIDP_DB = "file:{{ config_root }}/local/devidp/devidp.db"
 GRAM_IDP_BASE_URL = "{{env.GRAM_DEVIDP_EXTERNAL_URL}}/oauth2"
 GRAM_IDP_CLIENT_ID = "gram-local-dev"
-## Mock API key for the WorkOS SDK — any non-empty value works in mock-workos mode.
+## WorkOS API key. In mock-workos mode the mock endpoint accepts any value.
 ## Override in mise.local.toml with a real sk_test_... key for workos mode.
-GRAM_IDP_CLIENT_SECRET = "mock-workos-api-key"
+GRAM_IDP_CLIENT_SECRET = "unset"
 ## IDP mode: "mock-workos" (default) or "workos".
 ##
 ## mock-workos — fully local, zero config. dev-idp emulates the WorkOS API.
@@ -139,7 +139,7 @@ GRAM_IDP_CLIENT_SECRET = "mock-workos-api-key"
 ##
 ## workos      — real WorkOS via dev-idp proxy. Add these to mise.local.toml:
 ##                 GRAM_IDP_MODE = "workos"
-##                 WORKOS_API_KEY = "sk_test_..."
+##                 GRAM_IDP_CLIENT_SECRET = "sk_test_..."
 ##                 WORKOS_API_URL = "https://api.workos.com"
 ##                 GRAM_IDP_CLIENT_ID = "<your WorkOS client ID>"
 ##

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -480,13 +480,13 @@ func workosClientOpts(c *cli.Context) workos.ClientOpts {
 }
 
 func newAccessRoleProvider(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, c *cli.Context) (access.RoleProvider, error) {
-	apiKey := c.String("workos-api-key")
+	apiKey := c.String("idp-client-secret")
 
-	// Local dev: when a real WORKOS_API_KEY is configured (GRAM_IDP_MODE=workos),
+	// Local dev: when a real GRAM_IDP_CLIENT_SECRET is configured (GRAM_IDP_MODE=workos),
 	// use it so the access role provider proxies through dev-idp to real WorkOS.
 	// Otherwise fall back to the mock-workos emulator or a stub.
 	if c.String("environment") == "local" {
-		haveRealKey := apiKey != ""
+		haveRealKey := apiKey != "" && apiKey != "unset"
 		opts := workosClientOpts(c)
 
 		if haveRealKey {
@@ -511,7 +511,7 @@ func newAccessRoleProvider(ctx context.Context, logger *slog.Logger, guardianPol
 
 func newWorkOSClient(guardianPolicy *guardian.Policy, c *cli.Context) (client *workos.Client, workosAvailable bool, err error) {
 	env := c.String("environment")
-	apiKey := c.String("workos-api-key")
+	apiKey := c.String("idp-client-secret")
 
 	haveAPIKey := apiKey != "" && apiKey != "unset"
 	if env != "local" && !haveAPIKey {
@@ -522,10 +522,11 @@ func newWorkOSClient(guardianPolicy *guardian.Policy, c *cli.Context) (client *w
 }
 
 // newIDPUserManagementClient creates a WorkOS user-management SDK client
-// scoped to the IDP application key. Returns nil when the key is empty
-// (local dev with mock IDP).
+// scoped to the IDP application key. Returns nil only when the key is empty.
+// In mock-workos mode the key can be any non-empty string (e.g. "unset") —
+// the mock endpoint accepts it.
 func newIDPUserManagementClient(guardianPolicy *guardian.Policy, apiKey string, c *cli.Context) *usermanagement.Client {
-	if apiKey == "" || apiKey == "unset" {
+	if apiKey == "" {
 		return nil
 	}
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -180,7 +180,7 @@ func newStartCommand() *cli.Command {
 		},
 		&cli.StringFlag{
 			Name:    "idp-client-secret",
-			Usage:   "WorkOS API key scoped to the IDP application (falls back to workos-api-key if unset)",
+			Usage:   "WorkOS API key for user management and identity lookups",
 			EnvVars: []string{"GRAM_IDP_CLIENT_SECRET"},
 		},
 		&cli.BoolFlag{
@@ -391,12 +391,6 @@ func newStartCommand() *cli.Command {
 			Required: false,
 		},
 		&cli.StringFlag{
-			Name:     "workos-api-key",
-			Usage:    "WorkOS API key for user identity lookups",
-			EnvVars:  []string{"WORKOS_API_KEY"},
-			Required: false,
-		},
-		&cli.StringFlag{
 			Name:     "workos-endpoint",
 			Usage:    "Base URL for WorkOS API calls. Leave unset for production (defaults to https://api.workos.com); set to the dev-idp's mock-workos mode for fully-local development.",
 			EnvVars:  []string{"WORKOS_API_URL"},
@@ -541,13 +535,10 @@ func newStartCommand() *cli.Command {
 			}
 
 			idpClientSecret := c.String("idp-client-secret")
-			if idpClientSecret == "" {
-				idpClientSecret = c.String("workos-api-key")
-			}
 
 			umClient := newIDPUserManagementClient(guardianPolicy, idpClientSecret, c)
 			if umClient == nil {
-				return fmt.Errorf("failed to create IDP user management client: idp-client-secret (or workos-api-key) is required")
+				return fmt.Errorf("failed to create IDP user management client: idp-client-secret is required")
 			}
 
 			idpClient := identity.NewWorkOSAdapter(umClient)
@@ -978,7 +969,7 @@ func newStartCommand() *cli.Command {
 				posthogClient,
 				cache.NewRedisCacheAdapter(redisClient),
 			))
-			organizations.Attach(mux, organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, authzEngine, emailService, siteURL.String(), auditLogger, svixClient))
+			organizations.Attach(mux, organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, authzEngine, emailService, serverURL.String(), siteURL.String(), auditLogger, svixClient))
 			projects.Attach(mux, projects.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			packages.Attach(mux, packages.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -279,7 +279,7 @@ func newWorkerCommand() *cli.Command {
 		},
 		&cli.StringFlag{
 			Name:    "idp-client-secret",
-			Usage:   "WorkOS API key scoped to the IDP application (falls back to workos-api-key if unset)",
+			Usage:   "WorkOS API key for user management and identity lookups",
 			EnvVars: []string{"GRAM_IDP_CLIENT_SECRET"},
 		},
 		&cli.StringFlag{
@@ -292,12 +292,6 @@ func newWorkerCommand() *cli.Command {
 			Name:     "config-file",
 			Usage:    "Path to a config file to load. Supported formats are JSON, TOML and YAML.",
 			EnvVars:  []string{"GRAM_CONFIG_FILE"},
-			Required: false,
-		},
-		&cli.StringFlag{
-			Name:     "workos-api-key",
-			Usage:    "WorkOS API key for WorkOS API calls",
-			EnvVars:  []string{"WORKOS_API_KEY"},
 			Required: false,
 		},
 		&cli.StringFlag{
@@ -577,13 +571,10 @@ func newWorkerCommand() *cli.Command {
 			}
 
 			idpClientSecret := c.String("idp-client-secret")
-			if idpClientSecret == "" {
-				idpClientSecret = c.String("workos-api-key")
-			}
 
 			umClient := newIDPUserManagementClient(guardianPolicy, idpClientSecret, c)
 			if umClient == nil {
-				return fmt.Errorf("failed to create IDP user management client: idp-client-secret (or workos-api-key) is required")
+				return fmt.Errorf("failed to create IDP user management client: idp-client-secret is required")
 			}
 
 			idpClient := identity.NewWorkOSAdapter(umClient)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -199,6 +199,9 @@ const (
 	OpenRouterKeyLimitKey           = attribute.Key("gram.openrouter.key.limit")
 	OrganizationAccountTypeKey      = attribute.Key("gram.org.account_type")
 	OrganizationInviteIDKey         = attribute.Key("gram.org.invite.id")
+	OrganizationInviteEmailKey      = attribute.Key("gram.org.invite.email")
+	OrganizationInviteStateKey      = attribute.Key("gram.org.invite.state")
+	OrganizationInviteRoleSlugKey   = attribute.Key("gram.org.invite.role_slug")
 	OutboxIDKey                     = attribute.Key("gram.outbox.id")
 	OutboxPublicIDKey               = attribute.Key("gram.outbox.public_id")
 	OutboxBatchSizeKey              = attribute.Key("gram.outbox.batch_size")
@@ -938,6 +941,18 @@ func SlogOrganizationAccountType(v string) slog.Attr {
 func OrganizationInviteID(v string) attribute.KeyValue { return OrganizationInviteIDKey.String(v) }
 func SlogOrganizationInviteID(v string) slog.Attr {
 	return slog.String(string(OrganizationInviteIDKey), v)
+}
+
+func OrganizationInviteEmail(v string) attribute.KeyValue {
+	return OrganizationInviteEmailKey.String(v)
+}
+
+func OrganizationInviteState(v string) attribute.KeyValue {
+	return OrganizationInviteStateKey.String(v)
+}
+
+func OrganizationInviteRoleSlug(v string) attribute.KeyValue {
+	return OrganizationInviteRoleSlugKey.String(v)
 }
 
 func Outcome[V ~string](v V) attribute.KeyValue { return OutcomeKey.String(string(v)) }

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -176,9 +176,11 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 		return nil, err
 	}
 
-	trace.SpanFromContext(ctx).SetAttributes(
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
 		attr.OrganizationID(ac.ActiveOrganizationID),
 		attr.UserID(ac.UserID),
+		attr.OrganizationInviteEmail(strings.ToLower(strings.TrimSpace(payload.Email))),
 	)
 
 	rawToken, tokenHash, err := generateInviteToken()
@@ -211,6 +213,7 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 		if !roleSlug.Valid {
 			return nil, oops.E(oops.CodeBadRequest, nil, "role not found").Log(ctx, logger)
 		}
+		span.AddEvent("invite.role_resolved", trace.WithAttributes(attr.OrganizationInviteRoleSlug(roleSlug.String)))
 	}
 
 	normalizedEmail := strings.ToLower(strings.TrimSpace(payload.Email))
@@ -246,19 +249,27 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "create invitation").Log(ctx, logger)
 	}
+	span.SetAttributes(attr.OrganizationInviteID(row.ID.String()))
+	span.AddEvent("invite.created", trace.WithAttributes(
+		attr.OrganizationInviteID(row.ID.String()),
+		attr.OrganizationInviteEmail(normalizedEmail),
+	))
 
 	// Create the WorkOS passwordless magic-link session BEFORE committing
 	// the invite. If this fails the transaction rolls back, avoiding an
 	// orphaned invite row with no magic link.
+	redirectURI := s.serverURL + inviteCallbackPath
 	pwlSess, pwlErr := s.orgs.CreatePasswordlessSession(ctx, workos.CreatePasswordlessSessionOpts{
 		Email:       row.Email,
-		RedirectURI: s.serverURL + inviteCallbackPath,
+		RedirectURI: redirectURI,
 		ExpiresIn:   defaultInviteExpiryDays * 24 * 60 * 60,
 		State:       fmt.Sprintf("invite_token=%s", rawToken),
 	})
 	if pwlErr != nil {
+		span.RecordError(pwlErr)
 		return nil, oops.E(oops.CodeUnexpected, pwlErr, "failed to create invite link").Log(ctx, logger)
 	}
+	span.AddEvent("invite.workos_session_created")
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit invitation").Log(ctx, logger)
@@ -282,11 +293,14 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 			InviterName:      inviterName,
 			InviterEmail:     inviterEmail,
 		}); err != nil {
+			span.RecordError(err)
+			span.AddEvent("invite.email_failed")
 			// Revoke the invite so the user can retry — the invitee never
 			// received the magic link so the invite is useless.
 			_ = orgrepo.New(s.db).RevokeInvitation(ctx, row.ID)
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to send invite email").Log(ctx, logger)
 		}
+		span.AddEvent("invite.email_sent")
 	}
 
 	return dbInvitationToGen(&row, &ac.UserID), nil
@@ -307,9 +321,11 @@ func (s *Service) RevokeInvite(ctx context.Context, payload *gen.RevokeInvitePay
 		return err
 	}
 
-	trace.SpanFromContext(ctx).SetAttributes(
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
 		attr.OrganizationID(ac.ActiveOrganizationID),
 		attr.UserID(ac.UserID),
+		attr.OrganizationInviteID(payload.InvitationID),
 	)
 
 	inviteID, err := uuid.Parse(payload.InvitationID)
@@ -328,10 +344,16 @@ func (s *Service) RevokeInvite(ctx context.Context, payload *gen.RevokeInvitePay
 		return oops.E(oops.CodeForbidden, nil, "invitation does not belong to this organization").Log(ctx, logger)
 	}
 
+	span.SetAttributes(
+		attr.OrganizationInviteEmail(invite.Email),
+		attr.OrganizationInviteState(invite.State),
+	)
+
 	if err := orgrepo.New(s.db).RevokeInvitation(ctx, inviteID); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "revoke invitation").Log(ctx, logger)
 	}
 
+	span.AddEvent("invite.revoked")
 	return nil
 }
 
@@ -785,6 +807,10 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		attr.WorkOSUserID(profile.ID),
 		attr.AuthUserEmail(profile.Email),
 	)
+	span.AddEvent("invite.callback.code_exchanged", trace.WithAttributes(
+		attr.WorkOSUserID(profile.ID),
+		attr.AuthUserEmail(profile.Email),
+	))
 
 	// Extract invite_token from the state parameter.
 	stateParam := r.URL.Query().Get("state")
@@ -803,19 +829,32 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		redirectError("invite not found")
 		return
 	}
+	span.SetAttributes(
+		attr.OrganizationInviteID(invite.ID.String()),
+		attr.OrganizationInviteEmail(invite.Email),
+		attr.OrganizationInviteState(invite.State),
+		attr.OrganizationID(invite.OrganizationID),
+	)
 	if invite.State != "pending" {
+		span.AddEvent("invite.callback.rejected", trace.WithAttributes(attr.OrganizationInviteState(invite.State)))
 		redirectError("invite already used or revoked")
 		return
 	}
 	if invite.ExpiresAt.Valid && invite.ExpiresAt.Time.Before(time.Now()) {
+		span.AddEvent("invite.callback.rejected", trace.WithAttributes(attr.OrganizationInviteState("expired")))
 		redirectError("invite expired")
 		return
 	}
+	span.AddEvent("invite.callback.token_validated")
 
 	// Verify the authenticated email matches the invite.
 	inviteeEmail := strings.ToLower(profile.Email)
 	if invite.Email != inviteeEmail {
 		s.logger.WarnContext(ctx, fmt.Sprintf("invite callback: email mismatch (invite=%s, authenticated=%s)", invite.Email, inviteeEmail))
+		span.AddEvent("invite.callback.email_mismatch", trace.WithAttributes(
+			attr.OrganizationInviteEmail(invite.Email),
+			attr.AuthUserEmail(inviteeEmail),
+		))
 		redirectError("email does not match invitation")
 		return
 	}
@@ -848,6 +887,7 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		attr.UserID(gramUserID),
 		attr.OrganizationID(invite.OrganizationID),
 	)
+	span.AddEvent("invite.callback.user_provisioned", trace.WithAttributes(attr.UserID(gramUserID)))
 
 	if _, err := repo.UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
 		OrganizationID: invite.OrganizationID,
@@ -858,6 +898,7 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		redirectError("failed to join organization")
 		return
 	}
+	span.AddEvent("invite.callback.org_membership_created")
 
 	// Create the WorkOS organization membership so ListMembers returns the
 	// invited user with the correct role.
@@ -870,8 +911,10 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 			mid, err := s.orgs.CreateOrganizationMembership(ctx, profile.ID, org.WorkosID.String, invite.RoleSlug.String)
 			if err != nil {
 				s.logger.WarnContext(ctx, "invite callback: failed to create WorkOS membership", attr.SlogError(err))
+				span.RecordError(err)
 			} else {
 				workosMembershipID = mid
+				span.AddEvent("invite.callback.workos_membership_created")
 			}
 		}
 	}
@@ -890,6 +933,11 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 			WorkosLastEventID:  pgtype.Text{String: "", Valid: false},
 		}); err != nil {
 			s.logger.WarnContext(ctx, "invite callback: failed to sync role assignments", attr.SlogError(err))
+			span.RecordError(err)
+		} else {
+			span.AddEvent("invite.callback.rbac_synced", trace.WithAttributes(
+				attr.OrganizationInviteRoleSlug(invite.RoleSlug.String),
+			))
 		}
 	}
 
@@ -905,9 +953,11 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	if rowsAffected == 0 {
 		s.logger.WarnContext(ctx, "invite callback: invite was revoked or expired before acceptance")
+		span.AddEvent("invite.callback.acceptance_race_lost")
 		redirectError("invite already used, revoked, or expired")
 		return
 	}
+	span.AddEvent("invite.callback.invitation_accepted")
 
 	// Create a Gram session directly — no need to bounce through an external
 	// OIDC login. The invitee is already authenticated via the magic link.
@@ -920,9 +970,14 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.sessions.StoreSession(ctx, session); err != nil {
 		s.logger.ErrorContext(ctx, "invite callback: failed to store session", attr.SlogError(err))
+		span.RecordError(err)
 		redirectError("failed to create session")
 		return
 	}
+	span.AddEvent("invite.callback.session_created", trace.WithAttributes(
+		attr.UserID(gramUserID),
+		attr.OrganizationID(invite.OrganizationID),
+	))
 
 	// Invalidate cached user info so the session picks up fresh org memberships.
 	if err := s.sessions.InvalidateUserInfoCache(ctx, gramUserID); err != nil {
@@ -937,7 +992,15 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		Secure:   true,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	})
+	span.AddEvent("invite.callback.cookie_set")
+	s.logger.InfoContext(ctx, "invite callback: complete",
+		attr.SlogUserID(gramUserID),
+		attr.SlogOrganizationID(invite.OrganizationID),
+		attr.SlogOrganizationInviteID(invite.ID.String()),
+		attr.SlogAuthUserEmail(inviteeEmail),
+	)
 	http.Redirect(w, r, s.siteURL, http.StatusTemporaryRedirect)
 }
 

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -84,7 +84,8 @@ type Service struct {
 	userProvision UserProvisioner
 	features      orgFeatureChecker
 	email         *email.Service
-	siteURL       string // site URL; used for invite callback RedirectURI and post-callback redirect
+	serverURL     string // API server URL; used as WorkOS invite callback RedirectURI
+	siteURL       string // frontend URL; used for post-callback browser redirects
 	audit         *audit.Logger
 	svix          *svix.Svix
 }
@@ -93,7 +94,7 @@ var _ gen.Service = (*Service)(nil)
 
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, userProvision UserProvisioner, features orgFeatureChecker, authzEngine *authz.Engine, emailService *email.Service, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, userProvision UserProvisioner, features orgFeatureChecker, authzEngine *authz.Engine, emailService *email.Service, serverURL string, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
 	logger = logger.With(attr.SlogComponent("organizations"))
 
 	return &Service{
@@ -107,6 +108,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		userProvision: userProvision,
 		features:      features,
 		email:         emailService,
+		serverURL:     serverURL,
 		siteURL:       siteURL,
 		audit:         auditLogger,
 		svix:          svix,
@@ -245,21 +247,21 @@ func (s *Service) SendInvite(ctx context.Context, payload *gen.SendInvitePayload
 		return nil, oops.E(oops.CodeUnexpected, err, "create invitation").Log(ctx, logger)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit invitation").Log(ctx, logger)
-	}
-
-	// Create a WorkOS passwordless magic-link session for the invitee.
-	// RedirectURI points to our invite callback which exchanges the code,
-	// accepts the invite, and redirects to the dashboard.
+	// Create the WorkOS passwordless magic-link session BEFORE committing
+	// the invite. If this fails the transaction rolls back, avoiding an
+	// orphaned invite row with no magic link.
 	pwlSess, pwlErr := s.orgs.CreatePasswordlessSession(ctx, workos.CreatePasswordlessSessionOpts{
 		Email:       row.Email,
-		RedirectURI: s.siteURL + inviteCallbackPath,
+		RedirectURI: s.serverURL + inviteCallbackPath,
 		ExpiresIn:   defaultInviteExpiryDays * 24 * 60 * 60,
 		State:       fmt.Sprintf("invite_token=%s", rawToken),
 	})
 	if pwlErr != nil {
 		return nil, oops.E(oops.CodeUnexpected, pwlErr, "failed to create invite link").Log(ctx, logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit invitation").Log(ctx, logger)
 	}
 
 	if s.email != nil {

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -116,7 +116,7 @@ func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) 
 	svixClient, err := svix.New("test-token", &svix.SvixOptions{ServerUrl: svixSrv.URL()})
 	require.NoError(t, err)
 
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, authzEngine, nil, "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, authzEngine, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,
@@ -172,7 +172,7 @@ func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstan
 	svixClient, err := svix.New("test-token", &svix.SvixOptions{ServerUrl: svixSrv.URL()})
 	require.NoError(t, err)
 
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeaturesEnabled{}, authzEngine, nil, "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeaturesEnabled{}, authzEngine, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,
@@ -227,7 +227,7 @@ func newTestOrganizationsServiceWithEmail(t *testing.T) (context.Context, *testI
 	require.NoError(t, err)
 
 	emailService := email.NewService(logger, loopsMock)
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, authzEngine, emailService, "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, authzEngine, emailService, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,


### PR DESCRIPTION
## Summary

Three fixes to the team invite flow:

- **Fix invite callback URL**: Use `serverURL` (API server) for the WorkOS invite `RedirectURI` instead of `siteURL` (frontend). The `handleInviteCallback` handler is registered on the API server mux, so WorkOS must redirect there — not the dashboard.

- **Prevent orphaned invites**: Move `tx.Commit()` after `CreatePasswordlessSession` succeeds. Previously the invite row was committed before the external WorkOS call, leaving an orphaned `pending` invite with no magic link if the call failed.

- **Consolidate `WORKOS_API_KEY` → `GRAM_IDP_CLIENT_SECRET`**: Remove the duplicate `WORKOS_API_KEY` env var. All callers now use `GRAM_IDP_CLIENT_SECRET`. Default changed to `"unset"` in `mise.toml` — the mock-workos endpoint accepts any non-empty string, so no dummy value needed.

## Changes

| Area | Files | What |
|------|-------|------|
| Invite callback URL | `organizations/impl.go`, `start.go`, `setup_test.go` | Add `serverURL` param, use for `RedirectURI` |
| Orphaned invite fix | `organizations/impl.go` | Reorder: create passwordless session before `tx.Commit()` |
| Env var consolidation | `start.go`, `worker.go`, `deps.go`, `dev-idp/main.go`, `mise.toml`, `idp.mts`, dashboard files, `CONTRIBUTING.md` | Remove `WORKOS_API_KEY`, use `GRAM_IDP_CLIENT_SECRET` everywhere |

## Test plan

- [ ] `mise start:server --dev-single-process` boots without errors in mock-workos mode
- [ ] Send an invite via dashboard → email received with valid magic link
- [ ] Click magic link → redirects to API server callback → lands on dashboard logged in
- [ ] Verify `WORKOS_API_KEY` no longer referenced in codebase (except git history)
