### PR TITLE
chore(hk): source oxfmt excludes from .oxfmtrc.json to prevent drift

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -13,6 +13,7 @@
     "/client/sdk/**",
     "/elements/docs/**",
     "/elements/examples/tanstack-start/src/routeTree.gen.ts",
+    "/pnpm-lock.yaml",
     "/server/**/fixtures/**",
     "/server/gen/**",
     "/server/**/*_gen.yaml"

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,15 @@
 amends "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Builtins.pkl"
+import "pkl:json"
+
+// Source the oxfmt step's exclude list from `.oxfmtrc.json` so the two stay in sync.
+// Strip the leading `/` that .oxfmtrc.json uses for repo-root anchoring; hk globs are root-relative.
+local oxfmtIgnorePatterns: List<String> =
+  new json.Parser {}
+    .parse(read(".oxfmtrc.json"))
+    .getProperty("ignorePatterns")
+    .toList()
+    .map((p) -> let (s = p as String) if (s.startsWith("/")) s.substring(1, s.length) else s)
 
 local linters = new Mapping<String, Step> {
   ["pkleval"] = Builtins.pkl
@@ -48,14 +58,7 @@ local linters = new Mapping<String, Step> {
         "**/*.markdown.mdx",
         "**/*.md",
       )
-    exclude =
-      List(
-        ".speakeasy/**",
-        "server/gen/**",
-        "server/**/*_gen.yaml",
-        "client/sdk/**",
-        "pnpm-lock.yaml",
-      )
+    exclude = oxfmtIgnorePatterns
     check = "pnpm oxfmt --check {{files}}"
     fix = "pnpm oxfmt --write {{files}}"
   }


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2449/sync-hkpkl-oxfmt-step-with-oxfmtrcjson-ignorepatterns

The `hk` pre-commit hook globbed files for `oxfmt` independently of `.oxfmtrc.json`'s `ignorePatterns`. When a staged file matched `hk`'s glob but was ignored by `oxfmt` (e.g. `server/**/fixtures/**`), `oxfmt` received zero target files and exited with `Expected at least one target file`, failing the commit.

`hk.pkl` now parses `.oxfmtrc.json` and derives the `oxfmt` step's `exclude` list from `ignorePatterns` (stripping the leading `/` that anchors them to the repo root), so the two configs cannot diverge.

Also adds `/pnpm-lock.yaml` to `.oxfmtrc.json` — the only entry that was in `hk.pkl` excludes but not in `.oxfmtrc.json` — so `.oxfmtrc.json` is now the complete source of truth.