### PR TITLE
feat(collections): audit log collection mutations

### DIFF
--- a/.changeset/collections-audit.md
+++ b/.changeset/collections-audit.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Emit audit log entries for collection mutations: `mcp_collection:create`, `:update`, `:delete`, `:attach_server`, and `:detach_server`. Update/AttachServer/DetachServer now run in a transaction alongside the audit insert, and a new `urn.McpCollection` identifier (prefix `mcp_collection`) is used as the audit subject.

--- a/client/dashboard/src/pages/collections/CollectionDetail.tsx
+++ b/client/dashboard/src/pages/collections/CollectionDetail.tsx
@@ -75,12 +75,13 @@ function CollectionDetailInner() {
     useState<CatalogServer | null>(null);
   const [showBulkInstallDialog, setShowBulkInstallDialog] = useState(false);
   const [showAddDialog, setShowAddDialog] = useState(false);
+  const [editingServers, setEditingServers] = useState(false);
   const [editName, setEditName] = useState("");
   const [editDescription, setEditDescription] = useState("");
   const [editVisibility, setEditVisibility] = useState<"public" | "private">(
     "private",
   );
-  const [editSelectedToolsetIds, setEditSelectedToolsetIds] = useState<
+  const [selectedServerToolsetIds, setSelectedServerToolsetIds] = useState<
     Set<string>
   >(new Set());
   const [serverSearch, setServerSearch] = useState("");
@@ -162,7 +163,7 @@ function CollectionDetailInner() {
   );
 
   const toggleToolset = (toolsetId: string) => {
-    setEditSelectedToolsetIds((prev) => {
+    setSelectedServerToolsetIds((prev) => {
       const next = new Set(prev);
       if (next.has(toolsetId)) {
         next.delete(toolsetId);
@@ -373,7 +374,6 @@ function CollectionDetailInner() {
                         setEditName(collection.name);
                         setEditDescription(collection.description);
                         setEditVisibility(collection.visibility);
-                        setEditSelectedToolsetIds(new Set(attachedToolsetIds));
                         setEditing(true);
                       }}
                     >
@@ -405,7 +405,9 @@ function CollectionDetailInner() {
             {editing && (
               <RequireScope scope="org:admin" level="section">
                 <div className="mb-4 space-y-4 rounded-lg border p-5">
-                  <h2 className="text-base font-semibold">Edit Collection</h2>
+                  <h2 className="text-base font-semibold">
+                    Edit collection details
+                  </h2>
                   <div>
                     <label className="mb-1 block text-sm font-medium">
                       Name
@@ -461,11 +463,106 @@ function CollectionDetailInner() {
                     </div>
                   </div>
 
-                  {/* Server picker (edit mode only) */}
-                  <div>
-                    <label className="mb-2 block text-sm font-medium">
-                      MCP Servers ({editSelectedToolsetIds.size} selected)
-                    </label>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      disabled={isSaving || !editName}
+                      onClick={async () => {
+                        setIsSaving(true);
+                        try {
+                          await updateCollection.mutateAsync({
+                            request: {
+                              updateRequestBody: {
+                                collectionId: collection.id,
+                                name: editName,
+                                description: editDescription,
+                                visibility: editVisibility,
+                              },
+                            },
+                          });
+
+                          setEditing(false);
+                        } finally {
+                          setIsSaving(false);
+                        }
+                      }}
+                    >
+                      <Button.Text>
+                        {isSaving ? "Saving..." : "Save"}
+                      </Button.Text>
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      disabled={isSaving}
+                      onClick={() => {
+                        setEditing(false);
+                      }}
+                    >
+                      <Button.Text>Cancel</Button.Text>
+                    </Button>
+                  </div>
+                </div>
+              </RequireScope>
+            )}
+
+            {/* About */}
+            {!editing && (
+              <div className="mb-4 rounded-lg border p-5">
+                <h2 className="mb-2 text-base font-semibold">
+                  About this collection
+                </h2>
+                <p className="text-muted-foreground text-sm">
+                  {collection.description || "No description provided."}
+                </p>
+              </div>
+            )}
+
+            {/* MCP Servers */}
+            <div className="rounded-lg border p-5">
+              <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h2 className="text-base font-semibold">Included servers</h2>
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    These servers install together into the selected project.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="secondary" className="shrink-0">
+                    <Server className="mr-1 h-3 w-3" />
+                    {servers.length}
+                  </Badge>
+                  <RequireScope scope="org:admin" level="component">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="w-full sm:w-auto"
+                      disabled={isLoading || isSaving}
+                      onClick={() => {
+                        setServerSearch("");
+                        setSelectedServerToolsetIds(
+                          new Set(attachedToolsetIds),
+                        );
+                        setEditingServers((current) => !current);
+                      }}
+                    >
+                      <Button.Text>
+                        {editingServers ? "Cancel Edit" : "Edit Servers"}
+                      </Button.Text>
+                    </Button>
+                  </RequireScope>
+                </div>
+              </div>
+              {editingServers && (
+                <RequireScope scope="org:admin" level="section">
+                  <div className="mb-4 rounded-lg border p-4">
+                    <div className="mb-3">
+                      <h3 className="text-sm font-medium">Edit servers</h3>
+                      <p className="text-muted-foreground mt-1 text-xs">
+                        Select the MCP-enabled servers that should be included
+                        in this collection.
+                      </p>
+                    </div>
                     <div className="rounded-md border">
                       <div className="relative border-b">
                         <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
@@ -498,7 +595,9 @@ function CollectionDetailInner() {
                               className="hover:bg-accent/50 flex cursor-pointer items-start gap-3 border-b px-3 py-2.5 last:border-b-0"
                             >
                               <Checkbox
-                                checked={editSelectedToolsetIds.has(toolset.id)}
+                                checked={selectedServerToolsetIds.has(
+                                  toolset.id,
+                                )}
                                 disabled={isSaving}
                                 onCheckedChange={() =>
                                   toggleToolset(toolset.id)
@@ -528,155 +627,114 @@ function CollectionDetailInner() {
                         )}
                       </div>
                     </div>
-                  </div>
+                    <div className="mt-3 flex gap-2">
+                      <Button
+                        size="sm"
+                        disabled={isSaving}
+                        onClick={async () => {
+                          setIsSaving(true);
+                          try {
+                            const toAttach = [
+                              ...selectedServerToolsetIds,
+                            ].filter((id) => !attachedToolsetIds.has(id));
+                            const toDetach = [...attachedToolsetIds].filter(
+                              (id) => !selectedServerToolsetIds.has(id),
+                            );
 
-                  <div className="flex gap-2">
-                    <Button
-                      size="sm"
-                      disabled={isSaving || !editName}
-                      onClick={async () => {
-                        setIsSaving(true);
-                        try {
-                          // Update collection metadata
-                          await updateCollection.mutateAsync({
-                            request: {
-                              updateRequestBody: {
-                                collectionId: collection.id,
-                                name: editName,
-                                description: editDescription,
-                                visibility: editVisibility,
-                              },
-                            },
-                          });
-
-                          // Diff server changes: attach new, detach removed
-                          const toAttach = [...editSelectedToolsetIds].filter(
-                            (id) => !attachedToolsetIds.has(id),
-                          );
-                          const toDetach = [...attachedToolsetIds].filter(
-                            (id) => !editSelectedToolsetIds.has(id),
-                          );
-
-                          await Promise.all([
-                            ...toAttach.map((toolsetId) =>
-                              attachServer.mutateAsync({
-                                request: {
-                                  attachServerRequestBody: {
-                                    collectionId: collection.id,
-                                    toolsetId,
+                            await Promise.all([
+                              ...toAttach.map((toolsetId) =>
+                                attachServer.mutateAsync({
+                                  request: {
+                                    attachServerRequestBody: {
+                                      collectionId: collection.id,
+                                      toolsetId,
+                                    },
                                   },
-                                },
-                              }),
-                            ),
-                            ...toDetach.map((toolsetId) =>
-                              detachServer.mutateAsync({
-                                request: {
-                                  attachServerRequestBody: {
-                                    collectionId: collection.id,
-                                    toolsetId,
+                                }),
+                              ),
+                              ...toDetach.map((toolsetId) =>
+                                detachServer.mutateAsync({
+                                  request: {
+                                    attachServerRequestBody: {
+                                      collectionId: collection.id,
+                                      toolsetId,
+                                    },
                                   },
-                                },
-                              }),
-                            ),
-                          ]);
-
-                          setEditing(false);
+                                }),
+                              ),
+                            ]);
+                            setEditingServers(false);
+                            setSelectedServerToolsetIds(new Set());
+                            setServerSearch("");
+                          } finally {
+                            setIsSaving(false);
+                          }
+                        }}
+                      >
+                        <Button.Text>
+                          {isSaving
+                            ? "Saving..."
+                            : `Save ${selectedServerToolsetIds.size} ${selectedServerToolsetIds.size === 1 ? "Server" : "Servers"}`}
+                        </Button.Text>
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        disabled={isSaving}
+                        onClick={() => {
+                          setEditingServers(false);
+                          setSelectedServerToolsetIds(new Set());
                           setServerSearch("");
-                        } finally {
-                          setIsSaving(false);
-                        }
-                      }}
-                    >
-                      <Button.Text>
-                        {isSaving ? "Saving..." : "Save"}
-                      </Button.Text>
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      disabled={isSaving}
-                      onClick={() => {
-                        setEditing(false);
-                        setServerSearch("");
-                      }}
-                    >
-                      <Button.Text>Cancel</Button.Text>
-                    </Button>
+                        }}
+                      >
+                        <Button.Text>Cancel</Button.Text>
+                      </Button>
+                    </div>
                   </div>
-                </div>
-              </RequireScope>
-            )}
-
-            {/* About */}
-            {!editing && (
-              <div className="mb-4 rounded-lg border p-5">
-                <h2 className="mb-2 text-base font-semibold">
-                  About this collection
-                </h2>
+                </RequireScope>
+              )}
+              {editingServers ? null : isLoading ? (
                 <p className="text-muted-foreground text-sm">
-                  {collection.description || "No description provided."}
+                  Loading servers...
                 </p>
-              </div>
-            )}
-
-            {/* MCP Servers (read-only list) */}
-            {!editing && (
-              <div className="rounded-lg border p-5">
-                <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <h2 className="text-base font-semibold">
-                      Included servers
-                    </h2>
-                    <p className="text-muted-foreground mt-1 text-sm">
-                      These servers install together into the selected project.
-                    </p>
-                  </div>
-                  <Badge variant="secondary" className="shrink-0">
-                    <Server className="mr-1 h-3 w-3" />
-                    {servers.length}
-                  </Badge>
-                </div>
-                {isLoading ? (
+              ) : servers.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-8 text-center">
+                  <Server className="text-muted-foreground mb-2 h-8 w-8" />
                   <p className="text-muted-foreground text-sm">
-                    Loading servers...
+                    No servers in this collection yet.
                   </p>
-                ) : servers.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center py-8 text-center">
-                    <Server className="text-muted-foreground mb-2 h-8 w-8" />
-                    <p className="text-muted-foreground text-sm">
-                      No servers in this collection yet.
-                    </p>
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    {rawServers.map((server, index) => {
-                      const installableServer = installableServers[index];
-                      return (
-                        <div
-                          key={server.registrySpecifier}
-                          className="bg-card hover:bg-accent/30 flex flex-col gap-4 rounded-lg border p-4 transition-colors sm:flex-row sm:items-center"
-                        >
-                          <div className="bg-muted/60 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border">
-                            {server.iconUrl ? (
-                              <img
-                                src={server.iconUrl}
-                                alt=""
-                                className="h-6 w-6 rounded"
-                              />
-                            ) : (
-                              <ServerIcon className="text-muted-foreground h-5 w-5" />
-                            )}
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {rawServers.map((server, index) => {
+                    const installableServer = installableServers[index];
+                    return (
+                      <div
+                        key={server.registrySpecifier}
+                        className="bg-card hover:bg-accent/30 flex flex-col gap-4 rounded-lg border p-4 transition-colors sm:flex-row sm:items-center"
+                      >
+                        <div className="bg-muted/60 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border">
+                          {server.iconUrl ? (
+                            <img
+                              src={server.iconUrl}
+                              alt=""
+                              className="h-6 w-6 rounded"
+                            />
+                          ) : (
+                            <ServerIcon className="text-muted-foreground h-5 w-5" />
+                          )}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="truncate text-sm font-medium">
+                              {server.title ?? server.registrySpecifier}
+                            </span>
                           </div>
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2">
-                              <span className="truncate text-sm font-medium">
-                                {server.title ?? server.registrySpecifier}
-                              </span>
-                            </div>
-                            <p className="text-muted-foreground mt-1 line-clamp-2 text-xs">
-                              {server.description || server.registrySpecifier}
-                            </p>
-                          </div>
+                          <p className="text-muted-foreground mt-1 line-clamp-2 text-xs">
+                            {server.description || server.registrySpecifier}
+                          </p>
+                        </div>
+                        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
                           <RequireScope scope="project:write" level="component">
                             <Button
                               size="sm"
@@ -698,12 +756,12 @@ function CollectionDetailInner() {
                             </Button>
                           </RequireScope>
                         </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Sidebar */}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1017,7 +1017,7 @@ func newStartCommand() *cli.Command {
 			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, platformSvc, billingTracker, telemLogger, productFeatures, serverURL, authzEngine))
 			mcpmetadata.Attach(mux, mcpMetadataService)
 			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine))
-			collections.Attach(mux, collections.NewService(logger, tracerProvider, db, sessionManager, authzEngine, serverURL))
+			collections.Attach(mux, collections.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, serverURL))
 			mcp.Attach(mux, mcpService, mcpMetadataService)
 			chat.Attach(mux, chatService)
 			variations.Attach(mux, variations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))

--- a/server/internal/audit/collections.go
+++ b/server/internal/audit/collections.go
@@ -1,0 +1,242 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/audit/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	ActionMcpCollectionCreate       Action = "mcp_collection:create"
+	ActionMcpCollectionUpdate       Action = "mcp_collection:update"
+	ActionMcpCollectionDelete       Action = "mcp_collection:delete"
+	ActionMcpCollectionAttachServer Action = "mcp_collection:attach_server"
+	ActionMcpCollectionDetachServer Action = "mcp_collection:detach_server"
+)
+
+type LogMcpCollectionCreateEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	CollectionURN  urn.McpCollection
+	CollectionName string
+	CollectionSlug string
+}
+
+func (l *Logger) LogMcpCollectionCreate(ctx context.Context, dbtx repo.DBTX, event LogMcpCollectionCreateEvent) error {
+	action := ActionMcpCollectionCreate
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.CollectionURN.ID.String(),
+		SubjectType:        string(subjectTypeMcpCollection),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.CollectionName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.CollectionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	return l.log(ctx, dbtx, entry)
+}
+
+type LogMcpCollectionUpdateEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	CollectionURN            urn.McpCollection
+	CollectionName           string
+	CollectionSlug           string
+	CollectionSnapshotBefore *types.MCPCollection
+	CollectionSnapshotAfter  *types.MCPCollection
+}
+
+func (l *Logger) LogMcpCollectionUpdate(ctx context.Context, dbtx repo.DBTX, event LogMcpCollectionUpdateEvent) error {
+	action := ActionMcpCollectionUpdate
+
+	beforeSnapshot, err := marshalAuditPayload(event.CollectionSnapshotBefore)
+	if err != nil {
+		return fmt.Errorf("marshal %s before snapshot: %w", action, err)
+	}
+
+	afterSnapshot, err := marshalAuditPayload(event.CollectionSnapshotAfter)
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.CollectionURN.ID.String(),
+		SubjectType:        string(subjectTypeMcpCollection),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.CollectionName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.CollectionSlug),
+
+		BeforeSnapshot: beforeSnapshot,
+		AfterSnapshot:  afterSnapshot,
+		Metadata:       nil,
+	}
+
+	return l.log(ctx, dbtx, entry)
+}
+
+type LogMcpCollectionDeleteEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	CollectionURN  urn.McpCollection
+	CollectionName string
+	CollectionSlug string
+}
+
+func (l *Logger) LogMcpCollectionDelete(ctx context.Context, dbtx repo.DBTX, event LogMcpCollectionDeleteEvent) error {
+	action := ActionMcpCollectionDelete
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.CollectionURN.ID.String(),
+		SubjectType:        string(subjectTypeMcpCollection),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.CollectionName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.CollectionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       nil,
+	}
+
+	return l.log(ctx, dbtx, entry)
+}
+
+type LogMcpCollectionAttachServerEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	CollectionURN  urn.McpCollection
+	CollectionName string
+	CollectionSlug string
+	ToolsetURN     urn.Toolset
+}
+
+func (l *Logger) LogMcpCollectionAttachServer(ctx context.Context, dbtx repo.DBTX, event LogMcpCollectionAttachServerEvent) error {
+	action := ActionMcpCollectionAttachServer
+
+	metadata, err := marshalAuditPayload(map[string]string{
+		"toolset_id": event.ToolsetURN.ID.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.CollectionURN.ID.String(),
+		SubjectType:        string(subjectTypeMcpCollection),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.CollectionName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.CollectionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	return l.log(ctx, dbtx, entry)
+}
+
+type LogMcpCollectionDetachServerEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	CollectionURN  urn.McpCollection
+	CollectionName string
+	CollectionSlug string
+	ToolsetURN     urn.Toolset
+}
+
+func (l *Logger) LogMcpCollectionDetachServer(ctx context.Context, dbtx repo.DBTX, event LogMcpCollectionDetachServerEvent) error {
+	action := ActionMcpCollectionDetachServer
+
+	metadata, err := marshalAuditPayload(map[string]string{
+		"toolset_id": event.ToolsetURN.ID.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.CollectionURN.ID.String(),
+		SubjectType:        string(subjectTypeMcpCollection),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.CollectionName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.CollectionSlug),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	return l.log(ctx, dbtx, entry)
+}

--- a/server/internal/audit/events.go
+++ b/server/internal/audit/events.go
@@ -16,6 +16,7 @@ const (
 	subjectTypeCustomDomain        subjectType = "custom_domain"
 	subjectTypeDeployment          subjectType = "deployment"
 	subjectTypeEnvironment         subjectType = "environment"
+	subjectTypeMcpCollection       subjectType = "mcp_collection"
 	subjectTypeMcpEndpoint         subjectType = "mcp_endpoint"
 	subjectTypeMcpServer           subjectType = "mcp_server"
 	subjectTypeOtelForwarding      subjectType = "otel_forwarding_config"

--- a/server/internal/collections/audit_test.go
+++ b/server/internal/collections/audit_test.go
@@ -1,0 +1,225 @@
+package collections_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/collections"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+)
+
+func TestCollectionsService_Audit_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionCreate)
+	require.NoError(t, err)
+
+	result, err := ti.service.Create(ctx, &gen.CreatePayload{
+		Name:                 "Audited Collection",
+		Slug:                 "audited-collection",
+		Description:          nil,
+		McpRegistryNamespace: "com.example.audited",
+		Visibility:           "private",
+		ToolsetIds:           []string{},
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionCreate)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionMcpCollectionCreate)
+	require.NoError(t, err)
+	require.Equal(t, "mcp_collection", record.SubjectType)
+	require.Equal(t, "Audited Collection", record.SubjectDisplay)
+	require.Equal(t, "audited-collection", record.SubjectSlug)
+}
+
+func TestCollectionsService_Audit_CreateFailureDoesNotLog(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionCreate)
+	require.NoError(t, err)
+
+	_, err = ti.service.Create(ctx, &gen.CreatePayload{
+		Name:                 "Invalid Toolset Collection",
+		Slug:                 "invalid-toolset-collection",
+		Description:          nil,
+		McpRegistryNamespace: "com.example.invalid-toolset",
+		Visibility:           "private",
+		ToolsetIds:           []string{"not-a-uuid"},
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+	})
+	require.Error(t, err)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionCreate)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount, afterCount)
+}
+
+func TestCollectionsService_Audit_ForbiddenCreateDoesNotLog(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+	ctx = authztest.WithExactGrants(t, ctx)
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionCreate)
+	require.NoError(t, err)
+
+	_, err = ti.service.Create(ctx, &gen.CreatePayload{
+		Name:                 "Forbidden Collection",
+		Slug:                 "forbidden-collection",
+		Description:          nil,
+		McpRegistryNamespace: "com.example.forbidden",
+		Visibility:           "private",
+		ToolsetIds:           []string{},
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+	})
+	require.Error(t, err)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionCreate)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount, afterCount)
+}
+
+func TestCollectionsService_Audit_Update(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+	collection := createCollection(t, ctx, ti, "Before Update", "before-update", "com.example.before-update")
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionUpdate)
+	require.NoError(t, err)
+
+	desc := "Updated description"
+	updated, err := ti.service.Update(ctx, &gen.UpdatePayload{
+		CollectionID: collection.ID,
+		Name:         new("After Update"),
+		Description:  &desc,
+		Visibility:   new("public"),
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "After Update", updated.Name)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionUpdate)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionMcpCollectionUpdate)
+	require.NoError(t, err)
+	require.Equal(t, "mcp_collection", record.SubjectType)
+	require.Equal(t, "After Update", record.SubjectDisplay)
+	require.Equal(t, "before-update", record.SubjectSlug)
+	require.NotNil(t, record.BeforeSnapshot)
+	require.NotNil(t, record.AfterSnapshot)
+
+	beforeSnapshot, err := audittest.DecodeAuditData(record.BeforeSnapshot)
+	require.NoError(t, err)
+	require.Equal(t, "Before Update", beforeSnapshot["Name"])
+
+	afterSnapshot, err := audittest.DecodeAuditData(record.AfterSnapshot)
+	require.NoError(t, err)
+	require.Equal(t, "After Update", afterSnapshot["Name"])
+}
+
+func TestCollectionsService_Audit_Delete(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+	collection := createCollection(t, ctx, ti, "Delete Me", "delete-me", "com.example.delete-me")
+
+	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionDelete)
+	require.NoError(t, err)
+
+	err = ti.service.Delete(ctx, &gen.DeletePayload{
+		CollectionID: collection.ID,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+
+	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionDelete)
+	require.NoError(t, err)
+	require.Equal(t, beforeCount+1, afterCount)
+
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionMcpCollectionDelete)
+	require.NoError(t, err)
+	require.Equal(t, "mcp_collection", record.SubjectType)
+	require.Equal(t, "Delete Me", record.SubjectDisplay)
+	require.Equal(t, "delete-me", record.SubjectSlug)
+}
+
+func TestCollectionsService_Audit_AttachAndDetachServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestCollectionsService(t)
+	toolset := createMCPEnabledToolset(t, ctx, ti, "Audited Toolset", "")
+	collection := createCollection(t, ctx, ti, "Attach Detach", "attach-detach", "com.example.attach-detach")
+
+	beforeAttachCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionAttachServer)
+	require.NoError(t, err)
+
+	_, err = ti.service.AttachServer(ctx, &gen.AttachServerPayload{
+		CollectionID: collection.ID,
+		ToolsetID:    toolset.ID,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+
+	afterAttachCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionAttachServer)
+	require.NoError(t, err)
+	require.Equal(t, beforeAttachCount+1, afterAttachCount)
+
+	attachRecord, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionMcpCollectionAttachServer)
+	require.NoError(t, err)
+	require.Equal(t, "mcp_collection", attachRecord.SubjectType)
+	require.Equal(t, "Attach Detach", attachRecord.SubjectDisplay)
+
+	attachMetadata, err := audittest.DecodeAuditData(attachRecord.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, toolset.ID, attachMetadata["toolset_id"])
+
+	beforeDetachCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionDetachServer)
+	require.NoError(t, err)
+
+	err = ti.service.DetachServer(ctx, &gen.DetachServerPayload{
+		CollectionID: collection.ID,
+		ToolsetID:    toolset.ID,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+
+	afterDetachCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionDetachServer)
+	require.NoError(t, err)
+	require.Equal(t, beforeDetachCount+1, afterDetachCount)
+
+	detachRecord, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionMcpCollectionDetachServer)
+	require.NoError(t, err)
+	require.Equal(t, "mcp_collection", detachRecord.SubjectType)
+	require.Equal(t, "Attach Detach", detachRecord.SubjectDisplay)
+
+	detachMetadata, err := audittest.DecodeAuditData(detachRecord.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, toolset.ID, detachMetadata["toolset_id"])
+}
+
+//go:fix inline
+func strPtr(value string) *string {
+	return new(value)
+}

