### PR TITLE
fix(dashboard): preserve deny rules when viewing allow rule

### DIFF
--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -362,9 +362,14 @@ export function CreateRoleDialog({
           let rules = [...grant.rules];
           if (editingRuleIndex >= 0 && editingRuleIndex < rules.length) {
             // Editing existing rule — replace in place
+            const originalRule = grant.rules[editingRuleIndex];
             rules[editingRuleIndex] = draftRule;
             // Allow changed → clear deny exceptions (they were scoped to old allow)
-            if (draftRule.effect === "allow") {
+            if (
+              draftRule.effect === "allow" &&
+              JSON.stringify(originalRule?.selectors) !==
+                JSON.stringify(draftRule.selectors)
+            ) {
               rules = rules.filter((r) => r.effect !== "deny");
             }
           } else if (draftRule.effect === "deny") {

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -365,10 +365,16 @@ export function CreateRoleDialog({
             const originalRule = grant.rules[editingRuleIndex];
             rules[editingRuleIndex] = draftRule;
             // Allow changed → clear deny exceptions (they were scoped to old allow)
+            const toSortedJSON = (s: Selector[] | null | undefined) =>
+              JSON.stringify(
+                [...(s ?? [])].sort((a, b) =>
+                  JSON.stringify(a).localeCompare(JSON.stringify(b)),
+                ),
+              );
             if (
               draftRule.effect === "allow" &&
-              JSON.stringify(originalRule?.selectors) !==
-                JSON.stringify(draftRule.selectors)
+              toSortedJSON(originalRule?.selectors) !==
+                toSortedJSON(draftRule.selectors)
             ) {
               rules = rules.filter((r) => r.effect !== "deny");
             }


### PR DESCRIPTION
## Summary

- Opening an allow rule in the RBAC role editor to view it (without making changes) was clearing all deny exceptions for that scope
- Now compares original selectors vs draft before removing deny rules — only clears when allow actually changed

## Test plan

- [ ] Create a role with an allow rule on `mcp:connect` (e.g. all servers)
- [ ] Add a deny exception (e.g. deny specific tool)
- [ ] Click the allow rule chip to open the editor, then close without changes
- [ ] Verify deny exception is preserved
- [ ] Edit the allow rule (change selectors), save — verify deny exception is cleared