### PR TITLE
feat(observe): add role filter to logs and insights

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -196,6 +196,7 @@ export function InsightsToolsContent() {
     selectedRoleIds,
     roleOptions,
     handleRoleSelectionChange,
+    roleFilterPending,
   } = useObserveFilters();
 
   const [selectedLog, setSelectedLog] = useState<TelemetryLogRecord | null>(
@@ -237,6 +238,7 @@ export function InsightsToolsContent() {
         ),
       initialPageParam: undefined as string | undefined,
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      enabled: !roleFilterPending,
       throwOnError: false,
     }),
   );
@@ -269,6 +271,7 @@ export function InsightsToolsContent() {
           },
         }),
       ),
+    enabled: !roleFilterPending,
     throwOnError: false,
   });
 
@@ -477,7 +480,9 @@ function HooksInnerContent({
                   <Spinner className="mr-0 size-5" />
                   <span>Loading hook events...</span>
                 </div>
-              ) : groupedTraces.length === 0 && activeFilters.length === 0 ? (
+              ) : groupedTraces.length === 0 &&
+                activeFilters.length === 0 &&
+                selectedRoleIds.length === 0 ? (
                 <HooksEmptyState
                   title="No Insights Generated"
                   subtitle="Install Observability plugin in your AI agent to start generating tool insights"

--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -193,6 +193,9 @@ export function InsightsToolsContent() {
     setDateRangeParam,
     setCustomRangeParam,
     clearCustomRange,
+    selectedRoleIds,
+    roleOptions,
+    handleRoleSelectionChange,
   } = useObserveFilters();
 
   const [selectedLog, setSelectedLog] = useState<TelemetryLogRecord | null>(
@@ -213,6 +216,7 @@ export function InsightsToolsContent() {
         "hooks-traces",
         activeFilters,
         selectedHookTypes,
+        selectedRoleIds,
         from.toISOString(),
         to.toISOString(),
       ],
@@ -328,6 +332,9 @@ export function InsightsToolsContent() {
           addFilter={addFilter}
           selectedHookTypes={selectedHookTypes}
           onHookTypesChange={handleHookTypesChange}
+          roleOptions={roleOptions}
+          selectedRoleIds={selectedRoleIds}
+          onRoleSelectionChange={handleRoleSelectionChange}
           selectedLog={selectedLog}
           setSelectedLog={setSelectedLog}
           dateRange={dateRange}
@@ -359,6 +366,9 @@ function HooksInnerContent({
   addFilter,
   selectedHookTypes,
   onHookTypesChange,
+  roleOptions,
+  selectedRoleIds,
+  onRoleSelectionChange,
   selectedLog,
   setSelectedLog,
   dateRange,
@@ -385,6 +395,9 @@ function HooksInnerContent({
   addFilter: (chip: FilterChip) => void;
   selectedHookTypes: TypesToInclude[];
   onHookTypesChange: (types: TypesToInclude[]) => void;
+  roleOptions: Array<{ id: string; name: string }>;
+  selectedRoleIds: string[];
+  onRoleSelectionChange: (values: string[]) => void;
   selectedLog: TelemetryLogRecord | null;
   setSelectedLog: (log: TelemetryLogRecord | null) => void;
   dateRange: DateRangePreset;
@@ -439,6 +452,9 @@ function HooksInnerContent({
             activeFilters={activeFilters}
             selectedTypes={selectedHookTypes}
             onTypesChange={onHookTypesChange}
+            roleOptions={roleOptions}
+            selectedRoleIds={selectedRoleIds}
+            onRoleSelectionChange={onRoleSelectionChange}
             dateRange={dateRange}
             customRange={customRange}
             customRangeLabel={customRangeLabel}

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -92,6 +92,9 @@ export function LogsTools() {
     setDateRangeParam,
     setCustomRangeParam,
     clearCustomRange,
+    selectedRoleIds,
+    roleOptions,
+    handleRoleSelectionChange,
   } = useObserveFilters();
 
   const [expandedTraceId, setExpandedTraceId] = useState<string | null>(null);
@@ -117,6 +120,7 @@ export function LogsTools() {
         "hooks-traces",
         activeFilters,
         selectedHookTypes,
+        selectedRoleIds,
         from.toISOString(),
         to.toISOString(),
       ],
@@ -237,6 +241,9 @@ export function LogsTools() {
             addFilter={addFilter}
             selectedHookTypes={selectedHookTypes}
             onHookTypesChange={handleHookTypesChange}
+            roleOptions={roleOptions}
+            selectedRoleIds={selectedRoleIds}
+            onRoleSelectionChange={handleRoleSelectionChange}
             expandedTraceId={expandedTraceId}
             toggleExpand={toggleExpand}
             selectedLog={selectedLog}
@@ -273,6 +280,9 @@ function HooksInnerContent({
   activeFilters,
   selectedHookTypes,
   onHookTypesChange,
+  roleOptions,
+  selectedRoleIds,
+  onRoleSelectionChange,
   expandedTraceId,
   toggleExpand,
   selectedLog,
@@ -304,6 +314,9 @@ function HooksInnerContent({
   addFilter: (chip: FilterChip) => void;
   selectedHookTypes: TypesToInclude[];
   onHookTypesChange: (types: TypesToInclude[]) => void;
+  roleOptions: Array<{ id: string; name: string }>;
+  selectedRoleIds: string[];
+  onRoleSelectionChange: (values: string[]) => void;
   expandedTraceId: string | null;
   toggleExpand: (traceId: string) => void;
   selectedLog: TelemetryLogRecord | null;
@@ -354,6 +367,9 @@ function HooksInnerContent({
             activeFilters={activeFilters}
             selectedTypes={selectedHookTypes}
             onTypesChange={onHookTypesChange}
+            roleOptions={roleOptions}
+            selectedRoleIds={selectedRoleIds}
+            onRoleSelectionChange={onRoleSelectionChange}
             dateRange={dateRange}
             customRange={customRange}
             customRangeLabel={customRangeLabel}

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -95,6 +95,7 @@ export function LogsTools() {
     selectedRoleIds,
     roleOptions,
     handleRoleSelectionChange,
+    roleFilterPending,
   } = useObserveFilters();
 
   const [expandedTraceId, setExpandedTraceId] = useState<string | null>(null);
@@ -141,6 +142,7 @@ export function LogsTools() {
         ),
       initialPageParam: undefined as string | undefined,
       getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      enabled: !roleFilterPending,
       throwOnError: false,
     }),
   );
@@ -407,6 +409,7 @@ function HooksInnerContent({
                     isLoading={isLoading}
                     groupedTraces={groupedTraces}
                     activeFilters={activeFilters}
+                    selectedRoleIds={selectedRoleIds}
                     expandedTraceId={expandedTraceId}
                     isFetchingNextPage={isFetchingNextPage}
                     onToggleExpand={toggleExpand}
@@ -444,6 +447,7 @@ export function LogsToolsContent({
   isLoading,
   groupedTraces,
   activeFilters,
+  selectedRoleIds,
   expandedTraceId,
   isFetchingNextPage,
   onToggleExpand,
@@ -454,6 +458,7 @@ export function LogsToolsContent({
   isLoading: boolean;
   groupedTraces: HookTrace[];
   activeFilters: FilterChip[];
+  selectedRoleIds: string[];
   expandedTraceId: string | null;
   isFetchingNextPage: boolean;
   onToggleExpand: (traceId: string) => void;
@@ -480,7 +485,7 @@ export function LogsToolsContent({
   }
 
   if (groupedTraces.length === 0) {
-    const hasFilters = activeFilters.length > 0;
+    const hasFilters = activeFilters.length > 0 || selectedRoleIds.length > 0;
 
     if (!hasFilters) {
       return <HooksEmptyState />;

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -36,6 +36,9 @@ export function ObserveFilterBar({
   onServerSelectionChange,
   userEmailOptions,
   onUserEmailSelectionChange,
+  roleOptions,
+  selectedRoleIds,
+  onRoleSelectionChange,
   activeFilters,
   selectedTypes,
   onTypesChange,
@@ -52,6 +55,9 @@ export function ObserveFilterBar({
   onServerSelectionChange: (values: string[]) => void;
   userEmailOptions: string[];
   onUserEmailSelectionChange: (values: string[]) => void;
+  roleOptions: Array<{ id: string; name: string }>;
+  selectedRoleIds: string[];
+  onRoleSelectionChange: (values: string[]) => void;
   activeFilters: FilterChip[];
   selectedTypes: TypesToInclude[];
   onTypesChange: (types: TypesToInclude[]) => void;
@@ -101,6 +107,15 @@ export function ObserveFilterBar({
         onValueChange={onUserEmailSelectionChange}
         placeholder="Filter by user email"
         className="min-w-[200px] flex-1"
+        hideSelectAll
+        singleLine
+      />
+      <MultiSelect
+        options={roleOptions.map((r) => ({ label: r.name, value: r.id }))}
+        defaultValue={selectedRoleIds}
+        onValueChange={onRoleSelectionChange}
+        placeholder="Filter by role"
+        className="min-w-[160px] flex-1"
         hideSelectAll
         singleLine
       />

--- a/client/dashboard/src/components/observe/observeFilterUtils.test.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { Operator } from "@gram/client/models/components";
-import { buildLogFilters, mergeFilterChip } from "./observeFilterUtils";
+import type { AccessMember } from "@gram/client/models/components";
+import {
+  buildLogFilters,
+  mergeFilterChip,
+  resolveRoleEmails,
+} from "./observeFilterUtils";
 
 describe("buildLogFilters", () => {
   it("uses exact in matching for a single curated filter value", () => {
@@ -108,5 +113,97 @@ describe("mergeFilterChip", () => {
         path: "gram.tool_call.source",
       }),
     ).toEqual({ filters: activeFilters, merged: null });
+  });
+});
+
+describe("resolveRoleEmails", () => {
+  const members: AccessMember[] = [
+    {
+      id: "m1",
+      email: "alice@example.com",
+      name: "Alice",
+      roleId: "role-admin",
+      joinedAt: new Date(),
+      photoUrl: undefined,
+    },
+    {
+      id: "m2",
+      email: "bob@example.com",
+      name: "Bob",
+      roleId: "role-member",
+      joinedAt: new Date(),
+      photoUrl: undefined,
+    },
+    {
+      id: "m3",
+      email: "carol@example.com",
+      name: "Carol",
+      roleId: "role-admin",
+      joinedAt: new Date(),
+      photoUrl: undefined,
+    },
+  ];
+
+  it("returns emails for members matching the selected role IDs", () => {
+    expect(resolveRoleEmails(["role-admin"], members)).toEqual([
+      "alice@example.com",
+      "carol@example.com",
+    ]);
+  });
+
+  it("unions emails across multiple selected roles", () => {
+    expect(resolveRoleEmails(["role-admin", "role-member"], members)).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+      "carol@example.com",
+    ]);
+  });
+
+  it("returns empty array when no roles selected", () => {
+    expect(resolveRoleEmails([], members)).toEqual([]);
+  });
+
+  it("returns empty array when members list is empty", () => {
+    expect(resolveRoleEmails(["role-admin"], [])).toEqual([]);
+  });
+});
+
+describe("buildLogFilters with role emails", () => {
+  it("injects role emails as a user.email in filter when no existing user filter", () => {
+    const result = buildLogFilters(
+      [],
+      ["alice@example.com", "carol@example.com"],
+    );
+    expect(result).toEqual([
+      {
+        path: "user.email",
+        operator: Operator.In,
+        values: ["alice@example.com", "carol@example.com"],
+      },
+    ]);
+  });
+
+  it("merges role emails with explicit user email filter (deduplicates)", () => {
+    const result = buildLogFilters(
+      [
+        {
+          display: "alice@example.com",
+          filters: ["alice@example.com"],
+          path: "user.email",
+        },
+      ],
+      ["alice@example.com", "carol@example.com"],
+    );
+    expect(result).toEqual([
+      {
+        path: "user.email",
+        operator: Operator.In,
+        values: ["alice@example.com", "carol@example.com"],
+      },
+    ]);
+  });
+
+  it("returns undefined when both activeFilters and roleEmails are empty", () => {
+    expect(buildLogFilters([], [])).toBeUndefined();
   });
 });

--- a/client/dashboard/src/components/observe/observeFilterUtils.test.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.test.ts
@@ -152,11 +152,13 @@ describe("resolveRoleEmails", () => {
   });
 
   it("unions emails across multiple selected roles", () => {
-    expect(resolveRoleEmails(["role-admin", "role-member"], members)).toEqual([
-      "alice@example.com",
-      "bob@example.com",
-      "carol@example.com",
-    ]);
+    expect(resolveRoleEmails(["role-admin", "role-member"], members)).toEqual(
+      expect.arrayContaining([
+        "alice@example.com",
+        "carol@example.com",
+        "bob@example.com",
+      ]),
+    );
   });
 
   it("returns empty array when no roles selected", () => {

--- a/client/dashboard/src/components/observe/observeFilterUtils.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.ts
@@ -1,6 +1,9 @@
 import type { DateRangePreset } from "@gram-ai/elements";
-import { Operator, type LogFilter } from "@gram/client/models/components";
-import type { AccessMember } from "@gram/client/models/components";
+import {
+  Operator,
+  type LogFilter,
+  type AccessMember,
+} from "@gram/client/models/components";
 import type { FilterChip } from "@/components/observe/ObserveFilterBar";
 
 export const validPresets: DateRangePreset[] = [

--- a/client/dashboard/src/components/observe/observeFilterUtils.ts
+++ b/client/dashboard/src/components/observe/observeFilterUtils.ts
@@ -1,5 +1,6 @@
 import type { DateRangePreset } from "@gram-ai/elements";
 import { Operator, type LogFilter } from "@gram/client/models/components";
+import type { AccessMember } from "@gram/client/models/components";
 import type { FilterChip } from "@/components/observe/ObserveFilterBar";
 
 export const validPresets: DateRangePreset[] = [
@@ -42,20 +43,33 @@ export function safeBase64Decode(str: string): string | null {
   }
 }
 
+export function resolveRoleEmails(
+  roleIds: string[],
+  members: AccessMember[],
+): string[] {
+  if (roleIds.length === 0) return [];
+  const roleSet = new Set(roleIds);
+  const emails = members
+    .filter((m) => roleSet.has(m.roleId))
+    .map((m) => m.email);
+  return [...new Set(emails)];
+}
+
 export function buildLogFilters(
   activeFilters: FilterChip[],
+  roleEmails: string[] = [],
 ): LogFilter[] | undefined {
   const byPath = new Map<string, string[]>();
   for (const chip of activeFilters) {
     byPath.set(chip.path, [...(byPath.get(chip.path) ?? []), ...chip.filters]);
   }
+  if (roleEmails.length > 0) {
+    const existing = byPath.get("user.email") ?? [];
+    byPath.set("user.email", [...new Set([...existing, ...roleEmails])]);
+  }
   const filters: LogFilter[] = [];
   for (const [path, values] of byPath) {
-    filters.push({
-      path,
-      operator: Operator.In,
-      values,
-    });
+    filters.push({ path, operator: Operator.In, values });
   }
   return filters.length > 0 ? filters : undefined;
 }

--- a/client/dashboard/src/components/observe/useObserveFilters.test.tsx
+++ b/client/dashboard/src/components/observe/useObserveFilters.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, useNavigate } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { AccessMember, Role } from "@gram/client/models/components";
@@ -25,6 +25,8 @@ function useObserveFiltersWithNavigation() {
 }
 
 describe("useObserveFilters", () => {
+  afterEach(() => vi.clearAllMocks());
+
   const mockMembers: AccessMember[] = [
     {
       id: "m1",
@@ -72,14 +74,20 @@ describe("useObserveFilters", () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    vi.mocked(useMembers).mockReturnValue({
+    const membersResult = {
       data: { members: mockMembers },
       isLoading: false,
-    } as unknown as ReturnType<typeof useMembers>);
-    vi.mocked(useRoles).mockReturnValue({
+    } satisfies Pick<ReturnType<typeof useMembers>, "data" | "isLoading">;
+    const rolesResult = {
       data: { roles: mockRoles },
       isLoading: false,
-    } as unknown as ReturnType<typeof useRoles>);
+    } satisfies Pick<ReturnType<typeof useRoles>, "data" | "isLoading">;
+    vi.mocked(useMembers).mockReturnValue(
+      membersResult as unknown as ReturnType<typeof useMembers>,
+    );
+    vi.mocked(useRoles).mockReturnValue(
+      rolesResult as unknown as ReturnType<typeof useRoles>,
+    );
     function Wrapper({ children }: { children: ReactNode }) {
       return (
         <QueryClientProvider client={qc}>
@@ -94,14 +102,20 @@ describe("useObserveFilters", () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    vi.mocked(useMembers).mockReturnValue({
+    const membersResult = {
       data: { members: [] },
       isLoading: false,
-    } as unknown as ReturnType<typeof useMembers>);
-    vi.mocked(useRoles).mockReturnValue({
+    } satisfies Pick<ReturnType<typeof useMembers>, "data" | "isLoading">;
+    const rolesResult = {
       data: { roles: [] },
       isLoading: false,
-    } as unknown as ReturnType<typeof useRoles>);
+    } satisfies Pick<ReturnType<typeof useRoles>, "data" | "isLoading">;
+    vi.mocked(useMembers).mockReturnValue(
+      membersResult as unknown as ReturnType<typeof useMembers>,
+    );
+    vi.mocked(useRoles).mockReturnValue(
+      rolesResult as unknown as ReturnType<typeof useRoles>,
+    );
     function RouterWrapper({ children }: { children: ReactNode }) {
       return (
         <QueryClientProvider client={qc}>
@@ -160,14 +174,20 @@ describe("useObserveFilters", () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    vi.mocked(useMembers).mockReturnValue({
+    const membersResult = {
       data: { members: [] },
       isLoading: false,
-    } as unknown as ReturnType<typeof useMembers>);
-    vi.mocked(useRoles).mockReturnValue({
+    } satisfies Pick<ReturnType<typeof useMembers>, "data" | "isLoading">;
+    const rolesResult = {
       data: { roles: [] },
       isLoading: false,
-    } as unknown as ReturnType<typeof useRoles>);
+    } satisfies Pick<ReturnType<typeof useRoles>, "data" | "isLoading">;
+    vi.mocked(useMembers).mockReturnValue(
+      membersResult as unknown as ReturnType<typeof useMembers>,
+    );
+    vi.mocked(useRoles).mockReturnValue(
+      rolesResult as unknown as ReturnType<typeof useRoles>,
+    );
     function RouterWrapper({ children }: { children: ReactNode }) {
       return (
         <QueryClientProvider client={qc}>

--- a/client/dashboard/src/components/observe/useObserveFilters.test.tsx
+++ b/client/dashboard/src/components/observe/useObserveFilters.test.tsx
@@ -1,9 +1,22 @@
 import type { ReactNode } from "react";
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter, useNavigate } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { AccessMember, Role } from "@gram/client/models/components";
+import { Operator } from "@gram/client/models/components";
 import { DEFAULT_HOOK_TYPES } from "./observeFilterConstants";
 import { useObserveFilters } from "./useObserveFilters";
+
+vi.mock("@gram/client/react-query/members.js", () => ({
+  useMembers: vi.fn(),
+}));
+vi.mock("@gram/client/react-query/roles.js", () => ({
+  useRoles: vi.fn(),
+}));
+
+import { useMembers } from "@gram/client/react-query/members.js";
+import { useRoles } from "@gram/client/react-query/roles.js";
 
 function useObserveFiltersWithNavigation() {
   const filters = useObserveFilters();
@@ -12,18 +25,96 @@ function useObserveFiltersWithNavigation() {
 }
 
 describe("useObserveFilters", () => {
+  const mockMembers: AccessMember[] = [
+    {
+      id: "m1",
+      email: "alice@example.com",
+      name: "Alice",
+      roleId: "role-admin",
+      joinedAt: new Date(),
+      photoUrl: undefined,
+    },
+    {
+      id: "m2",
+      email: "bob@example.com",
+      name: "Bob",
+      roleId: "role-member",
+      joinedAt: new Date(),
+      photoUrl: undefined,
+    },
+  ];
+  const mockRoles: Role[] = [
+    {
+      id: "role-admin",
+      name: "Admin",
+      slug: "admin",
+      description: "",
+      isSystem: true,
+      memberCount: 1,
+      grants: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: "role-member",
+      name: "Member",
+      slug: "member",
+      description: "",
+      isSystem: false,
+      memberCount: 1,
+      grants: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  function makeWrapper(initialUrl: string) {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(useMembers).mockReturnValue({
+      data: { members: mockMembers },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMembers>);
+    vi.mocked(useRoles).mockReturnValue({
+      data: { roles: mockRoles },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useRoles>);
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={qc}>
+          <MemoryRouter initialEntries={[initialUrl]}>{children}</MemoryRouter>
+        </QueryClientProvider>
+      );
+    }
+    return Wrapper;
+  }
+
   it("derives chips and hook types from browser navigation", () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(useMembers).mockReturnValue({
+      data: { members: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMembers>);
+    vi.mocked(useRoles).mockReturnValue({
+      data: { roles: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useRoles>);
     function RouterWrapper({ children }: { children: ReactNode }) {
       return (
-        <MemoryRouter
-          initialEntries={[
-            "/?server=api&user=alex@example.com&hookTypes=mcp",
-            "/?server=api-v2&user=becca@example.com&hookTypes=local,skill",
-          ]}
-          initialIndex={1}
-        >
-          {children}
-        </MemoryRouter>
+        <QueryClientProvider client={qc}>
+          <MemoryRouter
+            initialEntries={[
+              "/?server=api&user=alex@example.com&hookTypes=mcp",
+              "/?server=api-v2&user=becca@example.com&hookTypes=local,skill",
+            ]}
+            initialIndex={1}
+          >
+            {children}
+          </MemoryRouter>
+        </QueryClientProvider>
       );
     }
 
@@ -66,11 +157,24 @@ describe("useObserveFilters", () => {
   });
 
   it("falls back to default hook types when the URL param is cleared", () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(useMembers).mockReturnValue({
+      data: { members: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMembers>);
+    vi.mocked(useRoles).mockReturnValue({
+      data: { roles: [] },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useRoles>);
     function RouterWrapper({ children }: { children: ReactNode }) {
       return (
-        <MemoryRouter initialEntries={["/?hookTypes=local"]}>
-          {children}
-        </MemoryRouter>
+        <QueryClientProvider client={qc}>
+          <MemoryRouter initialEntries={["/?hookTypes=local"]}>
+            {children}
+          </MemoryRouter>
+        </QueryClientProvider>
       );
     }
 
@@ -85,5 +189,51 @@ describe("useObserveFilters", () => {
     expect(result.current.filters.selectedHookTypes).toEqual(
       DEFAULT_HOOK_TYPES,
     );
+  });
+
+  it("parses role URL param and exposes selectedRoleIds", () => {
+    const { result } = renderHook(() => useObserveFilters(), {
+      wrapper: makeWrapper("/?role=role-admin"),
+    });
+    expect(result.current.selectedRoleIds).toEqual(["role-admin"]);
+  });
+
+  it("exposes roleOptions derived from roles data", () => {
+    const { result } = renderHook(() => useObserveFilters(), {
+      wrapper: makeWrapper("/"),
+    });
+    expect(result.current.roleOptions).toEqual([
+      { id: "role-admin", name: "Admin" },
+      { id: "role-member", name: "Member" },
+    ]);
+  });
+
+  it("includes resolved role emails in logFilters when role is selected", () => {
+    const { result } = renderHook(() => useObserveFilters(), {
+      wrapper: makeWrapper("/?role=role-admin"),
+    });
+    expect(result.current.logFilters).toEqual([
+      {
+        path: "user.email",
+        operator: Operator.In,
+        values: ["alice@example.com"],
+      },
+    ]);
+  });
+
+  it("handleRoleSelectionChange sets role URL param", () => {
+    const { result } = renderHook(() => useObserveFiltersWithNavigation(), {
+      wrapper: makeWrapper("/"),
+    });
+    act(() => result.current.filters.handleRoleSelectionChange(["role-admin"]));
+    expect(result.current.filters.selectedRoleIds).toEqual(["role-admin"]);
+  });
+
+  it("handleRoleSelectionChange with empty array clears role URL param", () => {
+    const { result } = renderHook(() => useObserveFiltersWithNavigation(), {
+      wrapper: makeWrapper("/?role=role-admin"),
+    });
+    act(() => result.current.filters.handleRoleSelectionChange([]));
+    expect(result.current.filters.selectedRoleIds).toEqual([]);
   });
 });

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -7,10 +7,13 @@ import {
   buildLogFilters,
   isValidPreset,
   mergeFilterChip,
+  resolveRoleEmails,
   safeBase64Decode,
   safeBase64Encode,
 } from "./observeFilterUtils";
 import { DEFAULT_HOOK_TYPES, VALID_HOOK_TYPES } from "./observeFilterConstants";
+import { useMembers } from "@gram/client/react-query/members.js";
+import { useRoles } from "@gram/client/react-query/roles.js";
 
 const SERVER_FILTER_PATH = "gram.tool_call.source";
 const USER_EMAIL_FILTER_PATH = "user.email";
@@ -65,6 +68,9 @@ export function useObserveFilters() {
   const [knownServers, setKnownServers] = useState<string[]>([]);
   const [knownUserEmails, setKnownUserEmails] = useState<string[]>([]);
 
+  const { data: membersData } = useMembers();
+  const { data: rolesData } = useRoles();
+
   const urlRange = searchParams.get("range");
   const urlFrom = searchParams.get("from");
   const urlTo = searchParams.get("to");
@@ -83,6 +89,25 @@ export function useObserveFilters() {
     }
     return null;
   }, [urlFrom, urlTo]);
+
+  const selectedRoleIds = useMemo(() => {
+    const raw = searchParams.get("role");
+    if (!raw) return [];
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }, [searchParams]);
+
+  const roleOptions = useMemo(
+    () => (rolesData?.roles ?? []).map((r) => ({ id: r.id, name: r.name })),
+    [rolesData],
+  );
+
+  const roleEmails = useMemo(
+    () => resolveRoleEmails(selectedRoleIds, membersData?.members ?? []),
+    [selectedRoleIds, membersData],
+  );
 
   const updateSearchParams = useCallback(
     (updates: Record<string, string | null>) => {
@@ -135,8 +160,8 @@ export function useObserveFilters() {
   }, [from, to]);
 
   const logFilters = useMemo(
-    () => buildLogFilters(activeFilters),
-    [activeFilters],
+    () => buildLogFilters(activeFilters, roleEmails),
+    [activeFilters, roleEmails],
   );
 
   const addKnownServers = useCallback((names: string[]) => {
@@ -198,6 +223,24 @@ export function useObserveFilters() {
             next.set("server", values.join(","));
           } else {
             next.delete("server");
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleRoleSelectionChange = useCallback(
+    (values: string[]) => {
+      setSearchParams(
+        (urlPrev) => {
+          const next = new URLSearchParams(urlPrev);
+          if (values.length > 0) {
+            next.set("role", values.join(","));
+          } else {
+            next.delete("role");
           }
           return next;
         },
@@ -280,5 +323,8 @@ export function useObserveFilters() {
     setDateRangeParam,
     setCustomRangeParam,
     clearCustomRange,
+    selectedRoleIds,
+    roleOptions,
+    handleRoleSelectionChange,
   };
 }

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -68,7 +68,7 @@ export function useObserveFilters() {
   const [knownServers, setKnownServers] = useState<string[]>([]);
   const [knownUserEmails, setKnownUserEmails] = useState<string[]>([]);
 
-  const { data: membersData } = useMembers();
+  const { data: membersData, isLoading: membersLoading } = useMembers();
   const { data: rolesData } = useRoles();
 
   const urlRange = searchParams.get("range");
@@ -163,6 +163,8 @@ export function useObserveFilters() {
     () => buildLogFilters(activeFilters, roleEmails),
     [activeFilters, roleEmails],
   );
+
+  const roleFilterPending = selectedRoleIds.length > 0 && membersLoading;
 
   const addKnownServers = useCallback((names: string[]) => {
     if (names.length === 0) return;
@@ -326,5 +328,6 @@ export function useObserveFilters() {
     selectedRoleIds,
     roleOptions,
     handleRoleSelectionChange,
+    roleFilterPending,
   };
 }

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -100,7 +100,10 @@ export function useObserveFilters() {
   }, [searchParams]);
 
   const roleOptions = useMemo(
-    () => (rolesData?.roles ?? []).map((r) => ({ id: r.id, name: r.name })),
+    () =>
+      (rolesData?.roles ?? [])
+        .filter((r) => r.memberCount > 0)
+        .map((r) => ({ id: r.id, name: r.name })),
     [rolesData],
   );
 


### PR DESCRIPTION
## Summary

- Add role filter MultiSelect to `ObserveFilterBar` so users can filter logs/insights by organizational role
- Resolve selected role IDs to member emails via `resolveRoleEmails` utility, then merge into ClickHouse `user.email` filter
- Guard against stale queries while members list is loading (`roleFilterPending` + `enabled` prop)
- Hide roles with zero members from the dropdown

## Root cause

Logs/insights in ClickHouse store `user.email` but not role. To filter by role, we resolve role → member emails at query time using the existing `/access/members` and `/access/roles` API responses, then add the emails as an `IN` filter on `user.email`.

## Visual

<img width="1736" height="751" alt="image" src="https://github.com/user-attachments/assets/f3805673-9730-4640-8476-ebd7166bd410" />

## Test plan

- [x] Select a role with members — logs update to show only that role's members
- [x] Select multiple roles — union of member emails applied
- [x] Clear role filter — all logs return
- [x] Roles with zero members do not appear in dropdown
