### PR TITLE
feat(hooks): check non-shadow MCP against org custom domains

### DIFF
--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -716,7 +716,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, payload *gen.ClaudePaylo
 	switch {
 	case matched == nil:
 		detail = fmt.Sprintf("MCP server %q is not in the active configuration", serverPrefix)
-	case matched.URL != "" && !isGramHostedMCPURL(matched.URL):
+	case matched.URL != "" && !s.isGramHostedMCPURLForOrg(ctx, matched.URL, metadata.GramOrgID):
 		detail = fmt.Sprintf("MCP server %q is not Gram-hosted (URL: %s)", serverPrefix, matched.URL)
 	case matched.URL == "" && matched.Command != "":
 		// Local stdio servers have no URL, so the Gram-hosted check above

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 )
 
@@ -114,8 +115,9 @@ func resolvedMCPMatch(matched *MCPServerEntry, serverPrefix string) string {
 }
 
 // isGramHostedMCPURL reports whether rawURL points at a Gram-managed MCP
-// server. Exact host match, case-insensitive.
-func isGramHostedMCPURL(rawURL string) bool {
+// server. Checks the canonical host plus any additional trusted hosts.
+// Exact host match, case-insensitive.
+func isGramHostedMCPURL(rawURL string, additionalTrustedHosts ...string) bool {
 	if rawURL == "" {
 		return false
 	}
@@ -123,7 +125,30 @@ func isGramHostedMCPURL(rawURL string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.EqualFold(u.Hostname(), gramHostedMCPHost)
+	hostname := u.Hostname()
+	if strings.EqualFold(hostname, gramHostedMCPHost) {
+		return true
+	}
+	for _, h := range additionalTrustedHosts {
+		if strings.EqualFold(hostname, h) {
+			return true
+		}
+	}
+	return false
+}
+
+// isGramHostedMCPURLForOrg checks if a URL is a Gram-managed MCP server for
+// the given organization. It checks against the canonical host plus any
+// verified and activated custom domain for the org.
+func (s *Service) isGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool {
+	if rawURL == "" || orgID == "" {
+		return isGramHostedMCPURL(rawURL)
+	}
+	customDomain, err := repo.New(s.db).GetCustomDomainByOrganization(ctx, orgID)
+	if err != nil || !customDomain.Verified || !customDomain.Activated {
+		return isGramHostedMCPURL(rawURL)
+	}
+	return isGramHostedMCPURL(rawURL, customDomain.Domain)
 }
 
 // isMatchedMCPApproved returns whether the call has been allowlisted

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -138,15 +138,19 @@ func isGramHostedMCPURL(rawURL string, additionalTrustedHosts ...string) bool {
 }
 
 // isGramHostedMCPURLForOrg checks if a URL is a Gram-managed MCP server for
-// the given organization. It checks against the canonical host plus any
-// verified and activated custom domain for the org.
+// the given organization. It checks against the canonical host first (no DB
+// hit), then falls back to checking the org's custom domain if needed.
 func (s *Service) isGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool {
+	// Fast path: check canonical host first to avoid DB lookup for app.getgram.ai URLs
+	if isGramHostedMCPURL(rawURL) {
+		return true
+	}
 	if rawURL == "" || orgID == "" {
-		return isGramHostedMCPURL(rawURL)
+		return false
 	}
 	customDomain, err := repo.New(s.db).GetCustomDomainByOrganization(ctx, orgID)
 	if err != nil || !customDomain.Verified || !customDomain.Activated {
-		return isGramHostedMCPURL(rawURL)
+		return false
 	}
 	return isGramHostedMCPURL(rawURL, customDomain.Domain)
 }

--- a/server/internal/hooks/mcp_match_test.go
+++ b/server/internal/hooks/mcp_match_test.go
@@ -60,26 +60,53 @@ func TestMatchCachedMCPEntry(t *testing.T) {
 
 func TestIsGramHostedMCPURL(t *testing.T) {
 	t.Parallel()
-	cases := []struct {
-		url  string
-		want bool
-	}{
-		{"https://app.getgram.ai/mcp/team-foo", true},
-		{"https://APP.GETGRAM.AI/mcp/team-foo", true}, // case-insensitive
-		{"http://app.getgram.ai/mcp/team-foo", true},  // http allowed (rare but valid)
-		{"https://chat.speakeasy.com/mcp/linear", false},
-		{"https://evil.getgram.ai/mcp/x", false}, // subdomain squat must NOT pass
-		{"https://mcp.slack.com/mcp", false},
-		{"http://localhost:8080/mcp/x", false},
-		{"", false},
-		{"not a url at all", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.url, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, isGramHostedMCPURL(tc.url))
-		})
-	}
+
+	t.Run("canonical host only", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			url  string
+			want bool
+		}{
+			{"https://app.getgram.ai/mcp/team-foo", true},
+			{"https://APP.GETGRAM.AI/mcp/team-foo", true}, // case-insensitive
+			{"http://app.getgram.ai/mcp/team-foo", true},  // http allowed (rare but valid)
+			{"https://chat.speakeasy.com/mcp/linear", false},
+			{"https://evil.getgram.ai/mcp/x", false}, // subdomain squat must NOT pass
+			{"https://mcp.slack.com/mcp", false},
+			{"http://localhost:8080/mcp/x", false},
+			{"", false},
+			{"not a url at all", false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.url, func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tc.want, isGramHostedMCPURL(tc.url))
+			})
+		}
+	})
+
+	t.Run("with additional trusted hosts", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			url         string
+			extraHosts  []string
+			want        bool
+			description string
+		}{
+			{"https://chat.speakeasy.com/mcp/linear", []string{"chat.speakeasy.com"}, true, "custom domain matches"},
+			{"https://CHAT.SPEAKEASY.COM/mcp/linear", []string{"chat.speakeasy.com"}, true, "custom domain case-insensitive"},
+			{"https://app.getgram.ai/mcp/x", []string{"chat.speakeasy.com"}, true, "canonical still works with extra hosts"},
+			{"https://other.example.com/mcp/x", []string{"chat.speakeasy.com"}, false, "unknown host rejected"},
+			{"https://mcp.slack.com/mcp", []string{"chat.speakeasy.com"}, false, "third party rejected"},
+			{"", []string{"chat.speakeasy.com"}, false, "empty URL"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.description, func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tc.want, isGramHostedMCPURL(tc.url, tc.extraHosts...))
+			})
+		}
+	})
 }
 
 func TestParseClaudeToolName(t *testing.T) {


### PR DESCRIPTION
Update the Gram-hosted MCP URL check to validate against the org's verified and activated custom domain in addition to app.getgram.ai. This allows orgs with custom domains (e.g. chat.speakeasy.com) to use MCP servers on their custom domain without triggering shadow MCP blocks.

https://claude.ai/code/session_01VtreBfx7tb3m7fD9SFPoAm