### PR TITLE
feat(dashboard): consolidate member management into team page

### DIFF
--- a/client/dashboard/src/pages/access/MembersTab.tsx
+++ b/client/dashboard/src/pages/access/MembersTab.tsx
@@ -1,232 +1,41 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Heading } from "@/components/ui/heading";
 import { Type } from "@/components/ui/type";
-import { HumanizeDateTime } from "@/lib/dates";
-import { cn } from "@/lib/utils";
-import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import { useMembers } from "@gram/client/react-query/members.js";
-import { useRoles } from "@gram/client/react-query/roles.js";
-import { SkeletonTable } from "@/components/ui/skeleton";
-import {
-  Button,
-  Column,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  Icon,
-  Table,
-} from "@speakeasy-api/moonshine";
-import { Ellipsis } from "lucide-react";
-import { useState } from "react";
-import { Link, useNavigate } from "react-router";
-import { ChangeRoleDialog } from "./ChangeRoleDialog";
-import { RequireScope } from "@/components/require-scope";
-import { useOrganization } from "@/contexts/Auth";
-import { useTelemetry } from "@/contexts/Telemetry";
+import { Button, Icon } from "@speakeasy-api/moonshine";
 import { useOrgRoutes } from "@/routes";
-
-function getInitials(name: string) {
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-}
-
-function MemberActionsMenu({
-  onChangeRole,
-  onViewChallenges,
-}: {
-  onChangeRole: () => void;
-  onViewChallenges: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "text-muted-foreground hover:bg-accent hover:text-foreground flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition-colors",
-            open && "bg-accent text-foreground",
-          )}
-        >
-          <Ellipsis className="h-4 w-4" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <RequireScope scope="org:admin" level="component">
-          <DropdownMenuItem onSelect={() => setTimeout(onChangeRole, 0)}>
-            Change role
-          </DropdownMenuItem>
-        </RequireScope>
-        <DropdownMenuItem onSelect={() => setTimeout(onViewChallenges, 0)}>
-          View challenges
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
+import { Users } from "lucide-react";
 
 export function MembersTab() {
-  const [changingMember, setChangingMember] = useState<AccessMember | null>(
-    null,
-  );
-  const navigate = useNavigate();
-  const organization = useOrganization();
-  const telemetry = useTelemetry();
   const orgRoutes = useOrgRoutes();
-  const isTeamPageEnabled =
-    telemetry.isFeatureEnabled("gram-team-page") ?? false;
-  const { data: membersData, isLoading: membersLoading } = useMembers();
-  const { data: rolesData } = useRoles();
-  const roles = rolesData?.roles ?? [];
-  const members = [...(membersData?.members ?? [])].sort((a, b) =>
-    a.name.localeCompare(b.name),
-  );
-
-  const getRoleName = (roleId: string) =>
-    roles.find((r) => r.id === roleId)?.name ?? "Unknown";
-
-  const columns: Column<AccessMember>[] = [
-    {
-      key: "member",
-      header: "Member",
-      width: "200px",
-      render: (member) => (
-        <div className="flex items-center gap-3 overflow-hidden">
-          <Avatar className="h-8 w-8 shrink-0">
-            {member.photoUrl && (
-              <AvatarImage src={member.photoUrl} alt={member.name} />
-            )}
-            <AvatarFallback className="text-xs">
-              {getInitials(member.name)}
-            </AvatarFallback>
-          </Avatar>
-          <Type variant="body" className="truncate font-medium">
-            {member.name}
-          </Type>
-        </div>
-      ),
-    },
-    {
-      key: "email",
-      header: "Email",
-      width: "1fr",
-      render: (member) => (
-        <Type variant="body" className="text-muted-foreground">
-          {member.email}
-        </Type>
-      ),
-    },
-    {
-      key: "role",
-      header: "Role",
-      width: "140px",
-      render: (member) => (
-        <Type variant="body">
-          <Link
-            to={`${orgRoutes.access.roles.href()}?editRole=${member.roleId}`}
-            className="text-primary hover:text-primary/80 underline decoration-dotted underline-offset-4 transition-colors"
-          >
-            {getRoleName(member.roleId)}
-          </Link>
-        </Type>
-      ),
-    },
-    {
-      key: "joinedAt",
-      header: "Joined",
-      width: "160px",
-      render: (member) => (
-        <Type variant="body" className="text-muted-foreground">
-          <HumanizeDateTime date={member.joinedAt} />
-        </Type>
-      ),
-    },
-    {
-      key: "actions",
-      header: "",
-      width: "60px",
-      render: (member) => (
-        <MemberActionsMenu
-          onChangeRole={() => setChangingMember(member)}
-          onViewChallenges={() => {
-            navigate(
-              `${orgRoutes.access.challenges.href()}?identity=${encodeURIComponent(member.email)}`,
-            );
-          }}
-        />
-      ),
-    },
-  ];
+  const { data: membersData } = useMembers();
+  const memberCount = membersData?.members?.length ?? 0;
 
   return (
     <div>
-      <div className="mb-1 flex items-center justify-between">
-        <div>
-          <Heading variant="h4">Team Members</Heading>
+      <div className="mb-4">
+        <Heading variant="h4">Team Members</Heading>
+        <Type muted small className="mt-1">
+          Member management has moved to the Team page.
+        </Type>
+      </div>
+
+      <div className="border-border bg-muted/20 flex flex-col items-center gap-4 rounded-lg border py-12">
+        <Users className="text-muted-foreground h-10 w-10" />
+        <div className="text-center">
+          <Type variant="body" className="font-medium">
+            {memberCount} team member{memberCount === 1 ? "" : "s"}
+          </Type>
           <Type muted small className="mt-1">
-            Manage role assignments for your team members.
+            Invite, remove, and manage roles for your team in one place.
           </Type>
         </div>
+        <Button size="sm" onClick={() => orgRoutes.team.goTo()}>
+          <Button.Text>Go to Team</Button.Text>
+          <Button.RightIcon>
+            <Icon name="arrow-right" className="h-4 w-4" />
+          </Button.RightIcon>
+        </Button>
       </div>
-
-      {membersLoading ? (
-        <div className="mt-4">
-          <SkeletonTable />
-        </div>
-      ) : (
-        <Table
-          columns={columns}
-          data={members}
-          rowKey={(row) => row.id}
-          className="mt-4 rounded-b-none"
-        />
-      )}
-      <div className="border-border bg-muted/20 flex justify-center rounded-b-lg border border-t-0 py-3">
-        <RequireScope scope="org:admin" level="component">
-          {isTeamPageEnabled ? (
-            <Button
-              variant="tertiary"
-              size="sm"
-              onClick={() => orgRoutes.team.goTo()}
-            >
-              <Button.Text>Manage Team</Button.Text>
-              <Button.RightIcon>
-                <Icon name="arrow-right" className="h-4 w-4" />
-              </Button.RightIcon>
-            </Button>
-          ) : (
-            <Button variant="tertiary" size="sm" asChild>
-              <a
-                href={
-                  organization?.userWorkspaceSlugs?.length
-                    ? `https://app.speakeasy.com/org/${organization.slug}/${organization.userWorkspaceSlugs[0]}/settings/team`
-                    : "https://app.speakeasy.com"
-                }
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Button.Text>Manage Team</Button.Text>
-                <Button.RightIcon>
-                  <Icon name="external-link" className="h-4 w-4" />
-                </Button.RightIcon>
-              </a>
-            </Button>
-          )}
-        </RequireScope>
-      </div>
-
-      <ChangeRoleDialog
-        member={changingMember}
-        onOpenChange={(open: boolean) => {
-          if (!open) setChangingMember(null);
-        }}
-      />
     </div>
   );
 }

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -51,7 +51,6 @@ import {
   ChevronRight,
   Ellipsis,
   RefreshCw,
-  Trash2,
   UserPlus,
   Users,
   X,

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -40,6 +40,8 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Icon,
+  Input,
   Stack,
   Table,
 } from "@speakeasy-api/moonshine";
