### PR TITLE
fix(assistants): start Fly machine after image recycle

### DIFF
--- a/.changeset/age-2372-fly-recycle-start.md
+++ b/.changeset/age-2372-fly-recycle-start.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistant runtimes no longer get stuck unresponsive after a Gram release. When the assistant runtime image was upgraded in place, the underlying VM was being left stopped, so the next chat turn timed out and the assistant stopped responding. Subsequent turns now bring the runtime back up cleanly.

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -619,6 +619,10 @@ func (f *FlyRuntimeBackend) maybeRecycleImage(
 	if err != nil {
 		return nil, fmt.Errorf("recycle assistant fly runtime machine: %w", err)
 	}
+	// flaps Update leaves the machine stopped; Start before waiting.
+	if _, err := flapsClient.Start(ctx, appName, updated.ID, ""); err != nil {
+		return nil, fmt.Errorf("start assistant fly runtime machine after recycle: %w", err)
+	}
 	if err := f.tracedWaitStarted(ctx, flapsClient, appName, updated, true); err != nil {
 		return nil, fmt.Errorf("wait for assistant fly runtime machine recycle: %w", err)
 	}

--- a/server/internal/assistants/runtime_fly_test.go
+++ b/server/internal/assistants/runtime_fly_test.go
@@ -660,6 +660,7 @@ func TestFlyRuntimeBackendEnsureRecyclesStaleImageWhenIdle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, flapsClient.updateCalls)
+	require.GreaterOrEqual(t, flapsClient.startCalls, 1)
 	require.True(t, result.ColdStart)
 
 	var metadata flyRuntimeMetadata
@@ -901,6 +902,7 @@ type testFlyRuntimeFlapsClient struct {
 	launchMachine *fly.Machine
 	launchErr     error
 	startErr      error
+	startCalls    int
 	stopErr       error
 	stopCalls     int
 	destroyErr    error
@@ -948,6 +950,7 @@ func (c *testFlyRuntimeFlapsClient) List(_ context.Context, _ string, _ string) 
 }
 
 func (c *testFlyRuntimeFlapsClient) Start(_ context.Context, _ string, _ string, _ string) (*fly.MachineStartResponse, error) {
+	c.startCalls++
 	if c.startErr != nil {
 		return nil, c.startErr
 	}


### PR DESCRIPTION
## Summary

- `maybeRecycleImage` was issuing `flapsClient.Update` (in-place patch, `RequiresReplacement:false`) and then waiting 45s for the machine to reach `started` — but flaps Update leaves the machine stopped. Every wait timed out, every assistant runtime on the affected machine went silent after a gram-worker image upgrade, and Fly eventually auto-cleaned the stopped VMs (subsequent admissions hit `not_found`).
- Call `flapsClient.Start` between Update and WaitStarted, mirroring the cold-start path at `runtime_fly.go:319`.
- Backfill a `startCalls` recorder on the test flaps stub and assert the recycle path now calls Start.

Closes [AGE-2372](https://linear.app/speakeasy/issue/AGE-2372/fix-start-fly-machine-after-image-recycle-to-avoid-stuck-stopped)

✻ Clauded...