### PR TITLE
fix: preserve inline json values in audit logs outbox entries

### DIFF
--- a/.changeset/wicked-towns-think.md
+++ b/.changeset/wicked-towns-think.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fixed a bug where snapshot and metadata fields in audit log outbox entries were being base64-encoded instead of preserved as inline JSON objects.

--- a/server/internal/audit/audittest/queries.sql
+++ b/server/internal/audit/audittest/queries.sql
@@ -20,3 +20,12 @@ FROM audit_logs;
 SELECT COUNT(*)
 FROM audit_logs
 WHERE action = @action;
+
+-- name: GetLatestOutboxPayloadByOrg :one
+-- Returns the JSON payload of the most-recently inserted outbox entry for an org+event_type pair.
+SELECT payload
+FROM outbox
+WHERE organization_id = @organization_id
+  AND event_type = @event_type
+ORDER BY id DESC
+LIMIT 1;

--- a/server/internal/audit/audittest/repo/queries.sql.go
+++ b/server/internal/audit/audittest/repo/queries.sql.go
@@ -75,3 +75,25 @@ func (q *Queries) GetLatestAuditLogByAction(ctx context.Context, action string) 
 	)
 	return i, err
 }
+
+const getLatestOutboxPayloadByOrg = `-- name: GetLatestOutboxPayloadByOrg :one
+SELECT payload
+FROM outbox
+WHERE organization_id = $1
+  AND event_type = $2
+ORDER BY id DESC
+LIMIT 1
+`
+
+type GetLatestOutboxPayloadByOrgParams struct {
+	OrganizationID string
+	EventType      string
+}
+
+// Returns the JSON payload of the most-recently inserted outbox entry for an org+event_type pair.
+func (q *Queries) GetLatestOutboxPayloadByOrg(ctx context.Context, arg GetLatestOutboxPayloadByOrgParams) ([]byte, error) {
+	row := q.db.QueryRow(ctx, getLatestOutboxPayloadByOrg, arg.OrganizationID, arg.EventType)
+	var payload []byte
+	err := row.Scan(&payload)
+	return payload, err
+}

--- a/server/internal/audit/logger_test.go
+++ b/server/internal/audit/logger_test.go
@@ -1,6 +1,7 @@
 package audit_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -9,11 +10,57 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	auditrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/outbox"
 	testrepo "github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
+
+func TestLogger_OutboxEntrySnapshotsAreInlineJSON(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	orgID := uuid.New().String()
+	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Test Org",
+		Slug:        "test-org-" + orgID[:8],
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	assetID, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	logger := audit.NewLogger()
+	err = logger.LogAssetCreate(ctx, conn, audit.LogAssetCreateEvent{
+		OrganizationID: orgID,
+		ProjectID:      uuid.NullUUID{},
+		Actor:          urn.NewPrincipal(urn.PrincipalTypeUser, "user_test01"),
+		AssetURN:       urn.NewAsset(urn.AssetKindImage, assetID),
+		AssetName:      "Test Asset",
+	})
+	require.NoError(t, err)
+
+	payload, err := auditrepo.New(conn).GetLatestOutboxPayloadByOrg(ctx, auditrepo.GetLatestOutboxPayloadByOrgParams{
+		OrganizationID: orgID,
+		EventType:      string(outbox.EventTypeAuditLogCreated),
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+
+	// metadata must be a JSON object inlined into the payload, not a base64-encoded string.
+	_, ok := decoded["metadata"].(map[string]any)
+	require.True(t, ok, "metadata should be a JSON object, not a base64 string; payload=%s", string(payload))
+}
 
 func TestLogger_WritesAuditLogAndOutboxEntry(t *testing.T) {
 	t.Parallel()

--- a/server/internal/audit/outbox.go
+++ b/server/internal/audit/outbox.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -11,21 +12,21 @@ import (
 )
 
 type outboxEntry struct {
-	ID                 uuid.UUID     `json:"id,omitzero"`
-	OrganizationID     string        `json:"organization_id,omitzero"`
-	ProjectID          uuid.NullUUID `json:"project_id,omitzero"`
-	ActorID            string        `json:"actor_id,omitzero"`
-	ActorType          string        `json:"actor_type,omitzero"`
-	ActorDisplayName   string        `json:"actor_display_name,omitzero"`
-	ActorSlug          string        `json:"actor_slug,omitzero"`
-	Action             string        `json:"action,omitzero"`
-	SubjectID          string        `json:"subject_id,omitzero"`
-	SubjectType        string        `json:"subject_type,omitzero"`
-	SubjectDisplayName string        `json:"subject_display_name,omitzero"`
-	SubjectSlug        string        `json:"subject_slug,omitzero"`
-	BeforeSnapshot     []byte        `json:"before_snapshot,omitempty"`
-	AfterSnapshot      []byte        `json:"after_snapshot,omitempty"`
-	Metadata           []byte        `json:"metadata,omitempty"`
+	ID                 uuid.UUID       `json:"id,omitzero"`
+	OrganizationID     string          `json:"organization_id,omitzero"`
+	ProjectID          uuid.NullUUID   `json:"project_id,omitzero"`
+	ActorID            string          `json:"actor_id,omitzero"`
+	ActorType          string          `json:"actor_type,omitzero"`
+	ActorDisplayName   string          `json:"actor_display_name,omitzero"`
+	ActorSlug          string          `json:"actor_slug,omitzero"`
+	Action             string          `json:"action,omitzero"`
+	SubjectID          string          `json:"subject_id,omitzero"`
+	SubjectType        string          `json:"subject_type,omitzero"`
+	SubjectDisplayName string          `json:"subject_display_name,omitzero"`
+	SubjectSlug        string          `json:"subject_slug,omitzero"`
+	BeforeSnapshot     json.RawMessage `json:"before_snapshot,omitempty"`
+	AfterSnapshot      json.RawMessage `json:"after_snapshot,omitempty"`
+	Metadata           json.RawMessage `json:"metadata,omitempty"`
 }
 
 func appendToOutbox(ctx context.Context, dbtx repo.DBTX, input repo.InsertAuditLogParams, result repo.InsertAuditLogRow) error {


### PR DESCRIPTION
When building the outbox entry, BeforeSnapshot, AfterSnapshot, and Metadata were passed as plain []byte. The JSON marshaler treats []byte as base64, so these fields were being encoded as base64 strings instead of inline JSON objects in the outbox payload.

Casting to json.RawMessage tells the marshaler to embed the bytes verbatim, keeping snapshots and metadata readable as JSON.