### PR TITLE
feat(dashboard): authentication UI for remote-backed MCP servers

### DIFF
--- a/.changeset/mcp-server-authentication-ui.md
+++ b/.changeset/mcp-server-authentication-ui.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Added remote-based MCP server authentication UI

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -40,6 +40,7 @@ import { useState } from "react";
 import { Navigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { MCPTeamAccessTab } from "../MCPTeamAccessTab";
+import { AuthenticationTab } from "./tabs/authentication/AuthenticationTab";
 import { EndpointsTab } from "./tabs/EndpointsTab";
 import { OverviewTab } from "./tabs/OverviewTab";
 import { SettingsTab } from "./tabs/SettingsTab";
@@ -47,6 +48,7 @@ import { SettingsTab } from "./tabs/SettingsTab";
 const VALID_TABS = [
   "overview",
   "endpoints",
+  "authentication",
   "team-access",
   "settings",
 ] as const;
@@ -63,12 +65,16 @@ export default function MCPServerDetails() {
   const isRemoteMcpEnabled =
     telemetry.isFeatureEnabled("gram-remote-mcp") ?? false;
   const isRbacEnabled = telemetry.isFeatureEnabled("gram-rbac") ?? false;
+  const isUserSessionManagementEnabled =
+    telemetry.isFeatureEnabled("gram-user-session-management") ?? false;
   const idOrSlug = mcpServerSlug ?? "";
 
   const [activeTab, setActiveTab] = useState<TabValue>(() => {
     const hash = window.location.hash.replace("#", "");
     if (!isValidTab(hash)) return "overview";
     if (hash === "team-access" && !isRbacEnabled) return "overview";
+    if (hash === "authentication" && !isUserSessionManagementEnabled)
+      return "overview";
     return hash;
   });
 
@@ -136,6 +142,11 @@ export default function MCPServerDetails() {
                   Endpoints
                   {endpoints.length > 0 && ` (${endpoints.length})`}
                 </PageTabsTrigger>
+                {isUserSessionManagementEnabled && (
+                  <PageTabsTrigger value="authentication">
+                    Authentication
+                  </PageTabsTrigger>
+                )}
                 {isRbacEnabled && (
                   <PageTabsTrigger value="team-access">
                     Team Access
@@ -155,6 +166,8 @@ export default function MCPServerDetails() {
               endpoints={endpoints}
               isLoadingEndpoints={isLoadingEndpoints}
               onShowEndpoints={() => handleTabChange("endpoints")}
+              showAuthentication={isUserSessionManagementEnabled}
+              onShowAuthentication={() => handleTabChange("authentication")}
             />
           </TabsContent>
 
@@ -170,6 +183,15 @@ export default function MCPServerDetails() {
               />
             )}
           </TabsContent>
+
+          {isUserSessionManagementEnabled && mcpServer && (
+            <TabsContent
+              value="authentication"
+              className="mt-0 min-h-0 flex-1 overflow-y-auto"
+            >
+              <AuthenticationTab mcpServer={mcpServer} />
+            </TabsContent>
+          )}
 
           {isRbacEnabled && mcpServer && (
             <TabsContent
@@ -204,6 +226,9 @@ export default function MCPServerDetails() {
   );
 }
 
+// The dropdown only offers the two states that gate whether the server
+// serves traffic. Any other stored visibility values render their label via
+// currentLabel below.
 const VISIBILITY_OPTIONS: {
   value: McpServerVisibility;
   label: string;
@@ -221,16 +246,9 @@ const VISIBILITY_OPTIONS: {
   {
     value: "private",
     label: "Private",
-    description: "Requires Gram platform authentication.",
+    description: "The server serves traffic.",
     dotClass: "bg-blue-400",
     hoverDotClass: "group-hover:bg-blue-400",
-  },
-  {
-    value: "public",
-    label: "Public",
-    description: "Relies solely on the server's configured authentication.",
-    dotClass: "bg-green-400",
-    hoverDotClass: "group-hover:bg-green-400",
   },
 ];
 
@@ -272,6 +290,10 @@ function MCPServerStatusDropdown({ server }: { server: McpServer }) {
           remoteMcpServerId: server.remoteMcpServerId ?? undefined,
           toolsetId: server.toolsetId ?? undefined,
           environmentId: server.environmentId ?? undefined,
+          // updateMcpServer is a full-record replace for the optional UUID
+          // references. Forwarding userSessionIssuerId keeps the stored
+          // value intact across a visibility-only update.
+          userSessionIssuerId: server.userSessionIssuerId ?? undefined,
           visibility: next,
         },
       },

--- a/client/dashboard/src/pages/mcp/x/tabs/OverviewTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/OverviewTab.tsx
@@ -16,9 +16,17 @@ import type {
 import {
   useGetRemoteMcpServer,
   useListToolsets,
+  useRemoteSessionClients,
 } from "@gram/client/react-query/index.js";
 import { Badge, Button, Stack } from "@speakeasy-api/moonshine";
-import { ArrowRight, Network, Plus, Wrench } from "lucide-react";
+import {
+  ArrowRight,
+  Lock,
+  Network,
+  Plus,
+  ShieldCheck,
+  Wrench,
+} from "lucide-react";
 import { useMemo, type ReactNode } from "react";
 
 export function OverviewTab({
@@ -26,11 +34,15 @@ export function OverviewTab({
   endpoints,
   isLoadingEndpoints,
   onShowEndpoints,
+  showAuthentication,
+  onShowAuthentication,
 }: {
   mcpServer: McpServer | undefined;
   endpoints: McpEndpoint[];
   isLoadingEndpoints: boolean;
   onShowEndpoints: () => void;
+  showAuthentication: boolean;
+  onShowAuthentication: () => void;
 }) {
   return (
     <div className="mx-auto w-full max-w-[1270px] space-y-8 px-8 py-8">
@@ -39,6 +51,12 @@ export function OverviewTab({
         isLoading={isLoadingEndpoints}
         onShowEndpoints={onShowEndpoints}
       />
+      {showAuthentication && mcpServer && (
+        <AuthenticationOverviewSection
+          mcpServer={mcpServer}
+          onNavigate={onShowAuthentication}
+        />
+      )}
       {mcpServer && <SourcesSection mcpServer={mcpServer} />}
 
       {/* TODO(AGE-2239): wire the install-page branding affordance in once
@@ -115,6 +133,107 @@ function InstallPageRow({ endpoint }: { endpoint: McpEndpoint }) {
     <Type muted small>
       URL unavailable (custom domain still resolving).
     </Type>
+  );
+}
+
+function AuthenticationOverviewSection({
+  mcpServer,
+  onNavigate,
+}: {
+  mcpServer: McpServer;
+  onNavigate: () => void;
+}) {
+  const userSessionIssuerId = mcpServer.userSessionIssuerId;
+  const { data: clientsResult, isLoading } = useRemoteSessionClients(
+    { userSessionIssuerId },
+    undefined,
+    { enabled: !!userSessionIssuerId },
+  );
+
+  // Count distinct upstream identity providers (one user_session_issuer can be
+  // paired with the same remote_session_issuer through multiple clients).
+  const providerCount = clientsResult
+    ? new Set(
+        clientsResult.result.items.map(
+          (client) => client.remoteSessionIssuerId,
+        ),
+      ).size
+    : 0;
+
+  return (
+    <section>
+      <Heading variant="h4" className="mb-3">
+        Authentication
+      </Heading>
+      <Type muted small className="mb-4">
+        Manage security for MCP Clients
+      </Type>
+      {!userSessionIssuerId ? (
+        <Stack gap={3}>
+          <Stack direction="horizontal" gap={2} align="center">
+            <Lock className="text-muted-foreground size-4" />
+            <Type className="font-medium">
+              No remote identity providers configured yet.
+            </Type>
+          </Stack>
+          <div>
+            <Button variant="secondary" onClick={onNavigate}>
+              <Button.LeftIcon>
+                <Plus className="size-4" />
+              </Button.LeftIcon>
+              <Button.Text>Configure Authentication</Button.Text>
+            </Button>
+          </div>
+        </Stack>
+      ) : (
+        <button
+          type="button"
+          onClick={onNavigate}
+          className="block w-full cursor-pointer text-left hover:no-underline"
+        >
+          <DotCard
+            icon={<ShieldCheck className="text-muted-foreground h-8 w-8" />}
+          >
+            <div className="mb-2 flex items-start justify-between gap-2">
+              <Type
+                variant="subheading"
+                as="div"
+                className="text-md group-hover:text-primary transition-colors"
+              >
+                Platform authentication enabled
+              </Type>
+            </div>
+            {isLoading ? (
+              <Type muted small>
+                Loading identity providers…
+              </Type>
+            ) : providerCount === 0 ? (
+              <Stack direction="horizontal" gap={2} align="center">
+                <Lock className="text-muted-foreground size-4" />
+                <Type className="font-medium">
+                  No remote identity providers configured yet.
+                </Type>
+              </Stack>
+            ) : (
+              <Type muted small>
+                {providerCount === 1
+                  ? "1 remote identity provider configured."
+                  : `${providerCount} remote identity providers configured.`}
+              </Type>
+            )}
+            <div className="mt-auto flex items-center justify-between gap-2 pt-2">
+              <Badge variant="success">
+                <Badge.Text>OAuth-gated</Badge.Text>
+              </Badge>
+              <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
+                <span>Open</span>
+                <ArrowRight className="h-3.5 w-3.5" />
+              </div>
+            </div>
+          </DotCard>
+        </button>
+      )}
+    </section>
   );
 }
 

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -1,0 +1,614 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Type } from "@/components/ui/type";
+import { useFetcher } from "@/contexts/Fetcher";
+import { useSdkClient } from "@/contexts/Sdk";
+import {
+  buildUserSessionResourceSlug,
+  DEFAULT_USER_SESSION_DURATION_HOURS,
+} from "@/lib/externalMcpUserSessions";
+import { proxyRegisterUpstreamClient } from "@/lib/proxyRegisterUpstreamClient";
+import type {
+  McpServer,
+  RemoteSessionIssuer,
+  UserSessionIssuer,
+} from "@gram/client/models/components";
+import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/client/models/components";
+import {
+  invalidateAllGetMcpServer,
+  invalidateAllMcpServers,
+  invalidateAllRemoteSessionClients,
+  invalidateAllRemoteSessionIssuers,
+  invalidateAllUserSessionIssuers,
+} from "@gram/client/react-query/index.js";
+import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  ClientCredentialsFields,
+  DcrNotice,
+  EndpointsFields,
+  IssuerUrlField,
+  OverridesFields,
+  TokenEndpointAuthMethodField,
+} from "./IssuerFormFields";
+import { narrowTokenEndpointAuthMethod, parseScopes } from "./issuerFormUtils";
+import { useIssuerDiscovery } from "./useIssuerDiscovery";
+
+type Mode = "select" | "new";
+
+export function AttachRemoteIdentityProviderSheet({
+  open,
+  onOpenChange,
+  mcpServer,
+  userSessionIssuer,
+  selectableIssuers,
+  initialIssuerUrl,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mcpServer: McpServer;
+  // null when the MCP server has no user_session_issuer linked yet — the
+  // first add also creates one and links it via updateMcpServer.
+  userSessionIssuer: UserSessionIssuer | null;
+  // Project-scope remote_session_issuers that are not already associated with
+  // userSessionIssuer. Empty list hides the "Select existing" mode.
+  selectableIssuers: RemoteSessionIssuer[];
+  // When the caller opens via "Start With Discovered Configuration", this is the
+  // authorization_servers[0] entry from the RFC 9728 probe. The sheet starts
+  // in "new" mode and runs RFC 8414 discovery against this URL to prefill the
+  // upstream endpoints.
+  initialIssuerUrl?: string;
+}) {
+  const client = useSdkClient();
+  const { fetch: authedFetch } = useFetcher();
+  const queryClient = useQueryClient();
+
+  const hasSelectable = selectableIssuers.length > 0;
+  const [mode, setMode] = useState<Mode>(
+    initialIssuerUrl || !hasSelectable ? "new" : "select",
+  );
+  const [selectedIssuerId, setSelectedIssuerId] = useState<string>("");
+
+  const [slug, setSlug] = useState("");
+  // When the operator hasn't manually edited Slug, we keep it in lockstep
+  // with a slugified form of the Issuer URL hostname (similar to the remote
+  // MCP source slug auto-derivation). Once they type into Slug we treat it
+  // as their value and stop overwriting it.
+  const [slugDirty, setSlugDirty] = useState(false);
+
+  // Issuer URL + 4 endpoint fields + discovery state live in the shared
+  // hook. The hook seeds from `null` here — the Attach sheet starts blank
+  // and the "Start With Discovered Configuration" path triggers an explicit
+  // runDiscover below.
+  const discovery = useIssuerDiscovery(null);
+  const {
+    issuerUrl,
+    setIssuerUrl,
+    authorizationEndpoint,
+    setAuthorizationEndpoint,
+    tokenEndpoint,
+    setTokenEndpoint,
+    registrationEndpoint,
+    setRegistrationEndpoint,
+    jwksUri,
+    setJwksUri,
+    discoveredSnapshot,
+    discoverPending,
+    discoverError,
+    setDiscoverError,
+    runDiscover,
+    handleResetEndpoints,
+    resetEndpointState,
+    showDiscoverControls,
+    showResetControls,
+    endpointWarnings,
+  } = discovery;
+
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [tokenEndpointAuthMethod, setTokenEndpointAuthMethod] = useState<
+    CreateRemoteSessionClientFormTokenEndpointAuthMethod | ""
+  >("");
+
+  // Per-client OAuth dance overrides. Both apply regardless of how the client
+  // was registered (DCR vs manual). scopeOverride is comma-separated, parsed
+  // into string[] on submit. audienceOverride is RFC 8707 — only ever sent
+  // at flow time, never at DCR registration.
+  const [scopeOverride, setScopeOverride] = useState("");
+  const [audienceOverride, setAudienceOverride] = useState("");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Reset transient state whenever the sheet is reopened. The mcpServer slug
+  // seeds the default new-issuer slug so most operators can submit without
+  // touching the field, but we still allow editing.
+  useEffect(() => {
+    if (!open) return;
+    setMode(initialIssuerUrl || !hasSelectable ? "new" : "select");
+    setSelectedIssuerId("");
+    // Seed the slug from the Issuer URL when we have one (the "Start With
+    // Discovered Configuration" path). Otherwise fall back to the
+    // mcpServer-based default. Either way slugDirty resets to false so the
+    // operator's first keystroke in the field starts locking it in.
+    setSlug(
+      deriveSlugFromUrl(initialIssuerUrl ?? "") ??
+        buildUserSessionResourceSlug(mcpServer.slug ?? "mcp"),
+    );
+    setSlugDirty(false);
+    setIssuerUrl(initialIssuerUrl ?? "");
+    resetEndpointState();
+    setDiscoverError(null);
+    setClientId("");
+    setClientSecret("");
+    setTokenEndpointAuthMethod("");
+    setScopeOverride("");
+    setAudienceOverride("");
+    setSubmitting(false);
+    setSubmitError(null);
+  }, [
+    open,
+    mcpServer.slug,
+    initialIssuerUrl,
+    hasSelectable,
+    setIssuerUrl,
+    resetEndpointState,
+    setDiscoverError,
+  ]);
+
+  // Auto-run discovery when the sheet opens with a seeded URL (came in via
+  // "Start With Discovered Configuration"). Manual configure leaves this to the
+  // explicit "Discover" button in the Endpoints section.
+  useEffect(() => {
+    if (!open || !initialIssuerUrl) return;
+    void runDiscover(initialIssuerUrl);
+  }, [open, initialIssuerUrl, runDiscover]);
+
+  // Resolve the issuer record the operator picked in Select-existing mode.
+  // We need it to know whether the picked issuer supports DCR and to pull
+  // its registration_endpoint at submit time.
+  const selectedIssuer =
+    mode === "select"
+      ? selectableIssuers.find((issuer) => issuer.id === selectedIssuerId)
+      : undefined;
+
+  // DCR is offered automatically when a registration_endpoint is present.
+  // In Add-new the value comes from the form (filled by discovery or typed);
+  // in Select-existing it comes from the picked issuer record. Either way we
+  // hide the manual client_id / client_secret form and call proxy-register
+  // on submit.
+  const dcrAvailable =
+    mode === "new"
+      ? registrationEndpoint.trim().length > 0
+      : !!selectedIssuer?.registrationEndpoint;
+
+  const submittable = useMemo(() => {
+    if (mode === "select") return !!selectedIssuerId;
+    if (!slug.trim() || !issuerUrl.trim()) return false;
+    if (!dcrAvailable && !clientId.trim()) return false;
+    return true;
+  }, [mode, selectedIssuerId, slug, issuerUrl, dcrAvailable, clientId]);
+
+  const handleSubmit = async () => {
+    if (!submittable || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      // Step 1: ensure a user_session_issuer exists. First-add auto-creates
+      // one with the conservative interactive challenge mode and a 2-week
+      // session lifetime — these match the wire-user-session-issuer defaults.
+      let issuerId = userSessionIssuer?.id;
+      if (!issuerId) {
+        const created = await client.userSessionIssuers.create({
+          createUserSessionIssuerForm: {
+            slug: buildUserSessionResourceSlug(mcpServer.slug ?? "mcp"),
+            authnChallengeMode: "interactive",
+            sessionDurationHours: DEFAULT_USER_SESSION_DURATION_HOURS,
+          },
+        });
+        issuerId = created.id;
+      }
+
+      // Step 2: resolve the remote_session_issuer — pick existing or create a
+      // new one from the form fields. Empty endpoint inputs are omitted so
+      // the backend can store them as null rather than empty strings.
+      let resolvedIssuer: RemoteSessionIssuer | undefined;
+      let remoteIssuerId: string;
+      if (mode === "select") {
+        remoteIssuerId = selectedIssuerId;
+        resolvedIssuer = selectableIssuers.find(
+          (issuer) => issuer.id === selectedIssuerId,
+        );
+      } else {
+        const created = await client.remoteSessionIssuers.create({
+          createRemoteSessionIssuerForm: {
+            slug: slug.trim(),
+            issuer: issuerUrl.trim(),
+            authorizationEndpoint: authorizationEndpoint.trim() || undefined,
+            tokenEndpoint: tokenEndpoint.trim() || undefined,
+            registrationEndpoint: registrationEndpoint.trim() || undefined,
+            jwksUri: jwksUri.trim() || undefined,
+            // RFC 8414 metadata arrays are NOT NULL on the server side. When
+            // discovery ran we forward what it returned; when the operator
+            // typed everything by hand we send empty arrays so the upstream
+            // matches "issuer did not advertise these" semantics.
+            scopesSupported: discoveredSnapshot?.scopesSupported ?? [],
+            grantTypesSupported: discoveredSnapshot?.grantTypesSupported ?? [],
+            responseTypesSupported:
+              discoveredSnapshot?.responseTypesSupported ?? [],
+            tokenEndpointAuthMethodsSupported:
+              discoveredSnapshot?.tokenEndpointAuthMethodsSupported ?? [],
+          },
+        });
+        remoteIssuerId = created.id;
+        resolvedIssuer = created;
+      }
+
+      // Step 3: obtain client credentials. When DCR is available the proxy
+      // registers Gram with the upstream and hands back client_id /
+      // client_secret; otherwise we use what the operator typed. The scope
+      // override (if set) is forwarded to the registration call so the
+      // upstream registers the client with that scope set. DCR fires in both
+      // modes — in Add-new it uses the form field, in Select-existing it
+      // uses the picked issuer's saved registration_endpoint.
+      const parsedScopes = parseScopes(scopeOverride);
+      const trimmedAudience = audienceOverride.trim();
+      const registrationEndpointForDcr =
+        resolvedIssuer?.registrationEndpoint ?? "";
+      let clientCredentials: {
+        clientId: string;
+        clientSecret?: string;
+        tokenEndpointAuthMethod?: CreateRemoteSessionClientFormTokenEndpointAuthMethod;
+      };
+      // Tracks when DCR returns an auth method the SDK enum doesn't model
+      // (e.g. `none`, `private_key_jwt`). We swallow it for the local client
+      // record but warn the operator after success so they understand why
+      // their client may not behave as the upstream advertised.
+      let unsupportedDcrAuthMethod: string | null = null;
+      if (dcrAvailable && registrationEndpointForDcr) {
+        const registered = await proxyRegisterUpstreamClient(authedFetch, {
+          registrationEndpoint: registrationEndpointForDcr,
+          // RFC 7591 §2: scope is a space-separated string at registration
+          // time. Only forward if the operator typed an override.
+          scope: parsedScopes.length > 0 ? parsedScopes.join(" ") : undefined,
+          // Forward the operator's auth-method preference so DCR registers
+          // the client with that method. Omit when blank so the upstream
+          // picks its own default.
+          tokenEndpointAuthMethod: tokenEndpointAuthMethod || undefined,
+        });
+        const narrowedDcrMethod = narrowTokenEndpointAuthMethod(
+          registered.tokenEndpointAuthMethod,
+        );
+        if (registered.tokenEndpointAuthMethod && !narrowedDcrMethod) {
+          unsupportedDcrAuthMethod = registered.tokenEndpointAuthMethod;
+        }
+        clientCredentials = {
+          clientId: registered.clientId,
+          clientSecret: registered.clientSecret || undefined,
+          // Prefer the upstream-confirmed method when it's one we support;
+          // fall back to the operator's selection so a known-good value
+          // still lands on the client record even if DCR echoed back
+          // something unknown. Treat the operator's "" sentinel (no
+          // selection) as undefined so the API sees an omitted value.
+          tokenEndpointAuthMethod:
+            narrowedDcrMethod ?? (tokenEndpointAuthMethod || undefined),
+        };
+      } else {
+        clientCredentials = {
+          clientId: clientId.trim(),
+          clientSecret: clientSecret.trim() || undefined,
+          tokenEndpointAuthMethod: tokenEndpointAuthMethod || undefined,
+        };
+      }
+
+      // Step 4: create the remote_session_client binding the resolved issuer
+      // to the user_session_issuer. Scope/audience overrides are stored on
+      // the client and consumed at OAuth dance time.
+      await client.remoteSessionClients.create({
+        createRemoteSessionClientForm: {
+          remoteSessionIssuerId: remoteIssuerId,
+          userSessionIssuerId: issuerId,
+          clientId: clientCredentials.clientId,
+          clientSecret: clientCredentials.clientSecret,
+          tokenEndpointAuthMethod: clientCredentials.tokenEndpointAuthMethod,
+          scope: parsedScopes.length > 0 ? parsedScopes : undefined,
+          audience: trimmedAudience || undefined,
+        },
+      });
+
+      // Step 5: on first-add, point the MCP server at the freshly-created
+      // user_session_issuer and set visibility to private so the server
+      // begins serving traffic. updateMcpServer is a full-record replace,
+      // so re-send the existing UUID references alongside the update.
+      if (!userSessionIssuer) {
+        await client.mcpServers.update({
+          updateMcpServerForm: {
+            id: mcpServer.id,
+            name: mcpServer.name ?? undefined,
+            remoteMcpServerId: mcpServer.remoteMcpServerId ?? undefined,
+            toolsetId: mcpServer.toolsetId ?? undefined,
+            environmentId: mcpServer.environmentId ?? undefined,
+            visibility: "private",
+            userSessionIssuerId: issuerId,
+          },
+        });
+      }
+
+      await Promise.all([
+        invalidateAllUserSessionIssuers(queryClient, { refetchType: "all" }),
+        invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
+        invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
+        invalidateAllGetMcpServer(queryClient, { refetchType: "all" }),
+        invalidateAllMcpServers(queryClient, { refetchType: "all" }),
+      ]);
+
+      toast.success("Identity provider attached");
+      if (unsupportedDcrAuthMethod) {
+        toast.warning(
+          `Upstream issuer reported token endpoint auth method "${unsupportedDcrAuthMethod}", which the platform doesn't model. The client falls back to ${tokenEndpointAuthMethod || "client_secret_basic"} — adjust on the identity provider's Modify sheet if needed.`,
+        );
+      }
+      onOpenChange(false);
+    } catch (error) {
+      // Backend Create messages aren't always actionable (e.g. the generic
+      // "create remote session issuer" fallback) but specific ones like
+      // "an identity provider with slug already exists" or 4xx validation
+      // errors absolutely are — surface error.message when present and only
+      // fall back to a friendly default when we have nothing better.
+      console.error("Attach identity provider failed", error);
+      setSubmitError(
+        error instanceof Error && error.message
+          ? error.message
+          : "An unexpected error occurred. Please try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-[560px] flex-col sm:max-w-[560px]"
+      >
+        <SheetHeader className="px-6 pt-6 pb-0">
+          <SheetTitle className="text-lg font-semibold">
+            Attach Remote Identity Provider
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-6">
+          {hasSelectable && <ModeSwitch mode={mode} onChange={setMode} />}
+
+          {mode === "select" ? (
+            <SelectExistingFields
+              selectableIssuers={selectableIssuers}
+              selectedIssuerId={selectedIssuerId}
+              onChange={setSelectedIssuerId}
+            />
+          ) : (
+            <Stack gap={4}>
+              <IssuerUrlField
+                issuerUrl={issuerUrl}
+                onIssuerUrlChange={(value) => {
+                  setIssuerUrl(value);
+                  // A stale error from a previous URL would be misleading once
+                  // the operator starts typing a new target; clear it so the
+                  // next Discover click starts fresh.
+                  setDiscoverError(null);
+                  // Auto-derive the slug from the hostname while the operator
+                  // hasn't customized it. We swallow URL parse failures so the
+                  // slug stays stable while a partial URL is being typed.
+                  if (!slugDirty) {
+                    const derived = deriveSlugFromUrl(value);
+                    if (derived) setSlug(derived);
+                  }
+                  // When the URL diverges from a settled discovery, every
+                  // downstream field (endpoints, credentials, scope/audience,
+                  // DCR-vs-manual decision) was tied to that prior URL and is
+                  // now stale. Reset the form so the operator runs Discover
+                  // again against the new target and gets a coherent state.
+                  if (
+                    discoveredSnapshot &&
+                    value.trim() !== discoveredSnapshot.url
+                  ) {
+                    resetEndpointState();
+                    setClientId("");
+                    setClientSecret("");
+                    setTokenEndpointAuthMethod("");
+                    setScopeOverride("");
+                    setAudienceOverride("");
+                  }
+                }}
+              />
+
+              <Stack gap={2}>
+                <Label className="text-muted-foreground text-xs">Slug</Label>
+                <Input
+                  value={slug}
+                  onChange={(value) => {
+                    setSlug(value);
+                    setSlugDirty(true);
+                  }}
+                  placeholder="my-identity-provider"
+                />
+                <Type muted small>
+                  Project-unique identifier for this identity provider.
+                  Auto-derived from the Issuer URL until you edit it.
+                </Type>
+              </Stack>
+
+              <EndpointsFields
+                issuerUrl={issuerUrl}
+                authorizationEndpoint={authorizationEndpoint}
+                tokenEndpoint={tokenEndpoint}
+                registrationEndpoint={registrationEndpoint}
+                jwksUri={jwksUri}
+                endpointWarnings={endpointWarnings}
+                discoverPending={discoverPending}
+                discoverError={discoverError}
+                showDiscoverControls={showDiscoverControls}
+                showResetControls={showResetControls}
+                onAuthorizationEndpointChange={setAuthorizationEndpoint}
+                onTokenEndpointChange={setTokenEndpoint}
+                onRegistrationEndpointChange={setRegistrationEndpoint}
+                onJwksUriChange={setJwksUri}
+                onDiscover={() => runDiscover(issuerUrl)}
+                onResetEndpoints={handleResetEndpoints}
+              />
+            </Stack>
+          )}
+
+          {dcrAvailable ? (
+            <>
+              <DcrNotice />
+              {/* token_endpoint_auth_method stays editable even in DCR so
+                  operators can override the upstream-assigned default. The
+                  selected value is forwarded into the proxy-register call so
+                  the upstream registers the client with the desired method. */}
+              <TokenEndpointAuthMethodField
+                value={tokenEndpointAuthMethod}
+                onChange={setTokenEndpointAuthMethod}
+              />
+            </>
+          ) : (
+            <ClientCredentialsFields
+              clientId={clientId}
+              clientSecret={clientSecret}
+              tokenEndpointAuthMethod={tokenEndpointAuthMethod}
+              onClientIdChange={setClientId}
+              onClientSecretChange={setClientSecret}
+              onTokenEndpointAuthMethodChange={setTokenEndpointAuthMethod}
+            />
+          )}
+
+          <OverridesFields
+            scopeOverride={scopeOverride}
+            audienceOverride={audienceOverride}
+            onScopeOverrideChange={setScopeOverride}
+            onAudienceOverrideChange={setAudienceOverride}
+          />
+
+          {submitError && (
+            <Alert variant="error" dismissible={false}>
+              {submitError}
+            </Alert>
+          )}
+        </div>
+
+        <SheetFooter className="flex-row items-center justify-end gap-2 border-t px-6 py-4">
+          <Button
+            variant="secondary"
+            disabled={submitting}
+            onClick={() => onOpenChange(false)}
+          >
+            <Button.Text>Cancel</Button.Text>
+          </Button>
+          <Button
+            variant="primary"
+            disabled={!submittable || submitting}
+            onClick={handleSubmit}
+          >
+            <Button.Text>
+              {submitting ? "Attaching…" : "Attach Identity Provider"}
+            </Button.Text>
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ModeSwitch({
+  mode,
+  onChange,
+}: {
+  mode: Mode;
+  onChange: (next: Mode) => void;
+}) {
+  return (
+    <Stack direction="horizontal" gap={2}>
+      <Button
+        variant={mode === "select" ? "primary" : "secondary"}
+        onClick={() => onChange("select")}
+      >
+        <Button.Text>Select existing</Button.Text>
+      </Button>
+      <Button
+        variant={mode === "new" ? "primary" : "secondary"}
+        onClick={() => onChange("new")}
+      >
+        <Button.Text>Add new</Button.Text>
+      </Button>
+    </Stack>
+  );
+}
+
+function SelectExistingFields({
+  selectableIssuers,
+  selectedIssuerId,
+  onChange,
+}: {
+  selectableIssuers: RemoteSessionIssuer[];
+  selectedIssuerId: string;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <Stack gap={2}>
+      <Label className="text-muted-foreground text-xs">Identity Provider</Label>
+      <Select value={selectedIssuerId} onValueChange={onChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Choose an identity provider…" />
+        </SelectTrigger>
+        <SelectContent>
+          {selectableIssuers.map((issuer) => (
+            <SelectItem key={issuer.id} value={issuer.id}>
+              {issuer.slug} — {issuer.issuer}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Type muted small>
+        Pick an identity provider already configured on this project.
+      </Type>
+    </Stack>
+  );
+}
+
+// Derive a project-unique slug from the Issuer URL's hostname. Mirrors the
+// hyphen-style transform used by buildUserSessionResourceSlug's internal
+// slugify helper so the auto-filled value matches what an operator would
+// reasonably hand-write. Returns null for unparseable URLs — the caller
+// keeps the prior slug in that case so partial typing doesn't blow it away.
+function deriveSlugFromUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    const host = new URL(trimmed).hostname;
+    if (!host) return null;
+    const slug = host
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    return slug || null;
+  } catch {
+    return null;
+  }
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -36,7 +36,7 @@ import {
   invalidateAllUserSessionIssuers,
 } from "@gram/client/react-query/index.js";
 import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -111,7 +111,7 @@ export function AttachRemoteIdentityProviderSheet({
     discoveredSnapshot,
     discoverPending,
     discoverError,
-    setDiscoverError,
+    clearDiscoverError,
     runDiscover,
     handleResetEndpoints,
     resetEndpointState,
@@ -133,83 +133,10 @@ export function AttachRemoteIdentityProviderSheet({
   const [scopeOverride, setScopeOverride] = useState("");
   const [audienceOverride, setAudienceOverride] = useState("");
 
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  // Reset transient state whenever the sheet is reopened. The mcpServer slug
-  // seeds the default new-issuer slug so most operators can submit without
-  // touching the field, but we still allow editing.
-  useEffect(() => {
-    if (!open) return;
-    setMode(initialIssuerUrl || !hasSelectable ? "new" : "select");
-    setSelectedIssuerId("");
-    // Seed the slug from the Issuer URL when we have one (the "Start With
-    // Discovered Configuration" path). Otherwise fall back to the
-    // mcpServer-based default. Either way slugDirty resets to false so the
-    // operator's first keystroke in the field starts locking it in.
-    setSlug(
-      deriveSlugFromUrl(initialIssuerUrl ?? "") ??
-        buildUserSessionResourceSlug(mcpServer.slug ?? "mcp"),
-    );
-    setSlugDirty(false);
-    setIssuerUrl(initialIssuerUrl ?? "");
-    resetEndpointState();
-    setDiscoverError(null);
-    setClientId("");
-    setClientSecret("");
-    setTokenEndpointAuthMethod("");
-    setScopeOverride("");
-    setAudienceOverride("");
-    setSubmitting(false);
-    setSubmitError(null);
-  }, [
-    open,
-    mcpServer.slug,
-    initialIssuerUrl,
-    hasSelectable,
-    setIssuerUrl,
-    resetEndpointState,
-    setDiscoverError,
-  ]);
-
-  // Auto-run discovery when the sheet opens with a seeded URL (came in via
-  // "Start With Discovered Configuration"). Manual configure leaves this to the
-  // explicit "Discover" button in the Endpoints section.
-  useEffect(() => {
-    if (!open || !initialIssuerUrl) return;
-    void runDiscover(initialIssuerUrl);
-  }, [open, initialIssuerUrl, runDiscover]);
-
-  // Resolve the issuer record the operator picked in Select-existing mode.
-  // We need it to know whether the picked issuer supports DCR and to pull
-  // its registration_endpoint at submit time.
-  const selectedIssuer =
-    mode === "select"
-      ? selectableIssuers.find((issuer) => issuer.id === selectedIssuerId)
-      : undefined;
-
-  // DCR is offered automatically when a registration_endpoint is present.
-  // In Add-new the value comes from the form (filled by discovery or typed);
-  // in Select-existing it comes from the picked issuer record. Either way we
-  // hide the manual client_id / client_secret form and call proxy-register
-  // on submit.
-  const dcrAvailable =
-    mode === "new"
-      ? registrationEndpoint.trim().length > 0
-      : !!selectedIssuer?.registrationEndpoint;
-
-  const submittable = useMemo(() => {
-    if (mode === "select") return !!selectedIssuerId;
-    if (!slug.trim() || !issuerUrl.trim()) return false;
-    if (!dcrAvailable && !clientId.trim()) return false;
-    return true;
-  }, [mode, selectedIssuerId, slug, issuerUrl, dcrAvailable, clientId]);
-
-  const handleSubmit = async () => {
-    if (!submittable || submitting) return;
-    setSubmitting(true);
-    setSubmitError(null);
-    try {
+  const attachMutation = useMutation({
+    mutationFn: async (): Promise<{
+      unsupportedDcrAuthMethod: string | null;
+    }> => {
       // Step 1: ensure a user_session_issuer exists. First-add auto-creates
       // one with the conservative interactive challenge mode and a 2-week
       // session lifetime — these match the wire-user-session-issuer defaults.
@@ -350,6 +277,9 @@ export function AttachRemoteIdentityProviderSheet({
         });
       }
 
+      return { unsupportedDcrAuthMethod };
+    },
+    onSuccess: async ({ unsupportedDcrAuthMethod }) => {
       await Promise.all([
         invalidateAllUserSessionIssuers(queryClient, { refetchType: "all" }),
         invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
@@ -365,21 +295,97 @@ export function AttachRemoteIdentityProviderSheet({
         );
       }
       onOpenChange(false);
-    } catch (error) {
+    },
+    onError: (error) => {
       // Backend Create messages aren't always actionable (e.g. the generic
       // "create remote session issuer" fallback) but specific ones like
       // "an identity provider with slug already exists" or 4xx validation
-      // errors absolutely are — surface error.message when present and only
-      // fall back to a friendly default when we have nothing better.
+      // errors absolutely are — useMutation surfaces error.message via
+      // attachMutation.error so we only need to log here.
       console.error("Attach identity provider failed", error);
-      setSubmitError(
-        error instanceof Error && error.message
-          ? error.message
-          : "An unexpected error occurred. Please try again.",
-      );
-    } finally {
-      setSubmitting(false);
-    }
+    },
+  });
+
+  const submitting = attachMutation.isPending;
+  const submitError = attachMutation.error
+    ? attachMutation.error instanceof Error && attachMutation.error.message
+      ? attachMutation.error.message
+      : "An unexpected error occurred. Please try again."
+    : null;
+  const { reset: resetAttachMutation } = attachMutation;
+
+  // Reset transient state whenever the sheet is reopened. The mcpServer slug
+  // seeds the default new-issuer slug so most operators can submit without
+  // touching the field, but we still allow editing.
+  useEffect(() => {
+    if (!open) return;
+    setMode(initialIssuerUrl || !hasSelectable ? "new" : "select");
+    setSelectedIssuerId("");
+    // Seed the slug from the Issuer URL when we have one (the "Start With
+    // Discovered Configuration" path). Otherwise fall back to the
+    // mcpServer-based default. Either way slugDirty resets to false so the
+    // operator's first keystroke in the field starts locking it in.
+    setSlug(
+      deriveSlugFromUrl(initialIssuerUrl ?? "") ??
+        buildUserSessionResourceSlug(mcpServer.slug ?? "mcp"),
+    );
+    setSlugDirty(false);
+    setIssuerUrl(initialIssuerUrl ?? "");
+    resetEndpointState();
+    clearDiscoverError();
+    setClientId("");
+    setClientSecret("");
+    setTokenEndpointAuthMethod("");
+    setScopeOverride("");
+    setAudienceOverride("");
+    resetAttachMutation();
+  }, [
+    open,
+    mcpServer.slug,
+    initialIssuerUrl,
+    hasSelectable,
+    setIssuerUrl,
+    resetEndpointState,
+    clearDiscoverError,
+    resetAttachMutation,
+  ]);
+
+  // Auto-run discovery when the sheet opens with a seeded URL (came in via
+  // "Start With Discovered Configuration"). Manual configure leaves this to the
+  // explicit "Discover" button in the Endpoints section.
+  useEffect(() => {
+    if (!open || !initialIssuerUrl) return;
+    void runDiscover(initialIssuerUrl);
+  }, [open, initialIssuerUrl, runDiscover]);
+
+  // Resolve the issuer record the operator picked in Select-existing mode.
+  // We need it to know whether the picked issuer supports DCR and to pull
+  // its registration_endpoint at submit time.
+  const selectedIssuer =
+    mode === "select"
+      ? selectableIssuers.find((issuer) => issuer.id === selectedIssuerId)
+      : undefined;
+
+  // DCR is offered automatically when a registration_endpoint is present.
+  // In Add-new the value comes from the form (filled by discovery or typed);
+  // in Select-existing it comes from the picked issuer record. Either way we
+  // hide the manual client_id / client_secret form and call proxy-register
+  // on submit.
+  const dcrAvailable =
+    mode === "new"
+      ? registrationEndpoint.trim().length > 0
+      : !!selectedIssuer?.registrationEndpoint;
+
+  const submittable = useMemo(() => {
+    if (mode === "select") return !!selectedIssuerId;
+    if (!slug.trim() || !issuerUrl.trim()) return false;
+    if (!dcrAvailable && !clientId.trim()) return false;
+    return true;
+  }, [mode, selectedIssuerId, slug, issuerUrl, dcrAvailable, clientId]);
+
+  const handleSubmit = () => {
+    if (!submittable || submitting) return;
+    attachMutation.mutate();
   };
 
   return (
@@ -412,7 +418,7 @@ export function AttachRemoteIdentityProviderSheet({
                   // A stale error from a previous URL would be misleading once
                   // the operator starts typing a new target; clear it so the
                   // next Discover click starts fresh.
-                  setDiscoverError(null);
+                  clearDiscoverError();
                   // Auto-derive the slug from the hostname while the operator
                   // hasn't customized it. We swallow URL parse failures so the
                   // slug stays stable while a partial URL is being typed.

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/AuthenticationTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/AuthenticationTab.tsx
@@ -5,7 +5,6 @@ import type {
   RemoteSessionIssuer,
 } from "@gram/client/models/components";
 import {
-  useRemoteSessionClients,
   useRemoteSessionIssuers,
   useUserSessionIssuer,
 } from "@gram/client/react-query/index.js";
@@ -16,6 +15,7 @@ import { EmptyAuthenticationState } from "./EmptyAuthenticationState";
 import { UserSessionsSection } from "./UserSessionsSection";
 import { ModifyRemoteIdentityProviderSheet } from "./ModifyRemoteIdentityProviderSheet";
 import { RemoteIdentityProvidersTable } from "./RemoteIdentityProvidersTable";
+import { useAllRemoteSessionClients } from "./useAllRemoteSessionClients";
 import { useProtectedResourceMetadata } from "./useProtectedResourceMetadata";
 
 export function AuthenticationTab({ mcpServer }: { mcpServer: McpServer }) {
@@ -52,17 +52,16 @@ export function AuthenticationTab({ mcpServer }: { mcpServer: McpServer }) {
     [issuersResult],
   );
 
-  const { data: clientsResult, isLoading: isLoadingClients } =
-    useRemoteSessionClients({ userSessionIssuerId }, undefined, {
-      enabled: issuerConfigured,
-    });
-
-  const associatedIssuerIds = useMemo(() => {
-    if (!clientsResult) return new Set<string>();
-    return new Set(
-      clientsResult.result.items.map((client) => client.remoteSessionIssuerId),
+  const { items: allClients, isLoading: isLoadingClients } =
+    useAllRemoteSessionClients(
+      { userSessionIssuerId },
+      { enabled: issuerConfigured },
     );
-  }, [clientsResult]);
+
+  const associatedIssuerIds = useMemo(
+    () => new Set(allClients.map((client) => client.remoteSessionIssuerId)),
+    [allClients],
+  );
 
   const associatedIssuers = useMemo<RemoteSessionIssuer[]>(
     () => allIssuers.filter((issuer) => associatedIssuerIds.has(issuer.id)),
@@ -137,6 +136,16 @@ export function AuthenticationTab({ mcpServer }: { mcpServer: McpServer }) {
             onAdd={() => openSheet(undefined)}
             onEdit={handleEdit}
             onDelete={handleDelete}
+            // TODO(AGE-2554): remove this gate when the runtime resolver
+            // supports multiple remote_session_clients per
+            // user_session_issuer. Today ResolveOneAccessToken enforces
+            // len(clients) == 1 as an invariant; a second attach reaches a
+            // state where MCP requests fail with CodeUnexpected.
+            attachDisabledReason={
+              associatedIssuers.length > 0
+                ? "Multiple identity providers per server are not yet supported."
+                : undefined
+            }
           />
         </>
       )}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/AuthenticationTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/AuthenticationTab.tsx
@@ -1,0 +1,172 @@
+import { Heading } from "@/components/ui/heading";
+import { Type } from "@/components/ui/type";
+import type {
+  McpServer,
+  RemoteSessionIssuer,
+} from "@gram/client/models/components";
+import {
+  useRemoteSessionClients,
+  useRemoteSessionIssuers,
+  useUserSessionIssuer,
+} from "@gram/client/react-query/index.js";
+import { useMemo, useState } from "react";
+import { AttachRemoteIdentityProviderSheet } from "./AttachRemoteIdentityProviderSheet";
+import { DeleteRemoteIdentityProviderDialog } from "./DeleteRemoteIdentityProviderDialog";
+import { EmptyAuthenticationState } from "./EmptyAuthenticationState";
+import { UserSessionsSection } from "./UserSessionsSection";
+import { ModifyRemoteIdentityProviderSheet } from "./ModifyRemoteIdentityProviderSheet";
+import { RemoteIdentityProvidersTable } from "./RemoteIdentityProvidersTable";
+import { useProtectedResourceMetadata } from "./useProtectedResourceMetadata";
+
+export function AuthenticationTab({ mcpServer }: { mcpServer: McpServer }) {
+  const userSessionIssuerId = mcpServer.userSessionIssuerId;
+  const issuerConfigured = !!userSessionIssuerId;
+
+  const { data: userSessionIssuer, isLoading: isLoadingUserSessionIssuer } =
+    useUserSessionIssuer({ id: userSessionIssuerId }, undefined, {
+      enabled: issuerConfigured,
+    });
+
+  // Probe the remote MCP server's protected-resource metadata so the empty
+  // state can offer "Start With Discovered Configuration". The probe runs
+  // server-side under guardian.Policy — see useProtectedResourceMetadata.
+  const { status: probeStatus, metadata: protectedResourceMetadata } =
+    useProtectedResourceMetadata(
+      mcpServer.remoteMcpServerId,
+      !issuerConfigured,
+    );
+
+  const authorizationServer =
+    protectedResourceMetadata?.authorizationServers?.[0];
+
+  // Pull project-scope remote_session_issuers + the clients paired with the
+  // current user_session_issuer (when configured). The clients list tells us
+  // which issuers are "associated" with this server.
+  // NOTE(AGE-2494): listRemoteSessionIssuers is project-scope only — there's
+  // no API surface for org-level records yet. When AGE-2494 lands, augment
+  // the selectable list with org-scope rows.
+  const { data: issuersResult, isLoading: isLoadingIssuers } =
+    useRemoteSessionIssuers();
+  const allIssuers = useMemo(
+    () => issuersResult?.result.items ?? [],
+    [issuersResult],
+  );
+
+  const { data: clientsResult, isLoading: isLoadingClients } =
+    useRemoteSessionClients({ userSessionIssuerId }, undefined, {
+      enabled: issuerConfigured,
+    });
+
+  const associatedIssuerIds = useMemo(() => {
+    if (!clientsResult) return new Set<string>();
+    return new Set(
+      clientsResult.result.items.map((client) => client.remoteSessionIssuerId),
+    );
+  }, [clientsResult]);
+
+  const associatedIssuers = useMemo<RemoteSessionIssuer[]>(
+    () => allIssuers.filter((issuer) => associatedIssuerIds.has(issuer.id)),
+    [allIssuers, associatedIssuerIds],
+  );
+
+  const selectableIssuers = useMemo<RemoteSessionIssuer[]>(
+    () => allIssuers.filter((issuer) => !associatedIssuerIds.has(issuer.id)),
+    [allIssuers, associatedIssuerIds],
+  );
+
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [sheetInitialUrl, setSheetInitialUrl] = useState<string | undefined>(
+    undefined,
+  );
+
+  const openSheet = (initialIssuerUrl?: string) => {
+    setSheetInitialUrl(initialIssuerUrl);
+    setSheetOpen(true);
+  };
+
+  // Delete + Modify dialog state. Keep the issuer around for one render after
+  // close so the dialog/sheet body finishes its closing animation against the
+  // row that triggered it.
+  const [deleteTarget, setDeleteTarget] = useState<RemoteSessionIssuer | null>(
+    null,
+  );
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [modifyTarget, setModifyTarget] = useState<RemoteSessionIssuer | null>(
+    null,
+  );
+  const [modifyOpen, setModifyOpen] = useState(false);
+
+  const handleEdit = (issuer: RemoteSessionIssuer) => {
+    setModifyTarget(issuer);
+    setModifyOpen(true);
+  };
+
+  const handleDelete = (issuer: RemoteSessionIssuer) => {
+    setDeleteTarget(issuer);
+    setDeleteOpen(true);
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-[1270px] space-y-8 px-8 py-8">
+      {!issuerConfigured ? (
+        <section>
+          <Heading variant="h4" className="mb-3">
+            Get Started
+          </Heading>
+          <Type muted small className="mb-4">
+            Configure an upstream identity provider so MCP clients authenticate
+            against it before reaching this server.
+          </Type>
+          <EmptyAuthenticationState
+            probeStatus={probeStatus}
+            hasDiscoveredAuthorizationServer={!!authorizationServer}
+            onUseDiscovered={() => openSheet(authorizationServer)}
+            onStartManual={() => openSheet(undefined)}
+          />
+        </section>
+      ) : isLoadingUserSessionIssuer || !userSessionIssuer ? (
+        <Type muted small>
+          Loading authentication configuration…
+        </Type>
+      ) : (
+        <>
+          <UserSessionsSection userSessionIssuer={userSessionIssuer} />
+          <RemoteIdentityProvidersTable
+            associatedIssuers={associatedIssuers}
+            isLoading={isLoadingIssuers || isLoadingClients}
+            onAdd={() => openSheet(undefined)}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+          />
+        </>
+      )}
+
+      <AttachRemoteIdentityProviderSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        mcpServer={mcpServer}
+        userSessionIssuer={userSessionIssuer ?? null}
+        selectableIssuers={selectableIssuers}
+        initialIssuerUrl={sheetInitialUrl}
+      />
+
+      {deleteTarget && userSessionIssuerId && (
+        <DeleteRemoteIdentityProviderDialog
+          open={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          userSessionIssuerId={userSessionIssuerId}
+          issuer={deleteTarget}
+        />
+      )}
+
+      {modifyTarget && userSessionIssuer && (
+        <ModifyRemoteIdentityProviderSheet
+          open={modifyOpen}
+          onOpenChange={setModifyOpen}
+          userSessionIssuer={userSessionIssuer}
+          issuer={modifyTarget}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/DeleteRemoteIdentityProviderDialog.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/DeleteRemoteIdentityProviderDialog.tsx
@@ -1,0 +1,173 @@
+import { Input } from "@/components/ui/input";
+import { Type } from "@/components/ui/type";
+import { useSdkClient } from "@/contexts/Sdk";
+import type { RemoteSessionIssuer } from "@gram/client/models/components";
+import {
+  invalidateAllRemoteSessionClients,
+  invalidateAllRemoteSessionIssuers,
+} from "@gram/client/react-query/index.js";
+import { Alert, Button, Dialog } from "@speakeasy-api/moonshine";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+export function DeleteRemoteIdentityProviderDialog({
+  open,
+  onOpenChange,
+  userSessionIssuerId,
+  issuer,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  // The user_session_issuer this provider is associated with on the current
+  // MCP server. We scope the delete to the clients linking this pair —
+  // delete-semantics #1: remove the association, leave the
+  // remote_session_issuer record alone so other servers can still use it.
+  userSessionIssuerId: string;
+  issuer: RemoteSessionIssuer;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content>
+        {open && (
+          <DeleteRemoteIdentityProviderDialogBody
+            userSessionIssuerId={userSessionIssuerId}
+            issuer={issuer}
+            onClose={() => onOpenChange(false)}
+          />
+        )}
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+function DeleteRemoteIdentityProviderDialogBody({
+  userSessionIssuerId,
+  issuer,
+  onClose,
+}: {
+  userSessionIssuerId: string;
+  issuer: RemoteSessionIssuer;
+  onClose: () => void;
+}) {
+  const client = useSdkClient();
+  const queryClient = useQueryClient();
+
+  const [confirmation, setConfirmation] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setConfirmation("");
+    setSubmitting(false);
+    setError(null);
+  }, [issuer.id]);
+
+  const inputMatches = confirmation === issuer.issuer;
+
+  const handleConfirm = async () => {
+    if (!inputMatches || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Collect every remote_session_client that joins this
+      // user_session_issuer to this remote_session_issuer, walking cursor
+      // pagination so a pairing with more than a page's worth of clients is
+      // fully drained. The uniqueness is per
+      // (project, issuer, user_session_issuer, client_id), so a single
+      // pair can have multiple rows.
+      const clientIds: string[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = await client.remoteSessionClients.list({
+          userSessionIssuerId,
+          remoteSessionIssuerId: issuer.id,
+          limit: 100,
+          cursor,
+        });
+        for (const remoteClient of page.result.items) {
+          clientIds.push(remoteClient.id);
+        }
+        cursor = page.result.nextCursor || undefined;
+      } while (cursor);
+      for (const id of clientIds) {
+        await client.remoteSessionClients.delete({ id });
+      }
+      await Promise.all([
+        invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
+        invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
+      ]);
+      toast.success("Identity provider removed from this server");
+      onClose();
+    } catch (err) {
+      console.error("Delete identity provider failed", err);
+      setError(
+        err instanceof Error && err.message
+          ? err.message
+          : "An unexpected error occurred. Please try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog.Header>
+        <Dialog.Title>Remove Remote Identity Provider</Dialog.Title>
+        <Dialog.Description>
+          This removes the identity provider's association with this MCP server.
+          The provider configuration stays in the project and can be re-attached
+          later or used by other servers.
+        </Dialog.Description>
+      </Dialog.Header>
+
+      <div className="grid gap-2">
+        <Type small>
+          To confirm, type the issuer URL: <strong>{issuer.issuer}</strong>
+        </Type>
+        <Input
+          value={confirmation}
+          onChange={setConfirmation}
+          placeholder={issuer.issuer}
+          disabled={submitting}
+        />
+      </div>
+
+      <Alert variant="warning" dismissible={false}>
+        Removing {issuer.issuer} from this server cannot be undone — any active
+        user sessions issued via this identity provider will need to
+        re-authenticate.
+      </Alert>
+
+      {error && (
+        <Alert variant="error" dismissible={false}>
+          {error}
+        </Alert>
+      )}
+
+      <Dialog.Footer>
+        <Button variant="secondary" onClick={onClose} disabled={submitting}>
+          <Button.Text>Cancel</Button.Text>
+        </Button>
+        <Button
+          variant="destructive-primary"
+          disabled={!inputMatches || submitting}
+          onClick={handleConfirm}
+        >
+          {submitting ? (
+            <>
+              <Button.LeftIcon>
+                <Loader2 className="size-4 animate-spin" />
+              </Button.LeftIcon>
+              <Button.Text>Removing</Button.Text>
+            </>
+          ) : (
+            <Button.Text>Remove</Button.Text>
+          )}
+        </Button>
+      </Dialog.Footer>
+    </>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/DeleteRemoteIdentityProviderDialog.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/DeleteRemoteIdentityProviderDialog.tsx
@@ -64,7 +64,7 @@ function DeleteRemoteIdentityProviderDialogBody({
     setError(null);
   }, [issuer.id]);
 
-  const inputMatches = confirmation === issuer.issuer;
+  const inputMatches = confirmation.trim() === issuer.issuer;
 
   const handleConfirm = async () => {
     if (!inputMatches || submitting) return;

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/EmptyAuthenticationState.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/EmptyAuthenticationState.tsx
@@ -1,0 +1,77 @@
+import { RequireScope } from "@/components/require-scope";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Button, Stack } from "@speakeasy-api/moonshine";
+import type { ProtectedResourceProbeStatus } from "./useProtectedResourceMetadata";
+
+export function EmptyAuthenticationState({
+  probeStatus,
+  hasDiscoveredAuthorizationServer,
+  onUseDiscovered,
+  onStartManual,
+}: {
+  probeStatus: ProtectedResourceProbeStatus;
+  // True only when the RFC 9728 probe returned at least one
+  // authorization_servers entry — without one there's nothing to seed
+  // discovery with even if the probe succeeded.
+  hasDiscoveredAuthorizationServer: boolean;
+  onUseDiscovered: () => void;
+  onStartManual: () => void;
+}) {
+  const probing = probeStatus === "loading";
+  const discoverAvailable =
+    probeStatus === "available" && hasDiscoveredAuthorizationServer;
+
+  const discoverButton = (
+    <Button
+      variant="secondary"
+      disabled={!discoverAvailable || probing}
+      onClick={onUseDiscovered}
+    >
+      <Button.Text>Start With Discovered Configuration</Button.Text>
+    </Button>
+  );
+
+  return (
+    <RequireScope scope="mcp:write" level="component">
+      <Stack direction="horizontal" gap={2}>
+        {discoverAvailable ? (
+          discoverButton
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* Disabled native buttons don't fire pointer events, so the
+                  tooltip never opens on hover without a wrapper. Adding the
+                  button role + aria-disabled lets assistive tech announce
+                  the wrapper as a disabled button rather than an unlabelled
+                  focusable region. */}
+              <span
+                role="button"
+                aria-disabled="true"
+                tabIndex={0}
+                aria-label={
+                  probing
+                    ? "Discover unavailable: probing remote URL for OAuth protected resource metadata"
+                    : "Discover unavailable: OAuth protected resource metadata not advertised"
+                }
+              >
+                {discoverButton}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {probing
+                ? "Probing the remote URL for OAuth protected resource metadata…"
+                : "OAuth protected resource metadata unavailable"}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        <Button variant="secondary" onClick={onStartManual}>
+          <Button.Text>Start Manual Configuration</Button.Text>
+        </Button>
+      </Stack>
+    </RequireScope>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/IssuerFormFields.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/IssuerFormFields.tsx
@@ -1,0 +1,371 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Type } from "@/components/ui/type";
+import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/client/models/components";
+import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
+
+// Shared form-field components used by both AttachRemoteIdentityProviderSheet
+// and ModifyRemoteIdentityProviderSheet. The state lives in the parent sheet;
+// these are pure presentation components. Type aliases and small helpers
+// live in issuerFormUtils.ts so this module exports components only (react
+// fast refresh requirement).
+
+// IssuerUrlField is the single Issuer URL input. Split out from the Endpoints
+// section so callers can render a Slug field between them.
+export function IssuerUrlField({
+  issuerUrl,
+  onIssuerUrlChange,
+}: {
+  issuerUrl: string;
+  onIssuerUrlChange: (value: string) => void;
+}) {
+  return (
+    <Stack gap={2}>
+      <Label className="text-muted-foreground text-xs">Issuer URL</Label>
+      <Input
+        value={issuerUrl}
+        onChange={onIssuerUrlChange}
+        placeholder="https://login.example.com"
+      />
+      <Type muted small>
+        Issuer URL of the upstream authorization server.
+      </Type>
+    </Stack>
+  );
+}
+
+// EndpointsFields renders the Endpoints section: Discover/Reset slot, the
+// four RFC 8414 endpoint inputs, and any discovery warnings. Pure
+// presentation — discovery state and handlers stay in the parent sheet.
+export function EndpointsFields({
+  issuerUrl,
+  authorizationEndpoint,
+  tokenEndpoint,
+  registrationEndpoint,
+  jwksUri,
+  endpointWarnings,
+  discoverPending,
+  discoverError,
+  showDiscoverControls,
+  showResetControls,
+  onAuthorizationEndpointChange,
+  onTokenEndpointChange,
+  onRegistrationEndpointChange,
+  onJwksUriChange,
+  onDiscover,
+  onResetEndpoints,
+}: {
+  issuerUrl: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  jwksUri: string;
+  endpointWarnings: string[];
+  discoverPending: boolean;
+  discoverError: string | null;
+  showDiscoverControls: boolean;
+  showResetControls: boolean;
+  onAuthorizationEndpointChange: (value: string) => void;
+  onTokenEndpointChange: (value: string) => void;
+  onRegistrationEndpointChange: (value: string) => void;
+  onJwksUriChange: (value: string) => void;
+  onDiscover: () => void;
+  onResetEndpoints: () => void;
+}) {
+  return (
+    <Stack gap={3} className="border-t pt-6">
+      <Stack gap={1}>
+        <Label className="text-sm font-medium">Endpoints</Label>
+        {showDiscoverControls && (
+          <Type muted small>
+            Discover fetches the issuer's RFC 8414 metadata and fills these
+            fields in. Edit anything that needs to be overridden.
+          </Type>
+        )}
+        {showResetControls && (
+          <Type muted small>
+            Restore discovered values for modified endpoints.
+          </Type>
+        )}
+      </Stack>
+
+      {showDiscoverControls && (
+        <div>
+          <Button
+            variant="secondary"
+            disabled={!issuerUrl.trim() || discoverPending}
+            onClick={onDiscover}
+          >
+            <Button.Text>
+              {discoverPending ? "Discovering…" : "Discover"}
+            </Button.Text>
+          </Button>
+        </div>
+      )}
+
+      {showResetControls && (
+        <div>
+          <Button variant="secondary" onClick={onResetEndpoints}>
+            <Button.Text>Reset to Discovered Values</Button.Text>
+          </Button>
+        </div>
+      )}
+
+      {showDiscoverControls && discoverError && (
+        <Alert variant="error" dismissible={false}>
+          {discoverError}
+        </Alert>
+      )}
+
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">
+          Authorization Endpoint
+        </Label>
+        <Input
+          value={authorizationEndpoint}
+          onChange={onAuthorizationEndpointChange}
+          placeholder="https://login.example.com/authorize"
+        />
+      </Stack>
+
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">Token Endpoint</Label>
+        <Input
+          value={tokenEndpoint}
+          onChange={onTokenEndpointChange}
+          placeholder="https://login.example.com/token"
+        />
+      </Stack>
+
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">
+          Registration Endpoint (optional)
+        </Label>
+        <Input
+          value={registrationEndpoint}
+          onChange={onRegistrationEndpointChange}
+          placeholder="https://login.example.com/register"
+        />
+      </Stack>
+
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">
+          JWKS URI (optional)
+        </Label>
+        <Input
+          value={jwksUri}
+          onChange={onJwksUriChange}
+          placeholder="https://login.example.com/.well-known/jwks.json"
+        />
+      </Stack>
+
+      {endpointWarnings.length > 0 && (
+        <Alert variant="warning" dismissible={false}>
+          <Stack gap={1}>
+            {endpointWarnings.map((warning) => (
+              <span key={warning}>{warning}</span>
+            ))}
+          </Stack>
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+// DcrNotice replaces the OAuth Client Credentials form when the issuer
+// advertises a registration_endpoint. In Add we still call proxy-register to
+// obtain credentials; in Modify the existing client_id is kept and only
+// scope/audience can drift. The token_endpoint_auth_method field stays
+// editable in both DCR and manual modes — see TokenEndpointAuthMethodField.
+export function DcrNotice({ description }: { description?: string }) {
+  return (
+    <Stack gap={2} className="border-t pt-6">
+      <Label className="text-sm font-medium">OAuth Client Credentials</Label>
+      <Type muted small>
+        {description ??
+          "The issuer advertises a registration endpoint (RFC 7591), so the platform will automatically register a client on save."}
+      </Type>
+    </Stack>
+  );
+}
+
+// TokenEndpointAuthMethodField is the standalone Select for the upstream
+// token endpoint auth method. It renders in both DCR mode (alongside
+// DcrNotice so operators can override the upstream-assigned default) and in
+// the manual ClientCredentialsFields. Extracted so the two paths stay in
+// lockstep on the enum values and placeholder copy.
+export function TokenEndpointAuthMethodField({
+  value,
+  onChange,
+}: {
+  value: CreateRemoteSessionClientFormTokenEndpointAuthMethod | "";
+  onChange: (
+    value: CreateRemoteSessionClientFormTokenEndpointAuthMethod | "",
+  ) => void;
+}) {
+  return (
+    <Stack gap={2}>
+      <Label className="text-muted-foreground text-xs">
+        Token Endpoint Auth Method
+      </Label>
+      <Select
+        value={value}
+        onValueChange={(next) =>
+          onChange(next as CreateRemoteSessionClientFormTokenEndpointAuthMethod)
+        }
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="client_secret_basic (default)" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            value={
+              CreateRemoteSessionClientFormTokenEndpointAuthMethod.ClientSecretBasic
+            }
+          >
+            client_secret_basic
+          </SelectItem>
+          <SelectItem
+            value={
+              CreateRemoteSessionClientFormTokenEndpointAuthMethod.ClientSecretPost
+            }
+          >
+            client_secret_post
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </Stack>
+  );
+}
+
+// ClientCredentialsFields is used by both Add (editable client_id) and
+// Modify (client_id read-only — the API has no rotate path; create a fresh
+// remote_session_client if you need a new one). clientSecret stays an input
+// in both — empty means "leave existing in place" in Modify.
+export function ClientCredentialsFields({
+  clientId,
+  clientSecret,
+  tokenEndpointAuthMethod,
+  clientIdEditable = true,
+  clientSecretLabel = "Client Secret (optional)",
+  clientSecretPlaceholder = "••••••••",
+  onClientIdChange,
+  onClientSecretChange,
+  onTokenEndpointAuthMethodChange,
+}: {
+  clientId: string;
+  clientSecret: string;
+  tokenEndpointAuthMethod:
+    | CreateRemoteSessionClientFormTokenEndpointAuthMethod
+    | "";
+  clientIdEditable?: boolean;
+  clientSecretLabel?: string;
+  clientSecretPlaceholder?: string;
+  onClientIdChange: (value: string) => void;
+  onClientSecretChange: (value: string) => void;
+  onTokenEndpointAuthMethodChange: (
+    value: CreateRemoteSessionClientFormTokenEndpointAuthMethod | "",
+  ) => void;
+}) {
+  return (
+    <Stack gap={4} className="border-t pt-6">
+      <Stack gap={1}>
+        <Label className="text-sm font-medium">OAuth Client Credentials</Label>
+        <Type muted small>
+          Gram acts as an OAuth client against the upstream issuer. Register a
+          client with the issuer out-of-band and paste the credentials here.
+        </Type>
+      </Stack>
+
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">Client ID</Label>
+        {clientIdEditable ? (
+          <Input
+            value={clientId}
+            onChange={onClientIdChange}
+            placeholder="client_abc123"
+          />
+        ) : (
+          <Type small mono className="break-all">
+            {clientId || "—"}
+          </Type>
+        )}
+      </Stack>
+
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">
+          {clientSecretLabel}
+        </Label>
+        <Input
+          type="password"
+          value={clientSecret}
+          onChange={onClientSecretChange}
+          placeholder={clientSecretPlaceholder}
+        />
+      </Stack>
+
+      <TokenEndpointAuthMethodField
+        value={tokenEndpointAuthMethod}
+        onChange={onTokenEndpointAuthMethodChange}
+      />
+    </Stack>
+  );
+}
+
+// OverridesFields renders the per-client OAuth dance overrides. Both fields
+// are optional and apply in both DCR and manual modes — they control what
+// Gram sends at authorize/token time, independent of how the client was
+// registered.
+export function OverridesFields({
+  scopeOverride,
+  audienceOverride,
+  onScopeOverrideChange,
+  onAudienceOverrideChange,
+}: {
+  scopeOverride: string;
+  audienceOverride: string;
+  onScopeOverrideChange: (value: string) => void;
+  onAudienceOverrideChange: (value: string) => void;
+}) {
+  return (
+    <Stack gap={4} className="border-t pt-6">
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">
+          Scope (override)
+        </Label>
+        <Input
+          value={scopeOverride}
+          onChange={onScopeOverrideChange}
+          placeholder="read, write, openid"
+        />
+        <Type muted small>
+          Comma-separated. When provided, Gram requests these scopes during the
+          OAuth dance; otherwise it falls back to the issuer's scopes_supported.
+        </Type>
+      </Stack>
+
+      <Stack gap={2}>
+        <Label className="text-muted-foreground text-xs">
+          Audience (optional)
+        </Label>
+        <Input
+          value={audienceOverride}
+          onChange={onAudienceOverrideChange}
+          placeholder="https://api.example.com"
+        />
+        <Type muted small>
+          When provided, Gram includes this audience in authorize and token
+          requests (RFC 8707). Required by some providers (e.g. Auth0) to return
+          JWT access tokens.
+        </Type>
+      </Stack>
+    </Stack>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/ModifyRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/ModifyRemoteIdentityProviderSheet.tsx
@@ -18,10 +18,9 @@ import {
   invalidateAllRemoteSessionClients,
   invalidateAllRemoteSessionIssuers,
   useMcpServers,
-  useRemoteSessionClients,
 } from "@gram/client/react-query/index.js";
 import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -31,6 +30,7 @@ import {
   OverridesFields,
 } from "./IssuerFormFields";
 import { parseScopes } from "./issuerFormUtils";
+import { useAllRemoteSessionClients } from "./useAllRemoteSessionClients";
 import { useIssuerDiscovery } from "./useIssuerDiscovery";
 
 export function ModifyRemoteIdentityProviderSheet({
@@ -45,19 +45,16 @@ export function ModifyRemoteIdentityProviderSheet({
   issuer: RemoteSessionIssuer;
 }) {
   // Fetch every remote_session_client tied to this issuer (across all
-  // user_session_issuers in the project). We need the unfiltered list to
-  // compute which OTHER MCP servers are also using this issuer so the
-  // operator gets a heads-up that issuer/endpoint edits will affect them.
-  const { data: clientsResult, isLoading: isLoadingClients } =
-    useRemoteSessionClients({ remoteSessionIssuerId: issuer.id }, undefined, {
-      enabled: open,
-    });
-  // Memoize so the empty-array fallback doesn't churn a new reference on
-  // every render, which would invalidate downstream useMemo dependencies.
-  const allClients = useMemo(
-    () => clientsResult?.result.items ?? [],
-    [clientsResult],
-  );
+  // user_session_issuers in the project), walking every page. We need the
+  // unfiltered list to compute which OTHER MCP servers are also using this
+  // issuer so the operator gets a heads-up that issuer/endpoint edits will
+  // affect them — a single-page fetch would silently undercount once a
+  // project crosses the default page size of 50.
+  const { items: allClients, isLoading: isLoadingClients } =
+    useAllRemoteSessionClients(
+      { remoteSessionIssuerId: issuer.id },
+      { enabled: open },
+    );
   const primaryClient: RemoteSessionClient | undefined = allClients.find(
     (clientRow) => clientRow.userSessionIssuerId === userSessionIssuer.id,
   );
@@ -158,7 +155,7 @@ function ModifyRemoteIdentityProviderSheetBody({
     discoveredSnapshot,
     discoverPending,
     discoverError,
-    setDiscoverError,
+    clearDiscoverError,
     runDiscover,
     handleResetEndpoints,
     resetEndpointState,
@@ -177,46 +174,28 @@ function ModifyRemoteIdentityProviderSheetBody({
   const [scopeOverride, setScopeOverride] = useState("");
   const [audienceOverride, setAudienceOverride] = useState("");
 
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  // Seed client-derived fields exactly once per sheet open, the first time
-  // the client lookup resolves. The sheet body remounts on close (the
-  // `{open && <Body />}` pattern in the parent), so the ref resets naturally
-  // on the next open — no need to wire it to the open prop. Guarding via a
-  // ref instead of a narrow useEffect dependency keeps the linter happy AND
-  // prevents subsequent refetches from clobbering in-progress edits.
-  const clientFieldsInitializedRef = useRef(false);
-  useEffect(() => {
-    if (!primaryClient || clientFieldsInitializedRef.current) return;
-    setTokenEndpointAuthMethod(primaryClient.tokenEndpointAuthMethod ?? "");
-    setScopeOverride((primaryClient.scope ?? []).join(", "));
-    setAudienceOverride(primaryClient.audience ?? "");
-    clientFieldsInitializedRef.current = true;
-  }, [primaryClient]);
-
-  const submittable = !!primaryClient && issuerUrl.trim().length > 0;
-
-  const handleSubmit = async () => {
-    if (!submittable || submitting || !primaryClient) return;
-    setSubmitting(true);
-    setSubmitError(null);
-    try {
+  const modifyMutation = useMutation({
+    mutationFn: async () => {
+      if (!primaryClient) {
+        throw new Error("No primary remote session client to update.");
+      }
       const parsedScopes = parseScopes(scopeOverride);
       const trimmedAudience = audienceOverride.trim();
 
-      // Update the remote_session_issuer. The backend UPDATE uses COALESCE on
-      // each field — omitting a value keeps it as-is. We send the current
-      // form state for every field so the saved record matches what the
-      // operator sees.
+      // Update the remote_session_issuer. The backend now reads an explicit
+      // empty string on the four nullable endpoint fields as "clear to
+      // NULL"; an omitted field keeps the existing value. Send the trimmed
+      // input directly (including "") so blanking out a field in the UI
+      // actually clears the saved record — especially registration_endpoint,
+      // which is the signal Gram uses for "DCR is supported on this issuer".
       await client.remoteSessionIssuers.update({
         updateRemoteSessionIssuerForm: {
           id: issuer.id,
           issuer: issuerUrl.trim(),
-          authorizationEndpoint: authorizationEndpoint.trim() || undefined,
-          tokenEndpoint: tokenEndpoint.trim() || undefined,
-          registrationEndpoint: registrationEndpoint.trim() || undefined,
-          jwksUri: jwksUri.trim() || undefined,
+          authorizationEndpoint: authorizationEndpoint.trim(),
+          tokenEndpoint: tokenEndpoint.trim(),
+          registrationEndpoint: registrationEndpoint.trim(),
+          jwksUri: jwksUri.trim(),
           scopesSupported: discoveredSnapshot?.scopesSupported,
           grantTypesSupported: discoveredSnapshot?.grantTypesSupported,
           responseTypesSupported: discoveredSnapshot?.responseTypesSupported,
@@ -243,24 +222,47 @@ function ModifyRemoteIdentityProviderSheetBody({
           audience: trimmedAudience || undefined,
         },
       });
-
+    },
+    onSuccess: async () => {
       await Promise.all([
         invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
         invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
       ]);
-
       toast.success("Identity provider updated");
       onClose();
-    } catch (error) {
+    },
+    onError: (error) => {
       console.error("Modify identity provider failed", error);
-      setSubmitError(
-        error instanceof Error && error.message
-          ? error.message
-          : "An unexpected error occurred. Please try again.",
-      );
-    } finally {
-      setSubmitting(false);
-    }
+    },
+  });
+
+  const submitting = modifyMutation.isPending;
+  const submitError = modifyMutation.error
+    ? modifyMutation.error instanceof Error && modifyMutation.error.message
+      ? modifyMutation.error.message
+      : "An unexpected error occurred. Please try again."
+    : null;
+
+  // Seed client-derived fields exactly once per sheet open, the first time
+  // the client lookup resolves. The sheet body remounts on close (the
+  // `{open && <Body />}` pattern in the parent), so the ref resets naturally
+  // on the next open — no need to wire it to the open prop. Guarding via a
+  // ref instead of a narrow useEffect dependency keeps the linter happy AND
+  // prevents subsequent refetches from clobbering in-progress edits.
+  const clientFieldsInitializedRef = useRef(false);
+  useEffect(() => {
+    if (!primaryClient || clientFieldsInitializedRef.current) return;
+    setTokenEndpointAuthMethod(primaryClient.tokenEndpointAuthMethod ?? "");
+    setScopeOverride((primaryClient.scope ?? []).join(", "));
+    setAudienceOverride(primaryClient.audience ?? "");
+    clientFieldsInitializedRef.current = true;
+  }, [primaryClient]);
+
+  const submittable = !!primaryClient && issuerUrl.trim().length > 0;
+
+  const handleSubmit = () => {
+    if (!submittable || submitting || !primaryClient) return;
+    modifyMutation.mutate();
   };
 
   return (
@@ -294,7 +296,7 @@ function ModifyRemoteIdentityProviderSheetBody({
           issuerUrl={issuerUrl}
           onIssuerUrlChange={(value) => {
             setIssuerUrl(value);
-            setDiscoverError(null);
+            clearDiscoverError();
             // Same reset semantics as Attach: when the URL diverges from the
             // settled state, every downstream field was tied to that prior
             // URL. Clear them so re-Discover (or manual re-entry) produces a

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/ModifyRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/ModifyRemoteIdentityProviderSheet.tsx
@@ -1,0 +1,390 @@
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Type } from "@/components/ui/type";
+import { useSdkClient } from "@/contexts/Sdk";
+import type {
+  RemoteSessionClient,
+  RemoteSessionIssuer,
+  UserSessionIssuer,
+} from "@gram/client/models/components";
+import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/client/models/components";
+import {
+  invalidateAllRemoteSessionClients,
+  invalidateAllRemoteSessionIssuers,
+  useMcpServers,
+  useRemoteSessionClients,
+} from "@gram/client/react-query/index.js";
+import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  ClientCredentialsFields,
+  EndpointsFields,
+  IssuerUrlField,
+  OverridesFields,
+} from "./IssuerFormFields";
+import { parseScopes } from "./issuerFormUtils";
+import { useIssuerDiscovery } from "./useIssuerDiscovery";
+
+export function ModifyRemoteIdentityProviderSheet({
+  open,
+  onOpenChange,
+  userSessionIssuer,
+  issuer,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userSessionIssuer: UserSessionIssuer;
+  issuer: RemoteSessionIssuer;
+}) {
+  // Fetch every remote_session_client tied to this issuer (across all
+  // user_session_issuers in the project). We need the unfiltered list to
+  // compute which OTHER MCP servers are also using this issuer so the
+  // operator gets a heads-up that issuer/endpoint edits will affect them.
+  const { data: clientsResult, isLoading: isLoadingClients } =
+    useRemoteSessionClients({ remoteSessionIssuerId: issuer.id }, undefined, {
+      enabled: open,
+    });
+  // Memoize so the empty-array fallback doesn't churn a new reference on
+  // every render, which would invalidate downstream useMemo dependencies.
+  const allClients = useMemo(
+    () => clientsResult?.result.items ?? [],
+    [clientsResult],
+  );
+  const primaryClient: RemoteSessionClient | undefined = allClients.find(
+    (clientRow) => clientRow.userSessionIssuerId === userSessionIssuer.id,
+  );
+  const otherUserSessionIssuerIds = useMemo(
+    () =>
+      new Set(
+        allClients
+          .map((clientRow) => clientRow.userSessionIssuerId)
+          .filter((id) => id !== userSessionIssuer.id),
+      ),
+    [allClients, userSessionIssuer.id],
+  );
+
+  // Look up the MCP servers in the project that bind any of those "other"
+  // user_session_issuers — those are the servers whose authentication will
+  // be touched by issuer-level edits in this sheet.
+  const { data: serversResult } = useMcpServers(undefined, undefined, {
+    enabled: open && otherUserSessionIssuerIds.size > 0,
+  });
+  const affectedMcpServers = useMemo(() => {
+    const servers = serversResult?.mcpServers ?? [];
+    return servers.filter(
+      (mcpServer) =>
+        mcpServer.userSessionIssuerId != null &&
+        otherUserSessionIssuerIds.has(mcpServer.userSessionIssuerId),
+    );
+  }, [serversResult, otherUserSessionIssuerIds]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-[560px] flex-col sm:max-w-[560px]"
+      >
+        <SheetHeader className="px-6 pt-6 pb-0">
+          <SheetTitle className="text-lg font-semibold">
+            Modify Remote Identity Provider
+          </SheetTitle>
+        </SheetHeader>
+
+        {open && (
+          <ModifyRemoteIdentityProviderSheetBody
+            issuer={issuer}
+            primaryClient={primaryClient}
+            isLoadingClient={isLoadingClients}
+            affectedMcpServers={affectedMcpServers}
+            onClose={() => onOpenChange(false)}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ModifyRemoteIdentityProviderSheetBody({
+  issuer,
+  primaryClient,
+  isLoadingClient,
+  affectedMcpServers,
+  onClose,
+}: {
+  issuer: RemoteSessionIssuer;
+  primaryClient: RemoteSessionClient | undefined;
+  isLoadingClient: boolean;
+  affectedMcpServers: { id: string; name?: string | undefined }[];
+  onClose: () => void;
+}) {
+  const client = useSdkClient();
+  const queryClient = useQueryClient();
+
+  // Issuer URL + endpoints + discovery state come from the shared hook. The
+  // loaded record seeds the snapshot so the Discover/Reset slot and the
+  // URL-change reset behave the same way the Attach sheet does, just with
+  // saved data as the baseline.
+  const discovery = useIssuerDiscovery({
+    issuerUrl: issuer.issuer,
+    authorizationEndpoint: issuer.authorizationEndpoint ?? "",
+    tokenEndpoint: issuer.tokenEndpoint ?? "",
+    registrationEndpoint: issuer.registrationEndpoint ?? "",
+    jwksUri: issuer.jwksUri ?? "",
+    scopesSupported: issuer.scopesSupported ?? [],
+    grantTypesSupported: issuer.grantTypesSupported ?? [],
+    responseTypesSupported: issuer.responseTypesSupported ?? [],
+    tokenEndpointAuthMethodsSupported:
+      issuer.tokenEndpointAuthMethodsSupported ?? [],
+  });
+  const {
+    issuerUrl,
+    setIssuerUrl,
+    authorizationEndpoint,
+    tokenEndpoint,
+    registrationEndpoint,
+    jwksUri,
+    setAuthorizationEndpoint,
+    setTokenEndpoint,
+    setRegistrationEndpoint,
+    setJwksUri,
+    discoveredSnapshot,
+    discoverPending,
+    discoverError,
+    setDiscoverError,
+    runDiscover,
+    handleResetEndpoints,
+    resetEndpointState,
+    showDiscoverControls,
+    showResetControls,
+    endpointWarnings,
+  } = discovery;
+
+  // Client-side form state. clientId is informational only — the API has no
+  // rotate path, so it stays read-only. clientSecret starts blank; a typed
+  // value rotates the secret, blank means "leave unchanged".
+  const [clientSecret, setClientSecret] = useState("");
+  const [tokenEndpointAuthMethod, setTokenEndpointAuthMethod] = useState<
+    CreateRemoteSessionClientFormTokenEndpointAuthMethod | ""
+  >("");
+  const [scopeOverride, setScopeOverride] = useState("");
+  const [audienceOverride, setAudienceOverride] = useState("");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Seed client-derived fields exactly once per sheet open, the first time
+  // the client lookup resolves. The sheet body remounts on close (the
+  // `{open && <Body />}` pattern in the parent), so the ref resets naturally
+  // on the next open — no need to wire it to the open prop. Guarding via a
+  // ref instead of a narrow useEffect dependency keeps the linter happy AND
+  // prevents subsequent refetches from clobbering in-progress edits.
+  const clientFieldsInitializedRef = useRef(false);
+  useEffect(() => {
+    if (!primaryClient || clientFieldsInitializedRef.current) return;
+    setTokenEndpointAuthMethod(primaryClient.tokenEndpointAuthMethod ?? "");
+    setScopeOverride((primaryClient.scope ?? []).join(", "));
+    setAudienceOverride(primaryClient.audience ?? "");
+    clientFieldsInitializedRef.current = true;
+  }, [primaryClient]);
+
+  const submittable = !!primaryClient && issuerUrl.trim().length > 0;
+
+  const handleSubmit = async () => {
+    if (!submittable || submitting || !primaryClient) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const parsedScopes = parseScopes(scopeOverride);
+      const trimmedAudience = audienceOverride.trim();
+
+      // Update the remote_session_issuer. The backend UPDATE uses COALESCE on
+      // each field — omitting a value keeps it as-is. We send the current
+      // form state for every field so the saved record matches what the
+      // operator sees.
+      await client.remoteSessionIssuers.update({
+        updateRemoteSessionIssuerForm: {
+          id: issuer.id,
+          issuer: issuerUrl.trim(),
+          authorizationEndpoint: authorizationEndpoint.trim() || undefined,
+          tokenEndpoint: tokenEndpoint.trim() || undefined,
+          registrationEndpoint: registrationEndpoint.trim() || undefined,
+          jwksUri: jwksUri.trim() || undefined,
+          scopesSupported: discoveredSnapshot?.scopesSupported,
+          grantTypesSupported: discoveredSnapshot?.grantTypesSupported,
+          responseTypesSupported: discoveredSnapshot?.responseTypesSupported,
+          tokenEndpointAuthMethodsSupported:
+            discoveredSnapshot?.tokenEndpointAuthMethodsSupported,
+        },
+      });
+
+      // Update the remote_session_client overrides. clientSecret is only
+      // forwarded when the operator typed a new value (blank means keep the
+      // stored secret in place — see ClientCredentialsFields placeholder).
+      await client.remoteSessionClients.update({
+        updateRemoteSessionClientForm: {
+          id: primaryClient.id,
+          clientSecret: clientSecret.trim() || undefined,
+          tokenEndpointAuthMethod: tokenEndpointAuthMethod || undefined,
+          // Backend update uses COALESCE — omitting (undefined) keeps the
+          // stored value, sending an empty array would clear it. Mirror the
+          // audience handling here: only send when non-empty so the Modify
+          // UI never silently wipes existing overrides. Clearing today
+          // requires the operator to detach + re-attach the identity
+          // provider with new settings.
+          scope: parsedScopes.length > 0 ? parsedScopes : undefined,
+          audience: trimmedAudience || undefined,
+        },
+      });
+
+      await Promise.all([
+        invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
+        invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
+      ]);
+
+      toast.success("Identity provider updated");
+      onClose();
+    } catch (error) {
+      console.error("Modify identity provider failed", error);
+      setSubmitError(
+        error instanceof Error && error.message
+          ? error.message
+          : "An unexpected error occurred. Please try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex-1 space-y-6 overflow-y-auto px-6 py-6">
+        {affectedMcpServers.length > 0 && (
+          <Alert variant="warning" dismissible={false}>
+            <Stack gap={2}>
+              <Type className="font-medium">
+                Heads up — this identity provider is shared with{" "}
+                {affectedMcpServers.length === 1
+                  ? "1 other MCP server"
+                  : `${affectedMcpServers.length} other MCP servers`}{" "}
+                in this project.
+              </Type>
+              <Type small>
+                Issuer URL and endpoint edits apply to every server that uses
+                this provider. Client credentials, scope, and audience changes
+                only affect this server.
+              </Type>
+              <Type small mono>
+                {affectedMcpServers
+                  .map((server) => server.name?.trim() || server.id.slice(0, 8))
+                  .join(", ")}
+              </Type>
+            </Stack>
+          </Alert>
+        )}
+
+        <IssuerUrlField
+          issuerUrl={issuerUrl}
+          onIssuerUrlChange={(value) => {
+            setIssuerUrl(value);
+            setDiscoverError(null);
+            // Same reset semantics as Attach: when the URL diverges from the
+            // settled state, every downstream field was tied to that prior
+            // URL. Clear them so re-Discover (or manual re-entry) produces a
+            // coherent result. clientId is intentionally NOT cleared — the
+            // existing client record stays in place since the API has no
+            // rotate path for client_id.
+            if (discoveredSnapshot && value.trim() !== discoveredSnapshot.url) {
+              resetEndpointState();
+              setClientSecret("");
+              setTokenEndpointAuthMethod("");
+              setScopeOverride("");
+              setAudienceOverride("");
+            }
+          }}
+        />
+
+        <Stack gap={2}>
+          <Label className="text-muted-foreground text-xs">Slug</Label>
+          <Type small mono>
+            {issuer.slug}
+          </Type>
+          <Type muted small>
+            Slug is the stable identifier for this identity provider and can't
+            be renamed here.
+          </Type>
+        </Stack>
+
+        <EndpointsFields
+          issuerUrl={issuerUrl}
+          authorizationEndpoint={authorizationEndpoint}
+          tokenEndpoint={tokenEndpoint}
+          registrationEndpoint={registrationEndpoint}
+          jwksUri={jwksUri}
+          endpointWarnings={endpointWarnings}
+          discoverPending={discoverPending}
+          discoverError={discoverError}
+          showDiscoverControls={showDiscoverControls}
+          showResetControls={showResetControls}
+          onAuthorizationEndpointChange={setAuthorizationEndpoint}
+          onTokenEndpointChange={setTokenEndpoint}
+          onRegistrationEndpointChange={setRegistrationEndpoint}
+          onJwksUriChange={setJwksUri}
+          onDiscover={() => runDiscover(issuerUrl)}
+          onResetEndpoints={handleResetEndpoints}
+        />
+
+        {isLoadingClient ? (
+          <Type muted small>
+            Loading client credentials…
+          </Type>
+        ) : (
+          <ClientCredentialsFields
+            clientId={primaryClient?.clientId ?? ""}
+            clientSecret={clientSecret}
+            tokenEndpointAuthMethod={tokenEndpointAuthMethod}
+            clientIdEditable={false}
+            clientSecretLabel="Client Secret (leave blank to keep existing)"
+            clientSecretPlaceholder="Type a new secret to rotate"
+            onClientIdChange={() => undefined}
+            onClientSecretChange={setClientSecret}
+            onTokenEndpointAuthMethodChange={setTokenEndpointAuthMethod}
+          />
+        )}
+
+        <OverridesFields
+          scopeOverride={scopeOverride}
+          audienceOverride={audienceOverride}
+          onScopeOverrideChange={setScopeOverride}
+          onAudienceOverrideChange={setAudienceOverride}
+        />
+
+        {submitError && (
+          <Alert variant="error" dismissible={false}>
+            {submitError}
+          </Alert>
+        )}
+      </div>
+
+      <SheetFooter className="flex-row items-center justify-end gap-2 border-t px-6 py-4">
+        <Button variant="secondary" disabled={submitting} onClick={onClose}>
+          <Button.Text>Cancel</Button.Text>
+        </Button>
+        <Button
+          variant="primary"
+          disabled={!submittable || submitting || isLoadingClient}
+          onClick={handleSubmit}
+        >
+          <Button.Text>{submitting ? "Saving…" : "Save"}</Button.Text>
+        </Button>
+      </SheetFooter>
+    </>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/RemoteIdentityProvidersTable.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/RemoteIdentityProvidersTable.tsx
@@ -1,0 +1,103 @@
+import { RequireScope } from "@/components/require-scope";
+import { Heading } from "@/components/ui/heading";
+import { Type } from "@/components/ui/type";
+import type { RemoteSessionIssuer } from "@gram/client/models/components";
+import { Button, Stack } from "@speakeasy-api/moonshine";
+import { Lock, Plus, Trash2 } from "lucide-react";
+
+export function RemoteIdentityProvidersTable({
+  associatedIssuers,
+  isLoading,
+  onAdd,
+  onEdit,
+  onDelete,
+}: {
+  associatedIssuers: RemoteSessionIssuer[];
+  isLoading: boolean;
+  onAdd: () => void;
+  onEdit: (issuer: RemoteSessionIssuer) => void;
+  onDelete: (issuer: RemoteSessionIssuer) => void;
+}) {
+  return (
+    <section>
+      <Heading variant="h4" className="mb-3">
+        Remote Identity Providers
+      </Heading>
+      <Type muted small className="mb-4">
+        Upstream identity providers users authenticate against to access MCP
+        Server functionality.
+      </Type>
+      {isLoading ? (
+        <Type muted small>
+          Loading…
+        </Type>
+      ) : (
+        <Stack gap={3}>
+          {associatedIssuers.length === 0 ? (
+            <Stack direction="horizontal" gap={2} align="center">
+              <Lock className="text-muted-foreground size-4" />
+              <Type className="font-medium">
+                No remote identity providers configured yet.
+              </Type>
+            </Stack>
+          ) : (
+            associatedIssuers.map((issuer) => (
+              <RemoteIdentityProviderRow
+                key={issuer.id}
+                issuer={issuer}
+                onEdit={() => onEdit(issuer)}
+                onDelete={() => onDelete(issuer)}
+              />
+            ))
+          )}
+          <div>
+            <RequireScope scope="mcp:write" level="component">
+              <Button variant="secondary" onClick={onAdd}>
+                <Button.LeftIcon>
+                  <Plus className="size-4" />
+                </Button.LeftIcon>
+                <Button.Text>Attach Remote Identity Provider</Button.Text>
+              </Button>
+            </RequireScope>
+          </div>
+        </Stack>
+      )}
+    </section>
+  );
+}
+
+function RemoteIdentityProviderRow({
+  issuer,
+  onEdit,
+  onDelete,
+}: {
+  issuer: RemoteSessionIssuer;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <Stack direction="horizontal" gap={2} align="center">
+        <Stack gap={0} className="min-w-0 flex-1">
+          <Type small className="truncate font-mono">
+            {issuer.slug}
+          </Type>
+          <Type muted mono variant="small" className="break-all">
+            {issuer.issuer}
+          </Type>
+        </Stack>
+        <RequireScope scope="mcp:write" level="component">
+          <Button size="md" variant="secondary" onClick={onEdit}>
+            <Button.Text>Edit</Button.Text>
+          </Button>
+          <Button size="md" variant="destructive-secondary" onClick={onDelete}>
+            <Button.LeftIcon>
+              <Trash2 className="size-4" />
+            </Button.LeftIcon>
+            <Button.Text>Delete</Button.Text>
+          </Button>
+        </RequireScope>
+      </Stack>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/RemoteIdentityProvidersTable.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/RemoteIdentityProvidersTable.tsx
@@ -1,5 +1,10 @@
 import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import type { RemoteSessionIssuer } from "@gram/client/models/components";
 import { Button, Stack } from "@speakeasy-api/moonshine";
@@ -11,12 +16,17 @@ export function RemoteIdentityProvidersTable({
   onAdd,
   onEdit,
   onDelete,
+  attachDisabledReason,
 }: {
   associatedIssuers: RemoteSessionIssuer[];
   isLoading: boolean;
   onAdd: () => void;
   onEdit: (issuer: RemoteSessionIssuer) => void;
   onDelete: (issuer: RemoteSessionIssuer) => void;
+  // When set, the Attach button renders disabled with this string as its
+  // tooltip. Used to surface the temporary single-provider constraint until
+  // multi-client support lands.
+  attachDisabledReason?: string;
 }) {
   return (
     <section>
@@ -52,12 +62,38 @@ export function RemoteIdentityProvidersTable({
           )}
           <div>
             <RequireScope scope="mcp:write" level="component">
-              <Button variant="secondary" onClick={onAdd}>
-                <Button.LeftIcon>
-                  <Plus className="size-4" />
-                </Button.LeftIcon>
-                <Button.Text>Attach Remote Identity Provider</Button.Text>
-              </Button>
+              {attachDisabledReason ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    {/* Disabled native buttons don't fire pointer events, so
+                        the tooltip never opens on hover without a wrapper.
+                        Matches the EmptyAuthenticationState pattern. */}
+                    <span
+                      role="button"
+                      aria-disabled="true"
+                      tabIndex={0}
+                      aria-label={attachDisabledReason}
+                    >
+                      <Button variant="secondary" disabled>
+                        <Button.LeftIcon>
+                          <Plus className="size-4" />
+                        </Button.LeftIcon>
+                        <Button.Text>
+                          Attach Remote Identity Provider
+                        </Button.Text>
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{attachDisabledReason}</TooltipContent>
+                </Tooltip>
+              ) : (
+                <Button variant="secondary" onClick={onAdd}>
+                  <Button.LeftIcon>
+                    <Plus className="size-4" />
+                  </Button.LeftIcon>
+                  <Button.Text>Attach Remote Identity Provider</Button.Text>
+                </Button>
+              )}
             </RequireScope>
           </div>
         </Stack>

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/UserSessionsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/UserSessionsSection.tsx
@@ -1,0 +1,177 @@
+import { RequireScope } from "@/components/require-scope";
+import { Heading } from "@/components/ui/heading";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Type } from "@/components/ui/type";
+import type { UserSessionIssuer } from "@gram/client/models/components";
+import {
+  invalidateAllUserSessionIssuer,
+  invalidateAllUserSessionIssuers,
+  useUpdateUserSessionIssuerMutation,
+} from "@gram/client/react-query/index.js";
+import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+type DurationUnit = "hour" | "day" | "week";
+
+const DURATION_UNIT_HOURS: Record<DurationUnit, number> = {
+  hour: 1,
+  day: 24,
+  week: 24 * 7,
+};
+
+const DURATION_UNIT_OPTIONS: ReadonlyArray<{
+  value: DurationUnit;
+  label: string;
+}> = [
+  { value: "hour", label: "Hours" },
+  { value: "day", label: "Days" },
+  { value: "week", label: "Weeks" },
+];
+
+// Pick the largest whole unit that divides the hours value evenly. 168 → 1
+// week, 48 → 2 days, 36 → 36 hours. Keeps the inputs readable when the row
+// loads a saved value.
+function splitIntoUnit(hours: number): {
+  number: number;
+  unit: DurationUnit;
+} {
+  if (hours > 0 && hours % DURATION_UNIT_HOURS.week === 0) {
+    return { number: hours / DURATION_UNIT_HOURS.week, unit: "week" };
+  }
+  if (hours > 0 && hours % DURATION_UNIT_HOURS.day === 0) {
+    return { number: hours / DURATION_UNIT_HOURS.day, unit: "day" };
+  }
+  return { number: Math.max(0, hours), unit: "hour" };
+}
+
+export function UserSessionsSection({
+  userSessionIssuer,
+}: {
+  userSessionIssuer: UserSessionIssuer;
+}) {
+  const queryClient = useQueryClient();
+  const initialSplit = splitIntoUnit(userSessionIssuer.sessionDurationHours);
+  const [durationNumber, setDurationNumber] = useState(initialSplit.number);
+  const [durationUnit, setDurationUnit] = useState<DurationUnit>(
+    initialSplit.unit,
+  );
+
+  // Resync from the saved record whenever it changes — post-save refetch,
+  // switching MCP servers, etc. Safe because dirty edits can't have produced
+  // a new server value without going through handleSave first.
+  useEffect(() => {
+    const split = splitIntoUnit(userSessionIssuer.sessionDurationHours);
+    setDurationNumber(split.number);
+    setDurationUnit(split.unit);
+  }, [userSessionIssuer.sessionDurationHours]);
+
+  const update = useUpdateUserSessionIssuerMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        invalidateAllUserSessionIssuers(queryClient, { refetchType: "all" }),
+        invalidateAllUserSessionIssuer(queryClient, { refetchType: "all" }),
+      ]);
+      toast.success("Session duration updated");
+    },
+    onError: (error) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update session duration",
+      );
+    },
+  });
+
+  const draftHours = durationNumber * DURATION_UNIT_HOURS[durationUnit];
+  const dirty = draftHours !== userSessionIssuer.sessionDurationHours;
+  const valid = draftHours > 0;
+
+  const handleSave = () => {
+    update.mutate({
+      request: {
+        updateUserSessionIssuerForm: {
+          id: userSessionIssuer.id,
+          sessionDurationHours: draftHours,
+        },
+      },
+    });
+  };
+
+  const handleNumberChange = (raw: string) => {
+    const parsed = parseInt(raw, 10);
+    setDurationNumber(Number.isFinite(parsed) && parsed >= 0 ? parsed : 0);
+  };
+
+  const handleUnitChange = (value: string) => {
+    setDurationUnit(value as DurationUnit);
+  };
+
+  return (
+    <section>
+      <Heading variant="h4" className="mb-3">
+        User Sessions
+      </Heading>
+      <Type muted small className="mb-4">
+        The platform issues user sessions for this MCP server. Attach remote
+        identity providers to delegate server functionality authentication.
+      </Type>
+      <Stack gap={4}>
+        <Stack gap={2}>
+          <Label className="text-muted-foreground text-xs">
+            Session Duration
+          </Label>
+          <Stack direction="horizontal" gap={2} align="center">
+            <Input
+              type="number"
+              min="1"
+              value={String(durationNumber)}
+              onChange={handleNumberChange}
+              className="w-[100px]"
+            />
+            <Select value={durationUnit} onValueChange={handleUnitChange}>
+              <SelectTrigger className="w-[120px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DURATION_UNIT_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <RequireScope scope="mcp:write" level="component">
+              <Button
+                variant="primary"
+                disabled={!dirty || !valid || update.isPending}
+                onClick={handleSave}
+              >
+                <Button.Text>Save</Button.Text>
+              </Button>
+            </RequireScope>
+          </Stack>
+          <Type muted small>
+            How long an issued user session stays valid before the user must
+            re-authenticate.
+          </Type>
+        </Stack>
+
+        {update.isError && (
+          <Alert variant="error" dismissible={false}>
+            {update.error.message}
+          </Alert>
+        )}
+      </Stack>
+    </section>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/issuerFormUtils.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/issuerFormUtils.ts
@@ -1,0 +1,40 @@
+import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/client/models/components";
+
+// Snapshot of the issuer + RFC 8414 metadata for a given Issuer URL. Created
+// fresh on every successful discovery and seeded from saved records in the
+// Modify sheet. Drives the Discover/Reset slot and the URL-change reset.
+export type DiscoveredEndpoints = {
+  url: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  jwksUri: string;
+  scopesSupported: string[];
+  grantTypesSupported: string[];
+  responseTypesSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+};
+
+// Matches the OAuth Proxy wizard's parseScopes helper: split on commas, trim,
+// drop empties. Kept local rather than imported across feature folders so the
+// authentication module stays self-contained.
+export function parseScopes(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+}
+
+export function narrowTokenEndpointAuthMethod(
+  value: string | null | undefined,
+): CreateRemoteSessionClientFormTokenEndpointAuthMethod | undefined {
+  if (
+    value ===
+      CreateRemoteSessionClientFormTokenEndpointAuthMethod.ClientSecretBasic ||
+    value ===
+      CreateRemoteSessionClientFormTokenEndpointAuthMethod.ClientSecretPost
+  ) {
+    return value;
+  }
+  return undefined;
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/useAllRemoteSessionClients.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/useAllRemoteSessionClients.ts
@@ -1,0 +1,47 @@
+import type { RemoteSessionClient } from "@gram/client/models/components";
+import type { ListRemoteSessionClientsRequest } from "@gram/client/models/operations";
+import { useRemoteSessionClientsInfinite } from "@gram/client/react-query/index.js";
+import { useEffect, useMemo } from "react";
+
+// Walk every page of remote_session_clients matching the filter and return
+// the flattened list. The Authentication tab derivations (associated
+// providers, affectedMcpServers) need the full set across paginated
+// responses — a single-page fetch silently undercounts once a project
+// crosses the default page size of 50. The Delete dialog walks pages
+// imperatively inside its submit handler; this hook is the declarative
+// equivalent for components that need the list in their render.
+//
+// AGE-2554 will likely move this to a backend aggregate endpoint when
+// multi-client support lands; the helper exists so the temporary client-
+// side walk stays out of every consumer.
+export function useAllRemoteSessionClients(
+  filters: Pick<
+    ListRemoteSessionClientsRequest,
+    "userSessionIssuerId" | "remoteSessionIssuerId"
+  >,
+  options?: { enabled?: boolean },
+): { items: RemoteSessionClient[]; isLoading: boolean } {
+  const query = useRemoteSessionClientsInfinite(filters, undefined, {
+    enabled: options?.enabled,
+  });
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const items = useMemo<RemoteSessionClient[]>(
+    () => query.data?.pages.flatMap((page) => page.result.items) ?? [],
+    [query.data],
+  );
+
+  // Keep isLoading true while more pages are still being fetched so the
+  // consumer's spinner stays up until the list is complete — otherwise it
+  // would flicker off after the first page even though more rows are
+  // coming.
+  const isLoading = query.isLoading || hasNextPage;
+
+  return { items, isLoading };
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/useIssuerDiscovery.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/useIssuerDiscovery.ts
@@ -1,0 +1,195 @@
+import { useSdkClient } from "@/contexts/Sdk";
+import { useCallback, useMemo, useState } from "react";
+import type { DiscoveredEndpoints } from "./issuerFormUtils";
+
+// Initial form values for the Issuer URL + endpoint fields. Pass `null` for
+// the Attach sheet (everything starts blank); pass the loaded record's values
+// in the Modify sheet so the snapshot is seeded and the Reset/Discover slot
+// behaves consistently against saved state.
+export type UseIssuerDiscoveryInitial = {
+  issuerUrl: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  jwksUri: string;
+  scopesSupported: string[];
+  grantTypesSupported: string[];
+  responseTypesSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+} | null;
+
+// Encapsulates the Issuer URL + 4 endpoint state, RFC 8414 metadata
+// snapshot, discovery RPC call, Discover/Reset slot derivations, and the
+// endpoint-validation warnings. Used by both AttachRemoteIdentityProviderSheet
+// and ModifyRemoteIdentityProviderSheet — those sheets compose their own
+// slug / credentials / override state on top.
+export function useIssuerDiscovery(initial: UseIssuerDiscoveryInitial) {
+  const client = useSdkClient();
+
+  const [issuerUrl, setIssuerUrl] = useState(initial?.issuerUrl ?? "");
+  const [authorizationEndpoint, setAuthorizationEndpoint] = useState(
+    initial?.authorizationEndpoint ?? "",
+  );
+  const [tokenEndpoint, setTokenEndpoint] = useState(
+    initial?.tokenEndpoint ?? "",
+  );
+  const [registrationEndpoint, setRegistrationEndpoint] = useState(
+    initial?.registrationEndpoint ?? "",
+  );
+  const [jwksUri, setJwksUri] = useState(initial?.jwksUri ?? "");
+  const [discoveredSnapshot, setDiscoveredSnapshot] =
+    useState<DiscoveredEndpoints | null>(() =>
+      initial
+        ? {
+            url: initial.issuerUrl,
+            authorizationEndpoint: initial.authorizationEndpoint,
+            tokenEndpoint: initial.tokenEndpoint,
+            registrationEndpoint: initial.registrationEndpoint,
+            jwksUri: initial.jwksUri,
+            scopesSupported: initial.scopesSupported,
+            grantTypesSupported: initial.grantTypesSupported,
+            responseTypesSupported: initial.responseTypesSupported,
+            tokenEndpointAuthMethodsSupported:
+              initial.tokenEndpointAuthMethodsSupported,
+          }
+        : null,
+    );
+  const [discoverPending, setDiscoverPending] = useState(false);
+  const [discoverError, setDiscoverError] = useState<string | null>(null);
+  const [discoverRan, setDiscoverRan] = useState(false);
+
+  const urlMatchesLastDiscovery =
+    discoveredSnapshot != null && issuerUrl.trim() === discoveredSnapshot.url;
+  const showDiscoverControls = !urlMatchesLastDiscovery;
+
+  const endpointsDivergeFromSnapshot = useMemo(() => {
+    if (!discoveredSnapshot) return false;
+    const fields: ReadonlyArray<readonly [string, string]> = [
+      [discoveredSnapshot.authorizationEndpoint, authorizationEndpoint],
+      [discoveredSnapshot.tokenEndpoint, tokenEndpoint],
+      [discoveredSnapshot.registrationEndpoint, registrationEndpoint],
+      [discoveredSnapshot.jwksUri, jwksUri],
+    ];
+    return fields.some(([snap, current]) => snap !== "" && current !== snap);
+  }, [
+    discoveredSnapshot,
+    authorizationEndpoint,
+    tokenEndpoint,
+    registrationEndpoint,
+    jwksUri,
+  ]);
+
+  const showResetControls =
+    !showDiscoverControls && endpointsDivergeFromSnapshot;
+
+  const endpointWarnings = useMemo(() => {
+    if (!discoverRan) return [];
+    const warnings: string[] = [];
+    if (!authorizationEndpoint.trim()) {
+      warnings.push("Authorization endpoint not advertised by the issuer.");
+    }
+    if (!tokenEndpoint.trim()) {
+      warnings.push("Token endpoint not advertised by the issuer.");
+    }
+    return warnings;
+  }, [discoverRan, authorizationEndpoint, tokenEndpoint]);
+
+  const runDiscover = useCallback(
+    async (url: string) => {
+      const trimmed = url.trim();
+      if (!trimmed) return;
+      setDiscoverPending(true);
+      setDiscoverError(null);
+      try {
+        const draft = await client.remoteSessionIssuers.discover({
+          discoverRemoteSessionIssuerRequestBody: { issuer: trimmed },
+        });
+        const snapshot: DiscoveredEndpoints = {
+          url: trimmed,
+          authorizationEndpoint: draft.authorizationEndpoint ?? "",
+          tokenEndpoint: draft.tokenEndpoint ?? "",
+          registrationEndpoint: draft.registrationEndpoint ?? "",
+          jwksUri: draft.jwksUri ?? "",
+          scopesSupported: draft.scopesSupported ?? [],
+          grantTypesSupported: draft.grantTypesSupported ?? [],
+          responseTypesSupported: draft.responseTypesSupported ?? [],
+          tokenEndpointAuthMethodsSupported:
+            draft.tokenEndpointAuthMethodsSupported ?? [],
+        };
+        setAuthorizationEndpoint(snapshot.authorizationEndpoint);
+        setTokenEndpoint(snapshot.tokenEndpoint);
+        setRegistrationEndpoint(snapshot.registrationEndpoint);
+        setJwksUri(snapshot.jwksUri);
+        setDiscoveredSnapshot(snapshot);
+        setDiscoverRan(true);
+      } catch (error) {
+        setDiscoverError(
+          error instanceof Error
+            ? error.message
+            : "Discovery failed against this issuer URL.",
+        );
+      } finally {
+        setDiscoverPending(false);
+      }
+    },
+    [client],
+  );
+
+  // Restore only the fields discovery actually returned. User additions to
+  // fields discovery left empty stay untouched.
+  const handleResetEndpoints = useCallback(() => {
+    if (!discoveredSnapshot) return;
+    if (discoveredSnapshot.authorizationEndpoint) {
+      setAuthorizationEndpoint(discoveredSnapshot.authorizationEndpoint);
+    }
+    if (discoveredSnapshot.tokenEndpoint) {
+      setTokenEndpoint(discoveredSnapshot.tokenEndpoint);
+    }
+    if (discoveredSnapshot.registrationEndpoint) {
+      setRegistrationEndpoint(discoveredSnapshot.registrationEndpoint);
+    }
+    if (discoveredSnapshot.jwksUri) {
+      setJwksUri(discoveredSnapshot.jwksUri);
+    }
+  }, [discoveredSnapshot]);
+
+  // Clears endpoint state + snapshot + discoverRan. Used by the URL-change
+  // cascade in the parent sheets so a divergent URL leaves the form in a
+  // coherent state until the operator re-runs Discover or types values in.
+  const resetEndpointState = useCallback(() => {
+    setAuthorizationEndpoint("");
+    setTokenEndpoint("");
+    setRegistrationEndpoint("");
+    setJwksUri("");
+    setDiscoveredSnapshot(null);
+    setDiscoverRan(false);
+  }, []);
+
+  // Intentionally narrow: setDiscoveredSnapshot and discoverRan stay
+  // internal. Parents drive snapshot transitions via runDiscover /
+  // resetEndpointState, and read endpointWarnings rather than discoverRan
+  // directly. Keeping these out of the return type prevents callers from
+  // bypassing the state machine.
+  return {
+    issuerUrl,
+    setIssuerUrl,
+    authorizationEndpoint,
+    setAuthorizationEndpoint,
+    tokenEndpoint,
+    setTokenEndpoint,
+    registrationEndpoint,
+    setRegistrationEndpoint,
+    jwksUri,
+    setJwksUri,
+    discoveredSnapshot,
+    discoverPending,
+    discoverError,
+    setDiscoverError,
+    runDiscover,
+    handleResetEndpoints,
+    resetEndpointState,
+    showDiscoverControls,
+    showResetControls,
+    endpointWarnings,
+  };
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/useIssuerDiscovery.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/useIssuerDiscovery.ts
@@ -1,4 +1,5 @@
 import { useSdkClient } from "@/contexts/Sdk";
+import { useMutation } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import type { DiscoveredEndpoints } from "./issuerFormUtils";
 
@@ -54,9 +55,46 @@ export function useIssuerDiscovery(initial: UseIssuerDiscoveryInitial) {
           }
         : null,
     );
-  const [discoverPending, setDiscoverPending] = useState(false);
-  const [discoverError, setDiscoverError] = useState<string | null>(null);
   const [discoverRan, setDiscoverRan] = useState(false);
+
+  const discoverMutation = useMutation({
+    mutationFn: async (url: string): Promise<DiscoveredEndpoints> => {
+      const draft = await client.remoteSessionIssuers.discover({
+        discoverRemoteSessionIssuerRequestBody: { issuer: url },
+      });
+      return {
+        url,
+        authorizationEndpoint: draft.authorizationEndpoint ?? "",
+        tokenEndpoint: draft.tokenEndpoint ?? "",
+        registrationEndpoint: draft.registrationEndpoint ?? "",
+        jwksUri: draft.jwksUri ?? "",
+        scopesSupported: draft.scopesSupported ?? [],
+        grantTypesSupported: draft.grantTypesSupported ?? [],
+        responseTypesSupported: draft.responseTypesSupported ?? [],
+        tokenEndpointAuthMethodsSupported:
+          draft.tokenEndpointAuthMethodsSupported ?? [],
+      };
+    },
+    onSuccess: (snapshot) => {
+      setAuthorizationEndpoint(snapshot.authorizationEndpoint);
+      setTokenEndpoint(snapshot.tokenEndpoint);
+      setRegistrationEndpoint(snapshot.registrationEndpoint);
+      setJwksUri(snapshot.jwksUri);
+      setDiscoveredSnapshot(snapshot);
+      setDiscoverRan(true);
+    },
+  });
+
+  const discoverPending = discoverMutation.isPending;
+  const discoverError = discoverMutation.error
+    ? discoverMutation.error instanceof Error
+      ? discoverMutation.error.message
+      : "Discovery failed against this issuer URL."
+    : null;
+  const { reset: resetDiscoverMutation } = discoverMutation;
+  const clearDiscoverError = useCallback(() => {
+    resetDiscoverMutation();
+  }, [resetDiscoverMutation]);
 
   const urlMatchesLastDiscovery =
     discoveredSnapshot != null && issuerUrl.trim() === discoveredSnapshot.url;
@@ -94,45 +132,14 @@ export function useIssuerDiscovery(initial: UseIssuerDiscoveryInitial) {
     return warnings;
   }, [discoverRan, authorizationEndpoint, tokenEndpoint]);
 
+  const { mutate: triggerDiscover } = discoverMutation;
   const runDiscover = useCallback(
-    async (url: string) => {
+    (url: string) => {
       const trimmed = url.trim();
       if (!trimmed) return;
-      setDiscoverPending(true);
-      setDiscoverError(null);
-      try {
-        const draft = await client.remoteSessionIssuers.discover({
-          discoverRemoteSessionIssuerRequestBody: { issuer: trimmed },
-        });
-        const snapshot: DiscoveredEndpoints = {
-          url: trimmed,
-          authorizationEndpoint: draft.authorizationEndpoint ?? "",
-          tokenEndpoint: draft.tokenEndpoint ?? "",
-          registrationEndpoint: draft.registrationEndpoint ?? "",
-          jwksUri: draft.jwksUri ?? "",
-          scopesSupported: draft.scopesSupported ?? [],
-          grantTypesSupported: draft.grantTypesSupported ?? [],
-          responseTypesSupported: draft.responseTypesSupported ?? [],
-          tokenEndpointAuthMethodsSupported:
-            draft.tokenEndpointAuthMethodsSupported ?? [],
-        };
-        setAuthorizationEndpoint(snapshot.authorizationEndpoint);
-        setTokenEndpoint(snapshot.tokenEndpoint);
-        setRegistrationEndpoint(snapshot.registrationEndpoint);
-        setJwksUri(snapshot.jwksUri);
-        setDiscoveredSnapshot(snapshot);
-        setDiscoverRan(true);
-      } catch (error) {
-        setDiscoverError(
-          error instanceof Error
-            ? error.message
-            : "Discovery failed against this issuer URL.",
-        );
-      } finally {
-        setDiscoverPending(false);
-      }
+      triggerDiscover(trimmed);
     },
-    [client],
+    [triggerDiscover],
   );
 
   // Restore only the fields discovery actually returned. User additions to
@@ -184,7 +191,7 @@ export function useIssuerDiscovery(initial: UseIssuerDiscoveryInitial) {
     discoveredSnapshot,
     discoverPending,
     discoverError,
-    setDiscoverError,
+    clearDiscoverError,
     runDiscover,
     handleResetEndpoints,
     resetEndpointState,

--- a/client/dashboard/src/pages/mcp/x/tabs/authentication/useProtectedResourceMetadata.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/authentication/useProtectedResourceMetadata.ts
@@ -1,0 +1,58 @@
+import { useSdkClient } from "@/contexts/Sdk";
+import type { ProtectedResourceMetadata } from "@gram/client/models/components";
+import { useQuery } from "@tanstack/react-query";
+
+export type ProtectedResourceProbeStatus =
+  | "idle"
+  | "loading"
+  | "available"
+  | "unavailable";
+
+export type ProtectedResourceProbeResult = {
+  status: ProtectedResourceProbeStatus;
+  metadata: ProtectedResourceMetadata | null;
+};
+
+// Calls remoteMcp.discoverProtectedResourceMetadata instead of probing from
+// the browser. The endpoint runs the RFC 9728 probe under guardian.Policy and
+// returns HTTP 200 with available=false for any probe-level failure (404,
+// CORS-N/A, malformed, transport error, etc.), so we only treat transport /
+// server errors here as "unavailable" — normal upstream unavailability flows
+// through the success path.
+export function useProtectedResourceMetadata(
+  remoteMcpServerId: string | undefined,
+  enabled: boolean,
+): ProtectedResourceProbeResult {
+  const client = useSdkClient();
+
+  const query = useQuery({
+    queryKey: ["protected-resource-metadata", remoteMcpServerId],
+    queryFn: async () => {
+      if (!remoteMcpServerId) throw new Error("no remote mcp server id");
+      return client.remoteMcp.discoverProtectedResourceMetadata({
+        discoverProtectedResourceMetadataRequestBody: {
+          remoteMcpServerId,
+        },
+      });
+    },
+    enabled: enabled && !!remoteMcpServerId,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!enabled || !remoteMcpServerId) {
+    return { status: "idle", metadata: null };
+  }
+  if (query.isLoading) {
+    return { status: "loading", metadata: null };
+  }
+  if (
+    query.isError ||
+    !query.data ||
+    !query.data.available ||
+    !query.data.metadata
+  ) {
+    return { status: "unavailable", metadata: null };
+  }
+  return { status: "available", metadata: query.data.metadata };
+}

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -31,6 +31,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
@@ -881,7 +883,22 @@ type ProxyRegisterResponse struct {
 func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	if _, err := s.sessions.AuthenticateWithCookie(ctx); err != nil {
+	// The session cookie is SameSite=Lax so it does not flow on cross-origin
+	// fetch from the dashboard in dev (where the dashboard and API run on
+	// different origins). Goa-generated endpoints accept the Gram-Session
+	// header, so this raw handler falls back to the header when context has
+	// no token, keeping the four UI surfaces that hit /oauth/proxy-register
+	// (OAuth wizard, external-MCP onboarding, wire-user-session-issuer
+	// modal, MCP authentication sheet) functional in dev.
+	//
+	// SessionMiddleware could populate the session token in context from the
+	// Gram-Session header when the cookie is absent — every raw handler
+	// would then pick it up without per-handler fallback.
+	sessionToken, _ := contextvalues.GetSessionTokenFromContext(ctx)
+	if sessionToken == "" {
+		sessionToken = r.Header.Get(constants.SessionHeader)
+	}
+	if _, err := s.sessions.Authenticate(ctx, sessionToken); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authentication required").Log(ctx, s.logger)
 	}
 

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -75,6 +75,9 @@ func (s *Service) DiscoverRemoteSessionIssuer(ctx context.Context, payload *gen.
 
 	doc, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
 	if err != nil {
+		if df, ok := errors.AsType[*discoveryError](err); ok {
+			return nil, oops.E(oops.CodeGatewayError, err, "%s", df.UserMessage()).Log(ctx, logger)
+		}
 		return nil, oops.E(oops.CodeGatewayError, err, "discover issuer metadata").Log(ctx, logger)
 	}
 
@@ -415,14 +418,62 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 	return nil
 }
 
+// discoveryError captures enough context about a failed RFC 8414 fetch that
+// the handler can compose a user-facing message naming the well-known URL and,
+// when available, the upstream HTTP status. Status is zero when no HTTP
+// response was received (transport error, malformed URL, etc.).
+type discoveryError struct {
+	WellKnownURL string
+	Status       int
+	cause        error
+}
+
+func (e *discoveryError) Error() string {
+	switch {
+	case e.WellKnownURL == "":
+		return e.cause.Error()
+	case e.Status > 0:
+		return fmt.Sprintf("discover %s: HTTP %d: %s", e.WellKnownURL, e.Status, e.cause)
+	default:
+		return fmt.Sprintf("discover %s: %s", e.WellKnownURL, e.cause)
+	}
+}
+
+func (e *discoveryError) Unwrap() error { return e.cause }
+
+// UserMessage produces the public, user-facing summary surfaced through the
+// management API. Callers wrap it in an oops.E to attach the gateway error
+// code and id.
+func (e *discoveryError) UserMessage() string {
+	switch {
+	case e.Status == http.StatusNotFound:
+		return fmt.Sprintf("OAuth metadata not found at %s", e.WellKnownURL)
+	case e.Status >= 400:
+		return fmt.Sprintf("Unexpected HTTP %d from %s", e.Status, e.WellKnownURL)
+	case e.Status == http.StatusOK:
+		// 200 made it back but the body was unreadable or malformed.
+		return fmt.Sprintf("OAuth metadata at %s was not a valid RFC 8414 document", e.WellKnownURL)
+	case e.WellKnownURL != "":
+		return fmt.Sprintf("Could not reach OAuth metadata at %s", e.WellKnownURL)
+	default:
+		return "Could not compute OAuth metadata URL for the supplied issuer"
+	}
+}
+
 // discoverIssuerMetadata fetches and parses an RFC 8414
 // .well-known/oauth-authorization-server document, returning the parsed body
 // and any deviations from the spec callers should be aware of. The supplied
-// guardian.Policy gates the outbound dial.
+// guardian.Policy gates the outbound dial. Failures are wrapped in a
+// *discoveryError so the handler can attach the upstream URL and status to
+// the user-facing error.
 func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuerURL string) (rfc8414Document, []string, error) {
 	wellKnown, err := wellKnownURL(issuerURL)
 	if err != nil {
-		return rfc8414Document{}, nil, fmt.Errorf("compute well-known url: %w", err)
+		return rfc8414Document{}, nil, &discoveryError{
+			WellKnownURL: "",
+			Status:       0,
+			cause:        fmt.Errorf("compute well-known url: %w", err),
+		}
 	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, discoveryHTTPTimeout)
@@ -430,28 +481,48 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, wellKnown, nil)
 	if err != nil {
-		return rfc8414Document{}, nil, fmt.Errorf("build discovery request: %w", err)
+		return rfc8414Document{}, nil, &discoveryError{
+			WellKnownURL: wellKnown,
+			Status:       0,
+			cause:        fmt.Errorf("build discovery request: %w", err),
+		}
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := policy.Client().Do(req)
 	if err != nil {
-		return rfc8414Document{}, nil, fmt.Errorf("fetch discovery document: %w", err)
+		return rfc8414Document{}, nil, &discoveryError{
+			WellKnownURL: wellKnown,
+			Status:       0,
+			cause:        fmt.Errorf("fetch discovery document: %w", err),
+		}
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
-		return rfc8414Document{}, nil, fmt.Errorf("discovery returned status %d", resp.StatusCode)
+		return rfc8414Document{}, nil, &discoveryError{
+			WellKnownURL: wellKnown,
+			Status:       resp.StatusCode,
+			cause:        fmt.Errorf("discovery returned status %d", resp.StatusCode),
+		}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return rfc8414Document{}, nil, fmt.Errorf("read discovery body: %w", err)
+		return rfc8414Document{}, nil, &discoveryError{
+			WellKnownURL: wellKnown,
+			Status:       resp.StatusCode,
+			cause:        fmt.Errorf("read discovery body: %w", err),
+		}
 	}
 
 	var doc rfc8414Document
 	if err := json.Unmarshal(body, &doc); err != nil {
-		return rfc8414Document{}, nil, fmt.Errorf("decode discovery document: %w", err)
+		return rfc8414Document{}, nil, &discoveryError{
+			WellKnownURL: wellKnown,
+			Status:       resp.StatusCode,
+			cause:        fmt.Errorf("decode discovery document: %w", err),
+		}
 	}
 
 	warnings := collectDiscoveryWarnings(issuerURL, doc)

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -182,6 +182,18 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid issuer id").Log(ctx, logger)
 	}
 
+	// slug and issuer are NOT NULL on the row. The SQL update treats an
+	// explicit empty string as "clear to NULL" for the four nullable
+	// endpoint columns, but applying that to slug/issuer would violate the
+	// constraint, so reject empty here with an actionable error before the
+	// query runs.
+	if payload.Slug != nil && *payload.Slug == "" {
+		return nil, oops.E(oops.CodeBadRequest, nil, "slug cannot be set to empty").Log(ctx, logger)
+	}
+	if payload.Issuer != nil && *payload.Issuer == "" {
+		return nil, oops.E(oops.CodeBadRequest, nil, "issuer cannot be set to empty").Log(ctx, logger)
+	}
+
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
 		return nil, err
 	}

--- a/server/internal/remotesessions/issuerhandlers_test.go
+++ b/server/internal/remotesessions/issuerhandlers_test.go
@@ -321,6 +321,145 @@ func TestUpdateRemoteSessionIssuer_NotFound(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeNotFound)
 }
 
+// An explicit empty string on any of the four nullable endpoint fields
+// clears the column to NULL. registration_endpoint clearing is the
+// operator-facing path for disabling DCR on a saved issuer.
+func TestUpdateRemoteSessionIssuer_ClearsNullableEndpoints(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayload("idp-clear"))
+	require.NoError(t, err)
+	require.NotNil(t, created.AuthorizationEndpoint)
+	require.NotNil(t, created.TokenEndpoint)
+	require.NotNil(t, created.RegistrationEndpoint)
+	require.NotNil(t, created.JwksURI)
+
+	empty := ""
+	updated, err := ti.service.UpdateRemoteSessionIssuer(ctx, &gen.UpdateRemoteSessionIssuerPayload{
+		SessionToken:                      nil,
+		ApikeyToken:                       nil,
+		ProjectSlugInput:                  nil,
+		ID:                                created.ID,
+		Slug:                              nil,
+		Issuer:                            nil,
+		AuthorizationEndpoint:             &empty,
+		TokenEndpoint:                     &empty,
+		RegistrationEndpoint:              &empty,
+		JwksURI:                           &empty,
+		ScopesSupported:                   nil,
+		GrantTypesSupported:               nil,
+		ResponseTypesSupported:            nil,
+		TokenEndpointAuthMethodsSupported: nil,
+		Oidc:                              nil,
+		Passthrough:                       nil,
+	})
+	require.NoError(t, err)
+	require.Nil(t, updated.AuthorizationEndpoint)
+	require.Nil(t, updated.TokenEndpoint)
+	require.Nil(t, updated.RegistrationEndpoint)
+	require.Nil(t, updated.JwksURI)
+}
+
+// Omitting a nullable endpoint field keeps the existing value rather than
+// clearing it. Guards against future regressions in the three-state
+// COALESCE/CASE shape of UpdateRemoteSessionIssuer.
+func TestUpdateRemoteSessionIssuer_OmittedKeepsExisting(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayload("idp-keep"))
+	require.NoError(t, err)
+	require.NotNil(t, created.RegistrationEndpoint)
+
+	newSlug := "idp-keep-renamed"
+	updated, err := ti.service.UpdateRemoteSessionIssuer(ctx, &gen.UpdateRemoteSessionIssuerPayload{
+		SessionToken:                      nil,
+		ApikeyToken:                       nil,
+		ProjectSlugInput:                  nil,
+		ID:                                created.ID,
+		Slug:                              &newSlug,
+		Issuer:                            nil,
+		AuthorizationEndpoint:             nil,
+		TokenEndpoint:                     nil,
+		RegistrationEndpoint:              nil,
+		JwksURI:                           nil,
+		ScopesSupported:                   nil,
+		GrantTypesSupported:               nil,
+		ResponseTypesSupported:            nil,
+		TokenEndpointAuthMethodsSupported: nil,
+		Oidc:                              nil,
+		Passthrough:                       nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.RegistrationEndpoint)
+	require.Equal(t, *created.RegistrationEndpoint, *updated.RegistrationEndpoint)
+}
+
+func TestUpdateRemoteSessionIssuer_BadRequestEmptySlug(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayload("idp-empty-slug"))
+	require.NoError(t, err)
+
+	empty := ""
+	_, err = ti.service.UpdateRemoteSessionIssuer(ctx, &gen.UpdateRemoteSessionIssuerPayload{
+		SessionToken:                      nil,
+		ApikeyToken:                       nil,
+		ProjectSlugInput:                  nil,
+		ID:                                created.ID,
+		Slug:                              &empty,
+		Issuer:                            nil,
+		AuthorizationEndpoint:             nil,
+		TokenEndpoint:                     nil,
+		RegistrationEndpoint:              nil,
+		JwksURI:                           nil,
+		ScopesSupported:                   nil,
+		GrantTypesSupported:               nil,
+		ResponseTypesSupported:            nil,
+		TokenEndpointAuthMethodsSupported: nil,
+		Oidc:                              nil,
+		Passthrough:                       nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+func TestUpdateRemoteSessionIssuer_BadRequestEmptyIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayload("idp-empty-issuer"))
+	require.NoError(t, err)
+
+	empty := ""
+	_, err = ti.service.UpdateRemoteSessionIssuer(ctx, &gen.UpdateRemoteSessionIssuerPayload{
+		SessionToken:                      nil,
+		ApikeyToken:                       nil,
+		ProjectSlugInput:                  nil,
+		ID:                                created.ID,
+		Slug:                              nil,
+		Issuer:                            &empty,
+		AuthorizationEndpoint:             nil,
+		TokenEndpoint:                     nil,
+		RegistrationEndpoint:              nil,
+		JwksURI:                           nil,
+		ScopesSupported:                   nil,
+		GrantTypesSupported:               nil,
+		ResponseTypesSupported:            nil,
+		TokenEndpointAuthMethodsSupported: nil,
+		Oidc:                              nil,
+		Passthrough:                       nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
 func TestDeleteRemoteSessionIssuer(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/issuerhandlers_test.go
+++ b/server/internal/remotesessions/issuerhandlers_test.go
@@ -491,3 +491,55 @@ func TestDiscoverRemoteSessionIssuer_BadURL(t *testing.T) {
 	require.Error(t, err)
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }
+
+// statusOnlyServer returns an httptest.Server that responds to the well-known
+// path with the supplied HTTP status and no body. Use it to exercise the
+// discoveryFailure → UserMessage path in DiscoverRemoteSessionIssuer.
+func statusOnlyServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/.well-known/oauth-authorization-server") {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestDiscoverRemoteSessionIssuer_NotFoundSurfacesWellKnownURL(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server := statusOnlyServer(t, http.StatusNotFound)
+
+	_, err := ti.service.DiscoverRemoteSessionIssuer(ctx, &gen.DiscoverRemoteSessionIssuerPayload{
+		Issuer:           server.URL,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeGatewayError)
+	require.Contains(t, err.Error(), "OAuth metadata not found at")
+	require.Contains(t, err.Error(), "/.well-known/oauth-authorization-server")
+}
+
+func TestDiscoverRemoteSessionIssuer_UnexpectedStatusSurfacesCode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server := statusOnlyServer(t, http.StatusServiceUnavailable)
+
+	_, err := ti.service.DiscoverRemoteSessionIssuer(ctx, &gen.DiscoverRemoteSessionIssuerPayload{
+		Issuer:           server.URL,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeGatewayError)
+	require.Contains(t, err.Error(), "Unexpected HTTP 503")
+	require.Contains(t, err.Error(), "/.well-known/oauth-authorization-server")
+}

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -54,14 +54,32 @@ ORDER BY id DESC
 LIMIT sqlc.arg('limit_value');
 
 -- name: UpdateRemoteSessionIssuer :one
+-- Three-state semantics on the nullable endpoint columns: an omitted narg
+-- (NULL) keeps the existing value, an explicit empty string clears the
+-- column to NULL, any other value sets it. Operators need the clear path
+-- to disable DCR or remove stale discovery results on already-saved
+-- issuers. slug and issuer are NOT NULL; the handler rejects an explicit
+-- empty for those before reaching this query.
 UPDATE remote_session_issuers
 SET
     slug = COALESCE(sqlc.narg('slug'), slug),
     issuer = COALESCE(sqlc.narg('issuer'), issuer),
-    authorization_endpoint = COALESCE(sqlc.narg('authorization_endpoint'), authorization_endpoint),
-    token_endpoint = COALESCE(sqlc.narg('token_endpoint'), token_endpoint),
-    registration_endpoint = COALESCE(sqlc.narg('registration_endpoint'), registration_endpoint),
-    jwks_uri = COALESCE(sqlc.narg('jwks_uri'), jwks_uri),
+    authorization_endpoint = CASE
+        WHEN sqlc.narg('authorization_endpoint')::text = '' THEN NULL
+        ELSE COALESCE(sqlc.narg('authorization_endpoint'), authorization_endpoint)
+    END,
+    token_endpoint = CASE
+        WHEN sqlc.narg('token_endpoint')::text = '' THEN NULL
+        ELSE COALESCE(sqlc.narg('token_endpoint'), token_endpoint)
+    END,
+    registration_endpoint = CASE
+        WHEN sqlc.narg('registration_endpoint')::text = '' THEN NULL
+        ELSE COALESCE(sqlc.narg('registration_endpoint'), registration_endpoint)
+    END,
+    jwks_uri = CASE
+        WHEN sqlc.narg('jwks_uri')::text = '' THEN NULL
+        ELSE COALESCE(sqlc.narg('jwks_uri'), jwks_uri)
+    END,
     scopes_supported = COALESCE(sqlc.narg('scopes_supported')::text[], scopes_supported),
     grant_types_supported = COALESCE(sqlc.narg('grant_types_supported')::text[], grant_types_supported),
     response_types_supported = COALESCE(sqlc.narg('response_types_supported')::text[], response_types_supported),

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -1045,10 +1045,22 @@ UPDATE remote_session_issuers
 SET
     slug = COALESCE($1, slug),
     issuer = COALESCE($2, issuer),
-    authorization_endpoint = COALESCE($3, authorization_endpoint),
-    token_endpoint = COALESCE($4, token_endpoint),
-    registration_endpoint = COALESCE($5, registration_endpoint),
-    jwks_uri = COALESCE($6, jwks_uri),
+    authorization_endpoint = CASE
+        WHEN $3::text = '' THEN NULL
+        ELSE COALESCE($3, authorization_endpoint)
+    END,
+    token_endpoint = CASE
+        WHEN $4::text = '' THEN NULL
+        ELSE COALESCE($4, token_endpoint)
+    END,
+    registration_endpoint = CASE
+        WHEN $5::text = '' THEN NULL
+        ELSE COALESCE($5, registration_endpoint)
+    END,
+    jwks_uri = CASE
+        WHEN $6::text = '' THEN NULL
+        ELSE COALESCE($6, jwks_uri)
+    END,
     scopes_supported = COALESCE($7::text[], scopes_supported),
     grant_types_supported = COALESCE($8::text[], grant_types_supported),
     response_types_supported = COALESCE($9::text[], response_types_supported),
@@ -1077,6 +1089,12 @@ type UpdateRemoteSessionIssuerParams struct {
 	ProjectID                         uuid.UUID
 }
 
+// Three-state semantics on the nullable endpoint columns: an omitted narg
+// (NULL) keeps the existing value, an explicit empty string clears the
+// column to NULL, any other value sets it. Operators need the clear path
+// to disable DCR or remove stale discovery results on already-saved
+// issuers. slug and issuer are NOT NULL; the handler rejects an explicit
+// empty for those before reaching this query.
 func (q *Queries) UpdateRemoteSessionIssuer(ctx context.Context, arg UpdateRemoteSessionIssuerParams) (RemoteSessionIssuer, error) {
 	row := q.db.QueryRow(ctx, updateRemoteSessionIssuer,
 		arg.Slug,


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2488/initial-user-session-issuer-management-ui-for-remote-backed-mcp

Adds an Authentication tab and Overview section to MCP server detail pages under `/x/mcp/`, gated on the `gram-user-session-management` PostHog flag. Operators configure the platform user session issuer (session duration) and manage upstream identity providers — attach via discovery (RFC 9728 probe on the remote URL plus RFC 8414 metadata on the issuer) with optional Dynamic Client Registration (RFC 7591), or via manual configuration. Modify and detach flows live alongside, with a type-the-issuer-URL confirmation on detach.

Supporting backend changes:

- `discoveryError` carries the well-known URL and HTTP status so the handler returns actionable user-facing messages (e.g. "OAuth metadata not found at …", "Unexpected HTTP 503 from …") instead of a generic gateway error.
- `handleProxyRegister` falls back to the `Gram-Session` header when no session cookie is in context (dev cross-origin case).
- MCP server visibility dropdown drops `public`; first IdP attach auto-transitions `disabled`→`private`; visibility-only updates forward `userSessionIssuerId` so the auth chain isn't dropped.