### PR TITLE
feat(assistants): surface MCP auth URL via Slack block-kit button

### DIFF
--- a/.changeset/slack-mcp-auth-ephemeral-button.md
+++ b/.changeset/slack-mcp-auth-ephemeral-button.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistants on Slack now surface MCP OAuth re-auth via an ephemeral Block Kit button instead of dumping the raw URL into the thread, so only the user that needs to authenticate sees the prompt.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1829,7 +1829,7 @@ Your text responses are not delivered to the user. To communicate, call a tool (
 
 Two MCP authentication events may appear in this thread, each delivered as a <message-context> block with EventType and field lines.
 
-- EventType "assistant_mcp_auth_required" carries an AuthURL. Relay AuthURL to the user verbatim through an output tool (do not shorten, summarize, or rewrite it). Reference the MCP server using its MCPSlug rather than MCPServerID.
+- EventType "assistant_mcp_auth_required" carries an AuthURL. Surface AuthURL to the user verbatim through an output tool (do not shorten, summarize, or rewrite it); follow any source-specific output preferences for whether the URL is shown directly, hidden behind a button, or delivered to a single recipient. Reference the MCP server using its MCPSlug rather than MCPServerID.
 
 - EventType "assistant_mcp_auth" reports the result. When Status is "success" and you still need that server, call mcp_force_reconnect with server_id set to the MCPServerID value, then continue your task. When Status is "failed", inform the user via an output tool and include the ErrorDescription if present.`
 
@@ -1842,11 +1842,14 @@ func composeInstructions(base string, thread assistantThreadRecord) (string, err
 	if err != nil {
 		return "", fmt.Errorf("load assistant thread context: %w", err)
 	}
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 4)
 	if base != "" {
 		parts = append(parts, base)
 	}
 	parts = append(parts, outputChannelAddendum)
+	if guidance := adapter.OutputChannelGuidance(); guidance != "" {
+		parts = append(parts, guidance)
+	}
 	if ctxBlock != "" {
 		parts = append(parts, ctxBlock)
 	}

--- a/server/internal/assistants/source_adapter.go
+++ b/server/internal/assistants/source_adapter.go
@@ -84,9 +84,7 @@ func (slackAdapter) ThreadContext(sourceRefJSON []byte) (string, error) {
 func (slackAdapter) OutputChannelGuidance() string {
 	return `## Slack output preferences
 
-When relaying an "assistant_mcp_auth_required" AuthURL, call platform_slack_post_ephemeral so only the user who needs to authenticate sees it. Address it to the UserID of the user whose most recent request triggered the auth flow; set channel_id to the conversation ChannelID and thread_ts to the conversation ThreadID so the prompt anchors in the active thread. Render the AuthURL as a single Block Kit actions block containing one primary-style button labelled "Authenticate" whose url is the AuthURL verbatim; keep any surrounding section text short and never include the AuthURL itself in plain text.
-
-For all other outbound replies, prefer platform_slack_send_message in the active thread.`
+When relaying an "assistant_mcp_auth_required" AuthURL, prefer platform_slack_post_ephemeral so only the requesting user sees it, and render the AuthURL as a Block Kit actions block containing a single primary button rather than as plain text.`
 }
 
 func (slackAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) {

--- a/server/internal/assistants/source_adapter.go
+++ b/server/internal/assistants/source_adapter.go
@@ -8,6 +8,7 @@ import (
 
 type sourceAdapter interface {
 	ThreadContext(sourceRefJSON []byte) (string, error)
+	OutputChannelGuidance() string
 	DecodeTurn(event assistantThreadEventRecord) (string, error)
 }
 
@@ -78,6 +79,14 @@ func (slackAdapter) ThreadContext(sourceRefJSON []byte) (string, error) {
 		fmt.Fprintf(&b, "UserID: %s\n", ref.UserID)
 	}
 	return b.String(), nil
+}
+
+func (slackAdapter) OutputChannelGuidance() string {
+	return `## Slack output preferences
+
+When relaying an "assistant_mcp_auth_required" AuthURL, call platform_slack_post_ephemeral so only the user who needs to authenticate sees it. Address it to the UserID of the user whose most recent request triggered the auth flow; set channel_id to the conversation ChannelID and thread_ts to the conversation ThreadID so the prompt anchors in the active thread. Render the AuthURL as a single Block Kit actions block containing one primary-style button labelled "Authenticate" whose url is the AuthURL verbatim; keep any surrounding section text short and never include the AuthURL itself in plain text.
+
+For all other outbound replies, prefer platform_slack_send_message in the active thread.`
 }
 
 func (slackAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) {
@@ -162,6 +171,8 @@ func (cronAdapter) ThreadContext(sourceRefJSON []byte) (string, error) {
 	return b.String(), nil
 }
 
+func (cronAdapter) OutputChannelGuidance() string { return "" }
+
 func (cronAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) {
 	var payload cronEventPayload
 	if err := json.Unmarshal(event.NormalizedPayloadJSON, &payload); err != nil {
@@ -215,6 +226,8 @@ func (wakeAdapter) ThreadContext(sourceRefJSON []byte) (string, error) {
 	}
 	return b.String(), nil
 }
+
+func (wakeAdapter) OutputChannelGuidance() string { return "" }
 
 func (wakeAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) {
 	var payload wakeEventPayload


### PR DESCRIPTION
## Summary

- Slack source adapter now contributes output-channel guidance in the assistant runtime instructions, telling the LLM to relay `assistant_mcp_auth_required` AuthURLs via `platform_slack_post_ephemeral` with a single primary-style Block Kit button — no more dumping raw URLs into the channel.
- Ephemeral target derives from the conversation `UserID`/`ChannelID`/`ThreadID` already exposed in the Slack thread context, so only the user that needs to authenticate sees the prompt.
- Other sources (cron, wake) opt out via a no-op `OutputChannelGuidance()` on the `sourceAdapter` interface.

Closes [AGE-2464](https://linear.app/speakeasy/issue/AGE-2464/improve-oauth-21-auth-url-surfacing-in-slack-use-block-kit-ephemeral).

✻ Clauded...