### PR TITLE
feat(remotesessions): backwards-compat /oauth/callback for legacy-registered clients

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.761.5
 sources:
     Gram-Internal:
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:4f5d0ec1263cc5417617a7cee7786490592d78f7f02371310ef59fe4a224f01f
-        sourceBlobDigest: sha256:16a89de83ab7c177db0d5f4bf86f6f3fbcad0a7b69c026c8bb9dc71377230dd2
+        sourceRevisionDigest: sha256:5a5c5eaef59fff8c0e5bfff4d448fe4b0569b10c6b166130669202062d807b75
+        sourceBlobDigest: sha256:965b1aeebf5ac706e257163351a4de98da7e3c38929df760c4703da66e8aaa88
         tags:
             - latest
             - 0.0.1
@@ -11,8 +11,8 @@ targets:
     gram-internal:
         source: Gram-Internal
         sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:4f5d0ec1263cc5417617a7cee7786490592d78f7f02371310ef59fe4a224f01f
-        sourceBlobDigest: sha256:16a89de83ab7c177db0d5f4bf86f6f3fbcad0a7b69c026c8bb9dc71377230dd2
+        sourceRevisionDigest: sha256:5a5c5eaef59fff8c0e5bfff4d448fe4b0569b10c6b166130669202062d807b75
+        sourceBlobDigest: sha256:965b1aeebf5ac706e257163351a4de98da7e3c38929df760c4703da66e8aaa88
         codeSamplesNamespace: gram-api-description-typescript-code-samples
         codeSamplesRevisionDigest: sha256:901f3d0135976214725cabf726813f14f2148dc9cf0938525f6216c163ced2bc
 workflow:

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -577,6 +577,31 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 		return oops.E(oops.CodeBadRequest, err, "failed to decode OAuth request info from state").Log(ctx, s.logger)
 	}
 
+	// Backwards-compat shim for remote_session_clients whose upstream
+	// registration still points at /oauth/callback. BuildAuthorizationUrl
+	// tagged the envelope with remote_sessions=true; forward into
+	// /mcp/remote_login_callback with the inner state_id so the
+	// remotesessions flow can finish the token exchange. Once
+	// oauth_proxy_servers are dropped and traffic to /oauth/callback drains
+	// to only these forwarded responses, this shim becomes the only purpose
+	// of /oauth/callback.
+	if oauthReqInfo["remote_sessions"] == "true" {
+		fwd := url.Values{}
+		fwd.Set("state", oauthReqInfo["state_id"])
+		if code := r.URL.Query().Get("code"); code != "" {
+			fwd.Set("code", code)
+		}
+		if errCode := r.URL.Query().Get("error"); errCode != "" {
+			fwd.Set("error", errCode)
+		}
+		if desc := r.URL.Query().Get("error_description"); desc != "" {
+			fwd.Set("error_description", desc)
+		}
+		target := strings.TrimRight(s.serverURL.String(), "/") + "/mcp/remote_login_callback?" + fwd.Encode()
+		http.Redirect(w, r, target, http.StatusFound)
+		return nil
+	}
+
 	mcpSlug := oauthReqInfo["mcp_slug"]
 	projectIDStr := oauthReqInfo["project_id"]
 	if mcpSlug == "" || projectIDStr == "" {

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -160,6 +160,11 @@ type Client struct {
 	IssuerScopesSupported []string
 	Audience              string
 	Passthrough           bool
+	// LegacyCallbackUrl flips BuildAuthorizationUrl onto the
+	// /oauth/callback redirect_uri (with a JSON state carrying
+	// remote_sessions=true) so a client registered against the old
+	// oauth_proxy_servers URL keeps working without re-registration.
+	LegacyCallbackUrl bool
 }
 
 func (c Client) resolveScopes() []string {
@@ -198,6 +203,7 @@ func (m *ChallengeManager) ListClients(
 			IssuerScopesSupported: r.ScopesSupported,
 			Audience:              conv.FromPGTextOrEmpty[string](r.ClientAudience),
 			Passthrough:           r.Passthrough,
+			LegacyCallbackUrl:     r.LegacyCallbackUrl,
 		})
 	}
 	return out, nil
