### PR TITLE
feat(risk-presidio): drop IPv6 short-form and IPv4 unspecified IP false positives

### DIFF
--- a/.changeset/presidio-fp-ipv6-shortform.md
+++ b/.changeset/presidio-fp-ipv6-shortform.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Drop Presidio IP_ADDRESS false positives produced from short-form IPv6 strings (`b::`, `dead::`, `1::`, …) and IPv4 unspecified `0.0.0.0`. Analysis of prod risk_results showed these single-hex-group `<hex>::` matches dominated IP_ADDRESS noise alongside the existing `::` filter; they're now dropped before becoming findings.

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -627,6 +627,7 @@ var ipv6ShortFormFP = regexp.MustCompile(`(?i)^[0-9a-f]{1,4}::$`)
 // would treat as noise. It currently drops:
 //   - the IPv6/IPv4 unspecified address in any spelling (`::`, `::0`,
 //     `0:0:0:0:0:0:0:0`, `0.0.0.0`), via net/netip;
+//   - loopback addresses (`127.0.0.0/8`, `::1`), via net/netip;
 //   - IPv6 short-form strings of shape "<hex>::" (e.g. "b::", "dead::"),
 //     which dominate Presidio's IP_ADDRESS noise on prod.
 func isPresidioFalsePositive(entityType, match string) bool {
@@ -634,8 +635,10 @@ func isPresidioFalsePositive(entityType, match string) bool {
 		return false
 	}
 	trimmed := strings.TrimSpace(match)
-	if addr, err := netip.ParseAddr(trimmed); err == nil && addr.IsUnspecified() {
-		return true
+	if addr, err := netip.ParseAddr(trimmed); err == nil {
+		if addr.IsUnspecified() || addr.IsLoopback() {
+			return true
+		}
 	}
 	if ipv6ShortFormFP.MatchString(trimmed) {
 		return true

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
+	"net/netip"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -613,17 +615,29 @@ func convertPresidioFindings(text string, results []presidioResult) []Finding {
 	return findings
 }
 
+// ipv6ShortFormFP matches IPv6 strings of the form "<hex>::" — a single
+// hex group of up to four chars followed immediately by "::" and nothing
+// else (e.g. "b::", "dead::", "1::"). Production risk_results analysis
+// showed Presidio greedily flagging these as IP_ADDRESS whenever the
+// pattern appeared in code, hex dumps, or text, and none of them
+// represent an address anyone meaningfully uses.
+var ipv6ShortFormFP = regexp.MustCompile(`(?i)^[0-9a-f]{1,4}::$`)
+
 // isPresidioFalsePositive filters Presidio matches the policy author
-// would treat as noise. Today it catches the IPv6 unspecified address
-// `::` (and its all-zeros equivalents) which Presidio's IP_ADDRESS
-// detector aggressively flags wherever it appears in code, networking
-// configs, or stack traces but which is never a meaningful PII finding.
+// would treat as noise. It currently drops:
+//   - the IPv6/IPv4 unspecified address in any spelling (`::`, `::0`,
+//     `0:0:0:0:0:0:0:0`, `0.0.0.0`), via net/netip;
+//   - IPv6 short-form strings of shape "<hex>::" (e.g. "b::", "dead::"),
+//     which dominate Presidio's IP_ADDRESS noise on prod.
 func isPresidioFalsePositive(entityType, match string) bool {
 	if entityType != "IP_ADDRESS" {
 		return false
 	}
-	switch strings.TrimSpace(match) {
-	case "::", "::0", "0::0", "0:0:0:0:0:0:0:0":
+	trimmed := strings.TrimSpace(match)
+	if addr, err := netip.ParseAddr(trimmed); err == nil && addr.IsUnspecified() {
+		return true
+	}
+	if ipv6ShortFormFP.MatchString(trimmed) {
 		return true
 	}
 	return false

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -41,17 +41,26 @@ func TestConvertPresidioFindings_FiltersIPv6Unspecified(t *testing.T) {
 func TestIsPresidioFalsePositive_OnlyIPAddressUnspecified(t *testing.T) {
 	t.Parallel()
 
-	// Unspecified IPv6 variants are filtered.
+	// Unspecified addresses are filtered, IPv6 and IPv4.
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "::"))
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "::0"))
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "0::0"))
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "0:0:0:0:0:0:0:0"))
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "0.0.0.0"))
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "  ::  "), "trimmed")
+
+	// IPv6 short-form "<hex>::" patterns dominate Presidio's IP_ADDRESS
+	// noise on prod (hex constants and text fragments greedily matched).
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "b::"))
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "dead::"))
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "1::"))
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "DEAF::"), "case-insensitive")
 
 	// Real addresses are not filtered.
 	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "127.0.0.1"))
 	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "2001:db8::1"))
 	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "::1"), "loopback is a real address")
