### PR TITLE
fix(zero): share Fly creds + OCI app with assistant runtime in zero:fly

### DIFF
--- a/.mise-tasks/zero/fly.mts
+++ b/.mise-tasks/zero/fly.mts
@@ -145,30 +145,6 @@ async function run() {
     process.exit(0);
   }
 
-  const initialAssistantApp =
-    process.env["GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"]?.split("/")[1] ||
-    `${app}-assistants`;
-  const assistantApp = await text({
-    message:
-      "🎈 Enter your Fly.io app name for Gram assistant runtime images (must be separate from the functions app)",
-    initialValue: initialAssistantApp,
-    validate: (value) => {
-      if (!value) return "Assistant runtime app name is required.";
-      if (value === app) {
-        return "Must be different from the Gram Functions app to avoid tag collisions.";
-      }
-    },
-  });
-  if (isCancel(assistantApp)) {
-    cancel("Operation cancelled.");
-    process.exit(0);
-  }
-
-  note(
-    `Create the app if it does not exist yet:\n  fly apps create -o ${org} ${assistantApp}\n\nThen build + push:\n  mise run build:assistants-runtime-image --arch amd64`,
-    "Assistant runtime registry",
-  );
-
   const initialTigrisBucket =
     process.env["GRAM_FUNCTIONS_TIGRIS_BUCKET_URI"]?.slice("s3://".length) ||
     undefined;
@@ -234,7 +210,10 @@ async function run() {
     `GRAM_FUNCTIONS_RUNNER_OCI_IMAGE=registry.fly.io/${app}`,
     `GRAM_FUNCTIONS_RUNNER_VERSION=main`,
     `GRAM_FUNCTIONS_FLYIO_REGION=us`,
-    `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE=registry.fly.io/${assistantApp}`,
+    `GRAM_ASSISTANT_RUNTIME_FLYIO_ORG=${org}`,
+    `GRAM_ASSISTANT_RUNTIME_FLYIO_API_TOKEN=${token}`,
+    `GRAM_ASSISTANT_RUNTIME_FLYIO_REGION=us`,
+    `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE=registry.fly.io/${app}`,
     `GRAM_ASSISTANT_RUNTIME_IMAGE_VERSION=dev`,
     `GRAM_FUNCTIONS_TIGRIS_BUCKET_URI=s3://${bucket}`,
     `GRAM_FUNCTIONS_TIGRIS_KEY=${tigrisKey}`,


### PR DESCRIPTION
## Summary

- `zero:fly` already prompted for Fly credentials but never wrote the assistant-runtime equivalents, so `mise start:server` after a fresh `./zero` failed `FlyRuntimeConfig.Validate()`.
- Reuse the functions Fly token, org, region, and OCI registry app for the assistant runtime — assistants push their image under a separate `:dev` tag, so a second Fly app isn't required for local dev.
- Drops the dedicated "assistant runtime app" prompt; the script now writes `GRAM_ASSISTANT_RUNTIME_FLYIO_{API_TOKEN,ORG,REGION}` alongside the existing `GRAM_ASSISTANT_RUNTIME_OCI_IMAGE` + `_IMAGE_VERSION`.

Closes [AGE-2370](https://linear.app/speakeasy/issue/AGE-2370/restore-dev-bootable-assistant-runtime-default).

✻ Clauded...