### PR TITLE
feat(dashboard): link MCP server rows in assistant draft panel

### DIFF
--- a/.changeset/age-2346-assistant-spec-panel-mcp-link.md
+++ b/.changeset/age-2346-assistant-spec-panel-mcp-link.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The Assistants spec panel now links each attached MCP server to its MCP details page, so you can jump straight from the draft view to inspect or configure the server.

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantDraftPanel.tsx
@@ -129,19 +129,24 @@ export function AssistantDraftPanel() {
             >
               <Stack gap={2}>
                 {a.toolsets.map((t) => (
-                  <div
+                  <routes.mcp.details.Link
                     key={t.toolsetSlug}
-                    className="border-border flex items-center justify-between rounded-md border px-3 py-2"
+                    params={[t.toolsetSlug]}
+                    className="border-border hover:bg-surface-secondary flex items-center justify-between rounded-md border px-3 py-2 transition-colors hover:no-underline"
                   >
-                    <Stack gap={0}>
-                      <code className="text-xs">{t.toolsetSlug}</code>
+                    <Stack gap={0} className="min-w-0">
+                      <code className="truncate text-xs">{t.toolsetSlug}</code>
                       {t.environmentSlug && (
                         <Type small muted className="text-[11px]">
                           env: {t.environmentSlug}
                         </Type>
                       )}
                     </Stack>
-                  </div>
+                    <Icon
+                      name="chevron-right"
+                      className="text-muted-foreground h-4 w-4 shrink-0"
+                    />
+                  </routes.mcp.details.Link>
                 ))}
               </Stack>
             </Section>


### PR DESCRIPTION
## Summary

- Wrap each toolset row in the Assistants spec panel (`AssistantDraftPanel`) with `routes.mcp.details.Link`, so clicking jumps straight to the MCP server's details page.
- Add a chevron affordance using the shared moonshine `Icon` (matches the convention used by `ChatDetailPanel`, `Triggers`, etc.) and `hover:bg-surface-secondary` styling matching `ExternalMCPServerCard`.

Closes [AGE-2346](https://linear.app/speakeasy/issue/AGE-2346/feat-assistants-spec-panel-provides-quick-link-from-link-mcp-server-to)

✻ Clauded...