### PR TITLE
feat(dashboard): redesign sidenav with collapsible groups and sliding highlight

### DIFF
--- a/client/dashboard/src/App.css
+++ b/client/dashboard/src/App.css
@@ -96,6 +96,43 @@
   }
 }
 
+@keyframes nav-shimmer {
+  0% {
+    background-position: 200% center;
+  }
+  100% {
+    background-position: -200% center;
+  }
+}
+
+.nav-shimmer {
+  background: linear-gradient(
+    90deg,
+    currentColor 25%,
+    oklch(1 0 0 / 0.6) 50%,
+    currentColor 75%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: nav-shimmer 1.2s ease-in-out infinite;
+}
+
+.dark .nav-shimmer {
+  background: linear-gradient(
+    90deg,
+    currentColor 25%,
+    oklch(1 0 0 / 0.4) 50%,
+    currentColor 75%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: nav-shimmer 1.2s ease-in-out infinite;
+}
+
 .server-card:hover .scroll-dots-target,
 .dot-card:hover .scroll-dots-target {
   animation: scroll-dots 3s linear infinite;

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -1,11 +1,13 @@
-import { NavButton } from "@/components/nav-menu";
+import {
+  CollapsibleNavGroup,
+  CollapsibleNavItem,
+  NavButton,
+  NavGroupProvider,
+} from "@/components/nav-menu";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
@@ -15,7 +17,7 @@ import { Scope } from "@/hooks/useRBAC";
 import { useProductTier } from "@/hooks/useProductTier";
 import { AppRoute, useOrgRoutes, useRoutes } from "@/routes";
 import { useGetPeriodUsage } from "@gram/client/react-query";
-import { cn, Stack } from "@speakeasy-api/moonshine";
+import { cn, Icon, Stack } from "@speakeasy-api/moonshine";
 import { MinusIcon, TestTube2Icon, Undo2 } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
@@ -26,6 +28,20 @@ import { Button } from "./ui/button";
 import { Type } from "./ui/type";
 
 function ScopeGatedNavItem({
+  item,
+  scope,
+}: {
+  item: AppRoute;
+  scope: Scope | Scope[];
+}) {
+  return (
+    <RequireScope scope={scope} level="section">
+      <CollapsibleNavItem item={item} />
+    </RequireScope>
+  );
+}
+
+function ScopeGatedTopLevelItem({
   item,
   scope,
 }: {
@@ -55,21 +71,73 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
   const isAssistantsEnabled = telemetry.isFeatureEnabled("assistants") ?? false;
 
+  const connectActive = [
+    routes.sources,
+    routes.catalog,
+    routes.playground,
+    routes.deployments,
+  ].some((r) => r.active);
+
+  const buildActive = [
+    routes.mcp,
+    routes.clis,
+    routes.plugins,
+    routes.environments,
+    ...(isAssistantsEnabled ? [routes.assistants] : []),
+  ].some((r) => r.active);
+
+  const observeActive = [routes.insights, routes.logs].some((r) => r.active);
+
+  const securityActive = [routes.riskOverview, routes.policyCenter].some(
+    (r) => r.active,
+  );
+
+  const activeGroup = connectActive
+    ? "Connect"
+    : buildActive
+      ? "Build"
+      : observeActive
+        ? "Observe"
+        : securityActive
+          ? "Security"
+          : undefined;
+
+  // Find the specific active route title for the sliding highlight
+  const allNavRoutes = [
+    routes.home,
+    routes.sources,
+    routes.catalog,
+    routes.playground,
+    routes.deployments,
+    routes.mcp,
+    ...(isAssistantsEnabled ? [routes.assistants] : []),
+    routes.clis,
+    routes.plugins,
+    routes.environments,
+    routes.insights,
+    routes.logs,
+    routes.riskOverview,
+    routes.policyCenter,
+    routes.settings,
+  ];
+  const activeRoute = allNavRoutes.find((r) => r.active);
+  const activeItem = activeRoute?.title;
+
   return (
     <Sidebar collapsible="icon" {...props}>
-      <SidebarContent className="pt-2">
-        <SidebarGroup>
-          <SidebarGroupLabel>project</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <ScopeGatedNavItem item={routes.home} scope="project:read" />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>connect</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
+      <SidebarContent className="pt-5">
+        <NavGroupProvider activeGroup={activeGroup} activeItem={activeItem}>
+          <SidebarMenu className="gap-1 px-2">
+            {/* Home — top-level, no group */}
+            <ScopeGatedTopLevelItem item={routes.home} scope="project:read" />
+
+            {/* Connect group */}
+            <CollapsibleNavGroup
+              label="Connect"
+              Icon={(p) => <Icon {...p} name="plug" />}
+              defaultHref={routes.sources.href()}
+              isActive={connectActive}
+            >
               <ScopeGatedNavItem
                 item={routes.sources}
                 scope={["project:read", "project:write"]}
@@ -86,13 +154,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={routes.deployments}
                 scope={["project:read", "project:write"]}
               />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>build</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
+            </CollapsibleNavGroup>
+
+            {/* Build group */}
+            <CollapsibleNavGroup
+              label="Build"
+              Icon={(p) => <Icon {...p} name="hammer" />}
+              defaultHref={routes.mcp.href()}
+              isActive={buildActive}
+            >
               <ScopeGatedNavItem
                 item={routes.mcp}
                 scope={["mcp:read", "mcp:write"]}
@@ -112,22 +182,26 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={routes.environments}
                 scope={["project:read", "project:write"]}
               />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>observe</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
+            </CollapsibleNavGroup>
+
+            {/* Observe group */}
+            <CollapsibleNavGroup
+              label="Observe"
+              Icon={(p) => <Icon {...p} name="eye" />}
+              defaultHref={routes.insights.href()}
+              isActive={observeActive}
+            >
               <ScopeGatedNavItem item={routes.insights} scope="project:read" />
               <ScopeGatedNavItem item={routes.logs} scope="project:read" />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>security</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
+            </CollapsibleNavGroup>
+
+            {/* Security group */}
+            <CollapsibleNavGroup
+              label="Security"
+              Icon={(p) => <Icon {...p} name="shield" />}
+              defaultHref={routes.riskOverview.href()}
+              isActive={securityActive}
+            >
               <ScopeGatedNavItem
                 item={routes.riskOverview}
                 scope="project:read"
@@ -136,17 +210,16 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={routes.policyCenter}
                 scope={["project:read", "project:write"]}
               />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>settings</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <ScopeGatedNavItem item={routes.settings} scope="project:write" />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+            </CollapsibleNavGroup>
+
+            {/* Settings — top-level, no group */}
+            <ScopeGatedTopLevelItem
+              item={routes.settings}
+              scope="project:write"
+            />
+          </SidebarMenu>
+        </NavGroupProvider>
+
         <div className="mt-auto px-2 py-3 group-data-[collapsible=icon]:px-0">
           <Link
             to={`/${orgSlug}`}

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -99,7 +99,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       : observeActive
         ? "Observe"
         : securityActive
-          ? "Security"
+          ? "Secure"
           : undefined;
 
   // Find the specific active route title for the sliding highlight
@@ -197,7 +197,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
             {/* Security group */}
             <CollapsibleNavGroup
-              label="Security"
+              label="Secure"
               Icon={(p) => <Icon {...p} name="shield" />}
               defaultHref={routes.riskOverview.href()}
               isActive={securityActive}

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -92,15 +92,21 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     (r) => r.active,
   );
 
-  const activeGroup = connectActive
-    ? "Connect"
-    : buildActive
-      ? "Build"
-      : observeActive
-        ? "Observe"
-        : securityActive
-          ? "Secure"
-          : undefined;
+  let activeGroup: string | undefined;
+  switch (true) {
+    case connectActive:
+      activeGroup = "Connect";
+      break;
+    case buildActive:
+      activeGroup = "Build";
+      break;
+    case observeActive:
+      activeGroup = "Observe";
+      break;
+    case securityActive:
+      activeGroup = "Secure";
+      break;
+  }
 
   // Find the specific active route title for the sliding highlight
   const allNavRoutes = [

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -140,7 +140,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               label="Connect"
               Icon={(p) => <Icon {...p} name="plug" />}
               defaultHref={routes.sources.href()}
-              isActive={connectActive}
             >
               <ScopeGatedNavItem
                 item={routes.sources}
@@ -165,7 +164,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               label="Build"
               Icon={(p) => <Icon {...p} name="hammer" />}
               defaultHref={routes.mcp.href()}
-              isActive={buildActive}
             >
               <ScopeGatedNavItem
                 item={routes.mcp}
@@ -193,7 +191,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               label="Observe"
               Icon={(p) => <Icon {...p} name="eye" />}
               defaultHref={routes.insights.href()}
-              isActive={observeActive}
             >
               <ScopeGatedNavItem item={routes.insights} scope="project:read" />
               <ScopeGatedNavItem item={routes.logs} scope="project:read" />
@@ -204,7 +201,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               label="Secure"
               Icon={(p) => <Icon {...p} name="shield" />}
               defaultHref={routes.riskOverview.href()}
-              isActive={securityActive}
             >
               <ScopeGatedNavItem
                 item={routes.riskOverview}

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -126,7 +126,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarContent className="pt-5">
-        <NavGroupProvider activeGroup={activeGroup} activeItem={activeItem}>
+        <NavGroupProvider
+          activeGroup={activeGroup}
+          defaultOpenGroups={!activeGroup ? ["Connect", "Build"] : undefined}
+          activeItem={activeItem}
+        >
           <SidebarMenu className="gap-1 px-2">
             {/* Home — top-level, no group */}
             <ScopeGatedTopLevelItem item={routes.home} scope="project:read" />

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -1,9 +1,5 @@
 import { SidebarMenu, SidebarMenuItem } from "@/components/ui/sidebar";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { AppRoute } from "@/routes";
 import { Loader2 } from "lucide-react";
@@ -181,7 +177,7 @@ export function NavGroupProvider({
       registerRef,
       containerRef,
     }),
-    [openGroup, hoveredItem, resolvedActive, registerRef],
+    [openGroup, setOpenGroup, hoveredItem, resolvedActive, registerRef],
   );
 
   return (

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -1,12 +1,15 @@
+import { SidebarMenu, SidebarMenuItem } from "@/components/ui/sidebar";
 import {
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from "@/components/ui/sidebar";
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { AppRoute } from "@/routes";
 import { Loader2 } from "lucide-react";
+import { motion } from "motion/react";
 import React from "react";
+import { Link } from "react-router";
 import { ProductTierBadge } from "./product-tier-badge";
 import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge";
 import { Type } from "./ui/type";
@@ -47,7 +50,203 @@ function NavMenuButton({ item }: { item: AppRoute }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Sliding highlight context
+// ---------------------------------------------------------------------------
+
+type HighlightRect = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+type NavContextValue = {
+  openGroup: string | null;
+  setOpenGroup: (group: string | null) => void;
+  hoveredItem: string | null;
+  setHoveredItem: (item: string | null) => void;
+  activeItem: string | null;
+  registerRef: (id: string, el: HTMLElement | null) => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+};
+
+const NavGroupContext = React.createContext<NavContextValue>({
+  openGroup: null,
+  setOpenGroup: () => {},
+  hoveredItem: null,
+  setHoveredItem: () => {},
+  activeItem: null,
+  registerRef: () => {},
+  containerRef: { current: null },
+});
+
+export function NavGroupProvider({
+  activeGroup,
+  activeItem,
+  children,
+}: {
+  activeGroup?: string;
+  activeItem?: string;
+  children: React.ReactNode;
+}) {
+  const [openGroup, _setOpenGroup] = React.useState<string | null>(
+    activeGroup ?? null,
+  );
+  const [hoveredItem, setHoveredItem] = React.useState<string | null>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const itemRefs = React.useRef<Map<string, HTMLElement>>(new Map());
+  const [highlightRect, setHighlightRect] =
+    React.useState<HighlightRect | null>(null);
+  const suppressUntilRef = React.useRef(0);
+
+  // Accordion animation takes ~200ms — suppress highlight recomputation
+  // during that window to avoid jitter on shifting sub-items.
+  const ACCORDION_DURATION = 250;
+
+  const setOpenGroup = React.useCallback((group: string | null) => {
+    suppressUntilRef.current = Date.now() + ACCORDION_DURATION;
+    _setOpenGroup(group);
+  }, []);
+
+  React.useEffect(() => {
+    suppressUntilRef.current = Date.now() + ACCORDION_DURATION;
+    _setOpenGroup(activeGroup ?? null);
+  }, [activeGroup]);
+
+  const resolvedActive = activeItem ?? activeGroup ?? null;
+  const target = hoveredItem ?? resolvedActive;
+
+  const computeRect = React.useCallback(() => {
+    if (!target || !containerRef.current) {
+      setHighlightRect(null);
+      return;
+    }
+    const el = itemRefs.current.get(target);
+    if (!el) {
+      setHighlightRect(null);
+      return;
+    }
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    setHighlightRect({
+      top: elRect.top - containerRect.top,
+      left: elRect.left - containerRect.left,
+      width: elRect.width,
+      height: elRect.height,
+    });
+  }, [target]);
+
+  // Compute highlight position (with post-accordion delay)
+  React.useEffect(() => {
+    const remaining = suppressUntilRef.current - Date.now();
+    if (remaining > 0) {
+      const timer = setTimeout(computeRect, remaining);
+      return () => clearTimeout(timer);
+    }
+    computeRect();
+  }, [computeRect]);
+
+  // Recompute on layout changes, but skip during accordion
+  React.useEffect(() => {
+    if (!containerRef.current) return;
+
+    const observer = new ResizeObserver(() => {
+      if (Date.now() < suppressUntilRef.current) return;
+      computeRect();
+    });
+
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [computeRect]);
+
+  const registerRef = React.useCallback(
+    (id: string, el: HTMLElement | null) => {
+      if (el) {
+        itemRefs.current.set(id, el);
+      } else {
+        itemRefs.current.delete(id);
+      }
+    },
+    [],
+  );
+
+  const value = React.useMemo<NavContextValue>(
+    () => ({
+      openGroup,
+      setOpenGroup,
+      hoveredItem,
+      setHoveredItem,
+      activeItem: resolvedActive,
+      registerRef,
+      containerRef,
+    }),
+    [openGroup, hoveredItem, resolvedActive, registerRef],
+  );
+
+  return (
+    <NavGroupContext.Provider value={value}>
+      <div ref={containerRef} className="relative">
+        {highlightRect && (
+          <motion.div
+            className="bg-card ring-border/50 pointer-events-none absolute rounded-lg ring-1"
+            animate={{
+              top: highlightRect.top,
+              left: highlightRect.left,
+              width: highlightRect.width,
+              height: highlightRect.height,
+            }}
+            transition={{
+              type: "spring",
+              bounce: 0.15,
+              duration: 0.3,
+            }}
+          />
+        )}
+        {children}
+      </div>
+    </NavGroupContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook for registering item ref + hover handlers
+// ---------------------------------------------------------------------------
+
+const HOVER_INTENT_MS = 600;
+
+function useNavItem(id: string) {
+  const { registerRef, setHoveredItem } = React.useContext(NavGroupContext);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const ref = React.useCallback(
+    (el: HTMLElement | null) => registerRef(id, el),
+    [id, registerRef],
+  );
+
+  const onMouseEnter = React.useCallback(() => {
+    timerRef.current = setTimeout(() => setHoveredItem(id), HOVER_INTENT_MS);
+  }, [id, setHoveredItem]);
+
+  const onMouseLeave = React.useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setHoveredItem(null);
+  }, [setHoveredItem]);
+
+  React.useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { ref, onMouseEnter, onMouseLeave };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level nav button (Home, Settings, etc.)
+// ---------------------------------------------------------------------------
+
 export function NavButton({
+  id,
   title,
   titleNode,
   href,
@@ -57,6 +256,7 @@ export function NavButton({
   onClick,
   stage,
 }: {
+  id?: string;
   title: string;
   titleNode?: React.ReactNode;
   href?: string;
@@ -66,6 +266,8 @@ export function NavButton({
   Icon?: React.ComponentType<{ className?: string }>;
   stage?: ReleaseStage;
 }) {
+  const itemId = id ?? title;
+  const navItem = useNavItem(itemId);
   const [isLoading, setIsLoading] = React.useState(false);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -87,36 +289,166 @@ export function NavButton({
   };
 
   return (
-    <SidebarMenuButton
-      className="group/nav-button"
-      tooltip={title}
-      href={href}
-      target={target}
-      isActive={active}
-      onClick={handleClick}
+    <div
+      ref={navItem.ref}
+      onMouseEnter={navItem.onMouseEnter}
+      onMouseLeave={navItem.onMouseLeave}
     >
-      {isLoading ? (
-        <Loader2 className="trans text-muted-foreground animate-spin" />
-      ) : (
-        Icon && <Icon className={cn("trans text-muted-foreground")} />
-      )}
-      <Type
-        variant="small"
-        className="transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0"
+      <Link
+        to={href ?? "#"}
+        target={target}
+        onClick={handleClick}
+        className={cn(
+          "relative z-[1] flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm transition-colors hover:no-underline",
+          "group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2!",
+          active
+            ? "text-foreground font-semibold"
+            : "text-muted-foreground font-medium",
+        )}
       >
-        {titleNode ?? title}
-      </Type>
-      {title === "Billing" && <ProductTierBadge />}
-      {stage && (
-        // Hide in collapsed-icon mode so the rail stays icon-only; the page
-        // title still carries the stage signal. The badge keeps its own
-        // tooltip so users learn what "preview"/"beta" mean on hover.
-        <ReleaseStageBadge
-          stage={stage}
-          size="xs"
-          className="ml-auto group-data-[collapsible=icon]:hidden"
-        />
-      )}
-    </SidebarMenuButton>
+        {isLoading ? (
+          <Loader2 className="trans text-muted-foreground size-4 shrink-0 animate-spin" />
+        ) : (
+          Icon && (
+            <Icon
+              className={cn(
+                "trans size-4 shrink-0",
+                active ? "text-foreground" : "text-muted-foreground",
+              )}
+            />
+          )
+        )}
+        <Type
+          variant="small"
+          className="transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0"
+        >
+          {titleNode ?? title}
+        </Type>
+        {title === "Billing" && <ProductTierBadge />}
+        {stage && (
+          <ReleaseStageBadge
+            stage={stage}
+            size="xs"
+            className="ml-auto group-data-[collapsible=icon]:hidden"
+          />
+        )}
+      </Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Collapsible nav group (Connect, Build, etc.)
+// ---------------------------------------------------------------------------
+
+export function CollapsibleNavGroup({
+  label,
+  Icon,
+  defaultHref,
+  isActive,
+  children,
+}: {
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  defaultHref?: string;
+  isActive: boolean;
+  children: React.ReactNode;
+}) {
+  const { openGroup, setOpenGroup } = React.useContext(NavGroupContext);
+  const navItem = useNavItem(label);
+  const isOpen = openGroup === label || (openGroup === null && isActive);
+
+  const handleClick = () => {
+    if (!isOpen) {
+      setOpenGroup(label);
+    }
+  };
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={() => setOpenGroup(isOpen ? null : label)}
+    >
+      <SidebarMenuItem>
+        <div
+          ref={navItem.ref}
+          onMouseEnter={navItem.onMouseEnter}
+          onMouseLeave={navItem.onMouseLeave}
+        >
+          <Link
+            to={defaultHref ?? "#"}
+            onClick={handleClick}
+            className={cn(
+              "relative z-[1] flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors hover:no-underline",
+              "group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2!",
+              "cursor-pointer outline-hidden",
+              isOpen
+                ? "text-foreground font-semibold"
+                : "text-muted-foreground font-medium",
+            )}
+          >
+            <Icon
+              className={cn(
+                "size-4 shrink-0 transition-colors",
+                isOpen ? "text-foreground" : "text-muted-foreground",
+              )}
+            />
+            <span className="flex-1 truncate transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0">
+              {label}
+            </span>
+          </Link>
+        </div>
+
+        <CollapsibleContent className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden">
+          <div className="border-border mt-1 ml-4 border-l pl-2 group-data-[collapsible=icon]:hidden">
+            <ul className="flex flex-col gap-0.5 py-0.5">{children}</ul>
+          </div>
+        </CollapsibleContent>
+      </SidebarMenuItem>
+    </Collapsible>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-item inside a CollapsibleNavGroup
+// ---------------------------------------------------------------------------
+
+export function CollapsibleNavItem({
+  item,
+  stage,
+}: {
+  item: AppRoute;
+  stage?: ReleaseStage;
+}) {
+  const navItem = useNavItem(item.title);
+
+  return (
+    <li data-sidebar="menu-item">
+      <div
+        ref={navItem.ref}
+        onMouseEnter={navItem.onMouseEnter}
+        onMouseLeave={navItem.onMouseLeave}
+      >
+        <Link
+          to={item.href()}
+          className={cn(
+            "relative z-[1] flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:no-underline",
+            item.active
+              ? "text-foreground font-semibold"
+              : "text-muted-foreground",
+          )}
+        >
+          <span className="truncate">{item.title}</span>
+          {item.title === "Billing" && <ProductTierBadge />}
+          {(stage ?? item.stage) && (
+            <ReleaseStageBadge
+              stage={(stage ?? item.stage)!}
+              size="xs"
+              className="ml-auto"
+            />
+          )}
+        </Link>
+      </div>
+    </li>
   );
 }

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -454,8 +454,6 @@ export function CollapsibleNavGroup({
   label: string;
   Icon: React.ComponentType<{ className?: string }>;
   defaultHref?: string;
-  /** @deprecated No longer used — open state managed by NavGroupProvider */
-  isActive?: boolean;
   children: React.ReactNode;
 }) {
   const { openGroups, toggleGroup, openGroup } =

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -422,6 +422,7 @@ export function NavButton({
           variant="small"
           className={cn(
             "transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0",
+            active && "font-semibold",
             isLoading && "nav-shimmer",
           )}
         >

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -335,8 +335,8 @@ function useNavItem(id: string) {
   }, [setHoveredItem]);
 
   React.useEffect(() => {
+    const s = stateRef.current;
     return () => {
-      const s = stateRef.current;
       if (s.intervalId) clearInterval(s.intervalId);
     };
   }, []);
@@ -449,13 +449,13 @@ export function CollapsibleNavGroup({
   label,
   Icon,
   defaultHref,
-  isActive,
   children,
 }: {
   label: string;
   Icon: React.ComponentType<{ className?: string }>;
   defaultHref?: string;
-  isActive: boolean;
+  /** @deprecated No longer used — open state managed by NavGroupProvider */
+  isActive?: boolean;
   children: React.ReactNode;
 }) {
   const { openGroups, toggleGroup, openGroup } =

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -504,7 +504,7 @@ export function CollapsibleNavGroup({
           <div className="border-border mt-1 ml-4 border-l pl-2 group-data-[collapsible=icon]:hidden">
             <motion.ul
               className="flex flex-col gap-0.5 py-0.5"
-              initial="closed"
+              initial={isOpen ? "open" : "closed"}
               animate={isOpen ? "open" : "closed"}
               variants={{
                 open: {

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -2,7 +2,6 @@ import { SidebarMenu, SidebarMenuItem } from "@/components/ui/sidebar";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { AppRoute } from "@/routes";
-import { Loader2 } from "lucide-react";
 import { motion } from "motion/react";
 import React from "react";
 import { Link } from "react-router";
@@ -58,8 +57,9 @@ type HighlightRect = {
 };
 
 type NavContextValue = {
-  openGroup: string | null;
-  setOpenGroup: (group: string | null) => void;
+  openGroups: Set<string>;
+  toggleGroup: (group: string) => void;
+  openGroup: (group: string) => void;
   hoveredItem: string | null;
   setHoveredItem: (item: string | null) => void;
   activeItem: string | null;
@@ -68,8 +68,9 @@ type NavContextValue = {
 };
 
 const NavGroupContext = React.createContext<NavContextValue>({
-  openGroup: null,
-  setOpenGroup: () => {},
+  openGroups: new Set(),
+  toggleGroup: () => {},
+  openGroup: () => {},
   hoveredItem: null,
   setHoveredItem: () => {},
   activeItem: null,
@@ -79,16 +80,21 @@ const NavGroupContext = React.createContext<NavContextValue>({
 
 export function NavGroupProvider({
   activeGroup,
+  defaultOpenGroups,
   activeItem,
   children,
 }: {
   activeGroup?: string;
+  defaultOpenGroups?: string[];
   activeItem?: string;
   children: React.ReactNode;
 }) {
-  const [openGroup, _setOpenGroup] = React.useState<string | null>(
-    activeGroup ?? null,
-  );
+  const defaultsRef = React.useRef(new Set(defaultOpenGroups ?? []));
+  const [openGroups, _setOpenGroups] = React.useState<Set<string>>(() => {
+    const initial = new Set(defaultOpenGroups ?? []);
+    if (activeGroup) initial.add(activeGroup);
+    return initial;
+  });
   const [hoveredItem, setHoveredItem] = React.useState<string | null>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
   const itemRefs = React.useRef<Map<string, HTMLElement>>(new Map());
@@ -96,18 +102,57 @@ export function NavGroupProvider({
     React.useState<HighlightRect | null>(null);
   const suppressUntilRef = React.useRef(0);
 
-  // Accordion animation takes ~200ms — suppress highlight recomputation
-  // during that window to avoid jitter on shifting sub-items.
   const ACCORDION_DURATION = 250;
 
-  const setOpenGroup = React.useCallback((group: string | null) => {
+  const toggleGroup = React.useCallback((group: string) => {
     suppressUntilRef.current = Date.now() + ACCORDION_DURATION;
-    _setOpenGroup(group);
+    _setOpenGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(group)) {
+        next.delete(group);
+      } else {
+        // Opening a non-default group collapses defaults
+        if (!defaultsRef.current.has(group)) {
+          for (const d of defaultsRef.current) next.delete(d);
+        }
+        next.add(group);
+      }
+      return next;
+    });
+  }, []);
+
+  const openGroupFn = React.useCallback((group: string) => {
+    suppressUntilRef.current = Date.now() + ACCORDION_DURATION;
+    _setOpenGroups((prev) => {
+      if (prev.has(group)) return prev;
+      const next = new Set<string>();
+      // Opening a non-default group collapses defaults
+      if (!defaultsRef.current.has(group)) {
+        next.add(group);
+      } else {
+        for (const g of prev) next.add(g);
+        next.add(group);
+      }
+      return next;
+    });
   }, []);
 
   React.useEffect(() => {
+    defaultsRef.current = new Set(defaultOpenGroups ?? []);
+  }, [defaultOpenGroups]);
+
+  React.useEffect(() => {
     suppressUntilRef.current = Date.now() + ACCORDION_DURATION;
-    _setOpenGroup(activeGroup ?? null);
+    if (activeGroup) {
+      _setOpenGroups((prev) => {
+        if (prev.has(activeGroup)) return prev;
+        const next = new Set(prev);
+        next.add(activeGroup);
+        return next;
+      });
+    } else if (defaultsRef.current.size > 0) {
+      _setOpenGroups(new Set(defaultsRef.current));
+    }
   }, [activeGroup]);
 
   const resolvedActive = activeItem ?? activeGroup ?? null;
@@ -169,15 +214,23 @@ export function NavGroupProvider({
 
   const value = React.useMemo<NavContextValue>(
     () => ({
-      openGroup,
-      setOpenGroup,
+      openGroups,
+      toggleGroup,
+      openGroup: openGroupFn,
       hoveredItem,
       setHoveredItem,
       activeItem: resolvedActive,
       registerRef,
       containerRef,
     }),
-    [openGroup, setOpenGroup, hoveredItem, resolvedActive, registerRef],
+    [
+      openGroups,
+      toggleGroup,
+      openGroupFn,
+      hoveredItem,
+      resolvedActive,
+      registerRef,
+    ],
   );
 
   return (
@@ -208,32 +261,87 @@ export function NavGroupProvider({
 // Hook for registering item ref + hover handlers
 // ---------------------------------------------------------------------------
 
-const HOVER_INTENT_MS = 200;
+// Settle-based hover intent: only triggers when the mouse slows down
+// inside the centre vertical zone of the element, ignoring edge hovers
+// and fast drive-by movements.
+const SETTLE_INTERVAL_MS = 100;
+const SETTLE_THRESHOLD_PX = 4;
+const CENTER_ZONE = 0.3; // fraction of height from each edge to exclude
 
 function useNavItem(id: string) {
   const { registerRef, setHoveredItem } = React.useContext(NavGroupContext);
-  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const elRef = React.useRef<HTMLElement | null>(null);
   const ref = React.useCallback(
-    (el: HTMLElement | null) => registerRef(id, el),
+    (el: HTMLElement | null) => {
+      elRef.current = el;
+      registerRef(id, el);
+    },
     [id, registerRef],
   );
 
-  const onMouseEnter = React.useCallback(() => {
-    timerRef.current = setTimeout(() => setHoveredItem(id), HOVER_INTENT_MS);
-  }, [id, setHoveredItem]);
+  const stateRef = React.useRef({
+    intervalId: null as ReturnType<typeof setInterval> | null,
+    prevX: 0,
+    prevY: 0,
+    curX: 0,
+    curY: 0,
+  });
+
+  const onMouseMove = React.useCallback((e: React.MouseEvent) => {
+    stateRef.current.curX = e.clientX;
+    stateRef.current.curY = e.clientY;
+  }, []);
+
+  const onMouseEnter = React.useCallback(
+    (e: React.MouseEvent) => {
+      const s = stateRef.current;
+      s.prevX = e.clientX;
+      s.prevY = e.clientY;
+      s.curX = e.clientX;
+      s.curY = e.clientY;
+
+      if (s.intervalId) clearInterval(s.intervalId);
+      s.intervalId = setInterval(() => {
+        const dy = s.curY - s.prevY;
+        if (Math.abs(dy) < SETTLE_THRESHOLD_PX) {
+          // Check mouse is in centre vertical zone of the element
+          const el = elRef.current;
+          if (el) {
+            const rect = el.getBoundingClientRect();
+            const margin = rect.height * CENTER_ZONE;
+            if (s.curY < rect.top + margin || s.curY > rect.bottom - margin) {
+              s.prevY = s.curY;
+              return; // too close to edge — keep waiting
+            }
+          }
+          if (s.intervalId) clearInterval(s.intervalId);
+          s.intervalId = null;
+          setHoveredItem(id);
+        }
+        s.prevX = s.curX;
+        s.prevY = s.curY;
+      }, SETTLE_INTERVAL_MS);
+    },
+    [id, setHoveredItem],
+  );
 
   const onMouseLeave = React.useCallback(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
+    const s = stateRef.current;
+    if (s.intervalId) {
+      clearInterval(s.intervalId);
+      s.intervalId = null;
+    }
     setHoveredItem(null);
   }, [setHoveredItem]);
 
   React.useEffect(() => {
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      const s = stateRef.current;
+      if (s.intervalId) clearInterval(s.intervalId);
     };
   }, []);
 
-  return { ref, onMouseEnter, onMouseLeave };
+  return { ref, onMouseEnter, onMouseLeave, onMouseMove };
 }
 
 // ---------------------------------------------------------------------------
@@ -288,6 +396,7 @@ export function NavButton({
       ref={navItem.ref}
       onMouseEnter={navItem.onMouseEnter}
       onMouseLeave={navItem.onMouseLeave}
+      onMouseMove={navItem.onMouseMove}
     >
       <Link
         to={href ?? "#"}
@@ -301,21 +410,20 @@ export function NavButton({
             : "text-muted-foreground hover:text-foreground font-medium",
         )}
       >
-        {isLoading ? (
-          <Loader2 className="trans text-muted-foreground size-4 shrink-0 animate-spin" />
-        ) : (
-          Icon && (
-            <Icon
-              className={cn(
-                "trans size-4 shrink-0",
-                active ? "text-foreground" : "text-muted-foreground",
-              )}
-            />
-          )
+        {Icon && (
+          <Icon
+            className={cn(
+              "trans size-4 shrink-0",
+              active ? "text-foreground" : "text-muted-foreground",
+            )}
+          />
         )}
         <Type
           variant="small"
-          className="transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0"
+          className={cn(
+            "transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0",
+            isLoading && "nav-shimmer",
+          )}
         >
           {titleNode ?? title}
         </Type>
@@ -324,7 +432,8 @@ export function NavButton({
           <ReleaseStageBadge
             stage={stage}
             size="xs"
-            className="ml-auto group-data-[collapsible=icon]:hidden"
+            noTooltip
+            className="-my-1 origin-left scale-75 group-data-[collapsible=icon]:hidden"
           />
         )}
       </Link>
@@ -349,26 +458,25 @@ export function CollapsibleNavGroup({
   isActive: boolean;
   children: React.ReactNode;
 }) {
-  const { openGroup, setOpenGroup } = React.useContext(NavGroupContext);
+  const { openGroups, toggleGroup, openGroup } =
+    React.useContext(NavGroupContext);
   const navItem = useNavItem(label);
-  const isOpen = openGroup === label || (openGroup === null && isActive);
+  const isOpen = openGroups.has(label);
 
   const handleClick = () => {
     if (!isOpen) {
-      setOpenGroup(label);
+      openGroup(label);
     }
   };
 
   return (
-    <Collapsible
-      open={isOpen}
-      onOpenChange={() => setOpenGroup(isOpen ? null : label)}
-    >
+    <Collapsible open={isOpen} onOpenChange={() => toggleGroup(label)}>
       <SidebarMenuItem>
         <div
           ref={navItem.ref}
           onMouseEnter={navItem.onMouseEnter}
           onMouseLeave={navItem.onMouseLeave}
+          onMouseMove={navItem.onMouseMove}
         >
           <Link
             to={defaultHref ?? "#"}
@@ -396,7 +504,21 @@ export function CollapsibleNavGroup({
 
         <CollapsibleContent className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden">
           <div className="border-border mt-1 ml-4 border-l pl-2 group-data-[collapsible=icon]:hidden">
-            <ul className="flex flex-col gap-0.5 py-0.5">{children}</ul>
+            <motion.ul
+              className="flex flex-col gap-0.5 py-0.5"
+              initial="closed"
+              animate={isOpen ? "open" : "closed"}
+              variants={{
+                open: {
+                  transition: { staggerChildren: 0.04, delayChildren: 0.05 },
+                },
+                closed: {
+                  transition: { staggerChildren: 0.02, staggerDirection: -1 },
+                },
+              }}
+            >
+              {children}
+            </motion.ul>
           </div>
         </CollapsibleContent>
       </SidebarMenuItem>
@@ -416,16 +538,45 @@ export function CollapsibleNavItem({
   stage?: ReleaseStage;
 }) {
   const navItem = useNavItem(item.title);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleClick = () => {
+    setIsLoading(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(
+      () => setIsLoading(false),
+      NAV_LOADING_DURATION_MS,
+    );
+  };
 
   return (
-    <li data-sidebar="menu-item">
+    <motion.li
+      data-sidebar="menu-item"
+      variants={{
+        open: {
+          opacity: 1,
+          y: 0,
+          transition: { duration: 0.15, ease: [0.4, 0, 0.2, 1] },
+        },
+        closed: { opacity: 0, y: -4, transition: { duration: 0.1 } },
+      }}
+    >
       <div
         ref={navItem.ref}
         onMouseEnter={navItem.onMouseEnter}
         onMouseLeave={navItem.onMouseLeave}
+        onMouseMove={navItem.onMouseMove}
       >
         <Link
           to={item.href()}
+          onClick={handleClick}
           className={cn(
             "relative z-[1] flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:no-underline",
             item.active
@@ -433,17 +584,20 @@ export function CollapsibleNavItem({
               : "text-muted-foreground hover:text-foreground",
           )}
         >
-          <span className="truncate">{item.title}</span>
+          <span className={cn("truncate", isLoading && "nav-shimmer")}>
+            {item.title}
+          </span>
           {item.title === "Billing" && <ProductTierBadge />}
           {(stage ?? item.stage) && (
             <ReleaseStageBadge
               stage={(stage ?? item.stage)!}
               size="xs"
-              className="ml-auto"
+              noTooltip
+              className="-my-1 origin-left scale-75"
             />
           )}
         </Link>
       </div>
-    </li>
+    </motion.li>
   );
 }

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -193,9 +193,8 @@ export function NavGroupProvider({
               height: highlightRect.height,
             }}
             transition={{
-              type: "spring",
-              bounce: 0.15,
-              duration: 0.3,
+              duration: 0.25,
+              ease: [0.4, 0, 0.2, 1],
             }}
           />
         )}
@@ -209,7 +208,7 @@ export function NavGroupProvider({
 // Hook for registering item ref + hover handlers
 // ---------------------------------------------------------------------------
 
-const HOVER_INTENT_MS = 600;
+const HOVER_INTENT_MS = 200;
 
 function useNavItem(id: string) {
   const { registerRef, setHoveredItem } = React.useContext(NavGroupContext);
@@ -299,7 +298,7 @@ export function NavButton({
           "group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2!",
           active
             ? "text-foreground font-semibold"
-            : "text-muted-foreground font-medium",
+            : "text-muted-foreground hover:text-foreground font-medium",
         )}
       >
         {isLoading ? (
@@ -380,7 +379,7 @@ export function CollapsibleNavGroup({
               "cursor-pointer outline-hidden",
               isOpen
                 ? "text-foreground font-semibold"
-                : "text-muted-foreground font-medium",
+                : "text-muted-foreground hover:text-foreground font-medium",
             )}
           >
             <Icon
@@ -431,7 +430,7 @@ export function CollapsibleNavItem({
             "relative z-[1] flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:no-underline",
             item.active
               ? "text-foreground font-semibold"
-              : "text-muted-foreground",
+              : "text-muted-foreground hover:text-foreground",
           )}
         >
           <span className="truncate">{item.title}</span>

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -78,6 +78,8 @@ const NavGroupContext = React.createContext<NavContextValue>({
   containerRef: { current: null },
 });
 
+const ACCORDION_DURATION = 250;
+
 export function NavGroupProvider({
   activeGroup,
   defaultOpenGroups,
@@ -101,8 +103,6 @@ export function NavGroupProvider({
   const [highlightRect, setHighlightRect] =
     React.useState<HighlightRect | null>(null);
   const suppressUntilRef = React.useRef(0);
-
-  const ACCORDION_DURATION = 250;
 
   const toggleGroup = React.useCallback((group: string) => {
     suppressUntilRef.current = Date.now() + ACCORDION_DURATION;

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -1,11 +1,13 @@
-import { NavButton } from "@/components/nav-menu";
+import {
+  CollapsibleNavGroup,
+  CollapsibleNavItem,
+  NavButton,
+  NavGroupProvider,
+} from "@/components/nav-menu";
 import { RequireScope } from "@/components/require-scope";
 import {
   Sidebar,
   SidebarContent,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
@@ -17,12 +19,21 @@ import { Icon } from "@speakeasy-api/moonshine";
 import { ExternalLink } from "lucide-react";
 import * as React from "react";
 
-/**
- * Nav items use hasAnyScope — the link is enabled if the user holds ANY of the
- * provided scopes (view OR mutate). Fine-grained enforcement happens inside
- * each page via page-level and component-level RequireScope guards.
- */
 function ScopeGatedNavItem({
+  item,
+  scope,
+}: {
+  item: AppRoute;
+  scope: Scope | Scope[];
+}) {
+  return (
+    <RequireScope scope={scope} level="section">
+      <CollapsibleNavItem item={item} />
+    </RequireScope>
+  );
+}
+
+function ScopeGatedTopLevelItem({
   item,
   scope,
 }: {
@@ -58,35 +69,69 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       ? `https://app.speakeasy.com/org/${organization.slug}/${organization.userWorkspaceSlugs[0]}/settings/team`
       : "https://app.speakeasy.com";
 
+  const settingsActive = [
+    orgRoutes.billing,
+    orgRoutes.team,
+    orgRoutes.apiKeys,
+    orgRoutes.domains,
+    orgRoutes.logs,
+    orgRoutes.webhooks,
+    orgRoutes.adminSettings,
+  ].some((r) => r.active);
+
+  const secureActive = [
+    orgRoutes.auditLogs,
+    orgRoutes.identity,
+    orgRoutes.access,
+  ].some((r) => r.active);
+
+  const activeGroup = settingsActive
+    ? "Settings"
+    : secureActive
+      ? "Security"
+      : undefined;
+
+  const allOrgNavRoutes = [
+    orgRoutes.home,
+    orgRoutes.collections,
+    orgRoutes.billing,
+    orgRoutes.team,
+    orgRoutes.apiKeys,
+    orgRoutes.domains,
+    orgRoutes.logs,
+    orgRoutes.webhooks,
+    orgRoutes.adminSettings,
+    orgRoutes.auditLogs,
+    orgRoutes.identity,
+    orgRoutes.access,
+  ];
+  const activeRoute = allOrgNavRoutes.find((r) => r.active);
+  const activeItem = activeRoute?.title;
+
   return (
     <Sidebar collapsible="icon" {...props}>
-      <SidebarContent className="pt-2">
-        <SidebarGroup>
-          <SidebarGroupLabel>projects</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <ScopeGatedNavItem
-                item={orgRoutes.home}
-                scope={["org:read", "project:read", "org:admin"]}
-              />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>explore</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <ScopeGatedNavItem
-                item={orgRoutes.collections}
-                scope={["org:read", "org:admin"]}
-              />
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>settings</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
+      <SidebarContent className="pt-5">
+        <NavGroupProvider activeGroup={activeGroup} activeItem={activeItem}>
+          <SidebarMenu className="gap-1 px-2">
+            {/* Home — top-level */}
+            <ScopeGatedTopLevelItem
+              item={orgRoutes.home}
+              scope={["org:read", "project:read", "org:admin"]}
+            />
+
+            {/* Collections — top-level */}
+            <ScopeGatedTopLevelItem
+              item={orgRoutes.collections}
+              scope={["org:read", "org:admin"]}
+            />
+
+            {/* Settings group */}
+            <CollapsibleNavGroup
+              label="Settings"
+              Icon={(p) => <Icon {...p} name="settings" />}
+              defaultHref={orgRoutes.billing.href()}
+              isActive={settingsActive}
+            >
               <ScopeGatedNavItem
                 item={orgRoutes.billing}
                 scope={["org:read", "org:admin"]}
@@ -97,12 +142,12 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   scope={["org:read", "org:admin"]}
                 />
               ) : (
-                <SidebarMenuItem>
-                  <RequireScope
-                    scope={["org:read", "org:admin"]}
-                    level="component"
-                    className="w-full"
-                  >
+                <RequireScope
+                  scope={["org:read", "org:admin"]}
+                  level="component"
+                  className="w-full"
+                >
+                  <li data-sidebar="menu-item">
                     <NavButton
                       title="Team"
                       titleNode={
@@ -115,8 +160,8 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       target="_blank"
                       Icon={(props) => <Icon name="users-round" {...props} />}
                     />
-                  </RequireScope>
-                </SidebarMenuItem>
+                  </li>
+                </RequireScope>
               )}
               <ScopeGatedNavItem item={orgRoutes.apiKeys} scope="org:admin" />
               <ScopeGatedNavItem
@@ -131,23 +176,16 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={orgRoutes.webhooks}
                 scope={["org:read", "org:admin"]}
               />
-              {isAdmin && (
-                <SidebarMenuItem>
-                  <NavButton
-                    title={orgRoutes.adminSettings.title}
-                    href={orgRoutes.adminSettings.href()}
-                    active={orgRoutes.adminSettings.active}
-                    Icon={orgRoutes.adminSettings.Icon}
-                  />
-                </SidebarMenuItem>
-              )}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <SidebarGroup>
-          <SidebarGroupLabel>secure</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
+              {isAdmin && <CollapsibleNavItem item={orgRoutes.adminSettings} />}
+            </CollapsibleNavGroup>
+
+            {/* Secure group */}
+            <CollapsibleNavGroup
+              label="Security"
+              Icon={(p) => <Icon {...p} name="shield-check" />}
+              defaultHref={orgRoutes.auditLogs.href()}
+              isActive={secureActive}
+            >
               <ScopeGatedNavItem
                 item={orgRoutes.auditLogs}
                 scope={["org:read", "org:admin"]}
@@ -162,9 +200,9 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   scope={["org:read", "org:admin"]}
                 />
               )}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+            </CollapsibleNavGroup>
+          </SidebarMenu>
+        </NavGroupProvider>
       </SidebarContent>
     </Sidebar>
   );

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -11,12 +11,10 @@ import {
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { useIsAdmin, useOrganization } from "@/contexts/Auth";
-import { useTelemetry } from "@/contexts/Telemetry";
+import { useIsAdmin } from "@/contexts/Auth";
 import { Scope, useRBAC } from "@/hooks/useRBAC";
 import { AppRoute, useOrgRoutes } from "@/routes";
 import { Icon } from "@speakeasy-api/moonshine";
-import { ExternalLink } from "lucide-react";
 import * as React from "react";
 
 function ScopeGatedNavItem({
@@ -56,22 +54,11 @@ function ScopeGatedTopLevelItem({
 
 export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const orgRoutes = useOrgRoutes();
-  const organization = useOrganization();
   const isAdmin = useIsAdmin();
-  const telemetry = useTelemetry();
   const { isRbacEnabled } = useRBAC();
-  const isTeamPageEnabled =
-    telemetry.isFeatureEnabled("gram-team-page") ?? false;
-
-  const externalTeamUrl =
-    organization?.userWorkspaceSlugs &&
-    organization.userWorkspaceSlugs.length > 0
-      ? `https://app.speakeasy.com/org/${organization.slug}/${organization.userWorkspaceSlugs[0]}/settings/team`
-      : "https://app.speakeasy.com";
 
   const settingsActive = [
     orgRoutes.billing,
-    orgRoutes.team,
     orgRoutes.apiKeys,
     orgRoutes.domains,
     orgRoutes.logs,
@@ -94,8 +81,8 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const allOrgNavRoutes = [
     orgRoutes.home,
     orgRoutes.collections,
-    orgRoutes.billing,
     orgRoutes.team,
+    orgRoutes.billing,
     orgRoutes.apiKeys,
     orgRoutes.domains,
     orgRoutes.logs,
@@ -111,7 +98,11 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarContent className="pt-5">
-        <NavGroupProvider activeGroup={activeGroup} activeItem={activeItem}>
+        <NavGroupProvider
+          activeGroup={activeGroup}
+          defaultOpenGroups={["Settings", "Secure"]}
+          activeItem={activeItem}
+        >
           <SidebarMenu className="gap-1 px-2">
             {/* Home — top-level */}
             <ScopeGatedTopLevelItem
@@ -125,6 +116,12 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               scope={["org:read", "org:admin"]}
             />
 
+            {/* Team — top-level */}
+            <ScopeGatedTopLevelItem
+              item={orgRoutes.team}
+              scope={["org:read", "org:admin"]}
+            />
+
             {/* Settings group */}
             <CollapsibleNavGroup
               label="Settings"
@@ -135,33 +132,6 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={orgRoutes.billing}
                 scope={["org:read", "org:admin"]}
               />
-              {isTeamPageEnabled ? (
-                <ScopeGatedNavItem
-                  item={orgRoutes.team}
-                  scope={["org:read", "org:admin"]}
-                />
-              ) : (
-                <RequireScope
-                  scope={["org:read", "org:admin"]}
-                  level="component"
-                  className="w-full"
-                >
-                  <li data-sidebar="menu-item">
-                    <NavButton
-                      title="Team"
-                      titleNode={
-                        <span className="flex items-center gap-1.5">
-                          Team
-                          <ExternalLink className="text-muted-foreground h-3 w-3" />
-                        </span>
-                      }
-                      href={externalTeamUrl}
-                      target="_blank"
-                      Icon={(props) => <Icon name="users-round" {...props} />}
-                    />
-                  </li>
-                </RequireScope>
-              )}
               <ScopeGatedNavItem item={orgRoutes.apiKeys} scope="org:admin" />
               <ScopeGatedNavItem
                 item={orgRoutes.domains}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -88,7 +88,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const activeGroup = settingsActive
     ? "Settings"
     : secureActive
-      ? "Security"
+      ? "Secure"
       : undefined;
 
   const allOrgNavRoutes = [
@@ -181,7 +181,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
             {/* Secure group */}
             <CollapsibleNavGroup
-              label="Security"
+              label="Secure"
               Icon={(p) => <Icon {...p} name="shield-check" />}
               defaultHref={orgRoutes.auditLogs.href()}
               isActive={secureActive}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -130,7 +130,6 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               label="Settings"
               Icon={(p) => <Icon {...p} name="settings" />}
               defaultHref={orgRoutes.billing.href()}
-              isActive={settingsActive}
             >
               <ScopeGatedNavItem
                 item={orgRoutes.billing}
@@ -184,7 +183,6 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               label="Secure"
               Icon={(p) => <Icon {...p} name="shield-check" />}
               defaultHref={orgRoutes.auditLogs.href()}
-              isActive={secureActive}
             >
               <ScopeGatedNavItem
                 item={orgRoutes.auditLogs}

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -4,19 +4,11 @@ import { PageHeader } from "@/components/page-header";
 import {
   Sidebar,
   SidebarContent,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarInset,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
   SidebarProvider,
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Type } from "@/components/ui/type";
 import BookDemo from "@/pages/demo/BookDemo";
-import { Icon } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useIsAdminRef } from "@/contexts/Sdk";
@@ -264,28 +256,23 @@ export const ProjectProvider = ({
   );
 };
 
-/** Static nav items matching the real sidebar groups — no auth context needed. */
-const LOADING_NAV = {
-  project: [{ label: "Home", icon: "house" as const }],
-  connect: [
-    { label: "Sources", icon: "file-code" as const },
-    { label: "Catalog", icon: "store" as const },
-    { label: "Playground", icon: "message-circle" as const },
-  ],
-  build: [
-    { label: "Chat Elements", icon: "message-circle" as const },
-    { label: "MCP", icon: "network" as const },
-    { label: "Assistants", icon: "bot" as const },
-    { label: "Skills", icon: "terminal" as const },
-  ],
-  observe: [
-    { label: "Insights", icon: "layout-dashboard" as const },
-    { label: "MCP Logs", icon: "file-text" as const },
-    { label: "Agent Sessions", icon: "messages-square" as const },
-    { label: "Hooks", icon: "webhook" as const },
-  ],
-  settings: [{ label: "Settings", icon: "settings" as const }],
-};
+/** Skeleton nav group matching the new collapsible sidebar style. */
+const SkeletonNavItem = ({ width = "w-20" }: { width?: string }) => (
+  <div className="flex items-center gap-2 px-2 py-2">
+    <Skeleton className="h-4 w-4 shrink-0 rounded" />
+    <Skeleton className={`h-3.5 ${width}`} />
+  </div>
+);
+
+const SkeletonNavGroup = () => (
+  <div className="border-border mt-1 ml-4 border-l pl-2">
+    <div className="flex flex-col gap-0.5 py-0.5">
+      <Skeleton className="mx-2 my-1.5 h-3 w-16" />
+      <Skeleton className="mx-2 my-1.5 h-3 w-20" />
+      <Skeleton className="mx-2 my-1.5 h-3 w-14" />
+    </div>
+  </div>
+);
 
 /**
  * Lightweight shell that mirrors the real AppLayout structure,
@@ -317,29 +304,20 @@ const AppLoadingShell = () => (
       {/* Body */}
       <div className="flex w-full flex-1 overflow-hidden pt-2">
         <Sidebar collapsible="offcanvas" variant="inset">
-          <SidebarContent className="pt-2">
-            {Object.entries(LOADING_NAV).map(([group, items]) => (
-              <SidebarGroup key={group}>
-                <SidebarGroupLabel className="text-sidebar-foreground">
-                  {group}
-                </SidebarGroupLabel>
-                <SidebarGroupContent>
-                  <SidebarMenu>
-                    {items.map((item) => (
-                      <SidebarMenuItem key={item.label}>
-                        <SidebarMenuButton>
-                          <Icon
-                            name={item.icon}
-                            className="text-muted-foreground"
-                          />
-                          <Type variant="small">{item.label}</Type>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    ))}
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </SidebarGroup>
-            ))}
+          <SidebarContent className="pt-5">
+            <div className="flex flex-col gap-1 px-2">
+              {/* Home */}
+              <SkeletonNavItem width="w-16" />
+              {/* Connect group */}
+              <SkeletonNavItem width="w-20" />
+              <SkeletonNavGroup />
+              {/* Build group */}
+              <SkeletonNavItem width="w-14" />
+              {/* Observe group */}
+              <SkeletonNavItem width="w-20" />
+              {/* Security group */}
+              <SkeletonNavItem width="w-18" />
+            </div>
           </SidebarContent>
         </Sidebar>
         <SidebarInset>


### PR DESCRIPTION
## Summary

- Replaces flat `SidebarGroup`/`SidebarGroupLabel` nav with accordion-style collapsible groups (Connect, Build, Observe, Security) inspired by Polar's sidebar design
- Adds animated sliding highlight (`motion.div`) that follows hover with 600ms intent delay and snaps back to active item on mouse leave
- Group headers navigate to the group's default page on click (e.g., Connect → Sources)
- Only one group open at a time (accordion behavior) with suppress window to avoid jitter during expand/collapse animations
- Updates loading shell skeleton to match new nav layout
- Applied to both project sidebar (`app-sidebar.tsx`) and org sidebar (`org-sidebar.tsx`)

## Changes

- `nav-menu.tsx` — New `NavGroupProvider` (sliding highlight context), `CollapsibleNavGroup`, `CollapsibleNavItem`, updated `NavButton` with ref-based hover tracking
- `app-sidebar.tsx` — Rewired to use collapsible groups with scope-gated items
- `org-sidebar.tsx` — Same treatment for org-level nav (Settings, Security groups)
- `AuthProvider.tsx` — Replaced old `LOADING_NAV` with skeleton components matching new style

## Test plan

- [ ] Verify accordion behavior: opening one group closes others
- [ ] Verify sliding highlight follows hover after 600ms, snaps back on mouse leave
- [ ] Verify group header click navigates to default page
- [ ] Verify active item highlight persists on page refresh
- [ ] Verify collapsed sidebar (icon mode) still works
- [ ] Verify org sidebar groups (Settings, Security) work correctly
- [ ] Verify loading skeleton renders while auth is loading
- [ ] Verify RBAC scope gating still hides unauthorized items