### PR TITLE
fix(zero): persist Fly.io skip choice across runs

### DIFF
--- a/.mise-tasks/zero/fly.mts
+++ b/.mise-tasks/zero/fly.mts
@@ -47,6 +47,15 @@ function isExistingConfigComplete(): boolean {
   }
 
   const content = readFileSync(configPath, "utf-8");
+  const functionsProvider = configValue(content, "GRAM_FUNCTIONS_PROVIDER");
+
+  // Skip was chosen previously — local provider with assistant runtime placeholders
+  if (functionsProvider === "local") {
+    return (
+      configValue(content, "GRAM_ASSISTANT_RUNTIME_PROVIDER") !== undefined
+    );
+  }
+
   const requiredKeys = [
     "GRAM_FUNCTIONS_PROVIDER",
     "GRAM_FUNCTIONS_FLYIO_API_TOKEN",


### PR DESCRIPTION
## Summary

- Selecting "Skip" on the Fly.io/Tigris setup step during `./zero` was not persisted — the prompt reappeared on every run
- Root cause: `isExistingConfigComplete()` required `GRAM_FUNCTIONS_PROVIDER=flyio` and all 15 config keys (including Tigris creds), but the skip path writes `GRAM_FUNCTIONS_PROVIDER=local` with only 7 keys
- Fix: recognize `local` provider as complete config when assistant runtime provider is also set

## Test plan

- [ ] Run `./zero`, select "Skip" on Fly.io setup
- [ ] Run `./zero` again — should no longer prompt for Fly.io setup
- [ ] Run `mise run zero:fly --restart` — should re-prompt regardless