@@ -124,19 +126,28 @@ export function TeamInner() {
 
   const MEMBERS_PAGE_SIZE = 10;
   const [page, setPage] = useState(0);
+  const [search, setSearch] = useState("");
 
   const { data: membersData } = useListOrganizationUsersSuspense();
   const { data: invitesData } = useListInvitesSuspense();
   const { data: rolesData } = useRoles();
   const { data: accessMembersData } = useMembers();
 
-  const members = useMemo(
+  const allMembers = useMemo(
     () =>
       [...(membersData?.users ?? [])].sort((a, b) =>
         a.name.localeCompare(b.name),
       ),
     [membersData?.users],
   );
+  const members = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return allMembers;
+    return allMembers.filter(
+      (m) =>
+        m.name.toLowerCase().includes(q) || m.email.toLowerCase().includes(q),
+    );
+  }, [allMembers, search]);
   const totalPages = Math.ceil(members.length / MEMBERS_PAGE_SIZE);
   const safePage = Math.min(page, Math.max(totalPages - 1, 0));
   const visibleMembers = members.slice(
@@ -742,6 +753,23 @@ export function TeamInner() {
               </Button>
             </RequireScope>
           </Stack>
+
+          <div className="relative">
+            <Icon
+              name="search"
+              className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2"
+            />
+            <Input
+              type="text"
+              placeholder="Search members..."
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(0);
+              }}
+              className="mb-4 w-full py-2 pl-9 text-sm"
+            />
+          </div>
 
           <Table
             columns={memberColumns}

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -771,25 +771,29 @@ export function TeamInner() {
             />
           </div>
 
-          <Table
-            columns={memberColumns}
-            data={visibleMembers}
-            rowKey={(row) => row.userId}
-            className="min-h-fit"
-            noResultsMessage={
-              <Stack
-                gap={2}
-                className="bg-background h-full p-8"
-                align="center"
-                justify="center"
-              >
-                <Users className="text-muted-foreground h-12 w-12" />
-                <Type variant="body" className="text-muted-foreground">
-                  No team members yet
-                </Type>
-              </Stack>
-            }
-          />
+          <div className="min-h-[580px]">
+            <Table
+              columns={memberColumns}
+              data={visibleMembers}
+              rowKey={(row) => row.userId}
+              className="min-h-fit"
+              noResultsMessage={
+                <Stack
+                  gap={2}
+                  className="bg-background h-full p-8"
+                  align="center"
+                  justify="center"
+                >
+                  <Users className="text-muted-foreground h-12 w-12" />
+                  <Type variant="body" className="text-muted-foreground">
+                    {search
+                      ? "No members matching your search"
+                      : "No team members yet"}
+                  </Type>
+                </Stack>
+              }
+            />
+          </div>
           {totalPages > 1 && (
             <div className="flex items-center justify-between border-t px-4 py-3">
               <Type variant="body" className="text-muted-foreground text-sm">

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -32,13 +32,37 @@ import {
   OrganizationInvitation,
 } from "@gram/client/models/components";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { Button, Column, Stack, Table } from "@speakeasy-api/moonshine";
+import {
+  Button,
+  Column,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Stack,
+  Table,
+} from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { RefreshCw, Trash2, UserPlus, Users, X } from "lucide-react";
-import { useState } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Ellipsis,
+  RefreshCw,
+  Trash2,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { RequireScope } from "@/components/require-scope";
 import { useRBAC } from "@/hooks/useRBAC";
+import { useOrgRoutes } from "@/routes";
+import { cn } from "@/lib/utils";
+import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import { ChangeRoleDialog } from "@/pages/access/ChangeRoleDialog";
 
 function getMemberColors(id: string) {
   let hash = 2166136261;
@@ -79,6 +103,8 @@ export function TeamInner() {
   const user = useUser();
   const { isRbacEnabled } = useRBAC();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const orgRoutes = useOrgRoutes();
 
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState("");
@@ -92,13 +118,31 @@ export function TeamInner() {
   );
   const [inviteToCancel, setInviteToCancel] =
     useState<OrganizationInvitation | null>(null);
+  const [changingMember, setChangingMember] = useState<AccessMember | null>(
+    null,
+  );
+
+  const MEMBERS_PAGE_SIZE = 10;
+  const [page, setPage] = useState(0);
 
   const { data: membersData } = useListOrganizationUsersSuspense();
   const { data: invitesData } = useListInvitesSuspense();
   const { data: rolesData } = useRoles();
   const { data: accessMembersData } = useMembers();
 
-  const members = membersData?.users ?? [];
+  const members = useMemo(
+    () =>
+      [...(membersData?.users ?? [])].sort((a, b) =>
+        a.name.localeCompare(b.name),
+      ),
+    [membersData?.users],
+  );
+  const totalPages = Math.ceil(members.length / MEMBERS_PAGE_SIZE);
+  const safePage = Math.min(page, Math.max(totalPages - 1, 0));
+  const visibleMembers = members.slice(
+    safePage * MEMBERS_PAGE_SIZE,
+    (safePage + 1) * MEMBERS_PAGE_SIZE,
+  );
   const invites = invitesData?.invitations ?? [];
   const roles = rolesData?.roles ?? [];
   const accessMembers = accessMembersData?.members ?? [];
@@ -113,6 +157,7 @@ export function TeamInner() {
 
   // Cross-reference AccessMember (has roleId) by user ID
   const roleByUserId = new Map(accessMembers.map((m) => [m.id, m.roleId]));
+  const accessMemberByUserId = new Map(accessMembers.map((m) => [m.id, m]));
   const roleBySlug = new Map(roles.map((role) => [role.slug, role]));
   const getRoleName = (roleId: string) =>
     roles.find((r) => r.id === roleId)?.name ?? "Unknown";
@@ -151,8 +196,10 @@ export function TeamInner() {
   });
 
   const removeMemberMutation = useRemoveOrganizationUserMutation({
-    onError: () => {
-      toast.error("Failed to remove member");
+    onError: (error) => {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove member",
+      );
     },
   });
 
@@ -357,19 +404,30 @@ export function TeamInner() {
         </Type>
       ),
     },
-    {
-      key: "role",
-      header: "Role",
-      width: "140px",
-      render: (member) => {
-        const roleId = roleByUserId.get(member.userId);
-        return (
-          <Type variant="body" className="text-muted-foreground">
-            {roleId ? getRoleName(roleId) : "—"}
-          </Type>
-        );
-      },
-    },
+    ...(isRbacEnabled
+      ? [
+          {
+            key: "role",
+            header: "Role",
+            width: "140px",
+            render: (member) => {
+              const roleId = roleByUserId.get(member.userId);
+              if (!roleId)
+                return <span className="text-muted-foreground">—</span>;
+              return (
+                <Type variant="body">
+                  <Link
+                    to={`${orgRoutes.access.roles.href()}?editRole=${roleId}`}
+                    className="text-primary hover:text-primary/80 underline decoration-dotted underline-offset-4 transition-colors"
+                  >
+                    {getRoleName(roleId)}
+                  </Link>
+                </Type>
+              );
+            },
+          } satisfies Column<OrganizationUser>,
+        ]
+      : []),
     {
       key: "lastLogin",
       header: "Last active",
@@ -390,38 +448,84 @@ export function TeamInner() {
     {
       key: "actions",
       header: "",
-      width: "80px",
+      width: "60px",
       render: (member) => {
         const memberRoleId = roleByUserId.get(member.userId);
         const isLastAdmin =
           adminRoleId != null &&
           memberRoleId === adminRoleId &&
           adminCount <= 1;
-
-        if (member.email === user.email) {
-          return (
-            <Type variant="body" className="text-muted-foreground text-sm">
-              You
-            </Type>
-          );
-        }
-
-        if (isLastAdmin) return null;
+        const isSelf = member.email === user.email;
+        const roleId = roleByUserId.get(member.userId);
+        const accessMember: AccessMember | undefined =
+          accessMemberByUserId.get(member.userId) ??
+          (roleId
+            ? {
+                id: member.userId,
+                name: member.name,
+                email: member.email,
+                photoUrl: member.photoUrl,
+                roleId,
+                joinedAt: member.createdAt,
+              }
+            : undefined);
 
         return (
-          <RequireScope scope="org:admin" level="component">
-            <Button
-              variant="tertiary"
-              size="sm"
-              onClick={() => setMemberToRemove(member)}
-              className="hover:text-destructive"
-            >
-              <Button.LeftIcon>
-                <Trash2 className="h-4 w-4" />
-              </Button.LeftIcon>
-              <Button.Text className="sr-only">Remove member</Button.Text>
-            </Button>
-          </RequireScope>
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className={cn(
+                  "text-muted-foreground hover:bg-accent hover:text-foreground flex h-8 w-8 cursor-pointer items-center justify-center rounded-md transition-colors",
+                )}
+              >
+                <Ellipsis className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {isRbacEnabled && accessMember && !isSelf && (
+                <RequireScope scope="org:admin" level="component">
+                  <DropdownMenuItem
+                    onSelect={() =>
+                      setTimeout(() => setChangingMember(accessMember), 0)
+                    }
+                  >
+                    Change role
+                  </DropdownMenuItem>
+                </RequireScope>
+              )}
+              {isRbacEnabled && (
+                <DropdownMenuItem
+                  onSelect={() =>
+                    setTimeout(
+                      () =>
+                        navigate(
+                          `${orgRoutes.access.challenges.href()}?identity=${encodeURIComponent(member.email)}`,
+                        ),
+                      0,
+                    )
+                  }
+                >
+                  View challenges
+                </DropdownMenuItem>
+              )}
+              {!isSelf && !isLastAdmin && (
+                <>
+                  {isRbacEnabled && <DropdownMenuSeparator />}
+                  <RequireScope scope="org:admin" level="component">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onSelect={() =>
+                        setTimeout(() => setMemberToRemove(member), 0)
+                      }
+                    >
+                      Remove member
+                    </DropdownMenuItem>
+                  </RequireScope>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         );
       },
     },
@@ -641,7 +745,7 @@ export function TeamInner() {
 
           <Table
             columns={memberColumns}
-            data={members}
+            data={visibleMembers}
             rowKey={(row) => row.userId}
             className="min-h-fit"
             noResultsMessage={
@@ -658,6 +762,39 @@ export function TeamInner() {
               </Stack>
             }
           />
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between border-t px-4 py-3">
+              <Type variant="body" className="text-muted-foreground text-sm">
+                {safePage * MEMBERS_PAGE_SIZE + 1}–
+                {Math.min((safePage + 1) * MEMBERS_PAGE_SIZE, members.length)}{" "}
+                of {members.length}
+              </Type>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  onClick={() => setPage((p) => p - 1)}
+                  disabled={safePage === 0}
+                >
+                  <Button.LeftIcon>
+                    <ChevronLeft className="size-4" />
+                  </Button.LeftIcon>
+                  <Button.Text className="sr-only">Previous page</Button.Text>
+                </Button>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={safePage >= totalPages - 1}
+                >
+                  <Button.LeftIcon>
+                    <ChevronRight className="size-4" />
+                  </Button.LeftIcon>
+                  <Button.Text className="sr-only">Next page</Button.Text>
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Pending Invites Section */}
@@ -832,6 +969,16 @@ export function TeamInner() {
           </div>
         </Dialog.Content>
       </Dialog>
+
+      {/* Change Role Dialog */}
+      {isRbacEnabled && (
+        <ChangeRoleDialog
+          member={changingMember}
+          onOpenChange={(open) => {
+            if (!open) setChangingMember(null);
+          }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- **Team page** now serves as the single member management surface — absorbs role management actions (change role, view challenges) previously only in the RBAC Members tab
- Members table sorted alphabetically with paginated prev/next navigation (10 per page)
- Per-member dropdown menu with context-aware actions: Change role, View challenges, Remove member (self-row gets limited menu)
- Role column links directly to role editor when RBAC enabled
- **RBAC Members tab** replaced with signpost card redirecting to Team page

## Changes

| File | What changed |
|------|-------------|
| `Team.tsx` | Alphabetical sort, pagination, dropdown actions menu, ChangeRoleDialog integration, synthetic AccessMember fallback, role column as link |
| `MembersTab.tsx` | Replaced table with signpost to Team page |

## Test plan

- [ ] Verify Team page shows paginated members with prev/next controls
- [ ] Click member dropdown → "Change role" opens dialog, updates role
- [ ] Click member dropdown → "View challenges" navigates to challenges filtered by email
- [ ] Click member dropdown → "Remove member" shows confirmation, removes user
- [ ] Self-row shows dropdown with only "View challenges"
- [ ] Role column links to role editor page
- [ ] RBAC Members tab shows signpost with "Go to Team" button
- [ ] Non-RBAC mode: role column hidden, RBAC-specific menu items hidden