### PR TITLE
feat(mcp): issuer-gated dashboard Connect + non-empty resource_metadata

### DIFF
--- a/.changeset/dashboard-issuer-gated-connect.md
+++ b/.changeset/dashboard-issuer-gated-connect.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+The playground's Connect button now drives the issuer-gated OAuth flow when a toolset is bound to a user-session issuer, so connecting to MCP servers like `speakeasy-team-github` lands an upstream session that the runtime can resolve. The connection-status badge and the 401 challenge on `/mcp/{slug}` both read from the issuer-gated session store for these toolsets, and the security-check fallback now always emits a non-empty `resource_metadata` URL.

--- a/client/dashboard/src/pages/playground/PlaygroundAuth.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundAuth.tsx
@@ -54,10 +54,12 @@ function ExternalMcpOAuthConnection({
   toolsetSlug,
   oauthMode,
   providerName,
+  isIssuerGated,
 }: {
   toolsetSlug: string;
   oauthMode: "custom-proxy" | "external";
   providerName: string;
+  isIssuerGated: boolean;
 }) {
   const { data: toolset } = useToolset(toolsetSlug);
   const project = useProject();
@@ -72,6 +74,18 @@ function ExternalMcpOAuthConnection({
         clearInterval(pollTimerRef.current);
       }
     };
+  }, []);
+
+  // Auto-close when this page is loaded inside the issuer-connect popup:
+  // the server redirects back to the dashboard URL with ?issuer_connected=1
+  // after writing remote_sessions; the parent window's popup-close polling
+  // then refetches status.
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.opener) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("issuer_connected") === "1") {
+      window.close();
+    }
   }, []);
 
   // Query OAuth status using the shared hook
@@ -130,7 +144,10 @@ function ExternalMcpOAuthConnection({
       project: project.slug,
     });
 
-    const authUrl = `${apiUrl}/oauth-external/authorize?${params.toString()}`;
+    const endpoint = isIssuerGated
+      ? "/oauth-external/issuer-connect"
+      : "/oauth-external/authorize";
+    const authUrl = `${apiUrl}${endpoint}?${params.toString()}`;
 
     const width = 600;
     const height = 700;
@@ -197,16 +214,18 @@ function ExternalMcpOAuthConnection({
         </Type>
 
         {isConnected ? (
-          <Button
-            size="sm"
-            variant="outline"
-            className="w-full"
-            onClick={() => disconnectMutation.mutate()}
-            disabled={disconnectMutation.isPending}
-          >
-            <LogOut className="mr-2 size-3" />
-            Disconnect
-          </Button>
+          isIssuerGated ? null : (
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-full"
+              onClick={() => disconnectMutation.mutate()}
+              disabled={disconnectMutation.isPending}
+            >
+              <LogOut className="mr-2 size-3" />
+              Disconnect
+            </Button>
+          )
         ) : (
           <Button
             size="sm"
@@ -405,6 +424,7 @@ export function PlaygroundAuth({
             toolsetSlug={toolset.slug}
             oauthMode={oauthMode}
             providerName={oauthProviderName}
+            isIssuerGated={loginSecured}
           />
         )}
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -754,7 +754,6 @@ func newStartCommand() *cli.Command {
 				return err
 			}
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager, identityResolver, guardianPolicy)
-			externalOAuthService := oauth.NewExternalOAuthService(logger, guardianPolicy, db, cache.NewRedisCacheAdapter(redisClient), authorizer, encryptionClient, externalMcpOAuthConfig)
 			shadowMCPClient := shadowmcp.NewClient(logger, db, cache.NewRedisCacheAdapter(redisClient))
 			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemLogger, auditLogger, serverURL)
 
@@ -786,6 +785,8 @@ func newStartCommand() *cli.Command {
 				cache.NewRedisCacheAdapter(redisClient),
 				serverURL,
 			)
+
+			externalOAuthService := oauth.NewExternalOAuthService(logger, guardianPolicy, db, cache.NewRedisCacheAdapter(redisClient), authorizer, encryptionClient, remoteChallengeManager, externalMcpOAuthConfig)
 
 			mcpService := mcp.NewService(
 				logger,

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -384,6 +384,7 @@ func (s *Service) buildRemoteSessionCards(
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
 		Subject:             challengeState.Subject,
 		McpSlug:             mcpSlug,
+		FinalRedirectURI:    "",
 	}
 
 	cards := make([]remoteSessionCard, 0, len(clients))

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -491,12 +491,12 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		}
 	}
 
-	var oauthProtectedResourceURL string
+	oauthProtectedResourceURL, err := url.JoinPath(baseURL, wellknown.OAuthProtectedResourcePath, mcpRouteBase, mcpSlug)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to build OAuth protected resource URL").Log(ctx, s.logger)
+	}
+
 	if !issuerGated {
-		oauthProtectedResourceURL, err = url.JoinPath(baseURL, wellknown.OAuthProtectedResourcePath, mcpRouteBase, mcpSlug)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to build OAuth protected resource URL").Log(ctx, s.logger)
-		}
 		switch {
 		case toolset.McpIsPublic && toolset.ExternalOauthServerID.Valid:
 			// External OAuth server flow — collect token if present

--- a/server/internal/mcp/remotelogin_integration_test.go
+++ b/server/internal/mcp/remotelogin_integration_test.go
@@ -79,7 +79,7 @@ func TestRemoteLoginCallback_AuthenticatedSubject(t *testing.T) {
 		CreatedAt:           time.Now(),
 	}))
 
