### PR TITLE
feat(dashboard): rank Top Users by token consumption

### DIFF
--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -10,9 +10,11 @@ import { useOrgRoutes, useRoutes } from "@/routes";
 import {
   useAuditLogs,
   useGramContext,
+  useMembers,
   useProductFeatures,
 } from "@gram/client/react-query";
 import { telemetryGetProjectOverview } from "@gram/client/funcs/telemetryGetProjectOverview";
+import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
 import { unwrapAsync } from "@gram/client/types/fp";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
@@ -77,6 +79,42 @@ export function ProjectDashboard() {
     enabled: logsEnabled,
     placeholderData: keepPreviousData,
   });
+
+  const { data: membersData, isPending: isMembersPending } = useMembers();
+  const members = useMemo(() => membersData?.members ?? [], [membersData]);
+
+  const { data: topUsersSearchData, isPending: isTopUsersPending } = useQuery({
+    queryKey: ["project", "topUsers", from.toISOString(), to.toISOString()],
+    queryFn: () =>
+      unwrapAsync(
+        telemetrySearchUsers(client, {
+          searchUsersPayload: {
+            filter: { from, to, eventSource: "hook" },
+            limit: 200,
+            sort: "desc",
+            userType: "internal",
+          },
+        }),
+      ),
+    enabled: logsEnabled,
+    placeholderData: keepPreviousData,
+  });
+
+  const topUsersByTokens = useMemo(() => {
+    if (!topUsersSearchData?.users) return [];
+    const memberById = new Map(members.map((m) => [m.id, m]));
+    return [...topUsersSearchData.users]
+      .sort((a, b) => b.totalTokens - a.totalTokens)
+      .slice(0, 5)
+      .map((u) => ({
+        key: u.userId,
+        label: memberById.get(u.userId)?.name ?? u.userId,
+        value: u.totalTokens,
+      }));
+  }, [topUsersSearchData, members]);
+
+  const isTopUsersLoading =
+    logsEnabled && (isTopUsersPending || isMembersPending);
 
   const featuresSettled = !isFeaturesPending || isFeaturesError;
   const isOverviewLoading =
@@ -246,20 +284,12 @@ export function ProjectDashboard() {
                     </CardActions>
                   }
                 >
-                  {isOverviewPending ? (
+                  {isTopUsersLoading ? (
                     <SkeletonList />
-                  ) : (overview?.summary.topUsers.length ?? 0) === 0 ? (
+                  ) : topUsersByTokens.length === 0 ? (
                     <EmptyState message="No user activity recorded" />
                   ) : (
-                    <RankedBarList
-                      items={(overview?.summary.topUsers ?? [])
-                        .slice(0, 5)
-                        .map((u) => ({
-                          key: u.userId,
-                          label: u.userId,
-                          value: u.activityCount,
-                        }))}
-                    />
+                    <RankedBarList items={topUsersByTokens} />
                   )}
                 </DashboardCard>
 


### PR DESCRIPTION
## Summary

- Replaces the `overview.summary.topUsers` (activity-count) data source with a `telemetrySearchUsers` call for the Project Overview "Top Users" card
- Fetches up to 200 users with `eventSource: "hook"` and `userType: "internal"`, then sorts client-side by `totalTokens` descending to get the real top 5
- Resolves member names via `useMembers()` — falls back to raw `userId` if the user isn't an org member
- Loading state waits for both `telemetrySearchUsers` and `useMembers` to settle before replacing the skeleton

No changes to card layout, title, tooltip, actions, or surrounding UI.

## Test plan

- [ ] Open the Project Overview page and verify the Top Users card loads without errors
- [ ] Confirm the ranked list shows member names (not raw user IDs) where available
- [ ] Change the date range and verify the card re-fetches with updated results
- [ ] Verify the skeleton shows while data is loading and the empty state shows when there is no hook activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)