### PR TITLE
chore(dashboard): link MCP servers in challenges table and filter incomplete rows

### DIFF
--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -23,6 +23,7 @@ import { Check, Loader2 } from "lucide-react";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
+import { isDisplayableBucket } from "./challengeHelpers";
 import { useChallengeRowColumns } from "./useChallengeRowColumns";
 import { useGrantFlow } from "./useGrantFlow";
 
@@ -291,15 +292,16 @@ export function ChallengesTab() {
     setPageCount(1);
   }
 
-  // Accumulate results as pages load.
+  // Accumulate results as pages load, excluding buckets with no scope.
   useEffect(() => {
     if (!data?.buckets) return;
+    const withScope = data.buckets.filter(isDisplayableBucket);
     if (pageCount === 1) {
-      setAccumulated(data.buckets);
+      setAccumulated(withScope);
     } else {
       setAccumulated((prev) => {
         const existingIds = new Set(prev.map((b) => b.id));
-        const newItems = data.buckets.filter((b) => !existingIds.has(b.id));
+        const newItems = withScope.filter((b) => !existingIds.has(b.id));
         return [...prev, ...newItems];
       });
     }

--- a/client/dashboard/src/pages/access/ResourceLink.tsx
+++ b/client/dashboard/src/pages/access/ResourceLink.tsx
@@ -7,12 +7,14 @@ export function ResourceLink({
   challenge,
   orgSlug,
   projectMap,
+  toolsetMap,
 }: {
   challenge: ChallengeBucket;
   orgSlug: string;
   projectMap: Map<string, { slug: string; name: string }>;
+  toolsetMap: Map<string, { slug: string; name: string; projectId: string }>;
 }) {
-  const { resourceKind, resourceId, projectId } = challenge;
+  const { resourceKind, resourceId } = challenge;
 
   if (!resourceKind || !resourceId) {
     return (
@@ -36,10 +38,17 @@ export function ResourceLink({
     IconEl = FolderOpen;
     to = proj ? `/${orgSlug}/projects/${proj.slug}` : null;
   } else if (resourceKind === "mcp") {
-    label = resourceId;
     IconEl = Plug;
-    const proj = projectId ? projectMap.get(projectId) : undefined;
-    to = proj ? `/${orgSlug}/projects/${proj.slug}/mcp/${resourceId}` : null;
+    const toolset = toolsetMap.get(resourceId);
+    if (toolset) {
+      label = toolset.name;
+      const proj = projectMap.get(toolset.projectId);
+      to = proj
+        ? `/${orgSlug}/projects/${proj.slug}/mcp/${toolset.slug}`
+        : null;
+    } else {
+      label = resourceId;
+    }
   }
 
   if (to) {

--- a/client/dashboard/src/pages/access/challengeHelpers.ts
+++ b/client/dashboard/src/pages/access/challengeHelpers.ts
@@ -1,6 +1,12 @@
 import type { AuthzChallenge } from "@gram/client/models/components/authzchallenge.js";
+import type { ChallengeBucket } from "@gram/client/models/components/challengebucket.js";
 
 type Reason = AuthzChallenge["reason"];
+
+/** Keep only buckets that have a scope and a fully-specified resource. */
+export function isDisplayableBucket(b: ChallengeBucket): boolean {
+  return !!b.scope && !!b.resourceKind && !!b.resourceId;
+}
 
 export function getInitials(identifier: string): string {
   const name = identifier.split("@")[0] ?? identifier;

--- a/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
+++ b/client/dashboard/src/pages/access/useChallengeRowColumns.tsx
@@ -11,6 +11,7 @@ import { useSession } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
 import type { ChallengeBucket } from "@gram/client/models/components/challengebucket.js";
 import { useMembers } from "@gram/client/react-query/members.js";
+import { useListToolsetsForOrg } from "@gram/client/react-query/listToolsetsForOrg.js";
 import { Column } from "@speakeasy-api/moonshine";
 import { KeyRound } from "lucide-react";
 import { useMemo } from "react";
@@ -28,6 +29,7 @@ export function useChallengeRowColumns(
   const { orgSlug } = useSlugs();
   const { organization } = useSession();
   const { data: membersData } = useMembers();
+  const { data: toolsetsData } = useListToolsetsForOrg();
   const projectMap = useMemo(() => {
     const m = new Map<string, { slug: string; name: string }>();
     for (const p of organization.projects) {
@@ -35,6 +37,16 @@ export function useChallengeRowColumns(
     }
     return m;
   }, [organization.projects]);
+  const toolsetMap = useMemo(() => {
+    const m = new Map<
+      string,
+      { slug: string; name: string; projectId: string }
+    >();
+    for (const t of toolsetsData?.toolsets ?? []) {
+      m.set(t.id, { slug: t.slug, name: t.name, projectId: t.projectId });
+    }
+    return m;
+  }, [toolsetsData]);
   const memberMap = useMemo(() => {
     const m = new Map<string, { email: string; photoUrl?: string }>();
     for (const member of membersData?.members ?? []) {
@@ -162,6 +174,7 @@ export function useChallengeRowColumns(
               challenge={row}
               orgSlug={orgSlug ?? ""}
               projectMap={projectMap}
+              toolsetMap={toolsetMap}
             />
           </div>
         ),
@@ -234,6 +247,7 @@ export function useChallengeRowColumns(
   }, [
     orgSlug,
     projectMap,
+    toolsetMap,
     memberMap,
     animatingOutIds,
     outcomeFilter,

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -15,6 +15,7 @@ import { useRBAC } from "@/hooks/useRBAC";
 import { Outcome } from "@gram/client/models/operations/listchallengebuckets.js";
 import { useChallengeBuckets } from "@gram/client/react-query/challengeBuckets.js";
 import { ChallengesEmptyState } from "@/pages/access/ChallengesTab";
+import { isDisplayableBucket } from "@/pages/access/challengeHelpers";
 import { useChallengeRowColumns } from "@/pages/access/useChallengeRowColumns";
 import { useGrantFlow } from "@/pages/access/useGrantFlow";
 import { Table } from "@speakeasy-api/moonshine";
@@ -231,7 +232,10 @@ function RecentChallenges() {
     limit: 5,
   });
 
-  const buckets = data?.buckets ?? [];
+  const buckets = useMemo(
+    () => (data?.buckets ?? []).filter(isDisplayableBucket),
+    [data?.buckets],
+  );
 
   const challengeRowColumns = useChallengeRowColumns();
 


### PR DESCRIPTION
## Summary

- MCP server resources in the challenges table now link to the MCP detail page (previously showed raw UUID with no link)
- Resolves MCP server UUID → slug/name using org toolsets data so the link and label are correct
- Filters out challenge rows missing a required scope or resource from both the main challenges table and the recent challenges widget on the org home page
- Extracts shared `isDisplayableBucket` predicate into `challengeHelpers.ts`

## Test plan

- [ ] Navigate to Roles & Permissions → Authorization Challenges tab
- [ ] Verify MCP server resources show server name with a clickable link to the MCP detail page
- [ ] Verify org/project resources still link correctly
- [ ] Verify challenges with no scope or no resource are excluded from the table
- [ ] Check the org home "Recent Challenges" widget applies the same filtering
