### PR TITLE
fix(background): avoid WorkOS org slug upserts

### DIFF
--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -31,6 +31,7 @@ type WorkOSClient interface {
 	ListGlobalRoles(ctx context.Context) ([]workos.Role, error)
 	ListEvents(ctx context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error)
 	UpdateUserExternalID(ctx context.Context, workosUserID, externalID string) error
+	UpdateOrganizationExternalID(ctx context.Context, workosOrgID, externalID string) error
 }
 
 type BackfillWorkOSOrganizationParams struct {

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -92,6 +92,45 @@ func TestBackfillWorkOSOrganization_ExternalIDChangeDoesNotChangeOrganizationID(
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
+func TestBackfillWorkOSOrganization_DoesNotClearDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_preserves_disabled")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_backfill_disabled"
+	const workosOrgID = "org_01JBACKFILLDISABLED"
+
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	_, err := orgrepo.New(conn).DisableOrganizationByWorkosID(ctx, orgrepo.DisableOrganizationByWorkosIDParams{
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosLastEventID: conv.ToPGText(""),
+	})
+	require.NoError(t, err)
+
+	workosClient := newWorkOSSnapshotClient(t, ctx,
+		workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Still Disabled",
+			ExternalID: organizationID,
+			CreatedAt:  "2026-05-07T11:00:00Z",
+			UpdatedAt:  "2026-05-07T12:00:00Z",
+		},
+		nil,
+		nil,
+	)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+
+	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	org, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, "Backfill Still Disabled", org.Name)
+	require.True(t, org.DisabledAt.Valid)
+}
+
 func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -14,10 +14,12 @@ import (
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/auth/orgslug"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/database"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgid "github.com/speakeasy-api/gram/server/internal/organizations/id"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
@@ -42,10 +44,8 @@ type ProcessWorkOSOrganizationEventsResult struct {
 }
 
 // ProcessWorkOSOrganizationEvents pages through WorkOS organization-scoped events
-// since the stored cursor, advancing the cursor as it goes. Event handling itself
-// (upserting org metadata, role rows, etc.) is wired in a follow-up PR — for now
-// the activity only advances the cursor so subsequent runs pick up where this
-// left off.
+// since the stored cursor, applying supported organization, role, and
+// membership events in a transaction before advancing the cursor.
 type ProcessWorkOSOrganizationEvents struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
@@ -151,22 +151,14 @@ func (p *ProcessWorkOSOrganizationEvents) handlePage(ctx context.Context, logger
 		if err != nil {
 			return lastEventID, oops.E(oops.CodeUnexpected, err, "failed to handle WorkOS event").Log(ctx, eventLogger)
 		}
-		if eventID != "" {
-			lastEventID = eventID
-		}
+		lastEventID = eventID
 	}
 
 	return lastEventID, nil
 }
 
