### PR TITLE
chore: add glint rule for audit action naming

### DIFF
--- a/glint/audit_action_naming.go
+++ b/glint/audit_action_naming.go
@@ -1,0 +1,112 @@
+package glint
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	auditActionNamingAnalyzer = "auditactionnaming"
+	auditActionNamingDoc      = "audit Action constants must use <namespace>:<verb> names with lowercase snake_case segments"
+)
+
+type auditActionNamingSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newAuditActionNamingAnalyzer(rule auditActionNamingSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: auditActionNamingAnalyzer,
+		Doc:  auditActionNamingDoc,
+		Run: func(pass *analysis.Pass) (any, error) {
+			if !strings.HasSuffix(pass.Pkg.Path(), auditPkgPathSuffix) {
+				return nil, nil
+			}
+
+			for _, file := range pass.Files {
+				for _, decl := range file.Decls {
+					genDecl, ok := decl.(*ast.GenDecl)
+					if !ok || genDecl.Tok != token.CONST {
+						continue
+					}
+
+					for _, spec := range genDecl.Specs {
+						valueSpec, ok := spec.(*ast.ValueSpec)
+						if !ok {
+							continue
+						}
+
+						for _, name := range valueSpec.Names {
+							actionName, ok := auditActionConstName(pass.TypesInfo.Defs[name])
+							if !ok {
+								continue
+							}
+
+							if isAuditActionName(actionName) {
+								continue
+							}
+
+							pass.ReportRangef(name, "name audit action %q as <namespace>:<verb> with lowercase snake_case segments", actionName)
+						}
+					}
+				}
+			}
+
+			return nil, nil
+		},
+	}
+}
+
+func auditActionConstName(obj types.Object) (string, bool) {
+	constantObj, ok := obj.(*types.Const)
+	if !ok || constantObj.Val().Kind() != constant.String {
+		return "", false
+	}
+
+	named, ok := constantObj.Type().(*types.Named)
+	if !ok {
+		return "", false
+	}
+
+	typeName := named.Obj()
+	if typeName == nil || typeName.Pkg() == nil {
+		return "", false
+	}
+
+	if typeName.Name() != "Action" || !strings.HasSuffix(typeName.Pkg().Path(), auditPkgPathSuffix) {
+		return "", false
+	}
+
+	return constant.StringVal(constantObj.Val()), true
+}
+
+func isAuditActionName(name string) bool {
+	parts := strings.Split(name, ":")
+	if len(parts) != 2 {
+		return false
+	}
+
+	return isAuditActionSegment(parts[0]) && isAuditActionSegment(parts[1])
+}
+
+func isAuditActionSegment(segment string) bool {
+	if segment == "" {
+		return false
+	}
+
+	for _, r := range segment {
+		if r == '_' {
+			continue
+		}
+		if r < 'a' || r > 'z' {
+			return false
+		}
+	}
+
+	return true
+}

