### PR TITLE
feat(mcp): accept assistant JWT on issuer-gated /mcp/{slug}

### DIFF
--- a/.changeset/assistant-issuer-gated-mcp-fallback.md
+++ b/.changeset/assistant-issuer-gated-mcp-fallback.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Issuer-gated MCP servers now accept an assistant-runtime JWT and use the assistant owner's linked upstream account, so the runtime can call `/mcp/{slug}` without re-prompting for login. Requests with no linked upstream still return a 401 + WWW-Authenticate as before.

--- a/server/internal/mcp/assistant_resolver_integration_test.go
+++ b/server/internal/mcp/assistant_resolver_integration_test.go
@@ -1,0 +1,154 @@
+// Asserts the issuer-gated /mcp/{slug} resolver accepts an assistant
+// JWT and forwards the owning user's remote_session access token to the
+// upstream MCP server.
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/assistants"
+	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	externalmcp_types "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/testmcp"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestServePublic_AssistantTokenResolvesOwnerRemoteSessionToUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mockTools := []testmcp.Tool{{
+		Name:        "ping",
+		Description: "Returns pong",
+		InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		Response: testmcp.ToolResponse{
+			Content: []map[string]any{{"type": "text", "text": "pong"}},
+		},
+	}}
+	mockServer := newMockExternalMCPServer(t, externalmcp_types.TransportTypeStreamableHTTP, mockTools)
+	t.Cleanup(mockServer.Close)
+
+	var capturedAuth atomic.Value
+	target, err := url.Parse(mockServer.URL)
+	require.NoError(t, err)
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	recorder := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			capturedAuth.Store(auth)
+		}
+		proxy.ServeHTTP(w, r)
+	}))
+	t.Cleanup(recorder.Close)
+
+	fixture := createIssuerGatedExternalMCPFixture(t, ctx, ti, authCtx, "assistant-resolver", recorder.URL)
+
+	ownerSubject := urn.NewUserSubject(authCtx.UserID)
+	insertRemoteSessionAccessToken(t, ctx, ti, fixture.UserSessionIssuer.ID, fixture.RemoteSessionClient.ID, ownerSubject, "valid-upstream-token", time.Now().Add(time.Hour))
+
+	assistantToken := mintAssistantBearerForOwner(t, ti, authCtx)
+
+	initBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "assistant-runtime", "version": "1.0.0"},
+		},
+	})
+	require.NoError(t, err)
+	initResp, err := servePublicHTTP(t, context.Background(), ti, fixture.Toolset.McpSlug.String, initBody, assistantToken, nil)
+	require.NoError(t, err, "initialize must succeed via the assistant-token fallback")
+	require.Equal(t, http.StatusOK, initResp.Code, "initialize response: %s", initResp.Body.String())
+
+	callBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      fixture.ToolName,
+			"arguments": map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	callResp, err := servePublicHTTP(t, context.Background(), ti, fixture.Toolset.McpSlug.String, callBody, assistantToken, nil)
+	require.NoError(t, err, "tools/call must succeed via the assistant-token fallback")
+	require.Equal(t, http.StatusOK, callResp.Code, "tools/call response: %s", callResp.Body.String())
+
+	got, _ := capturedAuth.Load().(string)
+	require.Equal(t, "Bearer valid-upstream-token", got,
+		"resolver must forward the owner's exchanged remote_session token even when the caller authenticated with an assistant JWT")
+}
+
+func TestServePublic_AssistantTokenWithoutRemoteSessionChallenges(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	fixture := createRemoteSessionResolverFixture(t, ctx, ti, authCtx, "assistant-resolver-no-session")
+
+	assistantToken := mintAssistantBearerForOwner(t, ti, authCtx)
+	w, err := servePublicHTTP(t, context.Background(), ti, fixture.Toolset.McpSlug.String, makeInitializeBody(), assistantToken, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unauthorized")
+	require.Contains(t, w.Header().Get("WWW-Authenticate"), "/.well-known/oauth-protected-resource/mcp/"+fixture.Toolset.McpSlug.String,
+		"assistant-token fallback must still 401 when the owner has no remote_session for the issuer")
+}
+
+func mintAssistantBearerForOwner(
+	t *testing.T,
+	ti *testInstance,
+	authCtx *contextvalues.AuthContext,
+) string {
+	t.Helper()
+
+	ctx := t.Context()
+
+	assistant, err := assistantsrepo.New(ti.conn).CreateAssistant(ctx, assistantsrepo.CreateAssistantParams{
+		ProjectID:       *authCtx.ProjectID,
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		CreatedByUserID: pgtype.Text{String: authCtx.UserID, Valid: true},
+		Name:            "Resolver Test Assistant " + uuid.NewString()[:8],
+		Model:           "openai/gpt-4o-mini",
+		Instructions:    "",
+		WarmTtlSeconds:  300,
+		MaxConcurrency:  1,
+		Status:          assistants.StatusActive,
+	})
+	require.NoError(t, err)
+
+	token, err := assistanttokens.New("test-jwt-secret", ti.conn, ti.authzEngine).Generate(assistanttokens.GenerateInput{
+		OrgID:       authCtx.ActiveOrganizationID,
+		ProjectID:   *authCtx.ProjectID,
+		UserID:      authCtx.UserID,
+		AssistantID: assistant.ID,
+		ThreadID:    uuid.Nil,
+		TTL:         time.Hour,
+	})
+	require.NoError(t, err)
+	return token
+}

--- a/server/internal/mcp/assistant_resolver_integration_test.go
+++ b/server/internal/mcp/assistant_resolver_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	externalmcp_types "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testmcp"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -117,6 +118,40 @@ func TestServePublic_AssistantTokenWithoutRemoteSessionChallenges(t *testing.T) 
 	require.Contains(t, err.Error(), "unauthorized")
 	require.Contains(t, w.Header().Get("WWW-Authenticate"), "/.well-known/oauth-protected-resource/mcp/"+fixture.Toolset.McpSlug.String,
 		"assistant-token fallback must still 401 when the owner has no remote_session for the issuer")
+}
+
+func TestServePublic_AssistantTokenFromForeignProjectChallenges(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	fixture := createRemoteSessionResolverFixture(t, ctx, ti, authCtx, "assistant-resolver-foreign")
+
+	ownerSubject := urn.NewUserSubject(authCtx.UserID)
+	insertRemoteSessionAccessToken(t, ctx, ti, fixture.UserSessionIssuer.ID, fixture.RemoteSessionClient.ID, ownerSubject, "valid-upstream-token", time.Now().Add(time.Hour))
+
+	foreignProject, err := projectsrepo.New(ti.conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "foreign-" + uuid.NewString()[:8],
+		Slug:           "foreign-" + uuid.NewString()[:8],
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+
+	foreignAuthCtx := &contextvalues.AuthContext{
+		ActiveOrganizationID: authCtx.ActiveOrganizationID,
+		UserID:               authCtx.UserID,
+		ProjectID:            &foreignProject.ID,
+	}
+	foreignToken := mintAssistantBearerForOwner(t, ti, foreignAuthCtx)
+
+	w, err := servePublicHTTP(t, context.Background(), ti, fixture.Toolset.McpSlug.String, makeInitializeBody(), foreignToken, nil)
+	require.Error(t, err)
+	require.Contains(t, w.Header().Get("WWW-Authenticate"), "/.well-known/oauth-protected-resource/mcp/"+fixture.Toolset.McpSlug.String,
+		"assistant token minted for a different project must not resolve this toolset's remote_session")
 }
 
 func mintAssistantBearerForOwner(

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -68,6 +68,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 )
 
@@ -451,6 +452,14 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	issuerGated := toolset.UserSessionIssuerID.Valid
 	if issuerGated {
 		newCtx, subject, ok := s.validateUserSessionToken(ctx, authToken, toolset)
+		if !ok {
+			// Accept an assistant-runtime JWT as its owning user, so the
+			// resolver picks up the remote_session keyed by user:<UserID>.
+			if assistCtx, claims, aerr := s.assistantTokens.Authorize(ctx, authToken); aerr == nil {
+				ssubj := urn.NewUserSubject(claims.UserID)
+				newCtx, subject, ok = assistCtx, &ssubj, true
+			}
+		}
 		if !ok {
 			return WriteAuthenticateChallenge(w, baseURL, mcpSlug, "expired or invalid access token")
 		}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -453,9 +453,11 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	if issuerGated {
 		newCtx, subject, ok := s.validateUserSessionToken(ctx, authToken, toolset)
 		if !ok {
-			// Accept an assistant-runtime JWT as its owning user, so the
-			// resolver picks up the remote_session keyed by user:<UserID>.
-			if assistCtx, claims, aerr := s.assistantTokens.Authorize(ctx, authToken); aerr == nil {
+			// Accept an assistant-runtime JWT, but only when the assistant
+			// belongs to the toolset's project — otherwise a token minted
+			// in project A could resolve a remote_session linked under
+			// the same user in project B.
+			if assistCtx, claims, aerr := s.assistantTokens.Authorize(ctx, authToken); aerr == nil && claims.ProjectID == toolset.ProjectID.String() {
 				ssubj := urn.NewUserSubject(claims.UserID)
 				newCtx, subject, ok = assistCtx, &ssubj, true
 			}


### PR DESCRIPTION
## Summary

- Fall back to `assistantTokens.Authorize` in `ServeToolsetResolved`'s issuer-gated branch when user-session validation fails, so the assistant runtime can hit `/mcp/{slug}` with its short-lived `gram-assistants` JWT.
- Treat the assistant as its owning user (`urn.NewUserSubject(claims.UserID)`), so the existing `remote_session` keyed by `user:<UserID>` resolves and the upstream OAuth token feeds `tokenInputs`.
- Negative path is unchanged: missing or invalid `remote_session` still surfaces 401 + `WWW-Authenticate`, and non-issuer-gated MCPs are untouched.

Closes [AGE-2373](https://linear.app/speakeasy/issue/AGE-2373/resolve-user-session-upstream-tokens-for-assistant-runtime-on-mcpslug).

✻ Clauded...