-// handleEvent will be implemented in a subsequent PR.
-//
-// Note: the cursor advances as soon as this returns nil, even though the
-// dispatched handler is currently a no-op. If the workflow runs before the
-// real handlers land, all in-flight WorkOS events will be consumed and the
-// cursor will move past them — real handlers will only see events going
-// forward. That is the intended design (sync handles forward, not history;
-// historical state is reconciled by the future backfill workflow).
+// handleEvent applies a single WorkOS event and advances the per-organization
+// cursor in the same transaction.
 func (p *ProcessWorkOSOrganizationEvents) handleEvent(ctx context.Context, logger *slog.Logger, workosOrgID string, event events.Event) (string, error) {
 	dbtx, err := p.db.Begin(ctx)
 	if err != nil {
@@ -174,7 +166,8 @@ func (p *ProcessWorkOSOrganizationEvents) handleEvent(ctx context.Context, logge
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
-	if err := handleOrganizationEvent(ctx, logger, dbtx, event); err != nil {
+	externalIDUpdate, err := handleOrganizationEvent(ctx, logger, dbtx, event)
+	if err != nil {
 		return "", err
 	}
 
@@ -189,29 +182,35 @@ func (p *ProcessWorkOSOrganizationEvents) handleEvent(ctx context.Context, logge
 		return "", fmt.Errorf("commit transaction: %w", err)
 	}
 
+	if externalIDUpdate != nil {
+		if err := p.workosClient.UpdateOrganizationExternalID(ctx, externalIDUpdate.workosOrgID, externalIDUpdate.externalID); err != nil {
+			logger.WarnContext(ctx, "failed to update WorkOS organization external ID", attr.SlogError(err))
+		}
+	}
+
 	return event.ID, nil
 }
 
 // handleOrganizationEvent dispatches a WorkOS event scoped to a specific
 // organization to its handler. Each handler is responsible for the
 // ShouldProcessEvent guard against duplicate apply.
-func handleOrganizationEvent(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+func handleOrganizationEvent(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) (*workosOrgExternalIDUpdate, error) {
 	switch event.Event {
 	case string(workos.EventKindOrganizationCreated), string(workos.EventKindOrganizationUpdated):
 		return handleOrganizationUpsert(ctx, logger, dbtx, event)
 	case string(workos.EventKindOrganizationDeleted):
-		return handleOrganizationDeleted(ctx, logger, dbtx, event)
+		return nil, handleOrganizationDeleted(ctx, logger, dbtx, event)
 	case string(workos.EventKindOrganizationRoleCreated), string(workos.EventKindOrganizationRoleUpdated):
-		return handleRoleUpsert(ctx, logger, dbtx, event)
+		return nil, handleRoleUpsert(ctx, logger, dbtx, event)
 	case string(workos.EventKindOrganizationRoleDeleted):
-		return handleRoleDeleted(ctx, logger, dbtx, event)
+		return nil, handleRoleDeleted(ctx, logger, dbtx, event)
 	case string(workos.EventKindOrganizationMembershipCreated), string(workos.EventKindOrganizationMembershipUpdated):
-		return handleOrganizationMembershipUpsert(ctx, logger, dbtx, event)
+		return nil, handleOrganizationMembershipUpsert(ctx, logger, dbtx, event)
 	case string(workos.EventKindOrganizationMembershipDeleted):
-		return handleOrganizationMembershipDeleted(ctx, logger, dbtx, event)
+		return nil, handleOrganizationMembershipDeleted(ctx, logger, dbtx, event)
 	}
 
-	return oops.Permanent(fmt.Errorf("unhandled workos organization event type: %s", event.Event))
+	return nil, oops.Permanent(fmt.Errorf("unhandled workos organization event type: %s", event.Event))
 }
 
 // workosOrganizationEventPayload is the relevant subset of an
@@ -223,32 +222,168 @@ type workosOrganizationEventPayload struct {
 	UpdatedAt  time.Time `json:"updated_at"`
 }
 
+type workosOrgExternalIDUpdate struct {
+	workosOrgID string
+	externalID  string
+}
+
+type resolvedWorkOSOrganization struct {
+	row                   orgrepo.OrganizationMetadatum
+	organizationID        string
+	isNew                 bool
+	needsExternalIDUpdate bool
+}
+
 // handleOrganizationUpsert applies an organization.created or
-// organization.updated event. Maps the WorkOS organization to a Gram org by
-// looking up workos_id; falls back to the payload's external_id for orgs not
-// yet linked.
-func handleOrganizationUpsert(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
+// organization.updated event. The mapping rules are:
+//
+//   - workos_id is authoritative first: if a Gram org already points at this
+//     WorkOS org, update that row.
+//   - otherwise, WorkOS external_id is the Gram org ID to link/update.
+//   - if WorkOS external_id points at no Gram org, create/link that local row
+//     using WorkOS external_id as the Gram org ID.
+//   - if WorkOS has no external_id, derive a deterministic Gram org ID from the
+//     WorkOS org ID, create/link that local row, then write the derived ID back
+//     to WorkOS after the DB transaction commits.
+//
+// WorkOS owns name/workos_id/cursor metadata, but never updates an existing
+// Gram slug. New org slugs are chosen once and uniqued locally.
+func handleOrganizationUpsert(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) (*workosOrgExternalIDUpdate, error) {
 	var payload workosOrganizationEventPayload
 	if err := json.Unmarshal(event.Data, &payload); err != nil {
-		return oops.Permanent(fmt.Errorf("unmarshal organization event payload: %w", err))
+		return nil, oops.Permanent(fmt.Errorf("unmarshal organization event payload: %w", err))
 	}
 
 	repo := orgrepo.New(dbtx)
 
+	resolved, err := resolveOrgForWorkOSEvent(ctx, repo, payload)
+	switch {
+	case err != nil:
+		return nil, err
+	case resolved.isNew:
+		if err := createOrganizationFromWorkOSEvent(ctx, repo, payload, event.ID, resolved.organizationID); err != nil {
+			return nil, err
+		}
+	default:
+		if err := updateOrganizationFromWorkOSEvent(ctx, repo, resolved.row, payload, event.ID); err != nil {
+			return nil, err
+		}
+	}
+
+	if resolved.needsExternalIDUpdate {
+		// The WorkOS write happens after commit in handleEvent so the remote
+		// external_id never points at an org row that failed to persist locally.
+		return &workosOrgExternalIDUpdate{workosOrgID: payload.ID, externalID: resolved.organizationID}, nil
+	}
+	return nil, nil
+}
+
+func resolveOrgForWorkOSEvent(ctx context.Context, repo *orgrepo.Queries, payload workosOrganizationEventPayload) (resolvedWorkOSOrganization, error) {
 	row, err := repo.GetOrganizationByWorkosID(ctx, conv.ToPGText(payload.ID))
 	switch {
+	case err == nil:
+		return resolvedWorkOSOrganization{
+			row:                   row,
+			organizationID:        row.ID,
+			isNew:                 false,
+			needsExternalIDUpdate: payload.ExternalID == "",
+		}, nil
 	case errors.Is(err, pgx.ErrNoRows):
-		if payload.ExternalID == "" {
-			// Unlinked org with no external_id: skip + advance cursor so a
-			// later event in the same stream that does carry an external_id
-			// (or sets workos_id via another path) can still land. A
-			// permanent error here would stall the per-org workflow and
-			// block every subsequent event for this org.
-			logger.WarnContext(ctx, "skipping organization event for unlinked org with no external_id", attr.SlogWorkOSOrganizationID(payload.ID))
-			return nil
-		}
+		// Resolve below by external_id or by a deterministic ID derived from
+		// the WorkOS org ID.
 	case err != nil:
-		return fmt.Errorf("get organization by workos id %q: %w", payload.ID, err)
+		return resolvedWorkOSOrganization{}, fmt.Errorf("get organization for workos id %q: %w", payload.ID, err)
+	}
+
+	organizationID := payload.ExternalID
+	needsExternalIDUpdate := false
+	if organizationID == "" {
+		organizationID = orgid.FromWorkOSID(payload.ID)
+		needsExternalIDUpdate = true
+	}
+
+	row, err = repo.GetOrganizationMetadata(ctx, organizationID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		var newRow orgrepo.OrganizationMetadatum
+		return resolvedWorkOSOrganization{
+			row:                   newRow,
+			organizationID:        organizationID,
+			isNew:                 true,
+			needsExternalIDUpdate: needsExternalIDUpdate,
+		}, nil
+	case err != nil:
+		return resolvedWorkOSOrganization{}, fmt.Errorf("get organization metadata %q: %w", organizationID, err)
+	default:
+		return resolvedWorkOSOrganization{
+			row:                   row,
+			organizationID:        organizationID,
+			isNew:                 false,
+			needsExternalIDUpdate: needsExternalIDUpdate,
+		}, nil
+	}
+}
+
+func createOrganizationFromWorkOSEvent(ctx context.Context, repo *orgrepo.Queries, payload workosOrganizationEventPayload, eventID string, organizationID string) error {
+	// A zero row makes the normal cursor check accept genuine creates while
+	// keeping the create path consistent if a row appears between resolve and
+	// insert.
+	var newRow orgrepo.OrganizationMetadatum
+	if !shouldApplyOrganizationEvent(newRow, payload, eventID) {
+		return nil
+	}
+
+	slug := orgslug.Slugify(payload.Name)
+	if slug == "" {
+		return fmt.Errorf("slugify workos organization name %q: empty slug", payload.Name)
+	}
+	if err := repo.LockOrganizationSlug(ctx, slug); err != nil {
+		return fmt.Errorf("lock organization slug %q: %w", slug, err)
+	}
+	uniqueSlug, err := orgslug.FindUnique(ctx, repo, slug)
+	if err != nil {
+		return fmt.Errorf("find unique slug for workos organization %q: %w", payload.ID, err)
+	}
+
+	_, err = repo.CreateOrganizationMetadataFromWorkOS(ctx, orgrepo.CreateOrganizationMetadataFromWorkOSParams{
+		ID:                organizationID,
+		Name:              payload.Name,
+		Slug:              uniqueSlug,
+		WorkosID:          conv.ToPGText(payload.ID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID: conv.ToPGText(eventID),
+	})
+	if err != nil {
+		return fmt.Errorf("create organization %q from workos event: %w", payload.ID, err)
+	}
+	return nil
+}
+
+func updateOrganizationFromWorkOSEvent(ctx context.Context, repo *orgrepo.Queries, row orgrepo.OrganizationMetadatum, payload workosOrganizationEventPayload, eventID string) error {
+	if !shouldApplyOrganizationEvent(row, payload, eventID) {
+		return nil
+	}
+
+	_, err := repo.UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
+		ID:                row.ID,
+		Name:              payload.Name,
+		WorkosID:          conv.ToPGText(payload.ID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(payload.UpdatedAt),
+		WorkosLastEventID: conv.ToPGText(eventID),
+	})
+	if err != nil {
+		return fmt.Errorf("update organization %q from workos event: %w", payload.ID, err)
+	}
+
+	return nil
+}
+
+func shouldApplyOrganizationEvent(row orgrepo.OrganizationMetadatum, payload workosOrganizationEventPayload, eventID string) bool {
+	sameWorkOSLink := !row.WorkosID.Valid || row.WorkosID.String == "" || row.WorkosID.String == payload.ID
+	if !sameWorkOSLink {
+		// The row is being relinked from another WorkOS org. Its stored cursor
+		// belongs to the previous WorkOS org, so this event must apply fresh.
+		return true
 	}
 
 	var lastEventID *string
@@ -259,28 +394,7 @@ func handleOrganizationUpsert(ctx context.Context, logger *slog.Logger, dbtx dat
 	if row.WorkosUpdatedAt.Valid {
 		rowUpdatedAt = &row.WorkosUpdatedAt.Time
 	}
-	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
-		return nil
-	}
-
-	organizationID := payload.ExternalID
-	if err == nil {
-		organizationID = row.ID
-	}
-
-	_, err = repo.UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
-		ID:                organizationID,
-		Name:              payload.Name,
-		Slug:              conv.ToSlug(payload.Name),
-		WorkosID:          conv.ToPGText(payload.ID),
-		WorkosUpdatedAt:   conv.ToPGTimestamptz(payload.UpdatedAt),
-		WorkosLastEventID: conv.ToPGText(event.ID),
-	})
-	if err != nil {
-		return fmt.Errorf("upsert organization %q from workos event: %w", payload.ID, err)
-	}
-
-	return nil
+	return ShouldProcessEvent(lastEventID, rowUpdatedAt, eventID, payload.UpdatedAt)
 }
 
 func handleOrganizationDeleted(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, event events.Event) error {
@@ -368,8 +482,11 @@ func upsertOrganizationRole(ctx context.Context, logger *slog.Logger, dbtx datab
 	if existing.WorkosLastEventID.Valid {
 		lastEventID = &existing.WorkosLastEventID.String
 	}
-	rowUpdatedAt := existing.WorkosUpdatedAt.Time
-	if !ShouldProcessEvent(lastEventID, &rowUpdatedAt, event.ID, payload.UpdatedAt) {
+	var rowUpdatedAt *time.Time
+	if existing.WorkosUpdatedAt.Valid {
+		rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+	}
+	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
 		return nil
 	}
 
@@ -424,8 +541,11 @@ func handleRoleDeleted(ctx context.Context, logger *slog.Logger, dbtx database.D
 	if existing.WorkosLastEventID.Valid {
 		lastEventID = &existing.WorkosLastEventID.String
 	}
-	rowUpdatedAt := existing.WorkosUpdatedAt.Time
-	if !ShouldProcessEvent(lastEventID, &rowUpdatedAt, event.ID, payload.UpdatedAt) {
+	var rowUpdatedAt *time.Time
+	if existing.WorkosUpdatedAt.Valid {
+		rowUpdatedAt = &existing.WorkosUpdatedAt.Time
+	}
+	if !ShouldProcessEvent(lastEventID, rowUpdatedAt, event.ID, payload.UpdatedAt) {
 		return nil
 	}
 

--- a/server/internal/background/activities/process_workos_org_events_test.go
+++ b/server/internal/background/activities/process_workos_org_events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgid "github.com/speakeasy-api/gram/server/internal/organizations/id"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
@@ -155,22 +157,24 @@ func TestProcessWorkOSOrganizationEvents_EmptyPage(t *testing.T) {
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
-func TestProcessWorkOSOrganizationEvents_SkipsUnlinkedOrgWithoutExternalID(t *testing.T) {
+func TestProcessWorkOSOrganizationEvents_CreatesOrgAndUpdatesWorkOSExternalIDWhenMissing(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	conn := newOrgEventsTestConn(t, "workos_org_events_unlinked_no_external_id")
+	conn := newOrgEventsTestConn(t, "workos_org_events_unlinked")
 	logger := testenv.NewLogger(t)
 
 	const workosOrgID = "org_01HZTESTBAD"
+	organizationID := orgid.FromWorkOSID(workosOrgID)
 
-	// First event has neither a Gram-side mapping nor an external_id — must
-	// not stall the stream. Second event in the same page carries the
-	// external_id and should be applied normally.
+	// The first event has no external_id, so Gram creates the org with a
+	// deterministic ID and updates WorkOS after commit. The second event still
+	// updates the existing workos_id-linked org even if its payload carries a
+	// different external_id.
 	stub := newWorkOSClientWithEvents([][]events.Event{
 		{
 			{ID: "event_01HZBAD", Event: "organization.updated", CreatedAt: time.Now(), Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Pending","updated_at":"2026-05-06T11:00:00Z"}`)},
-			{ID: "event_01HZGOOD", Event: "organization.updated", CreatedAt: time.Now(), Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Resolved","external_id":"sb_resolved","updated_at":"2026-05-06T12:00:00Z"}`)},
+			{ID: "event_01HZGOOD", Event: "organization.updated", CreatedAt: time.Now(), Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Resolved","external_id":"sb_missing","updated_at":"2026-05-06T12:00:00Z"}`)},
 		},
 	})
 
@@ -182,12 +186,215 @@ func TestProcessWorkOSOrganizationEvents_SkipsUnlinkedOrgWithoutExternalID(t *te
 
 	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
 	require.NoError(t, err)
-	require.Equal(t, "sb_resolved", row.ID)
+	require.Equal(t, organizationID, row.ID)
 	require.Equal(t, "Resolved", row.Name)
+	require.Equal(t, "pending", row.Slug)
+	require.Equal(t, []workos.OrgExternalIDUpdate{{WorkOSOrgID: workosOrgID, ExternalID: organizationID}}, stub.OrgExternalIDUpdates())
 
 	cursor, err := workosrepo.New(conn).GetOrganizationSyncLastEventID(ctx, workosOrgID)
 	require.NoError(t, err)
 	require.Equal(t, "event_01HZGOOD", cursor)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationCreateRejectsEmptySlug(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_empty_slug")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZEMPTYSLUG"
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZEMPTYSLUG",
+				Event:     "organization.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"!!!",` +
+					`"updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.Error(t, err)
+
+	_, err = orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	_, err = workosrepo.New(conn).GetOrganizationSyncLastEventID(ctx, workosOrgID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationExternalIDMissingLocallyCreates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_external_id_missing_locally_creates")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZMISSINGEXTERNAL"
+	const externalID = "sb_missing_external"
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZMISSINGEXTERNAL",
+				Event:     "organization.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Missing External","external_id":"` + externalID + `",` +
+					`"updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMISSINGEXTERNAL", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, externalID, row.ID)
+	require.Equal(t, "Missing External", row.Name)
+	require.Equal(t, "missing-external", row.Slug)
+
+	cursor, err := workosrepo.New(conn).GetOrganizationSyncLastEventID(ctx, workosOrgID)
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZMISSINGEXTERNAL", cursor)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationCreateHandlesConcurrentInsert(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_concurrent_insert")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZCONCURRENT"
+	const externalID = "sb_concurrent"
+
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Concurrent Original",
+		Slug: "concurrent-original",
+	})
+	require.NoError(t, err)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZCONCURRENT",
+				Event:     "organization.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Concurrent WorkOS","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZCONCURRENT", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, externalID, row.ID)
+	require.Equal(t, "Concurrent WorkOS", row.Name)
+	require.Equal(t, "concurrent-original", row.Slug)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationCreateAddsHashForTakenSlug(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_create_taken_slug")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZTAKENSLUG"
+	organizationID := orgid.FromWorkOSID(workosOrgID)
+
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   "sb_slug_owner",
+		Name: "Acme",
+		Slug: "acme",
+	})
+	require.NoError(t, err)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZTAKENSLUG",
+				Event:     "organization.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Acme",` +
+					`"updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZTAKENSLUG", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, organizationID, row.ID)
+	require.NotEqual(t, "acme", row.Slug)
+	require.True(t, strings.HasPrefix(row.Slug, "acme-"))
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationCreateConflictSkipsStaleEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_stale_create_conflict")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZSTALECREATE"
+	const externalID = "sb_stale_create"
+
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Newer Name",
+		Slug: "newer-name",
+	})
+	require.NoError(t, err)
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
+		ID:                externalID,
+		Name:              "Newer Name",
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)),
+		WorkosLastEventID: conv.ToPGText("event_01HZ0002"),
+	})
+	require.NoError(t, err)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZ0001",
+				Event:     "organization.created",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Older Name","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T11:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZ0001", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationMetadata(ctx, externalID)
+	require.NoError(t, err)
+	require.Equal(t, "Newer Name", row.Name)
+	require.Equal(t, "newer-name", row.Slug)
+	require.Equal(t, "event_01HZ0002", row.WorkosLastEventID.String)
 }
 
 func TestProcessWorkOSOrganizationEvents_OrganizationCreatedAndUpdated(t *testing.T) {
@@ -199,6 +406,13 @@ func TestProcessWorkOSOrganizationEvents_OrganizationCreatedAndUpdated(t *testin
 
 	const workosOrgID = "org_01HZCREATE"
 	const externalID = "sb_01HZCREATE"
+
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Original",
+		Slug: "original",
+	})
+	require.NoError(t, err)
 
 	created := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
 	updated := time.Date(2026, 5, 6, 11, 0, 0, 0, time.UTC)
@@ -223,18 +437,192 @@ func TestProcessWorkOSOrganizationEvents_OrganizationCreatedAndUpdated(t *testin
 	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
-	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
 
 	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
 	require.NoError(t, err)
 	require.Equal(t, externalID, row.ID)
 	require.Equal(t, "Acme Inc", row.Name)
+	require.Equal(t, "original", row.Slug)
 	require.True(t, row.WorkosLastEventID.Valid)
 	require.Equal(t, "event_01HZB", row.WorkosLastEventID.String)
 	require.True(t, row.WorkosUpdatedAt.Valid)
 	require.True(t, row.WorkosUpdatedAt.Time.Equal(updated))
 	require.False(t, row.DisabledAt.Valid)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationUpdatePreservesExistingSlugOnNameConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_slug_preserved")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_slug_preserved"
+	const workosOrgID = "org_01HZSLUGPRESERVE"
+
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   organizationID,
+		Name: "Original Name",
+		Slug: "original-name",
+	})
+	require.NoError(t, err)
+
+	err = orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   "gram_org_slug_owner",
+		Name: "Taken Name",
+		Slug: "taken-name",
+	})
+	require.NoError(t, err)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZSLUG1",
+				Event:     "organization.updated",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Taken Name","external_id":"` + organizationID +
+					`","updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZSLUG1", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, organizationID, row.ID)
+	require.Equal(t, "Taken Name", row.Name)
+	require.Equal(t, "original-name", row.Slug)
+	require.Equal(t, "event_01HZSLUG1", row.WorkosLastEventID.String)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationUpdateDoesNotRemapExistingWorkOSLink(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_no_remap")
+	logger := testenv.NewLogger(t)
+
+	const oldOrganizationID = "gram_org_old_workos_link"
+	const newOrganizationID = "gram_org_new_workos_link"
+	const workosOrgID = "org_01HZREMAP"
+
+	seedWorkOSOrganization(t, ctx, conn, oldOrganizationID, workosOrgID)
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   newOrganizationID,
+		Name: "Target Org",
+		Slug: "target-org",
+	})
+	require.NoError(t, err)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZREMAP",
+				Event:     "organization.updated",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Remapped Org","external_id":"` + newOrganizationID +
+					`","updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZREMAP", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, oldOrganizationID, row.ID)
+	require.Equal(t, "Remapped Org", row.Name)
+	require.Equal(t, oldOrganizationID, row.Slug)
+
+	targetRow, err := orgrepo.New(conn).GetOrganizationMetadata(ctx, newOrganizationID)
+	require.NoError(t, err)
+	require.False(t, targetRow.WorkosID.Valid)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationUpdateRelinksExternalIDMatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_relink_external_id")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_external_id_relink"
+	const oldWorkosOrgID = "org_01HZOLDLINK"
+	const newWorkosOrgID = "org_01HZNEWLINK"
+
+	seedWorkOSOrganization(t, ctx, conn, organizationID, oldWorkosOrgID)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZRELINK",
+				Event:     "organization.updated",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + newWorkosOrgID + `","object":"organization","name":"Relinked Org","external_id":"` + organizationID +
+					`","updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: newWorkosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZRELINK", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "Relinked Org", row.Name)
+	require.Equal(t, newWorkosOrgID, row.WorkosID.String)
+	require.Equal(t, "event_01HZRELINK", row.WorkosLastEventID.String)
+
+	_, err = orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(oldWorkosOrgID))
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationUpdateWithoutExternalIDKeepsExistingWorkOSLink(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_no_external_keeps_link")
+	logger := testenv.NewLogger(t)
+
+	const organizationID = "gram_org_existing_workos_link"
+	const workosOrgID = "org_01HZNOEXTERNAL"
+
+	seedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZNOEXTERNAL",
+				Event:     "organization.updated",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Still Linked",` +
+					`"updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	res, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+	require.Equal(t, "event_01HZNOEXTERNAL", res.LastEventID)
+
+	row, err := orgrepo.New(conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "Still Linked", row.Name)
+	require.True(t, row.WorkosID.Valid)
+	require.Equal(t, workosOrgID, row.WorkosID.String)
+	require.Equal(t, []workos.OrgExternalIDUpdate{{WorkOSOrgID: workosOrgID, ExternalID: organizationID}}, stub.OrgExternalIDUpdates())
 }
 
 func TestProcessWorkOSOrganizationEvents_OrganizationUpdateSkippedWhenStale(t *testing.T) {
@@ -246,6 +634,13 @@ func TestProcessWorkOSOrganizationEvents_OrganizationUpdateSkippedWhenStale(t *t
 
 	const workosOrgID = "org_01HZSTALE"
 	const externalID = "sb_01HZSTALE"
+
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Original",
+		Slug: "original-stale",
+	})
+	require.NoError(t, err)
 
 	stub := newWorkOSClientWithEvents([][]events.Event{
 		{
@@ -268,7 +663,7 @@ func TestProcessWorkOSOrganizationEvents_OrganizationUpdateSkippedWhenStale(t *t
 	})
 
 	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
-	_, err := activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
 
 	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
@@ -287,10 +682,16 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSetsDisabled(t *test
 	const workosOrgID = "org_01HZDELETE"
 	const externalID = "sb_01HZDELETE"
 
-	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Doomed",
+		Slug: "doomed",
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
 		ID:                externalID,
 		Name:              "Doomed",
-		Slug:              "doomed",
 		WorkosID:          conv.ToPGText(workosOrgID),
 		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Now()),
 		WorkosLastEventID: conv.ToPGText("event_00SEED"),
@@ -317,6 +718,60 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSetsDisabled(t *test
 	require.NoError(t, err)
 	require.True(t, row.DisabledAt.Valid)
 	require.Equal(t, "event_01HZDEL", row.WorkosLastEventID.String)
+}
+
+func TestProcessWorkOSOrganizationEvents_OrganizationUpdateDoesNotClearDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_org_events_org_update_preserves_disabled")
+	logger := testenv.NewLogger(t)
+
+	const workosOrgID = "org_01HZDISABLEDUPDATE"
+	const externalID = "sb_01HZDISABLEDUPDATE"
+
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Disabled",
+		Slug: "disabled",
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
+		ID:                externalID,
+		Name:              "Disabled",
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Date(2026, 5, 6, 11, 0, 0, 0, time.UTC)),
+		WorkosLastEventID: conv.ToPGText("event_01HZ001"),
+	})
+	require.NoError(t, err)
+	_, err = orgrepo.New(conn).DisableOrganizationByWorkosID(ctx, orgrepo.DisableOrganizationByWorkosIDParams{
+		WorkosID:          conv.ToPGText(workosOrgID),
+		WorkosLastEventID: conv.ToPGText("event_01HZ002"),
+	})
+	require.NoError(t, err)
+
+	stub := newWorkOSClientWithEvents([][]events.Event{
+		{
+			{
+				ID:        "event_01HZ003",
+				Event:     "organization.updated",
+				CreatedAt: time.Now(),
+				Data: []byte(`{"id":"` + workosOrgID + `","object":"organization","name":"Still Disabled","external_id":"` + externalID +
+					`","updated_at":"2026-05-06T12:00:00Z"}`),
+			},
+		},
+	})
+
+	activity := activities.NewProcessWorkOSOrganizationEvents(logger, conn, stub)
+	_, err = activity.Do(ctx, activities.ProcessWorkOSOrganizationEventsParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	row, err := orgrepo.New(conn).GetOrganizationByWorkosID(ctx, conv.ToPGText(workosOrgID))
+	require.NoError(t, err)
+	require.Equal(t, "Still Disabled", row.Name)
+	require.True(t, row.DisabledAt.Valid)
+	require.Equal(t, "event_01HZ003", row.WorkosLastEventID.String)
 }
 
 func TestProcessWorkOSGlobalRoleEvents_UpsertAndDelete(t *testing.T) {
@@ -372,10 +827,16 @@ func TestProcessWorkOSOrganizationEvents_OrganizationRoleUpsertAndDelete(t *test
 	const externalID = "sb_01HZORGROLE"
 	const slug = "billing-manager"
 
-	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Acme",
+		Slug: "acme",
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
 		ID:                externalID,
 		Name:              "Acme",
-		Slug:              "acme",
 		WorkosID:          conv.ToPGText(workosOrgID),
 		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Now()),
 		WorkosLastEventID: conv.ToPGText("event_00SEED"),
@@ -444,10 +905,16 @@ func TestProcessWorkOSOrganizationEvents_OrganizationDeletedSkippedWhenStale(t *
 	const externalID = "sb_01HZDELSTALE"
 
 	// Seed org with cursor advanced past the stale delete event ID.
-	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   externalID,
+		Name: "Live",
+		Slug: "live",
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
 		ID:                externalID,
 		Name:              "Live",
-		Slug:              "live",
 		WorkosID:          conv.ToPGText(workosOrgID),
 		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Now()),
 		WorkosLastEventID: conv.ToPGText("event_99FRESH"),
@@ -520,10 +987,16 @@ func newWorkOSMembershipEvent(t *testing.T, eventType, eventID, membershipID, wo
 func seedWorkOSOrganization(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, workosOrgID string) {
 	t.Helper()
 
-	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   organizationID,
+		Name: "Test Org",
+		Slug: organizationID,
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
 		ID:                organizationID,
 		Name:              "Test Org",
-		Slug:              organizationID,
 		WorkosID:          conv.ToPGText(workosOrgID),
 		WorkosUpdatedAt:   conv.ToPGTimestamptz(time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)),
 		WorkosLastEventID: conv.ToPGText("event_00SEED"),

--- a/server/internal/background/activities/process_workos_user_events_test.go
+++ b/server/internal/background/activities/process_workos_user_events_test.go
@@ -134,10 +134,16 @@ func TestProcessWorkOSUserEvents_LinksOptimisticRoleAssignments(t *testing.T) {
 	gramID := users.UserIDFromWorkOSID(workosUserID)
 	seedTime := time.Date(2026, 5, 10, 10, 0, 0, 0, time.UTC)
 
-	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   "org_role_assignment",
+		Name: "Role Assignment Org",
+		Slug: "role-assignment-org",
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
 		ID:                "org_role_assignment",
 		Name:              "Role Assignment Org",
-		Slug:              "role-assignment-org",
 		WorkosID:          conv.ToPGText("org_role_assignment"),
 		WorkosUpdatedAt:   conv.ToPGTimestamptz(seedTime),
 		WorkosLastEventID: conv.ToPGText("event_org_role_assignment"),
@@ -198,10 +204,16 @@ func TestProcessWorkOSUserEvents_LinksPendingRelationshipOverTombstone(t *testin
 	const secondMembershipID = "mem_relationship_tombstone_2"
 	seedTime := time.Date(2026, 5, 10, 10, 0, 0, 0, time.UTC)
 
-	_, err := orgrepo.New(conn).UpsertOrganizationMetadataFromWorkOS(ctx, orgrepo.UpsertOrganizationMetadataFromWorkOSParams{
+	err := orgrepo.New(conn).CreateOrganizationMetadata(ctx, orgrepo.CreateOrganizationMetadataParams{
+		ID:   organizationID,
+		Name: "Relationship Tombstone Org",
+		Slug: "relationship-tombstone-org",
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(conn).UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
 		ID:                organizationID,
 		Name:              "Relationship Tombstone Org",
-		Slug:              "relationship-tombstone-org",
 		WorkosID:          conv.ToPGText(workosOrgID),
 		WorkosUpdatedAt:   conv.ToPGTimestamptz(seedTime),
 		WorkosLastEventID: conv.ToPGText("event_org_relationship_tombstone"),

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -258,9 +258,6 @@ SELECT *
 FROM organization_invitations
 WHERE token_hash = @token_hash;
 
--- name: ClearOrganizationWorkosID :exec
-UPDATE organization_metadata SET workos_id = NULL WHERE id = @organization_id;
-
 -- name: CreateOrganizationMetadata :exec
 INSERT INTO organization_metadata (id, name, slug)
 VALUES (@id, @name, @slug);
@@ -517,11 +514,35 @@ WHERE organization_id = @organization_id
   AND workos_user_id = @workos_user_id
 ORDER BY role_urn;
 
+-- name: LockOrganizationSlug :exec
+SELECT pg_advisory_xact_lock(hashtext(@slug));
+
+-- name: CreateOrganizationMetadataFromWorkOS :one
+-- Create a Gram organization row from a WorkOS organization event. The caller
+-- chooses the Gram org ID from WorkOS external_id or a deterministic fallback.
+-- Slug is a Gram-owned initial value and is never updated by WorkOS sync.
+INSERT INTO organization_metadata (
+    id,
+    name,
+    slug,
+    workos_id,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    @id,
+    @name,
+    @slug,
+    @workos_id,
+    @workos_updated_at,
+    @workos_last_event_id
+)
+RETURNING *;
+
 -- name: UpsertOrganizationMetadataFromWorkOS :one
--- Upsert an organization row from a WorkOS organization event. Caller must
--- have already passed the row through ShouldProcessEvent. Sets workos_id and
--- the cursor columns; clears disabled_at so a deleted-then-recreated org
--- comes back online.
+-- Upsert a Gram organization row from a WorkOS organization event.
+-- The caller must only use this when WorkOS external_id is set and is the Gram
+-- org ID. Slug is a Gram-owned initial value chosen by the caller and is never
+-- updated by WorkOS sync after creation.
 INSERT INTO organization_metadata (
     id,
     name,
@@ -539,12 +560,24 @@ INSERT INTO organization_metadata (
 )
 ON CONFLICT (id) DO UPDATE SET
     name = EXCLUDED.name,
-    slug = EXCLUDED.slug,
     workos_id = EXCLUDED.workos_id,
     workos_updated_at = EXCLUDED.workos_updated_at,
     workos_last_event_id = EXCLUDED.workos_last_event_id,
-    disabled_at = NULL,
     updated_at = clock_timestamp()
+RETURNING *;
+
+-- name: UpdateOrganizationMetadataFromWorkOS :one
+-- Update an existing organization row from a WorkOS organization event. Caller
+-- must have already resolved the Gram organization and passed the row through
+-- ShouldProcessEvent. WorkOS does not own Gram slugs, so this only updates
+-- WorkOS-owned metadata and cursor columns.
+UPDATE organization_metadata
+SET name = @name,
+    workos_id = @workos_id,
+    workos_updated_at = @workos_updated_at,
+    workos_last_event_id = @workos_last_event_id,
+    updated_at = clock_timestamp()
+WHERE id = @id
 RETURNING *;
 
 -- name: ListOrganizationsForUser :many

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -98,15 +98,6 @@ func (q *Queries) AttachWorkOSUserToOrg(ctx context.Context, arg AttachWorkOSUse
 	return err
 }
 
-const clearOrganizationWorkosID = `-- name: ClearOrganizationWorkosID :exec
-UPDATE organization_metadata SET workos_id = NULL WHERE id = $1
-`
-
-func (q *Queries) ClearOrganizationWorkosID(ctx context.Context, organizationID string) error {
-	_, err := q.db.Exec(ctx, clearOrganizationWorkosID, organizationID)
-	return err
-}
-
 const createInvitation = `-- name: CreateInvitation :one
 INSERT INTO organization_invitations (
     organization_id,
@@ -176,6 +167,68 @@ type CreateOrganizationMetadataParams struct {
 func (q *Queries) CreateOrganizationMetadata(ctx context.Context, arg CreateOrganizationMetadataParams) error {
 	_, err := q.db.Exec(ctx, createOrganizationMetadata, arg.ID, arg.Name, arg.Slug)
 	return err
+}
+
+const createOrganizationMetadataFromWorkOS = `-- name: CreateOrganizationMetadataFromWorkOS :one
+INSERT INTO organization_metadata (
+    id,
+    name,
+    slug,
+    workos_id,
+    workos_updated_at,
+    workos_last_event_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6
+)
+RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+`
+
+type CreateOrganizationMetadataFromWorkOSParams struct {
+	ID                string
+	Name              string
+	Slug              string
+	WorkosID          pgtype.Text
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+}
+
+// Create a Gram organization row from a WorkOS organization event. The caller
+// chooses the Gram org ID from WorkOS external_id or a deterministic fallback.
+// Slug is a Gram-owned initial value and is never updated by WorkOS sync.
+func (q *Queries) CreateOrganizationMetadataFromWorkOS(ctx context.Context, arg CreateOrganizationMetadataFromWorkOSParams) (OrganizationMetadatum, error) {
+	row := q.db.QueryRow(ctx, createOrganizationMetadataFromWorkOS,
+		arg.ID,
+		arg.Name,
+		arg.Slug,
+		arg.WorkosID,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+	)
+	var i OrganizationMetadatum
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.GramAccountType,
+		&i.SsoConnectionID,
+		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
+		&i.SvixAppID,
+		&i.WebhooksEnabled,
+		&i.Whitelisted,
+		&i.FreeTrialStartedAt,
+		&i.FreeTrialEndsAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DisabledAt,
+	)
+	return i, err
 }
 
 const deleteOrganizationUserRelationship = `-- name: DeleteOrganizationUserRelationship :exec
@@ -845,6 +898,15 @@ func (q *Queries) ListPendingInvitations(ctx context.Context, organizationID str
 	return items, nil
 }
 
+const lockOrganizationSlug = `-- name: LockOrganizationSlug :exec
+SELECT pg_advisory_xact_lock(hashtext($1))
+`
+
+func (q *Queries) LockOrganizationSlug(ctx context.Context, slug string) error {
+	_, err := q.db.Exec(ctx, lockOrganizationSlug, slug)
+	return err
+}
+
 const markRoleAssignmentsDeleted = `-- name: MarkRoleAssignmentsDeleted :exec
 UPDATE organization_role_assignments
 SET workos_updated_at = $1,
@@ -1237,6 +1299,59 @@ func (q *Queries) UpdateInvitationRole(ctx context.Context, arg UpdateInvitation
 	return i, err
 }
 
+const updateOrganizationMetadataFromWorkOS = `-- name: UpdateOrganizationMetadataFromWorkOS :one
+UPDATE organization_metadata
+SET name = $1,
+    workos_id = $2,
+    workos_updated_at = $3,
+    workos_last_event_id = $4,
+    updated_at = clock_timestamp()
+WHERE id = $5
+RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
+`
+
+type UpdateOrganizationMetadataFromWorkOSParams struct {
+	Name              string
+	WorkosID          pgtype.Text
+	WorkosUpdatedAt   pgtype.Timestamptz
+	WorkosLastEventID pgtype.Text
+	ID                string
+}
+
+// Update an existing organization row from a WorkOS organization event. Caller
+// must have already resolved the Gram organization and passed the row through
+// ShouldProcessEvent. WorkOS does not own Gram slugs, so this only updates
+// WorkOS-owned metadata and cursor columns.
+func (q *Queries) UpdateOrganizationMetadataFromWorkOS(ctx context.Context, arg UpdateOrganizationMetadataFromWorkOSParams) (OrganizationMetadatum, error) {
+	row := q.db.QueryRow(ctx, updateOrganizationMetadataFromWorkOS,
+		arg.Name,
+		arg.WorkosID,
+		arg.WorkosUpdatedAt,
+		arg.WorkosLastEventID,
+		arg.ID,
+	)
+	var i OrganizationMetadatum
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.GramAccountType,
+		&i.SsoConnectionID,
+		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
+		&i.SvixAppID,
+		&i.WebhooksEnabled,
+		&i.Whitelisted,
+		&i.FreeTrialStartedAt,
+		&i.FreeTrialEndsAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DisabledAt,
+	)
+	return i, err
+}
+
 const upsertOrganizationMetadata = `-- name: UpsertOrganizationMetadata :one
 INSERT INTO organization_metadata (
     id,
@@ -1320,11 +1435,9 @@ INSERT INTO organization_metadata (
 )
 ON CONFLICT (id) DO UPDATE SET
     name = EXCLUDED.name,
-    slug = EXCLUDED.slug,
     workos_id = EXCLUDED.workos_id,
     workos_updated_at = EXCLUDED.workos_updated_at,
     workos_last_event_id = EXCLUDED.workos_last_event_id,
-    disabled_at = NULL,
     updated_at = clock_timestamp()
 RETURNING id, name, slug, gram_account_type, sso_connection_id, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, created_at, updated_at, disabled_at
 `
@@ -1338,10 +1451,10 @@ type UpsertOrganizationMetadataFromWorkOSParams struct {
 	WorkosLastEventID pgtype.Text
 }
 
-// Upsert an organization row from a WorkOS organization event. Caller must
-// have already passed the row through ShouldProcessEvent. Sets workos_id and
-// the cursor columns; clears disabled_at so a deleted-then-recreated org
-// comes back online.
+// Upsert a Gram organization row from a WorkOS organization event.
+// The caller must only use this when WorkOS external_id is set and is the Gram
+// org ID. Slug is a Gram-owned initial value chosen by the caller and is never
+// updated by WorkOS sync after creation.
 func (q *Queries) UpsertOrganizationMetadataFromWorkOS(ctx context.Context, arg UpsertOrganizationMetadataFromWorkOSParams) (OrganizationMetadatum, error) {
 	row := q.db.QueryRow(ctx, upsertOrganizationMetadataFromWorkOS,
 		arg.ID,

--- a/server/internal/thirdparty/workos/organization.go
+++ b/server/internal/thirdparty/workos/organization.go
@@ -118,17 +118,21 @@ func (wc *Client) EnsureOrgExternalID(ctx context.Context, workosOrgID, gramOrgI
 		return fmt.Errorf("workos org %s external_id mismatch: got %q, want %q", workosOrgID, org.ExternalID, gramOrgID)
 	}
 
-	_, err = wc.orgs.UpdateOrganization(ctx, organizations.UpdateOrganizationOpts{ //nolint:exhaustruct // deprecated WorkOS fields are intentionally omitted.
+	return wc.UpdateOrganizationExternalID(ctx, workosOrgID, gramOrgID)
+}
+
+func (wc *Client) UpdateOrganizationExternalID(ctx context.Context, workosOrgID, externalID string) error {
+	_, err := wc.orgs.UpdateOrganization(ctx, organizations.UpdateOrganizationOpts{ //nolint:exhaustruct // deprecated WorkOS fields are intentionally omitted.
 		Organization:     workosOrgID,
 		Name:             "",
 		Domains:          nil,
 		DomainData:       nil,
-		ExternalID:       gramOrgID,
+		ExternalID:       externalID,
 		StripeCustomerID: "",
 		Metadata:         nil,
 	})
 	if err != nil {
-		return fmt.Errorf("set workos org external_id: %w", err)
+		return fmt.Errorf("update organization external ID: %w", err)
 	}
 
 	return nil

--- a/server/internal/thirdparty/workos/stub.go
+++ b/server/internal/thirdparty/workos/stub.go
@@ -20,6 +20,7 @@ type StubClient struct {
 	eventPages            [][]events.Event
 	eventCalls            []events.ListEventsOpts
 	userExternalIDUpdates []UserExternalIDUpdate
+	orgExternalIDUpdates  []OrgExternalIDUpdate
 	next                  int
 	nowFn                 func() time.Time
 }
@@ -27,6 +28,11 @@ type StubClient struct {
 type UserExternalIDUpdate struct {
 	WorkOSUserID string
 	ExternalID   string
+}
+
+type OrgExternalIDUpdate struct {
+	WorkOSOrgID string
+	ExternalID  string
 }
 
 type stubOrgState struct {
@@ -49,6 +55,7 @@ func NewStubClient() *StubClient {
 		eventPages:            nil,
 		eventCalls:            make([]events.ListEventsOpts, 0),
 		userExternalIDUpdates: make([]UserExternalIDUpdate, 0),
+		orgExternalIDUpdates:  make([]OrgExternalIDUpdate, 0),
 		next:                  1,
 		nowFn:                 time.Now,
 	}
@@ -118,6 +125,13 @@ func (s *StubClient) UserExternalIDUpdates() []UserExternalIDUpdate {
 	defer s.mut.Unlock()
 
 	return append([]UserExternalIDUpdate(nil), s.userExternalIDUpdates...)
+}
+
+func (s *StubClient) OrgExternalIDUpdates() []OrgExternalIDUpdate {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	return append([]OrgExternalIDUpdate(nil), s.orgExternalIDUpdates...)
 }
 
 func (s *StubClient) ListEvents(_ context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error) {
@@ -282,6 +296,29 @@ func (s *StubClient) UpdateUserExternalID(_ context.Context, workosUserID, exter
 	defer s.mut.Unlock()
 
 	s.userExternalIDUpdates = append(s.userExternalIDUpdates, UserExternalIDUpdate{WorkOSUserID: workosUserID, ExternalID: externalID})
+	return nil
+}
+
+func (s *StubClient) UpdateOrganizationExternalID(_ context.Context, workosOrgID, externalID string) error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	state := s.orgState(workosOrgID)
+	state.organization.ExternalID = externalID
+	s.orgExternalIDUpdates = append(s.orgExternalIDUpdates, OrgExternalIDUpdate{WorkOSOrgID: workosOrgID, ExternalID: externalID})
+	return nil
+}
+
+func (s *StubClient) EnsureOrgExternalID(_ context.Context, workosOrgID, gramOrgID string) error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	state := s.orgState(workosOrgID)
+	if state.organization.ExternalID != "" && state.organization.ExternalID != gramOrgID {
+		return fmt.Errorf("workos org %s external_id mismatch: got %q, want %q", workosOrgID, state.organization.ExternalID, gramOrgID)
+	}
+	state.organization.ExternalID = gramOrgID
+	s.orgExternalIDUpdates = append(s.orgExternalIDUpdates, OrgExternalIDUpdate{WorkOSOrgID: workosOrgID, ExternalID: gramOrgID})
 	return nil
 }
 


### PR DESCRIPTION
## Why?

WorkOS organization sync was failing with `duplicate key value violates unique constraint "organization_metadata_slug_key"`. The upsert had `ON CONFLICT (id) DO UPDATE` but no protection against the separate slug unique index — when an event updated an org's name, the resulting slug could collide with a sibling row's existing slug and the whole event would fail (and retry forever).

## What?

Switched from blind upsert to fetch-then-write. Pure INSERT on the create path, pure UPDATE on the update path, slug never touched after initial creation.

Resolution flow for organization create/update events:

* Look up by `workos_id`. If found → update.
* Otherwise, if `external_id` is set → look up by it (Gram org ID = external_id). If found → update; if not → INSERT a new row using `external_id` as the Gram ID.
* Otherwise (no `external_id`), derive a deterministic Gram org ID via UUIDv5 from the WorkOS org ID, INSERT locally, then push that ID back to WorkOS as the `external_id` after the local transaction commits. Ordering ensures the remote `external_id` never points at a row that failed to persist. If the WorkOS write fails we log and rely on the next event to retry.

Also added a `ShouldProcessEvent` guard (event-ID lexicographic compare on ULIDs, falling back to `workos_updated_at`) so duplicate/out-of-order events from reconcile-overlap or backfill replay don't rewind state.

## Concurrency considerations

* Per-WorkOS-org workflows are serialized via Temporal `SignalWithStartWorkflow` + `USE_EXISTING`, so same-org events never race.
* Cross-org create race (two events resolving to the same Gram org ID): the second INSERT fails with a PK conflict, the activity returns the error, Temporal retries, and the retry resolves to the update path.
* Cross-org slug race (two different orgs slugifying to the same base): protected by `pg_advisory_xact_lock(hashtext(slug))` taken before `FindUnique`, so concurrent inserts on the same base slug serialize.
* Concurrency vs non-WorkOS writers (dashboard rename, signup flow, etc.) is
  NOT serialized by Temporal — only WorkOS sync vs WorkOS sync is. Known
  consequences:
  - Local UPDATE racing a WorkOS UPDATE: last writer wins. `ShouldProcessEvent`
    only de-dups WorkOS events against the cursor; it doesn't observe local writes.
  - Local INSERT racing a WorkOS INSERT on the same derived ID: second INSERT
    fails with PK conflict and Temporal retries into the update path.
  - Local INSERT racing a WorkOS INSERT on the same slug: advisory lock is
    WorkOS-side only; PG slug unique violation triggers retry + suffix.