### PR TITLE
fix: add drawer title to chat detail panel

### DIFF
--- a/.changeset/major-cups-scream.md
+++ b/.changeset/major-cups-scream.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fixes agent log drawer accessibility warnings

--- a/client/dashboard/src/components/nav-menu.test.tsx
+++ b/client/dashboard/src/components/nav-menu.test.tsx
@@ -47,6 +47,10 @@ vi.mock("./product-tier-badge", () => ({
   ProductTierBadge: () => null,
 }));
 
+vi.mock("./release-stage-badge", () => ({
+  ReleaseStageBadge: () => null,
+}));
+
 const TestIcon = ({ className }: { className?: string }) => (
   <svg data-testid="nav-icon" className={className} />
 );

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -20,6 +20,7 @@ import { Badge, Icon, Stack } from "@speakeasy-api/moonshine";
 import { format } from "date-fns";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Dialog } from "@/components/ui/dialog";
+import { DrawerTitle, DrawerDescription } from "@/components/ui/drawer";
 import {
   Popover,
   PopoverContent,
@@ -1023,11 +1024,23 @@ export function ChatDetailPanel({
   }, [riskResults]);
 
   if (chatLoading) {
-    return <div className="p-8">Loading chat details...</div>;
+    return (
+      <div className="p-8">
+        <DrawerTitle>Loading</DrawerTitle>
+        <DrawerDescription>Fetching chat session details...</DrawerDescription>
+      </div>
+    );
   }
 
   if (!chat) {
-    return <div className="p-8">Chat not found</div>;
+    return (
+      <div className="p-8">
+        <DrawerTitle>Not found</DrawerTitle>
+        <DrawerDescription>
+          The selected chat session could not be found.
+        </DrawerDescription>
+      </div>
+    );
   }
 
   const status = getOverallResolutionStatus(resolutions);
@@ -1058,7 +1071,7 @@ export function ChatDetailPanel({
       <div className="border-b p-6">
         <div className="mb-2 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h2 className="text-xl font-semibold">{getTraceId(chatId)}</h2>
+            <DrawerTitle className="text-xl">{getTraceId(chatId)}</DrawerTitle>
             {status !== "unresolved" && (
               <Badge
                 variant={
@@ -1118,7 +1131,7 @@ export function ChatDetailPanel({
         <div className="text-muted-foreground mb-3 font-mono text-sm">
           {format(new Date(chat.createdAt), "yyyy-MM-dd HH:mm:ss")}
         </div>
-        <div className="text-sm">{chat.title}</div>
+        <DrawerDescription className="text-sm">{chat.title}</DrawerDescription>
       </div>
 
       {/* Tabs */}


### PR DESCRIPTION
## Summary

Add title and description primitives to the chat detail panel used by agent logs/security drawers. `DrawerTitle` and `DrawerDescription` are needed for  accessibility and throw warnings in Datadog 

Also fixed an issue with a test Mock in the nav menu unit test that was broken