### PR TITLE
feat: enterprise onboarding setup wizard with subdomain auth

### DIFF
--- a/.mise-tasks/zero/hosts.sh
+++ b/.mise-tasks/zero/hosts.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# MISE description='Ensure setup.localhost is in /etc/hosts for enterprise onboarding dev.'
+# MISE hide=true
+
+ENTRY="127.0.0.1  setup.localhost"
+
+if grep -q 'setup\.localhost' /etc/hosts 2>/dev/null; then
+    echo "✅ setup.localhost already in /etc/hosts"
+    exit 0
+fi
+
+echo "Adding setup.localhost to /etc/hosts (requires sudo)"
+sudo sh -c "echo '$ENTRY' >> /etc/hosts"
+echo "✅ Added setup.localhost to /etc/hosts"

--- a/.mise-tasks/zero/tls.sh
+++ b/.mise-tasks/zero/tls.sh
@@ -117,6 +117,7 @@ cert_names() {
     "$server_host" \
     "$assistant_host" \
     "localhost" \
+    "setup.localhost" \
     "127.0.0.1" \
     "::1" \
     "gram.local" \

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -32,6 +32,7 @@ import CliCallback from "./pages/cli/CliCallback";
 import SlackRegister from "./pages/slackapp/SlackRegister";
 import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
 import SetupPage from "./pages/setup/Setup";
+import { isSetupDomain } from "./lib/utils";
 
 export default function App() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
@@ -247,6 +248,8 @@ const RouteProvider = () => {
           <Route index element={<SlackRegister />} />
         </Route>
         <Route path="/" element={<LoginCheck />}>
+          {/* On the setup subdomain, render the wizard at "/" so the org slug stays hidden */}
+          {isSetupDomain() && <Route index element={<SetupPage />} />}
           <Route path=":orgSlug/projects/:projectSlug">
             {routesWithSubroutes(outsideStructureRoutes)}
           </Route>

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -31,6 +31,7 @@ import { usePageTitle } from "./hooks/use-page-title";
 import CliCallback from "./pages/cli/CliCallback";
 import SlackRegister from "./pages/slackapp/SlackRegister";
 import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
+import SetupPage from "./pages/setup/Setup";
 
 export default function App() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
@@ -257,6 +258,7 @@ const RouteProvider = () => {
             />
             {routesWithSubroutes(authenticatedRoutes)}
           </Route>
+          <Route path=":orgSlug/setup" element={<SetupPage />} />
           <Route path=":orgSlug" element={<OrgLayout />}>
             {orgHomeRoute?.component && (
               <Route index element={<orgHomeRoute.component />} />

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -2,10 +2,12 @@ import { useIsAdmin, useOrganization, useSession } from "@/contexts/Auth.tsx";
 import { useSdkClient } from "@/contexts/Sdk.tsx";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
+import { isSetupDomain } from "@/lib/utils";
 import { Icon, Modal, ModalProvider } from "@speakeasy-api/moonshine";
 import { ShieldAlert } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
+import Login from "@/pages/login/Login";
 import { AppSidebar } from "./app-sidebar.tsx";
 import { BrandGradientLine } from "./brand-gradient-line.tsx";
 import { InsightsProvider } from "./insights-sidebar.tsx";
@@ -19,6 +21,10 @@ export const LoginCheck = () => {
   const location = useLocation();
 
   if (session.session === "") {
+    // On setup domain, render login inline — no redirect, no URL change
+    if (isSetupDomain()) {
+      return <Login />;
+    }
     const redirectTo = encodeURIComponent(location.pathname + location.search);
     return <Navigate to={`/login?redirect=${redirectTo}`} />;
   }

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -87,7 +87,8 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
     if (
       location.pathname === "/" ||
       UNAUTHENTICATED_PATHS.some((p) => location.pathname.startsWith(p)) ||
-      location.pathname.endsWith("/setup")
+      location.pathname.endsWith("/setup") ||
+      isSetupDomain()
     ) {
       return null;
     }
@@ -151,19 +152,22 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   // Handle initial navigation
   const redirectParam = searchParams.get("redirect");
 
-  // On the setup subdomain, always funnel authenticated users to the setup wizard
+  // On the setup subdomain, always funnel authenticated users to the setup wizard.
+  // The setup domain renders the wizard at "/" so the org slug stays out of the URL.
+  // Early-return after the redirect so we never hit the slug-based navigation below
+  // (which would redirect to /:orgSlug and cause a loop).
   if (isSetupDomain() && session.organization) {
-    const setupPath = `/${session.organization.slug}/setup`;
-    if (!location.pathname.startsWith(setupPath)) {
-      return <Navigate to={setupPath} replace />;
+    if (location.pathname !== "/") {
+      return <Navigate to="/" replace />;
     }
+    return (
+      <SessionContext.Provider value={session}>
+        {children}
+      </SessionContext.Provider>
+    );
   }
 
   if (redirectParam) {
-    // On setup domain, ignore redirect params that would leave the setup flow
-    if (isSetupDomain() && session.organization) {
-      return <Navigate to={`/${session.organization.slug}/setup`} replace />;
-    }
     return <Navigate to={redirectParam} replace />;
   } else if (isSlugExempt) {
     // Fall through to render children

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -85,7 +85,8 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
     // skeleton flash for logged-out users before the redirect to /login fires.
     if (
       location.pathname === "/" ||
-      UNAUTHENTICATED_PATHS.some((p) => location.pathname.startsWith(p))
+      UNAUTHENTICATED_PATHS.some((p) => location.pathname.startsWith(p)) ||
+      location.pathname.endsWith("/setup")
     ) {
       return null;
     }

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -29,6 +29,7 @@ import {
   useSearchParams,
 } from "react-router";
 import { orgRoutePaths } from "@/routes";
+import { isSetupDomain } from "@/lib/utils";
 import { useSlugs } from "./Sdk";
 import {
   useCaptureUserAuthorizationEvent,
@@ -149,7 +150,20 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
 
   // Handle initial navigation
   const redirectParam = searchParams.get("redirect");
+
+  // On the setup subdomain, always funnel authenticated users to the setup wizard
+  if (isSetupDomain() && session.organization) {
+    const setupPath = `/${session.organization.slug}/setup`;
+    if (!location.pathname.startsWith(setupPath)) {
+      return <Navigate to={setupPath} replace />;
+    }
+  }
+
   if (redirectParam) {
+    // On setup domain, ignore redirect params that would leave the setup flow
+    if (isSetupDomain() && session.organization) {
+      return <Navigate to={`/${session.organization.slug}/setup`} replace />;
+    }
     return <Navigate to={redirectParam} replace />;
   } else if (isSlugExempt) {
     // Fall through to render children

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -11,6 +11,12 @@ export function cn(...inputs: ClassValue[]) {
 // Use everywhere except the playground — MCP configs, callback URL
 // displays, anything operator-facing.
 export function getServerURL(): string {
+  // On the setup subdomain, route API calls through the current origin
+  // (Vite proxy in dev, same-origin in prod) so that session cookies —
+  // which are scoped to the setup host — are included by the browser.
+  if (isSetupDomain()) {
+    return window.location.origin;
+  }
   return __GRAM_SERVER_URL__ ?? window.location.origin;
 }
 
@@ -23,7 +29,10 @@ export function getPlaygroundMcpBaseURL(): string {
 }
 
 export function buildLoginRedirectURL(redirectTo: string | null): string {
-  let href = `${getServerURL()}/rpc/auth.login`;
+  // On the setup subdomain, route auth through the current origin so the
+  // session cookie is scoped to setup.* (Vite proxies /rpc to the server).
+  const base = isSetupDomain() ? window.location.origin : getServerURL();
+  let href = `${base}/rpc/auth.login`;
   if (redirectTo) href += `?redirect=${encodeURIComponent(redirectTo)}`;
   return href;
 }

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -42,6 +42,15 @@ export function assert(condition: unknown, message: string): asserts condition {
   }
 }
 
+/**
+ * Returns true when the dashboard is served from the setup subdomain
+ * (setup.getgram.ai in prod, setup.localhost in dev).
+ */
+export function isSetupDomain(): boolean {
+  const hostname = window.location.hostname;
+  return hostname.startsWith("setup.");
+}
+
 export function getCustomDomainCNAME(): string {
   try {
     const url = new URL(getServerURL());

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -53,11 +53,12 @@ export function assert(condition: unknown, message: string): asserts condition {
 
 /**
  * Returns true when the dashboard is served from the setup subdomain
- * (setup.getgram.ai in prod, setup.localhost in dev).
+ * (setup.getgram.ai in prod, setup.dev.getgram.ai in dev,
+ * setup.localhost in local dev, setup-pr-*.dev.getgram.ai in preview deploys).
  */
 export function isSetupDomain(): boolean {
   const hostname = window.location.hostname;
-  return hostname.startsWith("setup.");
+  return hostname.startsWith("setup.") || hostname.startsWith("setup-");
 }
 
 export function getCustomDomainCNAME(): string {

--- a/client/dashboard/src/pages/login/Login.tsx
+++ b/client/dashboard/src/pages/login/Login.tsx
@@ -1,6 +1,6 @@
 import { useSession } from "@/contexts/Auth";
 import { useRoutes } from "@/routes";
-import { buildLoginRedirectURL } from "@/lib/utils";
+import { buildLoginRedirectURL, isSetupDomain } from "@/lib/utils";
 import { JourneyDemo } from "./components/journey-demo";
 import { LoginSection } from "./components/login-section";
 import { useSearchParams, useNavigate } from "react-router";
@@ -24,6 +24,11 @@ export default function Login() {
       // round-trip even when a session already exists.
       if (disposition && redirectTo) {
         window.location.href = buildLoginRedirectURL(redirectTo);
+        return;
+      }
+      // On setup domain, always navigate to the setup wizard after auth
+      if (isSetupDomain()) {
+        navigate("/", { replace: true });
         return;
       }
       if (redirectTo) {

--- a/client/dashboard/src/pages/login/Login.tsx
+++ b/client/dashboard/src/pages/login/Login.tsx
@@ -14,9 +14,14 @@ export default function Login() {
 
   const explicitRedirect = searchParams.get("redirect");
   const disposition = searchParams.get("disposition");
-  const redirectTo =
-    explicitRedirect ??
-    (disposition ? `/?disposition=${encodeURIComponent(disposition)}` : null);
+  // On setup domain, redirect back to the setup origin after auth so the
+  // server doesn't send us to the default GRAM_SITE_URL (app domain).
+  const redirectTo = isSetupDomain()
+    ? window.location.origin
+    : (explicitRedirect ??
+      (disposition
+        ? `/?disposition=${encodeURIComponent(disposition)}`
+        : null));
   useEffect(() => {
     if (session.session !== "") {
       // Disposition signups must reach the server-side Callback so

--- a/client/dashboard/src/pages/setup/Setup.tsx
+++ b/client/dashboard/src/pages/setup/Setup.tsx
@@ -1,0 +1,5 @@
+import { EnterpriseSetupWizard } from "./components/onboarding-wizard";
+
+export default function SetupPage() {
+  return <EnterpriseSetupWizard />;
+}

--- a/client/dashboard/src/pages/setup/components/onboarding-footer.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-footer.tsx
@@ -1,0 +1,33 @@
+export function OnboardingFooter() {
+  return (
+    <footer className="border-border bg-card flex items-center justify-between border-t px-8 py-4">
+      <div className="flex items-center gap-6">
+        <a
+          href="#"
+          className="text-muted-foreground hover:text-foreground text-sm transition-colors"
+        >
+          Help Center
+        </a>
+        <a
+          href="#"
+          className="text-muted-foreground hover:text-foreground text-sm transition-colors"
+        >
+          Status
+        </a>
+        <a
+          href="#"
+          className="text-muted-foreground hover:text-foreground text-sm transition-colors"
+        >
+          Docs
+        </a>
+        <a
+          href="#"
+          className="text-muted-foreground hover:text-foreground text-sm transition-colors"
+        >
+          Contact Support
+        </a>
+      </div>
+      <span className="text-muted-foreground text-sm">Speakeasy 2026</span>
+    </footer>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/onboarding-header.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-header.tsx
@@ -1,0 +1,47 @@
+import { RotateCcw, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Logo } from "@speakeasy-api/moonshine";
+
+interface OnboardingHeaderProps {
+  onRestart?: () => void;
+  onLeave?: () => void;
+}
+
+export function OnboardingHeader({
+  onRestart,
+  onLeave,
+}: OnboardingHeaderProps) {
+  return (
+    <header className="border-border bg-background w-full border-b">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between py-4">
+        <div className="flex items-center gap-3">
+          <Logo variant="wordmark" className="w-32" />
+          <div className="bg-border h-4 w-px" />
+          <span className="text-foreground text-sm font-medium">
+            Set up workspace
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRestart}
+            className="text-muted-foreground hover:text-foreground gap-1.5"
+          >
+            <RotateCcw className="h-4 w-4" />
+            Restart
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onLeave}
+            className="text-muted-foreground hover:text-foreground gap-1.5"
+          >
+            <X className="h-4 w-4" />
+            Leave
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -1,0 +1,90 @@
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface Step {
+  id: string;
+  title: string;
+  description: string;
+}
+
+interface OnboardingStepperProps {
+  steps: Step[];
+  currentStep: number;
+  onStepClick?: (index: number) => void;
+}
+
+export function OnboardingStepper({
+  steps,
+  currentStep,
+  onStepClick,
+}: OnboardingStepperProps) {
+  return (
+    <nav className="flex flex-col" aria-label="Progress">
+      {steps.map((step, index) => {
+        const isCompleted = index < currentStep;
+        const isCurrent = index === currentStep;
+        const isUpcoming = index > currentStep;
+        const isLast = index === steps.length - 1;
+
+        return (
+          <div key={step.id} className="relative flex gap-4">
+            {/* Vertical line connector - runs through all steps except last */}
+            {!isLast && (
+              <div
+                className="absolute top-[28px] left-[13px] h-[calc(100%-28px)] w-px bg-[#e0e0e0]"
+                aria-hidden="true"
+              />
+            )}
+
+            {/* Step indicator */}
+            <div className="relative z-10 flex-shrink-0">
+              {isCurrent ? (
+                /* Active step: dark filled rounded rectangle */
+                <div className="flex h-[28px] w-[28px] items-center justify-center rounded-[8px] bg-[#1a1a1a] text-sm font-semibold text-white">
+                  {index + 1}
+                </div>
+              ) : isCompleted ? (
+                /* Completed step: dark circle with checkmark */
+                <button
+                  onClick={() => onStepClick?.(index)}
+                  className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-full bg-[#1a1a1a] text-white transition-colors hover:bg-[#333]"
+                >
+                  <Check className="h-3.5 w-3.5" strokeWidth={2.5} />
+                </button>
+              ) : (
+                /* Upcoming step: light outlined circle with white fill to cover track */
+                <div className="flex h-[28px] w-[28px] items-center justify-center rounded-full border border-[#d9d9d9] bg-[#f7f7f5] text-sm font-normal text-[#b5b5b5]">
+                  {index + 1}
+                </div>
+              )}
+            </div>
+
+            {/* Step content */}
+            <div className="min-w-0 pt-1 pb-8">
+              <h3
+                className={cn(
+                  "text-sm leading-tight font-semibold",
+                  isCurrent && "text-[#0f0f0f]",
+                  isCompleted && "text-[#0f0f0f]",
+                  isUpcoming && "text-[#a3a3a3]",
+                )}
+              >
+                {step.title}
+              </h3>
+              <p
+                className={cn(
+                  "mt-0.5 text-sm leading-snug",
+                  isCurrent && "text-[#737373]",
+                  isCompleted && "text-[#737373]",
+                  isUpcoming && "text-[#c4c4c4]",
+                )}
+              >
+                {step.description}
+              </p>
+            </div>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -1,0 +1,136 @@
+import { useState, useCallback } from "react";
+import { useNavigate } from "react-router";
+import { OnboardingHeader } from "./onboarding-header";
+import { OnboardingFooter } from "./onboarding-footer";
+import { OnboardingStepper, type Step } from "./onboarding-stepper";
+import {
+  ConnectIdpStep,
+  DirectorySyncStep,
+  InstrumentAgentsStep,
+  AddSourcesStep,
+  ConfirmTrafficStep,
+} from "./steps";
+
+const STEPS: Step[] = [
+  {
+    id: "connect-idp",
+    title: "Connect identity provider",
+    description: "Link SSO for authentication",
+  },
+  {
+    id: "directory-sync",
+    title: "Directory sync",
+    description: "Confirm users and roles",
+  },
+  {
+    id: "instrument-agents",
+    title: "Instrument agents",
+    description: "Connect AI coding assistants",
+  },
+  {
+    id: "add-sources",
+    title: "Add MCP sources",
+    description: "Configure tools and data access",
+  },
+  {
+    id: "confirm-traffic",
+    title: "Confirm traffic",
+    description: "Verify connectivity and compliance",
+  },
+];
+
+export function EnterpriseSetupWizard() {
+  const navigate = useNavigate();
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const goToStep = useCallback(
+    (index: number) => {
+      if (index < currentStep) {
+        setCurrentStep(index);
+      }
+    },
+    [currentStep],
+  );
+
+  const completeCurrentStep = useCallback(() => {
+    const nextIndex = currentStep + 1;
+    if (nextIndex < STEPS.length) {
+      setCurrentStep(nextIndex);
+    } else {
+      // All steps completed - redirect to org home
+      navigate("..");
+    }
+  }, [currentStep, navigate]);
+
+  const goBack = useCallback(() => {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
+    }
+  }, [currentStep]);
+
+  const handleRestart = () => {
+    setCurrentStep(0);
+  };
+
+  const handleLeave = () => {
+    navigate("..");
+  };
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 0:
+        return <ConnectIdpStep onComplete={completeCurrentStep} />;
+      case 1:
+        return (
+          <DirectorySyncStep onComplete={completeCurrentStep} onBack={goBack} />
+        );
+      case 2:
+        return (
+          <InstrumentAgentsStep
+            onComplete={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case 3:
+        return (
+          <AddSourcesStep onComplete={completeCurrentStep} onBack={goBack} />
+        );
+      case 4:
+        return (
+          <ConfirmTrafficStep
+            onComplete={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="bg-background flex min-h-screen flex-col">
+      {/* Header */}
+      <OnboardingHeader onRestart={handleRestart} onLeave={handleLeave} />
+
+      {/* Main content */}
+      <main className="flex flex-1 items-start justify-center px-8 py-16">
+        <div className="flex w-full max-w-5xl gap-24">
+          {/* Left: Stepper */}
+          <div className="w-64 flex-shrink-0">
+            <OnboardingStepper
+              steps={STEPS}
+              currentStep={currentStep}
+              onStepClick={goToStep}
+            />
+          </div>
+
+          {/* Right: Step content */}
+          <div className="max-w-xl flex-1">{renderStep()}</div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <OnboardingFooter />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/step-container.tsx
+++ b/client/dashboard/src/pages/setup/components/step-container.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+import { ArrowRight, ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface StepContainerProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  children: ReactNode;
+  onContinue?: () => void;
+  onBack?: () => void;
+  continueLabel?: string;
+  showBack?: boolean;
+  isLoading?: boolean;
+  canContinue?: boolean;
+}
+
+export function StepContainer({
+  icon,
+  title,
+  description,
+  children,
+  onContinue,
+  onBack,
+  continueLabel = "Continue",
+  showBack = false,
+  isLoading = false,
+  canContinue = true,
+}: StepContainerProps) {
+  return (
+    <div className="flex h-full flex-col">
+      {/* Icon */}
+      <div className="mb-6">{icon}</div>
+
+      {/* Header */}
+      <h1 className="text-foreground text-2xl font-semibold tracking-tight">
+        {title}
+      </h1>
+      <p className="text-muted-foreground mt-2 text-sm">{description}</p>
+
+      {/* Content */}
+      <div className="mt-8 flex-1">{children}</div>
+
+      {/* Divider */}
+      <div className="bg-border mt-8 h-px" />
+
+      {/* Actions */}
+      <div className="mt-6 flex items-center justify-between">
+        <div>
+          {showBack && (
+            <Button
+              variant="ghost"
+              onClick={onBack}
+              className="text-muted-foreground hover:text-foreground gap-1.5"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </Button>
+          )}
+        </div>
+        <Button
+          onClick={onContinue}
+          disabled={!canContinue || isLoading}
+          className="bg-accent hover:bg-accent/90 text-accent-foreground gap-1.5"
+        >
+          {isLoading ? "Loading..." : continueLabel}
+          {!isLoading && <ArrowRight className="h-4 w-4" />}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/steps/add-sources-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/add-sources-step.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { Database, Search } from "lucide-react";
+import { StepContainer } from "../step-container";
+import { MCP_SOURCES } from "../../mock-data";
+import type { McpSource } from "../../types";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface AddSourcesStepProps {
+  onComplete: () => void;
+  onBack: () => void;
+}
+
+export function AddSourcesStep({ onComplete, onBack }: AddSourcesStepProps) {
+  const [sources, setSources] = useState<McpSource[]>(MCP_SOURCES);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeTab, setActiveTab] = useState<"all" | "1st-party" | "3rd-party">(
+    "all",
+  );
+
+  const toggleSource = (sourceId: string) => {
+    setSources((prev) =>
+      prev.map((s) => (s.id === sourceId ? { ...s, enabled: !s.enabled } : s)),
+    );
+  };
+
+  const filteredSources = sources.filter((source) => {
+    const matchesSearch = source.name
+      .toLowerCase()
+      .includes(searchQuery.toLowerCase());
+    const matchesTab = activeTab === "all" || source.type === activeTab;
+    return matchesSearch && matchesTab;
+  });
+
+  const enabledCount = sources.filter((s) => s.enabled).length;
+  const firstPartyEnabled = sources.filter(
+    (s) => s.type === "1st-party" && s.enabled,
+  ).length;
+  const thirdPartyEnabled = sources.filter(
+    (s) => s.type === "3rd-party" && s.enabled,
+  ).length;
+
+  return (
+    <StepContainer
+      icon={
+        <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+          <Database className="text-foreground h-6 w-6" />
+        </div>
+      }
+      title="Add MCP sources"
+      description="Configure which tools and data sources your agents can access. Sanctioned servers will be distributed to your team."
+      onContinue={onComplete}
+      continueLabel="Continue"
+      showBack
+      onBack={onBack}
+    >
+      <div className="space-y-6">
+        {/* Stats */}
+        <div className="grid grid-cols-3 gap-4">
+          <div className="border-border bg-card rounded-lg border p-4">
+            <p className="text-foreground text-2xl font-semibold">
+              {enabledCount}
+            </p>
+            <p className="text-muted-foreground text-xs">Total enabled</p>
+          </div>
+          <div className="border-border bg-card rounded-lg border p-4">
+            <p className="text-foreground text-2xl font-semibold">
+              {firstPartyEnabled}
+            </p>
+            <p className="text-muted-foreground text-xs">1st party</p>
+          </div>
+          <div className="border-border bg-card rounded-lg border p-4">
+            <p className="text-foreground text-2xl font-semibold">
+              {thirdPartyEnabled}
+            </p>
+            <p className="text-muted-foreground text-xs">3rd party</p>
+          </div>
+        </div>
+
+        {/* Search and filter */}
+        <div className="flex items-center gap-3">
+          <div className="relative flex-1">
+            <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+            <Input
+              placeholder="Search sources..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <div className="border-border bg-card flex rounded-lg border p-1">
+            {(["all", "1st-party", "3rd-party"] as const).map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setActiveTab(tab)}
+                className={cn(
+                  "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                  activeTab === tab
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {tab === "all"
+                  ? "All"
+                  : tab === "1st-party"
+                    ? "1st Party"
+                    : "3rd Party"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Sources grid */}
+        <div className="grid max-h-[280px] grid-cols-2 gap-2 overflow-auto">
+          {filteredSources.map((source) => (
+            <div
+              key={source.id}
+              className={cn(
+                "flex items-center gap-3 rounded-lg border p-3 transition-colors",
+                source.enabled
+                  ? "border-foreground/20 bg-secondary/50"
+                  : "border-border bg-card",
+              )}
+            >
+              <div
+                className={cn(
+                  "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg",
+                  source.enabled ? "bg-foreground/10" : "bg-secondary",
+                )}
+              >
+                <span className="text-foreground text-sm font-semibold">
+                  {source.name.charAt(0)}
+                </span>
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-foreground truncate text-sm font-medium">
+                    {source.name}
+                  </p>
+                  <span
+                    className={cn(
+                      "flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase",
+                      source.type === "1st-party"
+                        ? "bg-foreground/10 text-foreground"
+                        : "bg-secondary text-muted-foreground",
+                    )}
+                  >
+                    {source.type === "1st-party" ? "1st" : "3rd"}
+                  </span>
+                </div>
+                <p className="text-muted-foreground truncate text-xs">
+                  {source.description}
+                </p>
+              </div>
+              <Switch
+                checked={source.enabled}
+                onCheckedChange={() => toggleSource(source.id)}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </StepContainer>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/steps/add-sources-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/add-sources-step.tsx
@@ -85,7 +85,7 @@ export function AddSourcesStep({ onComplete, onBack }: AddSourcesStepProps) {
             <Input
               placeholder="Search sources..."
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={(value) => setSearchQuery(value)}
               className="pl-9"
             />
           </div>

--- a/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
@@ -1,0 +1,230 @@
+import { useState, useEffect } from "react";
+import {
+  Activity,
+  Check,
+  Loader2,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  PartyPopper,
+} from "lucide-react";
+import { StepContainer } from "../step-container";
+import { MOCK_TRAFFIC_METRICS } from "../../mock-data";
+import type { TrafficMetric } from "../../types";
+import { cn } from "@/lib/utils";
+
+interface ConfirmTrafficStepProps {
+  onComplete: () => void;
+  onBack: () => void;
+}
+
+export function ConfirmTrafficStep({
+  onComplete,
+  onBack,
+}: ConfirmTrafficStepProps) {
+  const [checking, setChecking] = useState(true);
+  const [metrics, setMetrics] = useState<TrafficMetric[]>([]);
+  const [allHealthy, setAllHealthy] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setMetrics(MOCK_TRAFFIC_METRICS);
+      setChecking(false);
+      setAllHealthy(MOCK_TRAFFIC_METRICS.every((m) => m.healthy));
+    }, 2500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const TrendIcon = ({ trend }: { trend: TrafficMetric["trend"] }) => {
+    if (trend === "up") return <TrendingUp className="text-success h-4 w-4" />;
+    if (trend === "down")
+      return <TrendingDown className="text-destructive h-4 w-4" />;
+    return <Minus className="text-muted-foreground h-4 w-4" />;
+  };
+
+  if (checking) {
+    return (
+      <StepContainer
+        icon={
+          <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+            <Activity className="text-foreground h-6 w-6" />
+          </div>
+        }
+        title="Verifying traffic"
+        description="Checking that everything is connected and working properly..."
+        onContinue={() => {}}
+        showBack
+        onBack={onBack}
+        canContinue={false}
+        isLoading
+      >
+        <div className="flex flex-col items-center justify-center py-16">
+          <div className="relative mb-6">
+            <div className="bg-foreground/10 absolute inset-0 animate-ping rounded-full" />
+            <div className="bg-secondary relative flex h-16 w-16 items-center justify-center rounded-full">
+              <Loader2 className="text-foreground h-8 w-8 animate-spin" />
+            </div>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            Verifying connectivity and compliance
+          </p>
+        </div>
+      </StepContainer>
+    );
+  }
+
+  return (
+    <StepContainer
+      icon={
+        <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+          <Activity className="text-foreground h-6 w-6" />
+        </div>
+      }
+      title="Confirm traffic"
+      description="Verify that traffic is flowing and your team is compliant with configured policies."
+      onContinue={onComplete}
+      continueLabel="Go to Dashboard"
+      showBack
+      onBack={onBack}
+    >
+      <div className="space-y-6">
+        {/* Health status banner */}
+        <div
+          className={cn(
+            "rounded-lg border p-6",
+            allHealthy
+              ? "border-success/20 bg-success/5"
+              : "border-destructive/20 bg-destructive/5",
+          )}
+        >
+          <div className="flex items-center gap-4">
+            <div
+              className={cn(
+                "flex h-14 w-14 items-center justify-center rounded-full",
+                allHealthy ? "bg-success" : "bg-destructive",
+              )}
+            >
+              <Check className="text-background h-7 w-7" />
+            </div>
+            <div>
+              <p className="text-foreground text-xl font-semibold">
+                {allHealthy ? "All systems healthy" : "Attention required"}
+              </p>
+              <p className="text-muted-foreground">
+                {allHealthy
+                  ? "Traffic is flowing and compliance is verified"
+                  : "Some metrics require your attention"}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Metrics grid */}
+        <div className="grid grid-cols-2 gap-4">
+          {metrics.map((metric, index) => (
+            <div
+              key={index}
+              className={cn(
+                "rounded-lg border p-4",
+                metric.healthy
+                  ? "border-border bg-card"
+                  : "border-destructive/20 bg-destructive/5",
+              )}
+            >
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-muted-foreground text-sm">
+                  {metric.label}
+                </span>
+                <TrendIcon trend={metric.trend} />
+              </div>
+              <p className="text-foreground text-2xl font-semibold">
+                {metric.value}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Live activity */}
+        <div className="border-border bg-card overflow-hidden rounded-lg border">
+          <div className="border-border flex items-center justify-between border-b px-4 py-3">
+            <span className="text-foreground text-sm font-medium">
+              Recent activity
+            </span>
+            <span className="text-success flex items-center gap-1.5 text-xs">
+              <span className="bg-success h-1.5 w-1.5 animate-pulse rounded-full" />
+              Live
+            </span>
+          </div>
+          <div className="space-y-3 p-4">
+            {[
+              {
+                user: "sarah.chen@acme.com",
+                action: "Accessed GitHub MCP",
+                time: "2s ago",
+                status: "allowed",
+              },
+              {
+                user: "marcus.j@acme.com",
+                action: "Tool call: read_file",
+                time: "5s ago",
+                status: "allowed",
+              },
+              {
+                user: "e.rodriguez@acme.com",
+                action: "Requested: npm_install",
+                time: "12s ago",
+                status: "pending",
+              },
+              {
+                user: "d.kim@acme.com",
+                action: "Accessed Slack MCP",
+                time: "18s ago",
+                status: "allowed",
+              },
+            ].map((event, i) => (
+              <div key={i} className="flex items-center gap-3 text-sm">
+                <span
+                  className={cn(
+                    "h-2 w-2 flex-shrink-0 rounded-full",
+                    event.status === "allowed" && "bg-success",
+                    event.status === "blocked" && "bg-destructive",
+                    event.status === "pending" && "bg-chart-4",
+                  )}
+                />
+                <span className="text-foreground flex-1 truncate">
+                  <span className="font-medium">{event.user}</span>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    - {event.action}
+                  </span>
+                </span>
+                <span className="text-muted-foreground flex-shrink-0 text-xs">
+                  {event.time}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Success message */}
+        {allHealthy && (
+          <div className="bg-foreground/5 border-foreground/10 rounded-lg border p-4">
+            <div className="flex items-start gap-3">
+              <div className="bg-foreground mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded">
+                <PartyPopper className="text-background h-4 w-4" />
+              </div>
+              <div>
+                <p className="text-foreground text-sm font-medium">
+                  Setup complete!
+                </p>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  Your organization is ready to use Speakeasy.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </StepContainer>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { KeyRound, Check, ExternalLink } from "lucide-react";
+import { StepContainer } from "../step-container";
+import { IDP_PROVIDERS } from "../../mock-data";
+import { cn } from "@/lib/utils";
+
+interface ConnectIdpStepProps {
+  onComplete: () => void;
+}
+
+export function ConnectIdpStep({ onComplete }: ConnectIdpStepProps) {
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+
+  const handleConnect = async () => {
+    if (!selectedProvider) return;
+
+    setIsConnecting(true);
+    // Simulate connection
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    setIsConnecting(false);
+    setIsConnected(true);
+  };
+
+  const handleContinue = () => {
+    if (isConnected) {
+      onComplete();
+    } else {
+      handleConnect();
+    }
+  };
+
+  return (
+    <StepContainer
+      icon={
+        <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+          <KeyRound className="text-foreground h-6 w-6" />
+        </div>
+      }
+      title="Connect identity provider"
+      description="Connect your SSO provider to enable secure authentication for your team. This allows employees to sign in with their existing credentials."
+      onContinue={handleContinue}
+      continueLabel={
+        isConnected ? "Continue" : isConnecting ? "Connecting..." : "Connect"
+      }
+      isLoading={isConnecting}
+      canContinue={!!selectedProvider}
+    >
+      <div className="space-y-6">
+        <div>
+          <label className="text-foreground text-sm font-medium">
+            Select provider<span className="text-accent">*</span>
+          </label>
+          <div className="mt-3 grid grid-cols-2 gap-3">
+            {IDP_PROVIDERS.map((provider) => (
+              <button
+                key={provider.id}
+                onClick={() => {
+                  if (!isConnected) {
+                    setSelectedProvider(provider.id);
+                  }
+                }}
+                disabled={isConnected}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg border p-4 text-left transition-all",
+                  selectedProvider === provider.id
+                    ? "border-foreground bg-secondary"
+                    : "border-border bg-card hover:border-foreground/30",
+                  isConnected &&
+                    selectedProvider !== provider.id &&
+                    "cursor-not-allowed opacity-50",
+                )}
+              >
+                <div className="bg-secondary flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg">
+                  <span className="text-lg">{provider.icon}</span>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-foreground truncate text-sm font-medium">
+                      {provider.name}
+                    </span>
+                    {selectedProvider === provider.id && isConnected && (
+                      <span className="text-success bg-success/10 flex items-center gap-1 rounded px-1.5 py-0.5 text-xs">
+                        <Check className="h-3 w-3" />
+                        Connected
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-muted-foreground text-xs">
+                    {provider.type}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {selectedProvider && !isConnected && (
+          <div className="bg-secondary/50 border-border rounded-lg border p-4">
+            <div className="flex items-start gap-3">
+              <div className="bg-secondary mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded">
+                <ExternalLink className="text-muted-foreground h-4 w-4" />
+              </div>
+              <div>
+                <p className="text-foreground text-sm font-medium">
+                  {"You'll"} be redirected to complete setup
+                </p>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  After clicking Connect, {"you'll"} be taken to your identity
+                  provider to authorize the connection.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {isConnected && (
+          <div className="bg-success/5 border-success/20 rounded-lg border p-4">
+            <div className="flex items-start gap-3">
+              <div className="bg-success/10 mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded">
+                <Check className="text-success h-4 w-4" />
+              </div>
+              <div>
+                <p className="text-foreground text-sm font-medium">
+                  Successfully connected
+                </p>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  Your identity provider is now linked. Directory sync will
+                  begin automatically.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </StepContainer>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect } from "react";
+import { Users, Check, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import { StepContainer } from "../step-container";
+import { MOCK_DIRECTORY_USERS } from "../../mock-data";
+import type { DirectoryUser } from "../../types";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface DirectorySyncStepProps {
+  onComplete: () => void;
+  onBack: () => void;
+}
+
+export function DirectorySyncStep({
+  onComplete,
+  onBack,
+}: DirectorySyncStepProps) {
+  const [syncing, setSyncing] = useState(true);
+  const [users, setUsers] = useState<DirectoryUser[]>([]);
+  const [showAllMembers, setShowAllMembers] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setUsers(MOCK_DIRECTORY_USERS);
+      setSyncing(false);
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const admins = users.filter((u) => u.role === "admin");
+  const members = users.filter((u) => u.role === "member");
+  const displayedMembers = showAllMembers ? members : members.slice(0, 3);
+
+  const toggleUserRole = (userId: string) => {
+    setUsers((prev) =>
+      prev.map((u) =>
+        u.id === userId
+          ? { ...u, role: u.role === "admin" ? "member" : "admin" }
+          : u,
+      ),
+    );
+  };
+
+  if (syncing) {
+    return (
+      <StepContainer
+        icon={
+          <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+            <Users className="text-foreground h-6 w-6" />
+          </div>
+        }
+        title="Syncing directory"
+        description="Fetching users and groups from your identity provider..."
+        onContinue={() => {}}
+        showBack
+        onBack={onBack}
+        canContinue={false}
+      >
+        <div className="flex flex-col items-center justify-center py-16">
+          <Loader2 className="text-muted-foreground mb-4 h-8 w-8 animate-spin" />
+          <p className="text-muted-foreground text-sm">
+            This may take a moment
+          </p>
+        </div>
+      </StepContainer>
+    );
+  }
+
+  return (
+    <StepContainer
+      icon={
+        <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+          <Users className="text-foreground h-6 w-6" />
+        </div>
+      }
+      title="Confirm directory sync"
+      description="Review the users synced from your identity provider. Toggle roles as needed - admins can manage policies and settings."
+      onContinue={onComplete}
+      continueLabel="Continue"
+      showBack
+      onBack={onBack}
+    >
+      <div className="space-y-6">
+        {/* Summary stats */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="border-border bg-card rounded-lg border p-4">
+            <p className="text-foreground text-2xl font-semibold">
+              {admins.length}
+            </p>
+            <p className="text-muted-foreground text-sm">Administrators</p>
+          </div>
+          <div className="border-border bg-card rounded-lg border p-4">
+            <p className="text-foreground text-2xl font-semibold">
+              {members.length}
+            </p>
+            <p className="text-muted-foreground text-sm">Members</p>
+          </div>
+        </div>
+
+        {/* Admins */}
+        <div>
+          <label className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
+            Administrators
+          </label>
+          <div className="mt-2 space-y-2">
+            {admins.map((user) => (
+              <UserRow
+                key={user.id}
+                user={user}
+                onToggleRole={() => toggleUserRole(user.id)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Members */}
+        <div>
+          <label className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
+            Members
+          </label>
+          <div className="mt-2 space-y-2">
+            {displayedMembers.map((user) => (
+              <UserRow
+                key={user.id}
+                user={user}
+                onToggleRole={() => toggleUserRole(user.id)}
+              />
+            ))}
+          </div>
+          {members.length > 3 && (
+            <button
+              onClick={() => setShowAllMembers(!showAllMembers)}
+              className="text-muted-foreground hover:text-foreground mt-3 flex items-center gap-1 text-sm transition-colors"
+            >
+              {showAllMembers ? (
+                <>
+                  <ChevronUp className="h-4 w-4" />
+                  Show less
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-4 w-4" />
+                  Show {members.length - 3} more
+                </>
+              )}
+            </button>
+          )}
+        </div>
+
+        {/* Sync complete notice */}
+        <div className="bg-success/5 border-success/20 rounded-lg border p-4">
+          <div className="flex items-start gap-3">
+            <div className="bg-success/10 mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded">
+              <Check className="text-success h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-foreground text-sm font-medium">
+                Directory sync complete
+              </p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                {users.length} users imported. Roles will sync automatically
+                going forward.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </StepContainer>
+  );
+}
+
+function UserRow({
+  user,
+  onToggleRole,
+}: {
+  user: DirectoryUser;
+  onToggleRole: () => void;
+}) {
+  return (
+    <div className="border-border bg-card flex items-center gap-3 rounded-lg border p-3">
+      <div className="bg-secondary flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full">
+        <span className="text-foreground text-sm font-medium">
+          {user.name
+            .split(" ")
+            .map((n) => n[0])
+            .join("")}
+        </span>
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-medium">
+          {user.name}
+        </p>
+        <p className="text-muted-foreground truncate text-xs">{user.email}</p>
+      </div>
+      <button onClick={onToggleRole}>
+        <Badge
+          variant={user.role === "admin" ? "default" : "secondary"}
+          className={cn(
+            "cursor-pointer transition-colors",
+            user.role === "admin" &&
+              "bg-foreground text-background hover:bg-foreground/90",
+          )}
+        >
+          {user.role === "admin" ? "Admin" : "Member"}
+        </Badge>
+      </button>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/steps/index.ts
+++ b/client/dashboard/src/pages/setup/components/steps/index.ts
@@ -1,0 +1,5 @@
+export { ConnectIdpStep } from "./connect-idp-step";
+export { DirectorySyncStep } from "./directory-sync-step";
+export { InstrumentAgentsStep } from "./instrument-agents-step";
+export { AddSourcesStep } from "./add-sources-step";
+export { ConfirmTrafficStep } from "./confirm-traffic-step";

--- a/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/instrument-agents-step.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import { Terminal, Check, Copy, ExternalLink } from "lucide-react";
+import { StepContainer } from "../step-container";
+import { AGENT_PLATFORMS } from "../../mock-data";
+import type { AgentPlatform } from "../../types";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface InstrumentAgentsStepProps {
+  onComplete: () => void;
+  onBack: () => void;
+}
+
+const MOCK_WEBHOOK_URL = "https://api.speakeasy.com/hooks/acme-corp/agents";
+const MOCK_API_KEY = "sk_live_speakeasy_xxxxxxxxxxxxx";
+
+export function InstrumentAgentsStep({
+  onComplete,
+  onBack,
+}: InstrumentAgentsStepProps) {
+  const [platforms, setPlatforms] = useState<AgentPlatform[]>(AGENT_PLATFORMS);
+  const [copiedField, setCopiedField] = useState<string | null>(null);
+
+  const connectedCount = platforms.filter((p) => p.connected).length;
+
+  const togglePlatform = (platformId: string) => {
+    setPlatforms((prev) =>
+      prev.map((p) =>
+        p.id === platformId ? { ...p, connected: !p.connected } : p,
+      ),
+    );
+  };
+
+  const copyToClipboard = async (text: string, field: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
+
+  return (
+    <StepContainer
+      icon={
+        <div className="bg-secondary flex h-12 w-12 items-center justify-center rounded-lg">
+          <Terminal className="text-foreground h-6 w-6" />
+        </div>
+      }
+      title="Instrument agent platforms"
+      description="Connect the AI coding assistants used by your team. This enables traffic monitoring and policy enforcement."
+      onContinue={onComplete}
+      continueLabel="Continue"
+      showBack
+      onBack={onBack}
+    >
+      <div className="space-y-6">
+        {/* Credentials */}
+        <div className="border-border bg-card rounded-lg border p-4">
+          <label className="text-foreground text-sm font-medium">
+            Integration credentials
+          </label>
+          <p className="text-muted-foreground mt-1 mb-4 text-sm">
+            Use these credentials to configure your agent platforms.
+          </p>
+          <div className="space-y-3">
+            <div>
+              <label className="text-muted-foreground text-xs">
+                Webhook URL
+              </label>
+              <div className="mt-1 flex items-center gap-2">
+                <code className="bg-secondary text-foreground flex-1 truncate rounded px-3 py-2 font-mono text-sm">
+                  {MOCK_WEBHOOK_URL}
+                </code>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => copyToClipboard(MOCK_WEBHOOK_URL, "webhook")}
+                  className="flex-shrink-0"
+                >
+                  {copiedField === "webhook" ? (
+                    <Check className="text-success h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+            <div>
+              <label className="text-muted-foreground text-xs">API Key</label>
+              <div className="mt-1 flex items-center gap-2">
+                <code className="bg-secondary text-foreground flex-1 truncate rounded px-3 py-2 font-mono text-sm">
+                  {MOCK_API_KEY}
+                </code>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => copyToClipboard(MOCK_API_KEY, "apikey")}
+                  className="flex-shrink-0"
+                >
+                  {copiedField === "apikey" ? (
+                    <Check className="text-success h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Platforms */}
+        <div>
+          <div className="mb-3 flex items-center justify-between">
+            <label className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
+              Agent platforms
+            </label>
+            <span className="text-muted-foreground text-xs">
+              {connectedCount} of {platforms.length} enabled
+            </span>
+          </div>
+          <div className="space-y-2">
+            {platforms.map((platform) => (
+              <div
+                key={platform.id}
+                className={cn(
+                  "flex items-center gap-4 rounded-lg border p-4 transition-colors",
+                  platform.connected
+                    ? "border-foreground/20 bg-secondary/50"
+                    : "border-border bg-card",
+                )}
+              >
+                <div
+                  className={cn(
+                    "flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg",
+                    platform.connected ? "bg-foreground/10" : "bg-secondary",
+                  )}
+                >
+                  <span className="text-foreground text-base font-semibold">
+                    {platform.name.charAt(0)}
+                  </span>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-foreground text-sm font-medium">
+                    {platform.name}
+                  </p>
+                  <p className="text-muted-foreground truncate text-xs">
+                    {platform.description}
+                  </p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground flex-shrink-0"
+                >
+                  <ExternalLink className="mr-1 h-3 w-3" />
+                  Docs
+                </Button>
+                <Switch
+                  checked={platform.connected}
+                  onCheckedChange={() => togglePlatform(platform.id)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </StepContainer>
+  );
+}

--- a/client/dashboard/src/pages/setup/mock-data.ts
+++ b/client/dashboard/src/pages/setup/mock-data.ts
@@ -1,0 +1,180 @@
+import type {
+  IdpProvider,
+  DirectoryUser,
+  AgentPlatform,
+  McpSource,
+  TrafficMetric,
+} from "./types";
+
+export const IDP_PROVIDERS: IdpProvider[] = [
+  {
+    id: "okta",
+    name: "Okta",
+    icon: "O",
+    type: "SAML 2.0 / OIDC",
+    connected: false,
+  },
+  {
+    id: "azure",
+    name: "Microsoft Entra ID",
+    icon: "M",
+    type: "SAML 2.0 / OIDC",
+    connected: false,
+  },
+  {
+    id: "google",
+    name: "Google Workspace",
+    icon: "G",
+    type: "OIDC",
+    connected: false,
+  },
+  {
+    id: "onelogin",
+    name: "OneLogin",
+    icon: "1",
+    type: "SAML 2.0",
+    connected: false,
+  },
+  {
+    id: "jumpcloud",
+    name: "JumpCloud",
+    icon: "J",
+    type: "SAML 2.0 / OIDC",
+    connected: false,
+  },
+];
+
+export const MOCK_DIRECTORY_USERS: DirectoryUser[] = [
+  { id: "1", name: "Sarah Chen", email: "sarah.chen@acme.com", role: "admin" },
+  {
+    id: "2",
+    name: "Marcus Johnson",
+    email: "marcus.j@acme.com",
+    role: "admin",
+  },
+  {
+    id: "3",
+    name: "Emily Rodriguez",
+    email: "e.rodriguez@acme.com",
+    role: "member",
+  },
+  { id: "4", name: "David Kim", email: "d.kim@acme.com", role: "member" },
+  {
+    id: "5",
+    name: "Lisa Thompson",
+    email: "l.thompson@acme.com",
+    role: "member",
+  },
+  { id: "6", name: "James Wilson", email: "j.wilson@acme.com", role: "member" },
+  {
+    id: "7",
+    name: "Anna Martinez",
+    email: "a.martinez@acme.com",
+    role: "member",
+  },
+  { id: "8", name: "Michael Brown", email: "m.brown@acme.com", role: "member" },
+];
+
+export const AGENT_PLATFORMS: AgentPlatform[] = [
+  {
+    id: "cursor",
+    name: "Cursor",
+    description: "AI-powered code editor",
+    icon: "cursor",
+    connected: false,
+  },
+  {
+    id: "windsurf",
+    name: "Windsurf",
+    description: "Codeium IDE",
+    icon: "windsurf",
+    connected: false,
+  },
+  {
+    id: "claude-desktop",
+    name: "Claude Desktop",
+    description: "Anthropic desktop app",
+    icon: "claude",
+    connected: false,
+  },
+  {
+    id: "vscode",
+    name: "VS Code + Copilot",
+    description: "GitHub Copilot integration",
+    icon: "vscode",
+    connected: false,
+  },
+  {
+    id: "jetbrains",
+    name: "JetBrains IDEs",
+    description: "IntelliJ, PyCharm, etc.",
+    icon: "jetbrains",
+    connected: false,
+  },
+];
+
+export const MCP_SOURCES: McpSource[] = [
+  {
+    id: "github",
+    name: "GitHub",
+    type: "1st-party",
+    description: "Code repositories and issues",
+    enabled: false,
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    type: "1st-party",
+    description: "Team messaging and channels",
+    enabled: false,
+  },
+  {
+    id: "linear",
+    name: "Linear",
+    type: "1st-party",
+    description: "Issue tracking and projects",
+    enabled: false,
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    type: "1st-party",
+    description: "Documents and wikis",
+    enabled: false,
+  },
+  {
+    id: "jira",
+    name: "Jira",
+    type: "3rd-party",
+    description: "Project management",
+    enabled: false,
+  },
+  {
+    id: "confluence",
+    name: "Confluence",
+    type: "3rd-party",
+    description: "Documentation platform",
+    enabled: false,
+  },
+  {
+    id: "datadog",
+    name: "Datadog",
+    type: "3rd-party",
+    description: "Monitoring and analytics",
+    enabled: false,
+  },
+  {
+    id: "sentry",
+    name: "Sentry",
+    type: "3rd-party",
+    description: "Error tracking",
+    enabled: false,
+  },
+];
+
+export const MOCK_TRAFFIC_METRICS: TrafficMetric[] = [
+  { label: "Active Users", value: "24", trend: "up", healthy: true },
+  { label: "Tool Requests", value: "1,247", trend: "up", healthy: true },
+  { label: "Blocked Calls", value: "38", trend: "down", healthy: true },
+  { label: "Compliance Rate", value: "96.8%", trend: "stable", healthy: true },
+];

--- a/client/dashboard/src/pages/setup/types.ts
+++ b/client/dashboard/src/pages/setup/types.ts
@@ -1,0 +1,86 @@
+export type OnboardingStep =
+  | "connect-idp"
+  | "directory-sync"
+  | "instrument-agents"
+  | "add-sources"
+  | "confirm-traffic";
+
+export interface StepConfig {
+  id: OnboardingStep;
+  title: string;
+  description: string;
+  icon: string;
+}
+
+export const ONBOARDING_STEPS: StepConfig[] = [
+  {
+    id: "connect-idp",
+    title: "Connect Identity Provider",
+    description: "Link your SSO provider",
+    icon: "shield",
+  },
+  {
+    id: "directory-sync",
+    title: "Directory Sync",
+    description: "Confirm roles and admins",
+    icon: "users",
+  },
+  {
+    id: "instrument-agents",
+    title: "Instrument Agents",
+    description: "Setup agent platform hooks",
+    icon: "cpu",
+  },
+  {
+    id: "add-sources",
+    title: "Add MCP Sources",
+    description: "Configure 1st & 3rd party sources",
+    icon: "database",
+  },
+  {
+    id: "confirm-traffic",
+    title: "Confirm Traffic",
+    description: "Verify compliance",
+    icon: "activity",
+  },
+];
+
+// Mock data types
+export interface IdpProvider {
+  id: string;
+  name: string;
+  icon: string;
+  type: string;
+  connected: boolean;
+}
+
+export interface DirectoryUser {
+  id: string;
+  name: string;
+  email: string;
+  role: "admin" | "member";
+  avatarUrl?: string;
+}
+
+export interface AgentPlatform {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  connected: boolean;
+}
+
+export interface McpSource {
+  id: string;
+  name: string;
+  type: "1st-party" | "3rd-party";
+  description: string;
+  enabled: boolean;
+}
+
+export interface TrafficMetric {
+  label: string;
+  value: string;
+  trend: "up" | "down" | "stable";
+  healthy: boolean;
+}

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -92,7 +92,7 @@ export default defineConfig(({ command }) => {
     },
     server: {
       host: true,
-      allowedHosts: ["localhost", "127.0.0.1", "devbox"],
+      allowedHosts: ["localhost", "127.0.0.1", "devbox", "setup.localhost"],
       https: key && cert ? { key, cert } : void 0,
       // Setting these up to side-step cors issues experienced during
       // development. Specifically, the Vercel AI SDK does not forward cookies

--- a/mise.toml
+++ b/mise.toml
@@ -106,6 +106,11 @@ GRAM_ENVIRONMENT = "local"
 GRAM_HOST = "localhost" # Only needed for local development. In production, you should set GRAM_SERVER_URL and GRAM_SITE_URL directly.
 GRAM_SITE_PORT = "5173"
 GRAM_SITE_URL = "https://{{env.GRAM_HOST}}:{{env.GRAM_SITE_PORT}}"
+GRAM_SETUP_SITE_URL = "https://setup.{{env.GRAM_HOST}}:{{env.GRAM_SITE_PORT}}"
+## In production set this to the apex domain (e.g. getgram.ai) so session
+## cookies are shared across subdomains (app.*, setup.*).  Leave blank for
+## local dev — "localhost" is a reserved TLD and Chrome rejects Domain=localhost.
+# GRAM_COOKIE_DOMAIN = ""
 GRAM_SERVER_URL = "https://{{env.GRAM_HOST}}:{{env.GRAM_SERVER_PORT}}"
 GRAM_ASSETS_BACKEND = "fs"
 GRAM_ASSETS_URI = ".assets"

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -155,6 +155,16 @@ func newStartCommand() *cli.Command {
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:    "setup-site-url",
+			Usage:   "Origin of the enterprise setup subdomain (e.g. https://setup.getgram.ai)",
+			EnvVars: []string{"GRAM_SETUP_SITE_URL"},
+		},
+		&cli.StringFlag{
+			Name:    "cookie-domain",
+			Usage:   "Domain attribute for session cookies (e.g. getgram.ai, localhost)",
+			EnvVars: []string{"GRAM_COOKIE_DOMAIN"},
+		},
+		&cli.StringFlag{
 			Name:     "database-url",
 			Usage:    "Database URL",
 			EnvVars:  []string{"GRAM_DATABASE_URL"},
@@ -968,6 +978,8 @@ func newStartCommand() *cli.Command {
 					IDPBaseURL:        c.String("idp-base-url"),
 					GramServerURL:     c.String("server-url"),
 					SignInRedirectURL: auth.FormSignInRedirectURL(c.String("site-url")),
+					SetupSiteURL:      c.String("setup-site-url"),
+					CookieDomain:      c.String("cookie-domain"),
 					Environment:       c.String("environment"),
 				},
 				authzEngine,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -926,7 +926,13 @@ func newStartCommand() *cli.Command {
 			mux.Use(middleware.NewHTTPLoggingMiddleware(logger))
 			mux.Use(middleware.NewRecovery(logger))
 			mux.Use(middleware.CORSMiddleware(c.String("environment"), c.String("server-url"), chatSessionsManager))
-			mux.Use(customdomains.Middleware(logger, db, c.String("environment"), serverURL))
+			var setupSiteURL *url.URL
+			if raw := c.String("setup-site-url"); raw != "" {
+				if parsed, err := url.Parse(raw); err == nil {
+					setupSiteURL = parsed
+				}
+			}
+			mux.Use(customdomains.Middleware(logger, db, c.String("environment"), serverURL, setupSiteURL))
 			mux.Use(middleware.SessionMiddleware)
 			mux.Use(middleware.AdminOverrideMiddleware)
 			mux.Use(middleware.RBACOverrideMiddleware())

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -208,7 +208,7 @@ func (w *cookieDomainWriter) WriteHeader(statusCode int) {
 	if len(cookies) > 0 {
 		headers.Del("Set-Cookie")
 		for _, c := range cookies {
-			if strings.HasPrefix(c, "gram_session=") {
+			if strings.HasPrefix(c, "gram_session=") || strings.HasPrefix(c, nonceBindingCookie+"=") {
 				c += "; Domain=" + w.domain
 			}
 			headers.Add("Set-Cookie", c)
@@ -1054,15 +1054,23 @@ func (s *Service) buildCallbackURL(ctx context.Context) string {
 		returnAddress = "https://" + requestCtx.Host
 	}
 
-	// In local dev, if the login request came from the setup subdomain
-	// (detected via Referer host, since the Vite proxy rewrites Host),
-	// route the IDP callback through the setup origin so the nonce-binding
-	// cookie is scoped correctly.
-	if s.cfg.Environment == "local" && s.cfg.SetupSiteURL != "" {
+	// If the login request came from the setup subdomain, route the IDP
+	// callback through the setup origin so the nonce-binding cookie is
+	// scoped correctly.
+	if s.cfg.SetupSiteURL != "" {
 		if requestCtx, ok := contextvalues.GetRequestContext(ctx); ok && requestCtx != nil {
 			setupURL, err := url.Parse(s.cfg.SetupSiteURL)
-			if err == nil && requestCtx.RefererHost == setupURL.Host {
-				returnAddress = strings.TrimRight(s.cfg.SetupSiteURL, "/")
+			if err == nil {
+				// In local dev the Vite proxy rewrites Host, so check
+				// Referer. In deployed envs (dev/prod) the Host header
+				// arrives unmodified.
+				host := requestCtx.Host
+				if s.cfg.Environment == "local" {
+					host = requestCtx.RefererHost
+				}
+				if host == setupURL.Host {
+					returnAddress = strings.TrimRight(s.cfg.SetupSiteURL, "/")
+				}
 			}
 		}
 	}

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -203,7 +203,7 @@ type cookieDomainWriter struct {
 }
 
 func (w *cookieDomainWriter) WriteHeader(statusCode int) {
-	headers := w.ResponseWriter.Header()
+	headers := w.Header()
 	cookies := headers.Values("Set-Cookie")
 	if len(cookies) > 0 {
 		headers.Del("Set-Cookie")

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -88,6 +88,8 @@ type AuthConfigurations struct {
 	IDPBaseURL        string
 	GramServerURL     string
 	SignInRedirectURL string
+	SetupSiteURL      string // Origin of the enterprise setup subdomain (e.g. https://setup.getgram.ai)
+	CookieDomain      string // Domain attribute for session cookies (e.g. "getgram.ai", "localhost")
 	Environment       string
 }
 
@@ -168,7 +170,51 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	// context so validateAuthNonce() can verify it.
 	server.Callback = callbackNonceBindingMiddleware(server.Callback)
 
+	// If a cookie domain is configured, rewrite gram_session cookies to
+	// include Domain= so they're shared across subdomains (e.g. app.getgram.ai
+	// and setup.getgram.ai both under getgram.ai).
+	if service.cfg.CookieDomain != "" {
+		server.Login = cookieDomainMiddleware(service.cfg.CookieDomain)(server.Login)
+		server.Callback = cookieDomainMiddleware(service.cfg.CookieDomain)(server.Callback)
+		server.SwitchScopes = cookieDomainMiddleware(service.cfg.CookieDomain)(server.SwitchScopes)
+		server.Logout = cookieDomainMiddleware(service.cfg.CookieDomain)(server.Logout)
+		server.Info = cookieDomainMiddleware(service.cfg.CookieDomain)(server.Info)
+	}
+
 	srv.Mount(mux, server)
+}
+
+// cookieDomainMiddleware rewrites Set-Cookie headers for auth cookies
+// (gram_session, gram_auth_nonce) to include the specified Domain attribute.
+// This is needed because the Goa generated code and nonce middleware set
+// cookies without a Domain, making them host-only.
+func cookieDomainMiddleware(domain string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			wrapped := &cookieDomainWriter{ResponseWriter: w, domain: domain}
+			next.ServeHTTP(wrapped, r)
+		})
+	}
+}
+
+type cookieDomainWriter struct {
+	http.ResponseWriter
+	domain string
+}
+
+func (w *cookieDomainWriter) WriteHeader(statusCode int) {
+	headers := w.ResponseWriter.Header()
+	cookies := headers.Values("Set-Cookie")
+	if len(cookies) > 0 {
+		headers.Del("Set-Cookie")
+		for _, c := range cookies {
+			if strings.HasPrefix(c, "gram_session=") {
+				c += "; Domain=" + w.domain
+			}
+			headers.Add("Set-Cookie", c)
+		}
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
 }
 
 // loginNonceBindingMiddleware generates a random nonce-binding token, sets it
@@ -1008,6 +1054,19 @@ func (s *Service) buildCallbackURL(ctx context.Context) string {
 		returnAddress = "https://" + requestCtx.Host
 	}
 
+	// In local dev, if the login request came from the setup subdomain
+	// (detected via Referer host, since the Vite proxy rewrites Host),
+	// route the IDP callback through the setup origin so the nonce-binding
+	// cookie is scoped correctly.
+	if s.cfg.Environment == "local" && s.cfg.SetupSiteURL != "" {
+		if requestCtx, ok := contextvalues.GetRequestContext(ctx); ok && requestCtx != nil {
+			setupURL, err := url.Parse(s.cfg.SetupSiteURL)
+			if err == nil && requestCtx.RefererHost == setupURL.Host {
+				returnAddress = strings.TrimRight(s.cfg.SetupSiteURL, "/")
+			}
+		}
+	}
+
 	return returnAddress + "/rpc/auth.callback"
 }
 
@@ -1015,26 +1074,41 @@ func (s *Service) buildCallbackURL(ctx context.Context) string {
 var validOrgNameRegex = regexp.MustCompile(`^[a-zA-Z0-9\s-_]+$`)
 
 // callbackRedirectURL determines the redirect location after authentication. It
-// only allows relative URLs to prevent open redirect attacks (see relativeURL).
+// only allows relative URLs to prevent open redirect attacks (see relativeURL),
+// with the exception of the trusted setup subdomain origin (SetupSiteURL).
 // If no redirect is found, fall back to SignInRedirectURL.
 func (s *Service) callbackRedirectURL(
 	ctx context.Context,
 	payload *gen.CallbackPayload,
 ) string {
-	var location string
-
 	if state := decodeStateParam(payload); state != nil {
-		location = relativeURL(state.FinalDestinationURL)
-	}
+		// Allow absolute redirects to the trusted setup subdomain.
+		if s.cfg.SetupSiteURL != "" && isTrustedSetupRedirect(state.FinalDestinationURL, s.cfg.SetupSiteURL) {
+			s.logger.InfoContext(ctx, fmt.Sprintf("Redirecting to setup domain: '%s'", state.FinalDestinationURL))
+			return state.FinalDestinationURL
+		}
 
-	if location != "" {
-		msg := fmt.Sprintf("Found destination URL in state: '%s'", location)
-		s.logger.InfoContext(ctx, msg)
-
-		return location
+		if location := relativeURL(state.FinalDestinationURL); location != "" {
+			s.logger.InfoContext(ctx, fmt.Sprintf("Found destination URL in state: '%s'", location))
+			return location
+		}
 	}
 
 	return s.cfg.SignInRedirectURL
+}
+
+// isTrustedSetupRedirect returns true if destURL is an absolute URL whose
+// origin (scheme + host) matches the trusted setup site URL.
+func isTrustedSetupRedirect(destURL, setupSiteURL string) bool {
+	dest, err := url.Parse(destURL)
+	if err != nil || dest.Host == "" {
+		return false
+	}
+	trusted, err := url.Parse(setupSiteURL)
+	if err != nil || trusted.Host == "" {
+		return false
+	}
+	return dest.Scheme == trusted.Scheme && dest.Host == trusted.Host
 }
 
 // relativeURL converts any URL to a safe relative URL by extracting only the

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *url.URL) func(next http.Handler) http.Handler {
+func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *url.URL, setupSiteURL *url.URL) func(next http.Handler) http.Handler {
 	domainsRepo := domainsRepo.New(db)
 	logger = logger.With(attr.SlogComponent("custom_domains_middleware"))
 
@@ -46,6 +46,11 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 			}
 
 			if host == serverURL.Host {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if setupSiteURL != nil && host == setupSiteURL.Host {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/server/internal/customdomains/middleware_test.go
+++ b/server/internal/customdomains/middleware_test.go
@@ -214,7 +214,7 @@ func TestCustomDomainsMiddleware(t *testing.T) {
 			}
 
 			// Create the middleware
-			middlewareFunc := customdomains.Middleware(logger, instance.conn, tt.env, serverURL)
+			middlewareFunc := customdomains.Middleware(logger, instance.conn, tt.env, serverURL, nil)
 
 			// Create a test handler that captures context and responds
 			var capturedCtx context.Context
@@ -278,7 +278,7 @@ func TestCustomDomainsMiddleware_DeletedDomain(t *testing.T) {
 	err = instance.domainsRepo.DeleteCustomDomain(ctx, "org-deleted")
 	require.NoError(t, err)
 
-	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", serverURL)
+	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", serverURL, nil)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Handler should not be called for deleted domain")
@@ -310,7 +310,7 @@ func TestCustomDomainsMiddleware_DatabaseErrors(t *testing.T) {
 	require.NoError(t, err)
 	closedConn.Close()
 
-	middlewareFunc := customdomains.Middleware(logger, closedConn, "prod", serverURL)
+	middlewareFunc := customdomains.Middleware(logger, closedConn, "prod", serverURL, nil)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Handler should not be called when database error occurs")
@@ -339,7 +339,7 @@ func TestCustomDomainsMiddleware_MissingHost(t *testing.T) {
 	serverURL, err := url.Parse("https://api.speakeasyapi.dev")
 	require.NoError(t, err)
 
-	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", serverURL)
+	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", serverURL, nil)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Handler should not be called with empty host")

--- a/zero
+++ b/zero
@@ -114,6 +114,8 @@ interactive_only mise run zero:melange
 interactive_only mise run zero:fly
 mise run zero:encryption
 mise run zero:tls
+mise run zero:hosts
+
 assistant_runtime_provider="$(mise env GRAM_ASSISTANT_RUNTIME_PROVIDER 2>/dev/null | sed -n 's/^export GRAM_ASSISTANT_RUNTIME_PROVIDER=//p')"
 assistant_runtime_provider="${assistant_runtime_provider:-local}"
 if [[ "$assistant_runtime_provider" == "local" ]]; then


### PR DESCRIPTION
## Summary

- Adds enterprise onboarding setup wizard served from `setup.getgram.ai` (dev: `setup.localhost`)
- Implements full auth flow for the setup subdomain — session cookies, IDP callbacks, and trusted redirects all scoped correctly
- Opaquely rewrites `/:orgSlug/setup` to `/` on the setup domain so the org slug never appears in the URL

## Details

### Setup Wizard (`client/dashboard/src/pages/setup/`)
- Multi-step onboarding wizard: Connect IDP → Directory Sync → Add Sources → Instrument Agents → Confirm Traffic
- Self-contained with mock data for initial UI development
- Rendered at `/` on setup domain, `/:orgSlug/setup` on main domain

### Auth Flow (`server/internal/auth/impl.go`)
- `cookieDomainMiddleware` rewrites `gram_session` cookies with `Domain=` attribute in production so cookies are shared across `app.*` and `setup.*` subdomains
- `buildCallbackURL` detects setup-domain requests via Referer and routes IDP callbacks through setup origin (local dev only — prod uses shared cookie domain)
- `isTrustedSetupRedirect` allows absolute redirects to the setup subdomain origin after auth callback

### Client Auth (`client/dashboard/src/`)
- `getServerURL()` returns `window.location.origin` on setup domain so API calls go through the Vite proxy (dev) or same-origin (prod), ensuring session cookies are included
- `AuthProvider` early-returns on setup domain at `/` to avoid slug-based redirect loops
- `LoginCheck` renders login inline on setup domain (no URL redirect)
- `Login` component redirects back to setup origin after auth

### Config (`mise.toml`, `server/cmd/gram/start.go`)
- New env vars: `GRAM_SETUP_SITE_URL`, `GRAM_COOKIE_DOMAIN`
- `GRAM_COOKIE_DOMAIN` left commented out for local dev (Chrome rejects `Domain=localhost` per RFC 6761)

## Test plan

- [ ] Navigate to `setup.localhost:5173` — should show login, then setup wizard at `/` after auth
- [ ] Navigate to `localhost:5173` — normal app flow, unaffected
- [ ] Verify `/:orgSlug/setup` still works on main domain
- [ ] Check no redirect loops on setup domain
- [ ] Verify session cookie is set correctly (no `Domain=` in local dev)