### PR TITLE
fix(server): disable OpenRouter reasoning across completion paths

### DIFF
--- a/.changeset/age-2443-assistant-disable-reasoning.md
+++ b/.changeset/age-2443-assistant-disable-reasoning.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Assistant chat completions no longer generate hidden reasoning tokens. Previously, OpenRouter could route assistant turns through Anthropic variants that produced reasoning output the capture pipeline discarded before storage — yet still billed. The runtime now explicitly disables reasoning on outbound completions, eliminating that silent cost without changing observed assistant behavior.
+Chat completions no longer generate hidden reasoning tokens. Previously, OpenRouter could route requests through models that produced reasoning output Gram discarded before storage — yet still billed. The proxy and every internal completion caller (chat title generation, Slack agent loop, risk policy naming, structured object completion) now explicitly disable reasoning, eliminating that silent cost without changing observed behavior.

--- a/.changeset/age-2443-assistant-disable-reasoning.md
+++ b/.changeset/age-2443-assistant-disable-reasoning.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistant chat completions no longer generate hidden reasoning tokens. Previously, OpenRouter could route assistant turns through Anthropic variants that produced reasoning output the capture pipeline discarded before storage — yet still billed. The runtime now explicitly disables reasoning on outbound completions, eliminating that silent cost without changing observed assistant behavior.

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -300,11 +300,8 @@ async fn spawn_thread(
         .default_headers(chat_headers)
         .build()?;
 
-    // `effort: "none"` suppresses reasoning generation; `exclude: true` would
-    // only hide the output while still billing for it.
     let openrouter_config = OpenRouterConfig::new(String::new(), bootstrap.model.clone())
-        .with_base_url(bootstrap.completions_url.clone())
-        .with_extra_body_value("reasoning", serde_json::json!({ "effort": "none" }));
+        .with_base_url(bootstrap.completions_url.clone());
     let provider = OpenRouterProvider::from(openrouter_config);
 
     let completions_http = build_http(thread_http_client.clone(), tokens.clone());

--- a/agents/runner/src/runtime.rs
+++ b/agents/runner/src/runtime.rs
@@ -300,8 +300,11 @@ async fn spawn_thread(
         .default_headers(chat_headers)
         .build()?;
 
+    // `effort: "none"` suppresses reasoning generation; `exclude: true` would
+    // only hide the output while still billing for it.
     let openrouter_config = OpenRouterConfig::new(String::new(), bootstrap.model.clone())
-        .with_base_url(bootstrap.completions_url.clone());
+        .with_base_url(bootstrap.completions_url.clone())
+        .with_extra_body_value("reasoning", serde_json::json!({ "effort": "none" }));
     let provider = OpenRouterProvider::from(openrouter_config);
 
     let completions_http = build_http(thread_http_client.clone(), tokens.clone());

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -151,6 +151,7 @@ func (g *GenerateChatTitle) generateTitle(ctx context.Context, orgID, projectID 
 		HTTPMetadata:              nil,
 		APIKeyID:                  "",
 		JSONSchema:                nil,
+		Reasoning:                 &openrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
 		NormalizeOutboundMessages: false,
 	})
 	if err != nil {

--- a/server/internal/chat/agent_client.go
+++ b/server/internal/chat/agent_client.go
@@ -204,6 +204,7 @@ func (c *Client) AgentChat(
 			HTTPMetadata:              nil,
 			APIKeyID:                  "",
 			JSONSchema:                nil,
+			Reasoning:                 &openrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
 			NormalizeOutboundMessages: false,
 		}
 

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -825,6 +825,11 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	if r.Header.Get("Gram-Skip-Capture") == "1" {
 		completionChatID = uuid.Nil
 	}
+	reasoning := chatRequest.Reasoning
+	if reasoning == nil {
+		reasoning = &openrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil}
+	}
+
 	completionReq := openrouter.CompletionRequest{
 		OrgID:          orgID,
 		ProjectID:      authCtx.ProjectID.String(),
@@ -845,6 +850,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 		},
 		APIKeyID:                  authCtx.APIKeyID,
 		JSONSchema:                jsonSchema,
+		Reasoning:                 reasoning,
 		NormalizeOutboundMessages: r.URL.Query().Get("unstable_normalizeOutboundMessages") == "1",
 	}
 

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1033,6 +1033,7 @@ func (s *Service) generatePolicyName(ctx context.Context, orgID, projectID strin
 		HTTPMetadata:              nil,
 		APIKeyID:                  "",
 		JSONSchema:                nil,
+		Reasoning:                 &openrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
 		NormalizeOutboundMessages: false,
 	})
 	if err != nil {

--- a/server/internal/thirdparty/openrouter/completion_client.go
+++ b/server/internal/thirdparty/openrouter/completion_client.go
@@ -76,6 +76,12 @@ type CompletionRequest struct {
 
 	JSONSchema *or.ChatJSONSchemaConfig // For structured output mode
 
+	// Reasoning, when set, is forwarded verbatim to OpenRouter on the
+	// outbound `/chat/completions` body. Callers use it to disable or shape
+	// reasoning generation on routes (e.g. Anthropic) that would otherwise
+	// produce billable reasoning tokens.
+	Reasoning *Reasoning
+
 	// NormalizeOutboundMessages drops narrative text from assistant messages
 	// that also carry tool_calls before forwarding to OpenRouter. Opt-in via
 	// the `unstable_normalizeOutboundMessages=1` query string on the proxy.

--- a/server/internal/thirdparty/openrouter/types.go
+++ b/server/internal/thirdparty/openrouter/types.go
@@ -169,6 +169,21 @@ type OpenAIChatRequest struct {
 	Tools          []Tool             `json:"tools,omitempty"`
 	Temperature    float32            `json:"temperature,omitempty"`
 	ResponseFormat *or.ResponseFormat `json:"response_format,omitempty"`
+	Reasoning      *Reasoning         `json:"reasoning,omitempty"`
+}
+
+// Reasoning mirrors OpenRouter's `reasoning` request parameter. Callers set
+// this to override the upstream default — typically to suppress reasoning
+// generation on routes that would otherwise emit billable reasoning tokens.
+//
+// `Effort = "none"` disables reasoning generation outright. `Exclude = true`
+// only hides reasoning from the response and still incurs token cost.
+// `Effort` and `MaxTokens` are mutually exclusive per OpenRouter docs.
+type Reasoning struct {
+	Effort    string `json:"effort,omitempty"`
+	MaxTokens *int   `json:"max_tokens,omitempty"`
+	Exclude   *bool  `json:"exclude,omitempty"`
+	Enabled   *bool  `json:"enabled,omitempty"`
 }
 
 // ToolCallFunction represents the function part of a tool call

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -135,6 +135,7 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 		Tools:          req.Tools,
 		Temperature:    temp,
 		ResponseFormat: nil,
+		Reasoning:      req.Reasoning,
 	}
 
 	// Add JSON schema if provided
@@ -426,6 +427,7 @@ func (c *ChatClient) GetObjectCompletion(ctx context.Context, req ObjectCompleti
 		JSONSchema:                req.JSONSchema,
 		ChatID:                    uuid.Nil,
 		APIKeyID:                  "",
+		Reasoning:                 &Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
 		NormalizeOutboundMessages: false,
 	}
 


### PR DESCRIPTION
## Summary

- OpenRouter routes (notably Anthropic adaptive thinking) can emit billable reasoning tokens by default. Gram's response path strips reasoning content before storage, reasoning signatures aren't preserved across turns, and there's no interleaved-thinking-with-tools wiring — so any reasoning generated is pure cost.
- Add a typed `Reasoning` field to `OpenAIChatRequest` / `CompletionRequest`, plumb it through `initializeRequest` so it reaches the outbound OpenRouter body.
- Set `Reasoning.Effort = "none"` at every internal completion call site (chat title generation, Slack agent loop, risk policy naming, structured object completion). The `/chat/completions` proxy honors a caller-supplied `reasoning` field for forward compatibility, but falls back to the same disable when the field is absent.
- `effort: "none"` is the OpenRouter-documented disable that suppresses generation outright. `exclude: true` would only hide the output and still bill, per the [reasoning-tokens guide](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens).

Closes [AGE-2443](https://linear.app/speakeasy/issue/AGE-2443/disable-reasoningthinking-on-assistant-chat-completion-requests).

✻ Clauded...