### PR TITLE
mig(functions): add tags column to function_tool_definitions

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -424,6 +424,7 @@ CREATE TABLE IF NOT EXISTS function_tool_definitions (
   runtime TEXT NOT NULL, -- nodejs:22, python:3.12, ...
   name TEXT NOT NULL,
   description TEXT NOT NULL,
+  tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[] CHECK (array_length(tags, 1) <= 40),
   input_schema JSONB,
   -- Record<string, { description?: string }>
   variables JSONB,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -533,6 +533,7 @@ type FunctionToolDefinition struct {
 	Runtime         string
 	Name            string
 	Description     string
+	Tags            []string
 	InputSchema     []byte
 	Variables       []byte
 	AuthInput       []byte

--- a/server/internal/deployments/repo/models.go
+++ b/server/internal/deployments/repo/models.go
@@ -77,6 +77,7 @@ type FunctionToolDefinition struct {
 	Runtime         string
 	Name            string
 	Description     string
+	Tags            []string
 	InputSchema     []byte
 	Variables       []byte
 	AuthInput       []byte

--- a/server/internal/deployments/repo/queries.sql.go
+++ b/server/internal/deployments/repo/queries.sql.go
@@ -567,7 +567,7 @@ INSERT INTO function_tool_definitions (
   , $14
   , $15
 )
-RETURNING id, tool_urn, project_id, deployment_id, function_id, runtime, name, description, input_schema, variables, auth_input, meta, read_only_hint, destructive_hint, idempotent_hint, open_world_hint, created_at, updated_at, deleted_at, deleted
+RETURNING id, tool_urn, project_id, deployment_id, function_id, runtime, name, description, tags, input_schema, variables, auth_input, meta, read_only_hint, destructive_hint, idempotent_hint, open_world_hint, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateFunctionsToolParams struct {
@@ -616,6 +616,7 @@ func (q *Queries) CreateFunctionsTool(ctx context.Context, arg CreateFunctionsTo
 		&i.Runtime,
 		&i.Name,
 		&i.Description,
+		&i.Tags,
 		&i.InputSchema,
 		&i.Variables,
 		&i.AuthInput,

--- a/server/internal/testenv/testrepo/models.go
+++ b/server/internal/testenv/testrepo/models.go
@@ -40,6 +40,7 @@ type FunctionToolDefinition struct {
 	Runtime         string
 	Name            string
 	Description     string
+	Tags            []string
 	InputSchema     []byte
 	Variables       []byte
 	AuthInput       []byte

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -237,7 +237,7 @@ func (q *Queries) ListDeploymentFunctionsResources(ctx context.Context, deployme
 }
 
 const listDeploymentFunctionsTools = `-- name: ListDeploymentFunctionsTools :many
-SELECT id, tool_urn, project_id, deployment_id, function_id, runtime, name, description, input_schema, variables, auth_input, meta, read_only_hint, destructive_hint, idempotent_hint, open_world_hint, created_at, updated_at, deleted_at, deleted
+SELECT id, tool_urn, project_id, deployment_id, function_id, runtime, name, description, tags, input_schema, variables, auth_input, meta, read_only_hint, destructive_hint, idempotent_hint, open_world_hint, created_at, updated_at, deleted_at, deleted
 FROM function_tool_definitions
 WHERE deployment_id = $1
 `
@@ -260,6 +260,7 @@ func (q *Queries) ListDeploymentFunctionsTools(ctx context.Context, deploymentID
 			&i.Runtime,
 			&i.Name,
 			&i.Description,
+			&i.Tags,
 			&i.InputSchema,
 			&i.Variables,
 			&i.AuthInput,

--- a/server/internal/tools/repo/models.go
+++ b/server/internal/tools/repo/models.go
@@ -20,6 +20,7 @@ type FunctionToolDefinition struct {
 	Runtime         string
 	Name            string
 	Description     string
+	Tags            []string
 	InputSchema     []byte
 	Variables       []byte
 	AuthInput       []byte

--- a/server/internal/tools/repo/queries.sql.go
+++ b/server/internal/tools/repo/queries.sql.go
@@ -260,7 +260,7 @@ WITH deployment AS (
     LIMIT 1
 )
 SELECT
-  ftd.id, ftd.tool_urn, ftd.project_id, ftd.deployment_id, ftd.function_id, ftd.runtime, ftd.name, ftd.description, ftd.input_schema, ftd.variables, ftd.auth_input, ftd.meta, ftd.read_only_hint, ftd.destructive_hint, ftd.idempotent_hint, ftd.open_world_hint, ftd.created_at, ftd.updated_at, ftd.deleted_at, ftd.deleted,
+  ftd.id, ftd.tool_urn, ftd.project_id, ftd.deployment_id, ftd.function_id, ftd.runtime, ftd.name, ftd.description, ftd.tags, ftd.input_schema, ftd.variables, ftd.auth_input, ftd.meta, ftd.read_only_hint, ftd.destructive_hint, ftd.idempotent_hint, ftd.open_world_hint, ftd.created_at, ftd.updated_at, ftd.deleted_at, ftd.deleted,
   (select id from deployment) as owning_deployment_id,
   df.asset_id
 FROM function_tool_definitions ftd
@@ -301,6 +301,7 @@ func (q *Queries) FindFunctionToolsByUrn(ctx context.Context, arg FindFunctionTo
 			&i.FunctionToolDefinition.Runtime,
 			&i.FunctionToolDefinition.Name,
 			&i.FunctionToolDefinition.Description,
+			&i.FunctionToolDefinition.Tags,
 			&i.FunctionToolDefinition.InputSchema,
 			&i.FunctionToolDefinition.Variables,
 			&i.FunctionToolDefinition.AuthInput,

--- a/server/migrations/20260522194835_add_function_tool_definitions_tags.sql
+++ b/server/migrations/20260522194835_add_function_tool_definitions_tags.sql
@@ -1,0 +1,2 @@
+-- Modify "function_tool_definitions" table
+ALTER TABLE "function_tool_definitions" ADD CONSTRAINT "function_tool_definitions_tags_check" CHECK (array_length(tags, 1) <= 40), ADD COLUMN "tags" text[] NOT NULL DEFAULT ARRAY[]::text[];

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:90QHr82h58LVZNV3Ux41c96ZTU1TxQvkBi12Fu2yOzE=
+h1:lLa2t4Ol97WsK0k9H+F33HAJ9dzBRGKfRjNtzwoLtNs=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -187,3 +187,4 @@ h1:90QHr82h58LVZNV3Ux41c96ZTU1TxQvkBi12Fu2yOzE=
 20260520182725_project-marketplace-settings.sql h1:4RMTKbJZG0ft/SUEnGR737b3iTY1SOmIp6NnisqTYO8=
 20260520194157_decouple-ai-integration-poll-state.sql h1:JCk3JZ5s7TbCALqdW0sA1vbhFr3U/HYwTYdPkfYNbqg=
 20260522040618_add_legacy_callback_url_to_remote_session_clients.sql h1:LrHAK7LBxV+2oO4pYEz7dImXUpI0C9b3+0Q0as7GthA=
+20260522194835_add_function_tool_definitions_tags.sql h1:zNH0ilgmHU+szGwhIBKT3xSSrj0+ayoUk5nhCsgPFtU=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2348/gram-function-source-tag-ingestion

Mirrors the existing `tags` column on `http_tool_definitions`: `TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[]` with a `CHECK` constraint of `array_length(tags, 1) <= 40`.