### PR TITLE
fix(assistants): clarify OAuth is owner-only and lazy in system prompt

### DIFF
--- a/.changeset/age-2489-assistant-oauth-owner-only.md
+++ b/.changeset/age-2489-assistant-oauth-owner-only.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistants are now instructed to treat OAuth/MCP authentication as owner-only and to avoid pre-emptively prompting for auth on toolsets they have not yet needed.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1827,11 +1827,16 @@ Your text responses are not delivered to the user. To communicate, call a tool (
 
 ## MCP authentication
 
-OAuth and MCP authentication are owner-only: only the assistant's owner can sign in and complete the flow. Do not pre-emptively call tools or surface auth URLs to trigger authentication for toolsets you have not yet needed — only attempt the tool calls actually required for the current task. Auth events should appear only as a consequence of a tool call you genuinely needed to make.
+OAuth and MCP authentication are owner-only: only the assistant's owner can sign in and complete the flow. The AuthURL must never be visible to anyone other than the owner. Do not pre-emptively call tools or surface auth URLs to trigger authentication for toolsets you have not yet needed — only attempt the tool calls actually required for the current task. Auth events should appear only as a consequence of a tool call you genuinely needed to make.
 
 Two MCP authentication events may appear in this thread, each delivered as a <message-context> block with EventType and field lines.
 
-- EventType "assistant_mcp_auth_required" carries an AuthURL. Surface AuthURL to the user verbatim through an output tool (do not shorten, summarize, or rewrite it); follow any source-specific output preferences for whether the URL is shown directly, hidden behind a button, or delivered to a single recipient. Reference the MCP server using its MCPSlug rather than MCPServerID. The AuthURL can only be completed by the assistant's owner — if the requesting user is not the owner, frame the message so the owner is the one who must act.
+- EventType "assistant_mcp_auth_required" carries an AuthURL. Surface AuthURL to the owner verbatim through an output tool (do not shorten, summarize, or rewrite it). Reference the MCP server using its MCPSlug rather than MCPServerID.
+
+  Delivery rules — never post the AuthURL into a public or shared channel where non-owners can read it. Choose the most private channel available:
+    1. If the current conversation supports an owner-only ephemeral message (visible only to a single recipient), send the AuthURL there directly, addressed to the owner.
+    2. Otherwise, open a direct/private message to the owner and deliver the AuthURL there. Because the AuthURL expires, do not paste it cold into a DM that the owner has not engaged with recently. First ask the owner whether they are available to authenticate now; only after they confirm, re-attempt the tool call that required auth so a fresh AuthURL is issued, then deliver the new AuthURL in the same DM.
+    3. If neither an ephemeral message nor a DM to the owner is possible, do not surface the AuthURL at all; instead inform the requester (without the URL) that the assistant's owner must complete authentication and stop.
 
 - EventType "assistant_mcp_auth" reports the result. When Status is "success" and you still need that server, call mcp_force_reconnect with server_id set to the MCPServerID value, then continue your task. When Status is "failed", inform the user via an output tool and include the ErrorDescription if present.`
 

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1823,22 +1823,22 @@ const assistantRuntimeTokenTTL = 60 * time.Minute
 
 const outputChannelAddendum = `## Output channel
 
-Your text responses are not delivered to the user. To communicate, call a tool (e.g. post a Slack message, send an email). If no suitable tool is available, the user will not see your reply.
+Text responses not delivered to user. To communicate, call a tool (e.g. post Slack message, send email). No suitable tool = user won't see reply.
 
 ## MCP authentication
 
-OAuth and MCP authentication are owner-only: only the assistant's owner can sign in and complete the flow. The AuthURL must never be visible to anyone other than the owner. Do not pre-emptively call tools or surface auth URLs to trigger authentication for toolsets you have not yet needed — only attempt the tool calls actually required for the current task. Auth events should appear only as a consequence of a tool call you genuinely needed to make.
+OAuth + MCP auth are owner-only: only owner can sign in and complete flow. AuthURL must never be visible to non-owner. Don't pre-emptively call tools or surface auth URLs for toolsets not yet needed — only call tools required for current task. Auth events appear only as consequence of a needed tool call.
 
-Two MCP authentication events may appear in this thread, each delivered as a <message-context> block with EventType and field lines.
+Two MCP auth events may appear in thread, each as <message-context> block with EventType and field lines.
 
-- EventType "assistant_mcp_auth_required" carries an AuthURL. Surface AuthURL to the owner verbatim through an output tool (do not shorten, summarize, or rewrite it). Reference the MCP server using its MCPSlug rather than MCPServerID.
+- EventType "assistant_mcp_auth_required" carries AuthURL. Surface AuthURL to owner verbatim via output tool (don't shorten/summarize/rewrite). Reference MCP server by MCPSlug, not MCPServerID.
 
-  Delivery rules — never post the AuthURL into a public or shared channel where non-owners can read it. Choose the most private channel available:
-    1. If the current conversation supports an owner-only ephemeral message (visible only to a single recipient), send the AuthURL there directly, addressed to the owner.
-    2. Otherwise, open a direct/private message to the owner and deliver the AuthURL there. Because the AuthURL expires, do not paste it cold into a DM that the owner has not engaged with recently. First ask the owner whether they are available to authenticate now; only after they confirm, re-attempt the tool call that required auth so a fresh AuthURL is issued, then deliver the new AuthURL in the same DM.
-    3. If neither an ephemeral message nor a DM to the owner is possible, do not surface the AuthURL at all; instead inform the requester (without the URL) that the assistant's owner must complete authentication and stop.
+  Delivery rules — never post AuthURL to public or shared channel readable by non-owners. Pick most private channel available:
+    1. Conversation supports owner-only ephemeral message (single recipient) → send AuthURL there, addressed to owner.
+    2. Else DM the owner. AuthURL expires, so don't paste cold into DM owner hasn't engaged with recently. First ask owner if available to authenticate now; only after they confirm, re-attempt the tool call that required auth to issue a fresh AuthURL, then deliver new AuthURL in same DM.
+    3. Neither ephemeral nor DM possible → don't surface AuthURL; tell requester (without URL) that owner must complete auth, then stop.
 
-- EventType "assistant_mcp_auth" reports the result. When Status is "success" and you still need that server, call mcp_force_reconnect with server_id set to the MCPServerID value, then continue your task. When Status is "failed", inform the user via an output tool and include the ErrorDescription if present.`
+- EventType "assistant_mcp_auth" reports result. Status "success" + still need server → call mcp_force_reconnect with server_id = MCPServerID, then continue task. Status "failed" → inform user via output tool, include ErrorDescription if present.`
 
 func composeInstructions(base string, thread assistantThreadRecord) (string, error) {
 	adapter, err := getSourceAdapter(thread.SourceKind)

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1827,9 +1827,11 @@ Your text responses are not delivered to the user. To communicate, call a tool (
 
 ## MCP authentication
 
+OAuth and MCP authentication are owner-only: only the assistant's owner can sign in and complete the flow. Do not pre-emptively call tools or surface auth URLs to trigger authentication for toolsets you have not yet needed — only attempt the tool calls actually required for the current task. Auth events should appear only as a consequence of a tool call you genuinely needed to make.
+
 Two MCP authentication events may appear in this thread, each delivered as a <message-context> block with EventType and field lines.
 
-- EventType "assistant_mcp_auth_required" carries an AuthURL. Surface AuthURL to the user verbatim through an output tool (do not shorten, summarize, or rewrite it); follow any source-specific output preferences for whether the URL is shown directly, hidden behind a button, or delivered to a single recipient. Reference the MCP server using its MCPSlug rather than MCPServerID.
+- EventType "assistant_mcp_auth_required" carries an AuthURL. Surface AuthURL to the user verbatim through an output tool (do not shorten, summarize, or rewrite it); follow any source-specific output preferences for whether the URL is shown directly, hidden behind a button, or delivered to a single recipient. Reference the MCP server using its MCPSlug rather than MCPServerID. The AuthURL can only be completed by the assistant's owner — if the requesting user is not the owner, frame the message so the owner is the one who must act.
 
 - EventType "assistant_mcp_auth" reports the result. When Status is "success" and you still need that server, call mcp_force_reconnect with server_id set to the MCPServerID value, then continue your task. When Status is "failed", inform the user via an output tool and include the ErrorDescription if present.`
 


### PR DESCRIPTION
## Summary

- Adds two clarifications to the assistant runtime system prompt: OAuth/MCP auth is **owner-only** (only the assistant's owner can sign in to complete it), and assistants must not pre-emptively trigger or surface auth for toolsets they have not actually needed in the current task.
- Prevents the recently observed failure mode where an assistant surfaced an auth URL to a non-owner for a toolset it never needed.

Closes [AGE-2489](https://linear.app/speakeasy/issue/AGE-2489/system-prompt-clarify-that-oauthmcp-auth-is-owner-only-and-dont-prompt)

✻ Clauded...