### PR TITLE
feat(openrouter): attribute outbound completions with session, user, source, trace

### DIFF
--- a/.changeset/openrouter-attribution.md
+++ b/.changeset/openrouter-attribution.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Outbound OpenRouter chat completions now carry a session ID, user, source metadata, and distributed-trace identifiers so OpenRouter's dashboard can group requests per conversation and roll up cost per customer, and so Datadog traces correlate with OpenRouter's request records.

--- a/server/internal/thirdparty/openrouter/types.go
+++ b/server/internal/thirdparty/openrouter/types.go
@@ -161,6 +161,15 @@ func GetToolCallID(msg or.ChatMessages) *string {
 	}
 }
 
+// TraceConfig is the OpenRouter `trace` block for distributed trace correlation.
+type TraceConfig struct {
+	TraceID        string `json:"trace_id,omitempty"`
+	TraceName      string `json:"trace_name,omitempty"`
+	SpanName       string `json:"span_name,omitempty"`
+	GenerationName string `json:"generation_name,omitempty"`
+	ParentSpanID   string `json:"parent_span_id,omitempty"`
+}
+
 // OpenAIChatRequest represents the request structure for OpenAI chat completions
 type OpenAIChatRequest struct {
 	Model          string                             `json:"model"`
@@ -171,6 +180,12 @@ type OpenAIChatRequest struct {
 	ResponseFormat *or.ResponseFormat                 `json:"response_format,omitempty"`
 	Reasoning      *Reasoning                         `json:"reasoning,omitempty"`
 	CacheControl   *or.AnthropicCacheControlDirective `json:"cache_control,omitempty"`
+	// OpenRouter caps SessionID at 256 chars and Metadata at 16 entries with
+	// 64-char keys and 512-char values; callers must respect both.
+	SessionID string            `json:"session_id,omitempty"`
+	User      string            `json:"user,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Trace     *TraceConfig      `json:"trace,omitempty"`
 }
 
 // Reasoning mirrors OpenRouter's `reasoning` request parameter. Callers set

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -137,6 +137,32 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 		ResponseFormat: nil,
 		Reasoning:      req.Reasoning,
 		CacheControl:   req.CacheControl,
+		SessionID:      "",
+		User:           req.OrgID,
+		Metadata:       nil,
+		Trace:          nil,
+	}
+
+	if req.ChatID != uuid.Nil {
+		reqBody.SessionID = req.ChatID.String()
+	}
+
+	if req.UsageSource != "" {
+		reqBody.Metadata = map[string]string{"source": string(req.UsageSource)}
+	}
+
+	if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.HasTraceID() {
+		var parentSpanID string
+		if spanCtx.HasSpanID() {
+			parentSpanID = spanCtx.SpanID().String()
+		}
+		reqBody.Trace = &TraceConfig{
+			TraceID:        spanCtx.TraceID().String(),
+			TraceName:      "",
+			SpanName:       "",
+			GenerationName: "",
+			ParentSpanID:   parentSpanID,
+		}
 	}
 
 	// Add JSON schema if provided

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // Mock implementations for testing
@@ -1404,6 +1405,74 @@ func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
 		"server should receive a model from the allowlist, got: %s", receivedModel)
 	require.True(t, strings.HasPrefix(receivedModel, "openai/"),
 		"fallback model should be from the same provider (openai), got: %s", receivedModel)
+}
+
+// TestChatClient_GetCompletion_AttributionFields verifies that session_id, user,
+// metadata.source, and trace.trace_id are forwarded to OpenRouter so dashboard
+// grouping and Datadog APM correlation work.
+func TestChatClient_GetCompletion_AttributionFields(t *testing.T) {
+	t.Parallel()
+
+	var receivedRequestBody OpenAIChatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedRequestBody); !assert.NoError(t, err) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "msg_attr",
+			"model": "openai/gpt-5.4",
+			"choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+		}`))
+	}))
+	defer server.Close()
+
+	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+
+	client := NewUnifiedClient(
+		testenv.NewLogger(t),
+		guardianPolicy,
+		&mockProvisioner{apiKey: "test-api-key"},
+		&mockMessageCaptureStrategy{},
+		&mockUsageTrackingStrategy{},
+		&mockChatTitleGenerator{},
+		&mockTelemetryLogger{},
+	)
+	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
+
+	// Real SDK tracer (testenv's provider is noop, so it never produces a
+	// trace ID for the attribution path to pick up).
+	sdkProvider := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = sdkProvider.Shutdown(context.Background()) })
+	ctx, span := sdkProvider.Tracer("openrouter-test").Start(context.Background(), "test-span")
+	defer span.End()
+	spanCtx := span.SpanContext()
+
+	chatID := uuid.New()
+	projectID := uuid.New()
+	req := CompletionRequest{
+		OrgID:       "test-org",
+		ProjectID:   projectID.String(),
+		Messages:    []or.ChatMessages{CreateMessageUser("Hello")},
+		ChatID:      chatID,
+		UsageSource: billing.ModelUsageSourcePlayground,
+		APIKeyID:    "test-api-key-id",
+	}
+
+	_, err = client.GetCompletion(ctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, chatID.String(), receivedRequestBody.SessionID,
+		"session_id must mirror the chat ID for OpenRouter dashboard grouping")
+	require.Equal(t, "test-org", receivedRequestBody.User,
+		"user must be the org ID so per-customer cost rollups attribute spend correctly")
+	require.Equal(t, map[string]string{"source": string(billing.ModelUsageSourcePlayground)}, receivedRequestBody.Metadata)
+	require.NotNil(t, receivedRequestBody.Trace)
+	require.Equal(t, spanCtx.TraceID().String(), receivedRequestBody.Trace.TraceID)
+	require.Equal(t, spanCtx.SpanID().String(), receivedRequestBody.Trace.ParentSpanID)
 }
 
 // testTransport is a custom http.RoundTripper that redirects all requests to the test server


### PR DESCRIPTION
## Summary

- Outbound OpenRouter `/chat/completions` requests now include `session_id` (chat ID), `user` (org ID), `metadata.source`, and `trace.{trace_id, parent_span_id}` from the current OTel span.
- Lets the OpenRouter dashboard group requests per conversation and roll up cost per customer, and joins Gram's Datadog APM traces to OpenRouter's request records.
- All four fields use `omitempty`, so completions without a chat (e.g. internal title generation) or without a usage source still produce the same wire shape as before.

Closes [AGE-2445](https://linear.app/speakeasy/issue/AGE-2445/pass-session-id-user-metadata-trace-on-outbound-openrouter-requests).

✻ Clauded...