### PR TITLE
feat: improve trace session detail ux

### DIFF
--- a/.changeset/two-llamas-cross.md
+++ b/.changeset/two-llamas-cross.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Adds filtering and clearer presentation for trace entries

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -168,33 +168,56 @@ const ENTRY_TYPE_META: Record<
   {
     label: string;
     icon: IconName;
+    avatarClassName: string;
     iconClassName: string;
+    contentClassName: string;
+    collapsedClassName: string;
   }
 > = {
   user: {
     label: "User",
     icon: "user",
+    avatarClassName: "bg-muted",
     iconClassName: "text-muted-foreground",
+    contentClassName: "border border-border p-3",
+    collapsedClassName:
+      "border-l-3 border-border bg-muted/10 hover:bg-muted/30",
   },
   assistant: {
     label: "Assistant",
     icon: "bot",
+    avatarClassName: "bg-information-softest",
     iconClassName: "text-default-information",
+    contentClassName: "border border-border p-3",
+    collapsedClassName:
+      "border-l-3 border-information-default bg-muted/10 hover:bg-muted/30",
   },
   tool_call: {
     label: "Tool Call",
     icon: "zap",
+    avatarClassName: "bg-warning-softest",
     iconClassName: "text-warning-default",
+    contentClassName: "border border-border",
+    collapsedClassName:
+      "border-l-3 border-warning-default bg-muted/10 hover:bg-muted/30",
   },
   tool_result: {
     label: "Tool Result",
     icon: "terminal",
+    avatarClassName: "bg-success-softest",
     iconClassName: "text-success-default",
+    contentClassName: "",
+    collapsedClassName:
+      "border-l-3 border-success-default bg-muted/10 hover:bg-muted/30",
   },
   system: {
     label: "System Prompt",
     icon: "settings",
+    avatarClassName: "bg-accent",
     iconClassName: "text-muted-foreground",
+    contentClassName: "border border-border p-3",
+    collapsedClassName:
+      "border-l-3 border-border bg-muted/10 hover:bg-muted/30",
   },
 };
 
