### PR TITLE
feat: backwards compatible oauth for remote sessions

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,18 +1,8 @@
 speakeasyVersion: 1.761.5
-sources:
-    Gram-Internal:
-        sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:d9e283c3235fc106db59eca268cbfbd8cb4b914b410d3490bfc674e09dd577cf
-        sourceBlobDigest: sha256:97af901c580d544725fc5f117b3123dba70bad3a791204ae27a57f9ff3394da5
-        tags:
-            - latest
-            - 0.0.1
+sources: {}
 targets:
     gram-internal:
         source: Gram-Internal
-        sourceNamespace: gram-api-description
-        sourceRevisionDigest: sha256:d9e283c3235fc106db59eca268cbfbd8cb4b914b410d3490bfc674e09dd577cf
-        sourceBlobDigest: sha256:97af901c580d544725fc5f117b3123dba70bad3a791204ae27a57f9ff3394da5
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: pinned

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -579,6 +579,31 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 		return oops.E(oops.CodeBadRequest, err, "failed to decode OAuth request info from state").Log(ctx, s.logger)
 	}
 
+	// Backwards-compat shim for remote_session_clients whose upstream
+	// registration still points at /oauth/callback. BuildAuthorizationUrl
+	// tagged the envelope with remote_sessions=true; forward into
+	// /mcp/remote_login_callback with the inner state_id so the
+	// remotesessions flow can finish the token exchange. Once
+	// oauth_proxy_servers are dropped and traffic to /oauth/callback drains
+	// to only these forwarded responses, this shim becomes the only purpose
+	// of /oauth/callback.
+	if oauthReqInfo["remote_sessions"] == "true" {
+		fwd := url.Values{}
+		fwd.Set("state", oauthReqInfo["state_id"])
+		if code := r.URL.Query().Get("code"); code != "" {
+			fwd.Set("code", code)
+		}
+		if errCode := r.URL.Query().Get("error"); errCode != "" {
+			fwd.Set("error", errCode)
+		}
+		if desc := r.URL.Query().Get("error_description"); desc != "" {
+			fwd.Set("error_description", desc)
+		}
+		target := strings.TrimRight(s.serverURL.String(), "/") + "/mcp/remote_login_callback?" + fwd.Encode()
+		http.Redirect(w, r, target, http.StatusFound)
+		return nil
+	}
+
 	mcpSlug := oauthReqInfo["mcp_slug"]
 	projectIDStr := oauthReqInfo["project_id"]
 	if mcpSlug == "" || projectIDStr == "" {

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -160,6 +160,11 @@ type Client struct {
 	IssuerScopesSupported []string
 	Audience              string
 	Passthrough           bool
+	// LegacyCallbackUrl flips BuildAuthorizationUrl onto the
+	// /oauth/callback redirect_uri (with a JSON state carrying
+	// remote_sessions=true) so a client registered against the old
+	// oauth_proxy_servers URL keeps working without re-registration.
+	LegacyCallbackUrl bool
 }
 
 func (c Client) resolveScopes() []string {
@@ -195,6 +200,7 @@ func (m *ChallengeManager) ListClients(
 			IssuerScopesSupported: r.ScopesSupported,
 			Audience:              conv.FromPGTextOrEmpty[string](r.ClientAudience),
 			Passthrough:           r.Passthrough,
+			LegacyCallbackUrl:     r.LegacyCallbackUrl,
 		})
 	}
 	return out, nil
@@ -253,6 +259,24 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	}
 	codeChallenge := s256Challenge(verifier)
 	redirectURI := m.callbackURL(parent.RouteBase)
+	stateParam := stateID
+	if client.LegacyCallbackUrl {
+		// Upstream was registered against the legacy oauth_proxy_servers
+		// callback. Keep that exact redirect_uri so the upstream's
+		// strict-match check still passes, and wrap the state in a JSON
+		// envelope tagged remote_sessions=true so /oauth/callback can tell
+		// this response apart from a true proxy callback and forward to
+		// /mcp/remote_login_callback.
+		redirectURI = m.legacyCallbackURL()
+		envelope, eerr := json.Marshal(map[string]string{
+			"remote_sessions": "true",
+			"state_id":        stateID,
+		})
+		if eerr != nil {
+			return "", fmt.Errorf("marshal legacy state envelope: %w", eerr)
+		}
+		stateParam = string(envelope)
+	}
 
 	// Parse the upstream authorize URL before the cache write so a malformed
 	// endpoint can't leave an orphaned RemoteLoginState in Redis (its key is
@@ -286,7 +310,7 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	q.Set("response_type", "code")
 	q.Set("client_id", client.ExternalClientID)
 	q.Set("redirect_uri", redirectURI)
-	q.Set("state", stateID)
+	q.Set("state", stateParam)
 	q.Set("code_challenge", codeChallenge)
 	q.Set("code_challenge_method", "S256")
 	if scopes := client.resolveScopes(); len(scopes) > 0 {
@@ -452,6 +476,14 @@ func (m *ChallengeManager) callbackURL(routeBase string) string {
 		routeBase = "mcp"
 	}
 	return strings.TrimRight(m.serverURL.String(), "/") + "/" + routeBase + "/remote_login_callback"
+}
+
+// legacyCallbackURL is the oauth_proxy_servers-era redirect_uri. Used only
+// for clients flagged LegacyCallbackUrl whose upstream registration still
+// points at this path; /oauth/callback then forwards them into
+// /mcp/remote_login_callback by reading the JSON state envelope.
+func (m *ChallengeManager) legacyCallbackURL() string {
+	return strings.TrimRight(m.serverURL.String(), "/") + "/oauth/callback"
 }
 
 // tokenResponse is the slice of the upstream /token reply we care about.

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -107,6 +107,7 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 		TokenEndpointAuthMethod: conv.PtrToPGText(payload.TokenEndpointAuthMethod),
 		Scope:                   payload.Scope,
 		Audience:                conv.PtrToPGText(payload.Audience),
