### PR TITLE
fix(dashboard): show MCP servers for catalog-imported sources

### DIFF
--- a/client/dashboard/src/pages/sources/external-mcp/ExternalMCPDetails.tsx
+++ b/client/dashboard/src/pages/sources/external-mcp/ExternalMCPDetails.tsx
@@ -6,6 +6,7 @@ import { Heading } from "@/components/ui/heading";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
 import { useSdkClient } from "@/contexts/Sdk";
+import { attachmentToURNPrefix } from "@/lib/sources";
 import { useRoutes } from "@/routes";
 import {
   useLatestDeployment,
@@ -82,12 +83,16 @@ export default function ExternalMCPDetails() {
 
   const { data: toolsets, isLoading: isLoadingToolsets } = useListToolsets();
 
-  // Find ALL toolsets that use this external MCP source (could be multiple)
+  // Find ALL toolsets that use this external MCP source (could be multiple).
+  // A catalog-imported source contributes one URN per registry tool
+  // (`tools:externalmcp:<slug>:<toolName>`); only the no-tools fallback uses
+  // `:proxy`. Match the source-scoped prefix so both shapes are detected.
   const associatedToolsets = useMemo(() => {
     if (!toolsets?.toolsets || !source) return [];
 
+    const urnPrefix = attachmentToURNPrefix("externalmcp", source.slug);
     return toolsets.toolsets.filter((t) =>
-      t.toolUrns?.includes(`tools:externalmcp:${source.slug}:proxy`),
+      t.toolUrns?.some((urn) => urn.startsWith(urnPrefix)),
     );
   }, [toolsets, source]);
 


### PR DESCRIPTION
## Summary

- Source detail page for a catalog-imported External MCP (`/sources/externalmcp/<slug>`) was always rendering an empty MCP Servers tab, with the tab count stuck at 0, even when toolsets clearly included tools from that source.
- The filter at `client/dashboard/src/pages/sources/external-mcp/ExternalMCPDetails.tsx` only matched the URN shape `tools:externalmcp:<slug>:proxy`. On the backend, that URN is the fallback emitted only when the registry returns zero tools (`server/internal/externalmcp/process.go:260`). The common catalog-import path emits one URN per registry tool — `tools:externalmcp:<slug>:<toolName>` (`process.go:222`) — so the filter never matched.
- Switched to a source-scoped prefix match using the existing `attachmentToURNPrefix("externalmcp", slug)` helper from `client/dashboard/src/lib/sources.ts`, so toolsets are detected for both shapes (per-tool URNs *and* the proxy fallback).

## Test plan

- [ ] Open a project with a catalog-imported External MCP source that has been added to one or more toolsets.
- [ ] Navigate to `/sources/externalmcp/<slug>`.
- [ ] Verify the MCP Servers tab label includes the correct toolset count and the tab content lists each toolset that uses tools from this source.
- [ ] Verify the no-tools fallback path (catalog entries that surface only a proxy URN) still resolves to the same set of toolsets it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)