### PR TITLE
fix(dashboard): paginate all users for accurate token ranking, link to Employees page

### DIFF
--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -85,25 +85,34 @@ export function ProjectDashboard() {
 
   const { data: topUsersSearchData, isPending: isTopUsersPending } = useQuery({
     queryKey: ["project", "topUsers", from.toISOString(), to.toISOString()],
-    queryFn: () =>
-      unwrapAsync(
-        telemetrySearchUsers(client, {
-          searchUsersPayload: {
-            filter: { from, to, eventSource: "hook" },
-            limit: 200,
-            sort: "desc",
-            userType: "internal",
-          },
-        }),
-      ),
+    queryFn: async () => {
+      const users = [];
+      let cursor: string | undefined;
+      do {
+        const result = await unwrapAsync(
+          telemetrySearchUsers(client, {
+            searchUsersPayload: {
+              cursor,
+              filter: { from, to, eventSource: "hook" },
+              limit: 1000,
+              sort: "desc",
+              userType: "internal",
+            },
+          }),
+        );
+        users.push(...result.users);
+        cursor = result.nextCursor;
+      } while (cursor);
+      return users;
+    },
     enabled: logsEnabled,
     placeholderData: keepPreviousData,
   });
 
   const topUsersByTokens = useMemo(() => {
-    if (!topUsersSearchData?.users) return [];
+    if (!topUsersSearchData) return [];
     const memberById = new Map(members.map((m) => [m.id, m]));
-    return [...topUsersSearchData.users]
+    return [...topUsersSearchData]
       .sort((a, b) => b.totalTokens - a.totalTokens)
       .slice(0, 5)
       .map((u) => ({
@@ -280,7 +289,7 @@ export function ProjectDashboard() {
                           })
                         }
                       />
-                      <ViewAllLink to={routes.insights.tools.href()} />
+                      <ViewAllLink to={routes.insights.employees.href()} />
                     </CardActions>
                   }
                 >

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -274,7 +274,7 @@ export function ProjectDashboard() {
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <DashboardCard
                   title="Top Users"
-                  tooltip="End users ranked by total token consumption (input + output tokens) in the selected period."
+                  tooltip="Employees ranked by total token consumption (input + output tokens) in the selected period."
                   action={
                     <CardActions>
                       <ExploreWithAIButton

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -113,12 +113,17 @@ export function ProjectDashboard() {
     if (!topUsersSearchData) return [];
     const memberById = new Map(members.map((m) => [m.id, m]));
     return [...topUsersSearchData]
-      .sort((a, b) => b.totalTokens - a.totalTokens)
+      .sort(
+        (a, b) =>
+          b.totalInputTokens +
+          b.totalOutputTokens -
+          (a.totalInputTokens + a.totalOutputTokens),
+      )
       .slice(0, 5)
       .map((u) => ({
         key: u.userId,
         label: memberById.get(u.userId)?.name ?? u.userId,
-        value: u.totalTokens,
+        value: u.totalInputTokens + u.totalOutputTokens,
       }));
   }, [topUsersSearchData, members]);
 
@@ -269,7 +274,7 @@ export function ProjectDashboard() {
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <DashboardCard
                   title="Top Users"
-                  tooltip="End users ranked by activity in the selected period. Activity is measured in tool calls, skill invocations or in chat messages when agent sessions exist."
+                  tooltip="End users ranked by total token consumption (input + output tokens) in the selected period."
                   action={
                     <CardActions>
                       <ExploreWithAIButton


### PR DESCRIPTION
## Summary

Follow-up to #2985.

- **Full pagination**: the previous implementation fetched only 200 users (sorted by recency on the backend), so high-token users who hadn't been recently active could be missing from the ranking. Now pages through all results using the cursor loop — identical to the `fetchEmployeeUsage` pattern on the Insights Employees page — so the client-side sort by `totalTokens` is exact regardless of project size.
- **"View All" link**: now navigates to the Insights Employees page instead of the Tools page, since that's where the full user token breakdown lives.

## Test plan

- [ ] Verify the Top Users card on Project Overview still loads and ranks by tokens
- [ ] Confirm "View All" opens the Insights → Employees page
- [ ] On a project with >200 users, confirm the top token consumer appears even if they're not recently active

🤖 Generated with [Claude Code](https://claude.com/claude-code)