### PR TITLE
fix: update risk page shell

### DIFF
--- a/.changeset/stupid-candles-like.md
+++ b/.changeset/stupid-candles-like.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Updated risk overview and policy page headers to match the shared page layout and Moonshine CTA patterns.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/table";
 import { Type } from "@/components/ui/type";
 import {
+  Button as MoonshineButton,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -379,110 +380,115 @@ function PolicyCenterContent() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold">Risk Policies</h2>
-            <p className="text-muted-foreground text-sm">
-              Configure risk analysis rules to detect secrets and sensitive
-              information in chat messages.
-            </p>
-          </div>
-          <Button onClick={handleCreate}>
-            <Plus className="mr-2 h-4 w-4" />
-            New Policy
-          </Button>
-        </div>
-
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Action</TableHead>
-              <TableHead>Categories</TableHead>
-              <TableHead>Progress</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead className="w-[60px]" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {policies.map((policy) => {
-              const categories = sourcesToCategories(
-                policy.sources,
-                policy.presidioEntities,
-              );
-              return (
-                <TableRow
-                  key={policy.id}
-                  className="cursor-pointer"
-                  onClick={() => handleEdit(policy)}
-                >
-                  <TableCell className="font-medium">{policy.name}</TableCell>
-                  <TableCell>
-                    <ActionBadge
-                      action={(policy.action as PolicyAction) ?? "flag"}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex gap-1">
-                      {categories.map((cat) => (
-                        <Badge key={cat} variant="secondary">
-                          {RULE_CATEGORY_META[cat].label}
-                        </Badge>
-                      ))}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    {policy.pendingMessages > 0 ? (
-                      <span className="text-muted-foreground text-xs">
-                        {policy.totalMessages - policy.pendingMessages}/
-                        {policy.totalMessages} analyzed
-                      </span>
-                    ) : (
-                      <Badge variant="secondary">Complete</Badge>
-                    )}
-                  </TableCell>
-                  <TableCell onClick={(e) => e.stopPropagation()}>
-                    <Switch
-                      checked={policy.enabled}
-                      onCheckedChange={(checked) =>
-                        handleToggle(policy, checked)
-                      }
-                    />
-                  </TableCell>
-                  <TableCell onClick={(e) => e.stopPropagation()}>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <Ellipsis className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          className="cursor-pointer"
-                          onSelect={() =>
-                            setTimeout(() => setRunPanelPolicy(policy), 0)
-                          }
-                        >
-                          View Progress
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          className="text-destructive focus:text-destructive cursor-pointer"
-                          onSelect={() => handleDelete(policy.id)}
-                        >
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </TableCell>
+        <Page.Section>
+          <Page.Section.Title>Risk Policies</Page.Section.Title>
+          <Page.Section.Description className="max-w-2xl">
+            Configure risk analysis rules to detect secrets and sensitive
+            information in chat messages.
+          </Page.Section.Description>
+          <Page.Section.CTA>
+            <MoonshineButton onClick={handleCreate}>
+              <MoonshineButton.LeftIcon>
+                <Plus className="h-4 w-4" />
+              </MoonshineButton.LeftIcon>
+              <MoonshineButton.Text>New Policy</MoonshineButton.Text>
+            </MoonshineButton>
+          </Page.Section.CTA>
+          <Page.Section.Body>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead>Categories</TableHead>
+                  <TableHead>Progress</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="w-[60px]" />
                 </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
+              </TableHeader>
+              <TableBody>
+                {policies.map((policy) => {
+                  const categories = sourcesToCategories(
+                    policy.sources,
+                    policy.presidioEntities,
+                  );
+                  return (
+                    <TableRow
+                      key={policy.id}
+                      className="cursor-pointer"
+                      onClick={() => handleEdit(policy)}
+                    >
+                      <TableCell className="font-medium">
+                        {policy.name}
+                      </TableCell>
+                      <TableCell>
+                        <ActionBadge
+                          action={(policy.action as PolicyAction) ?? "flag"}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex gap-1">
+                          {categories.map((cat) => (
+                            <Badge key={cat} variant="secondary">
+                              {RULE_CATEGORY_META[cat].label}
+                            </Badge>
+                          ))}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {policy.pendingMessages > 0 ? (
+                          <span className="text-muted-foreground text-xs">
+                            {policy.totalMessages - policy.pendingMessages}/
+                            {policy.totalMessages} analyzed
+                          </span>
+                        ) : (
+                          <Badge variant="secondary">Complete</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <Switch
+                          checked={policy.enabled}
+                          onCheckedChange={(checked) =>
+                            handleToggle(policy, checked)
+                          }
+                        />
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Ellipsis className="h-4 w-4" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              className="cursor-pointer"
+                              onSelect={() =>
+                                setTimeout(() => setRunPanelPolicy(policy), 0)
+                              }
+                            >
+                              View Progress
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive cursor-pointer"
+                              onSelect={() => handleDelete(policy.id)}
+                            >
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </Page.Section.Body>
+        </Page.Section>
 
         {/* Edit/Create Sheet */}
         <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -24,6 +24,7 @@ import {
 import { ChatDetailPanel } from "@/pages/chatLogs/ChatDetailPanel";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { MetricCard } from "@/components/chart/MetricCard";
+import { Button as MoonshineButton, Icon } from "@speakeasy-api/moonshine";
 
 const RULE_ID_TO_CATEGORY = new Map<string, RuleCategory>();
 for (const [category, rules] of Object.entries(DETECTION_RULES)) {
@@ -198,17 +199,33 @@ function SecurityOverviewContent() {
 
   if (policies.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-4 py-20">
-        <Shield className="text-muted-foreground h-12 w-12" />
-        <h2 className="text-lg font-semibold">Risk Analysis</h2>
-        <p className="text-muted-foreground max-w-md text-center text-sm">
-          Monitor your chat messages for leaked secrets and sensitive data. Set
-          up a risk policy to get started.
-        </p>
-        <Button onClick={() => routes.policyCenter.goTo()}>
-          Go to Policy Center
-        </Button>
-      </div>
+      <Page.Section>
+        <Page.Section.Title>Risk Overview</Page.Section.Title>
+        <Page.Section.Description className="max-w-2xl">
+          Recent findings from risk analysis scans across your project.
+        </Page.Section.Description>
+        <Page.Section.CTA>
+          <MoonshineButton
+            variant="secondary"
+            onClick={() => routes.policyCenter.goTo()}
+          >
+            <MoonshineButton.Text>Manage Policies</MoonshineButton.Text>
+            <MoonshineButton.RightIcon>
+              <Icon name="arrow-right" />
+            </MoonshineButton.RightIcon>
+          </MoonshineButton>
+        </Page.Section.CTA>
+        <Page.Section.Body>
+          <div className="flex flex-col items-center justify-center gap-4 py-20">
+            <Shield className="text-muted-foreground h-12 w-12" />
+            <h2 className="text-lg font-semibold">Risk Analysis</h2>
+            <p className="text-muted-foreground max-w-md text-center text-sm">
+              Monitor your chat messages for leaked secrets and sensitive data.
+              Set up a risk policy to get started.
+            </p>
+          </div>
+        </Page.Section.Body>
+      </Page.Section>
     );
   }
 
@@ -231,9 +248,15 @@ function SecurityOverviewContent() {
         </Page.Section.Description>
 
         <Page.Section.CTA>
-          <Button variant="outline" onClick={() => routes.policyCenter.goTo()}>
-            Manage Policies
-          </Button>
+          <MoonshineButton
+            variant="secondary"
+            onClick={() => routes.policyCenter.goTo()}
+          >
+            <MoonshineButton.Text>Manage Policies</MoonshineButton.Text>
+            <MoonshineButton.RightIcon>
+              <Icon name="arrow-right" />
+            </MoonshineButton.RightIcon>
+          </MoonshineButton>
         </Page.Section.CTA>
 
         <Page.Section.Body>


### PR DESCRIPTION
### Summary

Clean up PR to align these pages with rest of app

- Updates `/risk-overview` to use the shared `Page.Section` header structure and Moonshine CTA button.
- Updates `/risk-policies` to use the same header layout as pages like `/sources`.
- Makes `New Policy` primary and adds a right-arrow affordance to the `Manage Policies` navigation CTA.

### Visuals
<img width="1321" height="258" alt="Screenshot 2026-05-15 at 1 21 36 PM" src="https://github.com/user-attachments/assets/c61d5e45-3f8a-43f9-b842-9fdd19b87ad7" />
<img width="1321" height="258" alt="Screenshot 2026-05-15 at 1 21 46 PM" src="https://github.com/user-attachments/assets/978839a0-0c63-4dbe-a2a3-fce48137402e" />

### Test Plan
- [x] `pnpm lint`
- [x] Visual spot check