### PR TITLE
fix(mcp): pin platform-toolset executor through dispatch

### DIFF
--- a/.changeset/assistant-trigger-self-update-fix.md
+++ b/.changeset/assistant-trigger-self-update-fix.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistants can now update their own triggers. Previously, calling `configure_trigger` on an existing trigger returned a generic internal error every time, even though the assistant could read its triggers fine — its scoped tool was being silently swapped for a stricter variant that demanded fields the assistant isn't allowed to send. As a side effect, an assistant's trigger list no longer leaks sibling assistants' triggers in the same project.

--- a/server/internal/gateway/models.go
+++ b/server/internal/gateway/models.go
@@ -1,13 +1,27 @@
 package gateway
 
 import (
+	"context"
 	"errors"
+	"io"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
+
+// PlatformDirectExecutor is the in-process call shape platform tools expose to
+// the runtime. PlatformToolCallPlan.Executor is set by callers that have
+// already resolved the executor (e.g. the platform-toolset endpoint, which
+// pins it to the toolset's matched entry) so the runtime skips its URN-keyed
+// registry lookup. Without this hook, an assistant-scoped executor in a
+// toolset slice can be silently overridden by a registry default that shares
+// the same URN.
+type PlatformDirectExecutor interface {
+	Call(ctx context.Context, env toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error
+}
 
 type FilterType string
 
@@ -135,6 +149,9 @@ type PlatformToolCallPlan struct {
 	OwnerKind   string `json:"owner_kind" yaml:"owner_kind"`
 	OwnerID     string `json:"owner_id" yaml:"owner_id"`
 	InputSchema []byte `json:"input_schema" yaml:"input_schema"`
+	// Executor pins this call to a specific executor instance and bypasses URN
+	// resolution in the platform runtime. In-process only; never serialized.
+	Executor PlatformDirectExecutor `json:"-" yaml:"-"`
 }
 
 // ExternalMCPToolCallPlan is an alias for externalmcp.ToolCallPlan.

--- a/server/internal/gateway/models.go
+++ b/server/internal/gateway/models.go
@@ -12,13 +12,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-// PlatformDirectExecutor is the in-process call shape platform tools expose to
-// the runtime. PlatformToolCallPlan.Executor is set by callers that have
-// already resolved the executor (e.g. the platform-toolset endpoint, which
-// pins it to the toolset's matched entry) so the runtime skips its URN-keyed
-// registry lookup. Without this hook, an assistant-scoped executor in a
-// toolset slice can be silently overridden by a registry default that shares
-// the same URN.
+// PlatformDirectExecutor lets a caller pin a specific executor to a plan so
+// the runtime skips URN resolution. Used where the caller's matching context
+// (e.g. a platform toolset slice) is more authoritative than the URN-keyed
+// registry — multiple scoped variants of one tool can share a URN.
 type PlatformDirectExecutor interface {
 	Call(ctx context.Context, env toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error
 }
@@ -149,8 +146,8 @@ type PlatformToolCallPlan struct {
 	OwnerKind   string `json:"owner_kind" yaml:"owner_kind"`
 	OwnerID     string `json:"owner_id" yaml:"owner_id"`
 	InputSchema []byte `json:"input_schema" yaml:"input_schema"`
-	// Executor pins this call to a specific executor instance and bypasses URN
-	// resolution in the platform runtime. In-process only; never serialized.
+	// Executor, when set, bypasses URN resolution in the platform runtime.
+	// In-process only; never serialized.
 	Executor PlatformDirectExecutor `json:"-" yaml:"-"`
 }
 

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -258,10 +258,8 @@ func (s *Service) callPlatformToolsetTool(
 		OwnerKind:   conv.PtrValOrEmpty(desc.OwnerKind, ""),
 		OwnerID:     conv.PtrValOrEmpty(desc.OwnerID, ""),
 		InputSchema: desc.InputSchema,
-		// The toolset slice is the source of truth for which executor backs a
-		// platform-toolset call. Skip the runtime's URN registry, which can
-		// hold a differently scoped variant (e.g. the non-assistant trigger
-		// tools registered for the general MCP path).
+		// The toolset slice is authoritative; the runtime's URN registry can
+		// hold a differently scoped variant of the same tool.
 		Executor: matched.Executor,
 	})
 

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -258,6 +258,11 @@ func (s *Service) callPlatformToolsetTool(
 		OwnerKind:   conv.PtrValOrEmpty(desc.OwnerKind, ""),
 		OwnerID:     conv.PtrValOrEmpty(desc.OwnerID, ""),
 		InputSchema: desc.InputSchema,
+		// The toolset slice is the source of truth for which executor backs a
+		// platform-toolset call. Skip the runtime's URN registry, which can
+		// hold a differently scoped variant (e.g. the non-assistant trigger
+		// tools registered for the general MCP path).
+		Executor: matched.Executor,
 	})
 
 	ctx, logger := o11y.EnrichToolCallContext(ctx, s.logger, descriptor.OrganizationSlug, descriptor.ProjectSlug)

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -141,12 +141,9 @@ func (s *Service) ExecuteTool(ctx context.Context, plan *gateway.ToolCallPlan, e
 		}
 	}
 