--- a/server/internal/collections/audit_test.go
+++ b/server/internal/collections/audit_test.go
@@ -103,12 +103,14 @@ func TestCollectionsService_Audit_Update(t *testing.T) {
 	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMcpCollectionUpdate)
 	require.NoError(t, err)
 
+	name := "After Update"
 	desc := "Updated description"
+	visibility := "public"
 	updated, err := ti.service.Update(ctx, &gen.UpdatePayload{
 		CollectionID: collection.ID,
-		Name:         new("After Update"),
+		Name:         &name,
 		Description:  &desc,
-		Visibility:   new("public"),
+		Visibility:   &visibility,
 		SessionToken: nil,
 		ApikeyToken:  nil,
 	})
@@ -217,9 +219,4 @@ func TestCollectionsService_Audit_AttachAndDetachServer(t *testing.T) {
 	detachMetadata, err := audittest.DecodeAuditData(detachRecord.Metadata)
 	require.NoError(t, err)
 	require.Equal(t, toolset.ID, detachMetadata["toolset_id"])
-}
-
-//go:fix inline
-func strPtr(value string) *string {
-	return new(value)
 }

--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -23,6 +23,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/collections/server"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -37,6 +38,7 @@ import (
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	toolsetsRepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type Service struct {
@@ -48,6 +50,7 @@ type Service struct {
 	orgRepo   *orgRepo.Queries
 	auth      *auth.Auth
 	authz     *authz.Engine
+	audit     *audit.Logger
 	sessions  *sessions.Manager
 	serverURL *url.URL
 }
@@ -57,7 +60,7 @@ const defaultCollectionSlug = "registry"
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, authzEngine *authz.Engine, serverURL *url.URL) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, authzEngine *authz.Engine, auditLogger *audit.Logger, serverURL *url.URL) *Service {
 	logger = logger.With(attr.SlogComponent("collections"))
 
 	return &Service{
@@ -69,6 +72,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		orgRepo:   orgRepo.New(db),
 		auth:      auth.New(logger, db, sessions, authzEngine),
 		authz:     authzEngine,
+		audit:     auditLogger,
 		sessions:  sessions,
 		serverURL: serverURL,
 	}
@@ -143,6 +147,18 @@ func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*type
 		}
 	}
 