+		LegacyCallbackUrl:       false,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "create remote session client").Log(ctx, logger)

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -262,6 +262,11 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		TokenEndpointAuthMethod: conv.PtrToPGText(payload.TokenEndpointAuthMethod),
 		Scope:                   payload.Scope,
 		Audience:                conv.PtrToPGText(payload.Audience),
+		// The cloned client_id is already registered upstream against the
+		// oauth_proxy_servers /oauth/callback URL; the authorize leg has to
+		// keep using that redirect_uri or the upstream's strict-match check
+		// rejects the request.
+		LegacyCallbackUrl: true,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "create remote session client").Log(ctx, logger)

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -436,6 +436,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -124,7 +124,8 @@ INSERT INTO remote_session_clients (
     client_secret_expires_at,
     token_endpoint_auth_method,
     scope,
-    audience
+    audience,
+    legacy_callback_url
 )
 VALUES (
     @project_id,
@@ -136,7 +137,8 @@ VALUES (
     @client_secret_expires_at,
     @token_endpoint_auth_method,
     sqlc.narg('scope')::text[],
-    @audience
+    @audience,
+    @legacy_callback_url
 )
 RETURNING *;
 
@@ -407,6 +409,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,
@@ -464,6 +467,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -113,7 +113,8 @@ INSERT INTO remote_session_clients (
     client_secret_expires_at,
     token_endpoint_auth_method,
     scope,
-    audience
+    audience,
+    legacy_callback_url
 )
 VALUES (
     $1,
@@ -125,7 +126,8 @@ VALUES (
     $7,
     $8,
     $9::text[],
-    $10
+    $10,
+    $11
 )
 RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, client_id, client_secret_encrypted, client_id_issued_at, client_secret_expires_at, token_endpoint_auth_method, scope, audience, legacy_callback_url, created_at, updated_at, deleted_at, deleted
 `
@@ -141,6 +143,7 @@ type CreateRemoteSessionClientParams struct {
 	TokenEndpointAuthMethod pgtype.Text
 	Scope                   []string
 	Audience                pgtype.Text
+	LegacyCallbackUrl       bool
 }
 
 func (q *Queries) CreateRemoteSessionClient(ctx context.Context, arg CreateRemoteSessionClientParams) (RemoteSessionClient, error) {
@@ -155,6 +158,7 @@ func (q *Queries) CreateRemoteSessionClient(ctx context.Context, arg CreateRemot
 		arg.TokenEndpointAuthMethod,
 		arg.Scope,
 		arg.Audience,
+		arg.LegacyCallbackUrl,
 	)
 	var i RemoteSessionClient
 	err := row.Scan(
@@ -531,6 +535,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,
@@ -554,6 +559,7 @@ type GetRemoteSessionClientWithIssuerByIDRow struct {
 	TokenEndpointAuthMethod pgtype.Text
 	ClientScope             []string
 	ClientAudience          pgtype.Text
+	LegacyCallbackUrl       bool
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	IssuerSlug              string
@@ -581,6 +587,7 @@ func (q *Queries) GetRemoteSessionClientWithIssuerByID(ctx context.Context, id u
 		&i.TokenEndpointAuthMethod,
 		&i.ClientScope,
 		&i.ClientAudience,
+		&i.LegacyCallbackUrl,
 		&i.RemoteSessionIssuerID,
 		&i.UserSessionIssuerID,
 		&i.IssuerSlug,
@@ -1030,6 +1037,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,
@@ -1064,6 +1072,7 @@ type ListRemoteSessionClientsForUserSessionIssuerRow struct {
 	TokenEndpointAuthMethod pgtype.Text
 	ClientScope             []string
 	ClientAudience          pgtype.Text
+	LegacyCallbackUrl       bool
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	IssuerSlug              string
@@ -1094,6 +1103,7 @@ func (q *Queries) ListRemoteSessionClientsForUserSessionIssuer(ctx context.Conte
 			&i.TokenEndpointAuthMethod,
 			&i.ClientScope,
 			&i.ClientAudience,
+			&i.LegacyCallbackUrl,
 			&i.RemoteSessionIssuerID,
 			&i.UserSessionIssuerID,
 			&i.IssuerSlug,

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -1132,6 +1132,7 @@ SELECT
     c.token_endpoint_auth_method           AS token_endpoint_auth_method,
     c.scope                                AS client_scope,
     c.audience                             AS client_audience,
+    c.legacy_callback_url                  AS legacy_callback_url,
     c.remote_session_issuer_id             AS remote_session_issuer_id,
     c.user_session_issuer_id               AS user_session_issuer_id,
     i.slug                                 AS issuer_slug,
@@ -1165,6 +1166,7 @@ type ListRemoteSessionClientsForUserSessionIssuerLegacyRow struct {
 	TokenEndpointAuthMethod pgtype.Text
 	ClientScope             []string
 	ClientAudience          pgtype.Text
+	LegacyCallbackUrl       bool
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	IssuerSlug              string
@@ -1194,6 +1196,7 @@ func (q *Queries) ListRemoteSessionClientsForUserSessionIssuerLegacy(ctx context
 			&i.TokenEndpointAuthMethod,
 			&i.ClientScope,
 			&i.ClientAudience,
+			&i.LegacyCallbackUrl,
 			&i.RemoteSessionIssuerID,
 			&i.UserSessionIssuerID,
 			&i.IssuerSlug,


### PR DESCRIPTION
accidentally merged #2998 into the migration instead of main