### PR TITLE
feat: auto-reconcile OpenRouter per-key credit limits via metrics workflow

### DIFF
--- a/.changeset/age-2341-auto-reconcile-openrouter-credit-limits.md
+++ b/.changeset/age-2341-auto-reconcile-openrouter-credit-limits.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+auto-reconcile OpenRouter per-key credit limits via metrics workflow

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -197,6 +197,7 @@ const (
 	OpenAPIPathKey                  = attribute.Key("gram.openapi.path")
 	OpenAPIVersionKey               = attribute.Key("gram.openapi.version")
 	OpenRouterKeyLimitKey           = attribute.Key("gram.openrouter.key.limit")
+	OpenRouterKeyPreviousLimitKey   = attribute.Key("gram.openrouter.key.previous_limit")
 	OrganizationAccountTypeKey      = attribute.Key("gram.org.account_type")
 	OrganizationInviteIDKey         = attribute.Key("gram.org.invite.id")
 	OutboxIDKey                     = attribute.Key("gram.outbox.id")
@@ -880,6 +881,13 @@ func SlogOpenAPIVersion(v string) slog.Attr      { return slog.String(string(Ope
 
 func OpenRouterKeyLimit(v int) attribute.KeyValue { return OpenRouterKeyLimitKey.Int(v) }
 func SlogOpenRouterKeyLimit(v int) slog.Attr      { return slog.Int(string(OpenRouterKeyLimitKey), v) }
+
+func OpenRouterKeyPreviousLimit(v int) attribute.KeyValue {
+	return OpenRouterKeyPreviousLimitKey.Int(v)
+}
+func SlogOpenRouterKeyPreviousLimit(v int) slog.Attr {
+	return slog.Int(string(OpenRouterKeyPreviousLimitKey), v)
+}
 
 func AccessMemberID(v string) attribute.KeyValue { return AccessMemberIDKey.String(v) }
 func SlogAccessMemberID(v string) slog.Attr      { return slog.String(string(AccessMemberIDKey), v) }

--- a/server/internal/background/activities/openrouter_credits_metrics.go
+++ b/server/internal/background/activities/openrouter_credits_metrics.go
@@ -71,7 +71,7 @@ func (c *CollectOpenRouterCreditsMetrics) Do(ctx context.Context, args CollectOp
 	g.SetLimit(openRouterCreditsPollConcurrency)
 	for i, row := range rows {
 		g.Go(func() error {
-			used, err := c.openRouter.GetKeyUsage(gctx, row.ApiKey)
+			used, upstreamLimit, err := c.openRouter.GetKeyUsage(gctx, row.ApiKey)
 			if err != nil {
 				// Skip on a per-org failure so one bad key does not blank the
 				// whole batch. The error is logged for diagnosis and swallowed
@@ -84,12 +84,27 @@ func (c *CollectOpenRouterCreditsMetrics) Do(ctx context.Context, args CollectOp
 				return nil
 			}
 
+			// Self-heal drift introduced by out-of-band edits on the OpenRouter
+			// dashboard so the same tick reports a consistent ratio. A failed
+			// write is swallowed for the same reason GetKeyUsage failures are
+			// — one bad org should not blank the batch — and we fall back to
+			// the cached DB value for this tick.
+			effectiveLimit, err := c.openRouter.ReconcileMonthlyCredits(gctx, row.OrganizationID, row.MonthlyCredits, upstreamLimit)
+			if err != nil {
+				c.logger.ErrorContext(gctx, "reconcile openrouter monthly credits",
+					attr.SlogOrganizationID(row.OrganizationID),
+					attr.SlogOrganizationSlug(row.OrganizationSlug),
+					attr.SlogError(err),
+				)
+				effectiveLimit = row.MonthlyCredits
+			}
+
 			results[i] = OpenRouterCreditsMetric{
 				OrganizationID:   row.OrganizationID,
 				OrganizationSlug: row.OrganizationSlug,
 				AccountType:      row.GramAccountType,
 				CreditsUsed:      used,
-				CreditLimit:      row.MonthlyCredits,
+				CreditLimit:      effectiveLimit,
 			}
 			return nil
 		})

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -8,6 +8,8 @@ type Development struct {
 	apiKey string
 }
 
+var _ Provisioner = (*Development)(nil)
+
 func NewDevelopment(apiKey string) *Development {
 	return &Development{apiKey: apiKey}
 }
@@ -24,8 +26,12 @@ func (o *Development) GetCreditsUsed(ctx context.Context, orgID string) (float64
 	return 12.5, 10, nil // arbitrary local numbers
 }
 
-func (o *Development) GetKeyUsage(ctx context.Context, apiKey string) (float64, error) {
-	return 12.5, nil // arbitrary local number
+func (o *Development) GetKeyUsage(ctx context.Context, apiKey string) (float64, *int64, error) {
+	return 12.5, nil, nil // arbitrary local number; unlimited dev key
+}
+
+func (o *Development) ReconcileMonthlyCredits(ctx context.Context, orgID string, currentLimit int64, upstreamLimit *int64) (int64, error) {
+	return currentLimit, nil
 }
 
 func (o *Development) GetModelUsage(ctx context.Context, generationID string, orgID string) (*ModelUsage, error) {

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -122,9 +122,28 @@ func IsSpecialLimitOrg(orgID string) bool {
 
 type Provisioner interface {
 	ProvisionAPIKey(ctx context.Context, orgID string) (string, error)
+
+	// RefreshAPIKeyLimit mutates the upstream OpenRouter key limit (PATCH
+	// /v1/keys/:hash) and mirrors the new value into the local DB.
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, limit *int) (int, error)
+
 	GetCreditsUsed(ctx context.Context, orgID string) (float64, int, error)
-	GetKeyUsage(ctx context.Context, apiKey string) (float64, error)
+
+	// GetKeyUsage issues GET /v1/key for the given API key and returns the
+	// rounded monthly usage along with the upstream-configured monthly limit
+	// already rounded to the int64 representation used by the DB. The limit is
+	// nil when OpenRouter returns an unlimited key.
+	GetKeyUsage(ctx context.Context, apiKey string) (used float64, limit *int64, err error)
+
+	// ReconcileMonthlyCredits compares upstreamLimit against the caller-supplied
+	// currentLimit (the DB-cached value) and writes the upstream value to the
+	// openrouter_api_keys row when they diverge. It is a DB-only reconciliation
+	// — it does NOT call OpenRouter — and is intended to self-heal drift
+	// introduced by out-of-band edits on the OpenRouter dashboard. A nil
+	// upstreamLimit (unlimited key) is treated as a no-op. Returns the
+	// effective limit the caller should use for the current tick.
+	ReconcileMonthlyCredits(ctx context.Context, orgID string, currentLimit int64, upstreamLimit *int64) (int64, error)
+
 	GetModelUsage(ctx context.Context, generationID string, orgID string) (*ModelUsage, error)
 }
 
@@ -142,6 +161,8 @@ type OpenRouter struct {
 	refresher       KeyRefresher
 	featureClient   *productfeatures.Client
 }
+
+var _ Provisioner = (*OpenRouter)(nil)
 
 func New(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, db *pgxpool.Pool, env string, provisioningKey string, refresher KeyRefresher, featureClient *productfeatures.Client, tracking billing.Tracker) *OpenRouter {
 	orClient := guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
@@ -284,7 +305,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string) (float64,
 		return 0, limit, nil // the key doesn't exist yet
 	}
 
-	used, err := o.GetKeyUsage(ctx, key.Key)
+	used, _, err := o.GetKeyUsage(ctx, key.Key)
 	if err != nil {
 		return 0, limit, err
 	}
@@ -293,14 +314,17 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string) (float64,
 }
 
 // GetKeyUsage issues the upstream `/v1/key` call with the given API key and
-// returns the rounded monthly usage. Callers that already have the key (e.g.
-// the credits monitoring activity, which joins openrouter_api_keys in a
-// single SQL query) can skip the org/key DB lookups in GetCreditsUsed.
-func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, error) {
+// returns the rounded monthly usage along with the upstream-configured monthly
+// limit already rounded to the int64 representation used by the DB. The
+// returned limit is nil when OpenRouter reports an unlimited key. Callers that
+// already have the key (e.g. the credits monitoring activity, which joins
+// openrouter_api_keys in a single SQL query) can skip the org/key DB lookups
+// in GetCreditsUsed.
+func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, *int64, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", OpenRouterBaseURL+"/v1/key", nil)
 	if err != nil {
 		o.logger.ErrorContext(ctx, "failed to build openrouter key usage request", attr.SlogError(err))
-		return 0, fmt.Errorf("build key usage request: %w", err)
+		return 0, nil, fmt.Errorf("build key usage request: %w", err)
 	}
 
 	req.Header.Set("Authorization", "Bearer "+apiKey)
@@ -309,7 +333,7 @@ func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, e
 	resp, err := o.orClient.Do(req)
 	if err != nil {
 		o.logger.ErrorContext(ctx, "failed to send openrouter key usage request", attr.SlogError(err))
-		return 0, fmt.Errorf("send key usage request: %w", err)
+		return 0, nil, fmt.Errorf("send key usage request: %w", err)
 	}
 
 	defer o11y.NoLogDefer(func() error {
@@ -317,13 +341,13 @@ func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, e
 	})
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, errors.New("fetch OpenRouter key usage: " + resp.Status)
+		return 0, nil, errors.New("fetch OpenRouter key usage: " + resp.Status)
 	}
 
 	var usageResp keyUsageResponse
 	if err := json.NewDecoder(resp.Body).Decode(&usageResp); err != nil {
 		o.logger.ErrorContext(ctx, "failed to decode key usage response", attr.SlogError(err))
-		return 0, fmt.Errorf("decode key usage response: %w", err)
+		return 0, nil, fmt.Errorf("decode key usage response: %w", err)
 	}
 
 	var creditsUsed float64
@@ -331,7 +355,42 @@ func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, e
 		creditsUsed = math.Round(*usageResp.Data.UsageMonthly*100) / 100
 	}
 
-	return creditsUsed, nil
+	var limit *int64
+	if usageResp.Data.Limit != nil {
+		l := int64(math.Round(*usageResp.Data.Limit))
+		limit = &l
+	}
+
+	return creditsUsed, limit, nil
+}
+
+// ReconcileMonthlyCredits self-heals drift in the locally cached monthly limit
+// after an out-of-band change on the OpenRouter dashboard. See the
+// Provisioner interface doc for the full contract.
+func (o *OpenRouter) ReconcileMonthlyCredits(ctx context.Context, orgID string, currentLimit int64, upstreamLimit *int64) (int64, error) {
+	if upstreamLimit == nil {
+		return currentLimit, nil
+	}
+
+	newLimit := *upstreamLimit
+	if newLimit == currentLimit {
+		return currentLimit, nil
+	}
+
+	if err := o.repo.UpdateOpenRouterKeyMonthlyCredits(ctx, repo.UpdateOpenRouterKeyMonthlyCreditsParams{
+		OrganizationID: orgID,
+		MonthlyCredits: newLimit,
+	}); err != nil {
+		return currentLimit, fmt.Errorf("reconcile openrouter monthly credits: %w", err)
+	}
+
+	o.logger.InfoContext(ctx, "reconciled openrouter monthly credits from upstream",
+		attr.SlogOrganizationID(orgID),
+		attr.SlogOpenRouterKeyPreviousLimit(int(currentLimit)),
+		attr.SlogOpenRouterKeyLimit(int(newLimit)),
+	)
+
+	return newLimit, nil
 }
 
 func (o *OpenRouter) getLimitForOrg(org orgRepo.OrganizationMetadatum) int {

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -24,3 +24,14 @@ SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key
 WHERE organization_id = @organization_id
   AND deleted IS FALSE
 RETURNING *;
+
+-- name: UpdateOpenRouterKeyMonthlyCredits :exec
+-- Updates only monthly_credits for the given organization. Used by the
+-- metrics-collection reconciliation path when the upstream OpenRouter limit
+-- diverges from the locally cached value (e.g. after a manual change on the
+-- OpenRouter dashboard). Distinct from UpdateOpenRouterKey, which is the
+-- key-provisioning write path and also mutates key/key_hash.
+UPDATE openrouter_api_keys
+SET monthly_credits = @monthly_credits
+WHERE organization_id = @organization_id
+  AND deleted IS FALSE;

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -113,3 +113,25 @@ func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterK
 	)
 	return i, err
 }
+
+const updateOpenRouterKeyMonthlyCredits = `-- name: UpdateOpenRouterKeyMonthlyCredits :exec
+UPDATE openrouter_api_keys
+SET monthly_credits = $1
+WHERE organization_id = $2
+  AND deleted IS FALSE
+`
+
+type UpdateOpenRouterKeyMonthlyCreditsParams struct {
+	MonthlyCredits int64
+	OrganizationID string
+}
+
+// Updates only monthly_credits for the given organization. Used by the
+// metrics-collection reconciliation path when the upstream OpenRouter limit
+// diverges from the locally cached value (e.g. after a manual change on the
+// OpenRouter dashboard). Distinct from UpdateOpenRouterKey, which is the
+// key-provisioning write path and also mutates key/key_hash.
+func (q *Queries) UpdateOpenRouterKeyMonthlyCredits(ctx context.Context, arg UpdateOpenRouterKeyMonthlyCreditsParams) error {
+	_, err := q.db.Exec(ctx, updateOpenRouterKeyMonthlyCredits, arg.MonthlyCredits, arg.OrganizationID)
+	return err
+}

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -30,6 +30,8 @@ type mockProvisioner struct {
 	err    error
 }
 
+var _ Provisioner = (*mockProvisioner)(nil)
+
 func (m *mockProvisioner) ProvisionAPIKey(ctx context.Context, orgID string) (string, error) {
 	if m.err != nil {
 		return "", m.err
@@ -45,8 +47,12 @@ func (m *mockProvisioner) GetCreditsUsed(ctx context.Context, orgID string) (flo
 	return 0, 0, nil
 }
 
-func (m *mockProvisioner) GetKeyUsage(ctx context.Context, apiKey string) (float64, error) {
-	return 0, nil
+func (m *mockProvisioner) GetKeyUsage(ctx context.Context, apiKey string) (float64, *int64, error) {
+	return 0, nil, nil
+}
+
+func (m *mockProvisioner) ReconcileMonthlyCredits(ctx context.Context, orgID string, currentLimit int64, upstreamLimit *int64) (int64, error) {
+	return currentLimit, nil
 }
 
 func (m *mockProvisioner) GetModelUsage(ctx context.Context, generationID string, orgID string) (*ModelUsage, error) {


### PR DESCRIPTION
[AGE-2341](https://linear.app/speakeasy/issue/AGE-2341/feat-auto-reconcile-openrouter-per-key-credit-limits-via-metrics)

## Summary

The 5-minute `CollectOpenRouterCreditsMetricsWorkflow` now self-heals drift between `openrouter_api_keys.monthly_credits` and the upstream OpenRouter dashboard value. `GetKeyUsage` already calls `/v1/key`; it now also surfaces the limit (rounded to `int64`), and `Provisioner.ReconcileMonthlyCredits` writes the upstream value to the DB when it differs from the cached value. The same tick emits `credits_remaining` and `credits_used_ratio` against the reconciled limit, so a manual limit bump on OpenRouter no longer surfaces as a >100% used-ratio.

Adds `UpdateOpenRouterKeyMonthlyCredits` SQLc query (org-scoped, distinct from `UpdateOpenRouterKey` which also rewrites `key`/`key_hash`) and a `gram.openrouter.key.previous_limit` attr for the transition log.