### PR TITLE
fix(assistants): skip unreachable MCP toolsets + log bootstrap errors

### DIFF
--- a/server/internal/assistants/resolve_mcp_servers_test.go
+++ b/server/internal/assistants/resolve_mcp_servers_test.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
@@ -38,7 +37,6 @@ func TestResolveAssistantMCPServers_UserToolsetsListedBeforePlatformServer(t *te
 
 	rows := []assistantToolsetRow{
 		{
-			ToolsetID:       uuid.New(),
 			ToolsetSlug:     "billing",
 			McpEnabled:      true,
 			McpSlug:         pgtype.Text{String: "billing-mcp", Valid: true},
@@ -72,19 +70,16 @@ func TestResolveAssistantMCPServers_MisconfiguredToolsetIsOmitted(t *testing.T) 
 
 	rows := []assistantToolsetRow{
 		{
-			ToolsetID:   uuid.New(),
 			ToolsetSlug: "no-mcp-slug",
 			McpEnabled:  true,
 			McpSlug:     pgtype.Text{Valid: false},
 		},
 		{
-			ToolsetID:   uuid.New(),
 			ToolsetSlug: "mcp-disabled",
 			McpEnabled:  false,
 			McpSlug:     pgtype.Text{String: "mcp-disabled-mcp", Valid: true},
 		},
 		{
-			ToolsetID:   uuid.New(),
 			ToolsetSlug: "billing",
 			McpEnabled:  true,
 			McpSlug:     pgtype.Text{String: "billing-mcp", Valid: true},

--- a/server/internal/assistants/resolve_mcp_servers_test.go
+++ b/server/internal/assistants/resolve_mcp_servers_test.go
@@ -1,13 +1,16 @@
 package assistants
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestResolveAssistantMCPServers_EmptyUserToolsetsStillGetsPlatformServer(t *testing.T) {
@@ -16,8 +19,7 @@ func TestResolveAssistantMCPServers_EmptyUserToolsetsStillGetsPlatformServer(t *
 	serverURL, err := url.Parse("https://gram.test")
 	require.NoError(t, err)
 
-	servers, err := resolveAssistantMCPServers(serverURL, nil)
-	require.NoError(t, err)
+	servers := resolveAssistantMCPServers(context.Background(), testenv.NewLogger(t), serverURL, nil)
 	require.Len(t, servers, 1)
 
 	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[0].ID)
@@ -36,6 +38,7 @@ func TestResolveAssistantMCPServers_UserToolsetsListedBeforePlatformServer(t *te
 
 	rows := []assistantToolsetRow{
 		{
+			ToolsetID:       uuid.New(),
 			ToolsetSlug:     "billing",
 			McpEnabled:      true,
 			McpSlug:         pgtype.Text{String: "billing-mcp", Valid: true},
@@ -43,8 +46,7 @@ func TestResolveAssistantMCPServers_UserToolsetsListedBeforePlatformServer(t *te
 		},
 	}
 
-	servers, err := resolveAssistantMCPServers(serverURL, rows)
-	require.NoError(t, err)
+	servers := resolveAssistantMCPServers(context.Background(), testenv.NewLogger(t), serverURL, rows)
 	require.Len(t, servers, 2)
 
 	require.Equal(t, "billing", servers[0].ID)
@@ -56,4 +58,44 @@ func TestResolveAssistantMCPServers_UserToolsetsListedBeforePlatformServer(t *te
 		"https://gram.test/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug,
 		servers[1].URL,
 	)
+}
+
+// A toolset that is attached to an assistant but whose MCP is disabled or
+// has no mcp_slug used to abort the entire bootstrap with a silent 500.
+// We now skip the broken toolset so the rest of the thread admits — the
+// assistant just won't see those tools.
+func TestResolveAssistantMCPServers_MisconfiguredToolsetIsOmitted(t *testing.T) {
+	t.Parallel()
+
+	serverURL, err := url.Parse("https://gram.test")
+	require.NoError(t, err)
+
+	rows := []assistantToolsetRow{
+		{
+			ToolsetID:   uuid.New(),
+			ToolsetSlug: "no-mcp-slug",
+			McpEnabled:  true,
+			McpSlug:     pgtype.Text{Valid: false},
+		},
+		{
+			ToolsetID:   uuid.New(),
+			ToolsetSlug: "mcp-disabled",
+			McpEnabled:  false,
+			McpSlug:     pgtype.Text{String: "mcp-disabled-mcp", Valid: true},
+		},
+		{
+			ToolsetID:   uuid.New(),
+			ToolsetSlug: "billing",
+			McpEnabled:  true,
+			McpSlug:     pgtype.Text{String: "billing-mcp", Valid: true},
+		},
+	}
+
+	servers := resolveAssistantMCPServers(context.Background(), testenv.NewLogger(t), serverURL, rows)
+	require.Len(t, servers, 2)
+
+	require.Equal(t, "billing", servers[0].ID)
+	require.Equal(t, "https://gram.test/mcp/billing-mcp", servers[0].URL)
+
+	require.Equal(t, "_platform-"+platformtools.AssistantsPlatformToolsetSlug, servers[1].ID)
 }

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1706,18 +1706,23 @@ func (s *ServiceCore) MintThreadScopedRuntimeToken(assistant assistantRecord, th
 // caller is responsible for confirming the requesting principal is
 // scoped to the thread's assistant before invoking this method.
 func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threadID, principalAssistantID uuid.UUID) (threadBootstrap, error) {
+	logAttrs := []slog.Attr{
+		attr.SlogProjectID(projectID.String()),
+		attr.SlogAssistantID(principalAssistantID.String()),
+		attr.SlogAssistantThreadID(threadID.String()),
+	}
 	row, err := assistantrepo.New(s.db).LoadAssistantThreadForBootstrap(ctx, assistantrepo.LoadAssistantThreadForBootstrapParams{
 		ThreadID:  threadID,
 		ProjectID: projectID,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return threadBootstrap{}, oops.E(oops.CodeNotFound, nil, "assistant thread not found")
+			return threadBootstrap{}, oops.E(oops.CodeNotFound, nil, "assistant thread not found").Log(ctx, s.logger, logAttrs...)
 		}
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant thread")
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant thread").Log(ctx, s.logger, logAttrs...)
 	}
 	if row.AssistantID != principalAssistantID {
-		return threadBootstrap{}, oops.E(oops.CodeForbidden, nil, "thread does not belong to assistant")
+		return threadBootstrap{}, oops.E(oops.CodeForbidden, nil, "thread does not belong to assistant").Log(ctx, s.logger, logAttrs...)
 	}
 
 	thread := assistantThreadRecord{
@@ -1748,28 +1753,29 @@ func (s *ServiceCore) BuildThreadBootstrap(ctx context.Context, projectID, threa
 	}
 	toolsets, err := s.loadAssistantToolsets(ctx, assistant.ProjectID, []uuid.UUID{assistant.ID})
 	if err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant toolsets")
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant toolsets").Log(ctx, s.logger, logAttrs...)
 	}
 	assistant.Toolsets = toolsets[assistant.ID]
 
 	runtimeServerURL := s.runtime.ServerURL()
 	if runtimeServerURL == nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, nil, "assistant runtime server url not configured")
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, nil, "assistant runtime server url not configured").Log(ctx, s.logger, logAttrs...)
 	}
 
-	mcpServers, err := resolveAssistantMCPServers(runtimeServerURL, assistant.Toolsets)
-	if err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "resolve assistant mcp servers")
-	}
+	// Misconfigured toolsets (no MCP slug, MCP disabled) are surfaced as
+	// best-effort URLs rather than aborting the whole bootstrap. The runner
+	// will discover the failure when it tries to list tools and the
+	// assistant can tell the user which integration is broken.
+	mcpServers := resolveAssistantMCPServers(ctx, s.logger, runtimeServerURL, assistant.Toolsets)
 
 	instructions, err := composeInstructions(assistant.Instructions, thread)
 	if err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "compose assistant instructions")
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "compose assistant instructions").Log(ctx, s.logger, logAttrs...)
 	}
 
 	history, err := s.loadChatHistory(ctx, thread.ChatID, thread.ProjectID)
 	if err != nil {
-		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant chat history")
+		return threadBootstrap{}, oops.E(oops.CodeUnexpected, err, "load assistant chat history").Log(ctx, s.logger, logAttrs...)
 	}
 
 	completionsEndpoint := runtimeServerURL.JoinPath("chat", "completions")