@@ -256,6 +262,24 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	}
 	codeChallenge := s256Challenge(verifier)
 	redirectURI := m.callbackURL(parent.RouteBase)
+	stateParam := stateID
+	if client.LegacyCallbackUrl {
+		// Upstream was registered against the legacy oauth_proxy_servers
+		// callback. Keep that exact redirect_uri so the upstream's
+		// strict-match check still passes, and wrap the state in a JSON
+		// envelope tagged remote_sessions=true so /oauth/callback can tell
+		// this response apart from a true proxy callback and forward to
+		// /mcp/remote_login_callback.
+		redirectURI = m.legacyCallbackURL()
+		envelope, eerr := json.Marshal(map[string]string{
+			"remote_sessions": "true",
+			"state_id":        stateID,
+		})
+		if eerr != nil {
+			return "", fmt.Errorf("marshal legacy state envelope: %w", eerr)
+		}
+		stateParam = string(envelope)
+	}
 
 	// Parse the upstream authorize URL before the cache write so a malformed
 	// endpoint can't leave an orphaned RemoteLoginState in Redis (its key is
@@ -289,7 +313,7 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	q.Set("response_type", "code")
 	q.Set("client_id", client.ExternalClientID)
 	q.Set("redirect_uri", redirectURI)
-	q.Set("state", stateID)
+	q.Set("state", stateParam)
 	q.Set("code_challenge", codeChallenge)
 	q.Set("code_challenge_method", "S256")
 	if scopes := client.resolveScopes(); len(scopes) > 0 {
@@ -455,6 +479,14 @@ func (m *ChallengeManager) callbackURL(routeBase string) string {
 		routeBase = "mcp"
 	}
 	return strings.TrimRight(m.serverURL.String(), "/") + "/" + routeBase + "/remote_login_callback"
+}
+
+// legacyCallbackURL is the oauth_proxy_servers-era redirect_uri. Used only
+// for clients flagged LegacyCallbackUrl whose upstream registration still
+// points at this path; /oauth/callback then forwards them into
+// /mcp/remote_login_callback by reading the JSON state envelope.
+func (m *ChallengeManager) legacyCallbackURL() string {
+	return strings.TrimRight(m.serverURL.String(), "/") + "/oauth/callback"
 }
 
 // tokenResponse is the slice of the upstream /token reply we care about.

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -207,6 +207,11 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		TokenEndpointAuthMethod: conv.PtrToPGText(payload.TokenEndpointAuthMethod),
 		Scope:                   payload.Scope,
 		Audience:                conv.PtrToPGText(payload.Audience),
