### PR TITLE
mig: add token_endpoint_auth_method to remote_session_clients

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -863,6 +863,7 @@ CREATE TABLE IF NOT EXISTS remote_session_clients (
   client_secret_encrypted TEXT,
   client_id_issued_at timestamptz,
   client_secret_expires_at timestamptz,
+  token_endpoint_auth_method TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1122,18 +1122,19 @@ type RemoteSession struct {
 }
 
 type RemoteSessionClient struct {
-	ID                    uuid.UUID
-	ProjectID             uuid.UUID
-	RemoteSessionIssuerID uuid.UUID
-	UserSessionIssuerID   uuid.UUID
-	ClientID              string
-	ClientSecretEncrypted pgtype.Text
-	ClientIDIssuedAt      pgtype.Timestamptz
-	ClientSecretExpiresAt pgtype.Timestamptz
-	CreatedAt             pgtype.Timestamptz
-	UpdatedAt             pgtype.Timestamptz
-	DeletedAt             pgtype.Timestamptz
-	Deleted               bool
+	ID                      uuid.UUID
+	ProjectID               uuid.UUID
+	RemoteSessionIssuerID   uuid.UUID
+	UserSessionIssuerID     uuid.UUID
+	ClientID                string
+	ClientSecretEncrypted   pgtype.Text
+	ClientIDIssuedAt        pgtype.Timestamptz
+	ClientSecretExpiresAt   pgtype.Timestamptz
+	TokenEndpointAuthMethod pgtype.Text
+	CreatedAt               pgtype.Timestamptz
+	UpdatedAt               pgtype.Timestamptz
+	DeletedAt               pgtype.Timestamptz
+	Deleted                 bool
 }
 
 type RemoteSessionIssuer struct {

--- a/server/internal/remotesessions/repo/models.go
+++ b/server/internal/remotesessions/repo/models.go
@@ -27,18 +27,19 @@ type RemoteSession struct {
 }
 
 type RemoteSessionClient struct {
-	ID                    uuid.UUID
-	ProjectID             uuid.UUID
-	RemoteSessionIssuerID uuid.UUID
-	UserSessionIssuerID   uuid.UUID
-	ClientID              string
-	ClientSecretEncrypted pgtype.Text
-	ClientIDIssuedAt      pgtype.Timestamptz
-	ClientSecretExpiresAt pgtype.Timestamptz
-	CreatedAt             pgtype.Timestamptz
-	UpdatedAt             pgtype.Timestamptz
-	DeletedAt             pgtype.Timestamptz
-	Deleted               bool
+	ID                      uuid.UUID
+	ProjectID               uuid.UUID
+	RemoteSessionIssuerID   uuid.UUID
+	UserSessionIssuerID     uuid.UUID
+	ClientID                string
+	ClientSecretEncrypted   pgtype.Text
+	ClientIDIssuedAt        pgtype.Timestamptz
+	ClientSecretExpiresAt   pgtype.Timestamptz
+	TokenEndpointAuthMethod pgtype.Text
+	CreatedAt               pgtype.Timestamptz
+	UpdatedAt               pgtype.Timestamptz
+	DeletedAt               pgtype.Timestamptz
+	Deleted                 bool
 }
 
 type RemoteSessionIssuer struct {

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -58,7 +58,7 @@ VALUES (
     $6,
     $7
 )
-RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRemoteSessionClientParams struct {
@@ -91,6 +91,7 @@ func (q *Queries) CreateRemoteSessionClient(ctx context.Context, arg CreateRemot
 		&i.ClientSecretEncrypted,
 		&i.ClientIDIssuedAt,
 		&i.ClientSecretExpiresAt,
+		&i.TokenEndpointAuthMethod,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -196,7 +197,7 @@ const deleteRemoteSessionClient = `-- name: DeleteRemoteSessionClient :one
 UPDATE remote_session_clients
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteRemoteSessionClientParams struct {
@@ -216,6 +217,7 @@ func (q *Queries) DeleteRemoteSessionClient(ctx context.Context, arg DeleteRemot
 		&i.ClientSecretEncrypted,
 		&i.ClientIDIssuedAt,
 		&i.ClientSecretExpiresAt,
+		&i.TokenEndpointAuthMethod,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -370,7 +372,7 @@ func (q *Queries) GetRemoteSessionByID(ctx context.Context, arg GetRemoteSession
 }
 
 const getRemoteSessionClientByID = `-- name: GetRemoteSessionClientByID :one
-SELECT id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, created_at, updated_at, deleted_at, deleted
 FROM remote_session_clients
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -392,6 +394,7 @@ func (q *Queries) GetRemoteSessionClientByID(ctx context.Context, arg GetRemoteS
 		&i.ClientSecretEncrypted,
 		&i.ClientIDIssuedAt,
 		&i.ClientSecretExpiresAt,
+		&i.TokenEndpointAuthMethod,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -630,7 +633,7 @@ func (q *Queries) ListConnectedClientIDsForSubject(ctx context.Context, arg List
 }
 
 const listRemoteSessionClientsByProjectID = `-- name: ListRemoteSessionClientsByProjectID :many
-SELECT id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, created_at, updated_at, deleted_at, deleted
 FROM remote_session_clients
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -673,6 +676,7 @@ func (q *Queries) ListRemoteSessionClientsByProjectID(ctx context.Context, arg L
 			&i.ClientSecretEncrypted,
 			&i.ClientIDIssuedAt,
 			&i.ClientSecretExpiresAt,
+			&i.TokenEndpointAuthMethod,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -944,7 +948,7 @@ SET
     user_session_issuer_id = COALESCE($3, user_session_issuer_id),
     updated_at = clock_timestamp()
 WHERE id = $4 AND project_id = $5 AND deleted IS FALSE
-RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRemoteSessionClientParams struct {
@@ -973,6 +977,7 @@ func (q *Queries) UpdateRemoteSessionClient(ctx context.Context, arg UpdateRemot
 		&i.ClientSecretEncrypted,
 		&i.ClientIDIssuedAt,
 		&i.ClientSecretExpiresAt,
+		&i.TokenEndpointAuthMethod,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260518213910_add-remote-session-client-token-endpoint-auth-method.sql
+++ b/server/migrations/20260518213910_add-remote-session-client-token-endpoint-auth-method.sql
@@ -1,0 +1,2 @@
+-- Modify "remote_session_clients" table
+ALTER TABLE "remote_session_clients" ADD COLUMN "token_endpoint_auth_method" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:OLmMeJJdIU+ScVppKRSNXG8swH5ZXzl2VjW7dpwSuZw=
+h1:LvR2Up6I4Li09LtfI4ElgEr738wykaSHNJMj6Pr1/08=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -182,3 +182,4 @@ h1:OLmMeJJdIU+ScVppKRSNXG8swH5ZXzl2VjW7dpwSuZw=
 20260515120000_ai-integration-configs.sql h1:bR1UTZ9lHjJUsJL1LY0ByUTkWefnmPOhovosRGRSJc0=
 20260518114737_add_effect_to_principal_grants.sql h1:J3lR6SeKv0v+S+ecUzf2oHgI2nI5aXCZXKimjxWmLOo=
 20260518145220_age-2366-mcp_servers-user_session_issuer_id.sql h1:sfZwy1S/Axh3pmIYxEW0/ODPqfZ8H4+id0EhWc8LNac=
+20260518213910_add-remote-session-client-token-endpoint-auth-method.sql h1:JuOMsaREjEdVpN5V9su1Gi7al06kmYwZw6LGLyYqq3o=


### PR DESCRIPTION
## Summary

- Adds a nullable `token_endpoint_auth_method TEXT` column to `remote_session_clients`.
- No app code; this PR ships the migration alone per the project rule (CLAUDE.md → "Migrations ship in their own PR").

The application side — Goa Enum, runtime branching, tests, SDK regen — is filed as a separate stacked PR.

NULL on the column resolves to `client_secret_basic` at runtime (no DB-level CHECK constraint, per app conventions).

Refs Linear [AGE-2387](https://linear.app/speakeasy/issue/AGE-2387/feat-support-client-secret-post-token-endpoint-auth-method).

## Test plan

- [ ] CI passes (`mise lint:migrations`, `mise db:migrate`).
- [ ] Verify column lands nullable on a fresh DB after `mise db:reset && mise db:migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)