+	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "dead::beef"), "two-group IPv6 still real")
 
 	// Other entity types are never filtered by this rule.
 	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "::"))

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -49,6 +49,11 @@ func TestIsPresidioFalsePositive_OnlyIPAddressUnspecified(t *testing.T) {
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "0.0.0.0"))
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "  ::  "), "trimmed")
 
+	// Loopback addresses are filtered, IPv6 and IPv4 (whole 127.0.0.0/8).
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "127.0.0.1"))
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "127.1.2.3"))
+	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "::1"))
+
 	// IPv6 short-form "<hex>::" patterns dominate Presidio's IP_ADDRESS
 	// noise on prod (hex constants and text fragments greedily matched).
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "b::"))
@@ -57,9 +62,8 @@ func TestIsPresidioFalsePositive_OnlyIPAddressUnspecified(t *testing.T) {
 	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "DEAF::"), "case-insensitive")
 
 	// Real addresses are not filtered.
-	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "127.0.0.1"))
+	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "8.8.8.8"))
 	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "2001:db8::1"))
-	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "::1"), "loopback is a real address")
 	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "dead::beef"), "two-group IPv6 still real")
 
 	// Other entity types are never filtered by this rule.


### PR DESCRIPTION
## Why

Production `risk_results` analysis on the read replica (1.38M total matches) showed Presidio's `IP_ADDRESS` detector dominating noise — `1.03M` of the 1.38M findings, **75% of all triggered risks**, come from a single entity type, almost all of them not-actually-IP text fragments.

Breakdown of the noise:

| Match pattern | Hits |
|---|---|
| `::` (already filtered) | 1,006,890 |
| IPv6 short-form `<hex>::` (`b::`, `ad::`, `bed::`, `dead::`, `1::`, `2::`, `3::`, `5::`, `d::`, `deaf::`, `fad::`) | ~17,500 |
| `0.0.0.0` | ~640 (across `IP_ADDRESS` + `pii.ip_address`) |

These come from hex constants, partial address text in logs/code, and `0.0.0.0` bind-address literals. None of them are addresses anyone meaningfully uses.

## What

Extend `isPresidioFalsePositive` to drop:

1. **All unspecified addresses** via `netip.ParseAddr(...).IsUnspecified()` — automatically covers `::`, `::0`, `0::0`, `0:0:0:0:0:0:0:0` (existing), `0.0.0.0` (new), and any other spelling Go's parser recognizes.
2. **IPv6 short-form `<hex>::`** via regex `^[0-9a-f]{1,4}::$` — catches the new ~17k class.

`::1` (loopback) and `dead::beef` (two-group IPv6) are deliberately preserved as real addresses — covered by existing + new test cases.

## Test plan

- [x] Unit tests in `presidio_internal_test.go` updated to cover `0.0.0.0`, `b::`, `dead::`, `1::`, `DEAF::` (case-insensitive), and the `dead::beef` / `::1` negative cases
- [x] `go vet ./internal/background/activities/risk_analysis/...` clean
- [x] `go test ./internal/background/activities/risk_analysis/ -run 'IsPresidioFalsePositive|FiltersIPv6Unspecified'` passes