### PR TITLE
fix(headless): swap removed start:mock-idp for start:dev-idp

### DIFF
--- a/.mise-tasks/start/headless.sh
+++ b/.mise-tasks/start/headless.sh
@@ -17,11 +17,11 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-echo "Logs: $LOG_DIR/{mock-idp,server,worker,dashboard}.log"
+echo "Logs: $LOG_DIR/{dev-idp,server,worker,dashboard}.log"
 echo ""
 
-echo "Starting mock-idp..."
-mise run start:mock-idp > "$LOG_DIR/mock-idp.log" 2>&1 &
+echo "Starting dev-idp..."
+mise run start:dev-idp > "$LOG_DIR/dev-idp.log" 2>&1 &
 
 echo "Starting server..."
 mise run start:server > "$LOG_DIR/server.log" 2>&1 &


### PR DESCRIPTION
## Summary

`.mise-tasks/start/headless.sh` invoked `mise run start:mock-idp`, which still points at `./mock-speakeasy-idp/main` — a directory that was deleted in PR #2825 (`fix(auth): admin override, slug dedup, and re-apply Speakeasy IDP removal`). Running `mise run start:headless` therefore fails immediately with `stat .../mock-speakeasy-idp/main: directory not found` and never starts the IDP, which in turn blocks login from a headless dev environment.

`mprocs.yaml` was already updated to use `start:dev-idp` at the time of the removal, so this is an orphaned reference in the headless flow. This patch:

- swaps `start:mock-idp` → `start:dev-idp`, and
- renames the log file from `mock-idp.log` → `dev-idp.log` so the new task's logs land in the path the user is told about.

## Why this matters

`mise run start:headless` is the documented headless equivalent of `madprocs`. Without this fix, anyone bringing up Gram outside the TUI hits a stale-task failure during onboarding and has to bypass the script. Reported during a fresh-checkout login walkthrough where everything else needed to be hand-wired before the dashboard could authenticate.

## Related stale references (not in this PR)

`.mise-tasks/seed.mts` carries the same bug: it still tries to authenticate via `${SPEAKEASY_SERVER_ADDRESS}/v1/speakeasy_provider/login`, which was the `mock-speakeasy-idp` API. Neither `SPEAKEASY_SERVER_ADDRESS` nor `SPEAKEASY_SECRET_KEY` is defined anywhere in `mise.toml` after #2825. `mise run seed` currently fails with `SPEAKEASY_SERVER_ADDRESS is not set`. Fixing it requires re-implementing the auth bootstrap against `dev-idp`'s mock-workos / OAuth2 flow (cookie-jar + `/rpc/auth.login` → `/rpc/auth.callback`), so it deserves its own PR.

## Test plan

- [ ] `mise run start:headless` reaches `All processes started.` without the IDP task crashing.
- [ ] `tail /tmp/gram-dev/dev-idp.log` shows `dev-idp listening` on `:35291`.
- [ ] Login flow against `https://localhost:5173` completes end-to-end against the mock-workos IDP.