### PR TITLE
chore: drop further calls to chat resolution workflow

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -719,7 +719,6 @@ func newStartCommand() *cli.Command {
 				captureStrategy,
 				chat.NewDefaultUsageTrackingStrategy(db, logger, openRouter, billingTracker, &background.FallbackModelUsageTracker{TemporalEnv: temporalEnv}),
 				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
-				&background.TemporalDelayedChatResolutionAnalyzer{TemporalEnv: temporalEnv},
 				telemLogger,
 			)
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -550,7 +550,6 @@ func newWorkerCommand() *cli.Command {
 				captureStrategy,
 				chat.NewDefaultUsageTrackingStrategy(db, logger, openRouter, billingTracker, &background.FallbackModelUsageTracker{TemporalEnv: temporalEnv}),
 				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
-				&background.TemporalDelayedChatResolutionAnalyzer{TemporalEnv: temporalEnv},
 				telemetryLogger,
 			)
 

--- a/server/internal/background/analyze_chat_resolutions.go
+++ b/server/internal/background/analyze_chat_resolutions.go
@@ -1,18 +1,14 @@
 package background
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	"go.temporal.io/api/enums/v1"
-	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	activities "github.com/speakeasy-api/gram/server/internal/background/activities/chat_resolutions"
-	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 )
 
 type AnalyzeChatResolutionsParams struct {
@@ -20,31 +16,6 @@ type AnalyzeChatResolutionsParams struct {
 	ProjectID uuid.UUID
 	OrgID     string
 	APIKeyID  string
-}
-
-// ChatResolutionAnalyzer schedules async chat resolution analysis.
-type ChatResolutionAnalyzer interface {
-	ScheduleChatResolutionAnalysis(ctx context.Context, chatID, projectID uuid.UUID, orgID, apiKeyID string) error
-}
-
-func ScheduleChatResolutionAnalysis(ctx context.Context, env *tenv.Environment, chatID, projectID uuid.UUID, orgID, apiKeyID string) error {
-	_, err := ExecuteAnalyzeChatResolutionsWorkflow(ctx, env, AnalyzeChatResolutionsParams{
-		ChatID:    chatID,
-		ProjectID: projectID,
-		OrgID:     orgID,
-		APIKeyID:  apiKeyID,
-	})
-	return err
-}
-
-func ExecuteAnalyzeChatResolutionsWorkflow(ctx context.Context, env *tenv.Environment, params AnalyzeChatResolutionsParams) (client.WorkflowRun, error) {
-	id := fmt.Sprintf("v1:analyze-chat-resolutions:%s", params.ChatID.String())
-	return env.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                    id,
-		TaskQueue:             string(env.Queue()),
-		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE, // Necessary for chats that are resumed after a while
-		WorkflowRunTimeout:    5 * time.Minute,
-	}, AnalyzeChatResolutionsWorkflow, params)
 }
 
 func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatResolutionsParams) error {

--- a/server/internal/background/delayed_chat_resolution_analysis.go
+++ b/server/internal/background/delayed_chat_resolution_analysis.go
@@ -1,14 +1,10 @@
 package background
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
-	"go.temporal.io/api/enums/v1"
-	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 )
 
