### PR TITLE
fix(triggers): map each top-level Slack message to its own assistant thread

### DIFF
--- a/.changeset/slack-assistant-thread-per-message.md
+++ b/.changeset/slack-assistant-thread-per-message.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Slack-triggered assistant chats now open a fresh assistant thread for each top-level message instead of folding distinct conversations onto a single per-channel thread. Top-level Slack messages and DMs used to share one Gram thread (and one Fly runtime) per channel, so unrelated users' messages bled into the same context window.

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -396,6 +396,25 @@ func decodeSlackEvent(raw json.RawMessage) (slackEventRequestBody, error) {
 	}
 }
 
+// slackCorrelationID derives the assistant-thread correlation key from a
+// Slack event. Top-level messages (empty thread_ts) fall back to the event's
+// own ts so each top-level message maps 1:1 to a Gram thread — Slack itself
+// promotes a top-level ts into thread_ts the moment anyone replies, so this
+// mirrors Slack's threading semantic. Channel-less events (e.g. team_join)
+// fall back to the workspace ID.
+func slackCorrelationID(channelID, threadID, fallbackTs, teamID string) string {
+	if threadID == "" {
+		threadID = fallbackTs
+	}
+	if channelID != "" && threadID != "" {
+		return channelID + ":" + threadID
+	}
+	if channelID != "" {
+		return channelID
+	}
+	return teamID
+}
+
 // slackInteractionPayload is the JSON body of a Block Kit interaction
 // envelope (e.g. block_actions). Slack form-encodes this under the "payload"
 // field of the webhook request body. We only model the fields needed to
