### PR TITLE
fix(chat): preserve cache_control through /chat/completions proxy

### DIFF
--- a/.changeset/anthropic-prompt-cache-passthrough.md
+++ b/.changeset/anthropic-prompt-cache-passthrough.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Anthropic prompt caching now actually takes effect for assistant chats. The `/chat/completions` proxy used to strip `cache_control` markers off the request body before forwarding to OpenRouter, so every Anthropic call billed at the full input rate. The proxy now preserves the markers at the top level, on tool definitions, and on message content blocks, so Claude requests with stable prefixes can serve from cache.

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -152,6 +152,7 @@ func (g *GenerateChatTitle) generateTitle(ctx context.Context, orgID, projectID 
 		APIKeyID:                  "",
 		JSONSchema:                nil,
 		Reasoning:                 &openrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
+		CacheControl:              nil,
 		NormalizeOutboundMessages: false,
 	})
 	if err != nil {

--- a/server/internal/background/activities/slack_chat_completion.go
+++ b/server/internal/background/activities/slack_chat_completion.go
@@ -101,6 +101,7 @@ func (s *SlackChatCompletion) Do(ctx context.Context, input SlackChatCompletionI
 				Description: "Returns the current date and time in ISO 8601 format.",
 				Parameters:  json.RawMessage(currentDatetimeParamsJSON),
 			},
+			CacheControl: nil,
 		},
 		Executor: func(ctx context.Context, rawArgs string) (string, error) {
 			return time.Now().Format(time.RFC3339), nil

--- a/server/internal/chat/agent_client.go
+++ b/server/internal/chat/agent_client.go
@@ -205,6 +205,7 @@ func (c *Client) AgentChat(
 			APIKeyID:                  "",
 			JSONSchema:                nil,
 			Reasoning:                 &openrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
+			CacheControl:              nil,
 			NormalizeOutboundMessages: false,
 		}
 
@@ -304,6 +305,7 @@ func (c *Client) LoadToolsetTools(
 					Description: mcpTool.Description,
 					Parameters:  mcpTool.InputSchema,
 				},
+				CacheControl: nil,
 			},
 			Executor: executor,
 		})

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -851,6 +851,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 		APIKeyID:                  authCtx.APIKeyID,
 		JSONSchema:                jsonSchema,
 		Reasoning:                 reasoning,
