### PR TITLE
chore(skill): add Drawer and Dialog accessibility rules to frontend skill

### DIFF
--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -286,3 +286,45 @@ Grep `stage="preview"` and `stage="beta"` and delete every match:
 - Inline `<ReleaseStageBadge>` usages — delete the element and unwrap the `flex items-center gap-2` div
 
 There's no other cleanup. The component itself stays in place for the next pre-GA feature.
+
+### Drawer Component Usage
+
+`DrawerContent` requires `DrawerTitle` (and optionally `DrawerDescription`) inside it. Omitting them generates a console error and breaks screen reader accessibility. `DrawerHeader` and `DrawerFooter` are optional layout wrappers.
+
+```tsx
+<Drawer>
+  <DrawerTrigger>Open</DrawerTrigger>
+  <DrawerContent>
+    <DrawerTitle>Session Details</DrawerTitle>
+    <DrawerDescription>Viewing trace for this chat.</DrawerDescription>
+    {/* content */}
+  </DrawerContent>
+</Drawer>
+```
+
+If the title is visually redundant, hide it from sighted users while keeping it for screen readers:
+
+```tsx
+<DrawerTitle className="sr-only">Details</DrawerTitle>
+```
+
+### Dialog Component Usage
+
+`DialogContent` requires `DialogTitle` (and optionally `DialogDescription`) inside it. Omitting them generates a console error and breaks screen reader accessibility. `DialogHeader` and `DialogFooter` are optional layout wrappers.
+
+```tsx
+<Dialog>
+  <DialogTrigger>Open</DialogTrigger>
+  <DialogContent>
+    <DialogTitle>Confirm Action</DialogTitle>
+    <DialogDescription>This cannot be undone.</DialogDescription>
+    {/* content */}
+  </DialogContent>
+</Dialog>
+```
+
+If the title is visually redundant, hide it from sighted users while keeping it for screen readers:
+
+```tsx
+<DialogTitle className="sr-only">Details</DialogTitle>
+```


### PR DESCRIPTION
## Summary

- Documents that `DrawerContent` requires `DrawerTitle` (and optionally `DrawerDescription`) to avoid console errors and satisfy screen reader accessibility
- Same rule applied to `DialogContent` → `DialogTitle`
- Includes `sr-only` escape hatch for visually redundant titles

## Root cause

Missing `DrawerTitle`/`DialogTitle` generates a console warning (`DialogContent requires a DialogTitle for the component to be accessible for screen reader users`) and breaks accessibility. This was not documented in the frontend skill, making it easy to miss when adding new drawers or dialogs. As this is an accessibility error it does not break anything but does generate error noise in console and DataDog

Recently fixed a bug about this here and adding to frontend skill to prevent this in future. https://github.com/speakeasy-api/gram/pull/2929

## Test plan

- [x] Audited all `DrawerContent`/`DialogContent` usages in the dashboard — 0 violations found
- [x] Verified `ChatDetailPanel` (the main `DrawerContent` consumer) renders `DrawerTitle` in all branches (loading, not-found, populated)