### PR TITLE
feat(triggers): add note field to cron triggers

### DIFF
--- a/.changeset/age-2453-cron-trigger-note.md
+++ b/.changeset/age-2453-cron-trigger-note.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Cron triggers now accept an optional `note` field, matching wake triggers. The note is included in every scheduled tick the assistant sees, letting one assistant carry multiple cron triggers with distinct per-schedule steering (e.g. "run daily digest" vs "check deploy status").

--- a/server/internal/assistants/source_adapter.go
+++ b/server/internal/assistants/source_adapter.go
@@ -141,6 +141,7 @@ type cronEventPayload struct {
 	Schedule          string `json:"schedule"`
 	FiredAt           string `json:"fired_at"`
 	TriggerInstanceID string `json:"trigger_instance_id"`
+	Note              string `json:"note,omitempty"`
 }
 
 type cronAdapter struct{}
@@ -181,6 +182,9 @@ func (cronAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) 
 		fmt.Fprintf(&b, "Scheduled run fired for schedule %q at %s. Execute the assistant's configured task for this tick.", payload.Schedule, payload.FiredAt)
 	} else {
 		fmt.Fprintf(&b, "Scheduled run fired at %s. Execute the assistant's configured task for this tick.", payload.FiredAt)
+	}
+	if payload.Note != "" {
+		fmt.Fprintf(&b, " Note: %s", payload.Note)
 	}
 	return b.String(), nil
 }

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -137,7 +137,8 @@ func (c slackTriggerConfig) Filter(event any) (bool, error) {
 }
 
 type cronTriggerConfig struct {
-	Schedule string `json:"schedule"`
+	Schedule string  `json:"schedule"`
+	Note     *string `json:"note,omitempty"`
 }
 
 func (c cronTriggerConfig) Filter(_ any) (bool, error) { return true, nil }
@@ -572,6 +573,7 @@ type cronTriggerEvent struct {
 	Schedule          string `json:"schedule" cel:"schedule"`
 	FiredAt           string `json:"fired_at" cel:"fired_at"`
 	TriggerInstanceID string `json:"trigger_instance_id" cel:"trigger_instance_id"`
+	Note              string `json:"note,omitempty" cel:"note"`
 }
 
 type wakeTriggerEvent struct {
@@ -866,10 +868,15 @@ func newCronDefinition() Definition {
 			if !ok {
 				return nil, fmt.Errorf("invalid cron config")
 			}
+			note := ""
+			if cfg.Note != nil {
+				note = *cfg.Note
+			}
 			event := cronTriggerEvent{
 				Schedule:          cfg.Schedule,
 				FiredAt:           firedAt.UTC().Format(time.RFC3339Nano),
 				TriggerInstanceID: instance.ID.String(),
+				Note:              note,
 			}
 			rawPayload, err := json.Marshal(event)
 			if err != nil {

--- a/server/internal/background/triggers/definitions_test.go
+++ b/server/internal/background/triggers/definitions_test.go
@@ -139,6 +139,34 @@ func TestCronBuildScheduledEventIsDeterministic(t *testing.T) {
 	require.Equal(t, instance.ID.String(), first.TriggerInstanceID)
 }
 
+func TestCronBuildScheduledEventPropagatesNote(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("cron")
+	require.True(t, ok)
+
+	note := "run the daily digest"
+	config, err := definition.DecodeConfig(map[string]any{
+		"schedule": "0 9 * * *",
+		"note":     note,
+	})
+	require.NoError(t, err)
+
+	instance := triggerrepo.TriggerInstance{
+		ID:             uuid.MustParse("22222222-3333-4444-5555-666666666666"),
+		DefinitionSlug: "cron",
+	}
+	firedAt := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	envelope, err := definition.BuildScheduledEvent(instance, config, firedAt)
+	require.NoError(t, err)
+
+	var event cronTriggerEvent
+	require.NoError(t, json.Unmarshal(envelope.RawPayload, &event))
+	require.Equal(t, note, event.Note)
+	require.Equal(t, "0 9 * * *", event.Schedule)
+}
+
 func TestBuildScheduleOptionsUsesSharedScheduleWorkflowInput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Adds an optional `note` field to cron triggers, mirroring the existing wake trigger shape.
- Each scheduled tick now includes the note in `cronTriggerEvent`; the assistant source adapter appends it to the per-turn prompt so one assistant can carry multiple cron triggers with distinct steering.
- Frontend picks up the field automatically through the schema-driven trigger config form (it appears under "Advanced").

Closes [AGE-2453](https://linear.app/speakeasy/issue/AGE-2453/add-free-text-note-field-to-cron-triggers-for-assistant-steering)

✻ Clauded...