+		// The cloned client_id is already registered upstream against the
+		// oauth_proxy_servers /oauth/callback URL; the authorize leg has to
+		// keep using that redirect_uri or the upstream's strict-match check
+		// rejects the request.
+		LegacyCallbackUrl: true,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "create remote session client").Log(ctx, logger)

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -106,7 +106,8 @@ INSERT INTO remote_session_clients (
     client_secret_expires_at,
     token_endpoint_auth_method,
     scope,
-    audience
+    audience,
+    legacy_callback_url
 )
 VALUES (
     @project_id,
@@ -118,7 +119,8 @@ VALUES (
     @client_secret_expires_at,
     @token_endpoint_auth_method,
     sqlc.narg('scope')::text[],
-    @audience
+    @audience,
+    @legacy_callback_url
 )
 RETURNING *;
 
@@ -259,6 +261,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,
@@ -285,6 +288,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -50,7 +50,8 @@ INSERT INTO remote_session_clients (
     client_secret_expires_at,
     token_endpoint_auth_method,
     scope,
-    audience
+    audience,
+    legacy_callback_url
 )
 VALUES (
     $1,
@@ -62,7 +63,8 @@ VALUES (
     $7,
     $8,
     $9::text[],
-    $10
+    $10,
+    $11
 )
 RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, legacy_callback_url, created_at, updated_at, deleted_at, deleted
 `
@@ -78,6 +80,7 @@ type CreateRemoteSessionClientParams struct {
 	TokenEndpointAuthMethod pgtype.Text
 	Scope                   []string
 	Audience                pgtype.Text
+	LegacyCallbackUrl       bool
 }
 
 func (q *Queries) CreateRemoteSessionClient(ctx context.Context, arg CreateRemoteSessionClientParams) (RemoteSessionClient, error) {
@@ -92,6 +95,7 @@ func (q *Queries) CreateRemoteSessionClient(ctx context.Context, arg CreateRemot
 		arg.TokenEndpointAuthMethod,
 		arg.Scope,
 		arg.Audience,
+		arg.LegacyCallbackUrl,
 	)
 	var i RemoteSessionClient
 	err := row.Scan(
@@ -432,6 +436,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,
@@ -455,6 +460,7 @@ type GetRemoteSessionClientWithIssuerByIDRow struct {
 	TokenEndpointAuthMethod pgtype.Text
 	ClientScope             []string
 	ClientAudience          pgtype.Text
+	LegacyCallbackUrl       bool
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	IssuerSlug              string
@@ -482,6 +488,7 @@ func (q *Queries) GetRemoteSessionClientWithIssuerByID(ctx context.Context, id u
 		&i.TokenEndpointAuthMethod,
 		&i.ClientScope,
 		&i.ClientAudience,
+		&i.LegacyCallbackUrl,
 		&i.RemoteSessionIssuerID,
 		&i.UserSessionIssuerID,
 		&i.IssuerSlug,
@@ -733,6 +740,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,
@@ -763,6 +771,7 @@ type ListRemoteSessionClientsForUserSessionIssuerRow struct {
 	TokenEndpointAuthMethod pgtype.Text
 	ClientScope             []string
 	ClientAudience          pgtype.Text
+	LegacyCallbackUrl       bool
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	IssuerSlug              string
@@ -793,6 +802,7 @@ func (q *Queries) ListRemoteSessionClientsForUserSessionIssuer(ctx context.Conte
 			&i.TokenEndpointAuthMethod,
 			&i.ClientScope,
 			&i.ClientAudience,
+			&i.LegacyCallbackUrl,
 			&i.RemoteSessionIssuerID,
 			&i.UserSessionIssuerID,
 			&i.IssuerSlug,


### PR DESCRIPTION
# Why this thing?

I was hoping we would not need this, but there are enough manually set up clients that have registered callback URLs in external systems that it's worth supporting the old callback URL.

This PR does two things:

1. It makes the new  auth challenge treat the old callback as a jumpthrough enpdoint by passing it a special flag (telling it to redirect to the new callback)
2. It automatically registers clients cloned from oauth_proxy_servers to inherit this behavior. Once this change is live, we should be able to migrate all remaining existing oauth proxy clients over to user sessions (those that are receiving traffic at least)

Stacked on #2997.

## Summary
- **Authorize** (`challenge.go`): when `client.LegacyCallbackUrl` is true, set `redirect_uri = <serverURL>/oauth/callback` and wrap `state` in a JSON envelope `{"remote_sessions":"true","state_id":"<id>"}` so the upstream still matches its strict-registered redirect_uri. The stored `RemoteLoginState.RedirectURI` matches, so the later token-endpoint `redirect_uri` form param matches too.
- **Forward** (`oauth.handleAuthorizationCallback`): after parsing state JSON, if `remote_sessions=true`, 302 to `<serverURL>/mcp/remote_login_callback?state=<state_id>&code=…&error=…&error_description=…`. The new handler finishes the exchange unchanged.
- **Clone** (`CloneClientFromOAuthProxyProvider`): every cloned proxy → remote_session_client now persists `legacy_callback_url=true`, since the upstream registration already points at `/oauth/callback`.

Deprecation plan lives in the schema comment from #2997 — when `oauth_proxy_servers` is fully removed, `/oauth/callback` collapses to just the forwarding shim, and once traffic to it drains, the column can be dropped (expand-contract).

## Test plan
- [ ] `go build ./...` (server) — done locally
- [ ] Unit + e2e: a legacy-flagged client end-to-end (authorize → upstream → `/oauth/callback` → `/mcp/remote_login_callback` → connect)
- [ ] Non-flagged clients still take the direct `/mcp/remote_login_callback` path
- [ ] Cloning an oauth_proxy_provider produces a client with `legacy_callback_url=true`