-	// Caller-supplied executor wins over the URN registry. Platform-toolset
-	// endpoints (assistants, etc.) pin the executor on the plan after matching
-	// against their toolset slice; falling back to URN lookup there would
-	// silently swap in a registry default that shares the same URN — see the
-	// assistant-scoped trigger tools, where the non-self-scoped variant
-	// rejects the input the assistant schema is allowed to send.
+	// A pinned executor wins over the URN registry: scoped variants of a
+	// platform tool share a URN, so the caller's match is more specific than
+	// what the registry would resolve.
 	if plan.Platform != nil && plan.Platform.Executor != nil {
 		var out bytes.Buffer
 		if err := plan.Platform.Executor.Call(ctx, env, requestBody, &out); err != nil {

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -141,6 +141,24 @@ func (s *Service) ExecuteTool(ctx context.Context, plan *gateway.ToolCallPlan, e
 		}
 	}
 
+	// Caller-supplied executor wins over the URN registry. Platform-toolset
+	// endpoints (assistants, etc.) pin the executor on the plan after matching
+	// against their toolset slice; falling back to URN lookup there would
+	// silently swap in a registry default that shares the same URN — see the
+	// assistant-scoped trigger tools, where the non-self-scoped variant
+	// rejects the input the assistant schema is allowed to send.
+	if plan.Platform != nil && plan.Platform.Executor != nil {
+		var out bytes.Buffer
+		if err := plan.Platform.Executor.Call(ctx, env, requestBody, &out); err != nil {
+			return nil, fmt.Errorf("execute platform tool %s: %w", plan.Descriptor.URN, err)
+		}
+		return &gateway.PlatformResult{
+			StatusCode:  http.StatusOK,
+			ContentType: "application/json",
+			Body:        out.Bytes(),
+		}, nil
+	}
+
 	executor, ok := s.executors[urnStr]
 	if !ok {
 		return nil, oops.E(oops.CodeNotFound, nil, "platform tool not found").Log(ctx, s.logger)

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -122,7 +122,7 @@ func TriggerExternalTools(db *pgxpool.Pool, app *bgtriggers.App, auditLogger *au
 }
 
 func (s *Service) ExecuteTool(ctx context.Context, plan *gateway.ToolCallPlan, env toolconfig.ToolCallEnv, requestBody io.Reader) (*gateway.PlatformResult, error) {
-	if plan == nil || plan.Kind != gateway.ToolKindPlatform || plan.Descriptor == nil {
+	if plan == nil || plan.Kind != gateway.ToolKindPlatform || plan.Descriptor == nil || plan.Platform == nil {
 		return nil, fmt.Errorf("invalid platform tool plan")
 	}
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -144,7 +144,7 @@ func (s *Service) ExecuteTool(ctx context.Context, plan *gateway.ToolCallPlan, e
 	// A pinned executor wins over the URN registry: scoped variants of a
 	// platform tool share a URN, so the caller's match is more specific than
 	// what the registry would resolve.
-	if plan.Platform != nil && plan.Platform.Executor != nil {
+	if plan.Platform.Executor != nil {
 		var out bytes.Buffer
 		if err := plan.Platform.Executor.Call(ctx, env, requestBody, &out); err != nil {
 			return nil, fmt.Errorf("execute platform tool %s: %w", plan.Descriptor.URN, err)

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -56,6 +56,7 @@ func TestService_ExecuteTool_RequiresProjectAuthContext(t *testing.T) {
 			ProjectID: projectID.String(),
 			URN:       urn.NewTool(urn.ToolKindPlatform, "logs", "search_logs"),
 		},
+		Platform: &gateway.PlatformToolCallPlan{},
 	}, toolconfig.ToolCallEnv{
 		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
 		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
@@ -82,6 +83,7 @@ func TestService_ExecuteTool_RejectsMismatchedProjectAuthContext(t *testing.T) {
 			ProjectID: descriptorProjectID.String(),
 			URN:       urn.NewTool(urn.ToolKindPlatform, "logs", "search_logs"),
 		},
+		Platform: &gateway.PlatformToolCallPlan{},
 	}, toolconfig.ToolCallEnv{
 		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
 		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -2,6 +2,10 @@ package runtime
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,6 +18,31 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
+
+type stubDirectExecutor struct {
+	response string
+	err      error
+	called   bool
+	gotBody  string
+}
+
+func (s *stubDirectExecutor) Call(_ context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	s.called = true
+	if payload != nil {
+		body, err := io.ReadAll(payload)
+		if err != nil {
+			return fmt.Errorf("read payload: %w", err)
+		}
+		s.gotBody = string(body)
+	}
+	if s.err != nil {
+		return s.err
+	}
+	if _, err := io.WriteString(wr, s.response); err != nil {
+		return fmt.Errorf("write response: %w", err)
+	}
+	return nil
+}
 
 func TestService_ExecuteTool_RequiresProjectAuthContext(t *testing.T) {
 	t.Parallel()
@@ -61,4 +90,131 @@ func TestService_ExecuteTool_RejectsMismatchedProjectAuthContext(t *testing.T) {
 	}, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "does not match project")
+}
+
+func TestService_ExecuteTool_UsesPlanExecutorOverride(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(testenv.NewLogger(t), nil, nil, audit.NewLogger())
+	projectID := uuid.New()
+	ctx := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{
+		ActiveOrganizationID:  "org-1",
+		UserID:                "user-1",
+		ExternalUserID:        "",
+		APIKeyID:              "",
+		SessionID:             nil,
+		ProjectID:             &projectID,
+		OrganizationSlug:      "org",
+		Email:                 nil,
+		AccountType:           "",
+		HasActiveSubscription: false,
+		Whitelisted:           false,
+		ProjectSlug:           nil,
+		APIKeyScopes:          nil,
+		IsAdmin:               false,
+	})
+
+	exec := &stubDirectExecutor{response: `{"ok":true}`, err: nil, called: false, gotBody: ""}
+
+	// The plan's URN deliberately points at no registered executor; the
+	// override must short-circuit the registry lookup that would otherwise
+	// 404.
+	result, err := svc.ExecuteTool(ctx, &gateway.ToolCallPlan{
+		Kind:        gateway.ToolKindPlatform,
+		BillingType: "",
+		Descriptor: &gateway.ToolDescriptor{
+			ID:               "",
+			Name:             "",
+			Description:      nil,
+			DeploymentID:     "",
+			ProjectID:        projectID.String(),
+			ProjectSlug:      "",
+			OrganizationID:   "",
+			OrganizationSlug: "",
+			URN:              urn.NewTool(urn.ToolKindPlatform, "unregistered", "tool"),
+		},
+		HTTP:     nil,
+		Function: nil,
+		Prompt:   nil,
+		Platform: &gateway.PlatformToolCallPlan{
+			SourceSlug:  "unregistered",
+			Managed:     false,
+			OwnerKind:   "",
+			OwnerID:     "",
+			InputSchema: nil,
+			Executor:    exec,
+		},
+		ExternalMCP: nil,
+	}, toolconfig.ToolCallEnv{
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		OAuthToken: "",
+		GramEmail:  "",
+	}, strings.NewReader(`{"hello":"world"}`))
+	require.NoError(t, err)
+	require.True(t, exec.called)
+	require.JSONEq(t, `{"hello":"world"}`, exec.gotBody)
+	require.NotNil(t, result)
+	require.JSONEq(t, `{"ok":true}`, string(result.Body))
+}
+
+func TestService_ExecuteTool_PlanExecutorOverrideSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(testenv.NewLogger(t), nil, nil, audit.NewLogger())
+	projectID := uuid.New()
+	ctx := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{
+		ActiveOrganizationID:  "org-1",
+		UserID:                "user-1",
+		ExternalUserID:        "",
+		APIKeyID:              "",
+		SessionID:             nil,
+		ProjectID:             &projectID,
+		OrganizationSlug:      "org",
+		Email:                 nil,
+		AccountType:           "",
+		HasActiveSubscription: false,
+		Whitelisted:           false,
+		ProjectSlug:           nil,
+		APIKeyScopes:          nil,
+		IsAdmin:               false,
+	})
+
+	exec := &stubDirectExecutor{response: "", err: errors.New("boom"), called: false, gotBody: ""}
+
+	_, err := svc.ExecuteTool(ctx, &gateway.ToolCallPlan{
+		Kind:        gateway.ToolKindPlatform,
+		BillingType: "",
+		Descriptor: &gateway.ToolDescriptor{
+			ID:               "",
+			Name:             "",
+			Description:      nil,
+			DeploymentID:     "",
+			ProjectID:        projectID.String(),
+			ProjectSlug:      "",
+			OrganizationID:   "",
+			OrganizationSlug: "",
+			URN:              urn.NewTool(urn.ToolKindPlatform, "unregistered", "tool"),
+		},
+		HTTP:     nil,
+		Function: nil,
+		Prompt:   nil,
+		Platform: &gateway.PlatformToolCallPlan{
+			SourceSlug:  "unregistered",
+			Managed:     false,
+			OwnerKind:   "",
+			OwnerID:     "",
+			InputSchema: nil,
+			Executor:    exec,
+		},
+		ExternalMCP: nil,
+	}, toolconfig.ToolCallEnv{
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		OAuthToken: "",
+		GramEmail:  "",
+	}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "boom")
+	require.True(t, exec.called)
 }

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -92,64 +92,34 @@ func TestService_ExecuteTool_RejectsMismatchedProjectAuthContext(t *testing.T) {
 	require.ErrorContains(t, err, "does not match project")
 }
 
+// overridePlan builds a plan whose URN is unregistered, so any test that
+// reaches the URN registry instead of the pinned executor would 404.
+func overridePlan(projectID uuid.UUID, exec gateway.PlatformDirectExecutor) *gateway.ToolCallPlan {
+	return &gateway.ToolCallPlan{
+		Kind: gateway.ToolKindPlatform,
+		Descriptor: &gateway.ToolDescriptor{
+			ProjectID: projectID.String(),
+			URN:       urn.NewTool(urn.ToolKindPlatform, "unregistered", "tool"),
+		},
+		Platform: &gateway.PlatformToolCallPlan{Executor: exec},
+	}
+}
+
 func TestService_ExecuteTool_UsesPlanExecutorOverride(t *testing.T) {
 	t.Parallel()
 
 	svc := NewService(testenv.NewLogger(t), nil, nil, audit.NewLogger())
 	projectID := uuid.New()
 	ctx := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{
-		ActiveOrganizationID:  "org-1",
-		UserID:                "user-1",
-		ExternalUserID:        "",
-		APIKeyID:              "",
-		SessionID:             nil,
-		ProjectID:             &projectID,
-		OrganizationSlug:      "org",
-		Email:                 nil,
-		AccountType:           "",
-		HasActiveSubscription: false,
-		Whitelisted:           false,
-		ProjectSlug:           nil,
-		APIKeyScopes:          nil,
-		IsAdmin:               false,
+		ActiveOrganizationID: "org-1",
+		ProjectID:            &projectID,
 	})
 
-	exec := &stubDirectExecutor{response: `{"ok":true}`, err: nil, called: false, gotBody: ""}
+	exec := &stubDirectExecutor{response: `{"ok":true}`}
 
-	// The plan's URN deliberately points at no registered executor; the
-	// override must short-circuit the registry lookup that would otherwise
-	// 404.
-	result, err := svc.ExecuteTool(ctx, &gateway.ToolCallPlan{
-		Kind:        gateway.ToolKindPlatform,
-		BillingType: "",
-		Descriptor: &gateway.ToolDescriptor{
-			ID:               "",
-			Name:             "",
-			Description:      nil,
-			DeploymentID:     "",
-			ProjectID:        projectID.String(),
-			ProjectSlug:      "",
-			OrganizationID:   "",
-			OrganizationSlug: "",
-			URN:              urn.NewTool(urn.ToolKindPlatform, "unregistered", "tool"),
-		},
-		HTTP:     nil,
-		Function: nil,
-		Prompt:   nil,
-		Platform: &gateway.PlatformToolCallPlan{
-			SourceSlug:  "unregistered",
-			Managed:     false,
-			OwnerKind:   "",
-			OwnerID:     "",
-			InputSchema: nil,
-			Executor:    exec,
-		},
-		ExternalMCP: nil,
-	}, toolconfig.ToolCallEnv{
+	result, err := svc.ExecuteTool(ctx, overridePlan(projectID, exec), toolconfig.ToolCallEnv{
 		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
 		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
-		OAuthToken: "",
-		GramEmail:  "",
 	}, strings.NewReader(`{"hello":"world"}`))
 	require.NoError(t, err)
 	require.True(t, exec.called)
@@ -164,55 +134,15 @@ func TestService_ExecuteTool_PlanExecutorOverrideSurfacesError(t *testing.T) {
 	svc := NewService(testenv.NewLogger(t), nil, nil, audit.NewLogger())
 	projectID := uuid.New()
 	ctx := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{
-		ActiveOrganizationID:  "org-1",
-		UserID:                "user-1",
-		ExternalUserID:        "",
-		APIKeyID:              "",
-		SessionID:             nil,
-		ProjectID:             &projectID,
-		OrganizationSlug:      "org",
-		Email:                 nil,
-		AccountType:           "",
-		HasActiveSubscription: false,
-		Whitelisted:           false,
-		ProjectSlug:           nil,
-		APIKeyScopes:          nil,
-		IsAdmin:               false,
+		ActiveOrganizationID: "org-1",
+		ProjectID:            &projectID,
 	})
 
-	exec := &stubDirectExecutor{response: "", err: errors.New("boom"), called: false, gotBody: ""}
+	exec := &stubDirectExecutor{err: errors.New("boom")}
 
-	_, err := svc.ExecuteTool(ctx, &gateway.ToolCallPlan{
-		Kind:        gateway.ToolKindPlatform,
-		BillingType: "",
-		Descriptor: &gateway.ToolDescriptor{
-			ID:               "",
-			Name:             "",
-			Description:      nil,
-			DeploymentID:     "",
-			ProjectID:        projectID.String(),
-			ProjectSlug:      "",
-			OrganizationID:   "",
-			OrganizationSlug: "",
-			URN:              urn.NewTool(urn.ToolKindPlatform, "unregistered", "tool"),
-		},
-		HTTP:     nil,
-		Function: nil,
-		Prompt:   nil,
-		Platform: &gateway.PlatformToolCallPlan{
-			SourceSlug:  "unregistered",
-			Managed:     false,
-			OwnerKind:   "",
-			OwnerID:     "",
-			InputSchema: nil,
-			Executor:    exec,
-		},
-		ExternalMCP: nil,
-	}, toolconfig.ToolCallEnv{
+	_, err := svc.ExecuteTool(ctx, overridePlan(projectID, exec), toolconfig.ToolCallEnv{
 		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
 		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
-		OAuthToken: "",
-		GramEmail:  "",
 	}, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "boom")

--- a/server/internal/toolsets/shared.go
+++ b/server/internal/toolsets/shared.go
@@ -134,6 +134,7 @@ func (t *Toolsets) extractPlatformToolCallPlan(ctx context.Context, projectID uu
 		OwnerKind:   conv.PtrValOrEmpty(tool.OwnerKind, ""),
 		OwnerID:     conv.PtrValOrEmpty(tool.OwnerID, ""),
 		InputSchema: tool.InputSchema,
+		Executor:    nil,
 	}
 
 	return gateway.NewPlatformToolCallPlan(descriptor, plan), nil


### PR DESCRIPTION
## Summary

- Assistants calling `configure_trigger` on an existing trigger were getting `-32603 internal error` on every update. The `/platform/mcp/{slug}` endpoint matched the assistant-scoped executor from the toolset slice for listing/auth, but then dispatched through the runtime's URN-keyed registry, which had the default (non-assistant) variant registered under the same URN. The default variant requires `target_kind`/`target_ref`/`target_display` in input — fields the assistant schema strips — so the call died with `target_ref is required`, masked as a generic internal error by the platform call wrapper.
- Adds `PlatformDirectExecutor` on `PlatformToolCallPlan` and pins it to the matched executor in `callPlatformToolsetTool`. The runtime Service prefers the override before falling back to the URN registry, so the toolset slice becomes the single source of truth for platform-toolset dispatch.
- Side-effect fix: assistant `list_triggers` now applies its self-scoping filter again. Both list and configure were silently running as the non-assistant variants under the same wiring bug; list "worked" only because the default variant has no required input and returned every trigger in the project, including ones owned by sibling assistants.
- Unit tests cover both the override hit path and error propagation through it.

✻ Clauded...