### PR TITLE
fix(telemetry): add hook_source to Claude Code usage metrics

### DIFF
--- a/.changeset/fix-token-graph-agent-filter.md
+++ b/.changeset/fix-token-graph-agent-filter.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix token graph blanking when filtering by agent type on /insights/costs. Claude Code usage metrics were missing the hook_source attribute, causing the filter to return no data for non-cursor agents.

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -274,6 +274,7 @@ func (s *Service) writeMetricsToClickHouse(ctx context.Context, payload *gen.Met
 			attr.ProjectIDKey:      projectID,
 			attr.OrganizationIDKey: orgID,
 			attr.ResourceURNKey:    urn,
+			attr.HookSourceKey:     "claude-code",
 		}
 
 		// Only include non-zero values


### PR DESCRIPTION
## Summary
- Fix token graph blanking when filtering by agent type on `/insights/costs` (except for cursor)
- Add missing `hook_source` attribute to Claude Code usage metrics in `writeMetricsToClickHouse`

## Root Cause
When filtering by agent type, the time series query filters on `hook_source`. Claude Code usage metric events were missing this attribute entirely, so filtering returned no token data and the chart showed "No data for selected time range".

Cursor hooks correctly set `hook_source="cursor"` on their usage metrics (see `cursor_hooks.go:292`), which is why that specific filter worked while others didn't.

## Changes
Added `attr.HookSourceKey: "claude-code"` to the attributes map in `writeMetricsToClickHouse` (`pending_helpers.go:277`).

## Test plan
- [ ] Navigate to `/insights/costs`
- [ ] Select an agent type other than "Cursor" from the dropdown filter (e.g., "Claude Code")
- [ ] Verify the token graph displays data correctly instead of blanking
- [ ] Verify "All Agents" and "Cursor" filters still work as before

Fixes AGE-2438

Slack thread: https://speakeasyapi.slack.com/archives/C0ARJG28X29/p1779307684790709?thread_ts=1779233461.032919&cid=C0ARJG28X29

https://claude.ai/code/session_01Sw9vovwFx6fNYYNirXPWxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw9vovwFx6fNYYNirXPWxo)_