### PR TITLE
feat(remotemcp): MCP resource method interceptors for /x/mcp

### DIFF
--- a/.changeset/age-2078-xmcp-resource-method-interceptors.md
+++ b/.changeset/age-2078-xmcp-resource-method-interceptors.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+initial MCP resource method interceptors

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -182,6 +182,34 @@ type Proxy struct {
 	// originating request ID is seen. Responses to non-tools/list requests
 	// skip this loop entirely.
 	ToolsListResponseInterceptors []ToolsListResponseInterceptor
+
+	// ResourcesReadRequestInterceptors run for inbound "resources/read"
+	// JSON-RPC requests only, after the generic UserRequestInterceptors
+	// chain has completed. Non-resources/read requests skip this loop
+	// entirely.
+	ResourcesReadRequestInterceptors []ResourcesReadRequestInterceptor
+
+	// ResourcesReadResponseInterceptors run for "resources/read" JSON-RPC
+	// responses only, after the generic RemoteMessageInterceptors chain has
+	// completed. Dispatches from either the JSON response path or — for
+	// SSE responses — when a terminal response event matching the
+	// originating request ID is seen. Responses to non-resources/read
+	// requests skip this loop entirely.
+	ResourcesReadResponseInterceptors []ResourcesReadResponseInterceptor
+
+	// ResourcesListRequestInterceptors run for inbound "resources/list"
+	// JSON-RPC requests only, after the generic UserRequestInterceptors
+	// chain has completed. Non-resources/list requests skip this loop
+	// entirely.
+	ResourcesListRequestInterceptors []ResourcesListRequestInterceptor
+
+	// ResourcesListResponseInterceptors run for "resources/list" JSON-RPC
+	// responses only, after the generic RemoteMessageInterceptors chain has
+	// completed. Dispatches from either the JSON response path or — for
+	// SSE responses — when a terminal response event matching the
+	// originating request ID is seen. Responses to non-resources/list
+	// requests skip this loop entirely.
+	ResourcesListResponseInterceptors []ResourcesListResponseInterceptor
 }
 
 // Delete forwards an inbound DELETE to the remote MCP server. In MCP's
@@ -275,7 +303,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 	// the user's MCP runtime sees upstream's actual response instead of
 	// silently misparsing it as an SSE stream.
 	if isEventStream(upstreamResp.Header) {
-		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, nil, nil)
+		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, nil, nil, nil, nil)
 		responseBytes = n
 		if streamErr != nil {
 			return streamErr
@@ -371,6 +399,24 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		}
 	}
 
+	resourcesReadReq, _ := resourcesReadRequestFromUserRequest(userReq)
+	if resourcesReadReq != nil {
+		// Attach the resource URI to the parent Post span so the
+		// `gram.resource.uri` attribute on traces populates for /x/mcp
+		// resource reads, mirroring how tools/call sets `tool_name`.
+		span.SetAttributes(attr.ResourceURI(resourcesReadReq.Params.URI))
+		if err := p.runResourcesReadRequestInterceptors(ctx, resourcesReadReq); err != nil {
+			return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
+		}
+	}
+
+	resourcesListReq, _ := resourcesListRequestFromUserRequest(userReq)
+	if resourcesListReq != nil {
+		if err := p.runResourcesListRequestInterceptors(ctx, resourcesListReq); err != nil {
+			return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
+		}
+	}
+
 	// Materialize any typed-setter mutations (e.g. ToolsCallRequest.SetArguments)
 	// into the cached body bytes so the forwarder sends the mutated payload
 	// upstream. A no-op when no interceptor mutated the request.