--- a/glint/audit_action_naming_test.go
+++ b/glint/audit_action_naming_test.go
@@ -1,0 +1,34 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAuditActionNaming(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditActionNamingAnalyzer(auditActionNamingSettings{}), "auditactionnaming/server/internal/audit")
+}
+
+func TestAuditActionNamingSkipsNonAuditPackage(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAuditActionNamingAnalyzer(auditActionNamingSettings{}), "notaudit")
+}
+
+func TestBuildAnalyzersSkipsDisabledAuditActionNaming(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+	p.settings.Rules.AuditActionNaming.Disabled = false
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, auditActionNamingAnalyzer, analyzers[0].Name)
+}

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -29,6 +29,7 @@ type ruleSettings struct {
 	AuditEventTypedSnapshot    auditEventTypedSnapshotSettings    `json:"audit-event-typed-snapshot"`
 	AuditEventURNNaming        auditEventURNNamingSettings        `json:"audit-event-urn-naming"`
 	AuditEventURNTyping        auditEventURNTypingSettings        `json:"audit-event-urn-typing"`
+	AuditActionNaming          auditActionNamingSettings          `json:"audit-action-naming"`
 	NoDirectChatMessageInsert  noDirectChatMessageInsertSettings  `json:"no-direct-chat-message-insert"`
 	NoSqlErrNoRows             noSqlErrNoRowsSettings             `json:"no-sql-err-no-rows"`
 	NoTestingRawSql            noTestingRawSqlSettings            `json:"no-testing-raw-sql"`
@@ -75,6 +76,9 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	}
 	if !p.settings.Rules.AuditEventURNTyping.Disabled {
 		analyzers = append(analyzers, newAuditEventURNTypingAnalyzer(p.settings.Rules.AuditEventURNTyping))
+	}
+	if !p.settings.Rules.AuditActionNaming.Disabled {
+		analyzers = append(analyzers, newAuditActionNamingAnalyzer(p.settings.Rules.AuditActionNaming))
 	}
 	if !p.settings.Rules.NoDirectChatMessageInsert.Disabled {
 		analyzers = append(analyzers, newNoDirectChatMessageInsertAnalyzer(p.settings.Rules.NoDirectChatMessageInsert))

--- a/glint/plugin_test.go
+++ b/glint/plugin_test.go
@@ -21,6 +21,7 @@ func disabledAllRulesPlugin() *plugin {
 				AuditEventTypedSnapshot:    auditEventTypedSnapshotSettings{Disabled: true},
 				AuditEventURNNaming:        auditEventURNNamingSettings{Disabled: true},
 				AuditEventURNTyping:        auditEventURNTypingSettings{Disabled: true},
+				AuditActionNaming:          auditActionNamingSettings{Disabled: true},
 				NoDirectChatMessageInsert:  noDirectChatMessageInsertSettings{Disabled: true},
 				NoSqlErrNoRows:             noSqlErrNoRowsSettings{Disabled: true},
 				NoTestingRawSql:            noTestingRawSqlSettings{Disabled: true},
@@ -44,5 +45,5 @@ func TestBuildAnalyzersAllEnabled(t *testing.T) {
 	p := &plugin{}
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
-	require.Len(t, analyzers, 12)
+	require.Len(t, analyzers, 13)
 }

--- a/glint/testdata/src/auditactionnaming/server/internal/audit/action_naming.go
+++ b/glint/testdata/src/auditactionnaming/server/internal/audit/action_naming.go
@@ -1,0 +1,17 @@
+package audit
+
+type Action string
+
+const (
+	ActionGood              Action = "api_key:create"
+	ActionGoodUnderscore    Action = "remote_session_client:delete"
+	ActionHyphenNamespace   Action = "api-key:create"    // want "name audit action \"api-key:create\" as <namespace>:<verb> with lowercase snake_case segments"
+	ActionUpperNamespace    Action = "Api:create"        // want "name audit action \"Api:create\" as <namespace>:<verb> with lowercase snake_case segments"
+	ActionMissingColon      Action = "project_create"    // want "name audit action \"project_create\" as <namespace>:<verb> with lowercase snake_case segments"
+	ActionEmptyNamespace    Action = ":create"           // want "name audit action \":create\" as <namespace>:<verb> with lowercase snake_case segments"
+	ActionEmptyVerb         Action = "project:"          // want "name audit action \"project:\" as <namespace>:<verb> with lowercase snake_case segments"
+	ActionUpperVerb         Action = "project:Create"    // want "name audit action \"project:Create\" as <namespace>:<verb> with lowercase snake_case segments"
+	ActionHyphenVerb        Action = "project:re-create" // want "name audit action \"project:re-create\" as <namespace>:<verb> with lowercase snake_case segments"
+	ActionMultipleColons    Action = "project:role:set"  // want "name audit action \"project:role:set\" as <namespace>:<verb> with lowercase snake_case segments"
+	NonActionStringConstant        = "api-key:create"
+)

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -148,6 +148,8 @@ linters:
               disabled: false
             audit-event-urn-typing:
               disabled: false
+            audit-action-naming:
+              disabled: true
     gosec:
       excludes:
         # Temporarily ignore this lint rule because it needs to be a separate


### PR DESCRIPTION
Introduce an auditactionnaming analyzer that checks server/internal/audit Action constants use the <namespace>:<verb> format with lowercase snake_case segments.