+	if err := s.audit.LogMcpCollectionCreate(ctx, dbtx, audit.LogMcpCollectionCreateEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		CollectionURN:    urn.NewMcpCollection(collection.ID),
+		CollectionName:   collection.Name,
+		CollectionSlug:   collection.Slug,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log collection creation").Log(ctx, s.logger)
+	}
+
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection").Log(ctx, s.logger)
 	}
@@ -211,7 +227,36 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid collection_id").Log(ctx, s.logger)
 	}
 
-	updated, err := s.repo.UpdateOrganizationMcpCollection(ctx, repo.UpdateOrganizationMcpCollectionParams{
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	tx := s.repo.WithTx(dbtx)
+
+	existing, err := tx.GetOrganizationMcpCollectionByID(ctx, repo.GetOrganizationMcpCollectionByIDParams{
+		ID:             collectionID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, oops.C(oops.CodeNotFound)
+		}
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
+	}
+
+	reg, err := tx.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
+		CollectionID:   collectionID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").Log(ctx, s.logger)
+	}
+
+	before := toMCPCollection(repo.CreateOrganizationMcpCollectionRow(existing), reg.Namespace)
+
+	updated, err := tx.UpdateOrganizationMcpCollection(ctx, repo.UpdateOrganizationMcpCollectionParams{
 		ID:             collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 		Name:           conv.PtrToPGTextEmpty(payload.Name),
@@ -225,15 +270,27 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to update collection").Log(ctx, s.logger)
 	}
 
-	reg, err := s.repo.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
-		CollectionID:   collectionID,
-		OrganizationID: authCtx.ActiveOrganizationID,
-	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").Log(ctx, s.logger)
+	after := toMCPCollection(repo.CreateOrganizationMcpCollectionRow(updated), reg.Namespace)
+
+	if err := s.audit.LogMcpCollectionUpdate(ctx, dbtx, audit.LogMcpCollectionUpdateEvent{
+		OrganizationID:           authCtx.ActiveOrganizationID,
+		Actor:                    urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName:         authCtx.Email,
+		ActorSlug:                nil,
+		CollectionURN:            urn.NewMcpCollection(updated.ID),
+		CollectionName:           updated.Name,
+		CollectionSlug:           updated.Slug,
+		CollectionSnapshotBefore: before,
+		CollectionSnapshotAfter:  after,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log collection update").Log(ctx, s.logger)
 	}
 
-	return toMCPCollection(repo.CreateOrganizationMcpCollectionRow(updated), reg.Namespace), nil
+	if err := dbtx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection update").Log(ctx, s.logger)
+	}
+
+	return after, nil
 }
 
 func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error {
@@ -293,6 +350,18 @@ func (s *Service) Delete(ctx context.Context, payload *gen.DeletePayload) error 
 		return oops.E(oops.CodeUnexpected, err, "failed to delete collection").Log(ctx, s.logger)
 	}
 
+	if err := s.audit.LogMcpCollectionDelete(ctx, dbtx, audit.LogMcpCollectionDeleteEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		CollectionURN:    urn.NewMcpCollection(collection.ID),
+		CollectionName:   collection.Name,
+		CollectionSlug:   collection.Slug,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "log collection deletion").Log(ctx, s.logger)
+	}
+
 	if err := dbtx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error saving collection deletion").Log(ctx, s.logger)
 	}
