### PR TITLE
chore: Migrate mcp_servers to user_session_issuer_id column

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2399,8 +2399,7 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   slug TEXT CHECK (slug IS NULL OR slug <> ''),
 
   environment_id uuid,
-  external_oauth_server_id uuid,
-  oauth_proxy_server_id uuid,
+  user_session_issuer_id uuid,
   remote_mcp_server_id uuid,
   toolset_id uuid,
   visibility TEXT NOT NULL CHECK (visibility <> ''),
@@ -2413,8 +2412,7 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_pkey PRIMARY KEY (id),
   CONSTRAINT mcp_servers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
   CONSTRAINT mcp_servers_environment_id_fkey FOREIGN KEY (environment_id) REFERENCES environments (id) ON DELETE SET NULL,
-  CONSTRAINT mcp_servers_external_oauth_server_id_fkey FOREIGN KEY (external_oauth_server_id) REFERENCES external_oauth_server_metadata (id) ON DELETE SET NULL,
-  CONSTRAINT mcp_servers_oauth_proxy_server_id_fkey FOREIGN KEY (oauth_proxy_server_id) REFERENCES oauth_proxy_servers (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_servers_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_remote_mcp_server_id_fkey FOREIGN KEY (remote_mcp_server_id) REFERENCES remote_mcp_servers (id) ON DELETE RESTRICT,
   CONSTRAINT mcp_servers_toolset_id_fkey FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE RESTRICT,
   -- Exactly one backend must be set: either a remote MCP server or a toolset.

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -691,20 +691,19 @@ type McpRegistry struct {
 }
 
 type McpServer struct {
-	ID                    uuid.UUID
-	ProjectID             uuid.UUID
-	Name                  pgtype.Text
-	Slug                  pgtype.Text
-	EnvironmentID         uuid.NullUUID
-	ExternalOauthServerID uuid.NullUUID
-	OauthProxyServerID    uuid.NullUUID
-	RemoteMcpServerID     uuid.NullUUID
-	ToolsetID             uuid.NullUUID
-	Visibility            string
-	CreatedAt             pgtype.Timestamptz
-	UpdatedAt             pgtype.Timestamptz
-	DeletedAt             pgtype.Timestamptz
-	Deleted               bool
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	Name                pgtype.Text
+	Slug                pgtype.Text
+	EnvironmentID       uuid.NullUUID
+	UserSessionIssuerID uuid.NullUUID
+	RemoteMcpServerID   uuid.NullUUID
+	ToolsetID           uuid.NullUUID
+	Visibility          string
+	CreatedAt           pgtype.Timestamptz
+	UpdatedAt           pgtype.Timestamptz
+	DeletedAt           pgtype.Timestamptz
+	Deleted             bool
 }
 
 type OauthProxyClientInfo struct {

--- a/server/internal/mcpservers/repo/models.go
+++ b/server/internal/mcpservers/repo/models.go
@@ -10,18 +10,17 @@ import (
 )
 
 type McpServer struct {
-	ID                    uuid.UUID
-	ProjectID             uuid.UUID
-	Name                  pgtype.Text
-	Slug                  pgtype.Text
-	EnvironmentID         uuid.NullUUID
-	ExternalOauthServerID uuid.NullUUID
-	OauthProxyServerID    uuid.NullUUID
-	RemoteMcpServerID     uuid.NullUUID
-	ToolsetID             uuid.NullUUID
-	Visibility            string
-	CreatedAt             pgtype.Timestamptz
-	UpdatedAt             pgtype.Timestamptz
-	DeletedAt             pgtype.Timestamptz
-	Deleted               bool
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+	Name                pgtype.Text
+	Slug                pgtype.Text
+	EnvironmentID       uuid.NullUUID
+	UserSessionIssuerID uuid.NullUUID
+	RemoteMcpServerID   uuid.NullUUID
+	ToolsetID           uuid.NullUUID
+	Visibility          string
+	CreatedAt           pgtype.Timestamptz
+	UpdatedAt           pgtype.Timestamptz
+	DeletedAt           pgtype.Timestamptz
+	Deleted             bool
 }

--- a/server/internal/mcpservers/repo/queries.sql.go
+++ b/server/internal/mcpservers/repo/queries.sql.go
@@ -26,7 +26,7 @@ VALUES (
     $4,
     $5
 )
-RETURNING id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateMCPServerParams struct {
@@ -52,8 +52,7 @@ func (q *Queries) CreateMCPServer(ctx context.Context, arg CreateMCPServerParams
 		&i.Name,
 		&i.Slug,
 		&i.EnvironmentID,
-		&i.ExternalOauthServerID,
-		&i.OauthProxyServerID,
+		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
 		&i.Visibility,
@@ -69,7 +68,7 @@ const deleteMCPServer = `-- name: DeleteMCPServer :one
 UPDATE mcp_servers
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteMCPServerParams struct {
@@ -86,8 +85,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 		&i.Name,
 		&i.Slug,
 		&i.EnvironmentID,
-		&i.ExternalOauthServerID,
-		&i.OauthProxyServerID,
+		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
 		&i.Visibility,
@@ -100,7 +98,7 @@ func (q *Queries) DeleteMCPServer(ctx context.Context, arg DeleteMCPServerParams
 }
 
 const getMCPServerByID = `-- name: GetMCPServerByID :one
-SELECT id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -119,8 +117,7 @@ func (q *Queries) GetMCPServerByID(ctx context.Context, arg GetMCPServerByIDPara
 		&i.Name,
 		&i.Slug,
 		&i.EnvironmentID,
-		&i.ExternalOauthServerID,
-		&i.OauthProxyServerID,
+		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
 		&i.Visibility,
@@ -133,7 +130,7 @@ func (q *Queries) GetMCPServerByID(ctx context.Context, arg GetMCPServerByIDPara
 }
 
 const listMCPServersByProjectID = `-- name: ListMCPServersByProjectID :many
-SELECT id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 FROM mcp_servers
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -163,8 +160,7 @@ func (q *Queries) ListMCPServersByProjectID(ctx context.Context, arg ListMCPServ
 			&i.Name,
 			&i.Slug,
 			&i.EnvironmentID,
-			&i.ExternalOauthServerID,
-			&i.OauthProxyServerID,
+			&i.UserSessionIssuerID,
 			&i.RemoteMcpServerID,
 			&i.ToolsetID,
 			&i.Visibility,
@@ -192,7 +188,7 @@ SET
     visibility = $4,
     updated_at = clock_timestamp()
 WHERE id = $5 AND project_id = $6 AND deleted IS FALSE
-RETURNING id, project_id, name, slug, environment_id, external_oauth_server_id, oauth_proxy_server_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, slug, environment_id, user_session_issuer_id, remote_mcp_server_id, toolset_id, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateMCPServerParams struct {
@@ -220,8 +216,7 @@ func (q *Queries) UpdateMCPServer(ctx context.Context, arg UpdateMCPServerParams
 		&i.Name,
 		&i.Slug,
 		&i.EnvironmentID,
-		&i.ExternalOauthServerID,
-		&i.OauthProxyServerID,
+		&i.UserSessionIssuerID,
 		&i.RemoteMcpServerID,
 		&i.ToolsetID,
 		&i.Visibility,

--- a/server/migrations/20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql
+++ b/server/migrations/20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql
@@ -1,0 +1,2 @@
+-- Modify "mcp_servers" table
+ALTER TABLE "mcp_servers" DROP COLUMN "external_oauth_server_id", DROP COLUMN "oauth_proxy_server_id", ADD COLUMN "user_session_issuer_id" uuid NULL, ADD CONSTRAINT "mcp_servers_user_session_issuer_id_fkey" FOREIGN KEY ("user_session_issuer_id") REFERENCES "user_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/server/migrations/20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql
+++ b/server/migrations/20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql
@@ -1,2 +1,3 @@
+-- atlas:nolint DS103
 -- Modify "mcp_servers" table
 ALTER TABLE "mcp_servers" DROP COLUMN "external_oauth_server_id", DROP COLUMN "oauth_proxy_server_id", ADD COLUMN "user_session_issuer_id" uuid NULL, ADD CONSTRAINT "mcp_servers_user_session_issuer_id_fkey" FOREIGN KEY ("user_session_issuer_id") REFERENCES "user_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:li4uDwWu94a+oPCtQsWoG04YQk7/NwhhMndrHnN5DZY=
+h1:OLmMeJJdIU+ScVppKRSNXG8swH5ZXzl2VjW7dpwSuZw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -181,4 +181,4 @@ h1:li4uDwWu94a+oPCtQsWoG04YQk7/NwhhMndrHnN5DZY=
 20260515094400_add_workos_role_assignments_deleted_at.sql h1:peR1HLGXocOJyh1WwnuLyDKzP+R47IMEB5Kho7lNuXg=
 20260515120000_ai-integration-configs.sql h1:bR1UTZ9lHjJUsJL1LY0ByUTkWefnmPOhovosRGRSJc0=
 20260518114737_add_effect_to_principal_grants.sql h1:J3lR6SeKv0v+S+ecUzf2oHgI2nI5aXCZXKimjxWmLOo=
-20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql h1:Gt7Ao+85WLw/fhfyHT6pbNA7Q7GdBNCyBTqKFeqLONk=
+20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql h1:sfZwy1S/Axh3pmIYxEW0/ODPqfZ8H4+id0EhWc8LNac=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:85vcqCBvfObg3aFVoPEWT+d8ofrrSGY0nnkgk6JWfqM=
+h1:li4uDwWu94a+oPCtQsWoG04YQk7/NwhhMndrHnN5DZY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -181,3 +181,4 @@ h1:85vcqCBvfObg3aFVoPEWT+d8ofrrSGY0nnkgk6JWfqM=
 20260515094400_add_workos_role_assignments_deleted_at.sql h1:peR1HLGXocOJyh1WwnuLyDKzP+R47IMEB5Kho7lNuXg=
 20260515120000_ai-integration-configs.sql h1:bR1UTZ9lHjJUsJL1LY0ByUTkWefnmPOhovosRGRSJc0=
 20260518114737_add_effect_to_principal_grants.sql h1:J3lR6SeKv0v+S+ecUzf2oHgI2nI5aXCZXKimjxWmLOo=
+20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql h1:Gt7Ao+85WLw/fhfyHT6pbNA7Q7GdBNCyBTqKFeqLONk=


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/AGE-2366/database-migration-to-add-user-session-issuer-id-to-mcp-servers

The `oauth_proxy_server_id` and `external_oauth_server_id` column code has already been removed. Confirmed the `mcp_servers` table has no rows in development and production.