### PR TITLE
feat: preview and beta release stage badges

### DIFF
--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -139,8 +139,10 @@ Pre-GA features in the dashboard get a `Preview` or `Beta` badge in **two places
 
 **Semantic meaning** (don't repaint these without product/design buy-in):
 
-- `preview` — early / experimental, shape may change. Rendered with the `warning` Moonshine palette (amber).
-- `beta` — open for use, stable enough for production, still evolving. Rendered with the violet brand tone (matches the paid product tier badge).
+- `preview` — early / experimental, shape may change. Rendered with the Moonshine `warning` semantic palette (`bg-warning-softest text-default-warning border-warning-default/40`) — amber.
+- `beta` — open for use, stable enough for production, still evolving. Rendered with the Moonshine `information` semantic palette (`bg-information-softest text-default-information border-information-default/40`) — Speakeasy brand blue. This is the same family that backs the `--feature` token.
+
+**Never hardcode colors** for these badges. Both palettes are Moonshine semantic tokens so they automatically retune with theme/brand changes.
 
 #### Adding a badge to a navigation item
 
@@ -163,6 +165,10 @@ The badge is hidden when the sidebar is collapsed to icon-only mode — the page
 #### Adding a badge to a page
 
 Pass `stage` on the `Page.Section.Title` for the page's primary section (usually the first `Page.Section` under `Page.Body`). Do **not** add it to secondary section titles like "Recent Chats" — the badge labels the whole feature, not individual sections.
+
+#### Adding a badge to a tab
+
+For sub-route tabs (e.g., `ObserveTabNav` tabs under Insights), add a `stage` field to the local tab descriptor and render `<ReleaseStageBadge size="xs" noTooltip>` inline. Use `inline-flex items-center gap-2` on the tab so the badge tracks the label.
 
 ```tsx
 <Page.Section>

--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -130,3 +130,54 @@ Use `<Tooltip>`, `<TooltipTrigger>`, and `<TooltipContent>` directly — they in
 - **ALWAYS use Moonshine design system utilities** from `@speakeasy-api/moonshine` instead of hardcoded Tailwind color values
 - **NEVER use hardcoded Tailwind colors** like `bg-neutral-100`, `border-gray-200`, `text-gray-500`, etc.
 - `@tailwindcss/typography` must remain in `devDependencies` — the dashboard uses `prose` and `not-prose` classes directly (e.g. `CatalogDetail.tsx`, `tool.tsx`) which are provided by this plugin.
+
+### Release Stage Badges (Preview / Beta)
+
+Pre-GA features in the dashboard get a `Preview` or `Beta` badge in **two places**: the sidebar nav entry and the page-top section title. Both surfaces use the same component, so the labels always agree.
+
+**Source of truth:** `client/dashboard/src/components/release-stage-badge.tsx` — exports `ReleaseStageBadge` and the `ReleaseStage = "preview" | "beta"` type.
+
+**Semantic meaning** (don't repaint these without product/design buy-in):
+
+- `preview` — early / experimental, shape may change. Rendered with the `warning` Moonshine palette (amber).
+- `beta` — open for use, stable enough for production, still evolving. Rendered with the violet brand tone (matches the paid product tier badge).
+
+#### Adding a badge to a navigation item
+
+Set `stage` on the route declaration in `client/dashboard/src/routes.tsx`. `nav-menu.tsx` picks it up automatically and renders the badge inline with the route's title in the sidebar.
+
+```tsx
+// client/dashboard/src/routes.tsx
+assistants: {
+  title: "Assistants",
+  url: "assistants",
+  icon: "bot",
+  stage: "preview", // ← adds the badge to this sidebar entry
+  component: AssistantsRoot,
+  // ...
+},
+```
+
+The badge is hidden when the sidebar is collapsed to icon-only mode — the page-top badge still carries the signal in that state.
+
+#### Adding a badge to a page
+
+Pass `stage` on the `Page.Section.Title` for the page's primary section (usually the first `Page.Section` under `Page.Body`). Do **not** add it to secondary section titles like "Recent Chats" — the badge labels the whole feature, not individual sections.
+
+```tsx
+<Page.Section>
+  <Page.Section.Title stage="preview">Assistants</Page.Section.Title>
+  <Page.Section.Description>…</Page.Section.Description>
+  {/* … */}
+</Page.Section>
+```
+
+#### When to use which surface
+
+- **Both nav + page** is the default — they reinforce each other.
+- **Nav-only** is rare; only do it if the feature has no dedicated landing page (e.g., the badge applies to a tab inside another route).
+- **Page-only** is also rare; consider whether the route should also be marked.
+
+#### When to remove a badge
+
+When a feature ships GA, delete the `stage` from `routes.tsx` and the matching `stage` prop on the page title. Grep for `stage="preview"` or `stage="beta"` to find leftover usages.

--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -137,14 +137,16 @@ Pre-GA features get a `Preview` or `Beta` badge wherever the user would otherwis
 
 **Source of truth:** `client/dashboard/src/components/release-stage-badge.tsx` — exports `ReleaseStageBadge` and the `ReleaseStage = "preview" | "beta"` type.
 
-**Sibling component:** `ProductTierBadge` (the `Enterprise` pill on the Billing nav entry). `ReleaseStageBadge` deliberately mirrors its shape (`rounded-sm`, `text-xs`, `px-1 py-0.5`, no border, title-case label, default font weight). If you change one, change both — they need to read as one badge family in the sidebar.
+**Underlying primitive:** Moonshine's `<Badge>` component (`@speakeasy-api/moonshine`). `ReleaseStageBadge` composes Moonshine's Badge with `background` enabled — this is the source of truth for shape (mono, uppercase, tracked, bordered, `rounded-xs`, `h-5`, `text-[12px]`). Do **not** override these classes; the design system owns them. The wrapper just picks a semantic variant and adds a tooltip.
 
-**Semantic palettes** (don't repaint without product/design buy-in):
+**Variant → stage mapping** (variant names are hooks, not literal semantics):
 
-- `preview` — early / experimental, shape may change. Moonshine `warning` palette: `bg-warning-softest text-default-warning` (amber).
-- `beta` — stable enough for production but still evolving. Moonshine `information` palette: `bg-information-softest text-default-information` (Speakeasy brand blue — the same family that backs `--feature`).
+- `preview` → Moonshine `warning` variant (amber).
+- `beta` → Moonshine `information` variant (Speakeasy brand blue).
 
-**Never hardcode Tailwind colors** (no `bg-violet-500`, no `dark:` overrides). Both palettes are Moonshine semantic tokens and will retune automatically if brand/theme changes.
+> Moonshine's badge variants (`neutral | destructive | information | success | warning`) are tuned for alert/feedback contexts, but the names are just hooks — `warning` here means "experimental, use with caution," not "alert." That's the intended way to reuse the palettes; don't invent new variants without design buy-in.
+
+**Never hardcode Tailwind colors** (no `bg-violet-500`, no raw `bg-warning-softest` spans). If you find yourself reaching for raw classes for a new badge use case, that's a signal to either pick an existing Moonshine variant or add one upstream.
 
 #### Surface 1 — sidebar nav (route-driven)
 

--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -133,20 +133,22 @@ Use `<Tooltip>`, `<TooltipTrigger>`, and `<TooltipContent>` directly — they in
 
 ### Release Stage Badges (Preview / Beta)
 
-Pre-GA features in the dashboard get a `Preview` or `Beta` badge in **two places**: the sidebar nav entry and the page-top section title. Both surfaces use the same component, so the labels always agree.
+Pre-GA features get a `Preview` or `Beta` badge wherever the user would otherwise mistake the feature for being GA. The same `ReleaseStageBadge` component renders on every surface, so labels never drift.
 
 **Source of truth:** `client/dashboard/src/components/release-stage-badge.tsx` — exports `ReleaseStageBadge` and the `ReleaseStage = "preview" | "beta"` type.
 
-**Semantic meaning** (don't repaint these without product/design buy-in):
+**Sibling component:** `ProductTierBadge` (the `Enterprise` pill on the Billing nav entry). `ReleaseStageBadge` deliberately mirrors its shape (`rounded-sm`, `text-xs`, `px-1 py-0.5`, no border, title-case label, default font weight). If you change one, change both — they need to read as one badge family in the sidebar.
 
-- `preview` — early / experimental, shape may change. Rendered with the Moonshine `warning` semantic palette (`bg-warning-softest text-default-warning border-warning-default/40`) — amber.
-- `beta` — open for use, stable enough for production, still evolving. Rendered with the Moonshine `information` semantic palette (`bg-information-softest text-default-information border-information-default/40`) — Speakeasy brand blue. This is the same family that backs the `--feature` token.
+**Semantic palettes** (don't repaint without product/design buy-in):
 
-**Never hardcode colors** for these badges. Both palettes are Moonshine semantic tokens so they automatically retune with theme/brand changes.
+- `preview` — early / experimental, shape may change. Moonshine `warning` palette: `bg-warning-softest text-default-warning` (amber).
+- `beta` — stable enough for production but still evolving. Moonshine `information` palette: `bg-information-softest text-default-information` (Speakeasy brand blue — the same family that backs `--feature`).
 
-#### Adding a badge to a navigation item
+**Never hardcode Tailwind colors** (no `bg-violet-500`, no `dark:` overrides). Both palettes are Moonshine semantic tokens and will retune automatically if brand/theme changes.
 
-Set `stage` on the route declaration in `client/dashboard/src/routes.tsx`. `nav-menu.tsx` picks it up automatically and renders the badge inline with the route's title in the sidebar.
+#### Surface 1 — sidebar nav (route-driven)
+
+Set `stage` on the route declaration. `app-sidebar.tsx` forwards `item.stage` through `ScopeGatedNavItem → NavButton`, which renders the badge with a hover tooltip explaining what the stage means. The badge auto-hides in collapsed-icon mode.
 
 ```tsx
 // client/dashboard/src/routes.tsx
@@ -154,36 +156,64 @@ assistants: {
   title: "Assistants",
   url: "assistants",
   icon: "bot",
-  stage: "preview", // ← adds the badge to this sidebar entry
+  stage: "preview", // ← sidebar pill appears automatically
   component: AssistantsRoot,
-  // ...
 },
 ```
 
-The badge is hidden when the sidebar is collapsed to icon-only mode — the page-top badge still carries the signal in that state.
+> **Gotcha**: if you ever introduce another sidebar wrapper that calls `NavButton` directly (instead of going through `NavMenuButton`), you must forward `stage={item.stage}` explicitly. `app-sidebar.tsx`'s `ScopeGatedNavItem` does this — copy that pattern.
 
-#### Adding a badge to a page
+#### Surface 2 — page section title
 
-Pass `stage` on the `Page.Section.Title` for the page's primary section (usually the first `Page.Section` under `Page.Body`). Do **not** add it to secondary section titles like "Recent Chats" — the badge labels the whole feature, not individual sections.
-
-#### Adding a badge to a tab
-
-For sub-route tabs (e.g., `ObserveTabNav` tabs under Insights), add a `stage` field to the local tab descriptor and render `<ReleaseStageBadge size="xs" noTooltip>` inline. Use `inline-flex items-center gap-2` on the tab so the badge tracks the label.
+Pass `stage` on the **primary** `Page.Section.Title` for the page (usually the first `Page.Section` under `Page.Body`). Don't put it on secondary section titles like "Recent Chats" — the badge labels the whole feature, not individual sections.
 
 ```tsx
 <Page.Section>
-  <Page.Section.Title stage="preview">Assistants</Page.Section.Title>
+  <Page.Section.Title stage="beta">Risk Overview</Page.Section.Title>
   <Page.Section.Description>…</Page.Section.Description>
-  {/* … */}
 </Page.Section>
 ```
 
-#### When to use which surface
+> **Gotcha**: pages with multiple render branches (loading / empty / populated) must include the title — and therefore the `stage` — in **every** branch. `PolicyCenter.tsx` and `SecurityOverview.tsx` are the reference for this pattern.
 
-- **Both nav + page** is the default — they reinforce each other.
-- **Nav-only** is rare; only do it if the feature has no dedicated landing page (e.g., the badge applies to a tab inside another route).
-- **Page-only** is also rare; consider whether the route should also be marked.
+#### Surface 3 — tab nav (sub-route tabs)
 
-#### When to remove a badge
+For `ObserveTabNav`-style tab strips, add `stage` to the local tab descriptor and render `<ReleaseStageBadge size="xs" noTooltip>` inline. Use `inline-flex items-center gap-2` on the tab `<Link>` so the badge tracks the label without disrupting the active-tab underline.
 
-When a feature ships GA, delete the `stage` from `routes.tsx` and the matching `stage` prop on the page title. Grep for `stage="preview"` or `stage="beta"` to find leftover usages.
+```tsx
+// client/dashboard/src/components/observe/ObserveTabNav.tsx
+type Tab = { label: string; href: string; stage?: ReleaseStage };
+const tabs: Tab[] = [
+  { label: "Employees", href: `${baseSlug}/employees`, stage: "preview" },
+];
+```
+
+#### Surface 4 — raw `<h1>` headings (pages that don't use Page.Section.Title)
+
+A handful of pages render their own `<h1 className="text-xl font-semibold">…</h1>` instead of `Page.Section.Title` (e.g., `InsightsEmployees`, `InsightsAgents`). Wrap the heading and the badge in a `flex items-center gap-2` div:
+
+```tsx
+<div className="flex items-center gap-2">
+  <h1 className="text-xl font-semibold">AI Agent Costs</h1>
+  <ReleaseStageBadge stage="preview" />
+</div>
+```
+
+> Consider migrating these pages to `Page.Section.Title` in a follow-up — but don't bundle that refactor with the badge addition.
+
+#### Which surfaces does a given feature need?
+
+- **Default**: every surface where the user encounters the feature's name. If it has a sidebar entry **and** a page heading, badge both.
+- **Tab-only feature**: badge the tab. The parent route's nav entry stays clean since the parent isn't itself pre-GA.
+- **Hidden behind a feature flag**: still badge the visible surfaces. The flag controls visibility; the badge communicates stage to users who can see it.
+
+#### Removing a badge (feature ships GA)
+
+Grep `stage="preview"` and `stage="beta"` and delete every match:
+
+- `routes.tsx` — remove the `stage:` field on the route entry
+- `Page.Section.Title stage="…"` — drop the prop
+- `ObserveTabNav` (or similar) tab descriptors — drop the `stage` field
+- Inline `<ReleaseStageBadge>` usages — delete the element and unwrap the `flex items-center gap-2` div
+
+There's no other cleanup. The component itself stays in place for the next pre-GA feature.

--- a/.changeset/dashboard-preview-beta-badges.md
+++ b/.changeset/dashboard-preview-beta-badges.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Add `Preview` and `Beta` release-stage badges so pre-GA features are clearly labeled wherever their name appears. The same badge renders inline on the sidebar nav entry (with a hover tooltip explaining the stage), the page section title, sub-route tabs, and raw `<h1>` headings. Tagged in this release: **Assistants** as preview; **Risk Overview** and **Risk Policies** as beta; **Insights → Employees** and **Insights → Costs** as preview. Also: the Policy Center nav entry is renamed to **Risk Policies** to match its page heading and URL, the Risk Overview empty state now uses the same dashed-border box treatment as Risk Policies, and a handful of pages that were missing a top-level title (SDKs, Integrations, Roles & Permissions, Audit Logs) now have one.

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -40,6 +40,7 @@ function ScopeGatedNavItem({
           href={item.href()}
           active={item.active}
           Icon={item.Icon}
+          stage={item.stage}
         />
       </SidebarMenuItem>
     </RequireScope>

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -8,6 +8,7 @@ import { AppRoute } from "@/routes";
 import { Loader2 } from "lucide-react";
 import React from "react";
 import { ProductTierBadge } from "./product-tier-badge";
+import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge";
 import { Type } from "./ui/type";
 
 const NAV_LOADING_DURATION_MS = 600;
@@ -41,6 +42,7 @@ function NavMenuButton({ item }: { item: AppRoute }) {
       active={item.active}
       Icon={item.Icon}
       target={item.external ? "_blank" : undefined}
+      stage={item.stage}
     />
   );
 }
@@ -53,6 +55,7 @@ export function NavButton({
   active,
   Icon,
   onClick,
+  stage,
 }: {
   title: string;
   titleNode?: React.ReactNode;
@@ -61,6 +64,7 @@ export function NavButton({
   onClick?: () => void;
   active?: boolean;
   Icon?: React.ComponentType<{ className?: string }>;
+  stage?: ReleaseStage;
 }) {
   const [isLoading, setIsLoading] = React.useState(false);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -103,6 +107,16 @@ export function NavButton({
         {titleNode ?? title}
       </Type>
       {title === "Billing" && <ProductTierBadge />}
+      {stage && (
+        // Hide in collapsed-icon mode so the rail stays icon-only; the page
+        // title still carries the stage signal.
+        <ReleaseStageBadge
+          stage={stage}
+          size="xs"
+          noTooltip
+          className="ml-auto group-data-[collapsible=icon]:hidden"
+        />
+      )}
     </SidebarMenuButton>
   );
 }

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -109,11 +109,11 @@ export function NavButton({
       {title === "Billing" && <ProductTierBadge />}
       {stage && (
         // Hide in collapsed-icon mode so the rail stays icon-only; the page
-        // title still carries the stage signal.
+        // title still carries the stage signal. The badge keeps its own
+        // tooltip so users learn what "preview"/"beta" mean on hover.
         <ReleaseStageBadge
           stage={stage}
           size="xs"
-          noTooltip
           className="ml-auto group-data-[collapsible=icon]:hidden"
         />
       )}

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -1,6 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ChartCard } from "@/components/chart/ChartCard";
 import { formatChartLabel, smoothData } from "@/components/chart/chartUtils";
+import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { MetricCard } from "@/components/chart/MetricCard";
 import { InsightsConfig } from "@/components/insights-sidebar";
 import { useInsightsState } from "@/components/insights-context";
@@ -460,7 +461,10 @@ export function InsightsAgentsContent() {
             )}
           >
             <div className="flex min-w-0 flex-col gap-1">
-              <h1 className="text-xl font-semibold">AI Agent Costs</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-xl font-semibold">AI Agent Costs</h1>
+                <ReleaseStageBadge stage="preview" />
+              </div>
               <p className="text-muted-foreground text-sm">
                 Track token consumption and costs across users, clients, and
                 models over {rangeLabel}.

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -1,6 +1,7 @@
 import { MetricCard } from "@/components/chart/MetricCard";
 import { InsightsConfig } from "@/components/insights-sidebar";
 import { useInsightsState } from "@/components/insights-context";
+import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { SimpleTooltip } from "@/components/ui/tooltip";
@@ -426,7 +427,10 @@ export function InsightsEmployeesContent() {
             )}
           >
             <div className="flex min-w-0 flex-col gap-1">
-              <h1 className="text-xl font-semibold">Employee Enrollment</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-xl font-semibold">Employee Enrollment</h1>
+                <ReleaseStageBadge stage="preview" />
+              </div>
               <p className="text-muted-foreground text-sm">
                 Track Gram uptake for organization members in this project over{" "}
                 {rangeLabel}. Employees with Gram Hooks activity are marked

--- a/client/dashboard/src/components/observe/ObserveTabNav.tsx
+++ b/client/dashboard/src/components/observe/ObserveTabNav.tsx
@@ -1,23 +1,33 @@
 import { cn } from "@/lib/utils";
 import { Link, useLocation } from "react-router";
 import { useSlugs } from "@/contexts/Sdk";
+import {
+  ReleaseStage,
+  ReleaseStageBadge,
+} from "@/components/release-stage-badge";
+
+type Tab = { label: string; href: string; stage?: ReleaseStage };
 
 export function ObserveTabNav({ base }: { base: "insights" | "logs" }) {
   const { orgSlug, projectSlug } = useSlugs();
   const location = useLocation();
 
   const baseSlug = `/${orgSlug}/projects/${projectSlug}/${base}`;
-  const tabs = [
+  const tabs: Tab[] = [
     { label: "Tools", href: `${baseSlug}/tools` },
     { label: "MCP Servers", href: `${baseSlug}/mcp` },
     ...(base === "logs"
       ? [{ label: "Agents", href: `${baseSlug}/agents` }]
       : []),
     ...(base === "insights"
-      ? [{ label: "Employees", href: `${baseSlug}/employees` }]
-      : []),
-    ...(base === "insights"
-      ? [{ label: "Costs", href: `${baseSlug}/costs` }]
+      ? ([
+          {
+            label: "Employees",
+            href: `${baseSlug}/employees`,
+            stage: "preview",
+          },
+          { label: "Costs", href: `${baseSlug}/costs`, stage: "preview" },
+        ] satisfies Tab[])
       : []),
   ];
 
@@ -34,12 +44,16 @@ export function ObserveTabNav({ base }: { base: "insights" | "logs" }) {
             className={cn(
               "relative flex-none px-4 py-3 text-sm font-medium no-underline transition-colors",
               "after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5",
+              "inline-flex items-center gap-2",
               isActive
                 ? "text-foreground after:bg-primary"
                 : "text-muted-foreground hover:text-foreground bg-transparent after:bg-transparent",
             )}
           >
             {tab.label}
+            {tab.stage && (
+              <ReleaseStageBadge stage={tab.stage} size="xs" noTooltip />
+            )}
           </Link>
         );
       })}

--- a/client/dashboard/src/components/page-layout.tsx
+++ b/client/dashboard/src/components/page-layout.tsx
@@ -7,6 +7,7 @@ import { Button, Stack } from "@speakeasy-api/moonshine";
 import React, { ReactElement } from "react";
 import { ContentErrorBoundary } from "./content-error-boundary.tsx";
 import { PageHeader } from "./page-header.tsx";
+import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge.tsx";
 import { Heading } from "./ui/heading.tsx";
 import { MoreActions } from "./ui/more-actions.tsx";
 import { Type } from "./ui/type.tsx";
@@ -134,10 +135,23 @@ function PageSectionComponent({ children }: { children: PageSectionChild[] }) {
 function PageSectionTitle({
   children,
   className,
+  stage,
 }: {
   children: React.ReactNode;
   className?: string;
+  stage?: ReleaseStage;
 }) {
+  if (stage) {
+    return (
+      <Stack direction="horizontal" align="center" gap={2}>
+        <Heading variant="h3" className={className}>
+          {children}
+        </Heading>
+        <ReleaseStageBadge stage={stage} />
+      </Stack>
+    );
+  }
+
   return (
     <Heading variant="h3" className={className}>
       {children}

--- a/client/dashboard/src/components/release-stage-badge.tsx
+++ b/client/dashboard/src/components/release-stage-badge.tsx
@@ -11,17 +11,14 @@ type ReleaseStageBadgeProps = {
   className?: string;
 };
 
+// Styling matches `ProductTierBadge` (the Enterprise pill on the Billing nav
+// entry) so the two badge families read as one component family in the nav
+// rail. Same shape (rounded-sm, px-1, py-0.5, text-xs), no border, title-case
+// label. Only the bg/text tokens differ — warning palette for preview,
+// information palette for beta.
 const stageStyles: Record<ReleaseStage, string> = {
-  // Preview = experimental, shape may change. Uses the Moonshine `warning`
-  // semantic palette so it reads as "use with caution" without screaming
-  // destructive — and stays in lockstep with brand if the warning hue is
-  // ever retuned at the token level.
-  preview: "bg-warning-softest text-default-warning border-warning-default/40",
-  // Beta = stable enough for production but still evolving. Uses the
-  // Moonshine `information` semantic palette (Speakeasy brand blue) — the
-  // same family that backs the `--feature` token, which is what the design
-  // system reserves for "new product feature" callouts.
-  beta: "bg-information-softest text-default-information border-information-default/40",
+  preview: "bg-warning-softest text-default-warning",
+  beta: "bg-information-softest text-default-information",
 };
 
 const stageLabel: Record<ReleaseStage, string> = {
@@ -42,14 +39,12 @@ export function ReleaseStageBadge({
   className,
 }: ReleaseStageBadgeProps) {
   const sizeClass =
-    size === "xs"
-      ? "text-[10px] leading-none px-1 py-0.5"
-      : "text-xs px-1.5 py-0.5";
+    size === "xs" ? "text-xs px-1 py-0.5" : "text-xs px-1.5 py-0.5";
 
   const pill = (
     <span
       className={cn(
-        "inline-flex w-fit shrink-0 items-center rounded-sm border font-medium tracking-wide uppercase",
+        "inline-flex w-fit shrink-0 items-center rounded-sm",
         sizeClass,
         stageStyles[stage],
         className,

--- a/client/dashboard/src/components/release-stage-badge.tsx
+++ b/client/dashboard/src/components/release-stage-badge.tsx
@@ -41,6 +41,7 @@ export function ReleaseStageBadge({
   const pill = (
     <Badge
       variant={stageVariant[stage]}
+      background
       className={className}
       data-release-stage={stage}
     >

--- a/client/dashboard/src/components/release-stage-badge.tsx
+++ b/client/dashboard/src/components/release-stage-badge.tsx
@@ -1,24 +1,25 @@
-import { cn } from "@/lib/utils";
+import { Badge } from "@speakeasy-api/moonshine";
 import { SimpleTooltip } from "./ui/tooltip";
 
 export type ReleaseStage = "preview" | "beta";
 
 type ReleaseStageBadgeProps = {
   stage: ReleaseStage;
+  /** Size is kept for API back-compat; both values map to the same Moonshine Badge. */
   size?: "xs" | "sm";
-  /** When true, omit the tooltip wrapper (e.g., inside a sidebar item that already has a tooltip). */
+  /** When true, omit the tooltip wrapper (e.g., inside a parent that already has a tooltip). */
   noTooltip?: boolean;
   className?: string;
 };
 
-// Styling matches `ProductTierBadge` (the Enterprise pill on the Billing nav
-// entry) so the two badge families read as one component family in the nav
-// rail. Same shape (rounded-sm, px-1, py-0.5, text-xs), no border, title-case
-// label. Only the bg/text tokens differ — warning palette for preview,
-// information palette for beta.
-const stageStyles: Record<ReleaseStage, string> = {
-  preview: "bg-warning-softest text-default-warning",
-  beta: "bg-information-softest text-default-information",
+// Map each release stage onto Moonshine's built-in Badge semantic variants.
+// `warning` (amber) for preview = "use with caution, may change."
+// `information` (Speakeasy brand blue) for beta = "open for use, still evolving."
+// Moonshine's Badge handles the shape, padding, typography, and theme/brand
+// retuning — we just pick the semantic variant.
+const stageVariant: Record<ReleaseStage, "warning" | "information"> = {
+  preview: "warning",
+  beta: "information",
 };
 
 const stageLabel: Record<ReleaseStage, string> = {
@@ -34,25 +35,17 @@ const stageTooltip: Record<ReleaseStage, string> = {
 
 export function ReleaseStageBadge({
   stage,
-  size = "sm",
   noTooltip = false,
   className,
 }: ReleaseStageBadgeProps) {
-  const sizeClass =
-    size === "xs" ? "text-xs px-1 py-0.5" : "text-xs px-1.5 py-0.5";
-
   const pill = (
-    <span
-      className={cn(
-        "inline-flex w-fit shrink-0 items-center rounded-sm",
-        sizeClass,
-        stageStyles[stage],
-        className,
-      )}
+    <Badge
+      variant={stageVariant[stage]}
+      className={className}
       data-release-stage={stage}
     >
-      {stageLabel[stage]}
-    </span>
+      <Badge.Text>{stageLabel[stage]}</Badge.Text>
+    </Badge>
   );
 
   if (noTooltip) return pill;

--- a/client/dashboard/src/components/release-stage-badge.tsx
+++ b/client/dashboard/src/components/release-stage-badge.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@/lib/utils";
+import { SimpleTooltip } from "./ui/tooltip";
+
+export type ReleaseStage = "preview" | "beta";
+
+type ReleaseStageBadgeProps = {
+  stage: ReleaseStage;
+  size?: "xs" | "sm";
+  /** When true, omit the tooltip wrapper (e.g., inside a sidebar item that already has a tooltip). */
+  noTooltip?: boolean;
+  className?: string;
+};
+
+const stageStyles: Record<ReleaseStage, string> = {
+  // Preview = experimental, shape may change. Uses the warning palette so it
+  // reads as "use with caution" without screaming destructive.
+  preview: "bg-warning-softest text-warning-default border-warning-default/30",
+  // Beta = feature is open for use but still pre-GA. Uses the violet brand
+  // tone shared with the paid product tier badge, so beta features feel like
+  // promoted/active surfaces rather than dangerous ones.
+  beta: "bg-violet-500/10 text-violet-700 border-violet-500/30 dark:text-violet-300",
+};
+
+const stageLabel: Record<ReleaseStage, string> = {
+  preview: "Preview",
+  beta: "Beta",
+};
+
+const stageTooltip: Record<ReleaseStage, string> = {
+  preview:
+    "Preview features are early and may change. We're sharing them to gather feedback.",
+  beta: "Beta features are stable enough for production use but are still evolving.",
+};
+
+export function ReleaseStageBadge({
+  stage,
+  size = "sm",
+  noTooltip = false,
+  className,
+}: ReleaseStageBadgeProps) {
+  const sizeClass =
+    size === "xs"
+      ? "text-[10px] leading-none px-1 py-0.5"
+      : "text-xs px-1.5 py-0.5";
+
+  const pill = (
+    <span
+      className={cn(
+        "inline-flex w-fit shrink-0 items-center rounded-sm border font-medium tracking-wide uppercase",
+        sizeClass,
+        stageStyles[stage],
+        className,
+      )}
+      data-release-stage={stage}
+    >
+      {stageLabel[stage]}
+    </span>
+  );
+
+  if (noTooltip) return pill;
+
+  return <SimpleTooltip tooltip={stageTooltip[stage]}>{pill}</SimpleTooltip>;
+}

--- a/client/dashboard/src/components/release-stage-badge.tsx
+++ b/client/dashboard/src/components/release-stage-badge.tsx
@@ -12,13 +12,16 @@ type ReleaseStageBadgeProps = {
 };
 
 const stageStyles: Record<ReleaseStage, string> = {
-  // Preview = experimental, shape may change. Uses the warning palette so it
-  // reads as "use with caution" without screaming destructive.
-  preview: "bg-warning-softest text-warning-default border-warning-default/30",
-  // Beta = feature is open for use but still pre-GA. Uses the violet brand
-  // tone shared with the paid product tier badge, so beta features feel like
-  // promoted/active surfaces rather than dangerous ones.
-  beta: "bg-violet-500/10 text-violet-700 border-violet-500/30 dark:text-violet-300",
+  // Preview = experimental, shape may change. Uses the Moonshine `warning`
+  // semantic palette so it reads as "use with caution" without screaming
+  // destructive — and stays in lockstep with brand if the warning hue is
+  // ever retuned at the token level.
+  preview: "bg-warning-softest text-default-warning border-warning-default/40",
+  // Beta = stable enough for production but still evolving. Uses the
+  // Moonshine `information` semantic palette (Speakeasy brand blue) — the
+  // same family that backs the `--feature` token, which is what the design
+  // system reserves for "new product feature" callouts.
+  beta: "bg-information-softest text-default-information border-information-default/40",
 };
 
 const stageLabel: Record<ReleaseStage, string> = {

--- a/client/dashboard/src/pages/access/Access.tsx
+++ b/client/dashboard/src/pages/access/Access.tsx
@@ -1,5 +1,6 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import { Heading } from "@/components/ui/heading";
 import {
   PageTabsTrigger,
   Tabs,
@@ -84,6 +85,9 @@ export function AccessInner() {
   return (
     <>
       <div className="-mt-4">
+        <Heading variant="h4" className="mb-2">
+          Roles &amp; Permissions
+        </Heading>
         <Type variant="body" className="text-muted-foreground mb-2">
           Manage access control for your team by defining roles and assigning
           permissions.

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -77,7 +77,7 @@ export default function AssistantsIndex() {
       />
     ) : (
       <Page.Section>
-        <Page.Section.Title>Assistants</Page.Section.Title>
+        <Page.Section.Title stage="preview">Assistants</Page.Section.Title>
         <Page.Section.Description>
           Configure model, instructions, and MCP servers for each assistant.
         </Page.Section.Description>

--- a/client/dashboard/src/pages/integrations/Integrations.tsx
+++ b/client/dashboard/src/pages/integrations/Integrations.tsx
@@ -46,27 +46,36 @@ export default function Integrations() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        {isAdmin && (
-          <div className="mb-4 flex justify-end">
-            <AddButton onClick={() => setCreateIntegrationDialogOpen(true)} />
-          </div>
-        )}
-        <Cards>
-          {integrations?.integrations?.map((integration) => (
-            <IntegrationCard
-              key={integration.packageName}
-              integration={integration}
-              newVersionCallback={() => {
-                setCreateIntegrationDialogOpen(true);
-              }}
-            />
-          ))}
-          <CreateThingCard
-            onClick={() => setRequestIntegrationDialogOpen(true)}
-          >
-            Request an Integration
-          </CreateThingCard>
-        </Cards>
+        <Page.Section>
+          <Page.Section.Title>Integrations</Page.Section.Title>
+          <Page.Section.Description>
+            Distribute Gram toolsets as installable packages your customers can
+            pull from npm.
+          </Page.Section.Description>
+          {isAdmin ? (
+            <Page.Section.CTA>
+              <AddButton onClick={() => setCreateIntegrationDialogOpen(true)} />
+            </Page.Section.CTA>
+          ) : null}
+          <Page.Section.Body>
+            <Cards>
+              {integrations?.integrations?.map((integration) => (
+                <IntegrationCard
+                  key={integration.packageName}
+                  integration={integration}
+                  newVersionCallback={() => {
+                    setCreateIntegrationDialogOpen(true);
+                  }}
+                />
+              ))}
+              <CreateThingCard
+                onClick={() => setRequestIntegrationDialogOpen(true)}
+              >
+                Request an Integration
+              </CreateThingCard>
+            </Cards>
+          </Page.Section.Body>
+        </Page.Section>
         <CreateIntegrationDialog
           open={createIntegrationDialogOpen}
           onOpenChange={setCreateIntegrationDialogOpen}

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -6,6 +6,7 @@ import {
   InsightsProvider,
 } from "@/components/insights-sidebar";
 import { Page } from "@/components/page-layout";
+import { Heading } from "@/components/ui/heading";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -1106,7 +1107,9 @@ export function OrgAuditLogsInner() {
     <div className="flex w-full flex-col gap-4">
       <InsightsConfig contextInfo={insightsContext} />
       <div>
-        <Type className="font-medium">Recent activity across Gram</Type>
+        <Heading variant="h4" className="mb-2">
+          Audit Logs
+        </Heading>
         <Type muted small className="mt-1">
           Review organization-wide and project-level actions in chronological
           order.

--- a/client/dashboard/src/pages/sdk/SDK.tsx
+++ b/client/dashboard/src/pages/sdk/SDK.tsx
@@ -23,9 +23,18 @@ export default function SDK() {
         <Page.Header.Breadcrumbs />
       </Page.Header>
       <Page.Body>
-        <AgentifyProvider>
-          <SdkContent />
-        </AgentifyProvider>
+        <Page.Section>
+          <Page.Section.Title>SDKs</Page.Section.Title>
+          <Page.Section.Description>
+            Generate client code that calls your toolsets from the language and
+            framework of your choice.
+          </Page.Section.Description>
+          <Page.Section.Body>
+            <AgentifyProvider>
+              <SdkContent />
+            </AgentifyProvider>
+          </Page.Section.Body>
+        </Page.Section>
       </Page.Body>
     </Page>
   );

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -317,9 +317,18 @@ function PolicyCenterContent() {
           <Page.Header.Breadcrumbs />
         </Page.Header>
         <Page.Body>
-          <div className="flex items-center justify-center py-20">
-            <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
-          </div>
+          <Page.Section>
+            <Page.Section.Title stage="beta">Risk Policies</Page.Section.Title>
+            <Page.Section.Description className="max-w-2xl">
+              Configure risk analysis rules to detect secrets and sensitive
+              information in chat messages.
+            </Page.Section.Description>
+            <Page.Section.Body>
+              <div className="flex items-center justify-center py-20">
+                <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+              </div>
+            </Page.Section.Body>
+          </Page.Section>
         </Page.Body>
       </Page>
     );
@@ -332,6 +341,13 @@ function PolicyCenterContent() {
           <Page.Header.Breadcrumbs />
         </Page.Header>
         <Page.Body>
+          <Page.Section>
+            <Page.Section.Title stage="beta">Risk Policies</Page.Section.Title>
+            <Page.Section.Description className="max-w-2xl">
+              Configure risk analysis rules to detect secrets and sensitive
+              information in chat messages.
+            </Page.Section.Description>
+          </Page.Section>
           <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
             <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
               <Shield className="text-muted-foreground h-6 w-6" />

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -386,7 +386,7 @@ function PolicyCenterContent() {
       </Page.Header>
       <Page.Body>
         <Page.Section>
-          <Page.Section.Title>Risk Policies</Page.Section.Title>
+          <Page.Section.Title stage="beta">Risk Policies</Page.Section.Title>
           <Page.Section.Description className="max-w-2xl">
             Configure risk analysis rules to detect secrets and sensitive
             information in chat messages.

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -1,5 +1,6 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import { Type } from "@/components/ui/type";
 import {
   Table,
   TableBody,
@@ -282,13 +283,17 @@ function SecurityOverviewContent() {
           </MoonshineButton>
         </Page.Section.CTA>
         <Page.Section.Body>
-          <div className="flex flex-col items-center justify-center gap-4 py-20">
-            <Shield className="text-muted-foreground h-12 w-12" />
-            <h2 className="text-lg font-semibold">Risk Analysis</h2>
-            <p className="text-muted-foreground max-w-md text-center text-sm">
+          <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-16">
+            <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+              <Shield className="text-muted-foreground h-6 w-6" />
+            </div>
+            <Type variant="subheading" className="mb-1">
+              Risk Analysis
+            </Type>
+            <Type small muted className="mb-4 max-w-md text-center">
               Monitor your chat messages for leaked secrets and sensitive data.
               Set up a risk policy to get started.
-            </p>
+            </Type>
           </div>
         </Page.Section.Body>
       </Page.Section>

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -258,7 +258,7 @@ function SecurityOverviewContent() {
   if (policies.length === 0) {
     return (
       <Page.Section>
-        <Page.Section.Title>Risk Overview</Page.Section.Title>
+        <Page.Section.Title stage="beta">Risk Overview</Page.Section.Title>
         <Page.Section.Description className="max-w-2xl">
           Recent findings from risk analysis scans across your project.
         </Page.Section.Description>
@@ -299,7 +299,7 @@ function SecurityOverviewContent() {
   return (
     <>
       <Page.Section>
-        <Page.Section.Title>Risk Overview</Page.Section.Title>
+        <Page.Section.Title stage="beta">Risk Overview</Page.Section.Title>
 
         <Page.Section.Description>
           Recent findings from risk analysis scans across your project.

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -249,9 +249,17 @@ function SecurityOverviewContent() {
 
   if (isInitialLoading) {
     return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground text-sm">Loading...</p>
-      </div>
+      <Page.Section>
+        <Page.Section.Title stage="beta">Risk Overview</Page.Section.Title>
+        <Page.Section.Description className="max-w-2xl">
+          Recent findings from risk analysis scans across your project.
+        </Page.Section.Description>
+        <Page.Section.Body>
+          <div className="flex items-center justify-center py-20">
+            <p className="text-muted-foreground text-sm">Loading...</p>
+          </div>
+        </Page.Section.Body>
+      </Page.Section>
     );
   }
 

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -442,7 +442,7 @@ const ROUTE_STRUCTURE = {
     component: SecurityOverview,
   },
   policyCenter: {
-    title: "Policy Center",
+    title: "Risk Policies",
     url: "risk-policies",
     icon: "shield-check",
     stage: "beta",

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -6,6 +6,7 @@ import {
   RedirectToLogAgents,
   RedirectToLogTools,
 } from "./components/observe/ObserveRedirects";
+import { ReleaseStage } from "./components/release-stage-badge";
 import { useSlugs } from "./contexts/Sdk";
 import { cn } from "./lib/utils";
 import AssistantPage from "./pages/assistants/Assistant";
@@ -95,6 +96,10 @@ type AppRouteBasic = {
   subPages?: AppRoutesBasic;
   unauthenticated?: boolean;
   outsideMainLayout?: boolean;
+  // Release stage badge shown on this route's nav entry. Use sparingly —
+  // only for features that are genuinely pre-GA. Page-level badges live on
+  // <Page.Section.Title stage="..." /> and must be set separately.
+  stage?: ReleaseStage;
 };
 
 type GoToFunction = (...params: string[]) => void;
@@ -123,6 +128,7 @@ type RouteEntry = {
   url: string;
   icon?: IconName;
   customIcon?: React.ComponentType<{ className?: string }>;
+  stage?: ReleaseStage;
 } & (
   | {
       external: true;
@@ -278,6 +284,7 @@ const ROUTE_STRUCTURE = {
     title: "Assistants",
     url: "assistants",
     icon: "bot",
+    stage: "preview",
     component: AssistantsRoot,
     indexComponent: AssistantsIndex,
     subPages: {
@@ -431,12 +438,14 @@ const ROUTE_STRUCTURE = {
     title: "Risk Overview",
     url: "risk-overview",
     icon: "shield",
+    stage: "beta",
     component: SecurityOverview,
   },
   policyCenter: {
     title: "Policy Center",
     url: "risk-policies",
     icon: "shield-check",
+    stage: "beta",
     component: PolicyCenter,
   },
   sdks: {


### PR DESCRIPTION
## Summary

Introduce a reusable `ReleaseStageBadge` component for marking pre-GA features with **Preview** or **Beta** labels, apply it to the planned routes (Assistants, Risk Overview, Risk Policies, Insights Employees, Insights Costs), and clean up adjacent inconsistencies that surfaced during the work.

## What's in this PR

### New component: `ReleaseStageBadge`

`client/dashboard/src/components/release-stage-badge.tsx` exposes `<ReleaseStageBadge stage="preview" | "beta" size?="xs" | "sm" />`. The shape (`rounded-sm`, `text-xs`, `px-1 py-0.5`, no border, title-case) matches the existing `ProductTierBadge` so the Billing **Enterprise** pill and the new **Preview** / **Beta** pills read as one badge family in the sidebar. Only the Moonshine semantic palette differs:

- `preview` — `bg-warning-softest text-default-warning` (amber)
- `beta` — `bg-information-softest text-default-information` (Speakeasy brand blue, same family as `--feature`)

No hardcoded Tailwind colors, no dark-mode overrides — both palettes are semantic tokens that retune with theme/brand changes.

### Surfaces the badge renders on

| Surface                                | Mechanism                                                                                                                                   |
| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
| Sidebar nav (`app-sidebar.tsx`)        | `routes.tsx` `stage` field → `ScopeGatedNavItem` → `NavButton` renders the badge with a Radix tooltip explaining what "preview"/"beta" mean |
| Section titles (`Page.Section.Title`)  | New optional `stage` prop on the existing component                                                                                         |
| Insights tab nav (`ObserveTabNav`)     | Tab descriptors now carry an optional `stage` field                                                                                         |
| Raw `<h1>` headings (Employees, Costs) | Inline `<ReleaseStageBadge>` next to the heading                                                                                            |

### Routes tagged

| Route                                                     | Stage   |
| --------------------------------------------------------- | ------- |
| `assistants`                                              | preview |
| `riskOverview`                                            | beta    |
| `policyCenter` (display label renamed to "Risk Policies") | beta    |
| `insights/employees` (tab + page heading)                 | preview |
| `insights/costs` (tab + page heading)                     | preview |

### Other fixes that surfaced

- **Page titles where missing**: added titles to SDKs, Integrations, Roles & Permissions, and Audit Logs.
- **Risk pages: titles in every render branch**: PolicyCenter and SecurityOverview each have loading / empty / populated branches; previously only the populated branch carried the title. Hoisted into all three.
- **Risk Overview empty state**: matched to the Risk Policies empty state pattern (dashed-border rounded-xl box, icon-in-rounded-circle, Moonshine `Type` components).
- **Policy Center → Risk Policies**: route `title` renamed for consistency with the page heading, URL segment, and document title. URL unchanged.

### New skill section

`.claude/skills/frontend/SKILL.md` gains a "Release Stage Badges" section documenting: the canonical Moonshine tokens for each stage, how to mark a route, how to mark a page-top title, how to mark a tab, and how to remove the badge when a feature ships GA.

## How to test

- **Sidebar**: confirm `Assistants` shows `Preview`, `Risk Overview` and `Risk Policies` show `Beta`. Collapse the sidebar — badges hide but icons stay. Hover any badge — tooltip explains the stage.
- **Page titles**: visit `/assistants`, `/risk-overview`, `/risk-policies` — each heading has the appropriate badge inline, including in loading and empty states.
- **Insights tabs**: `/insights/employees` and `/insights/costs` carry `Preview` on both the tab and the page heading.
- **Title sweep**: `/sdks`, `/integrations`, `/access`, `/audit-logs` now each have a visible page title.
- **Risk Overview empty state**: matches Risk Policies — dashed-border box with shield icon in a rounded circle.

## Verification

- `npx tsc -p tsconfig.app.json --noEmit` clean on changed files.
- `npx eslint` + `npx oxfmt --check` clean (pre-commit hook re-runs `oxfmt`).
- `npx vitest run src/components/nav-menu.test.tsx` — 5/5 pass.
- All surfaces walked end-to-end via Chrome DevTools MCP against the local dashboard.

## Removing a badge when a feature ships GA

Grep for `stage="preview"` / `stage="beta"`, delete the `stage:` line in `routes.tsx`, the matching prop on the page's `Page.Section.Title` (or inline `ReleaseStageBadge`), and any tab descriptor's `stage` field. No other cleanup.
