### PR TITLE
chore: add breaking change detection to webhooks catalog

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -60,6 +60,9 @@ plog:
   - "go.sum"
   - "plog/**"
 
+webhooks-catalog:
+  - "server/internal/outbox/events/catalog_gen.yaml"
+
 # Subset of `server` that gates the prompt-injection risk report job.
 risk_accuracy:
   - ".github/scripts/risk-metrics-comment.*"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,6 +49,7 @@ jobs:
       sdk-gen: ${{ steps.gates.outputs.sdk-gen }}
       risk_accuracy: ${{ steps.gates.outputs.risk_accuracy }}
       pi_classifier: ${{ steps.gates.outputs.pi_classifier }}
+      webhooks-catalog: ${{ steps.gates.outputs.webhooks-catalog }}
       elements-examples: ${{ steps.list-elements-examples.outputs.examples }}
     steps:
       - name: Checkout source code
@@ -147,6 +148,13 @@ jobs:
             echo "Prompt-injection classifier image build will run."
           else
             echo "Prompt-injection classifier image build will be skipped."
+          fi
+
+          if [[ "${{ steps.filter.outputs.webhooks-catalog }}" == "true" || "${{ github.event_name }}" == "merge_group" || "$HAS_FULL_CI_LABEL" == "true" ]]; then
+            echo "webhooks-catalog=true" >> $GITHUB_OUTPUT
+            echo "Webhooks catalog breaking-change check will run."
+          else
+            echo "Webhooks catalog breaking-change check will be skipped."
           fi
       - id: list-elements-examples
         name: List elements examples
@@ -499,6 +507,56 @@ jobs:
           dir-name: gram-clickhouse
           dev-url: docker://clickhouse/clickhouse-server/25.8.3/dev
           tag: ${{ steps.tag.outputs.tag }}
+
+  webhooks-catalog-breaking-changes:
+    name: Check webhooks catalog for breaking changes
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: changes
+    if: needs.changes.outputs.webhooks-catalog == 'true' && github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Check for breaking changes
+        run: mise run lint:webhooks-server
+
+      - name: Post review comment on breaking changes
+        if: hashFiles('breaking-changes.md') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          jq -n \
+            --arg commit_id "${{ github.event.pull_request.head.sha }}" \
+            --rawfile body breaking-changes.md \
+            '{
+              commit_id: $commit_id,
+              subject_type: "file",
+              path: "server/internal/outbox/events/catalog_gen.yaml",
+              body: $body
+            }' \
+            | gh api \
+                "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+                --method POST \
+                --input -
+
+      - name: Fail on breaking changes
+        if: hashFiles('breaking-changes.md') != ''
+        run: |
+          cat breaking-changes.md
+          exit 1
 
   server-build-lint:
     runs-on: blacksmith-16vcpu-ubuntu-2404
@@ -1606,6 +1664,7 @@ jobs:
       - elements-examples
       - atlas-lint
       - atlas-push
+      - webhooks-catalog-breaking-changes
     steps:
       - name: Check results
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ flags.local.csv
 node_modules
 bin
 junit-report.xml
+report.md
 .mise-tasks/local
 .assets
 .vscode/*

--- a/.mise-tasks/lint/webhooks-server.sh
+++ b/.mise-tasks/lint/webhooks-server.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#MISE description="Check webhooks catalog for breaking changes against a base ref"
+#MISE dir="{{ config_root }}"
+
+#USAGE flag "--base <ref>" help="Git ref to compare against" default="origin/main"
+
+set -eo pipefail
+
+CATALOG="server/internal/outbox/events/catalog_gen.yaml"
+BASE="${usage_base:-origin/main}"
+
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  openapi-changes markdown-report --no-logo \
+    --report-file breaking-changes.md \
+    --include-diff \
+    "${BASE}:${CATALOG}" "${CATALOG}"
+else
+  openapi-changes summary "${BASE}:${CATALOG}" "${CATALOG}"
+fi

--- a/hk.pkl
+++ b/hk.pkl
@@ -48,7 +48,14 @@ local linters = new Mapping<String, Step> {
         "**/*.markdown.mdx",
         "**/*.md",
       )
-    exclude = List(".speakeasy/**", "server/gen/**", "client/sdk/**", "pnpm-lock.yaml")
+    exclude =
+      List(
+        ".speakeasy/**",
+        "server/gen/**",
+        "server/**/*_gen.yaml",
+        "client/sdk/**",
+        "pnpm-lock.yaml",
+      )
     check = "pnpm oxfmt --check {{files}}"
     fix = "pnpm oxfmt --write {{files}}"
   }

--- a/mise.toml
+++ b/mise.toml
@@ -26,6 +26,7 @@ hk = "1.38.0"
 pkl = "0.31.0"
 "github:speakeasy-api/madprocs" = "0.1.33"
 "github:temporalio/cli" = "1.6.1"
+"github:pb33f/openapi-changes" = "0.2.7"
 
 # ℹ️ The settings below are sensible defaults for local development. When
 # deploying to production, you will want to configure these more carefully.


### PR DESCRIPTION
Adds a `webhooks-catalog-breaking-changes` CI job that uses `openapi-changes markdown-report` to compare `catalog_gen.yaml` on the PR branch against `origin/main`. If breaking changes are detected the report file is emitted (exit 0), posted as a file-level review comment, and the job is explicitly failed. A genuine tool error (non-zero exit) fails the job immediately without any continue-on-error gymnastics.

The check is also available locally as `mise run lint:webhooks-server` via `.mise-tasks/lint/webhooks-server.sh`. Locally it runs `openapi-changes summary` for interactive output; in CI it switches to `markdown-report` and writes `breaking-changes.md` to the workspace.

The check is gated by a new `webhooks-catalog` paths-filter so it only runs when the catalog file itself changes (plus `merge_group` and `ci:full` label). It is wired into `ci-gate` so it blocks merge.

`openapi-changes` (pb33f/openapi-changes v0.2.7) is also added to `mise.toml` so the tool is available locally for manual inspection.