-	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, &userSubject)
+	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, &userSubject, "")
 }
 
 // TestRemoteLoginCallback_AnonymousSubject covers the public-toolset
@@ -141,7 +141,39 @@ func TestRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 	require.NotNil(t, stamped.Subject)
 	require.Equal(t, anonymousSubject, *stamped.Subject)
 
-	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, stamped.Subject)
+	runRemoteLoginRoundTrip(t, ctx, ti, mgr, result, parentID, stamped.Subject, "")
+}
+
+func TestRemoteLoginCallback_FinalRedirectURI(t *testing.T) {
+	t.Parallel()
+
+	idp := devidptest.Launch(t, devidptest.LaunchOpts{})
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	result := oauthtest.CreateIssuerGatedToolset(t, ctx, ti.conn, ti.enc, authCtx, oauthtest.IssuerGatedToolsetOpts{
+		Slug:                         "issuer-final-redirect",
+		IsPublic:                     false,
+		UpstreamMetadata:             idp.OAuth21Metadata(t),
+		RemoteSessionCallbackBaseURL: ti.serverURL.String(),
+	})
+
+	mgr, _ := buildChallengeManagerForTest(t, ti)
+	userSubject := urn.NewUserSubject(uuid.NewString())
+
+	runRemoteLoginRoundTrip(
+		t,
+		ctx,
+		ti,
+		mgr,
+		result,
+		uuid.NewString(),
+		&userSubject,
+		"https://dashboard.example.com/playground?existing=1",
+	)
 }
 
 func TestRemoteLoginChallenge_CustomDomainRegistersGramCallback(t *testing.T) {
@@ -209,6 +241,7 @@ func runRemoteLoginRoundTrip(
 	result oauthtest.IssuerGatedToolsetResult,
 	parentChallengeID string,
 	expectedSubject *urn.SessionSubject,
+	finalRedirectURI string,
 ) {
 	t.Helper()
 
@@ -222,7 +255,7 @@ func runRemoteLoginRoundTrip(
 		UserSessionIssuerID: result.UserSessionIssuer.ID,
 		Subject:             expectedSubject,
 		McpSlug:             result.Toolset.McpSlug.String,
-		FinalRedirectURI:    "",
+		FinalRedirectURI:    finalRedirectURI,
 	}
 	authURL, err := mgr.BuildAuthorizationUrl(ctx, parent, clients[0])
 	require.NoError(t, err)
@@ -243,9 +276,13 @@ func runRemoteLoginRoundTrip(
 
 	cbW := httptest.NewRecorder()
 	require.NoError(t, mgr.HandleRemoteLoginCallback(cbW, cbReq))
-	require.Equal(t, http.StatusSeeOther, cbW.Code, "callback should redirect back to /connect")
-	require.Contains(t, cbW.Header().Get("Location"), "/mcp/"+result.Toolset.McpSlug.String+"/connect")
-	require.Contains(t, cbW.Header().Get("Location"), parentChallengeID)
+	require.Equal(t, http.StatusSeeOther, cbW.Code, "callback should redirect")
+	if finalRedirectURI != "" {
+		require.Equal(t, finalRedirectURI, cbW.Header().Get("Location"))
+	} else {
+		require.Contains(t, cbW.Header().Get("Location"), "/mcp/"+result.Toolset.McpSlug.String+"/connect")
+		require.Contains(t, cbW.Header().Get("Location"), parentChallengeID)
+	}
 
 	sessions, err := remotesessions_repo.New(ti.conn).ListRemoteSessionsByProjectID(ctx, remotesessions_repo.ListRemoteSessionsByProjectIDParams{
 		ProjectID:  result.Toolset.ProjectID,

--- a/server/internal/mcp/remotelogin_integration_test.go
+++ b/server/internal/mcp/remotelogin_integration_test.go
@@ -174,6 +174,7 @@ func TestRemoteLoginChallenge_CustomDomainRegistersGramCallback(t *testing.T) {
 		UserSessionIssuerID: result.UserSessionIssuer.ID,
 		Subject:             &userSubject,
 		McpSlug:             result.Toolset.McpSlug.String,
+		FinalRedirectURI:    "",
 	}, clients[0])
 	require.NoError(t, err)
 
@@ -221,6 +222,7 @@ func runRemoteLoginRoundTrip(
 		UserSessionIssuerID: result.UserSessionIssuer.ID,
 		Subject:             expectedSubject,
 		McpSlug:             result.Toolset.McpSlug.String,
+		FinalRedirectURI:    "",
 	}
 	authURL, err := mgr.BuildAuthorizationUrl(ctx, parent, clients[0])
 	require.NoError(t, err)

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -687,7 +688,7 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 	// by the dashboard user's subject URN. The legacy user_oauth_tokens
 	// path is the wrong source for these.
 	if toolset.UserSessionIssuerID.Valid {
-		return s.writeIssuerGatedStatus(ctx, w, authCtx.UserID, toolset.UserSessionIssuerID.UUID)
+		return s.writeIssuerGatedStatus(ctx, w, authCtx.UserID, toolset.ProjectID, toolset.UserSessionIssuerID.UUID)
 	}
 
 	// Check if user has a token for this toolset
@@ -745,19 +746,23 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 	return nil
 }
 
-// writeIssuerGatedStatus reports whether the dashboard user has any active
-// remote_sessions row under the toolset's user_session_issuer. Issuer-gated
-// toolsets bind upstream credentials to (subject, user_session_issuer_id)
-// in remote_sessions, not (user_id, toolset_id) in user_oauth_tokens.
-func (s *ExternalOAuthService) writeIssuerGatedStatus(ctx context.Context, w http.ResponseWriter, userID string, issuerID uuid.UUID) error {
+// writeIssuerGatedStatus reports whether the dashboard user has a USABLE
+// remote_sessions row under the toolset's user_session_issuer. Mirrors the
+// runtime's ResolveOneAccessToken view: a row whose access token expired
+// without a workable refresh path resolves to "needs_auth", not
+// "authenticated" — otherwise the dashboard badge lies about a connection
+// that the next /mcp/{slug} call will 401 on.
+func (s *ExternalOAuthService) writeIssuerGatedStatus(ctx context.Context, w http.ResponseWriter, userID string, projectID, issuerID uuid.UUID) error {
 	subject := urn.NewUserSubject(userID)
-	connected, err := s.remoteChallengeMgr.ConnectedClientIDs(ctx, subject, issuerID)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "list connected remote sessions").Log(ctx, s.logger)
-	}
+	token, err := s.remoteChallengeMgr.ResolveOneAccessToken(ctx, projectID, issuerID, subject)
 
 	status := "needs_auth"
-	if len(connected) > 0 {
+	switch {
+	case errors.Is(err, remotesessions.ErrNoValidToken):
+		// fall through with status="needs_auth"
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "resolve remote session").Log(ctx, s.logger)
+	case token != "":
 		status = "authenticated"
 	}
 

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -429,6 +429,9 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 	if !s.isAllowedRedirectHost(parsedRedirect.Hostname()) {
 		return oops.E(oops.CodeBadRequest, nil, "redirect_uri hostname not allowed").Log(ctx, s.logger)
 	}
+	redirectQuery := parsedRedirect.Query()
+	redirectQuery.Set("issuer_connected", "1")
+	parsedRedirect.RawQuery = redirectQuery.Encode()
 
 	toolsetID, err := uuid.Parse(toolsetIDStr)
 	if err != nil {
@@ -467,7 +470,7 @@ func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *htt
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
 		Subject:             &subject,
 		McpSlug:             mcpSlug,
-		FinalRedirectURI:    redirectURI,
+		FinalRedirectURI:    parsedRedirect.String(),
 	}
 	authURL, err := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, parent, clients[0])
 	if err != nil {

--- a/server/internal/oauth/external_oauth.go
+++ b/server/internal/oauth/external_oauth.go
@@ -41,7 +41,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projects_repo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 //go:embed hosted_external_oauth_success_page.html.tmpl
@@ -119,6 +121,7 @@ type ExternalOAuthService struct {
 	auth                 *auth.Auth
 	enc                  *encryption.Client
 	httpClient           *guardian.HTTPClient
+	remoteChallengeMgr   *remotesessions.ChallengeManager
 	successPageTmpl      *template.Template
 	successScriptHash    string
 	successScriptData    []byte
@@ -144,6 +147,7 @@ func NewExternalOAuthService(
 	cacheImpl cache.Cache,
 	auth *auth.Auth,
 	enc *encryption.Client,
+	remoteChallengeMgr *remotesessions.ChallengeManager,
 	cfg ExternalOAuthServiceConfig,
 ) *ExternalOAuthService {
 	stateStorage := cache.NewTypedObjectCache[ExternalOAuthState](
@@ -173,6 +177,7 @@ func NewExternalOAuthService(
 		auth:                 auth,
 		enc:                  enc,
 		httpClient:           guardianPolicy.Client(guardian.WithDefaultRetryConfig()),
+		remoteChallengeMgr:   remoteChallengeMgr,
 		successPageTmpl:      successPageTmpl,
 		successScriptHash:    scriptHashStr,
 		successScriptData:    externalOAuthSuccessScriptData,
@@ -188,6 +193,13 @@ func AttachExternalOAuth(mux goahttp.Muxer, service *ExternalOAuthService) {
 	// External OAuth authorization endpoint - initiates OAuth flow with external provider
 	o11y.AttachHandler(mux, "GET", "/oauth-external/authorize", func(w http.ResponseWriter, r *http.Request) {
 		oops.ErrHandle(service.logger, service.withAuth(service.handleExternalAuthorize)).ServeHTTP(w, r)
+	})
+
+	// Issuer-gated MCP connect - drives the user_session_issuer / remote_sessions
+	// flow from the dashboard. Skips DCR + consent UI; writes remote_sessions
+	// keyed by the dashboard user's subject URN.
+	o11y.AttachHandler(mux, "GET", "/oauth-external/issuer-connect", func(w http.ResponseWriter, r *http.Request) {
+		oops.ErrHandle(service.logger, service.withAuth(service.handleIssuerConnect)).ServeHTTP(w, r)
 	})
 
 	// Disconnect OAuth connection
@@ -378,6 +390,94 @@ func (s *ExternalOAuthService) handleExternalAuthorize(w http.ResponseWriter, r 
 
 	// Redirect to external OAuth provider
 	http.Redirect(w, r, authURL.String(), http.StatusFound)
+	return nil
+}
+
+// handleIssuerConnect initiates the upstream OAuth flow for an issuer-gated
+// toolset. The dashboard user is the subject; the upstream callback at
+// /mcp/remote_login_callback writes remote_sessions keyed by that subject.
+//
+// Skips DCR + the consent UI: the dashboard owns its own redirect surface
+// (validated against the allowed-host list), and the user authenticating
+// against the dashboard already authorises the link.
+//
+// Requires the toolset's user_session_issuer to have exactly one bound
+// remote_session_client — the same invariant the runtime resolver enforces
+// at ResolveOneAccessToken time.
+func (s *ExternalOAuthService) handleIssuerConnect(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		return oops.E(oops.CodeUnauthorized, nil, "authentication required").Log(ctx, s.logger)
+	}
+
+	toolsetIDStr := r.URL.Query().Get("toolset_id")
+	if toolsetIDStr == "" {
+		return oops.E(oops.CodeBadRequest, nil, "toolset_id is required").Log(ctx, s.logger)
+	}
+	redirectURI := r.URL.Query().Get("redirect_uri")
+	if redirectURI == "" {
+		return oops.E(oops.CodeBadRequest, nil, "redirect_uri is required").Log(ctx, s.logger)
+	}
+
+	parsedRedirect, err := url.Parse(redirectURI)
+	if err != nil || parsedRedirect.Scheme == "" || parsedRedirect.Host == "" {
+		return oops.E(oops.CodeBadRequest, nil, "invalid redirect_uri").Log(ctx, s.logger)
+	}
+	if !s.isAllowedRedirectHost(parsedRedirect.Hostname()) {
+		return oops.E(oops.CodeBadRequest, nil, "redirect_uri hostname not allowed").Log(ctx, s.logger)
+	}
+
+	toolsetID, err := uuid.Parse(toolsetIDStr)
+	if err != nil {
+		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
+	}
+
+	toolset, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        toolsetID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	if err != nil {
+		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+	}
+
+	if !toolset.UserSessionIssuerID.Valid {
+		return oops.E(oops.CodeBadRequest, nil, "toolset is not issuer-gated").Log(ctx, s.logger)
+	}
+
+	mcpSlug := toolset.McpSlug.String
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "toolset has no mcp slug").Log(ctx, s.logger)
+	}
+
+	clients, err := s.remoteChallengeMgr.ListClients(ctx, toolset.ProjectID, toolset.UserSessionIssuerID.UUID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list remote session clients").Log(ctx, s.logger)
+	}
+	if len(clients) != 1 {
+		return oops.E(oops.CodeInvariantViolation, nil, "issuer-gated dashboard connect requires exactly one remote_session_client, found %d", len(clients)).Log(ctx, s.logger)
+	}
+
+	subject := urn.NewUserSubject(authCtx.UserID)
+	parent := remotesessions.ParentChallenge{
+		ID:                  "",
+		ProjectID:           toolset.ProjectID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Subject:             &subject,
+		McpSlug:             mcpSlug,
+		FinalRedirectURI:    redirectURI,
+	}
+	authURL, err := s.remoteChallengeMgr.BuildAuthorizationUrl(ctx, parent, clients[0])
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build authorization URL").Log(ctx, s.logger)
+	}
+
+	s.logger.InfoContext(ctx, "redirecting to upstream issuer-gated OAuth provider",
+		attr.SlogUserID(authCtx.UserID),
+		attr.SlogToolsetID(toolset.ID.String()),
+	)
+	http.Redirect(w, r, authURL, http.StatusFound)
 	return nil
 }
 
@@ -575,11 +675,19 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 	}
 
 	// Load toolset to verify user has access
-	if _, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+	toolset, err := s.toolsetsRepo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
 		ID:        toolsetID,
 		ProjectID: *authCtx.ProjectID,
-	}); err != nil {
+	})
+	if err != nil {
 		return oops.E(oops.CodeNotFound, err, "toolset not found").Log(ctx, s.logger)
+	}
+
+	// Issuer-gated toolsets store upstream tokens in remote_sessions keyed
+	// by the dashboard user's subject URN. The legacy user_oauth_tokens
+	// path is the wrong source for these.
+	if toolset.UserSessionIssuerID.Valid {
+		return s.writeIssuerGatedStatus(ctx, w, authCtx.UserID, toolset.UserSessionIssuerID.UUID)
 	}
 
 	// Check if user has a token for this toolset