@@ -371,7 +394,7 @@ function ChatMessagesList({
   // A single segment (no compaction has ever occurred) stays flat — no accordion.
   if (maxGeneration === 0) {
     return (
-      <Stack direction="vertical" gap={4}>
+      <Stack direction="vertical">
         {visibleMessages.map((message) => (
           <MessageItem
             key={message.id}
@@ -399,7 +422,7 @@ function ChatMessagesList({
             </div>
           </AccordionTrigger>
           <AccordionContent>
-            <Stack direction="vertical" gap={4}>
+            <Stack direction="vertical">
               {groupMessages.map((message) => (
                 <MessageItem
                   key={message.id}
@@ -437,29 +460,18 @@ function MessageItem({
   const [contentRevealed, setContentRevealed] = useState(false);
   const isCollapsed = collapseNonRisk && !hasRisk && !expanded;
 
-  const parsedToolCalls: ToolCall[] | null = useMemo(() => {
-    if (!message.toolCalls) return null;
-    try {
-      let parsed: unknown = JSON.parse(message.toolCalls);
-      // Handle double-encoded JSON strings
-      if (typeof parsed === "string") {
-        parsed = JSON.parse(parsed);
-      }
-      return Array.isArray(parsed) ? (parsed as ToolCall[]) : null;
-    } catch {
-      return null;
-    }
-  }, [message.toolCalls]);
+  const parsedToolCalls = useMemo(
+    () => parseToolCalls(message.toolCalls),
+    [message.toolCalls],
+  );
+  const entryType = getTraceEntryType(message, parsedToolCalls);
+  const entryMeta = ENTRY_TYPE_META[entryType];
 
   if (isCollapsed) {
     const label =
-      message.role === "tool"
-        ? "Tool Result"
-        : message.role === "system"
-          ? "System Prompt"
-          : parsedToolCalls
-            ? `Tool Call: ${parsedToolCalls[0]?.function?.name ?? "unknown"}`
-            : message.role;
+      entryType === "tool_call"
+        ? `Tool Call: ${parsedToolCalls?.[0]?.function?.name ?? "unknown"}`
+        : entryMeta.label;
     const preview =
       !parsedToolCalls && typeof message.content === "string"
         ? message.content.trim().slice(0, 80)
@@ -469,14 +481,24 @@ function MessageItem({
       <button
         type="button"
         onClick={() => setExpanded(true)}
-        className="text-muted-foreground hover:bg-muted/50 flex w-full items-center gap-2 rounded px-1 py-1 text-xs transition-colors"
-      >
-        <Icon name="chevron-right" className="size-3 shrink-0" />
-        <span className="capitalize">{label}</span>
-        {message.createdAt && (
-          <span>{format(new Date(message.createdAt), "HH:mm:ss")}</span>
+        className={cn(
+          entryMeta.collapsedClassName,
+          "text-muted-foreground flex w-full items-center gap-3 truncate px-2 py-2 text-sm transition-colors",
+          "border-r-muted border-t-muted last:border-b-muted border border-b-transparent",
         )}
+      >
+        <Icon
+          name={entryMeta.icon}
+          className={cn("ml-1 size-4 shrink-0", entryMeta.iconClassName)}
+        />
+        {message.createdAt && (
+          <span className="font-mono text-xs">
+            {format(new Date(message.createdAt), "HH:mm:ss")}
+          </span>
+        )}
+        <span className="font-medium">{label}</span>
         {preview && <span className="truncate opacity-60">{preview}...</span>}
+        <Icon name="chevron-down" className="ml-auto size-3 shrink-0" />
       </button>
     );
   }
@@ -494,21 +516,29 @@ function MessageItem({
       {parsedToolCalls ? (
         parsedToolCalls.map((tc, idx: number) => (
           <div key={tc.id || idx} className="flex items-start gap-3">
-            <div className="bg-primary flex size-8 flex-shrink-0 items-center justify-center rounded-full">
-              <Icon name="zap" className="text-primary-foreground size-4" />
+            <div
+              className={cn(
+                "flex size-8 shrink-0 items-center justify-center rounded-full",
+                entryMeta.avatarClassName,
+              )}
+            >
+              <Icon
+                name={entryMeta.icon}
+                className={cn("size-4", entryMeta.iconClassName)}
+              />
             </div>
             <div className="min-w-0 flex-1">
               <div className="mb-1 flex items-center gap-2">
-                <span className="text-sm font-semibold">Tool Call</span>
+                <span className="text-muted-foreground font-mono text-xs">
+                  {message.createdAt &&
+                    format(new Date(message.createdAt), "HH:mm:ss")}
+                </span>
+                <span className="text-sm font-semibold">{entryMeta.label}</span>
                 {tc.id && (
                   <code className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                     {tc.id}
                   </code>
                 )}
-                <span className="text-muted-foreground text-xs">
-                  {message.createdAt &&
-                    format(new Date(message.createdAt), "HH:mm:ss")}
-                </span>
                 {riskResults && riskResults.length > 0 && (
                   <RiskBadgePopover results={riskResults} />
                 )}
@@ -516,10 +546,18 @@ function MessageItem({
               {hasSensitiveContent && !contentRevealed ? (
                 <MaskedContent onReveal={() => setContentRevealed(true)} />
               ) : (
-                <div className="bg-background overflow-hidden rounded-lg border text-sm">
-                  <div className="bg-muted/30 border-b p-3">
+                <div
+                  className={cn(
+                    "overflow-hidden rounded-lg text-sm",
+                    entryMeta.contentClassName,
+                  )}
+                >
+                  <div className="bg-background/50 border-b p-3">
                     <div className="flex items-center gap-2">
-                      <Icon name="zap" className="text-primary size-4" />
+                      <Icon
+                        name={entryMeta.icon}
+                        className={cn("size-4", entryMeta.iconClassName)}
+                      />
                       <span className="font-semibold">
                         {tc.function?.name || tc.name || "Tool Call"}
                       </span>
@@ -542,53 +580,43 @@ function MessageItem({
         ))
       ) : (
         <div className="flex items-start gap-3">
-          {message.role === "user" && (
-            <div className="bg-primary/10 flex size-8 flex-shrink-0 items-center justify-center rounded-full">
-              <Icon name="user" className="text-primary size-4" />
-            </div>
-          )}
-          {message.role === "assistant" && (
-            <div className="bg-muted flex size-8 flex-shrink-0 items-center justify-center rounded-full">
-              <Icon name="bot" className="size-4" />
-            </div>
-          )}
-          {message.role === "tool" && (
-            <div className="bg-primary flex size-8 flex-shrink-0 items-center justify-center rounded-full">
-              <Icon name="zap" className="text-primary-foreground size-4" />
-            </div>
-          )}
-          {message.role === "system" && (
-            <div className="bg-muted flex size-8 flex-shrink-0 items-center justify-center rounded-full">
-              <Icon name="settings" className="size-4" />
-            </div>
-          )}
+          <div
+            className={cn(
+              "flex size-8 shrink-0 items-center justify-center rounded-full",
+              entryMeta.avatarClassName,
+            )}
+          >
+            <Icon
+              name={entryMeta.icon}
+              className={cn("size-4", entryMeta.iconClassName)}
+            />
+          </div>
 
           <div className="min-w-0 flex-1">
             <div className="mb-1 flex items-center gap-2">
-              <span className="text-sm font-semibold capitalize">
-                {message.role === "tool"
-                  ? "Tool Result"
-                  : message.role === "system"
-                    ? "System Prompt"
-                    : message.role}
+              <span className="text-muted-foreground font-mono text-xs">
+                {message.createdAt &&
+                  format(new Date(message.createdAt), "HH:mm:ss")}
               </span>
+              <span className="text-sm font-semibold">{entryMeta.label}</span>
               {message.toolCallId && (
                 <code className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
                   {message.toolCallId}
                 </code>
               )}
-              <span className="text-muted-foreground text-xs">
-                {message.createdAt &&
-                  format(new Date(message.createdAt), "HH:mm:ss")}
-              </span>
               {riskResults && riskResults.length > 0 && (
                 <RiskBadgePopover results={riskResults} />
               )}
             </div>
             {hasSensitiveContent && !contentRevealed ? (
               <MaskedContent onReveal={() => setContentRevealed(true)} />
-            ) : message.role === "system" ? (
-              <details className="bg-muted/30 group overflow-hidden rounded-lg border text-sm">
+            ) : entryType === "system" ? (
+              <details
+                className={cn(
+                  "group overflow-hidden rounded-lg text-sm",
+                  entryMeta.contentClassName,
+                )}
+              >
                 <summary className="text-muted-foreground hover:bg-muted/50 flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs select-none">
                   <Icon
                     name="chevron-right"
@@ -606,12 +634,10 @@ function MessageItem({
               <div
                 className={cn(
                   "overflow-hidden rounded-lg text-sm",
-                  message.role === "user" && "bg-primary/5 p-3",
-                  message.role === "assistant" && "bg-muted/50 p-3",
-                  message.role === "tool" && "bg-background border",
+                  entryMeta.contentClassName,
                 )}
               >
-                {message.role === "tool" ? (
+                {entryType === "tool_result" ? (
                   <CodeBlock content={message.content ?? ""} maxHeight={300} />
                 ) : (
                   <MessageContent
@@ -682,7 +708,7 @@ function TelemetryLogsTab({
               {log.severityText || "INFO"}
             </Badge>
             <div className="min-w-0 flex-1 space-y-1">
-              <div className="text-sm font-medium break-words">
+              <div className="text-sm font-medium wrap-break-word">
                 {log.body.trim()}
               </div>
               <div className="text-muted-foreground flex items-center gap-3 text-xs">
@@ -1111,7 +1137,7 @@ export function ChatDetailPanel({
             </button>
           </div>
         </div>
-        <div className="text-muted-foreground mb-3 text-sm">
+        <div className="text-muted-foreground mb-3 font-mono text-sm">
           {format(new Date(chat.createdAt), "yyyy-MM-dd HH:mm:ss")}
         </div>
         <div className="text-sm">{chat.title}</div>

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -18,7 +18,7 @@ import { useLoadChat, useSearchLogsMutation } from "@gram/client/react-query";
 import { useRiskListResults } from "@gram/client/react-query/riskListResults.js";
 import { Badge, Icon, Stack, type IconName } from "@speakeasy-api/moonshine";
 import { format } from "date-fns";
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Dialog } from "@/components/ui/dialog";
 import {
   Popover,
@@ -170,8 +170,6 @@ const ENTRY_TYPE_META: Record<
     icon: IconName;
     avatarClassName: string;
     iconClassName: string;
-    contentClassName: string;
-    collapsedClassName: string;
   }
 > = {
   user: {
@@ -179,45 +177,30 @@ const ENTRY_TYPE_META: Record<
     icon: "user",
     avatarClassName: "bg-muted",
     iconClassName: "text-muted-foreground",
-    contentClassName: "border border-border p-3",
-    collapsedClassName:
-      "border-l-3 border-border bg-muted/10 hover:bg-muted/30",
   },
   assistant: {
     label: "Assistant",
     icon: "bot",
     avatarClassName: "bg-information-softest",
     iconClassName: "text-default-information",
-    contentClassName: "border border-border p-3",
-    collapsedClassName:
-      "border-l-3 border-information-default bg-muted/10 hover:bg-muted/30",
   },
   tool_call: {
     label: "Tool Call",
     icon: "zap",
     avatarClassName: "bg-warning-softest",
     iconClassName: "text-warning-default",
-    contentClassName: "border border-border",
-    collapsedClassName:
-      "border-l-3 border-warning-default bg-muted/10 hover:bg-muted/30",
   },
   tool_result: {
     label: "Tool Result",
     icon: "terminal",
     avatarClassName: "bg-success-softest",
     iconClassName: "text-success-default",
-    contentClassName: "",
-    collapsedClassName:
-      "border-l-3 border-success-default bg-muted/10 hover:bg-muted/30",
   },
   system: {
     label: "System Prompt",
     icon: "settings",
     avatarClassName: "bg-accent",
     iconClassName: "text-muted-foreground",
-    contentClassName: "border border-border p-3",
-    collapsedClassName:
-      "border-l-3 border-border bg-muted/10 hover:bg-muted/30",
   },
 };
 
@@ -320,7 +303,7 @@ function EntryTypeFilterBar({
   });
 
   return (
-    <div className="bg-background border-b px-6 py-3">
+    <div className="bg-background px-6 py-3">
       <div className="flex min-w-0 flex-col gap-2">
         <div className="text-sm font-medium">Entry type filter</div>
         <div>
@@ -385,8 +368,10 @@ function ChatMessagesList({
 
   if (visibleMessages.length === 0) {
     return (
-      <div className="text-muted-foreground rounded-lg border border-dashed p-6 text-center text-sm">
-        No entries match the selected filters.
+      <div className="border-muted border-t p-6">
+        <div className="text-muted-foreground rounded-lg border border-dashed p-6 text-center text-sm">
+          No entries match the selected filters.
+        </div>
       </div>
     );
   }
@@ -394,7 +379,7 @@ function ChatMessagesList({
   // A single segment (no compaction has ever occurred) stays flat — no accordion.
   if (maxGeneration === 0) {
     return (
-      <Stack direction="vertical">
+      <Stack direction="vertical" className="border-muted border-b">
         {visibleMessages.map((message) => (
           <MessageItem
             key={message.id}
@@ -451,14 +436,20 @@ function MessageItem({
   riskResults: RiskResult[] | undefined;
   collapseNonRisk?: boolean;
 }) {
-  const hasRisk = riskResults && riskResults.length > 0;
+  const hasRisk = !!riskResults && riskResults.length > 0;
   const hasSensitiveContent =
     riskResults?.some(
       (r) => r.source === "gitleaks" || r.source === "presidio",
     ) ?? false;
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(!collapseNonRisk || hasRisk);
   const [contentRevealed, setContentRevealed] = useState(false);
-  const isCollapsed = collapseNonRisk && !hasRisk && !expanded;
+  const isCollapsed = !expanded;
+
+  useEffect(() => {
+    if (!collapseNonRisk || hasRisk) {
+      setExpanded(true);
+    }
+  }, [collapseNonRisk, hasRisk]);
 
   const parsedToolCalls = useMemo(
     () => parseToolCalls(message.toolCalls),
@@ -466,196 +457,373 @@ function MessageItem({
   );
   const entryType = getTraceEntryType(message, parsedToolCalls);
   const entryMeta = ENTRY_TYPE_META[entryType];
-
-  if (isCollapsed) {
-    const label =
-      entryType === "tool_call"
-        ? `Tool Call: ${parsedToolCalls?.[0]?.function?.name ?? "unknown"}`
-        : entryMeta.label;
-    const preview =
-      !parsedToolCalls && typeof message.content === "string"
-        ? message.content.trim().slice(0, 80)
-        : "";
-
-    return (
-      <button
-        type="button"
-        onClick={() => setExpanded(true)}
-        className={cn(
-          entryMeta.collapsedClassName,
-          "flex w-full items-center gap-3 px-4 py-3",
-          "text-muted-foreground truncate text-sm transition-colors",
-          "border-r-muted border-t-muted last:border-b-muted border border-b-transparent",
-        )}
-      >
-        <Icon
-          name={entryMeta.icon}
-          className={cn("ml-1 size-4 shrink-0", entryMeta.iconClassName)}
-        />
-        {message.createdAt && (
-          <span className="font-mono text-xs">
-            {format(new Date(message.createdAt), "HH:mm:ss")}
-          </span>
-        )}
-        <span className="font-medium">{label}</span>
-        {preview && <span className="truncate opacity-60">{preview}...</span>}
-        <Icon name="chevron-down" className="ml-auto size-3 shrink-0" />
-      </button>
-    );
-  }
+  const label =
+    entryType === "tool_call"
+      ? `Tool Call: ${parsedToolCalls?.[0]?.function?.name ?? "unknown"}`
+      : entryMeta.label;
 
   return (
     <div>
-      {resolution && (
-        <div className="bg-primary/10 border-primary mb-3 rounded-lg border-l-4 p-3">
-          <div className="text-xs font-semibold">
-            Resolution Point: {resolution.resolution}
-          </div>
-        </div>
-      )}
+      <MessageItemToggle
+        createdAt={message.createdAt}
+        entryMeta={entryMeta}
+        isCollapsed={isCollapsed}
+        label={label}
+        onToggle={() => setExpanded((current) => !current)}
+        riskResults={riskResults}
+      />
 
-      {parsedToolCalls ? (
-        parsedToolCalls.map((tc, idx: number) => (
-          <div key={tc.id || idx} className="flex items-start gap-3">
-            <div
-              className={cn(
-                "flex size-8 shrink-0 items-center justify-center rounded-full",
-                entryMeta.avatarClassName,
-              )}
-            >
-              <Icon
-                name={entryMeta.icon}
-                className={cn("size-4", entryMeta.iconClassName)}
-              />
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="mb-1 flex items-center gap-2">
-                <span className="text-muted-foreground font-mono text-xs">
-                  {message.createdAt &&
-                    format(new Date(message.createdAt), "HH:mm:ss")}
-                </span>
-                <span className="text-sm font-semibold">{entryMeta.label}</span>
-                {tc.id && (
-                  <code className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
-                    {tc.id}
-                  </code>
-                )}
-                {riskResults && riskResults.length > 0 && (
-                  <RiskBadgePopover results={riskResults} />
-                )}
+      {isCollapsed ? null : (
+        <div className="pt-0 pr-3 pb-3 pl-12">
+          {resolution && (
+            <div className="bg-primary/10 border-primary mb-3 rounded-lg border-l-4 p-3">
+              <div className="text-xs font-semibold">
+                Resolution Point: {resolution.resolution}
               </div>
-              {hasSensitiveContent && !contentRevealed ? (
-                <MaskedContent onReveal={() => setContentRevealed(true)} />
-              ) : (
-                <div
-                  className={cn(
-                    "overflow-hidden rounded-lg text-sm",
-                    entryMeta.contentClassName,
-                  )}
-                >
-                  <div className="bg-background/50 border-b p-3">
-                    <div className="flex items-center gap-2">
-                      <Icon
-                        name={entryMeta.icon}
-                        className={cn("size-4", entryMeta.iconClassName)}
-                      />
-                      <span className="font-semibold">
-                        {tc.function?.name || tc.name || "Tool Call"}
-                      </span>
-                    </div>
-                  </div>
-                  {tc.function?.arguments && (
-                    <CodeBlock
-                      content={
-                        typeof tc.function.arguments === "string"
-                          ? tc.function.arguments
-                          : JSON.stringify(tc.function.arguments, null, 2)
-                      }
-                      maxHeight={300}
-                    />
-                  )}
-                </div>
-              )}
             </div>
-          </div>
-        ))
-      ) : (
-        <div className="flex items-start gap-3">
-          <div
-            className={cn(
-              "flex size-8 shrink-0 items-center justify-center rounded-full",
-              entryMeta.avatarClassName,
-            )}
-          >
-            <Icon
-              name={entryMeta.icon}
-              className={cn("size-4", entryMeta.iconClassName)}
-            />
-          </div>
+          )}
 
-          <div className="min-w-0 flex-1">
-            <div className="mb-1 flex items-center gap-2">
-              <span className="text-muted-foreground font-mono text-xs">
-                {message.createdAt &&
-                  format(new Date(message.createdAt), "HH:mm:ss")}
-              </span>
-              <span className="text-sm font-semibold">{entryMeta.label}</span>
-              {message.toolCallId && (
-                <code className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
-                  {message.toolCallId}
-                </code>
-              )}
-              {riskResults && riskResults.length > 0 && (
-                <RiskBadgePopover results={riskResults} />
-              )}
-            </div>
-            {hasSensitiveContent && !contentRevealed ? (
-              <MaskedContent onReveal={() => setContentRevealed(true)} />
-            ) : entryType === "system" ? (
-              <details
-                className={cn(
-                  "group overflow-hidden rounded-lg text-sm",
-                  entryMeta.contentClassName,
-                )}
-              >
-                <summary className="text-muted-foreground hover:bg-muted/50 flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs select-none">
-                  <Icon
-                    name="chevron-right"
-                    className="size-3 transition-transform group-open:rotate-90"
-                  />
-                  <span>Show content</span>
-                </summary>
-                <div className="border-t p-3 font-mono text-xs whitespace-pre-wrap">
-                  {typeof message.content === "string"
-                    ? message.content.trim()
-                    : JSON.stringify(message.content)}
-                </div>
-              </details>
-            ) : (
-              <div
-                className={cn(
-                  "overflow-hidden rounded-lg text-sm",
-                  entryMeta.contentClassName,
-                )}
-              >
-                {entryType === "tool_result" ? (
-                  <CodeBlock content={message.content ?? ""} maxHeight={300} />
-                ) : (
-                  <MessageContent
-                    content={
-                      typeof message.content === "string"
-                        ? message.content.trim()
-                        : JSON.stringify(message.content)
-                    }
-                  />
-                )}
-              </div>
-            )}
-          </div>
+          <TraceEntryBody
+            contentRevealed={contentRevealed}
+            entryMeta={entryMeta}
+            entryType={entryType}
+            hasSensitiveContent={hasSensitiveContent}
+            message={message}
+            onRevealContent={() => setContentRevealed(true)}
+            parsedToolCalls={parsedToolCalls}
+          />
         </div>
       )}
     </div>
   );
+}
+
+type TraceEntryMeta = (typeof ENTRY_TYPE_META)[TraceEntryType];
+
+function MessageItemToggle({
+  createdAt,
+  entryMeta,
+  isCollapsed,
+  label,
+  onToggle,
+  riskResults,
+}: {
+  createdAt: Date | string | undefined;
+  entryMeta: TraceEntryMeta;
+  isCollapsed: boolean;
+  label: string;
+  onToggle: () => void;
+  riskResults: RiskResult[] | undefined;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={!isCollapsed}
+      className={cn(
+        "flex w-full items-center gap-3 px-3 py-2",
+        "text-muted-foreground truncate text-sm transition-colors",
+        "border-t-muted border-y border-b-transparent",
+      )}
+    >
+      <div
+        className={cn(
+          "flex size-6 shrink-0 items-center justify-center rounded-full",
+          entryMeta.avatarClassName,
+        )}
+      >
+        <Icon
+          name={entryMeta.icon}
+          className={cn("size-4", entryMeta.iconClassName)}
+        />
+      </div>
+      {createdAt && (
+        <span className="font-mono text-xs">
+          {format(new Date(createdAt), "HH:mm:ss")}
+        </span>
+      )}
+      <span className="font-semibold">{label}</span>
+
+      {riskResults && riskResults.length > 0 && (
+        <RiskBadgePopover results={riskResults} />
+      )}
+
+      <Icon
+        name="chevron-down"
+        className={cn(
+          "ml-auto size-3 shrink-0 transition-transform",
+          isCollapsed && "-rotate-90",
+        )}
+      />
+    </button>
+  );
+}
+
+function TraceEntryBody({
+  contentRevealed,
+  entryMeta,
+  entryType,
+  hasSensitiveContent,
+  message,
+  onRevealContent,
+  parsedToolCalls,
+}: {
+  contentRevealed: boolean;
+  entryMeta: TraceEntryMeta;
+  entryType: TraceEntryType;
+  hasSensitiveContent: boolean;
+  message: ChatMessage;
+  onRevealContent: () => void;
+  parsedToolCalls: ToolCall[] | null;
+}) {
+  switch (entryType) {
+    case "tool_call":
+      return (
+        <ToolCallEntry
+          contentRevealed={contentRevealed}
+          entryMeta={entryMeta}
+          hasSensitiveContent={hasSensitiveContent}
+          onRevealContent={onRevealContent}
+          toolCalls={parsedToolCalls ?? []}
+        />
+      );
+    case "tool_result":
+      return (
+        <ToolResultEntry
+          content={message.content}
+          contentRevealed={contentRevealed}
+          entryMeta={entryMeta}
+          hasSensitiveContent={hasSensitiveContent}
+          onRevealContent={onRevealContent}
+          toolCallId={message.toolCallId}
+        />
+      );
+    case "system":
+      return (
+        <SystemEntry
+          content={message.content}
+          contentRevealed={contentRevealed}
+          hasSensitiveContent={hasSensitiveContent}
+          onRevealContent={onRevealContent}
+        />
+      );
+    case "assistant":
+    case "user":
+      return (
+        <TextMessageEntry
+          content={message.content}
+          contentRevealed={contentRevealed}
+          hasSensitiveContent={hasSensitiveContent}
+          onRevealContent={onRevealContent}
+          entryType={entryType}
+        />
+      );
+  }
+}
+
+function EntryContentFrame({
+  entryType,
+  children,
+}: {
+  entryType?: TraceEntryType;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "border-muted min-w-0 overflow-hidden rounded-md border text-sm",
+        {
+          "bg-neutral-default border-neutral-default": entryType === "user",
+          "bg-information-softest border-information-softest":
+            entryType === "assistant",
+        },
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SensitiveContentGate({
+  children,
+  contentRevealed,
+  hasSensitiveContent,
+  onRevealContent,
+}: {
+  children: ReactNode;
+  contentRevealed: boolean;
+  hasSensitiveContent: boolean;
+  onRevealContent: () => void;
+}) {
+  if (hasSensitiveContent && !contentRevealed) {
+    return <MaskedContent onReveal={onRevealContent} />;
+  }
+
+  return <>{children}</>;
+}
+
+function ToolCallEntry({
+  contentRevealed,
+  entryMeta,
+  hasSensitiveContent,
+  onRevealContent,
+  toolCalls,
+}: {
+  contentRevealed: boolean;
+  entryMeta: TraceEntryMeta;
+  hasSensitiveContent: boolean;
+  onRevealContent: () => void;
+  toolCalls: ToolCall[];
+}) {
+  return (
+    <div className="space-y-2">
+      {toolCalls.map((toolCall, idx) => (
+        <EntryContentFrame key={toolCall.id || idx} entryType={"tool_call"}>
+          <SensitiveContentGate
+            contentRevealed={contentRevealed}
+            hasSensitiveContent={hasSensitiveContent}
+            onRevealContent={onRevealContent}
+          >
+            <div className="p-3">
+              <div className="flex items-center gap-2">
+                <Icon
+                  name={entryMeta.icon}
+                  className={cn("size-4", entryMeta.iconClassName)}
+                />
+                <span className="truncate font-semibold">
+                  {toolCall.function?.name || toolCall.name || "Tool Call"}
+                </span>
+                {toolCall.id && (
+                  <Badge variant="neutral" className="ml-auto">
+                    <Badge.Text>{toolCall.id}</Badge.Text>
+                  </Badge>
+                )}
+              </div>
+            </div>
+            {toolCall.function?.arguments && (
+              <CodeBlock
+                content={
+                  typeof toolCall.function.arguments === "string"
+                    ? toolCall.function.arguments
+                    : JSON.stringify(toolCall.function.arguments, null, 2)
+                }
+                maxHeight={300}
+              />
+            )}
+          </SensitiveContentGate>
+        </EntryContentFrame>
+      ))}
+    </div>
+  );
+}
+
+function ToolResultEntry({
+  content,
+  contentRevealed,
+  entryMeta,
+  hasSensitiveContent,
+  onRevealContent,
+  toolCallId,
+}: {
+  content: unknown;
+  contentRevealed: boolean;
+  entryMeta: TraceEntryMeta;
+  hasSensitiveContent: boolean;
+  onRevealContent: () => void;
+  toolCallId: string | undefined;
+}) {
+  return (
+    <EntryContentFrame entryType="tool_result">
+      <SensitiveContentGate
+        contentRevealed={contentRevealed}
+        hasSensitiveContent={hasSensitiveContent}
+        onRevealContent={onRevealContent}
+      >
+        <div className="bg-background/50 p-3">
+          <div className="flex items-center gap-2">
+            <Icon
+              name={entryMeta.icon}
+              className={cn("size-4", entryMeta.iconClassName)}
+            />
+            <span className="font-semibold">Response</span>
+            {toolCallId && (
+              <Badge variant="neutral" className="ml-auto">
+                <Badge.Text>{toolCallId}</Badge.Text>
+              </Badge>
+            )}
+          </div>
+        </div>
+        <CodeBlock content={String(content ?? "")} maxHeight={300} />
+      </SensitiveContentGate>
+    </EntryContentFrame>
+  );
+}
+
+function SystemEntry({
+  content,
+  contentRevealed,
+  hasSensitiveContent,
+  onRevealContent,
+}: {
+  content: unknown;
+  contentRevealed: boolean;
+  hasSensitiveContent: boolean;
+  onRevealContent: () => void;
+}) {
+  return (
+    <EntryContentFrame>
+      <SensitiveContentGate
+        contentRevealed={contentRevealed}
+        hasSensitiveContent={hasSensitiveContent}
+        onRevealContent={onRevealContent}
+      >
+        <details className="group overflow-hidden">
+          <summary className="text-muted-foreground hover:bg-muted/50 flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs select-none">
+            <Icon
+              name="chevron-right"
+              className="size-3 transition-transform group-open:rotate-90"
+            />
+            <span>Show content</span>
+          </summary>
+          <div className="border-t p-3 font-mono text-xs whitespace-pre-wrap">
+            {formatMessageContent(content)}
+          </div>
+        </details>
+      </SensitiveContentGate>
+    </EntryContentFrame>
+  );
+}
+
+function TextMessageEntry({
+  content,
+  contentRevealed,
+  hasSensitiveContent,
+  onRevealContent,
+  entryType,
+}: {
+  content: unknown;
+  contentRevealed: boolean;
+  hasSensitiveContent: boolean;
+  onRevealContent: () => void;
+  entryType: TraceEntryType;
+}) {
+  return (
+    <EntryContentFrame entryType={entryType}>
+      <SensitiveContentGate
+        contentRevealed={contentRevealed}
+        hasSensitiveContent={hasSensitiveContent}
+        onRevealContent={onRevealContent}
+      >
+        <div className="overflow-hidden rounded-md p-3">
+          <MessageContent content={formatMessageContent(content)} />
+        </div>
+      </SensitiveContentGate>
+    </EntryContentFrame>
+  );
+}
+
+function formatMessageContent(content: unknown) {
+  return typeof content === "string" ? content.trim() : JSON.stringify(content);
 }
 
 function formatTimestamp(nanos: string): string {

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -483,7 +483,8 @@ function MessageItem({
         onClick={() => setExpanded(true)}
         className={cn(
           entryMeta.collapsedClassName,
-          "text-muted-foreground flex w-full items-center gap-3 truncate px-2 py-2 text-sm transition-colors",
+          "flex w-full items-center gap-3 px-4 py-3",
+          "text-muted-foreground truncate text-sm transition-colors",
           "border-r-muted border-t-muted last:border-b-muted border border-b-transparent",
         )}
       >
@@ -1338,15 +1339,13 @@ export function ChatDetailPanel({
           />
 
           {/* Chat Messages */}
-          <div className="p-6">
-            <ChatMessagesList
-              messages={chat.messages}
-              messageResolutionMap={messageResolutionMap}
-              riskResultsByMessage={riskResultsByMessage}
-              collapseNonRisk={collapseNonRisk}
-              enabledEntryTypes={enabledEntryTypes}
-            />
-          </div>
+          <ChatMessagesList
+            messages={chat.messages}
+            messageResolutionMap={messageResolutionMap}
+            riskResultsByMessage={riskResultsByMessage}
+            collapseNonRisk={collapseNonRisk}
+            enabledEntryTypes={enabledEntryTypes}
+          />
         </TabsContent>
 
         {/* Telemetry Logs Tab */}

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -497,7 +497,6 @@ function MessageItem({
 
           <TraceEntryBody
             contentRevealed={contentRevealed}
-            entryMeta={entryMeta}
             entryType={entryType}
             hasSensitiveContent={hasSensitiveContent}
             message={message}
@@ -573,7 +572,6 @@ function MessageItemToggle({
 
 function TraceEntryBody({
   contentRevealed,
-  entryMeta,
   entryType,
   hasSensitiveContent,
   message,
@@ -581,7 +579,6 @@ function TraceEntryBody({
   parsedToolCalls,
 }: {
   contentRevealed: boolean;
-  entryMeta: TraceEntryMeta;
   entryType: TraceEntryType;
   hasSensitiveContent: boolean;
   message: ChatMessage;
@@ -593,7 +590,6 @@ function TraceEntryBody({
       return (
         <ToolCallEntry
           contentRevealed={contentRevealed}
-          entryMeta={entryMeta}
           hasSensitiveContent={hasSensitiveContent}
           onRevealContent={onRevealContent}
           toolCalls={parsedToolCalls ?? []}
@@ -604,7 +600,6 @@ function TraceEntryBody({
         <ToolResultEntry
           content={message.content}
           contentRevealed={contentRevealed}
-          entryMeta={entryMeta}
           hasSensitiveContent={hasSensitiveContent}
           onRevealContent={onRevealContent}
           toolCallId={message.toolCallId}
@@ -676,13 +671,11 @@ function SensitiveContentGate({
 
 function ToolCallEntry({
   contentRevealed,
-  entryMeta,
   hasSensitiveContent,
   onRevealContent,
   toolCalls,
 }: {
   contentRevealed: boolean;
-  entryMeta: TraceEntryMeta;
   hasSensitiveContent: boolean;
   onRevealContent: () => void;
   toolCalls: ToolCall[];
@@ -698,10 +691,6 @@ function ToolCallEntry({
           >
             <div className="p-3">
               <div className="flex items-center gap-2">
-                <Icon
-                  name={entryMeta.icon}
-                  className={cn("size-4", entryMeta.iconClassName)}
-                />
                 <span className="truncate font-semibold">
                   {toolCall.function?.name || toolCall.name || "Tool Call"}
                 </span>
@@ -732,14 +721,12 @@ function ToolCallEntry({
 function ToolResultEntry({
   content,
   contentRevealed,
-  entryMeta,
   hasSensitiveContent,
   onRevealContent,
   toolCallId,
 }: {
   content: unknown;
   contentRevealed: boolean;
-  entryMeta: TraceEntryMeta;
   hasSensitiveContent: boolean;
   onRevealContent: () => void;
   toolCallId: string | undefined;
@@ -753,10 +740,6 @@ function ToolResultEntry({
       >
         <div className="bg-background/50 p-3">
           <div className="flex items-center gap-2">
-            <Icon
-              name={entryMeta.icon}
-              className={cn("size-4", entryMeta.iconClassName)}
-            />
             <span className="font-semibold">Response</span>
             {toolCallId && (
               <Badge variant="neutral" className="ml-auto">

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -32,6 +32,7 @@ import { MessageContent } from "@gram-ai/elements";
 import { useIsAdmin } from "@/contexts/Auth";
 import { toast } from "sonner";
 import { EntryTypeFilterBar } from "./TraceEntryFilterBar";
+import { TraceEntryIcon } from "./TraceEntryIcon";
 import {
   DEFAULT_ENABLED_ENTRY_TYPES,
   ENTRY_TYPE_META,
@@ -301,7 +302,7 @@ function MessageItem({
     <div>
       <MessageItemToggle
         createdAt={message.createdAt}
-        entryMeta={entryMeta}
+        entryType={entryType}
         isCollapsed={isCollapsed}
         label={label}
         onToggle={() => setExpanded((current) => !current)}
@@ -332,18 +333,16 @@ function MessageItem({
   );
 }
 
-type TraceEntryMeta = (typeof ENTRY_TYPE_META)[TraceEntryType];
-
 function MessageItemToggle({
   createdAt,
-  entryMeta,
+  entryType,
   isCollapsed,
   label,
   onToggle,
   riskResults,
 }: {
   createdAt: Date | string | undefined;
-  entryMeta: TraceEntryMeta;
+  entryType: TraceEntryType;
   isCollapsed: boolean;
   label: string;
   onToggle: () => void;
@@ -360,17 +359,7 @@ function MessageItemToggle({
         "border-t-muted border-y border-b-transparent",
       )}
     >
-      <div
-        className={cn(
-          "flex size-6 shrink-0 items-center justify-center rounded-full",
-          entryMeta.avatarClassName,
-        )}
-      >
-        <Icon
-          name={entryMeta.icon}
-          className={cn("size-4", entryMeta.iconClassName)}
-        />
-      </div>
+      <TraceEntryIcon entryType={entryType} />
       {createdAt && (
         <span className="font-mono text-xs">
           {format(new Date(createdAt), "HH:mm:ss")}

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -46,6 +46,8 @@ function getTraceId(chatId: string): string {
   return `trace-${chatId.slice(0, 3)}`;
 }
 
+const PANEL_TELEMETRY_LOG_LIMIT = 100;
+
 function downloadJsonFile(filename: string, data: unknown) {
   const json = JSON.stringify(data, null, 2);
   const blob = new Blob([json], { type: "application/json" });
@@ -70,6 +72,7 @@ function getTraceExportSlug(chat: { id: string; title?: string | null }) {
 function exportTraceDataAsJson({
   chatId,
   chat,
+  telemetryLogLimit,
   telemetryLogs,
   riskResults,
 }: {
@@ -79,18 +82,27 @@ function exportTraceDataAsJson({
     title?: string | null;
     messages: ChatMessage[];
   };
+  telemetryLogLimit: number;
   telemetryLogs: TelemetryLogRecord[];
   riskResults: RiskResult[];
 }) {
   try {
     const exported = {
       schemaVersion: 1,
+      exportScope: "chat_detail_panel",
       exportedAt: new Date().toISOString(),
       chatId,
-      chat,
-      messages: chat.messages,
-      telemetryLogs,
-      riskResults,
+      telemetryLogsQuery: {
+        filter: { gramChatId: chatId },
+        limit: telemetryLogLimit,
+        loadedCount: telemetryLogs.length,
+      },
+      panelData: {
+        chat,
+        messages: chat.messages,
+        telemetryLogs,
+        riskResults,
+      },
     };
 
     downloadJsonFile(`trace-${getTraceExportSlug(chat)}.json`, exported);
@@ -633,7 +645,7 @@ function EntryContentFrame({
       className={cn(
         "border-muted min-w-0 overflow-hidden rounded-md border text-sm",
         {
-          "bg-neutral-default border-neutral-default": entryType === "user",
+          "bg-muted/30 border-neutral-default": entryType === "user",
           "bg-information-softest border-information-softest":
             entryType === "assistant",
         },
@@ -1186,7 +1198,7 @@ export function ChatDetailPanel({
           filter: {
             gramChatId: chatId,
           },
-          limit: 100,
+          limit: PANEL_TELEMETRY_LOG_LIMIT,
         },
       },
     });
@@ -1278,6 +1290,7 @@ export function ChatDetailPanel({
                     exportTraceDataAsJson({
                       chatId,
                       chat,
+                      telemetryLogLimit: PANEL_TELEMETRY_LOG_LIMIT,
                       telemetryLogs: logs,
                       riskResults,
                     })

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -1,7 +1,7 @@
 import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { MultiSelect } from "@/components/ui/multi-select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   Accordion,
   AccordionContent,
@@ -216,6 +216,25 @@ const ENTRY_TYPE_META: Record<
   },
 };
 
+const ENTRY_TYPE_FILTER_STYLES: Record<FilterableTraceEntryType, string> = {
+  user: [
+    "border-border bg-accent/50 text-foreground",
+    "data-[state=on]:bg-accent data-[state=on]:text-foreground",
+  ].join(" "),
+  assistant: [
+    "border-information-default bg-information-softest text-foreground",
+    "data-[state=on]:bg-information-softest data-[state=on]:text-foreground",
+  ].join(" "),
+  tool_call: [
+    "border-warning-default bg-warning-softest text-foreground",
+    "data-[state=on]:bg-warning-softest data-[state=on]:text-foreground",
+  ].join(" "),
+  tool_result: [
+    "border-success-default bg-success-softest text-foreground",
+    "data-[state=on]:bg-success-softest data-[state=on]:text-foreground",
+  ].join(" "),
+};
+
 function parseToolCalls(toolCalls: string | undefined): ToolCall[] | null {
   if (!toolCalls) return null;
 
@@ -283,10 +302,10 @@ function getVisibleMessageCount(
   ).length;
 }
 
-function isFilterableEntryType(
-  value: string,
-): value is FilterableTraceEntryType {
-  return FILTERABLE_ENTRY_TYPES.includes(value as FilterableTraceEntryType);
+function getFilterableEntryTypes(values: string[]) {
+  return FILTERABLE_ENTRY_TYPES.filter((entryType) =>
+    values.includes(entryType),
+  );
 }
 
 function EntryTypeFilterBar({
@@ -302,41 +321,72 @@ function EntryTypeFilterBar({
   visibleCount: number;
   onChange: (value: FilterableTraceEntryType[]) => void;
 }) {
-  const options = FILTERABLE_ENTRY_TYPES.map((entryType) => {
-    const meta = ENTRY_TYPE_META[entryType];
-
-    return {
-      label: `${meta.label} (${counts[entryType].toLocaleString()})`,
-      value: entryType,
-      icon: ({ className }: { className?: string }) => (
-        <Icon name={meta.icon} className={cn(className, meta.iconClassName)} />
-      ),
-    };
-  });
-
   return (
     <div className="bg-background px-6 py-3">
-      <div className="flex min-w-0 flex-col gap-2">
-        <div className="text-sm font-medium">Entry type filter</div>
-        <div>
-          <MultiSelect
-            options={options}
-            defaultValue={value}
-            onValueChange={(next) =>
-              onChange(next.filter(isFilterableEntryType))
-            }
-            placeholder="Filter by entry type"
-            maxCount={10}
-            popoverClassName="min-w-[240px]"
-          />
-        </div>
-        <div>
-          <div className="text-muted-foreground text-xs">
+      <div className="flex min-w-0 flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-sm font-medium">Entries</div>
+          <div className="text-muted-foreground shrink-0 text-xs">
             Showing {visibleCount.toLocaleString()} of{" "}
-            {totalCount.toLocaleString()}{" "}
-            {visibleCount === 1 ? "entry" : "entries"}
+            {totalCount.toLocaleString()} entries
           </div>
         </div>
+        <ToggleGroup
+          type="multiple"
+          value={value}
+          onValueChange={(next) => {
+            const nextValue = getFilterableEntryTypes(next);
+            if (nextValue.length > 0) {
+              onChange(nextValue);
+            }
+          }}
+          className="border-border grid w-full grid-cols-2 rounded-none border lg:grid-cols-4"
+        >
+          {FILTERABLE_ENTRY_TYPES.map((entryType) => {
+            const meta = ENTRY_TYPE_META[entryType];
+            const count = counts[entryType];
+            const isSelected = value.includes(entryType);
+            const isDisabled = count === 0;
+
+            return (
+              <ToggleGroupItem
+                key={entryType}
+                value={entryType}
+                aria-label={`Toggle ${meta.label} entries`}
+                disabled={isDisabled}
+                className={cn(
+                  "h-10 min-w-0 justify-start rounded-none px-3 text-left shadow-none first:rounded-none last:rounded-none disabled:cursor-not-allowed disabled:opacity-45",
+                  isSelected && !isDisabled
+                    ? ENTRY_TYPE_FILTER_STYLES[entryType]
+                    : "border-border bg-background text-muted-foreground hover:border-muted-foreground/40 hover:bg-muted/30 hover:text-foreground",
+                )}
+              >
+                <Icon
+                  name={meta.icon}
+                  className={cn(
+                    "size-4 shrink-0",
+                    isSelected && !isDisabled
+                      ? meta.iconClassName
+                      : "text-muted-foreground",
+                  )}
+                />
+                <span className="min-w-0 flex-1 truncate font-medium">
+                  {meta.label}
+                </span>
+                <span
+                  className={cn(
+                    "rounded px-1.5 py-0.5 font-mono text-[10px] leading-none",
+                    isSelected && !isDisabled
+                      ? "bg-background/80 text-foreground"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {count.toLocaleString()}
+                </span>
+              </ToggleGroupItem>
+            );
+          })}
+        </ToggleGroup>
       </div>
     </div>
   );

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MultiSelect } from "@/components/ui/multi-select";
 import {
   Accordion,
   AccordionContent,
@@ -15,7 +16,7 @@ import type {
 } from "@gram/client/models/components";
 import { useLoadChat, useSearchLogsMutation } from "@gram/client/react-query";
 import { useRiskListResults } from "@gram/client/react-query/riskListResults.js";
-import { Badge, Icon, Stack } from "@speakeasy-api/moonshine";
+import { Badge, Icon, Stack, type IconName } from "@speakeasy-api/moonshine";
 import { format } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import { Dialog } from "@/components/ui/dialog";
@@ -45,68 +46,56 @@ function getTraceId(chatId: string): string {
   return `trace-${chatId.slice(0, 3)}`;
 }
 
-function exportChatAsJson(chat: {
-  id: string;
-  title: string;
-  source?: string;
-  createdAt: Date;
-  updatedAt: Date;
-  messages: Array<{
+function downloadJsonFile(filename: string, data: unknown) {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function getTraceExportSlug(chat: { id: string; title?: string | null }) {
+  const titleSlug = chat.title
+    ?.toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 40);
+
+  return titleSlug || chat.id.slice(0, 8);
+}
+
+function exportTraceDataAsJson({
+  chatId,
+  chat,
+  telemetryLogs,
+  riskResults,
+}: {
+  chatId: string;
+  chat: {
     id: string;
-    role: string;
-    content?: string;
-    model: string;
-    toolCallId?: string;
-    toolCalls?: string;
-    finishReason?: string;
-    createdAt: Date;
-    generation: number;
-  }>;
-  totalInputTokens?: number;
-  totalOutputTokens?: number;
-  totalTokens?: number;
-  totalCost?: number;
+    title?: string | null;
+    messages: ChatMessage[];
+  };
+  telemetryLogs: TelemetryLogRecord[];
+  riskResults: RiskResult[];
 }) {
   try {
     const exported = {
-      id: chat.id,
-      title: chat.title,
-      source: chat.source,
-      created_at: chat.createdAt.toISOString(),
-      updated_at: chat.updatedAt.toISOString(),
-      total_input_tokens: chat.totalInputTokens,
-      total_output_tokens: chat.totalOutputTokens,
-      total_tokens: chat.totalTokens,
-      total_cost: chat.totalCost,
-      messages: chat.messages.map((m) => ({
-        id: m.id,
-        role: m.role,
-        content: m.content,
-        model: m.model,
-        tool_call_id: m.toolCallId,
-        tool_calls: m.toolCalls ? JSON.parse(m.toolCalls) : undefined,
-        finish_reason: m.finishReason,
-        created_at: m.createdAt.toISOString(),
-        generation: m.generation,
-      })),
+      schemaVersion: 1,
+      exportedAt: new Date().toISOString(),
+      chatId,
+      chat,
+      messages: chat.messages,
+      telemetryLogs,
+      riskResults,
     };
 
-    const json = JSON.stringify(exported, null, 2);
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    const slug = chat.title
-      ? chat.title
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, "-")
-          .slice(0, 40)
-      : chat.id.slice(0, 8);
-    a.download = `chat-${slug}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
-  } catch (_err) {
-    toast.error("Failed to export chat session");
+    downloadJsonFile(`trace-${getTraceExportSlug(chat)}.json`, exported);
+  } catch {
+    toast.error("Failed to export trace data");
   }
 }
 
@@ -162,20 +151,203 @@ interface ToolCall {
   };
 }
 
+const FILTERABLE_ENTRY_TYPES = [
+  "user",
+  "assistant",
+  "tool_call",
+  "tool_result",
+] as const;
+
+type FilterableTraceEntryType = (typeof FILTERABLE_ENTRY_TYPES)[number];
+type TraceEntryType = FilterableTraceEntryType | "system";
+
+const DEFAULT_ENABLED_ENTRY_TYPES = [...FILTERABLE_ENTRY_TYPES];
+
+const ENTRY_TYPE_META: Record<
+  TraceEntryType,
+  {
+    label: string;
+    icon: IconName;
+    iconClassName: string;
+  }
+> = {
+  user: {
+    label: "User",
+    icon: "user",
+    iconClassName: "text-muted-foreground",
+  },
+  assistant: {
+    label: "Assistant",
+    icon: "bot",
+    iconClassName: "text-default-information",
+  },
+  tool_call: {
+    label: "Tool Call",
+    icon: "zap",
+    iconClassName: "text-warning-default",
+  },
+  tool_result: {
+    label: "Tool Result",
+    icon: "terminal",
+    iconClassName: "text-success-default",
+  },
+  system: {
+    label: "System Prompt",
+    icon: "settings",
+    iconClassName: "text-muted-foreground",
+  },
+};
+
+function parseToolCalls(toolCalls: string | undefined): ToolCall[] | null {
+  if (!toolCalls) return null;
+
+  try {
+    let parsed: unknown = JSON.parse(toolCalls);
+    // Handle double-encoded JSON strings.
+    if (typeof parsed === "string") {
+      parsed = JSON.parse(parsed);
+    }
+    return Array.isArray(parsed) ? (parsed as ToolCall[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function getTraceEntryType(
+  message: ChatMessage,
+  parsedToolCalls: ToolCall[] | null,
+): TraceEntryType {
+  if (parsedToolCalls && parsedToolCalls.length > 0) return "tool_call";
+  if (message.role === "tool") return "tool_result";
+  if (message.role === "user") return "user";
+  if (message.role === "assistant") return "assistant";
+  return "system";
+}
+
+function getEntryTypeCounts(
+  messages: ChatMessage[],
+): Record<FilterableTraceEntryType, number> {
+  const counts: Record<FilterableTraceEntryType, number> = {
+    user: 0,
+    assistant: 0,
+    tool_call: 0,
+    tool_result: 0,
+  };
+
+  for (const message of messages) {
+    const entryType = getTraceEntryType(
+      message,
+      parseToolCalls(message.toolCalls),
+    );
+    if (entryType !== "system") {
+      counts[entryType] += 1;
+    }
+  }
+
+  return counts;
+}
+
+function isMessageVisible(
+  message: ChatMessage,
+  enabledEntryTypes: FilterableTraceEntryType[],
+) {
+  const parsedToolCalls = parseToolCalls(message.toolCalls);
+  const entryType = getTraceEntryType(message, parsedToolCalls);
+  return entryType === "system" || enabledEntryTypes.includes(entryType);
+}
+
+function getVisibleMessageCount(
+  messages: ChatMessage[],
+  enabledEntryTypes: FilterableTraceEntryType[],
+) {
+  return messages.filter((message) =>
+    isMessageVisible(message, enabledEntryTypes),
+  ).length;
+}
+
+function isFilterableEntryType(
+  value: string,
+): value is FilterableTraceEntryType {
+  return FILTERABLE_ENTRY_TYPES.includes(value as FilterableTraceEntryType);
+}
+
+function EntryTypeFilterBar({
+  value,
+  counts,
+  totalCount,
+  visibleCount,
+  onChange,
+}: {
+  value: FilterableTraceEntryType[];
+  counts: Record<FilterableTraceEntryType, number>;
+  totalCount: number;
+  visibleCount: number;
+  onChange: (value: FilterableTraceEntryType[]) => void;
+}) {
+  const options = FILTERABLE_ENTRY_TYPES.map((entryType) => {
+    const meta = ENTRY_TYPE_META[entryType];
+
+    return {
+      label: `${meta.label} (${counts[entryType].toLocaleString()})`,
+      value: entryType,
+      icon: ({ className }: { className?: string }) => (
+        <Icon name={meta.icon} className={cn(className, meta.iconClassName)} />
+      ),
+    };
+  });
+
+  return (
+    <div className="bg-background border-b px-6 py-3">
+      <div className="flex min-w-0 flex-col gap-2">
+        <div className="text-sm font-medium">Entry type filter</div>
+        <div>
+          <MultiSelect
+            options={options}
+            defaultValue={value}
+            onValueChange={(next) =>
+              onChange(next.filter(isFilterableEntryType))
+            }
+            placeholder="Filter by entry type"
+            maxCount={10}
+            popoverClassName="min-w-[240px]"
+          />
+        </div>
+        <div>
+          <div className="text-muted-foreground text-xs">
+            Showing {visibleCount.toLocaleString()} of{" "}
+            {totalCount.toLocaleString()}{" "}
+            {visibleCount === 1 ? "entry" : "entries"}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function ChatMessagesList({
   messages,
   messageResolutionMap,
   riskResultsByMessage,
   collapseNonRisk,
+  enabledEntryTypes,
 }: {
   messages: ChatMessage[];
   messageResolutionMap: Map<string, ChatResolution>;
   riskResultsByMessage: Map<string, RiskResult[]>;
   collapseNonRisk?: boolean;
+  enabledEntryTypes: FilterableTraceEntryType[];
 }) {
+  const visibleMessages = useMemo(
+    () =>
+      messages.filter((message) =>
+        isMessageVisible(message, enabledEntryTypes),
+      ),
+    [enabledEntryTypes, messages],
+  );
+
   const groups = useMemo(() => {
     const byGeneration = new Map<number, ChatMessage[]>();
-    for (const m of messages) {
+    for (const m of visibleMessages) {
       const list = byGeneration.get(m.generation) ?? [];
       list.push(m);
       byGeneration.set(m.generation, list);
@@ -183,16 +355,24 @@ function ChatMessagesList({
     return Array.from(byGeneration.entries())
       .sort(([a], [b]) => a - b)
       .map(([generation, items]) => ({ generation, messages: items }));
-  }, [messages]);
+  }, [visibleMessages]);
 
   const maxGeneration =
     groups.length > 0 ? groups[groups.length - 1]!.generation : 0;
+
+  if (visibleMessages.length === 0) {
+    return (
+      <div className="text-muted-foreground rounded-lg border border-dashed p-6 text-center text-sm">
+        No entries match the selected filters.
+      </div>
+    );
+  }
 
   // A single segment (no compaction has ever occurred) stays flat — no accordion.
   if (maxGeneration === 0) {
     return (
       <Stack direction="vertical" gap={4}>
-        {messages.map((message) => (
+        {visibleMessages.map((message) => (
           <MessageItem
             key={message.id}
             message={message}
@@ -786,6 +966,9 @@ export function ChatDetailPanel({
 }: ChatDetailPanelProps) {
   const isAdmin = useIsAdmin();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [enabledEntryTypes, setEnabledEntryTypes] = useState<
+    FilterableTraceEntryType[]
+  >([...DEFAULT_ENABLED_ENTRY_TYPES]);
   const { data: chat, isLoading: chatLoading } = useLoadChat(
     { id: chatId },
     undefined,
@@ -819,9 +1002,13 @@ export function ChatDetailPanel({
 
   // Fetch risk findings for this chat
   const { data: riskData } = useRiskListResults({ chatId });
+  const riskResults = useMemo(
+    () => riskData?.results ?? [],
+    [riskData?.results],
+  );
   const riskResultsByMessage = useMemo(() => {
     const map = new Map<string, RiskResult[]>();
-    for (const r of riskData?.results ?? []) {
+    for (const r of riskResults) {
       const existing = map.get(r.chatMessageId);
       if (existing) {
         existing.push(r);
@@ -830,7 +1017,7 @@ export function ChatDetailPanel({
       }
     }
     return map;
-  }, [riskData]);
+  }, [riskResults]);
 
   if (chatLoading) {
     return <div className="p-8">Loading chat details...</div>;
@@ -847,6 +1034,11 @@ export function ChatDetailPanel({
   const endTime = chat.lastMessageTimestamp ?? chat.updatedAt;
   const duration = Math.round(
     (new Date(endTime).getTime() - new Date(chat.createdAt).getTime()) / 1000,
+  );
+  const entryTypeCounts = getEntryTypeCounts(chat.messages);
+  const visibleEntryCount = getVisibleMessageCount(
+    chat.messages,
+    enabledEntryTypes,
   );
 
   // Create a map of message IDs to resolution info for showing breakpoints
@@ -887,11 +1079,19 @@ export function ChatDetailPanel({
             {isAdmin && (
               <>
                 <button
-                  onClick={() => exportChatAsJson(chat)}
-                  className="hover:bg-muted text-muted-foreground rounded-md p-1 transition-colors"
-                  aria-label="Export chat as JSON"
+                  onClick={() =>
+                    exportTraceDataAsJson({
+                      chatId,
+                      chat,
+                      telemetryLogs: logs,
+                      riskResults,
+                    })
+                  }
+                  className="hover:bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm transition-colors"
+                  aria-label="Export data as JSON"
                 >
-                  <Icon name="download" className="size-5" />
+                  <Icon name="download" className="size-4" />
+                  <span>Export data</span>
                 </button>
                 <button
                   onClick={() => setShowDeleteConfirm(true)}
@@ -1103,6 +1303,14 @@ export function ChatDetailPanel({
             </div>
           )}
 
+          <EntryTypeFilterBar
+            value={enabledEntryTypes}
+            counts={entryTypeCounts}
+            totalCount={chat.messages.length}
+            visibleCount={visibleEntryCount}
+            onChange={setEnabledEntryTypes}
+          />
+
           {/* Chat Messages */}
           <div className="p-6">
             <ChatMessagesList
@@ -1110,6 +1318,7 @@ export function ChatDetailPanel({
               messageResolutionMap={messageResolutionMap}
               riskResultsByMessage={riskResultsByMessage}
               collapseNonRisk={collapseNonRisk}
+              enabledEntryTypes={enabledEntryTypes}
             />
           </div>
         </TabsContent>

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -1,7 +1,6 @@
 import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   Accordion,
   AccordionContent,
@@ -16,7 +15,7 @@ import type {
 } from "@gram/client/models/components";
 import { useLoadChat, useSearchLogsMutation } from "@gram/client/react-query";
 import { useRiskListResults } from "@gram/client/react-query/riskListResults.js";
-import { Badge, Icon, Stack, type IconName } from "@speakeasy-api/moonshine";
+import { Badge, Icon, Stack } from "@speakeasy-api/moonshine";
 import { format } from "date-fns";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Dialog } from "@/components/ui/dialog";
@@ -32,6 +31,19 @@ import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { MessageContent } from "@gram-ai/elements";
 import { useIsAdmin } from "@/contexts/Auth";
 import { toast } from "sonner";
+import { EntryTypeFilterBar } from "./TraceEntryFilterBar";
+import {
+  DEFAULT_ENABLED_ENTRY_TYPES,
+  ENTRY_TYPE_META,
+  type FilterableTraceEntryType,
+  type ToolCall,
+  type TraceEntryType,
+  getEntryTypeCounts,
+  getTraceEntryType,
+  getVisibleMessageCount,
+  isMessageVisible,
+  parseToolCalls,
+} from "./traceEntries";
 
 interface ChatDetailPanelProps {
   chatId: string;
@@ -151,245 +163,6 @@ function getSeverityBadgeVariant(
     default:
       return "neutral";
   }
-}
-
-interface ToolCall {
-  id?: string;
-  type?: string;
-  name?: string;
-  function?: {
-    name?: string;
-    arguments?: string | object;
-  };
-}
-
-const FILTERABLE_ENTRY_TYPES = [
-  "user",
-  "assistant",
-  "tool_call",
-  "tool_result",
-] as const;
-
-type FilterableTraceEntryType = (typeof FILTERABLE_ENTRY_TYPES)[number];
-type TraceEntryType = FilterableTraceEntryType | "system";
-
-const DEFAULT_ENABLED_ENTRY_TYPES = [...FILTERABLE_ENTRY_TYPES];
-
-const ENTRY_TYPE_META: Record<
-  TraceEntryType,
-  {
-    label: string;
-    icon: IconName;
-    avatarClassName: string;
-    iconClassName: string;
-  }
-> = {
-  user: {
-    label: "User",
-    icon: "user",
-    avatarClassName: "bg-muted",
-    iconClassName: "text-muted-foreground",
-  },
-  assistant: {
-    label: "Assistant",
-    icon: "bot",
-    avatarClassName: "bg-information-softest",
-    iconClassName: "text-default-information",
-  },
-  tool_call: {
-    label: "Tool Call",
-    icon: "zap",
-    avatarClassName: "bg-warning-softest",
-    iconClassName: "text-warning-default",
-  },
-  tool_result: {
-    label: "Tool Result",
-    icon: "terminal",
-    avatarClassName: "bg-success-softest",
-    iconClassName: "text-success-default",
-  },
-  system: {
-    label: "System Prompt",
-    icon: "settings",
-    avatarClassName: "bg-accent",
-    iconClassName: "text-muted-foreground",
-  },
-};
-
-const ENTRY_TYPE_FILTER_STYLES: Record<FilterableTraceEntryType, string> = {
-  user: [
-    "border-border bg-accent/50 text-foreground",
-    "data-[state=on]:bg-accent data-[state=on]:text-foreground",
-  ].join(" "),
-  assistant: [
-    "border-information-default bg-information-softest text-foreground",
-    "data-[state=on]:bg-information-softest data-[state=on]:text-foreground",
-  ].join(" "),
-  tool_call: [
-    "border-warning-default bg-warning-softest text-foreground",
-    "data-[state=on]:bg-warning-softest data-[state=on]:text-foreground",
-  ].join(" "),
-  tool_result: [
-    "border-success-default bg-success-softest text-foreground",
-    "data-[state=on]:bg-success-softest data-[state=on]:text-foreground",
-  ].join(" "),
-};
-
-function parseToolCalls(toolCalls: string | undefined): ToolCall[] | null {
-  if (!toolCalls) return null;
-
-  try {
-    let parsed: unknown = JSON.parse(toolCalls);
-    // Handle double-encoded JSON strings.
-    if (typeof parsed === "string") {
-      parsed = JSON.parse(parsed);
-    }
-    return Array.isArray(parsed) ? (parsed as ToolCall[]) : null;
-  } catch {
-    return null;
-  }
-}
-
-function getTraceEntryType(
-  message: ChatMessage,
-  parsedToolCalls: ToolCall[] | null,
-): TraceEntryType {
-  if (parsedToolCalls && parsedToolCalls.length > 0) return "tool_call";
-  if (message.role === "tool") return "tool_result";
-  if (message.role === "user") return "user";
-  if (message.role === "assistant") return "assistant";
-  return "system";
-}
-
-function getEntryTypeCounts(
-  messages: ChatMessage[],
-): Record<FilterableTraceEntryType, number> {
-  const counts: Record<FilterableTraceEntryType, number> = {
-    user: 0,
-    assistant: 0,
-    tool_call: 0,
-    tool_result: 0,
-  };
-
-  for (const message of messages) {
-    const entryType = getTraceEntryType(
-      message,
-      parseToolCalls(message.toolCalls),
-    );
-    if (entryType !== "system") {
-      counts[entryType] += 1;
-    }
-  }
-
-  return counts;
-}
-
-function isMessageVisible(
-  message: ChatMessage,
-  enabledEntryTypes: FilterableTraceEntryType[],
-) {
-  const parsedToolCalls = parseToolCalls(message.toolCalls);
-  const entryType = getTraceEntryType(message, parsedToolCalls);
-  return entryType === "system" || enabledEntryTypes.includes(entryType);
-}
-
-function getVisibleMessageCount(
-  messages: ChatMessage[],
-  enabledEntryTypes: FilterableTraceEntryType[],
-) {
-  return messages.filter((message) =>
-    isMessageVisible(message, enabledEntryTypes),
-  ).length;
-}
-
-function getFilterableEntryTypes(values: string[]) {
-  return FILTERABLE_ENTRY_TYPES.filter((entryType) =>
-    values.includes(entryType),
-  );
-}
-
-function EntryTypeFilterBar({
-  value,
-  counts,
-  totalCount,
-  visibleCount,
-  onChange,
-}: {
-  value: FilterableTraceEntryType[];
-  counts: Record<FilterableTraceEntryType, number>;
-  totalCount: number;
-  visibleCount: number;
-  onChange: (value: FilterableTraceEntryType[]) => void;
-}) {
-  return (
-    <div className="bg-background px-6 py-3">
-      <div className="flex min-w-0 flex-col gap-3">
-        <div className="flex items-center justify-between gap-3">
-          <div className="text-sm font-medium">Entries</div>
-          <div className="text-muted-foreground shrink-0 text-xs">
-            Showing {visibleCount.toLocaleString()} of{" "}
-            {totalCount.toLocaleString()} entries
-          </div>
-        </div>
-        <ToggleGroup
-          type="multiple"
-          value={value}
-          onValueChange={(next) => {
-            const nextValue = getFilterableEntryTypes(next);
-            if (nextValue.length > 0) {
-              onChange(nextValue);
-            }
-          }}
-          className="border-border grid w-full grid-cols-2 rounded-none border lg:grid-cols-4"
-        >
-          {FILTERABLE_ENTRY_TYPES.map((entryType) => {
-            const meta = ENTRY_TYPE_META[entryType];
-            const count = counts[entryType];
-            const isSelected = value.includes(entryType);
-            const isDisabled = count === 0;
-
-            return (
-              <ToggleGroupItem
-                key={entryType}
-                value={entryType}
-                aria-label={`Toggle ${meta.label} entries`}
-                disabled={isDisabled}
-                className={cn(
-                  "h-10 min-w-0 justify-start rounded-none px-3 text-left shadow-none first:rounded-none last:rounded-none disabled:cursor-not-allowed disabled:opacity-45",
-                  isSelected && !isDisabled
-                    ? ENTRY_TYPE_FILTER_STYLES[entryType]
-                    : "border-border bg-background text-muted-foreground hover:border-muted-foreground/40 hover:bg-muted/30 hover:text-foreground",
-                )}
-              >
-                <Icon
-                  name={meta.icon}
-                  className={cn(
-                    "size-4 shrink-0",
-                    isSelected && !isDisabled
-                      ? meta.iconClassName
-                      : "text-muted-foreground",
-                  )}
-                />
-                <span className="min-w-0 flex-1 truncate font-medium">
-                  {meta.label}
-                </span>
-                <span
-                  className={cn(
-                    "rounded px-1.5 py-0.5 font-mono text-[10px] leading-none",
-                    isSelected && !isDisabled
-                      ? "bg-background/80 text-foreground"
-                      : "bg-muted text-muted-foreground",
-                  )}
-                >
-                  {count.toLocaleString()}
-                </span>
-              </ToggleGroupItem>
-            );
-          })}
-        </ToggleGroup>
-      </div>
-    </div>
-  );
 }
 
 function ChatMessagesList({

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -46,7 +46,7 @@ export function EntryTypeFilterBar({
             onChange(nextValue);
           }
         }}
-        className="grid w-full grid-cols-2 gap-2 rounded-none p-2 pt-0 lg:grid-cols-4"
+        className="grid w-full grid-cols-2 gap-2 rounded-none px-3 pt-0 pb-2 lg:grid-cols-4"
       >
         {FILTERABLE_ENTRY_TYPES.map((entryType) => {
           const meta = ENTRY_TYPE_META[entryType];
@@ -64,11 +64,11 @@ export function EntryTypeFilterBar({
               disabled={isDisabled}
               className={cn(
                 "h-10 min-w-0 cursor-pointer px-3 disabled:cursor-not-allowed disabled:opacity-45",
-                "text-foreground hover:text-foreground justify-start text-left",
-                "bg-muted hover:bg-muted/50 rounded-lg shadow-none inset-shadow-xs transition-all",
+                "text-muted-foreground hover:text-foreground justify-start text-left",
+                "bg-background hover:bg-muted/40 rounded-lg shadow-none inset-shadow-xs transition-all",
                 "hover:border-muted-foreground/50 border-muted border",
                 canShowSelectedState &&
-                  "bg-muted border-muted-foreground hover:border-muted-foreground shadow-muted hover:shadow-sm",
+                  "bg-muted/80 border-muted-foreground hover:border-muted-foreground shadow-muted hover:shadow-sm",
               )}
             >
               <TraceEntryIcon entryType={entryType} disabled={isDisabled} />
@@ -77,10 +77,10 @@ export function EntryTypeFilterBar({
               </span>
               <span
                 className={cn(
-                  "rounded px-1.5 py-0.5 font-mono text-[10px] leading-none",
+                  "rounded-sm px-1.5 py-0.5 font-mono text-[10px] leading-none",
                   canShowSelectedState
-                    ? "bg-background/80 text-foreground"
-                    : "bg-muted text-muted-foreground",
+                    ? "bg-background text-foreground"
+                    : "bg-muted/40 text-muted-foreground",
                 )}
               >
                 {count.toLocaleString()}

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -7,25 +7,6 @@ import {
   type FilterableTraceEntryType,
 } from "./traceEntries";
 
-const ENTRY_TYPE_FILTER_STYLES: Record<FilterableTraceEntryType, string> = {
-  user: [
-    "border-border bg-accent/50 text-foreground",
-    "data-[state=on]:bg-accent data-[state=on]:text-foreground",
-  ].join(" "),
-  assistant: [
-    "border-information-default bg-information-softest text-foreground",
-    "data-[state=on]:bg-information-softest data-[state=on]:text-foreground",
-  ].join(" "),
-  tool_call: [
-    "border-warning-default bg-warning-softest text-foreground",
-    "data-[state=on]:bg-warning-softest data-[state=on]:text-foreground",
-  ].join(" "),
-  tool_result: [
-    "border-success-default bg-success-softest text-foreground",
-    "data-[state=on]:bg-success-softest data-[state=on]:text-foreground",
-  ].join(" "),
-};
-
 function getFilterableEntryTypes(values: string[]) {
   return FILTERABLE_ENTRY_TYPES.filter((entryType) =>
     values.includes(entryType),
@@ -38,80 +19,84 @@ export function EntryTypeFilterBar({
   totalCount,
   visibleCount,
   onChange,
+  title = "Entries Filter",
 }: {
   value: FilterableTraceEntryType[];
   counts: Record<FilterableTraceEntryType, number>;
   totalCount: number;
   visibleCount: number;
   onChange: (value: FilterableTraceEntryType[]) => void;
+  title?: string;
 }) {
   return (
-    <div className="bg-background px-6 py-3">
-      <div className="flex min-w-0 flex-col gap-3">
-        <div className="flex items-center justify-between gap-3">
-          <div className="text-sm font-medium">Entries</div>
-          <div className="text-muted-foreground shrink-0 text-xs">
-            Showing {visibleCount.toLocaleString()} of{" "}
-            {totalCount.toLocaleString()} entries
-          </div>
+    <div>
+      <div className="flex items-center justify-between gap-3 px-6 py-3">
+        <div className="text-sm font-medium">{title}</div>
+        <div className="text-muted-foreground shrink-0 text-xs">
+          Showing {visibleCount.toLocaleString()} of{" "}
+          {totalCount.toLocaleString()} entries
         </div>
-        <ToggleGroup
-          type="multiple"
-          value={value}
-          onValueChange={(next) => {
-            const nextValue = getFilterableEntryTypes(next);
-            if (nextValue.length > 0) {
-              onChange(nextValue);
-            }
-          }}
-          className="border-border grid w-full grid-cols-2 rounded-none border lg:grid-cols-4"
-        >
-          {FILTERABLE_ENTRY_TYPES.map((entryType) => {
-            const meta = ENTRY_TYPE_META[entryType];
-            const count = counts[entryType];
-            const isSelected = value.includes(entryType);
-            const isDisabled = count === 0;
+      </div>
+      <ToggleGroup
+        type="multiple"
+        value={value}
+        onValueChange={(next) => {
+          const nextValue = getFilterableEntryTypes(next);
+          if (nextValue.length > 0) {
+            onChange(nextValue);
+          }
+        }}
+        className="grid w-full grid-cols-2 gap-2 rounded-none p-2 pt-0 lg:grid-cols-4"
+      >
+        {FILTERABLE_ENTRY_TYPES.map((entryType) => {
+          const meta = ENTRY_TYPE_META[entryType];
+          const count = counts[entryType];
+          const isSelected = value.includes(entryType);
+          const isDisabled = count === 0;
+          // Defaults select every type, so zero-count items can be both selected and disabled.
+          const canShowSelectedState = isSelected && !isDisabled;
 
-            return (
-              <ToggleGroupItem
-                key={entryType}
-                value={entryType}
-                aria-label={`Toggle ${meta.label} entries`}
-                disabled={isDisabled}
+          return (
+            <ToggleGroupItem
+              key={entryType}
+              value={entryType}
+              aria-label={`Toggle ${meta.label} entries`}
+              disabled={isDisabled}
+              className={cn(
+                "h-10 min-w-0 cursor-pointer px-3 disabled:cursor-not-allowed disabled:opacity-45",
+                "text-foreground hover:text-foreground justify-start text-left",
+                "bg-muted hover:bg-muted/50 rounded-lg shadow-none inset-shadow-xs transition-all",
+                "hover:border-muted-foreground/50 border-muted border",
+                canShowSelectedState &&
+                  "bg-muted border-muted-foreground hover:border-muted-foreground shadow-muted hover:shadow-sm",
+              )}
+            >
+              <Icon
+                name={meta.icon}
                 className={cn(
-                  "h-10 min-w-0 justify-start rounded-none px-3 text-left shadow-none first:rounded-none last:rounded-none disabled:cursor-not-allowed disabled:opacity-45",
-                  isSelected && !isDisabled
-                    ? ENTRY_TYPE_FILTER_STYLES[entryType]
-                    : "border-border bg-background text-muted-foreground hover:border-muted-foreground/40 hover:bg-muted/30 hover:text-foreground",
+                  "size-4 shrink-0",
+                  canShowSelectedState
+                    ? meta.iconClassName
+                    : "text-muted-foreground",
+                )}
+              />
+              <span className="min-w-0 flex-1 truncate font-medium">
+                {meta.label}
+              </span>
+              <span
+                className={cn(
+                  "rounded px-1.5 py-0.5 font-mono text-[10px] leading-none",
+                  canShowSelectedState
+                    ? "bg-background/80 text-foreground"
+                    : "bg-muted text-muted-foreground",
                 )}
               >
-                <Icon
-                  name={meta.icon}
-                  className={cn(
-                    "size-4 shrink-0",
-                    isSelected && !isDisabled
-                      ? meta.iconClassName
-                      : "text-muted-foreground",
-                  )}
-                />
-                <span className="min-w-0 flex-1 truncate font-medium">
-                  {meta.label}
-                </span>
-                <span
-                  className={cn(
-                    "rounded px-1.5 py-0.5 font-mono text-[10px] leading-none",
-                    isSelected && !isDisabled
-                      ? "bg-background/80 text-foreground"
-                      : "bg-muted text-muted-foreground",
-                  )}
-                >
-                  {count.toLocaleString()}
-                </span>
-              </ToggleGroupItem>
-            );
-          })}
-        </ToggleGroup>
-      </div>
+                {count.toLocaleString()}
+              </span>
+            </ToggleGroupItem>
+          );
+        })}
+      </ToggleGroup>
     </div>
   );
 }

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -1,11 +1,11 @@
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
-import { Icon } from "@speakeasy-api/moonshine";
 import {
   ENTRY_TYPE_META,
   FILTERABLE_ENTRY_TYPES,
   type FilterableTraceEntryType,
 } from "./traceEntries";
+import { TraceEntryIcon } from "./TraceEntryIcon";
 
 function getFilterableEntryTypes(values: string[]) {
   return FILTERABLE_ENTRY_TYPES.filter((entryType) =>
@@ -71,15 +71,7 @@ export function EntryTypeFilterBar({
                   "bg-muted border-muted-foreground hover:border-muted-foreground shadow-muted hover:shadow-sm",
               )}
             >
-              <Icon
-                name={meta.icon}
-                className={cn(
-                  "size-4 shrink-0",
-                  canShowSelectedState
-                    ? meta.iconClassName
-                    : "text-muted-foreground",
-                )}
-              />
+              <TraceEntryIcon entryType={entryType} disabled={isDisabled} />
               <span className="min-w-0 flex-1 truncate font-medium">
                 {meta.label}
               </span>

--- a/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryFilterBar.tsx
@@ -1,0 +1,117 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+import { Icon } from "@speakeasy-api/moonshine";
+import {
+  ENTRY_TYPE_META,
+  FILTERABLE_ENTRY_TYPES,
+  type FilterableTraceEntryType,
+} from "./traceEntries";
+
+const ENTRY_TYPE_FILTER_STYLES: Record<FilterableTraceEntryType, string> = {
+  user: [
+    "border-border bg-accent/50 text-foreground",
+    "data-[state=on]:bg-accent data-[state=on]:text-foreground",
+  ].join(" "),
+  assistant: [
+    "border-information-default bg-information-softest text-foreground",
+    "data-[state=on]:bg-information-softest data-[state=on]:text-foreground",
+  ].join(" "),
+  tool_call: [
+    "border-warning-default bg-warning-softest text-foreground",
+    "data-[state=on]:bg-warning-softest data-[state=on]:text-foreground",
+  ].join(" "),
+  tool_result: [
+    "border-success-default bg-success-softest text-foreground",
+    "data-[state=on]:bg-success-softest data-[state=on]:text-foreground",
+  ].join(" "),
+};
+
+function getFilterableEntryTypes(values: string[]) {
+  return FILTERABLE_ENTRY_TYPES.filter((entryType) =>
+    values.includes(entryType),
+  );
+}
+
+export function EntryTypeFilterBar({
+  value,
+  counts,
+  totalCount,
+  visibleCount,
+  onChange,
+}: {
+  value: FilterableTraceEntryType[];
+  counts: Record<FilterableTraceEntryType, number>;
+  totalCount: number;
+  visibleCount: number;
+  onChange: (value: FilterableTraceEntryType[]) => void;
+}) {
+  return (
+    <div className="bg-background px-6 py-3">
+      <div className="flex min-w-0 flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-sm font-medium">Entries</div>
+          <div className="text-muted-foreground shrink-0 text-xs">
+            Showing {visibleCount.toLocaleString()} of{" "}
+            {totalCount.toLocaleString()} entries
+          </div>
+        </div>
+        <ToggleGroup
+          type="multiple"
+          value={value}
+          onValueChange={(next) => {
+            const nextValue = getFilterableEntryTypes(next);
+            if (nextValue.length > 0) {
+              onChange(nextValue);
+            }
+          }}
+          className="border-border grid w-full grid-cols-2 rounded-none border lg:grid-cols-4"
+        >
+          {FILTERABLE_ENTRY_TYPES.map((entryType) => {
+            const meta = ENTRY_TYPE_META[entryType];
+            const count = counts[entryType];
+            const isSelected = value.includes(entryType);
+            const isDisabled = count === 0;
+
+            return (
+              <ToggleGroupItem
+                key={entryType}
+                value={entryType}
+                aria-label={`Toggle ${meta.label} entries`}
+                disabled={isDisabled}
+                className={cn(
+                  "h-10 min-w-0 justify-start rounded-none px-3 text-left shadow-none first:rounded-none last:rounded-none disabled:cursor-not-allowed disabled:opacity-45",
+                  isSelected && !isDisabled
+                    ? ENTRY_TYPE_FILTER_STYLES[entryType]
+                    : "border-border bg-background text-muted-foreground hover:border-muted-foreground/40 hover:bg-muted/30 hover:text-foreground",
+                )}
+              >
+                <Icon
+                  name={meta.icon}
+                  className={cn(
+                    "size-4 shrink-0",
+                    isSelected && !isDisabled
+                      ? meta.iconClassName
+                      : "text-muted-foreground",
+                  )}
+                />
+                <span className="min-w-0 flex-1 truncate font-medium">
+                  {meta.label}
+                </span>
+                <span
+                  className={cn(
+                    "rounded px-1.5 py-0.5 font-mono text-[10px] leading-none",
+                    isSelected && !isDisabled
+                      ? "bg-background/80 text-foreground"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {count.toLocaleString()}
+                </span>
+              </ToggleGroupItem>
+            );
+          })}
+        </ToggleGroup>
+      </div>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/chatLogs/TraceEntryIcon.tsx
+++ b/client/dashboard/src/pages/chatLogs/TraceEntryIcon.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+import { Icon } from "@speakeasy-api/moonshine";
+import { ENTRY_TYPE_META, type TraceEntryType } from "./traceEntries";
+
+export function TraceEntryIcon({
+  entryType,
+  className,
+  iconClassName,
+  disabled = false,
+}: {
+  entryType: TraceEntryType;
+  className?: string;
+  iconClassName?: string;
+  disabled?: boolean;
+}) {
+  const entryMeta = ENTRY_TYPE_META[entryType];
+
+  return (
+    <div
+      className={cn(
+        "flex size-6 shrink-0 items-center justify-center rounded-full",
+        disabled ? "bg-muted" : entryMeta.avatarClassName,
+        className,
+      )}
+    >
+      <Icon
+        name={entryMeta.icon}
+        className={cn(
+          "size-4",
+          disabled ? "text-muted-foreground" : entryMeta.iconClassName,
+          iconClassName,
+        )}
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/chatLogs/traceEntries.ts
+++ b/client/dashboard/src/pages/chatLogs/traceEntries.ts
@@ -1,0 +1,134 @@
+import type { ChatMessage } from "@gram/client/models/components";
+import type { IconName } from "@speakeasy-api/moonshine";
+
+export interface ToolCall {
+  id?: string;
+  type?: string;
+  name?: string;
+  function?: {
+    name?: string;
+    arguments?: string | object;
+  };
+}
+
+export const FILTERABLE_ENTRY_TYPES = [
+  "user",
+  "assistant",
+  "tool_call",
+  "tool_result",
+] as const;
+
+export type FilterableTraceEntryType = (typeof FILTERABLE_ENTRY_TYPES)[number];
+export type TraceEntryType = FilterableTraceEntryType | "system";
+
+export const DEFAULT_ENABLED_ENTRY_TYPES = [...FILTERABLE_ENTRY_TYPES];
+
+export const ENTRY_TYPE_META: Record<
+  TraceEntryType,
+  {
+    label: string;
+    icon: IconName;
+    avatarClassName: string;
+    iconClassName: string;
+  }
+> = {
+  user: {
+    label: "User",
+    icon: "user",
+    avatarClassName: "bg-muted",
+    iconClassName: "text-muted-foreground",
+  },
+  assistant: {
+    label: "Assistant",
+    icon: "bot",
+    avatarClassName: "bg-information-softest",
+    iconClassName: "text-default-information",
+  },
+  tool_call: {
+    label: "Tool Call",
+    icon: "zap",
+    avatarClassName: "bg-warning-softest",
+    iconClassName: "text-warning-default",
+  },
+  tool_result: {
+    label: "Tool Result",
+    icon: "terminal",
+    avatarClassName: "bg-success-softest",
+    iconClassName: "text-success-default",
+  },
+  system: {
+    label: "System Prompt",
+    icon: "settings",
+    avatarClassName: "bg-accent",
+    iconClassName: "text-muted-foreground",
+  },
+};
+
+export function parseToolCalls(
+  toolCalls: string | undefined,
+): ToolCall[] | null {
+  if (!toolCalls) return null;
+
+  try {
+    let parsed: unknown = JSON.parse(toolCalls);
+    // Handle double-encoded JSON strings.
+    if (typeof parsed === "string") {
+      parsed = JSON.parse(parsed);
+    }
+    return Array.isArray(parsed) ? (parsed as ToolCall[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getTraceEntryType(
+  message: ChatMessage,
+  parsedToolCalls: ToolCall[] | null,
+): TraceEntryType {
+  if (parsedToolCalls && parsedToolCalls.length > 0) return "tool_call";
+  if (message.role === "tool") return "tool_result";
+  if (message.role === "user") return "user";
+  if (message.role === "assistant") return "assistant";
+  return "system";
+}
+
+export function getEntryTypeCounts(
+  messages: ChatMessage[],
+): Record<FilterableTraceEntryType, number> {
+  const counts: Record<FilterableTraceEntryType, number> = {
+    user: 0,
+    assistant: 0,
+    tool_call: 0,
+    tool_result: 0,
+  };
+
+  for (const message of messages) {
+    const entryType = getTraceEntryType(
+      message,
+      parseToolCalls(message.toolCalls),
+    );
+    if (entryType !== "system") {
+      counts[entryType] += 1;
+    }
+  }
+
+  return counts;
+}
+
+export function isMessageVisible(
+  message: ChatMessage,
+  enabledEntryTypes: FilterableTraceEntryType[],
+) {
+  const parsedToolCalls = parseToolCalls(message.toolCalls);
+  const entryType = getTraceEntryType(message, parsedToolCalls);
+  return entryType === "system" || enabledEntryTypes.includes(entryType);
+}
+
+export function getVisibleMessageCount(
+  messages: ChatMessage[],
+  enabledEntryTypes: FilterableTraceEntryType[],
+) {
+  return messages.filter((message) =>
+    isMessageVisible(message, enabledEntryTypes),
+  ).length;
+}


### PR DESCRIPTION
### Summary

- Adds trace entry filtering to the chat log session detail panel.
- Extracts trace entry parsing, filter bar, and icon rendering into reusable pieces.
- Refines trace message entry spacing and styling.
- Updates to export data button, is only visible to Admins


### Visual

[Video Link
](https://share.vidyard.com/watch/1LR3Du25GcFi2svyMY7C5F)<a href="https://share.vidyard.com/watch/1LR3Du25GcFi2svyMY7C5F">
<img
  style="width: 100%; margin: auto; display: block;"
  class="vidyard-player-embed"
  src="https://play.vidyard.com/1LR3Du25GcFi2svyMY7C5F.jpg"
  data-uuid="1LR3Du25GcFi2svyMY7C5F"
  data-v="4"
  data-type="inline"
/>
</a>

### Test Plan
- [x] cd client/dashboard && pnpm test
- [x] cd client/dashboard && pnpm lint