### PR TITLE
fix: restore oauth proxy auto configure

### DIFF
--- a/.changeset/age-2410-oauth-proxy-auto-config.md
+++ b/.changeset/age-2410-oauth-proxy-auto-config.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Keep the OAuth wizard auto-configure path on OAuth Proxy setup with DCR credentials, even when user-session onboarding is enabled for the organization.

--- a/client/dashboard/src/pages/mcp/oauth-wizard/AutoConfigureLoader.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/AutoConfigureLoader.tsx
@@ -1,23 +1,16 @@
 import { Type } from "@/components/ui/type";
 import { Loader2 } from "lucide-react";
 
-export function AutoConfigureLoader({
-  mode = "proxy",
-}: {
-  mode?: "proxy" | "user-sessions";
-}) {
+export function AutoConfigureLoader() {
   return (
     <div className="flex flex-col items-center justify-center gap-4 py-12">
       <Loader2 className="text-muted-foreground h-12 w-12 animate-spin" />
       <Type className="text-center text-lg font-medium">
-        {mode === "user-sessions"
-          ? "Setting up user sessions..."
-          : "Setting up OAuth Proxy..."}
+        Setting up OAuth Proxy...
       </Type>
       <Type muted small className="max-w-md text-center">
-        {mode === "user-sessions"
-          ? "Registering Gram with the upstream OAuth provider and linking the issuer to this toolset."
-          : "Registering Gram with the upstream OAuth provider and storing the returned credentials."}
+        Registering Gram with the upstream OAuth provider and storing the
+        returned credentials.
       </Type>
     </div>
   );

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
@@ -209,10 +209,15 @@ describe("OAuthWizard — rendering", () => {
     expect(screen.getByRole("button", { name: /External OAuth/ })).toBeTruthy();
   });
 
-  it("shows interactive auth status when user-session onboarding is enabled", () => {
+  it("keeps auto-configure labeled as OAuth Proxy when user-session onboarding is enabled", () => {
     mocks.isFeatureEnabled.mockReturnValue(true);
     renderWizard({ toolset: oauthToolset });
-    expect(screen.getByText("Interactive auth enabled")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Automatically set up OAuth Proxy based on pre-discovered details about this MCP server.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Interactive auth enabled")).toBeNull();
   });
 });
 

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -7,14 +7,10 @@ import { useTelemetry } from "@/contexts/Telemetry";
 import { Toolset } from "@/lib/toolTypes";
 import { getServerURL } from "@/lib/utils";
 import { useProductTier } from "@/hooks/useProductTier";
-import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import {
   invalidateAllGetMcpMetadata,
   invalidateAllListEnvironments,
-  invalidateAllRemoteSessionClients,
-  invalidateAllRemoteSessionIssuers,
   invalidateAllToolset,
-  invalidateAllUserSessionIssuers,
 } from "@gram/client/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { Globe } from "lucide-react";
@@ -109,12 +105,6 @@ function WizardBody({
             invalidateAllGetMcpMetadata(queryClient);
             invalidateAllListEnvironments(queryClient);
           },
-          invalidateOnUserSessionsCreate: () => {
-            invalidateAllToolset(queryClient);
-            invalidateAllRemoteSessionIssuers(queryClient);
-            invalidateAllRemoteSessionClients(queryClient);
-            invalidateAllUserSessionIssuers(queryClient);
-          },
           captureExternalSuccess: () =>
             telemetry.capture("mcp_event", {
               action: "external_oauth_configured",
@@ -123,11 +113,6 @@ function WizardBody({
           captureProxyCreateSuccess: () =>
             telemetry.capture("mcp_event", {
               action: "oauth_proxy_configured",
-              slug: toolsetSlug,
-            }),
-          captureUserSessionsCreateSuccess: () =>
-            telemetry.capture("mcp_event", {
-              action: "user_sessions_oauth_configured",
               slug: toolsetSlug,
             }),
         },
@@ -140,9 +125,6 @@ function WizardBody({
     toolsetSlug,
     toolsetName: toolset.name,
     activeOrganizationId: session.activeOrganizationId,
-    onboardToUserSessions:
-      telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
-      false,
   };
 
   return (
@@ -165,9 +147,6 @@ function WizardSteps({
   const hasMultipleOAuth2AuthCode = oauth2SecurityCount > 1;
 
   const isProxyCreating = state.matches({ proxy: "submitting" });
-  const isUserSessionsCreating = state.matches({
-    userSessions: "submitting",
-  });
   const isAutoRegistering = state.context.autoRegistering;
 
   return (
@@ -188,12 +167,7 @@ function WizardSteps({
       {state.matches({ proxy: "metadata" }) && <ProxyMetadataForm />}
 
       {(state.matches({ proxy: "registering" }) ||
-        (isProxyCreating && isAutoRegistering) ||
-        isUserSessionsCreating) && (
-        <AutoConfigureLoader
-          mode={isUserSessionsCreating ? "user-sessions" : "proxy"}
-        />
-      )}
+        (isProxyCreating && isAutoRegistering)) && <AutoConfigureLoader />}
 
       {state.matches({ proxy: "autoRegisterFailed" }) && (
         <AutoRegisterFailedStep error={state.context.error} onClose={onClose} />

--- a/client/dashboard/src/pages/mcp/oauth-wizard/PathSelection.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/PathSelection.tsx
@@ -15,11 +15,7 @@ import type { DiscoveredOAuth } from "./machine-types";
 export function PathSelection() {
   const send = WizardContext.useActorRef().send;
   const discovered = WizardContext.useSelector((s) => s.context.discovered);
-  const onboardToUserSessions = WizardContext.useSelector(
-    (s) => s.context.onboardToUserSessions,
-  );
   const canAutoConfigure = canAutoConfigureFromDiscovered(discovered);
-  const interactiveAuthEnabled = onboardToUserSessions && canAutoConfigure;
 
   return (
     <div className="space-y-4">
@@ -39,17 +35,11 @@ export function PathSelection() {
               <Badge key="recommended" variant="information">
                 Recommended
               </Badge>,
-              interactiveAuthEnabled && (
-                <Badge key="interactive-auth" variant="success">
-                  Interactive auth enabled
-                </Badge>
-              ),
             ]}
           >
             <Type muted small>
-              {onboardToUserSessions
-                ? "Automatically set up user sessions based on pre-discovered OAuth details about this MCP server."
-                : "Automatically set up OAuth Proxy based on pre-discovered details about this MCP server."}
+              Automatically set up OAuth Proxy based on pre-discovered details
+              about this MCP server.
             </Type>
           </PathOptionCard>
         )}

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
@@ -49,7 +49,6 @@ export type Context = {
   toolsetSlug: string;
   toolsetName: string;
   activeOrganizationId: string;
-  onboardToUserSessions: boolean;
 };
 
 export type Input = {
@@ -57,7 +56,6 @@ export type Input = {
   toolsetSlug: string;
   toolsetName: string;
   activeOrganizationId: string;
-  onboardToUserSessions?: boolean;
 };
 
 export type WizardEvent =

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.test.ts
@@ -20,7 +20,6 @@ import {
   nextEnvironmentName,
   type AddExternalOAuthInput,
   type AddOAuthProxyInput,
-  type ConfigureUserSessionsInput,
   type CreateEnvironmentInput,
   type CreateEnvironmentOutput,
   type DeleteEnvironmentInput,
@@ -76,9 +75,6 @@ function happyServices() {
         clientSecret: "auto-secret",
         tokenAuthMethod: "client_secret_basic",
       }),
-    ),
-    configureUserSessions: fromPromise<void, ConfigureUserSessionsInput>(
-      async () => {},
     ),
   };
 }
@@ -233,7 +229,6 @@ function withExternal(over: Partial<Context["external"]> = {}): Context {
     toolsetSlug: "",
     toolsetName: "",
     activeOrganizationId: "",
-    onboardToUserSessions: false,
   };
 }
 
@@ -697,37 +692,20 @@ describe("oauthWizardMachine — auto-configure from path selection", () => {
     expect(snap.context.result?.success).toBe(true);
   });
 
-  it("uses the user-session onboarding path when the feature flag is enabled", async () => {
-    const configureUserSessions = fromPromise<void, ConfigureUserSessionsInput>(
-      async ({ input }) => {
-        expect(input.toolsetSlug).toBe("ts");
-        expect(input.toolsetName).toBe("Toolset");
-        expect(input.oauth.registrationEndpoint).toBe(
-          VALID_PROXY_METADATA.registration_endpoint,
-        );
-      },
-    );
-    const actor = makeActor(
-      { ...inputWithDiscovered, onboardToUserSessions: true },
-      {
-        ...happyServices(),
-        configureUserSessions,
-      },
-    );
+  it("keeps using the OAuth proxy DCR path when auto-configuring", async () => {
+    const actor = makeActor(inputWithDiscovered);
     actor.start();
     actor.send({ type: "SELECT_PROXY_AUTO" });
 
-    expect(actor.getSnapshot().matches({ userSessions: "submitting" })).toBe(
-      true,
-    );
+    expect(actor.getSnapshot().matches({ proxy: "registering" })).toBe(true);
 
     await waitFor(actor, (s) => s.matches({ result: "success" }), {
       timeout: 1000,
     });
 
     const snap = actor.getSnapshot();
-    expect(snap.context.result?.message).toContain("User sessions");
-    expect(snap.context.envSlug).toBeNull();
+    expect(snap.context.result?.message).toContain("OAuth proxy");
+    expect(snap.context.envSlug).toBe("env-new");
   });
 
   it("registerClient failure routes to autoRegisterFailed", async () => {

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
@@ -1,8 +1,6 @@
 import { createActorContext } from "@xstate/react";
 import { assign, fromPromise, setup, type SnapshotFrom } from "xstate";
 
-import { externalMcpUserSessionOAuthConfigFromMetadata } from "@/lib/externalMcpUserSessions";
-
 import { checkCreds, checkExternal, checkProxyMeta } from "./guards";
 import {
   type Context,
@@ -13,7 +11,6 @@ import {
 import {
   type AddExternalOAuthInput,
   type AddOAuthProxyInput,
-  type ConfigureUserSessionsInput,
   type CreateEnvironmentInput,
   type CreateEnvironmentOutput,
   type DeleteEnvironmentInput,
@@ -48,7 +45,6 @@ function initialContext(input: Input): Context {
     toolsetSlug: input.toolsetSlug,
     toolsetName: input.toolsetName,
     activeOrganizationId: input.activeOrganizationId,
-    onboardToUserSessions: input.onboardToUserSessions ?? false,
   };
 }
 
@@ -109,15 +105,6 @@ export function canAutoConfigureFromDiscovered(
   );
 }
 
-function userSessionOAuthConfigFromDiscovered(d: DiscoveredOAuth | null) {
-  if (!d) return null;
-  return externalMcpUserSessionOAuthConfigFromMetadata({
-    slug: d.slug,
-    name: d.name,
-    metadata: d.metadata,
-  });
-}
-
 function placeholder<TInput, TOutput = void>(name: string) {
   return fromPromise<TOutput, TInput>(async () => {
     throw new Error(
@@ -144,9 +131,6 @@ export const oauthWizardMachine = setup({
     registerClient: placeholder<RegisterClientInput, RegisterClientOutput>(
       "registerClient",
     ),
-    configureUserSessions: placeholder<ConfigureUserSessionsInput>(
-      "configureUserSessions",
-    ),
   },
   guards: {
     validExternal: ({ context }) => checkExternal(context).ok,
@@ -154,17 +138,12 @@ export const oauthWizardMachine = setup({
     validCreds: ({ context }) => checkCreds(context).ok,
     canAutoConfigure: ({ context }) =>
       canAutoConfigureFromDiscovered(context.discovered),
-    shouldAutoConfigureUserSessions: ({ context }) =>
-      context.onboardToUserSessions &&
-      userSessionOAuthConfigFromDiscovered(context.discovered) !== null,
   },
   actions: {
     invalidateOnExternalSuccess: () => {},
     invalidateOnProxyCreate: () => {},
     captureExternalSuccess: () => {},
     captureProxyCreateSuccess: () => {},
-    captureUserSessionsCreateSuccess: () => {},
-    invalidateOnUserSessionsCreate: () => {},
   },
 }).createMachine({
   id: "oauthWizard",
@@ -198,22 +177,6 @@ export const oauthWizardMachine = setup({
         },
         SELECT_PROXY_AUTO: [
           {
-            guard: "shouldAutoConfigureUserSessions",
-            target: "userSessions.submitting",
-            actions: assign({
-              proxy: ({ context }) =>
-                context.discovered
-                  ? {
-                      ...context.proxy,
-                      ...proxyFieldsFromDiscovered(context.discovered),
-                      prefilled: true,
-                    }
-                  : context.proxy,
-              autoRegistering: () => true,
-              error: () => null,
-            }),
-          },
-          {
             guard: "canAutoConfigure",
             target: "proxy.registering",
             actions: assign({
@@ -230,54 +193,6 @@ export const oauthWizardMachine = setup({
             }),
           },
         ],
-      },
-    },
-
-    userSessions: {
-      initial: "submitting",
-      states: {
-        submitting: {
-          meta: { title: "Configure User Sessions" },
-          invoke: {
-            src: "configureUserSessions",
-            input: ({ context }): ConfigureUserSessionsInput => {
-              const oauth = userSessionOAuthConfigFromDiscovered(
-                context.discovered,
-              );
-              if (!oauth) {
-                throw new Error("registration_endpoint metadata is required");
-              }
-              return {
-                toolsetSlug: context.toolsetSlug,
-                toolsetName: context.toolsetName,
-                oauth,
-              };
-            },
-            onDone: {
-              target: "#oauthWizard.result.success",
-              actions: [
-                assign({
-                  result: () => ({
-                    success: true,
-                    message: "User sessions have been configured successfully.",
-                  }),
-                }),
-                "captureUserSessionsCreateSuccess",
-                "invalidateOnUserSessionsCreate",
-              ],
-            },
-            onError: {
-              target: "#oauthWizard.proxy.autoRegisterFailed",
-              actions: assign({
-                error: ({ event }) =>
-                  errorMessage(
-                    event.error,
-                    "Failed to configure user sessions",
-                  ),
-              }),
-            },
-          },
-        },
       },
     },
 

--- a/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/services.ts
@@ -9,11 +9,6 @@ import type { Gram } from "@gram/client";
 import type { QueryClient } from "@tanstack/react-query";
 import { fromPromise } from "xstate";
 
-import {
-  type ExternalMcpUserSessionOAuthConfig,
-  onboardExternalMcpToUserSessions,
-} from "@/lib/externalMcpUserSessions";
-
 import { parseScopes } from "./machine-types";
 
 type SignalArg = { signal: AbortSignal };
@@ -62,12 +57,6 @@ export type RegisterClientOutput = {
   tokenAuthMethod: string | null;
 };
 
-export type ConfigureUserSessionsInput = {
-  toolsetSlug: string;
-  toolsetName: string;
-  oauth: ExternalMcpUserSessionOAuthConfig;
-};
-
 export type AuthedFetch = (
   endpoint: string,
   opts: RequestInit,
@@ -84,9 +73,6 @@ export type WizardServices = {
   >;
   registerClient: ReturnType<
     typeof fromPromise<RegisterClientOutput, RegisterClientInput>
-  >;
-  configureUserSessions: ReturnType<
-    typeof fromPromise<void, ConfigureUserSessionsInput>
   >;
 };
 
@@ -185,6 +171,7 @@ export function createWizardServices(
       const response = await authedFetch("/oauth/proxy-register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           registration_endpoint: input.registrationEndpoint,
           scopes_supported: input.scopesSupported,
@@ -216,25 +203,12 @@ export function createWizardServices(
     },
   );
 
-  const configureUserSessions = fromPromise<void, ConfigureUserSessionsInput>(
-    async ({ input, signal }) => {
-      await onboardExternalMcpToUserSessions({
-        client,
-        toolsetSlug: input.toolsetSlug,
-        toolsetName: input.toolsetName,
-        oauth: input.oauth,
-        options: { fetchOptions: { signal } },
-      });
-    },
-  );
-
   return {
     addExternalOAuth,
     createEnvironment,
     addOAuthProxy,
     deleteEnvironment,
     registerClient,
-    configureUserSessions,
   };
 }
 


### PR DESCRIPTION
## Summary
- route OAuth wizard auto-configure back through OAuth Proxy DCR setup regardless of user-session onboarding
- remove the wizard's user-session auto-configure state and copy
- keep cookie credentials included for the /oauth/proxy-register helper call

## Tests
- pnpm tsc --noEmit
- pnpm vitest run src/pages/mcp/oauth-wizard/machine.test.ts src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx

Linear: AGE-2410