### PR TITLE
fix(mcp): always emit result field in JSON-RPC success responses

### DIFF
--- a/.changeset/age-2512-mcp-ping-result-field.md
+++ b/.changeset/age-2512-mcp-ping-result-field.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Always emit the `result` field in JSON-RPC success responses from the MCP server. Empty-result handlers (notably `ping`) previously sent `{"jsonrpc":"2.0","id":N}`, which violates JSON-RPC 2.0 and the MCP spec. Cursor's MCP SDK rejected those frames with `invalid_union` zod errors and dropped the transport to a failed state after each keep-alive ping.

--- a/server/internal/mcp/rpc.go
+++ b/server/internal/mcp/rpc.go
@@ -107,12 +107,12 @@ func (m *msgID) UnmarshalJSON(data []byte) error {
 type resultEnvelope[T any] struct {
 	JSONRPC string `json:"jsonrpc"`
 	ID      msgID  `json:"id"`
-	Result  T      `json:"result,omitempty,omitzero"`
+	Result  T      `json:"result"`
 }
 
 type result[T any] struct {
 	ID     msgID `json:"id"`
-	Result T     `json:"result,omitempty,omitzero"`
+	Result T     `json:"result"`
 }
 
 func (m result[T]) MarshalJSON() ([]byte, error) {

--- a/server/internal/mcp/rpc_ping_test.go
+++ b/server/internal/mcp/rpc_ping_test.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestHandlePing_IncludesEmptyResultObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := testenv.NewLogger(t)
+
+	bs, err := handlePing(ctx, logger, msgID{format: 1, Number: 42})
+	require.NoError(t, err)
+
+	// MCP/JSON-RPC require the result field be present even when empty.
+	// Cursor's zod schema rejects responses missing result/error/method.
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(bs, &decoded))
+	require.Contains(t, decoded, "result")
+	require.JSONEq(t, `{}`, string(decoded["result"]))
+	require.JSONEq(t, `42`, string(decoded["id"]))
+	require.JSONEq(t, `"2.0"`, string(decoded["jsonrpc"]))
+}


### PR DESCRIPTION
## What the customer reported

A customer using Cursor as their MCP client saw a recurring stream of `invalid_union` zod errors logged against their Gram MCP server. Disabling and re-enabling the MCP entry would buy a few minutes of quiet, then the same errors returned. The errors complained that an inbound frame from the server did not match any of the four JSON-RPC shapes that Cursor's MCP SDK accepts — it was missing `method`, `result`, and `error` all at once, while still carrying an `id`.

Their log showed the failure landing roughly 5–6 minutes after a successful connection, with no tool call in between.

## Why it happened

Cursor's MCP panel keep-alives idle connections by sending JSON-RPC `ping` requests so it can render the green/red status indicator. Our ping handler builds a `result[struct{}]` envelope with an empty struct as the result body. The `Result` field on the envelope was tagged `json:"result,omitempty,omitzero"`, and Go's encoder treats `struct{}{}` as the zero value, so the `result` field was dropped from the wire entirely. The frame Cursor received was:

```json
{"jsonrpc":"2.0","id":N}
```

This is invalid by JSON-RPC 2.0 (success responses must carry `result`) and by the MCP spec (ping responses must return `result: {}`). Cursor's MCP TypeScript SDK validates every inbound frame against a strict zod union of request / notification / response / error; the malformed ping fails all four branches, the SDK throws `invalid_union`, and Cursor's transport FSM flips `connected → failed`. The "disable / enable" workaround re-established the connection and reset the ~5 min ping clock, which is why the issue felt intermittent.

The bug never surfaced on other clients because most MCP clients we've seen don't keep-alive idle connections — they only open a session when invoking a tool, and every non-ping handler returns a non-zero `result`, so `omitzero` never kicks in.

## How this fix addresses it

- `server/internal/mcp/rpc.go`: drops `omitempty,omitzero` from the `Result` JSON tag on `resultEnvelope` and `result`. JSON-RPC success responses must always carry a `result` field; the previous tag was the only thing letting it disappear.
- `server/internal/mcp/rpc_ping_test.go`: new regression test that decodes `handlePing` output and asserts `result: {}` is present.

After the change, ping responses go out as `{"jsonrpc":"2.0","id":N,"result":{}}`, which satisfies Cursor's zod union and keeps the transport in the `connected` state across keep-alive cycles.

Linked: AGE-2512

## Test plan

- [x] `TestHandlePing_IncludesEmptyResultObject` passes locally
- [x] `go build ./...` clean
- [ ] Manual verification with MCP Inspector and Cursor against a local Gram MCP server: connect, idle past keep-alive, confirm no `transport_error` and `result: {}` on the wire