@@ -1820,15 +1826,22 @@ func composeInstructions(base string, thread assistantThreadRecord) (string, err
 	return strings.Join(parts, "\n\n"), nil
 }
 
-func resolveAssistantMCPServers(serverURL *url.URL, toolsets []assistantToolsetRow) ([]runtimeMCPServer, error) {
+func resolveAssistantMCPServers(ctx context.Context, logger *slog.Logger, serverURL *url.URL, toolsets []assistantToolsetRow) []runtimeMCPServer {
 	platformToolsets := []string{platformtools.AssistantsPlatformToolsetSlug}
 	servers := make([]runtimeMCPServer, 0, len(toolsets)+len(platformToolsets))
 	for _, t := range toolsets {
-		if !t.McpEnabled {
-			return nil, fmt.Errorf("toolset %q does not have MCP enabled", t.ToolsetSlug)
-		}
-		if !t.McpSlug.Valid || t.McpSlug.String == "" {
-			return nil, fmt.Errorf("toolset %q has no MCP slug", t.ToolsetSlug)
+		// Misconfiguration (no MCP slug, MCP disabled) is a tenant-side
+		// problem, not a server fault. Skip the broken toolset and let
+		// the rest of the thread admit — the assistant just won't see
+		// these tools.
+		if !t.McpEnabled || !t.McpSlug.Valid || t.McpSlug.String == "" {
+			logger.WarnContext(ctx, "skipping assistant toolset that is not MCP-reachable",
+				attr.SlogToolsetID(t.ToolsetID.String()),
+				attr.SlogToolsetSlug(t.ToolsetSlug),
+				attr.SlogToolsetMCPSlug(t.McpSlug.String),
+				attr.SlogToolsetMCPEnabled(t.McpEnabled),
+			)
+			continue
 		}
 
 		headers := map[string]string{}
@@ -1862,7 +1875,7 @@ func resolveAssistantMCPServers(serverURL *url.URL, toolsets []assistantToolsetR
 		})
 	}
 
-	return servers, nil
+	return servers
 }
 
 func (s *ServiceCore) ProcessThreadEventsByThreadID(ctx context.Context, projectID, threadID uuid.UUID) (ProcessThreadEventsResult, error) {

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -253,6 +253,7 @@ const (
 	ToolsetIDKey                    = attribute.Key("gram.toolset.id")
 	ToolsetSlugKey                  = attribute.Key("gram.toolset.slug")
 	ToolsetMCPSlugKey               = attribute.Key("gram.toolset.mcp_slug")
+	ToolsetMCPEnabledKey            = attribute.Key("gram.toolset.mcp_enabled")
 	VisibilityKey                   = attribute.Key("gram.visibility")
 
 	// Hooks
@@ -1117,6 +1118,9 @@ func SlogToolsetSlug(v string) slog.Attr      { return slog.String(string(Toolse
 
 func ToolsetMCPSlug(v string) attribute.KeyValue { return ToolsetMCPSlugKey.String(v) }
 func SlogToolsetMCPSlug(v string) slog.Attr      { return slog.String(string(ToolsetMCPSlugKey), v) }
+
+func ToolsetMCPEnabled(v bool) attribute.KeyValue { return ToolsetMCPEnabledKey.Bool(v) }
+func SlogToolsetMCPEnabled(v bool) slog.Attr      { return slog.Bool(string(ToolsetMCPEnabledKey), v) }
 
 func McpURL(v string) attribute.KeyValue { return McpURLKey.String(v) }
 func SlogMcpURL(v string) slog.Attr      { return slog.String(string(McpURLKey), v) }


### PR DESCRIPTION
## Summary
- `BuildThreadBootstrap` was aborting with a silent `oops.CodeUnexpected` 500 whenever an assistant had any toolset where `mcp_enabled=false` or `mcp_slug IS NULL`. `oops.ErrHandle` skips logging for `ShareableError`, so neither a log line nor an `error.message` reached Datadog. Every retry burned the same way until the runner gave up.
- `resolveAssistantMCPServers` is now permissive: misconfigured toolsets are skipped with a `WarnContext` carrying `toolset_id`, `toolset_slug`, `mcp_slug`, and `mcp_enabled`. The thread admits with the remaining servers; the assistant just doesn't see those tools.
- `BuildThreadBootstrap` chains `.Log(ctx, s.logger, project_id, assistant_id, thread_id)` on every error return so future failures appear as ERROR logs.

Closes AGE-2371.
https://linear.app/speakeasy/issue/AGE-2371/bootstrap-500s-silently-when-an-attached-toolset-is-not-mcp-reachable

Closes AGE-2087

✻ Clauded...