### PR TITLE
chore: move invite callback under /rpc

### DIFF
--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -115,7 +115,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 	}
 }
 
-const inviteCallbackPath = "/v1/auth/invite/callback"
+const inviteCallbackPath = "/rpc/organizations.inviteCallback"
 
 func Attach(mux goahttp.Muxer, service *Service) {
 	endpoints := gen.NewEndpoints(service)


### PR DESCRIPTION
## Summary

- Moves invite callback from `/v1/auth/invite/callback` to `/rpc/organizations.inviteCallback`
- The `/v1/auth` path wasn't in the ingress server routes, so it fell through to the dashboard catch-all
- Under `/rpc`, it's automatically routed to gram-server by existing ingress rules
- Once deployed, the `/v1/auth` ingress route added in [gram-infra#881](https://github.com/speakeasy-api/gram-infra/pull/881) can be reverted

## Context

When clicking an invite magic link, the OIDC code was never exchanged server-side because the callback hit the dashboard SPA instead of gram-server. The inviter's existing session cookie was used, logging the user in as the inviter rather than the invitee.

## Test plan

- [ ] Deploy to dev
- [ ] Send invite to a different email
- [ ] Click magic link → verify logged in as invitee, not inviter
- [ ] Verify normal `/rpc/auth.*` routes unaffected