### PR TITLE
fix(dashboard): preserve token graph data while filtering by agent type

### DIFF
--- a/.changeset/fix-token-graph-filter.md
+++ b/.changeset/fix-token-graph-filter.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix token graph blanking when filtering by agent type on /insights/costs

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -37,7 +37,7 @@ import {
   type DateRangePreset,
   getPresetRange,
 } from "@gram-ai/elements";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   BarElement,
   CategoryScale,
@@ -236,6 +236,7 @@ export function InsightsAgentsContent() {
         to,
         clientFilter !== "all" ? clientFilter : undefined,
       ),
+    placeholderData: keepPreviousData,
     throwOnError: false,
   });
 


### PR DESCRIPTION
## Summary
- Fix token graph blanking when filtering by agent type on `/insights/costs`
- Add `placeholderData: keepPreviousData` to `overviewQuery` so previous chart data remains visible while filtered results load

## Root Cause
When changing the agent type filter, `overviewQuery` gets a new query key which caused React Query to treat it as a fresh query with `undefined` data during loading. The chart's fallback `overviewQuery.data?.timeSeries ?? []` resulted in an empty array, showing "No data for selected time range".

## Test plan
- [ ] Navigate to `/insights/costs`
- [ ] Select an agent type from the dropdown filter
- [ ] Verify the token graph retains previous data while loading filtered results (no blank flash)
- [ ] Verify filtered data displays correctly once loaded

Fixes AGE-2438

Slack thread: https://speakeasyapi.slack.com/archives/C0ARJG28X29/p1779233726178049?thread_ts=1779233461.032919&cid=C0ARJG28X29

https://claude.ai/code/session_01S492fgSKxqAox2vwqRHFgX

---
_Generated by [Claude Code](https://claude.ai/code/session_01S492fgSKxqAox2vwqRHFgX)_