@@ -320,7 +389,15 @@ func (s *Service) AttachServer(ctx context.Context, payload *gen.AttachServerPay
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
 	}
 
-	collection, err := s.repo.GetOrganizationMcpCollectionByID(ctx, repo.GetOrganizationMcpCollectionByIDParams{
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	tx := s.repo.WithTx(dbtx)
+
+	collection, err := tx.GetOrganizationMcpCollectionByID(ctx, repo.GetOrganizationMcpCollectionByIDParams{
 		ID:             collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
@@ -331,16 +408,33 @@ func (s *Service) AttachServer(ctx context.Context, payload *gen.AttachServerPay
 		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
 	}
 
-	if err := s.attachServerToCollection(ctx, s.repo, collectionID, toolsetID, authCtx.ActiveOrganizationID, authCtx.UserID); err != nil {
+	if err := s.attachServerToCollection(ctx, tx, collectionID, toolsetID, authCtx.ActiveOrganizationID, authCtx.UserID); err != nil {
 		return nil, err
 	}
 
-	reg, err := s.repo.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
+	reg, err := tx.GetOrganizationMcpCollectionRegistryByID(ctx, repo.GetOrganizationMcpCollectionRegistryByIDParams{
 		CollectionID:   collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error accessing collection registry").Log(ctx, s.logger)
+	}
+
+	if err := s.audit.LogMcpCollectionAttachServer(ctx, dbtx, audit.LogMcpCollectionAttachServerEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		CollectionURN:    urn.NewMcpCollection(collection.ID),
+		CollectionName:   collection.Name,
+		CollectionSlug:   collection.Slug,
+		ToolsetURN:       urn.NewToolset(toolsetID),
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log collection server attachment").Log(ctx, s.logger)
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "error saving collection server attachment").Log(ctx, s.logger)
 	}
 
 	return toMCPCollection(repo.CreateOrganizationMcpCollectionRow(collection), reg.Namespace), nil
@@ -366,7 +460,15 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 		return oops.E(oops.CodeBadRequest, err, "invalid toolset_id").Log(ctx, s.logger)
 	}
 
-	_, err = s.repo.GetOrganizationMcpCollectionByID(ctx, repo.GetOrganizationMcpCollectionByIDParams{
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error accessing collections").Log(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	tx := s.repo.WithTx(dbtx)
+
+	collection, err := tx.GetOrganizationMcpCollectionByID(ctx, repo.GetOrganizationMcpCollectionByIDParams{
 		ID:             collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
@@ -377,12 +479,41 @@ func (s *Service) DetachServer(ctx context.Context, payload *gen.DetachServerPay
 		return oops.E(oops.CodeUnexpected, err, "error accessing collection").Log(ctx, s.logger)
 	}
 
-	if err := s.repo.DetachServerFromOrganizationMcpCollection(ctx, repo.DetachServerFromOrganizationMcpCollectionParams{
+	attached, err := tx.IsServerAttachedToOrganizationMcpCollection(ctx, repo.IsServerAttachedToOrganizationMcpCollectionParams{
+		CollectionID:   collectionID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ToolsetID:      toolsetID,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error checking collection server attachment").Log(ctx, s.logger)
+	}
+	if !attached {
+		return nil
+	}
+
+	if err := tx.DetachServerFromOrganizationMcpCollection(ctx, repo.DetachServerFromOrganizationMcpCollectionParams{
 		CollectionID:   collectionID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ToolsetID:      toolsetID,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to detach server from collection").Log(ctx, s.logger)
+	}
+
+	if err := s.audit.LogMcpCollectionDetachServer(ctx, dbtx, audit.LogMcpCollectionDetachServerEvent{
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		ActorDisplayName: authCtx.Email,
+		ActorSlug:        nil,
+		CollectionURN:    urn.NewMcpCollection(collection.ID),
+		CollectionName:   collection.Name,
+		CollectionSlug:   collection.Slug,
+		ToolsetURN:       urn.NewToolset(toolsetID),
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "log collection server detachment").Log(ctx, s.logger)
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error saving collection server detachment").Log(ctx, s.logger)
 	}
 
 	return nil

--- a/server/internal/collections/setup_test.go
+++ b/server/internal/collections/setup_test.go
@@ -79,7 +79,7 @@ func newTestCollectionsService(t *testing.T) (context.Context, *testInstance) {
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient(), cache.NoopCache)
 	auditLogger := audit.NewLogger()
 
-	svc := collections.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, testenv.DefaultSiteURL(t))
+	svc := collections.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, auditLogger, testenv.DefaultSiteURL(t))
 	toolsetsSvc := toolsets.NewService(logger, tracerProvider, conn, sessionManager, nil, authzEngine, auditLogger)
 
 	return ctx, &testInstance{

--- a/server/internal/urn/mcp_collection.go
+++ b/server/internal/urn/mcp_collection.go
@@ -1,0 +1,156 @@
+package urn
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type McpCollection struct {
+	ID uuid.UUID
+
+	checked bool
+	err     error
+}
+
+func NewMcpCollection(id uuid.UUID) McpCollection {
+	c := McpCollection{
+		ID:      id,
+		checked: false,
+		err:     nil,
+	}
+
+	_ = c.validate()
+
+	return c
+}
+
+func ParseMcpCollection(value string) (McpCollection, error) {
+	if value == "" {
+		return McpCollection{}, fmt.Errorf("%w: empty string", ErrInvalid)
+	}
+
+	parts := strings.SplitN(value, delimiter, 2)
+	if len(parts) != 2 || parts[1] == "" || strings.Contains(parts[1], delimiter) {
+		return McpCollection{}, fmt.Errorf("%w: expected two segments (mcp_collection:<uuid>)", ErrInvalid)
+	}
+
+	if parts[0] != "mcp_collection" {
+		truncated := parts[0][:min(maxSegmentLength, len(parts[0]))]
+		return McpCollection{}, fmt.Errorf("%w: expected mcp_collection urn (got: %q)", ErrInvalid, truncated)
+	}
+
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return McpCollection{}, fmt.Errorf("%w: invalid mcp_collection uuid", ErrInvalid)
+	}
+
+	return NewMcpCollection(id), nil
+}
+
+func (u McpCollection) IsZero() bool {
+	return u.ID == uuid.Nil
+}
+
+func (u McpCollection) String() string {
+	return "mcp_collection" + delimiter + u.ID.String()
+}
+
+func (u McpCollection) MarshalJSON() ([]byte, error) {
+	if err := u.validate(); err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(u.String())
+	if err != nil {
+		return nil, fmt.Errorf("mcp_collection urn to json: %w", err)
+	}
+
+	return b, nil
+}
+
+func (u *McpCollection) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("read mcp_collection urn string from json: %w", err)
+	}
+
+	parsed, err := ParseMcpCollection(s)
+	if err != nil {
+		return fmt.Errorf("parse mcp_collection urn json string: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u *McpCollection) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("cannot scan %T into McpCollection", value)
+	}
+
+	parsed, err := ParseMcpCollection(s)
+	if err != nil {
+		return fmt.Errorf("scan database value: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u McpCollection) Value() (driver.Value, error) {
+	if err := u.validate(); err != nil {
+		return nil, err
+	}
+
+	return u.String(), nil
+}
+
+func (u McpCollection) MarshalText() ([]byte, error) {
+	if err := u.validate(); err != nil {
+		return nil, fmt.Errorf("marshal mcp_collection urn text: %w", err)
+	}
+
+	return []byte(u.String()), nil
+}
+
+func (u *McpCollection) UnmarshalText(text []byte) error {
+	parsed, err := ParseMcpCollection(string(text))
+	if err != nil {
+		return fmt.Errorf("unmarshal mcp_collection urn text: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u *McpCollection) validate() error {
+	if u.checked {
+		return u.err
+	}
+
+	u.checked = true
+
+	if u.ID == uuid.Nil {
+		u.err = fmt.Errorf("%w: empty id", ErrInvalid)
+		return u.err
+	}
+
+	return nil
+}

--- a/server/internal/urn/mcp_collection_test.go
+++ b/server/internal/urn/mcp_collection_test.go
@@ -1,0 +1,64 @@
+package urn_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMcpCollectionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	original := urn.NewMcpCollection(id)
+
+	require.Equal(t, "mcp_collection:11111111-1111-1111-1111-111111111111", original.String())
+
+	parsed, err := urn.ParseMcpCollection(original.String())
+	require.NoError(t, err)
+	require.Equal(t, original.ID, parsed.ID)
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	require.Equal(t, `"mcp_collection:11111111-1111-1111-1111-111111111111"`, string(data))
+
+	var fromJSON urn.McpCollection
+	err = json.Unmarshal(data, &fromJSON)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, fromJSON.ID)
+
+	text, err := original.MarshalText()
+	require.NoError(t, err)
+
+	var fromText urn.McpCollection
+	err = fromText.UnmarshalText(text)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, fromText.ID)
+
+	value, err := original.Value()
+	require.NoError(t, err)
+
+	var fromDB urn.McpCollection
+	err = fromDB.Scan(value)
+	require.NoError(t, err)
+	require.Equal(t, original.ID, fromDB.ID)
+}
+
+func TestMcpCollectionRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	_, err := urn.ParseMcpCollection("")
+	require.ErrorIs(t, err, urn.ErrInvalid)
+
+	_, err = urn.ParseMcpCollection("toolset:11111111-1111-1111-1111-111111111111")
+	require.ErrorIs(t, err, urn.ErrInvalid)
+
+	_, err = urn.ParseMcpCollection("mcp_collection:not-a-uuid")
+	require.ErrorIs(t, err, urn.ErrInvalid)
+
+	_, err = urn.NewMcpCollection(uuid.Nil).MarshalJSON()
+	require.ErrorIs(t, err, urn.ErrInvalid)
+}


### PR DESCRIPTION
## Summary

Audit-log every collection mutation, and split the dashboard's collection editor so editing details no longer entangles attached-server management.

## Server — audit logging

Five new actions on the collections API:

- `mcp_collection:create`
- `mcp_collection:update` — before/after snapshots
- `mcp_collection:delete`
- `mcp_collection:attach_server` — `toolset_id` metadata
- `mcp_collection:detach_server` — `toolset_id` metadata

**New subject type.** `urn.McpCollection` (prefix `mcp_collection`) — full URN method set plus tests.

**Atomic emit.** `Update`, `AttachServer`, and `DetachServer` now run the mutation and the audit insert in one transaction. `Create` and `Delete` were already transactional.

**Wiring.** `audit.Logger` is injected into `collections.Service` from `cmd/gram/start.go`; tests pass it via `setup_test.go`. `audit_test.go` asserts one row per action per operation via `audittest.AuditLogCountByAction`.

## Dashboard — collection detail UX

`CollectionDetail.tsx` splits the single "edit" panel into two flows:

- **Edit collection details** — name, description, visibility.
- **Manage attached servers** — driven by a new `editingServers` state.

Selection state renamed `editSelectedToolsetIds` → `selectedServerToolsetIds` since it no longer participates in details edit.

## Test plan

- [ ] `mise run lint:server`
- [ ] `mise run test:server ./internal/collections/... ./internal/audit/... ./internal/urn/...`
- [ ] Server: as admin, create/update/delete a collection and attach/detach a server. Confirm `mcp_collection:*` rows in the audit logs endpoint.
- [ ] Dashboard: open a collection → Edit. Details save without touching servers. Server-management entry point still drives attach/detach.

Resolves AGE-2417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
