### PR TITLE
chore: pin sqlc version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@
 "aqua:ariga/atlas" = "1.0.0"
 "github:speakeasy-api/openapi" = "1.19.2"
 "github:speakeasy-api/speakeasy" = "1.761.5"
+"github:sqlc-dev/sqlc" = "1.31.1"
 "github:FiloSottile/mkcert" = "1.4.4"
 apko = "1.1.3"
 flyctl = "0.4.6"


### PR DESCRIPTION
## Summary
- Pin `sqlc` in `mise.toml` to `v1.31.1` using the GitHub release backend.
- Align local SQLC generation with CI so generated file headers do not drift between `v1.29.0` and `v1.31.1`.

## Test plan
- Ran `mise install github:sqlc-dev/sqlc` and verified the installed binary reports `v1.31.1`.
- Ran SQLC generation with `v1.31.1`; no additional tracked generated-file changes were produced on `main` beyond the tool pin.