@@ -472,12 +491,6 @@ func handleSlackInteraction(body []byte) (*WebhookIngressResult, error) {
 	if channelID == "" {
 		channelID = payload.Container.ChannelID
 	}
-	// Mirror the events path: keep threadID empty for clicks on a top-level
-	// message so the correlation is channel-only and lines up with the
-	// assistant thread opened by the original Events API message. Falling
-	// back to message.ts here would fork the conversation onto a new
-	// "channel:bot_message_ts" correlation that does not match the
-	// originating thread.
 	threadID := payload.Message.ThreadTs
 	if threadID == "" {
 		threadID = payload.Container.ThreadTs
@@ -510,19 +523,11 @@ func handleSlackInteraction(body []byte) (*WebhookIngressResult, error) {
 		BlockID:      action.BlockID,
 	}
 
-	correlationID := channelID
-	if channelID != "" && threadID != "" {
-		correlationID = channelID + ":" + threadID
-	}
-	if correlationID == "" {
-		correlationID = payload.Team.ID
-	}
-
 	return &WebhookIngressResult{
 		Response: nil,
 		Event: &EventEnvelope{
 			EventID:           uuid.NewSHA1(uuid.NameSpaceURL, body).String(),
-			CorrelationID:     correlationID,
+			CorrelationID:     slackCorrelationID(channelID, threadID, messageTs, payload.Team.ID),
 			TriggerInstanceID: "",
 			DefinitionSlug:    "slack",
 			Event:             normalized,
@@ -753,10 +758,6 @@ func newSlackDefinition() Definition {
 				return nil, fmt.Errorf("decode slack payload: %w", err)
 			}
 
-			// thread_ts is only set for replies inside a thread. For top-level
-			// messages we key the correlation on the channel alone so a user
-			// sending multiple standalone messages in a DM or channel lands
-			// on a single Gram thread rather than spawning one per message.
 			threadID := event.ThreadTs
 
 			eventID := req.EventID
@@ -810,19 +811,11 @@ func newSlackDefinition() Definition {
 				BlockID:      "",
 			}
 
-			correlationID := channelID
-			if channelID != "" && threadID != "" {
-				correlationID = channelID + ":" + threadID
-			}
-			if correlationID == "" {
-				correlationID = req.TeamID
-			}
-
 			return &WebhookIngressResult{
 				Response: nil,
 				Event: &EventEnvelope{
 					EventID:           eventID,
-					CorrelationID:     correlationID,
+					CorrelationID:     slackCorrelationID(channelID, threadID, timestamp, req.TeamID),
 					TriggerInstanceID: "",
 					DefinitionSlug:    "slack",
 					Event:             normalizedEvent,

--- a/server/internal/background/triggers/definitions_test.go
+++ b/server/internal/background/triggers/definitions_test.go
@@ -333,7 +333,7 @@ func TestSlackHandleWebhookBlockActionsRoutesToThread(t *testing.T) {
 	require.Equal(t, "approved", normalized.Text)
 }
 
-func TestSlackHandleWebhookBlockActionsTopLevelMessageStaysChannelOnly(t *testing.T) {
+func TestSlackHandleWebhookBlockActionsTopLevelMessageKeysOnMessageTs(t *testing.T) {
 	t.Parallel()
 
 	definition, ok := GetDefinition("slack")
@@ -343,9 +343,8 @@ func TestSlackHandleWebhookBlockActionsTopLevelMessageStaysChannelOnly(t *testin
 	require.NoError(t, err)
 
 	// Click on a top-level (non-threaded) message: message.thread_ts is
-	// empty. The events path leaves threadID empty in this case so the
-	// correlation collapses to the channel, matching the assistant thread
-	// that the originating top-level Events API message opened.
+	// empty. Correlation keys on the message's own ts so each top-level
+	// message maps to its own assistant thread.
 	payload := `{"type":"block_actions","team":{"id":"T1"},"user":{"id":"U1"},"channel":{"id":"C1"},"message":{"ts":"1700000001.000200"},"actions":[{"action_id":"x","block_id":"b","value":"v","type":"button"}]}`
 	body := []byte("payload=" + url.QueryEscape(payload))
 	headers := signedSlackHeaders(t, body, "secret")
@@ -355,11 +354,41 @@ func TestSlackHandleWebhookBlockActionsTopLevelMessageStaysChannelOnly(t *testin
 	require.NoError(t, err)
 	require.NotNil(t, result.Event)
 
-	require.Equal(t, "C1", result.Event.CorrelationID)
+	require.Equal(t, "C1:1700000001.000200", result.Event.CorrelationID)
 	normalized, ok := result.Event.Event.(slackTriggerEvent)
 	require.True(t, ok)
 	require.Empty(t, normalized.ThreadID)
 	require.Equal(t, "1700000001.000200", normalized.Timestamp)
+}
+
+func TestSlackHandleWebhookEventTopLevelMessageKeysOnEventTs(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("slack")
+	require.True(t, ok)
+
+	config, err := definition.DecodeConfig(nil)
+	require.NoError(t, err)
+
+	// Top-level Slack message has no thread_ts; correlation must fold the
+	// event ts in so distinct top-level messages route to distinct
+	// assistant threads instead of collapsing onto a channel-only key.
+	body := []byte(`{"type":"event_callback","team_id":"T1","event_id":"Ev1","event":{"type":"message","channel":"C1","user":"U1","text":"hello","ts":"1700000050.000900"}}`)
+	headers := signedSlackHeaders(t, body, "secret")
+
+	require.NoError(t, definition.AuthenticateWebhook(body, headers, map[string]string{
+		"SLACK_SIGNING_SECRET": "secret",
+	}, config))
+
+	result, err := definition.HandleWebhook(body, headers, config)
+	require.NoError(t, err)
+	require.NotNil(t, result.Event)
+
+	require.Equal(t, "C1:1700000050.000900", result.Event.CorrelationID)
+	normalized, ok := result.Event.Event.(slackTriggerEvent)
+	require.True(t, ok)
+	require.Empty(t, normalized.ThreadID)
+	require.Equal(t, "1700000050.000900", normalized.Timestamp)
 }
 
 func TestSlackHandleWebhookIgnoresUnsupportedInteractionType(t *testing.T) {


### PR DESCRIPTION
## Summary

- Slack ingress kept top-level (non-threaded) messages on a channel-only `correlation_id`, so unrelated users posting standalone top-level messages in the same channel collapsed onto one Gram chat — sharing context window and Fly runtime (14-day prod sample: 20% of Slack chats affected, worst offender pulled 9 distinct users into one assistant thread with 252 generations).
- Fall back to the event's own `ts` when `thread_ts` is empty, mirroring Slack's own promotion of a top-level `ts` into `thread_ts` the moment anyone replies. Applied at both ingress paths (Events API + Block Kit interactive) through a shared `slackCorrelationID` builder.
- `chat_id` is deterministic from `correlation_id`, so existing collapsed chats stay collapsed; new messages after deploy split into per-thread chats. No backfill required.

Closes [AGE-2444](https://linear.app/speakeasy/issue/AGE-2444/map-each-slack-top-level-messagethread-11-to-an-assistant-thread-stop).

✻ Clauded...