@@ -23,57 +19,6 @@ type DelayedChatResolutionAnalysisParams struct {
 	ProjectID uuid.UUID
 	OrgID     string
 	APIKeyID  string
-}
-
-// TemporalDelayedChatResolutionAnalyzer schedules delayed chat resolution analysis with inactivity detection.
-type TemporalDelayedChatResolutionAnalyzer struct {
-	TemporalEnv *tenv.Environment
-}
-
-func (t *TemporalDelayedChatResolutionAnalyzer) ScheduleChatResolutionAnalysis(ctx context.Context, chatID, projectID uuid.UUID, orgID, apiKeyID string) error {
-	workflowID := fmt.Sprintf("v1:delayed-chat-resolution-analysis:%s", chatID.String())
-
-	// First, try to signal an existing workflow to reset the timer
-	err := t.TemporalEnv.Client().SignalWorkflow(ctx, workflowID, "", SignalResetTimer, nil)
-	if err == nil {
-		// Successfully reset the timer on existing workflow
-		return nil
-	}
-
-	// Workflow doesn't exist yet, start a new one
-	_, err = ExecuteDelayedChatResolutionAnalysisWorkflow(ctx, t.TemporalEnv, DelayedChatResolutionAnalysisParams{
-		ChatID:    chatID,
-		ProjectID: projectID,
-		OrgID:     orgID,
-		APIKeyID:  apiKeyID,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to start delayed analysis workflow: %w", err)
-	}
-
-	return nil
-}
-
-func (t *TemporalDelayedChatResolutionAnalyzer) ResolveImmediately(ctx context.Context, chatID uuid.UUID) error {
-	workflowID := fmt.Sprintf("v1:delayed-chat-resolution-analysis:%s", chatID.String())
-
-	// Signal the workflow to resolve immediately
-	err := t.TemporalEnv.Client().SignalWorkflow(ctx, workflowID, "", SignalResolveImmediately, nil)
-	if err != nil {
-		return fmt.Errorf("failed to signal immediate resolution: %w", err)
-	}
-
-	return nil
-}
-
-func ExecuteDelayedChatResolutionAnalysisWorkflow(ctx context.Context, env *tenv.Environment, params DelayedChatResolutionAnalysisParams) (client.WorkflowRun, error) {
-	id := fmt.Sprintf("v1:delayed-chat-resolution-analysis:%s", params.ChatID.String())
-	return env.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                    id,
-		TaskQueue:             string(env.Queue()),
-		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		WorkflowRunTimeout:    24 * time.Hour, // Max time to wait for inactivity
-	}, DelayedChatResolutionAnalysisWorkflow, params)
 }
 
 func DelayedChatResolutionAnalysisWorkflow(ctx workflow.Context, params DelayedChatResolutionAnalysisParams) error {

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -53,11 +53,6 @@ import (
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-// ChatResolutionAnalyzer schedules async chat resolution analysis.
-type ChatResolutionAnalyzer interface {
-	ScheduleChatResolutionAnalysis(ctx context.Context, chatID, projectID uuid.UUID, orgID, apiKeyID string) error
-}
-
 type Service struct {
 	auth             *auth.Auth
 	db               *pgxpool.Pool

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -152,7 +152,7 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 	oauthService := oauth.NewService(logger, tracerProvider, meterProvider, conn, serverURL, cacheAdapter, enc, env, sessionManager, nil, guardianPolicy)
 	billingStub := billing.NewStubClient(logger, tracerProvider)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
-	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, nil, nil, nil, nil, nil)
+	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, nil, nil, nil, nil)
 	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
 	chatSessions := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 	featClient := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -141,7 +141,6 @@ func newTestClientForServer(t *testing.T, server *httptest.Server) *ChatClient {
 		&mockMessageCaptureStrategy{},
 		&mockUsageTrackingStrategy{},
 		&mockChatTitleGenerator{},
-		&mockChatResolutionAnalyzer{},
 		&mockTelemetryLogger{},
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -29,11 +29,6 @@ type ChatTitleGenerator interface {
 	ScheduleChatTitleGeneration(ctx context.Context, chatID, orgID, projectID string) error
 }
 
-// ChatResolutionAnalyzer schedules async chat resolution analysis.
-type ChatResolutionAnalyzer interface {
-	ScheduleChatResolutionAnalysis(ctx context.Context, chatID, projectID uuid.UUID, orgID, apiKeyID string) error
-}
-
 // TelemetryLogger emits telemetry events for observability.
 type TelemetryLogger interface {
 	Log(ctx context.Context, params telemetry.LogParams)
@@ -52,7 +47,6 @@ type ChatClient struct {
 	messageCaptureStrategy MessageCaptureStrategy
 	usageTrackingStrategy  UsageTrackingStrategy
 	chatTitleGenerator     ChatTitleGenerator
-	chatResolutionAnalyzer ChatResolutionAnalyzer
 	telemetryLogger        TelemetryLogger
 }
 
@@ -64,7 +58,6 @@ func NewUnifiedClient(
 	captureStrategy MessageCaptureStrategy,
 	trackingStrategy UsageTrackingStrategy,
 	chatTitleGenerator ChatTitleGenerator,
-	chatResolutionAnalyzer ChatResolutionAnalyzer,
 	telemetryLogger TelemetryLogger,
 ) *ChatClient {
 	return &ChatClient{
@@ -74,7 +67,6 @@ func NewUnifiedClient(
 		messageCaptureStrategy: captureStrategy,
 		usageTrackingStrategy:  trackingStrategy,
 		chatTitleGenerator:     chatTitleGenerator,
-		chatResolutionAnalyzer: chatResolutionAnalyzer,
 		telemetryLogger:        telemetryLogger,
 	}
 }
@@ -239,19 +231,6 @@ func (c *ChatClient) onMessageComplete(ctx context.Context, session CaptureSessi
 			projectID.String(),
 		); err != nil {
 			c.logger.WarnContext(ctx, "failed to schedule chat title generation", attr.SlogError(err))
-		}
-	}
-
-	// Schedule chat resolution analysis (will reset timer if already scheduled)
-	if c.chatResolutionAnalyzer != nil && req.ChatID != uuid.Nil {
-		if err := c.chatResolutionAnalyzer.ScheduleChatResolutionAnalysis(
-			context.WithoutCancel(ctx),
-			req.ChatID,
-			projectID,
-			req.OrgID,
-			req.APIKeyID,
-		); err != nil {
-			c.logger.WarnContext(ctx, "failed to schedule chat resolution analysis", attr.SlogError(err))
 		}
 	}
 

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -131,29 +131,6 @@ func (m *mockChatTitleGenerator) ScheduleChatTitleGeneration(ctx context.Context
 	return m.err
 }
 
-type mockChatResolutionAnalyzer struct {
-	mu        sync.Mutex
-	called    bool
-	err       error
-	chatID    uuid.UUID
-	projectID uuid.UUID
-	orgID     string
-	apiKeyID  string
-	callCount int
-}
-
-func (m *mockChatResolutionAnalyzer) ScheduleChatResolutionAnalysis(ctx context.Context, chatID, projectID uuid.UUID, orgID, apiKeyID string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.called = true
-	m.callCount++
-	m.chatID = chatID
-	m.projectID = projectID
-	m.orgID = orgID
-	m.apiKeyID = apiKeyID
-	return m.err
-}
-
 type mockTelemetryLogger struct {
 	mu     sync.Mutex
 	called bool
@@ -212,7 +189,6 @@ func TestChatClient_GetCompletion(t *testing.T) {
 	captureStrategy := &mockMessageCaptureStrategy{}
 	trackingStrategy := &mockUsageTrackingStrategy{}
 	titleGenerator := &mockChatTitleGenerator{}
-	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryLogger := &mockTelemetryLogger{}
 
 	tracerProvider := testenv.NewTracerProvider(t)
@@ -227,7 +203,6 @@ func TestChatClient_GetCompletion(t *testing.T) {
 		captureStrategy,
 		trackingStrategy,
 		titleGenerator,
-		resolutionAnalyzer,
 		telemetryLogger,
 	)
 
@@ -271,7 +246,6 @@ func TestChatClient_GetCompletion(t *testing.T) {
 	assert.True(t, captureStrategy.captureMessageCalled, "CaptureMessage should be called")
 	assert.True(t, trackingStrategy.trackUsageCalled, "TrackUsage should be called")
 	assert.True(t, titleGenerator.called, "ScheduleChatTitleGeneration should be called")
-	assert.True(t, resolutionAnalyzer.called, "ScheduleChatResolutionAnalysis should be called")
 	assert.True(t, telemetryLogger.called, "CreateLog should be called")
 
 	// Verify captured data
@@ -282,10 +256,6 @@ func TestChatClient_GetCompletion(t *testing.T) {
 	assert.Equal(t, chatID.String(), titleGenerator.chatID)
 	assert.Equal(t, "test-org", titleGenerator.orgID)
 	assert.Equal(t, projectID.String(), titleGenerator.projectID)
-	assert.Equal(t, chatID, resolutionAnalyzer.chatID)
-	assert.Equal(t, projectID, resolutionAnalyzer.projectID)
-	assert.Equal(t, "test-org", resolutionAnalyzer.orgID)
-	assert.Equal(t, "test-api-key-id", resolutionAnalyzer.apiKeyID)
 }
 
 func TestChatClient_GetCompletionStream(t *testing.T) {
@@ -336,7 +306,6 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 	captureStrategy := &mockMessageCaptureStrategy{}
 	trackingStrategy := &mockUsageTrackingStrategy{}
 	titleGenerator := &mockChatTitleGenerator{}
-	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryLogger := &mockTelemetryLogger{}
 
 	tracerProvider := testenv.NewTracerProvider(t)
@@ -351,7 +320,6 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 		captureStrategy,
 		trackingStrategy,
 		titleGenerator,
-		resolutionAnalyzer,
 		telemetryLogger,
 	)
 
@@ -401,7 +369,6 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 	assert.True(t, captureStrategy.captureMessageCalled, "CaptureMessage should be called")
 	assert.True(t, trackingStrategy.trackUsageCalled, "TrackUsage should be called")
 	assert.True(t, titleGenerator.called, "ScheduleChatTitleGeneration should be called")
-	assert.True(t, resolutionAnalyzer.called, "ScheduleChatResolutionAnalysis should be called")
 	assert.True(t, telemetryLogger.called, "CreateLog should be called")
 
 	// Verify captured data
@@ -452,7 +419,6 @@ func TestChatClient_GetCompletion_WithToolCalls(t *testing.T) {
 	captureStrategy := &mockMessageCaptureStrategy{}
 	trackingStrategy := &mockUsageTrackingStrategy{}
 	titleGenerator := &mockChatTitleGenerator{}
-	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
 	tracerProvider := testenv.NewTracerProvider(t)
@@ -467,7 +433,6 @@ func TestChatClient_GetCompletion_WithToolCalls(t *testing.T) {
 		captureStrategy,
 		trackingStrategy,
 		titleGenerator,
-		resolutionAnalyzer,
 		telemetryService,
 	)
 
@@ -563,7 +528,6 @@ func TestChatClient_NormalizesMixedAssistantOnlyForOpenRouterRequest(t *testing.
 		nil,
 		nil,
 		nil,
-		nil,
 	)
 	client.httpClient = &http.Client{
 		Transport: &testTransport{server: server},
@@ -644,7 +608,6 @@ func TestChatClient_PassesMixedAssistantThroughWhenNormalizeFlagUnset(t *testing
 		nil,
 		nil,
 		nil,
-		nil,
 	)
 	client.httpClient = &http.Client{
 		Transport: &testTransport{server: server},
@@ -710,7 +673,6 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 			}
 			trackingStrategy := &mockUsageTrackingStrategy{}
 			titleGenerator := &mockChatTitleGenerator{}
-			resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 			telemetryService := &mockTelemetryLogger{}
 
 			tracerProvider := testenv.NewTracerProvider(t)
@@ -725,7 +687,6 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 				captureStrategy,
 				trackingStrategy,
 				titleGenerator,
-				resolutionAnalyzer,
 				telemetryService,
 			)
 
@@ -782,7 +743,6 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 	captureStrategy := &mockMessageCaptureStrategy{}
 	trackingStrategy := &mockUsageTrackingStrategy{}
 	titleGenerator := &mockChatTitleGenerator{}
-	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
 	tracerProvider := testenv.NewTracerProvider(t)
@@ -797,7 +757,6 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 		captureStrategy,
 		trackingStrategy,
 		titleGenerator,
-		resolutionAnalyzer,
 		telemetryService,
 	)
 
@@ -834,11 +793,6 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 	titleGenerator.mu.Lock()
 	assert.Equal(t, 3, titleGenerator.callCount, "Title generation should be scheduled when isFirstMessage=true (mock always returns true)")
 	titleGenerator.mu.Unlock()
-
-	// Resolution analysis should be scheduled for every message (resets timer)
-	resolutionAnalyzer.mu.Lock()
-	assert.Equal(t, 3, resolutionAnalyzer.callCount, "Resolution analysis should be scheduled for each completion (resets timer)")
-	resolutionAnalyzer.mu.Unlock()
 }
 
 // trackingTitleGenerator records every ScheduleChatTitleGeneration call with its chatID.
@@ -965,7 +919,6 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 		&mockMessageCaptureStrategy{},
 		&mockUsageTrackingStrategy{},
 		titleGenerator,
-		&mockChatResolutionAnalyzer{},
 		&mockTelemetryLogger{},
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
@@ -1012,7 +965,6 @@ func TestChatClient_TitleGeneration_ScheduledPerCompletionWithValidChatID(t *tes
 		tracker,
 		&mockUsageTrackingStrategy{},
 		titleGenerator,
-		&mockChatResolutionAnalyzer{},
 		&mockTelemetryLogger{},
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
@@ -1078,7 +1030,6 @@ func TestChatClient_ReloadChat_NoDuplicateMessages(t *testing.T) {
 		tracker,
 		&mockUsageTrackingStrategy{},
 		&mockChatTitleGenerator{},
-		&mockChatResolutionAnalyzer{},
 		&mockTelemetryLogger{},
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
@@ -1193,7 +1144,6 @@ func TestChatClient_GetCompletion_WithJSONSchema(t *testing.T) {
 	captureStrategy := &mockMessageCaptureStrategy{}
 	trackingStrategy := &mockUsageTrackingStrategy{}
 	titleGenerator := &mockChatTitleGenerator{}
-	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
 	tracerProvider := testenv.NewTracerProvider(t)
@@ -1208,7 +1158,6 @@ func TestChatClient_GetCompletion_WithJSONSchema(t *testing.T) {
 		captureStrategy,
 		trackingStrategy,
 		titleGenerator,
-		resolutionAnalyzer,
 		telemetryService,
 	)
 
@@ -1310,7 +1259,6 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 	captureStrategy := &mockMessageCaptureStrategy{}
 	trackingStrategy := &mockUsageTrackingStrategy{}
 	titleGenerator := &mockChatTitleGenerator{}
-	resolutionAnalyzer := &mockChatResolutionAnalyzer{}
 	telemetryService := &mockTelemetryLogger{}
 
 	tracerProvider := testenv.NewTracerProvider(t)
@@ -1325,7 +1273,6 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 		captureStrategy,
 		trackingStrategy,
 		titleGenerator,
-		resolutionAnalyzer,
 		telemetryService,
 	)
 
@@ -1434,7 +1381,6 @@ func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
 		&mockMessageCaptureStrategy{},
 		&mockUsageTrackingStrategy{},
 		&mockChatTitleGenerator{},
-		&mockChatResolutionAnalyzer{},
 		&mockTelemetryLogger{},
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -126,7 +126,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
 	oauthService := oauth.NewService(logger, tracerProvider, meterProvider, conn, serverURL, cacheAdapter, enc, env, sessionManager, nil, guardianPolicy)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
-	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, nil, nil, nil, nil, nil)
+	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, nil, nil, nil, nil)
 	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }


### PR DESCRIPTION
This change removes calls to the deprecate chat resolution workflow. This feature is not used by customers at the moment and will be reenvisioned in the future.

The temporal workflow is not removed to allow for any ongoing runs to be first drained. A subsequent PR will remove the workflow and associated activities.