### PR TITLE
chore: consolidate telemetry api_host to metrics.speakeasy.com

### DIFF
--- a/client/dashboard/src/contexts/TelemetryProvider.tsx
+++ b/client/dashboard/src/contexts/TelemetryProvider.tsx
@@ -21,9 +21,7 @@ export const TelemetryProvider = (props: { children: ReactNode }) => {
       ? "phc_hiYSF5Axu49I1xs4Z5BG8KCI3PGNLM8ERRs7eocmfX9"
       : "phc_5S3YhOs1lONwM2yKa0ytVSAyWOR2GhVhwAebkyi022l",
     {
-      api_host: isProd
-        ? "https://metrics.speakeasy.com"
-        : "https://metrics.dev.speakeasy.com",
+      api_host: "https://metrics.speakeasy.com",
       feature_flag_request_timeout_ms: 1000,
     },
     "speakeasy",


### PR DESCRIPTION
## Summary
- Consolidate PostHog `api_host` to always use `https://metrics.speakeasy.com` for all environments
- Previously, non-prod environments used `metrics.dev.speakeasy.com` while prod used `metrics.speakeasy.com`
- PostHog project keys still differ per environment, so analytics data remains separated

## Test plan
- [ ] Verify PostHog events route correctly in dev/staging environments
- [ ] Confirm prod telemetry is unaffected