### PR TITLE
chore(gen): mark .speakeasy/out.openapi.yaml as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ server/gen/** linguist-generated
 server/internal/**/*.sql.go linguist-generated
 openrouter/** linguist-generated
 .speakeasy/*.lock linguist-generated
+.speakeasy/out.openapi.yaml linguist-generated


### PR DESCRIPTION
## Summary

Adds `.speakeasy/out.openapi.yaml` to the root `.gitattributes` linguist-generated list.

## Why

`.speakeasy/out.openapi.yaml` is the speakeasy-bundled OpenAPI spec (sources + overlays), entirely emitted by `mise run gen:all` and never hand-edited. The root `.gitattributes` already flags every other generator output (`client/sdk/**`, `server/gen/**`, `*.sql.go`, `openrouter/**`, `.speakeasy/*.lock`) as linguist-generated. This file was omitted.

Practical impact: `mise run git:squash-gen` uses `git check-attr linguist-generated` to decide which paths to scrub from messy commits into the consolidated `chore(gen):` tip. Without this flag, every PR that changes a service design ends up with the openapi.yaml diff leaking into the feature commit instead of getting consolidated.

## Test plan
- [ ] Confirm `git check-attr linguist-generated .speakeasy/out.openapi.yaml` reports `set` on this branch
- [ ] (Optional) Run `mise run git:squash-gen` on a branch with mixed hand + design changes; confirm the openapi.yaml ends up in the `chore(gen):` tip, not in the feature commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)