@@ -400,7 +446,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	// below is bypassed entirely for SSE responses because the body is
 	// not a single message to hand off — it's a stream of them.
 	if isEventStream(upstreamResp.Header) {
-		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, toolsCallReq, toolsListReq)
+		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, toolsCallReq, toolsListReq, resourcesReadReq, resourcesListReq)
 		responseBytes = n
 		if streamErr != nil {
 			return streamErr
@@ -443,6 +489,22 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		if toolsListReq != nil {
 			if toolsListResp, ok := toolsListResponseFromRemoteMessage(toolsListReq, remoteMsg); ok {
 				if err := p.runToolsListResponseInterceptors(ctx, toolsListResp); err != nil {
+					return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
+				}
+			}
+		}
+
+		if resourcesReadReq != nil {
+			if resourcesReadResp, ok := resourcesReadResponseFromRemoteMessage(resourcesReadReq, remoteMsg); ok {
+				if err := p.runResourcesReadResponseInterceptors(ctx, resourcesReadResp); err != nil {
+					return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
+				}
+			}
+		}
+
+		if resourcesListReq != nil {
+			if resourcesListResp, ok := resourcesListResponseFromRemoteMessage(resourcesListReq, remoteMsg); ok {
+				if err := p.runResourcesListResponseInterceptors(ctx, resourcesListResp); err != nil {
 					return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
 				}
 			}
@@ -578,6 +640,8 @@ func (p *Proxy) relaySSEStream(
 	upstreamResp *http.Response,
 	toolsCallReq *ToolsCallRequest,
 	toolsListReq *ToolsListRequest,
+	resourcesReadReq *ResourcesReadRequest,
+	resourcesListReq *ResourcesListRequest,
 ) (int64, error) {
 	applyResponseHeaders(w, upstreamResp)
 	w.WriteHeader(upstreamResp.StatusCode)
@@ -595,7 +659,7 @@ func (p *Proxy) relaySSEStream(
 
 	// Extract the request ID of the originating typed request once, so we
 	// can match it against response events to detect the terminal event.
-	// At most one of toolsCallReq and toolsListReq is non-nil for a given
+	// At most one of the typed request views is non-nil for a given
 	// inbound POST.
 	var terminalID jsonrpc.ID
 	var haveTerminalID bool
@@ -607,6 +671,16 @@ func (p *Proxy) relaySSEStream(
 		}
 	case toolsListReq != nil && len(toolsListReq.UserRequest.JSONRPCMessages) == 1:
 		if rpcReq, ok := toolsListReq.UserRequest.JSONRPCMessages[0].(*jsonrpc.Request); ok {
+			terminalID = rpcReq.ID
+			haveTerminalID = true
+		}
+	case resourcesReadReq != nil && len(resourcesReadReq.UserRequest.JSONRPCMessages) == 1:
+		if rpcReq, ok := resourcesReadReq.UserRequest.JSONRPCMessages[0].(*jsonrpc.Request); ok {
+			terminalID = rpcReq.ID
+			haveTerminalID = true
+		}
+	case resourcesListReq != nil && len(resourcesListReq.UserRequest.JSONRPCMessages) == 1:
+		if rpcReq, ok := resourcesListReq.UserRequest.JSONRPCMessages[0].(*jsonrpc.Request); ok {
 			terminalID = rpcReq.ID
 			haveTerminalID = true
 		}
@@ -652,8 +726,8 @@ func (p *Proxy) relaySSEStream(
 			// Typed dispatch on terminal response events. Same rejection
 			// semantics as the generic chain — a typed rejection
 			// substitutes the same way. At most one of the typed
-			// dispatchers fires per event because at most one of
-			// toolsCallReq/toolsListReq is non-nil.
+			// dispatchers fires per event because at most one of the
+			// typed request views is non-nil.
 			if rejectionErr == nil && haveTerminalID {
 				if resp, ok := msg.(*jsonrpc.Response); ok && jsonrpcIDsEqual(resp.ID, terminalID) {
 					switch {
@@ -666,6 +740,18 @@ func (p *Proxy) relaySSEStream(
 					case toolsListReq != nil:
 						if typedResp, typedOK := toolsListResponseFromRemoteMessage(toolsListReq, remoteMsg); typedOK {
 							if err := p.runToolsListResponseInterceptors(ctx, typedResp); err != nil {
+								rejectionErr = err
+							}
+						}
+					case resourcesReadReq != nil:
+						if typedResp, typedOK := resourcesReadResponseFromRemoteMessage(resourcesReadReq, remoteMsg); typedOK {
+							if err := p.runResourcesReadResponseInterceptors(ctx, typedResp); err != nil {
+								rejectionErr = err
+							}
+						}
+					case resourcesListReq != nil:
+						if typedResp, typedOK := resourcesListResponseFromRemoteMessage(resourcesListReq, remoteMsg); typedOK {
+							if err := p.runResourcesListResponseInterceptors(ctx, typedResp); err != nil {
 								rejectionErr = err
 							}
 						}
@@ -870,6 +956,78 @@ func (p *Proxy) runToolsListResponseInterceptors(ctx context.Context, list *Tool
 			span.RecordError(err, trace.WithStackTrace(true))
 			span.End()
 			return p.wrapInterceptorRejection(iterCtx, "tools/list response", interceptor.Name(), err)
+		}
+		span.End()
+	}
+	return nil
+}
+
+// runResourcesReadRequestInterceptors invokes each configured
+// ResourcesReadRequestInterceptor in order, returning the first wrapped
+// rejection error or nil if all interceptors accept the request.
+func (p *Proxy) runResourcesReadRequestInterceptors(ctx context.Context, read *ResourcesReadRequest) error {
+	for _, interceptor := range p.ResourcesReadRequestInterceptors {
+		iterCtx, span := p.Tracer.Start(ctx, "remotemcp.proxy.ResourcesReadRequestInterceptor",
+			trace.WithAttributes(attr.RemoteMCPProxyInterceptor(interceptor.Name())))
+		if err := interceptor.InterceptResourcesReadRequest(iterCtx, read); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.End()
+			return p.wrapInterceptorRejection(iterCtx, "resources/read request", interceptor.Name(), err)
+		}
+		span.End()
+	}
+	return nil
+}
+
+// runResourcesReadResponseInterceptors invokes each configured
+// ResourcesReadResponseInterceptor in order, returning the first wrapped
+// rejection error or nil if all interceptors accept the response.
+func (p *Proxy) runResourcesReadResponseInterceptors(ctx context.Context, read *ResourcesReadResponse) error {
+	for _, interceptor := range p.ResourcesReadResponseInterceptors {
+		iterCtx, span := p.Tracer.Start(ctx, "remotemcp.proxy.ResourcesReadResponseInterceptor",
+			trace.WithAttributes(attr.RemoteMCPProxyInterceptor(interceptor.Name())))
+		if err := interceptor.InterceptResourcesReadResponse(iterCtx, read); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.End()
+			return p.wrapInterceptorRejection(iterCtx, "resources/read response", interceptor.Name(), err)
+		}
+		span.End()
+	}
+	return nil
+}
+
+// runResourcesListRequestInterceptors invokes each configured
+// ResourcesListRequestInterceptor in order, returning the first wrapped
+// rejection error or nil if all interceptors accept the request.
+func (p *Proxy) runResourcesListRequestInterceptors(ctx context.Context, list *ResourcesListRequest) error {
+	for _, interceptor := range p.ResourcesListRequestInterceptors {
+		iterCtx, span := p.Tracer.Start(ctx, "remotemcp.proxy.ResourcesListRequestInterceptor",
+			trace.WithAttributes(attr.RemoteMCPProxyInterceptor(interceptor.Name())))
+		if err := interceptor.InterceptResourcesListRequest(iterCtx, list); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.End()
+			return p.wrapInterceptorRejection(iterCtx, "resources/list request", interceptor.Name(), err)
+		}
+		span.End()
+	}
+	return nil
+}
+
+// runResourcesListResponseInterceptors invokes each configured
+// ResourcesListResponseInterceptor in order, returning the first wrapped
+// rejection error or nil if all interceptors accept the response.
+func (p *Proxy) runResourcesListResponseInterceptors(ctx context.Context, list *ResourcesListResponse) error {
+	for _, interceptor := range p.ResourcesListResponseInterceptors {
+		iterCtx, span := p.Tracer.Start(ctx, "remotemcp.proxy.ResourcesListResponseInterceptor",
+			trace.WithAttributes(attr.RemoteMCPProxyInterceptor(interceptor.Name())))
+		if err := interceptor.InterceptResourcesListResponse(iterCtx, list); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err, trace.WithStackTrace(true))
+			span.End()
+			return p.wrapInterceptorRejection(iterCtx, "resources/list response", interceptor.Name(), err)
 		}
 		span.End()
 	}

--- a/server/internal/remotemcp/proxy/resources_list_request.go
+++ b/server/internal/remotemcp/proxy/resources_list_request.go
@@ -1,0 +1,67 @@
+package proxy
+
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// methodResourcesList is the MCP JSON-RPC method for resource discovery. The
+// official SDK keeps this constant unexported (mcp.methodListResources), so
+// we repeat it here rather than depend on the SDK's internal name.
+const methodResourcesList = "resources/list"
+
+// ResourcesListRequest is a "resources/list"-specific view over a UserRequest.
+// Instances are constructed by the proxy and passed to each
+// [ResourcesListRequestInterceptor] after the generic UserRequestInterceptor
+// chain has run.
+type ResourcesListRequest struct {
+	// Params is the decoded resources/list params. Per the MCP spec, params
+	// may be omitted entirely for resources/list; in that case Params is a
+	// zero-valued [mcp.ListResourcesParams].
+	Params *mcp.ListResourcesParams
+
+	// UserRequest is the underlying request. Other interceptors in the generic
+	// chain may already have observed it. Callers should prefer Params for
+	// resources/list-specific data; UserRequest is exposed for RPC-level needs
+	// (JSON-RPC ID, raw messages) and for forwarding control via the
+	// underlying HTTP request.
+	UserRequest *UserRequest
+}
+
+// resourcesListRequestFromUserRequest returns a ResourcesListRequest if req
+// carries exactly one JSON-RPC "resources/list" request whose params decode
+// cleanly. Anything else — notifications, responses, multiple messages,
+// unrelated methods, malformed params — returns ok=false so the typed
+// interceptor loop is skipped. Decoding failures do not abort the proxy; the
+// request is forwarded to upstream unchanged so upstream's own validation
+// surfaces.
+//
+// Per MCP spec, resources/list params are optional, so a missing or empty
+// params payload yields a zero-valued [mcp.ListResourcesParams] rather than a
+// decode failure.
+func resourcesListRequestFromUserRequest(req *UserRequest) (*ResourcesListRequest, bool) {
+	if req == nil || len(req.JSONRPCMessages) != 1 {
+		return nil, false
+	}
+	rpcReq, ok := req.JSONRPCMessages[0].(*jsonrpc.Request)
+	if !ok {
+		return nil, false
+	}
+	if rpcReq.Method != methodResourcesList {
+		return nil, false
+	}
+
+	params := &mcp.ListResourcesParams{
+		Cursor: "",
+		Meta:   nil,
+	}
+	if len(rpcReq.Params) > 0 {
+		if err := json.Unmarshal(rpcReq.Params, params); err != nil {
+			return nil, false
+		}
+	}
+
+	return &ResourcesListRequest{UserRequest: req, Params: params}, true
+}

--- a/server/internal/remotemcp/proxy/resources_list_request_interceptor.go
+++ b/server/internal/remotemcp/proxy/resources_list_request_interceptor.go
@@ -1,0 +1,35 @@
+package proxy
+
+import "context"
+
+// ResourcesListRequestInterceptor runs for each inbound "resources/list"
+// JSON-RPC request after the generic [UserRequestInterceptor] chain has
+// completed and before the request is forwarded to the remote MCP server.
+//
+// The current contract is inspection and rejection: implementations may
+// observe list and return a non-nil error to reject the resource discovery
+// request. Rejection produces a JSON-RPC error envelope back to the user
+// with the originating resources/list request id. Returning a [*RejectError]
+// lets the interceptor pick the JSON-RPC error code, message, and data;
+// returning a plain error falls back to a generic mapping (see
+// [RejectErrorFromCause]).
+//
+// Payload mutation has no typed setter on this view today — changes to
+// list.UserRequest or list.Params are silent no-ops and the request body
+// is forwarded verbatim. Typed setters will be introduced when a concrete
+// consumer needs to rewrite resources/list request payloads.
+//
+// Non-"resources/list" requests are not routed to this interface; implement
+// [UserRequestInterceptor] for RPC-agnostic hooks.
+type ResourcesListRequestInterceptor interface {
+	// InterceptResourcesListRequest is called with the parsed resources/list
+	// request. Implementations may inspect list and should return a non-nil
+	// error to reject the discovery request; the interceptor's error is
+	// surfaced to the user and the request is not forwarded to the remote
+	// server.
+	InterceptResourcesListRequest(ctx context.Context, list *ResourcesListRequest) error
+
+	// Name returns a stable identifier for this interceptor, used for tracing
+	// span attributes and log correlation.
+	Name() string
+}

--- a/server/internal/remotemcp/proxy/resources_list_request_interceptor_test.go
+++ b/server/internal/remotemcp/proxy/resources_list_request_interceptor_test.go
@@ -1,0 +1,34 @@
+package proxy_test
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+// mockResourcesListRequestInterceptor is a [proxy.ResourcesListRequestInterceptor]
+// used in tests to capture invocation order and optionally inject an error.
+type mockResourcesListRequestInterceptor struct {
+	name   string
+	called *int
+	order  *[]string
+	err    error
+	// lastCall captures the request observed on the most recent invocation,
+	// so tests can assert the proxy threaded the decoded params through.
+	lastCall **proxy.ResourcesListRequest
+}
+
+func (m *mockResourcesListRequestInterceptor) Name() string { return m.name }
+
+func (m *mockResourcesListRequestInterceptor) InterceptResourcesListRequest(_ context.Context, list *proxy.ResourcesListRequest) error {
+	if m.called != nil {
+		*m.called++
+	}
+	if m.order != nil {
+		*m.order = append(*m.order, m.name)
+	}
+	if m.lastCall != nil {
+		*m.lastCall = list
+	}
+	return m.err
+}

--- a/server/internal/remotemcp/proxy/resources_list_response.go
+++ b/server/internal/remotemcp/proxy/resources_list_response.go
@@ -1,0 +1,139 @@
+package proxy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ResourcesListResponse is a "resources/list"-specific view over the remote
+// message carrying the response. Instances are constructed by the proxy and
+// passed to each [ResourcesListResponseInterceptor] after the generic
+// [RemoteMessageInterceptor] chain has run.
+type ResourcesListResponse struct {
+	// Error is the JSON-RPC protocol error when upstream returned an error
+	// response (e.g. "method not found"). Mutually exclusive with Result.
+	Error *jsonrpc.Error
+
+	// RemoteMessage is the underlying remote message. Other interceptors in the
+	// generic chain may have observed it already.
+	RemoteMessage *RemoteMessage
+
+	// Request is the resources/list request this response is replying to.
+	// Available so interceptors can correlate input and output without
+	// re-parsing.
+	Request *ResourcesListRequest
+
+	// Result is the decoded resources/list result when upstream returned a
+	// JSON-RPC success response. Mutually exclusive with Error — exactly one
+	// of Result and Error is non-nil.
+	Result *mcp.ListResourcesResult
+}
+
+// resourcesListResponseFromRemoteMessage returns a ResourcesListResponse view
+// over msg if msg carries a JSON-RPC response whose payload decodes cleanly
+// as either a [mcp.ListResourcesResult] or a [jsonrpc.Error]. Anything else
+// returns ok=false so the typed interceptor loop is skipped. Decoding
+// failures do not abort the proxy; the response is relayed to the user
+// unchanged.
+//
+// Used by both the buffered JSON path and the SSE-terminal path. In both
+// cases msg.Message is already a *jsonrpc.Response decoded from the wire;
+// the helper just re-decodes its payload as a resources/list shape.
+func resourcesListResponseFromRemoteMessage(request *ResourcesListRequest, msg *RemoteMessage) (*ResourcesListResponse, bool) {
+	if request == nil || msg == nil {
+		return nil, false
+	}
+	rpcResp, ok := msg.Message.(*jsonrpc.Response)
+	if !ok {
+		return nil, false
+	}
+
+	resp := &ResourcesListResponse{
+		Error:         nil,
+		RemoteMessage: msg,
+		Request:       request,
+		Result:        nil,
+	}
+
+	if rpcResp.Error != nil {
+		var wireErr *jsonrpc.Error
+		if !errors.As(rpcResp.Error, &wireErr) {
+			return nil, false
+		}
+		resp.Error = wireErr
+		return resp, true
+	}
+
+	result := &mcp.ListResourcesResult{
+		Meta:       nil,
+		NextCursor: "",
+		Resources:  nil,
+	}
+	if err := json.Unmarshal(rpcResp.Result, result); err != nil {
+		return nil, false
+	}
+	resp.Result = result
+	return resp, true
+}
+
+// SetResources replaces the resources array on a successful resources/list
+// response, marking the underlying remote message dirty so the proxy
+// re-emits the mutated payload to the user. Use this for filter and inject
+// patterns: dropping resources that the caller is not authorized to see,
+// rewriting URIs, or replacing the array wholesale.
+//
+// A nil resources argument is normalized to an empty slice so the wire shape
+// stays spec-compliant — MCP resources/list responses carry a JSON array,
+// never null. Use an explicit empty slice or nil interchangeably when a
+// filter removes every entry.
+//
+// The replacement is observed by every subsequent interceptor in the same
+// chain through the shared *Result pointer — no re-read of wire bytes is
+// required. The outer jsonrpc.Message is re-encoded once after the chain
+// completes (see [RemoteMessage.materializedBytes]); this method does the
+// inner payload swap up front so the dirty signal alone is sufficient to
+// trigger that re-encode. Marshal happens before any typed-view or
+// underlying-message state is touched so a marshal failure leaves
+// everything at its pre-call values — the typed view and the wire
+// remain in sync regardless of the failure mode.
+//
+// Returns a [*MutationError] when the response carries a JSON-RPC Error
+// rather than a Result (mutually exclusive per the typed-view contract),
+// when marshaling the mutated ListResourcesResult fails, or when the
+// underlying jsonrpc.Message is not a *jsonrpc.Response. The proxy detects
+// [*MutationError] at the interceptor return path and surfaces it as an
+// HTTP 5xx via [oops.E] with [oops.CodeUnexpected] rather than as a
+// user-facing JSON-RPC rejection.
+func (r *ResourcesListResponse) SetResources(resources []*mcp.Resource) error {
+	if r.Result == nil {
+		return &MutationError{Op: "set resources", Cause: errors.New("response carries an error, not a result")}
+	}
+	rpcResp, ok := r.RemoteMessage.Message.(*jsonrpc.Response)
+	if !ok {
+		return &MutationError{Op: "set resources", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Response", r.RemoteMessage.Message)}
+	}
+
+	if resources == nil {
+		resources = []*mcp.Resource{}
+	}
+
+	// Stage the mutation against a temporary copy of Result so a marshal
+	// failure can't leave the typed view's Resources desynced from the
+	// underlying wire bytes. Only commit (assign to Result.Resources,
+	// rpcResp.Result, dirty) once marshaling has succeeded.
+	staged := *r.Result
+	staged.Resources = resources
+	payload, err := json.Marshal(&staged)
+	if err != nil {
+		return &MutationError{Op: "set resources", Cause: fmt.Errorf("marshal mutated ListResourcesResult: %w", err)}
+	}
+
+	r.Result.Resources = resources
+	rpcResp.Result = payload
+	r.RemoteMessage.dirty = true
+	return nil
+}

--- a/server/internal/remotemcp/proxy/resources_list_response_interceptor.go
+++ b/server/internal/remotemcp/proxy/resources_list_response_interceptor.go
@@ -1,0 +1,40 @@
+package proxy
+
+import "context"
+
+// ResourcesListResponseInterceptor runs for each "resources/list" JSON-RPC
+// response returned by the remote MCP server, after the generic
+// [RemoteMessageInterceptor] chain has completed and before the response is
+// relayed to the user.
+//
+// The current contract is inspection and rejection: implementations may
+// observe list and return a non-nil error to reject the response.
+// Rejection produces a JSON-RPC error envelope back to the user with the
+// originating resources/list request id — on the JSON path as the response
+// body, on the SSE path as a substitute event in place of the rejected
+// terminal event. Returning a [*RejectError] lets the interceptor pick
+// the JSON-RPC error code, message, and data; returning a plain error
+// falls back to a generic mapping (see [RejectErrorFromCause]).
+//
+// Payload mutation is available via [ResourcesListResponse.SetResources],
+// which rewrites the resources array before the response is relayed to the
+// user. Mutations are observed by every subsequent interceptor in the same
+// chain through the shared *Result pointer. Direct mutation of list.Result
+// fields without going through the setter is a silent no-op against the
+// wire — the framework only re-marshals the response when a typed setter
+// flips the dirty flag. If a downstream interceptor rejects, prior
+// mutations in the chain are discarded; the rejection envelope wins.
+//
+// Responses to non-"resources/list" requests are not routed to this
+// interface; implement [RemoteMessageInterceptor] for RPC-agnostic hooks.
+type ResourcesListResponseInterceptor interface {
+	// InterceptResourcesListResponse is called with the parsed resources/list
+	// response. Implementations may inspect list and should return a
+	// non-nil error to reject the response; the interceptor's error is
+	// surfaced to the user instead of the upstream payload.
+	InterceptResourcesListResponse(ctx context.Context, list *ResourcesListResponse) error
+
+	// Name returns a stable identifier for this interceptor, used for tracing
+	// span attributes and log correlation.
+	Name() string
+}

--- a/server/internal/remotemcp/proxy/resources_list_response_interceptor_test.go
+++ b/server/internal/remotemcp/proxy/resources_list_response_interceptor_test.go
@@ -1,0 +1,66 @@
+package proxy_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+// mockResourcesListResponseInterceptor is a [proxy.ResourcesListResponseInterceptor]
+// used in tests to capture invocation order and optionally inject an error.
+type mockResourcesListResponseInterceptor struct {
+	name   string
+	called *int
+	order  *[]string
+	err    error
+	// lastCall captures the response observed on the most recent invocation,
+	// so tests can assert the proxy threaded the decoded result/error
+	// through.
+	lastCall **proxy.ResourcesListResponse
+}
+
+func (m *mockResourcesListResponseInterceptor) Name() string { return m.name }
+
+func (m *mockResourcesListResponseInterceptor) InterceptResourcesListResponse(_ context.Context, list *proxy.ResourcesListResponse) error {
+	if m.called != nil {
+		*m.called++
+	}
+	if m.order != nil {
+		*m.order = append(*m.order, m.name)
+	}
+	if m.lastCall != nil {
+		*m.lastCall = list
+	}
+	return m.err
+}
+
+// mutatingResourcesListResponseInterceptor is a
+// [proxy.ResourcesListResponseInterceptor] that calls
+// [proxy.ResourcesListResponse.SetResources] with the result of
+// resourcesFn(currentResources). When err is non-nil, the interceptor
+// returns it AFTER mutating — used by tests covering the
+// "mutate-then-reject" composition.
+type mutatingResourcesListResponseInterceptor struct {
+	name        string
+	resourcesFn func([]*mcp.Resource) []*mcp.Resource
+	err         error
+}
+
+func (m *mutatingResourcesListResponseInterceptor) Name() string { return m.name }
+
+func (m *mutatingResourcesListResponseInterceptor) InterceptResourcesListResponse(_ context.Context, list *proxy.ResourcesListResponse) error {
+	if m.resourcesFn != nil {
+		var current []*mcp.Resource
+		if list.Result != nil {
+			current = list.Result.Resources
+		}
+		newResources := m.resourcesFn(current)
+		if err := list.SetResources(newResources); err != nil {
+			return fmt.Errorf("mutating interceptor %s: %w", m.name, err)
+		}
+	}
+	return m.err
+}

--- a/server/internal/remotemcp/proxy/resources_read_request.go
+++ b/server/internal/remotemcp/proxy/resources_read_request.go
@@ -1,0 +1,62 @@
+package proxy
+
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// methodResourcesRead is the MCP JSON-RPC method for resource reads. The
+// official SDK keeps this constant unexported (mcp.methodReadResource), so we
+// repeat it here rather than depend on the SDK's internal name.
+const methodResourcesRead = "resources/read"
+
+// ResourcesReadRequest is a "resources/read"-specific view over a UserRequest.
+// Instances are constructed by the proxy and passed to each
+// [ResourcesReadRequestInterceptor] after the generic UserRequestInterceptor
+// chain has run.
+type ResourcesReadRequest struct {
+	// Params is the decoded resources/read params. URI is the only
+	// spec-defined field and is required; per-protocol validation lives
+	// upstream so a malformed payload that nonetheless decodes here is still
+	// forwarded.
+	Params *mcp.ReadResourceParams
+
+	// UserRequest is the underlying request. Other interceptors in the generic
+	// chain may already have observed it. Callers should prefer Params for
+	// resources/read-specific data; UserRequest is exposed for RPC-level needs
+	// (JSON-RPC ID, raw messages) and for forwarding control via the
+	// underlying HTTP request.
+	UserRequest *UserRequest
+}
+
+// resourcesReadRequestFromUserRequest returns a ResourcesReadRequest if req
+// carries exactly one JSON-RPC "resources/read" request whose params decode
+// cleanly. Anything else — notifications, responses, multiple messages,
+// unrelated methods, malformed params — returns ok=false so the typed
+// interceptor loop is skipped. Decoding failures do not abort the proxy; the
+// request is forwarded to upstream unchanged so upstream's own validation
+// surfaces.
+func resourcesReadRequestFromUserRequest(req *UserRequest) (*ResourcesReadRequest, bool) {
+	if req == nil || len(req.JSONRPCMessages) != 1 {
+		return nil, false
+	}
+	rpcReq, ok := req.JSONRPCMessages[0].(*jsonrpc.Request)
+	if !ok {
+		return nil, false
+	}
+	if rpcReq.Method != methodResourcesRead {
+		return nil, false
+	}
+
+	params := &mcp.ReadResourceParams{
+		Meta: nil,
+		URI:  "",
+	}
+	if err := json.Unmarshal(rpcReq.Params, params); err != nil {
+		return nil, false
+	}
+
+	return &ResourcesReadRequest{UserRequest: req, Params: params}, true
+}

--- a/server/internal/remotemcp/proxy/resources_read_request_interceptor.go
+++ b/server/internal/remotemcp/proxy/resources_read_request_interceptor.go
@@ -1,0 +1,34 @@
+package proxy
+
+import "context"
+
+// ResourcesReadRequestInterceptor runs for each inbound "resources/read"
+// JSON-RPC request after the generic [UserRequestInterceptor] chain has
+// completed and before the request is forwarded to the remote MCP server.
+//
+// The current contract is inspection and rejection: implementations may
+// observe read and return a non-nil error to reject the resource read.
+// Rejection produces a JSON-RPC error envelope back to the user with the
+// originating resources/read request id. Returning a [*RejectError] lets the
+// interceptor pick the JSON-RPC error code, message, and data; returning
+// a plain error falls back to a generic mapping (see
+// [RejectErrorFromCause]).
+//
+// Payload mutation has no typed setter on this view today — changes to
+// read.UserRequest or read.Params are silent no-ops and the request body is
+// forwarded verbatim. Typed setters will be introduced when a concrete
+// consumer needs to rewrite resources/read request payloads.
+//
+// Non-"resources/read" requests are not routed to this interface; implement
+// [UserRequestInterceptor] for RPC-agnostic hooks.
+type ResourcesReadRequestInterceptor interface {
+	// InterceptResourcesReadRequest is called with the parsed resources/read
+	// request. Implementations may inspect read and should return a non-nil
+	// error to reject the resource read; the interceptor's error is surfaced
+	// to the user and the request is not forwarded to the remote server.
+	InterceptResourcesReadRequest(ctx context.Context, read *ResourcesReadRequest) error
+
+	// Name returns a stable identifier for this interceptor, used for tracing
+	// span attributes and log correlation.
+	Name() string
+}

--- a/server/internal/remotemcp/proxy/resources_read_request_interceptor_test.go
+++ b/server/internal/remotemcp/proxy/resources_read_request_interceptor_test.go
@@ -1,0 +1,34 @@
+package proxy_test
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+// mockResourcesReadRequestInterceptor is a [proxy.ResourcesReadRequestInterceptor]
+// used in tests to capture invocation order and optionally inject an error.
+type mockResourcesReadRequestInterceptor struct {
+	name   string
+	called *int
+	order  *[]string
+	err    error
+	// lastCall captures the request observed on the most recent invocation,
+	// so tests can assert the proxy threaded the decoded params through.
+	lastCall **proxy.ResourcesReadRequest
+}
+
+func (m *mockResourcesReadRequestInterceptor) Name() string { return m.name }
+
+func (m *mockResourcesReadRequestInterceptor) InterceptResourcesReadRequest(_ context.Context, read *proxy.ResourcesReadRequest) error {
+	if m.called != nil {
+		*m.called++
+	}
+	if m.order != nil {
+		*m.order = append(*m.order, m.name)
+	}
+	if m.lastCall != nil {
+		*m.lastCall = read
+	}
+	return m.err
+}

--- a/server/internal/remotemcp/proxy/resources_read_response.go
+++ b/server/internal/remotemcp/proxy/resources_read_response.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ResourcesReadResponse is a "resources/read"-specific view over the remote
+// message carrying the response. Instances are constructed by the proxy and
+// passed to each [ResourcesReadResponseInterceptor] after the generic
+// [RemoteMessageInterceptor] chain has run.
+type ResourcesReadResponse struct {
+	// Error is the JSON-RPC protocol error when upstream returned an error
+	// response (e.g. "resource not found", "method not found"). Mutually
+	// exclusive with Result.
+	Error *jsonrpc.Error
+
+	// RemoteMessage is the underlying remote message. Other interceptors in the
+	// generic chain may have observed it already.
+	RemoteMessage *RemoteMessage
+
+	// Request is the resources/read request this response is replying to.
+	// Available so interceptors can correlate input and output without
+	// re-parsing.
+	Request *ResourcesReadRequest
+
+	// Result is the decoded resources/read result when upstream returned a
+	// JSON-RPC success response. Mutually exclusive with Error — exactly one
+	// of Result and Error is non-nil.
+	Result *mcp.ReadResourceResult
+}
+
+// resourcesReadResponseFromRemoteMessage returns a ResourcesReadResponse view
+// over msg if msg carries a JSON-RPC response whose payload decodes cleanly
+// as either a [mcp.ReadResourceResult] or a [jsonrpc.Error]. Anything else
+// returns ok=false so the typed interceptor loop is skipped. Decoding
+// failures do not abort the proxy; the response is relayed to the user
+// unchanged.
+//
+// Used by both the buffered JSON path and the SSE-terminal path. In both
+// cases msg.Message is already a *jsonrpc.Response decoded from the wire;
+// the helper just re-decodes its payload as a resources/read shape.
+func resourcesReadResponseFromRemoteMessage(request *ResourcesReadRequest, msg *RemoteMessage) (*ResourcesReadResponse, bool) {
+	if request == nil || msg == nil {
+		return nil, false
+	}
+	rpcResp, ok := msg.Message.(*jsonrpc.Response)
+	if !ok {
+		return nil, false
+	}
+
+	resp := &ResourcesReadResponse{
+		Error:         nil,
+		RemoteMessage: msg,
+		Request:       request,
+		Result:        nil,
+	}
+
+	if rpcResp.Error != nil {
+		var wireErr *jsonrpc.Error
+		if !errors.As(rpcResp.Error, &wireErr) {
+			return nil, false
+		}
+		resp.Error = wireErr
+		return resp, true
+	}
+
+	result := &mcp.ReadResourceResult{
+		Meta:     nil,
+		Contents: nil,
+	}
+	if err := json.Unmarshal(rpcResp.Result, result); err != nil {
+		return nil, false
+	}
+	resp.Result = result
+	return resp, true
+}

--- a/server/internal/remotemcp/proxy/resources_read_response_interceptor.go
+++ b/server/internal/remotemcp/proxy/resources_read_response_interceptor.go
@@ -1,0 +1,37 @@
+package proxy
+
+import "context"
+
+// ResourcesReadResponseInterceptor runs for each "resources/read" JSON-RPC
+// response returned by the remote MCP server, after the generic
+// [RemoteMessageInterceptor] chain has completed and before the response is
+// relayed to the user.
+//
+// The current contract is inspection and rejection: implementations may
+// observe read and return a non-nil error to reject the response.
+// Rejection produces a JSON-RPC error envelope back to the user with the
+// originating resources/read request id — on the JSON path as the response
+// body, on the SSE path as a substitute event in place of the rejected
+// terminal event. Returning a [*RejectError] lets the interceptor pick
+// the JSON-RPC error code, message, and data; returning a plain error
+// falls back to a generic mapping (see [RejectErrorFromCause]).
+//
+// Payload mutation has no typed setter on this view today — changes to
+// read.Request, read.Result, or read.Error are silent no-ops and the
+// response body is relayed verbatim. Typed setters will be introduced
+// when a concrete consumer needs to rewrite resources/read response
+// payloads.
+//
+// Responses to non-"resources/read" requests are not routed to this
+// interface; implement [RemoteMessageInterceptor] for RPC-agnostic hooks.
+type ResourcesReadResponseInterceptor interface {
+	// InterceptResourcesReadResponse is called with the parsed resources/read
+	// response. Implementations may inspect read and should return a non-nil
+	// error to reject the response; the interceptor's error is surfaced to
+	// the user instead of the upstream payload.
+	InterceptResourcesReadResponse(ctx context.Context, read *ResourcesReadResponse) error
+
+	// Name returns a stable identifier for this interceptor, used for tracing
+	// span attributes and log correlation.
+	Name() string
+}

--- a/server/internal/remotemcp/proxy/resources_read_response_interceptor_test.go
+++ b/server/internal/remotemcp/proxy/resources_read_response_interceptor_test.go
@@ -1,0 +1,35 @@
+package proxy_test
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+// mockResourcesReadResponseInterceptor is a [proxy.ResourcesReadResponseInterceptor]
+// used in tests to capture invocation order and optionally inject an error.
+type mockResourcesReadResponseInterceptor struct {
+	name   string
+	called *int
+	order  *[]string
+	err    error
+	// lastCall captures the response observed on the most recent invocation,
+	// so tests can assert the proxy threaded the decoded result/error
+	// through.
+	lastCall **proxy.ResourcesReadResponse
+}
+
+func (m *mockResourcesReadResponseInterceptor) Name() string { return m.name }
+
+func (m *mockResourcesReadResponseInterceptor) InterceptResourcesReadResponse(_ context.Context, read *proxy.ResourcesReadResponse) error {
+	if m.called != nil {
+		*m.called++
+	}
+	if m.order != nil {
+		*m.order = append(*m.order, m.name)
+	}
+	if m.lastCall != nil {
+		*m.lastCall = read
+	}
+	return m.err
+}

--- a/server/internal/remotemcp/proxy/resources_test.go
+++ b/server/internal/remotemcp/proxy/resources_test.go
@@ -1,0 +1,308 @@
+package proxy_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+const (
+	resourcesReadRequest    = `{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"file:///etc/hosts"}}`
+	resourcesReadResponse   = `{"jsonrpc":"2.0","id":3,"result":{"contents":[{"uri":"file:///etc/hosts","text":"127.0.0.1 localhost"}]}}`
+	resourcesListRequest    = `{"jsonrpc":"2.0","id":4,"method":"resources/list","params":{}}`
+	resourcesListThreeItems = `{
+        "jsonrpc":"2.0",
+        "id":4,
+        "result":{
+            "resources":[
+                {"name":"a","uri":"file:///a"},
+                {"name":"b","uri":"file:///b"},
+                {"name":"c","uri":"file:///c"}
+            ]
+        }
+    }`
+)
+
+func TestProxy_Post_ResourcesReadRequestInterceptor_RunsForResourcesRead(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resourcesReadResponse))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var observed *proxy.ResourcesReadRequest
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesReadRequestInterceptors = []proxy.ResourcesReadRequestInterceptor{
+		&mockResourcesReadRequestInterceptor{name: "typed", lastCall: &observed},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesReadRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.NotNil(t, observed, "typed request interceptor must be invoked for resources/read")
+	require.NotNil(t, observed.Params)
+	require.Equal(t, "file:///etc/hosts", observed.Params.URI)
+}
+
+func TestProxy_Post_ResourcesReadRequestInterceptor_SkipsForNonResourcesRead(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var called int
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesReadRequestInterceptors = []proxy.ResourcesReadRequestInterceptor{
+		&mockResourcesReadRequestInterceptor{name: "typed", called: &called},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Zero(t, called, "typed resources/read interceptor must not run for initialize")
+}
+
+func TestProxy_Post_ResourcesReadRequestInterceptor_RejectionWritesJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called when a typed interceptor rejects resources/read")
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesReadRequestInterceptors = []proxy.ResourcesReadRequestInterceptor{
+		&mockResourcesReadRequestInterceptor{name: "typed", err: &proxy.RejectError{Code: proxy.RejectCodeServerError, Message: "policy violation", Data: nil}},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesReadRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"id":3`, "envelope must preserve the originating resources/read request id")
+	require.Contains(t, rr.Body.String(), `"code":-32000`, "RejectError code must propagate to the envelope")
+	require.Contains(t, rr.Body.String(), "policy violation")
+}
+
+func TestProxy_Post_ResourcesReadResponseInterceptor_RunsForSuccessResult(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resourcesReadResponse))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var observed *proxy.ResourcesReadResponse
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesReadResponseInterceptors = []proxy.ResourcesReadResponseInterceptor{
+		&mockResourcesReadResponseInterceptor{name: "typed", lastCall: &observed},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesReadRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.NotNil(t, observed, "typed response interceptor must run on resources/read response")
+	require.NotNil(t, observed.Result)
+	require.Len(t, observed.Result.Contents, 1)
+	require.Equal(t, "file:///etc/hosts", observed.Result.Contents[0].URI)
+}
+
+func TestProxy_Post_ResourcesListRequestInterceptor_RunsForResourcesList(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resourcesListThreeItems))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var observed *proxy.ResourcesListRequest
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesListRequestInterceptors = []proxy.ResourcesListRequestInterceptor{
+		&mockResourcesListRequestInterceptor{name: "typed", lastCall: &observed},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesListRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.NotNil(t, observed, "typed request interceptor must be invoked for resources/list")
+}
+
+func TestProxy_Post_ResourcesListResponseInterceptor_RunsForSuccessResult(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resourcesListThreeItems))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var observed *proxy.ResourcesListResponse
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesListResponseInterceptors = []proxy.ResourcesListResponseInterceptor{
+		&mockResourcesListResponseInterceptor{name: "typed", lastCall: &observed},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesListRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.NotNil(t, observed)
+	require.NotNil(t, observed.Result)
+	require.Len(t, observed.Result.Resources, 3)
+}
+
+func TestProxy_Post_ResourcesListResponse_SetResources_RewritesRelayedBody(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, resourcesListThreeItems)
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesListResponseInterceptors = []proxy.ResourcesListResponseInterceptor{
+		&mutatingResourcesListResponseInterceptor{
+			name: "keep-only-a",
+			resourcesFn: func(resources []*mcp.Resource) []*mcp.Resource {
+				kept := resources[:0]
+				for _, r := range resources {
+					if r.URI == "file:///a" {
+						kept = append(kept, r)
+					}
+				}
+				return kept
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesListRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	out := rr.Body.String()
+	require.Contains(t, out, `"file:///a"`, "kept resource must reach the client")
+	require.NotContains(t, out, `"file:///b"`, "filtered resource must not reach the client")
+	require.NotContains(t, out, `"file:///c"`, "filtered resource must not reach the client")
+	require.Contains(t, out, `"id":4`, "response id must survive re-encoding")
+}
+
+func TestProxy_Post_ResourcesListResponse_SetResources_EmptyArrayWhenAllFiltered(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, resourcesListThreeItems)
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesListResponseInterceptors = []proxy.ResourcesListResponseInterceptor{
+		&mutatingResourcesListResponseInterceptor{
+			name: "drop-all",
+			resourcesFn: func(_ []*mcp.Resource) []*mcp.Resource {
+				return nil
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesListRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	out := rr.Body.String()
+	require.Contains(t, out, `"resources":[]`, "nil resources must serialize as empty array, not null")
+}
+
+func TestProxy_Post_SSEResponse_TerminalEventDispatchesTypedResourcesReadInterceptor(t *testing.T) {
+	t.Parallel()
+
+	body := sseBody(
+		`{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"p","progress":0.5}}`,
+		resourcesReadResponse,
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(upstream.Close)
+
+	var observedTerminal *proxy.ResourcesReadResponse
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesReadResponseInterceptors = []proxy.ResourcesReadResponseInterceptor{
+		&mockResourcesReadResponseInterceptor{name: "typed", lastCall: &observedTerminal},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesReadRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.NotNil(t, observedTerminal, "typed resources/read response interceptor must fire on terminal SSE event")
+	require.NotNil(t, observedTerminal.Result)
+	require.Len(t, observedTerminal.Result.Contents, 1)
+}
+
+func TestProxy_Post_SSEResponse_TerminalEventDispatchesTypedResourcesListInterceptor(t *testing.T) {
+	t.Parallel()
+
+	body := sseBody(
+		`{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"p","progress":0.5}}`,
+		strings.ReplaceAll(resourcesListThreeItems, "\n", ""),
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(upstream.Close)
+
+	var observedTerminal *proxy.ResourcesListResponse
+	p := newProxyForTest(t, upstream.URL)
+	p.ResourcesListResponseInterceptors = []proxy.ResourcesListResponseInterceptor{
+		&mockResourcesListResponseInterceptor{name: "typed", lastCall: &observedTerminal},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(resourcesListRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+
+	require.NotNil(t, observedTerminal, "typed resources/list response interceptor must fire on terminal SSE event")
+	require.NotNil(t, observedTerminal.Result)
+	require.Len(t, observedTerminal.Result.Resources, 3)
+}

--- a/server/internal/xmcp/handler.go
+++ b/server/internal/xmcp/handler.go
@@ -386,6 +386,11 @@ func (s *Service) buildProxy(logger *slog.Logger, server *remotemcprepo.RemoteMc
 		NewToolsListShadowMCPInjectInterceptor(s.shadowmcpClient, serverID, projectID, logger),
 	)
 
+	// Resources request chain: free-tier ToolCalls usage limits apply to
+	// resources/read invocations alongside tools/call. Per-resource RBAC
+	// and the resources/list RBAC filter are deferred to a follow-up —
+	// the proxy interceptor surface is in place so they can attach later
+	// without touching the proxy package again.
 	return &proxy.Proxy{
 		GuardianPolicy:          s.guardianPolicy,
 		Logger:                  logger,
@@ -412,5 +417,13 @@ func (s *Service) buildProxy(logger *slog.Logger, server *remotemcprepo.RemoteMc
 			NewToolsListPostHogEventInterceptor(s.posthog, serverID, logger),
 		},
 		ToolsListResponseInterceptors: toolsListRespInterceptors,
+		ResourcesReadRequestInterceptors: []proxy.ResourcesReadRequestInterceptor{
+			s.resourcesReadUsageLimitsInterceptor,
+		},
+		ResourcesReadResponseInterceptors: []proxy.ResourcesReadResponseInterceptor{
+			s.resourcesReadUsageTrackingInterceptor,
+		},
+		ResourcesListRequestInterceptors:  nil,
+		ResourcesListResponseInterceptors: nil,
 	}
 }

--- a/server/internal/xmcp/resources_read_usage_limits_interceptor.go
+++ b/server/internal/xmcp/resources_read_usage_limits_interceptor.go
@@ -1,0 +1,92 @@
+package xmcp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+// ResourcesReadUsageLimitsInterceptor enforces the free-tier hard cap on
+// resources/read invocations by consulting the billing repository's cached
+// period usage. It mirrors [ToolsCallUsageLimitsInterceptor] — resource reads
+// are metered alongside tool calls in the same `ToolCalls` counter, so the
+// same cap applies. It is a [proxy.ResourcesReadRequestInterceptor]: it runs
+// after the generic user-request chain and before the request is forwarded
+// upstream. Non-free tiers and orgs with an active subscription skip the
+// check.
+//
+// The interceptor intentionally fails open when cached usage is unavailable
+// (the billing cache should always be warm, but a transient miss must not
+// take down resource reads). Failures are logged with the originating org ID
+// so operators can spot them in dashboards.
+type ResourcesReadUsageLimitsInterceptor struct {
+	billing billing.Repository
+	logger  *slog.Logger
+}
+
+var _ proxy.ResourcesReadRequestInterceptor = (*ResourcesReadUsageLimitsInterceptor)(nil)
+
+// NewResourcesReadUsageLimitsInterceptor constructs an interceptor bound to the
+// given billing repository. The same instance can be reused across requests.
+func NewResourcesReadUsageLimitsInterceptor(billingRepo billing.Repository, logger *slog.Logger) *ResourcesReadUsageLimitsInterceptor {
+	return &ResourcesReadUsageLimitsInterceptor{
+		billing: billingRepo,
+		logger:  logger,
+	}
+}
+
+// Name implements [proxy.ResourcesReadRequestInterceptor].
+func (i *ResourcesReadUsageLimitsInterceptor) Name() string {
+	return "resources-read-usage-limits"
+}
+
+// InterceptResourcesReadRequest implements [proxy.ResourcesReadRequestInterceptor].
+// It reads the organization and account type from the request's auth
+// context, consults cached billing usage, and returns a forbidden error when
+// the org has exceeded its hard cap. The cap shared with tools/call is
+// intentional — resource reads are accounted to the same `ToolCalls`
+// counter — so a free-tier org that has exhausted its quota on tool calls
+// is also blocked from resource reads, and vice versa.
+func (i *ResourcesReadUsageLimitsInterceptor) InterceptResourcesReadRequest(ctx context.Context, _ *proxy.ResourcesReadRequest) error {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil {
+		// No auth context means the runtime handler did not install one —
+		// fail open rather than guess at an identity to rate-limit against.
+		return nil
+	}
+
+	if authCtx.AccountType != string(billing.TierBase) {
+		return nil
+	}
+
+	// Hot-path: only read cached usage. A miss here is treated as a
+	// best-effort skip so billing cache issues never break resource reads.
+	periodUsage, err := i.billing.GetStoredPeriodUsage(ctx, authCtx.ActiveOrganizationID)
+	if err != nil {
+		i.logger.ErrorContext(ctx, "failed to get stored period usage",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+		return nil
+	}
+
+	if periodUsage == nil || periodUsage.HasActiveSubscription {
+		return nil
+	}
+
+	hardToolCallsLimit := 2 * periodUsage.IncludedToolCalls
+	if hardToolCallsLimit == 0 {
+		hardToolCallsLimit = defaultHardToolCallsLimit
+	}
+
+	if periodUsage.ToolCalls >= hardToolCallsLimit {
+		return oops.E(oops.CodeForbidden, errors.New("tool usage limit reached"), "tool usage limit reached").Log(ctx, i.logger, attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
+	}
+
+	return nil
+}

--- a/server/internal/xmcp/resources_read_usage_limits_interceptor_test.go
+++ b/server/internal/xmcp/resources_read_usage_limits_interceptor_test.go
@@ -1,0 +1,183 @@
+package xmcp_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/usage"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/xmcp"
+)
+
+func newResourcesReadRequestForInterceptor(t *testing.T, ctx context.Context) *proxy.ResourcesReadRequest {
+	t.Helper()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "/", http.NoBody)
+	require.NoError(t, err)
+
+	return &proxy.ResourcesReadRequest{
+		UserRequest: &proxy.UserRequest{
+			UserHTTPRequest: httpReq,
+			JSONRPCMessages: nil,
+		},
+		Params: nil,
+	}
+}
+
+func TestResourcesReadUsageLimitsInterceptor_Name(t *testing.T) {
+	t.Parallel()
+
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(&fakeBillingRepo{storedUsage: nil, storedErr: nil}, testenv.NewLogger(t))
+	require.Equal(t, "resources-read-usage-limits", interceptor.Name())
+}
+
+func TestResourcesReadUsageLimitsInterceptor_NoAuthContextPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	// Billing repo deliberately left without behavior: the interceptor must
+	// not reach it when auth context is missing.
+	repo := &fakeBillingRepo{storedUsage: nil, storedErr: errors.New("must not be called")}
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(repo, testenv.NewLogger(t))
+
+	ctx := t.Context()
+	read := newResourcesReadRequestForInterceptor(t, ctx)
+
+	require.NoError(t, interceptor.InterceptResourcesReadRequest(ctx, read))
+}
+
+func TestResourcesReadUsageLimitsInterceptor_NonBaseTierPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeBillingRepo{storedUsage: nil, storedErr: errors.New("must not be called")}
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(repo, testenv.NewLogger(t))
+
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-pro",
+		AccountType:          string(billing.TierPro),
+	})
+	read := newResourcesReadRequestForInterceptor(t, ctx)
+
+	require.NoError(t, interceptor.InterceptResourcesReadRequest(ctx, read))
+}
+
+func TestResourcesReadUsageLimitsInterceptor_BillingErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	// Billing cache miss must not take down resource reads — the interceptor
+	// logs and continues.
+	repo := &fakeBillingRepo{storedUsage: nil, storedErr: errors.New("cache miss")}
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(repo, testenv.NewLogger(t))
+
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-free",
+		AccountType:          string(billing.TierBase),
+	})
+	read := newResourcesReadRequestForInterceptor(t, ctx)
+
+	require.NoError(t, interceptor.InterceptResourcesReadRequest(ctx, read))
+}
+
+func TestResourcesReadUsageLimitsInterceptor_ActiveSubscriptionPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeBillingRepo{
+		storedUsage: &usage.PeriodUsage{
+			HasActiveSubscription: true,
+			ToolCalls:             999_999,
+			IncludedToolCalls:     0,
+		},
+		storedErr: nil,
+	}
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(repo, testenv.NewLogger(t))
+
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-free-with-sub",
+		AccountType:          string(billing.TierBase),
+	})
+	read := newResourcesReadRequestForInterceptor(t, ctx)
+
+	require.NoError(t, interceptor.InterceptResourcesReadRequest(ctx, read))
+}
+
+func TestResourcesReadUsageLimitsInterceptor_UnderHardLimitPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeBillingRepo{
+		storedUsage: &usage.PeriodUsage{
+			ToolCalls:             199,
+			IncludedToolCalls:     100,
+			HasActiveSubscription: false,
+		},
+		storedErr: nil,
+	}
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(repo, testenv.NewLogger(t))
+
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-free",
+		AccountType:          string(billing.TierBase),
+	})
+	read := newResourcesReadRequestForInterceptor(t, ctx)
+
+	require.NoError(t, interceptor.InterceptResourcesReadRequest(ctx, read))
+}
+
+func TestResourcesReadUsageLimitsInterceptor_AtOrOverHardLimitRejects(t *testing.T) {
+	t.Parallel()
+
+	// Resource reads share the same hard cap counter as tool calls.
+	repo := &fakeBillingRepo{
+		storedUsage: &usage.PeriodUsage{
+			ToolCalls:             200,
+			IncludedToolCalls:     100,
+			HasActiveSubscription: false,
+		},
+		storedErr: nil,
+	}
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(repo, testenv.NewLogger(t))
+
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-free",
+		AccountType:          string(billing.TierBase),
+	})
+	read := newResourcesReadRequestForInterceptor(t, ctx)
+
+	err := interceptor.InterceptResourcesReadRequest(ctx, read)
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestResourcesReadUsageLimitsInterceptor_ZeroIncludedUsesDefaultLimit(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeBillingRepo{
+		storedUsage: &usage.PeriodUsage{
+			ToolCalls:             2000,
+			IncludedToolCalls:     0,
+			HasActiveSubscription: false,
+		},
+		storedErr: nil,
+	}
+	interceptor := xmcp.NewResourcesReadUsageLimitsInterceptor(repo, testenv.NewLogger(t))
+
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-free",
+		AccountType:          string(billing.TierBase),
+	})
+	read := newResourcesReadRequestForInterceptor(t, ctx)
+
+	err := interceptor.InterceptResourcesReadRequest(ctx, read)
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}

--- a/server/internal/xmcp/resources_read_usage_tracking_interceptor.go
+++ b/server/internal/xmcp/resources_read_usage_tracking_interceptor.go
@@ -1,0 +1,124 @@
+package xmcp
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+// ResourcesReadUsageTrackingInterceptor emits a [billing.ToolCallUsageEvent]
+// for each resources/read response so Remote MCP Server resource reads feed
+// the same Polar meter that gates free-tier usage on the existing /mcp
+// endpoint. It mirrors [ToolsCallUsageTrackingInterceptor] — resources/read
+// is accounted to the same `ToolCalls` counter as tools/call, with the
+// resource URI carried on the `ResourceURI` field so downstream consumers
+// can distinguish the two. It is a [proxy.ResourcesReadResponseInterceptor]:
+// it runs after the generic [proxy.RemoteMessageInterceptor] chain has
+// accepted the response and before the payload is relayed to the user.
+//
+// Tracking is fire-and-forget: events are emitted in a goroutine bound to a
+// context derived via [context.WithoutCancel] so the call completes even if
+// the inbound request context cancels mid-relay. Missing auth context is
+// treated as a no-op and logged so operators can spot misconfiguration
+// without taking down resource reads.
+type ResourcesReadUsageTrackingInterceptor struct {
+	tracker billing.Tracker
+	logger  *slog.Logger
+}
+
+var _ proxy.ResourcesReadResponseInterceptor = (*ResourcesReadUsageTrackingInterceptor)(nil)
+
+// NewResourcesReadUsageTrackingInterceptor constructs an interceptor bound to
+// the given billing tracker. The same instance can be reused across requests.
+func NewResourcesReadUsageTrackingInterceptor(tracker billing.Tracker, logger *slog.Logger) *ResourcesReadUsageTrackingInterceptor {
+	return &ResourcesReadUsageTrackingInterceptor{
+		tracker: tracker,
+		logger:  logger,
+	}
+}
+
+// Name implements [proxy.ResourcesReadResponseInterceptor].
+func (i *ResourcesReadUsageTrackingInterceptor) Name() string {
+	return "resources-read-usage-tracking"
+}
+
+// InterceptResourcesReadResponse implements [proxy.ResourcesReadResponseInterceptor].
+// It emits a billing event for every observed resources/read response — paid
+// tiers included — so Polar metering matches the existing /mcp surface.
+// Always returns nil: tracking is best-effort and must not block the response
+// from reaching the user.
+//
+// The event populates `ResourceURI` from the originating request params and
+// leaves `ToolName` empty — the resource definition's display name is only
+// available after a prior resources/list response is correlated through a
+// per-session cache, which lives outside the proxy today.
+func (i *ResourcesReadUsageTrackingInterceptor) InterceptResourcesReadResponse(ctx context.Context, read *proxy.ResourcesReadResponse) error {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		i.logger.WarnContext(ctx, "skipping resource read usage tracking: missing auth context",
+			attr.SlogComponent("xmcp"))
+		return nil
+	}
+
+	resourceURI := read.Request.Params.URI
+
+	// Defensive: the proxy's typed-view constructor enforces a single
+	// JSON-RPC request, but this interceptor is publicly constructible —
+	// guard the index access so a caller handing us an empty slice gets a
+	// zero RequestBytes instead of a panic.
+	var requestBytes int64
+	if msgs := read.Request.UserRequest.JSONRPCMessages; len(msgs) > 0 {
+		if rpcReq, ok := msgs[0].(*jsonrpc.Request); ok {
+			requestBytes = int64(len(rpcReq.Params))
+		}
+	}
+
+	var outputBytes int64
+	if rpcResp, ok := read.RemoteMessage.Message.(*jsonrpc.Response); ok {
+		outputBytes = int64(len(rpcResp.Result))
+	}
+
+	var statusCode int
+	if read.RemoteMessage.RemoteHTTPResponse != nil {
+		statusCode = read.RemoteMessage.RemoteHTTPResponse.StatusCode
+	}
+
+	var sessionID *string
+	if read.RemoteMessage.UserHTTPRequest != nil {
+		sessionID = conv.PtrEmpty(read.RemoteMessage.UserHTTPRequest.Header.Get("Mcp-Session-Id"))
+	}
+
+	projectID := authCtx.ProjectID.String()
+	event := billing.ToolCallUsageEvent{
+		OrganizationID:        authCtx.ActiveOrganizationID,
+		RequestBytes:          requestBytes,
+		OutputBytes:           outputBytes,
+		ToolURN:               "",
+		ToolName:              "",
+		ResourceURI:           resourceURI,
+		ProjectID:             projectID,
+		ProjectSlug:           authCtx.ProjectSlug,
+		OrganizationSlug:      conv.PtrEmpty(authCtx.OrganizationSlug),
+		ToolsetSlug:           nil,
+		ChatID:                nil,
+		MCPURL:                nil,
+		Type:                  billing.ToolCallTypeExternalMCP,
+		ResponseStatusCode:    statusCode,
+		ToolsetID:             nil,
+		MCPSessionID:          sessionID,
+		FunctionCPUUsage:      nil,
+		FunctionMemUsage:      nil,
+		FunctionExecutionTime: nil,
+	}
+
+	go i.tracker.TrackToolCallUsage(context.WithoutCancel(ctx), event)
+
+	return nil
+}

--- a/server/internal/xmcp/resources_read_usage_tracking_interceptor_test.go
+++ b/server/internal/xmcp/resources_read_usage_tracking_interceptor_test.go
@@ -1,0 +1,170 @@
+package xmcp_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/xmcp"
+)
+
+func newResourcesReadResponseForInterceptor(t *testing.T, sessionID string, resourceURI string) *proxy.ResourcesReadResponse {
+	t.Helper()
+
+	rpcReq, err := jsonrpc.DecodeMessage([]byte(`{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"` + resourceURI + `"}}`))
+	require.NoError(t, err)
+	req, ok := rpcReq.(*jsonrpc.Request)
+	require.True(t, ok)
+
+	rpcResp, err := jsonrpc.DecodeMessage([]byte(`{"jsonrpc":"2.0","id":1,"result":{"contents":[{"uri":"` + resourceURI + `","text":"hello"}]}}`))
+	require.NoError(t, err)
+	resp, ok := rpcResp.(*jsonrpc.Response)
+	require.True(t, ok)
+
+	httpReq, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/server-id", http.NoBody)
+	require.NoError(t, err)
+	if sessionID != "" {
+		httpReq.Header.Set("Mcp-Session-Id", sessionID)
+	}
+
+	return &proxy.ResourcesReadResponse{
+		Error: nil,
+		RemoteMessage: &proxy.RemoteMessage{
+			UserHTTPRequest:    httpReq,
+			RemoteHTTPRequest:  nil,
+			RemoteHTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			Message:            resp,
+		},
+		Request: &proxy.ResourcesReadRequest{
+			UserRequest: &proxy.UserRequest{
+				UserHTTPRequest: httpReq,
+				JSONRPCMessages: []jsonrpc.Message{req},
+			},
+			Params: &mcp.ReadResourceParams{
+				Meta: nil,
+				URI:  resourceURI,
+			},
+		},
+		Result: &mcp.ReadResourceResult{
+			Meta:     nil,
+			Contents: nil,
+		},
+	}
+}
+
+func TestResourcesReadUsageTrackingInterceptor_Name(t *testing.T) {
+	t.Parallel()
+
+	interceptor := xmcp.NewResourcesReadUsageTrackingInterceptor(newFakeBillingTracker(), testenv.NewLogger(t))
+	require.Equal(t, "resources-read-usage-tracking", interceptor.Name())
+}
+
+func TestResourcesReadUsageTrackingInterceptor_NoAuthContextSkips(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeBillingTracker()
+	interceptor := xmcp.NewResourcesReadUsageTrackingInterceptor(tracker, testenv.NewLogger(t))
+
+	read := newResourcesReadResponseForInterceptor(t, "", "file:///etc/hosts")
+
+	require.NoError(t, interceptor.InterceptResourcesReadResponse(t.Context(), read))
+
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	require.Empty(t, tracker.events, "missing auth context must short-circuit before tracking")
+}
+
+func TestResourcesReadUsageTrackingInterceptor_EmitsEventForBaseTier(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeBillingTracker()
+	interceptor := xmcp.NewResourcesReadUsageTrackingInterceptor(tracker, testenv.NewLogger(t))
+
+	projectID := uuid.New()
+	projectSlug := "demo-project"
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-free",
+		AccountType:          string(billing.TierBase),
+		OrganizationSlug:     "demo-org",
+		ProjectID:            &projectID,
+		ProjectSlug:          &projectSlug,
+	})
+
+	read := newResourcesReadResponseForInterceptor(t, "session-abc", "file:///etc/hosts")
+
+	require.NoError(t, interceptor.InterceptResourcesReadResponse(ctx, read))
+
+	event := tracker.waitForEvent(t)
+	require.Equal(t, "org-free", event.OrganizationID)
+	require.Empty(t, event.ToolName, "ToolName is empty for resource reads — only ResourceURI is meaningful")
+	require.Equal(t, "file:///etc/hosts", event.ResourceURI)
+	require.Equal(t, projectID.String(), event.ProjectID)
+	require.NotNil(t, event.ProjectSlug)
+	require.Equal(t, projectSlug, *event.ProjectSlug)
+	require.NotNil(t, event.OrganizationSlug)
+	require.Equal(t, "demo-org", *event.OrganizationSlug)
+	require.Equal(t, billing.ToolCallTypeExternalMCP, event.Type)
+	require.Equal(t, http.StatusOK, event.ResponseStatusCode)
+	require.NotNil(t, event.MCPSessionID)
+	require.Equal(t, "session-abc", *event.MCPSessionID)
+	require.Positive(t, event.RequestBytes)
+	require.Positive(t, event.OutputBytes)
+}
+
+func TestResourcesReadUsageTrackingInterceptor_EmitsEventForPaidTier(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeBillingTracker()
+	interceptor := xmcp.NewResourcesReadUsageTrackingInterceptor(tracker, testenv.NewLogger(t))
+
+	projectID := uuid.New()
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-pro",
+		AccountType:          string(billing.TierPro),
+		ProjectID:            &projectID,
+	})
+
+	read := newResourcesReadResponseForInterceptor(t, "", "https://example.com/data")
+
+	require.NoError(t, interceptor.InterceptResourcesReadResponse(ctx, read))
+
+	event := tracker.waitForEvent(t)
+	require.Equal(t, "org-pro", event.OrganizationID)
+	require.Equal(t, "https://example.com/data", event.ResourceURI)
+	require.Equal(t, billing.ToolCallTypeExternalMCP, event.Type)
+	require.Nil(t, event.MCPSessionID, "absent Mcp-Session-Id header must not produce an empty-string pointer")
+}
+
+func TestResourcesReadUsageTrackingInterceptor_EmptyJSONRPCMessagesDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeBillingTracker()
+	interceptor := xmcp.NewResourcesReadUsageTrackingInterceptor(tracker, testenv.NewLogger(t))
+
+	projectID := uuid.New()
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-pro",
+		AccountType:          string(billing.TierPro),
+		ProjectID:            &projectID,
+	})
+
+	// The proxy's typed-view constructor never produces an empty
+	// JSONRPCMessages slice, but the interceptor is publicly constructible
+	// — assert it tolerates the edge case rather than panicking on [0].
+	read := newResourcesReadResponseForInterceptor(t, "", "file:///etc/hosts")
+	read.Request.UserRequest.JSONRPCMessages = nil
+
+	require.NoError(t, interceptor.InterceptResourcesReadResponse(ctx, read))
+
+	event := tracker.waitForEvent(t)
+	require.Zero(t, event.RequestBytes, "missing JSON-RPC request must zero RequestBytes, not panic")
+	require.Equal(t, "file:///etc/hosts", event.ResourceURI)
+}

--- a/server/internal/xmcp/service.go
+++ b/server/internal/xmcp/service.go
@@ -47,22 +47,24 @@ const RuntimePath = "/x/mcp/{slug}"
 
 // Service owns dependencies for the experimental MCP runtime endpoint.
 type Service struct {
-	logger                            *slog.Logger
-	tracer                            trace.Tracer
-	db                                *pgxpool.Pool
-	enc                               *encryption.Client
-	authz                             *authz.Engine
-	shadowmcpClient                   *shadowmcp.Client
-	mcpService                        *mcp.Service
-	serverURL                         *url.URL
-	guardianPolicy                    *guardian.Policy
-	posthog                           *posthog.Posthog
-	telemLogger                       *tm.Logger
-	proxyMetrics                      *proxy.Metrics
-	xmcpMetrics                       *metrics
-	toolsCallUsageLimitsInterceptor   *ToolsCallUsageLimitsInterceptor
-	toolsCallUsageTrackingInterceptor *ToolsCallUsageTrackingInterceptor
-	initializePostHogEventInterceptor *InitializePostHogEventInterceptor
+	logger                                *slog.Logger
+	tracer                                trace.Tracer
+	db                                    *pgxpool.Pool
+	enc                                   *encryption.Client
+	authz                                 *authz.Engine
+	shadowmcpClient                       *shadowmcp.Client
+	mcpService                            *mcp.Service
+	serverURL                             *url.URL
+	guardianPolicy                        *guardian.Policy
+	posthog                               *posthog.Posthog
+	telemLogger                           *tm.Logger
+	proxyMetrics                          *proxy.Metrics
+	xmcpMetrics                           *metrics
+	toolsCallUsageLimitsInterceptor       *ToolsCallUsageLimitsInterceptor
+	toolsCallUsageTrackingInterceptor     *ToolsCallUsageTrackingInterceptor
+	resourcesReadUsageLimitsInterceptor   *ResourcesReadUsageLimitsInterceptor
+	resourcesReadUsageTrackingInterceptor *ResourcesReadUsageTrackingInterceptor
+	initializePostHogEventInterceptor     *InitializePostHogEventInterceptor
 }
 
 // NewService constructs a Service with its full dependency graph wired up.
@@ -88,22 +90,24 @@ func NewService(
 	xmcpMetrics := newMetrics(meter, logger)
 
 	return &Service{
-		logger:                            logger,
-		tracer:                            tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/xmcp"),
-		db:                                db,
-		enc:                               enc,
-		authz:                             authzEngine,
-		shadowmcpClient:                   shadowmcpClient,
-		mcpService:                        mcpService,
-		serverURL:                         serverURL,
-		guardianPolicy:                    guardianPolicy,
-		posthog:                           posthogClient,
-		telemLogger:                       telemLogger,
-		proxyMetrics:                      proxy.NewMetrics(meter, logger),
-		xmcpMetrics:                       xmcpMetrics,
-		toolsCallUsageLimitsInterceptor:   NewToolsCallUsageLimitsInterceptor(billingRepo, logger),
-		toolsCallUsageTrackingInterceptor: NewToolsCallUsageTrackingInterceptor(billingTracker, logger),
-		initializePostHogEventInterceptor: NewInitializePostHogEventInterceptor(posthogClient, logger),
+		logger:                                logger,
+		tracer:                                tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/xmcp"),
+		db:                                    db,
+		enc:                                   enc,
+		authz:                                 authzEngine,
+		shadowmcpClient:                       shadowmcpClient,
+		mcpService:                            mcpService,
+		serverURL:                             serverURL,
+		guardianPolicy:                        guardianPolicy,
+		posthog:                               posthogClient,
+		telemLogger:                           telemLogger,
+		proxyMetrics:                          proxy.NewMetrics(meter, logger),
+		xmcpMetrics:                           xmcpMetrics,
+		toolsCallUsageLimitsInterceptor:       NewToolsCallUsageLimitsInterceptor(billingRepo, logger),
+		toolsCallUsageTrackingInterceptor:     NewToolsCallUsageTrackingInterceptor(billingTracker, logger),
+		resourcesReadUsageLimitsInterceptor:   NewResourcesReadUsageLimitsInterceptor(billingRepo, logger),
+		resourcesReadUsageTrackingInterceptor: NewResourcesReadUsageTrackingInterceptor(billingTracker, logger),
+		initializePostHogEventInterceptor:     NewInitializePostHogEventInterceptor(posthogClient, logger),
 	}
 }
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2078/mcp-resource-method-interceptors-for-xmcp-billinglimits-rbac-parity

The `proxy` package gains typed request/response views and interceptor interfaces for `resources/read` and `resources/list`, mirroring the existing `tools/*` surface. Dispatch runs in the buffered JSON path and the SSE-terminal path; `resources/list` responses gain a `SetResources` setter for downstream RBAC filtering.

The `xmcp` package gains two interceptors so `resources/read` invocations reach billing parity with `tools/call`: a usage-limits interceptor that shares the free-tier `ToolCalls` counter, and a usage-tracking interceptor that emits a `ToolCallUsageEvent` with `Type=ToolCallTypeExternalMCP` and `ResourceURI` populated from the request params.

Per-resource RBAC enforcement on `resources/read` and per-resource filtering on `resources/list` responses are deferred — the proxy interceptor surface is in place so they can attach later without touching the `proxy` package again.