@@ -632,6 +740,33 @@ func (s *ExternalOAuthService) handleExternalStatus(w http.ResponseWriter, r *ht
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
+		s.logger.ErrorContext(ctx, "failed to encode response", attr.SlogError(err))
+	}
+	return nil
+}
+
+// writeIssuerGatedStatus reports whether the dashboard user has any active
+// remote_sessions row under the toolset's user_session_issuer. Issuer-gated
+// toolsets bind upstream credentials to (subject, user_session_issuer_id)
+// in remote_sessions, not (user_id, toolset_id) in user_oauth_tokens.
+func (s *ExternalOAuthService) writeIssuerGatedStatus(ctx context.Context, w http.ResponseWriter, userID string, issuerID uuid.UUID) error {
+	subject := urn.NewUserSubject(userID)
+	connected, err := s.remoteChallengeMgr.ConnectedClientIDs(ctx, subject, issuerID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list connected remote sessions").Log(ctx, s.logger)
+	}
+
+	status := "needs_auth"
+	if len(connected) > 0 {
+		status = "authenticated"
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(handleExternalStatusResponse{
+		Status:       status,
+		ExpiresAt:    nil,
+		ProviderName: nil,
+	}); err != nil {
 		s.logger.ErrorContext(ctx, "failed to encode response", attr.SlogError(err))
 	}
 	return nil

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -404,14 +404,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 
 	redirect := fmt.Sprintf("%s/mcp/%s/connect?state=%s", strings.TrimRight(m.serverURL.String(), "/"), mcpSlug, url.QueryEscape(state.ParentChallengeID))
 	if state.FinalRedirectURI != "" {
-		if u, perr := url.Parse(state.FinalRedirectURI); perr == nil {
-			q := u.Query()
-			q.Set("issuer_connected", "1")
-			u.RawQuery = q.Encode()
-			redirect = u.String()
-		} else {
-			redirect = state.FinalRedirectURI
-		}
+		redirect = state.FinalRedirectURI
 	}
 	http.Redirect(w, r, redirect, http.StatusSeeOther)
 	return nil

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -54,12 +54,18 @@ import (
 // ParentChallenge projects the in-flight user-session AuthnChallengeState
 // into the fields the remote leg needs. mcp/ builds this from its
 // AuthnChallengeState; remotesessions/ never imports mcp/.
+//
+// FinalRedirectURI is set by callers that own their own redirect surface
+// (e.g. the dashboard's issuer-connect endpoint, which bypasses the consent
+// UI). When non-empty, HandleRemoteLoginCallback redirects there after the
+// upstream token exchange instead of bouncing back to /mcp/{slug}/connect.
 type ParentChallenge struct {
 	ID                  string
 	ProjectID           uuid.UUID
 	UserSessionIssuerID uuid.UUID
 	Subject             *urn.SessionSubject
 	McpSlug             string
+	FinalRedirectURI    string
 }
 
 // RemoteLoginState is the per-remote-leg Redis state, keyed by the opaque
@@ -76,7 +82,12 @@ type RemoteLoginState struct {
 	CodeVerifier          string              `json:"code_verifier"`
 	Subject               *urn.SessionSubject `json:"subject,omitempty"`
 	McpSlug               string              `json:"mcp_slug"`
-	CreatedAt             time.Time           `json:"created_at"`
+	// FinalRedirectURI overrides the default post-callback redirect to
+	// /mcp/{slug}/connect. Set by dashboard-driven flows that own their
+	// own popup-close surface (validated against an allow-list before
+	// it lands here).
+	FinalRedirectURI string    `json:"final_redirect_uri,omitempty"`
+	CreatedAt        time.Time `json:"created_at"`
 }
 
 var _ cache.CacheableObject[RemoteLoginState] = (*RemoteLoginState)(nil)
@@ -240,6 +251,7 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 		CodeVerifier:          verifier,
 		Subject:               parent.Subject,
 		McpSlug:               parent.McpSlug,
+		FinalRedirectURI:      parent.FinalRedirectURI,
 		CreatedAt:             time.Now(),
 	}
 	if err := m.cache.Store(ctx, state); err != nil {
@@ -391,6 +403,16 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	}
 
 	redirect := fmt.Sprintf("%s/mcp/%s/connect?state=%s", strings.TrimRight(m.serverURL.String(), "/"), mcpSlug, url.QueryEscape(state.ParentChallengeID))
+	if state.FinalRedirectURI != "" {
+		if u, perr := url.Parse(state.FinalRedirectURI); perr == nil {
+			q := u.Query()
+			q.Set("issuer_connected", "1")
+			u.RawQuery = q.Encode()
+			redirect = u.String()
+		} else {
+			redirect = state.FinalRedirectURI
+		}
+	}
 	http.Redirect(w, r, redirect, http.StatusSeeOther)
 	return nil
 }


### PR DESCRIPTION
## Summary

- Playground "Connect" now routes issuer-gated toolsets through a new `/oauth-external/issuer-connect` endpoint that builds an upstream OAuth challenge bound to the dashboard user's subject URN, so completing the flow lands a row in `remote_sessions` — the table the resolver reads from on `/mcp/{slug}`.
- `/oauth-external/status` and the "Connected" badge now consult `remote_sessions` (via `ChallengeManager.ConnectedClientIDs`) for issuer-gated toolsets instead of `user_oauth_tokens`.
- `oauthProtectedResourceURL` is built unconditionally in `ServeToolsetResolved`, so the security-check 401 fallback always carries a non-empty `Bearer resource_metadata="…"` URL (fixes the empty-header symptom for issuer-gated MCPs with required OAuth, e.g. `notion`).
- `HandleRemoteLoginCallback` honours an optional `FinalRedirectURI` on the parent challenge so the dashboard popup redirects back to its origin (with `?issuer_connected=1`) and auto-closes after the upstream token exchange writes `remote_sessions`.
- The Disconnect button is hidden for issuer-gated toolsets — disconnect support against `remote_sessions` is a follow-up.

Closes [AGE-2374](https://linear.app/speakeasy/issue/AGE-2374).

✻ Clauded...