+		CacheControl:              chatRequest.CacheControl,
 		NormalizeOutboundMessages: r.URL.Query().Get("unstable_normalizeOutboundMessages") == "1",
 	}
 

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1034,6 +1034,7 @@ func (s *Service) generatePolicyName(ctx context.Context, orgID, projectID strin
 		APIKeyID:                  "",
 		JSONSchema:                nil,
 		Reasoning:                 &openrouter.Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
+		CacheControl:              nil,
 		NormalizeOutboundMessages: false,
 	})
 	if err != nil {

--- a/server/internal/thirdparty/openrouter/cache_control_test.go
+++ b/server/internal/thirdparty/openrouter/cache_control_test.go
@@ -1,0 +1,78 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIChatRequest_PreservesCacheControl(t *testing.T) {
+	t.Parallel()
+
+	inbound := []byte(`{
+		"model": "anthropic/claude-4.6-sonnet",
+		"stream": false,
+		"cache_control": {"type": "ephemeral"},
+		"messages": [
+			{
+				"role": "system",
+				"content": [
+					{"type": "text", "text": "system prompt", "cache_control": {"type": "ephemeral"}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "hello"}
+				]
+			}
+		],
+		"tools": [
+			{
+				"type": "function",
+				"function": {"name": "do_thing", "parameters": {"type": "object"}},
+				"cache_control": {"type": "ephemeral"}
+			}
+		]
+	}`)
+
+	var req OpenAIChatRequest
+	require.NoError(t, json.Unmarshal(inbound, &req))
+
+	out, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+
+	require.Equal(t, "ephemeral", path(got, "cache_control", "type"),
+		"top-level cache_control must survive: %s", out)
+	require.Equal(t, "ephemeral", path(got, "tools", 0, "cache_control", "type"),
+		"per-tool cache_control must survive: %s", out)
+	require.Equal(t, "ephemeral", path(got, "messages", 0, "content", 0, "cache_control", "type"),
+		"per-content-block cache_control must survive: %s", out)
+}
+
+func path(root any, keys ...any) any {
+	cur := root
+	for _, k := range keys {
+		switch v := cur.(type) {
+		case map[string]any:
+			s, ok := k.(string)
+			if !ok {
+				return nil
+			}
+			cur = v[s]
+		case []any:
+			i, ok := k.(int)
+			if !ok || i < 0 || i >= len(v) {
+				return nil
+			}
+			cur = v[i]
+		default:
+			return nil
+		}
+	}
+	return cur
+}

--- a/server/internal/thirdparty/openrouter/completion_client.go
+++ b/server/internal/thirdparty/openrouter/completion_client.go
@@ -82,6 +82,8 @@ type CompletionRequest struct {
 	// produce billable reasoning tokens.
 	Reasoning *Reasoning
 
+	CacheControl *or.AnthropicCacheControlDirective
+
 	// NormalizeOutboundMessages drops narrative text from assistant messages
 	// that also carry tool_calls before forwarding to OpenRouter. Opt-in via
 	// the `unstable_normalizeOutboundMessages=1` query string on the proxy.

--- a/server/internal/thirdparty/openrouter/types.go
+++ b/server/internal/thirdparty/openrouter/types.go
@@ -163,13 +163,14 @@ func GetToolCallID(msg or.ChatMessages) *string {
 
 // OpenAIChatRequest represents the request structure for OpenAI chat completions
 type OpenAIChatRequest struct {
-	Model          string             `json:"model"`
-	Messages       []or.ChatMessages  `json:"messages"`
-	Stream         bool               `json:"stream"`
-	Tools          []Tool             `json:"tools,omitempty"`
-	Temperature    float32            `json:"temperature,omitempty"`
-	ResponseFormat *or.ResponseFormat `json:"response_format,omitempty"`
-	Reasoning      *Reasoning         `json:"reasoning,omitempty"`
+	Model          string                             `json:"model"`
+	Messages       []or.ChatMessages                  `json:"messages"`
+	Stream         bool                               `json:"stream"`
+	Tools          []Tool                             `json:"tools,omitempty"`
+	Temperature    float32                            `json:"temperature,omitempty"`
+	ResponseFormat *or.ResponseFormat                 `json:"response_format,omitempty"`
+	Reasoning      *Reasoning                         `json:"reasoning,omitempty"`
+	CacheControl   *or.AnthropicCacheControlDirective `json:"cache_control,omitempty"`
 }
 
 // Reasoning mirrors OpenRouter's `reasoning` request parameter. Callers set
@@ -202,8 +203,9 @@ type ToolCall struct {
 
 // Tool defines a function tool available to the model
 type Tool struct {
-	Type     string              `json:"type"` // always "function"
-	Function *FunctionDefinition `json:"function"`
+	Type         string                      `json:"type"` // always "function"
+	Function     *FunctionDefinition         `json:"function"`
+	CacheControl *or.ChatContentCacheControl `json:"cache_control,omitempty"`
 }
 
 // FunctionDefinition defines a callable function's name and input schema

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -136,6 +136,7 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 		Temperature:    temp,
 		ResponseFormat: nil,
 		Reasoning:      req.Reasoning,
+		CacheControl:   req.CacheControl,
 	}
 
 	// Add JSON schema if provided
@@ -425,6 +426,7 @@ func (c *ChatClient) GetObjectCompletion(ctx context.Context, req ObjectCompleti
 		UserEmail:                 "",
 		HTTPMetadata:              req.HTTPMetadata,
 		JSONSchema:                req.JSONSchema,
+		CacheControl:              nil,
 		ChatID:                    uuid.Nil,
 		APIKeyID:                  "",
 		Reasoning:                 &Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},


### PR DESCRIPTION
## Summary

- The `/chat/completions` proxy unmarshalled inbound requests into local typed structs (`OpenAIChatRequest`, `Tool`) that didn't model Anthropic's `cache_control` markers, so re-marshalling silently stripped them before forwarding to OpenRouter — 0 cache hits across 4,544 Anthropic assistant requests in 14 days.
- Adds `cache_control` to `OpenAIChatRequest` (top-level directive), to the local `Tool` struct (per-tool marker), and threads it through `CompletionRequest`. SDK message types already preserve `cache_control` on content blocks via `or.ChatContentText.CacheControl`.
- New unit test round-trips a representative agentkit payload and asserts the marker survives at all three locations.

Closes [AGE-2442](https://linear.app/speakeasy/issue/AGE-2442/restore-anthropic-prompt-caching-by-preserving-cache-control-through).

✻ Clauded...