### PR TITLE
chore(gen): take ownership of client/sdk/.gitattributes via .genignore

### DIFF
--- a/client/sdk/.genignore
+++ b/client/sdk/.genignore
@@ -1,0 +1,1 @@
+.gitattributes

--- a/client/sdk/.gitattributes
+++ b/client/sdk/.gitattributes
@@ -1,2 +1,0 @@
-# This allows generated code to be indexed correctly
-*.ts linguist-generated=false


### PR DESCRIPTION
## Summary

Deletes `client/sdk/.gitattributes` and adds `client/sdk/.genignore` containing one line:
```
.gitattributes
```

## Why

`client/sdk/.gitattributes` contains a single override — `*.ts linguist-generated=false` — which is incorrect: every `.ts` file under `client/sdk/` is generated by speakeasy. The override defeats the root `.gitattributes` `client/sdk/** linguist-generated` rule and causes GitHub to show the SDK as huge TypeScript codebase in language stats, plus shows generated diffs in PRs as if they were hand-written.

Just deleting the file isn't enough — speakeasy regenerates it on every `mise run gen:all`. Per [Speakeasy's `.genignore` docs](https://www.speakeasy.com/docs/sdks/customize/code/custom-code/genignore), `.genignore` "removes matched files from the generation process and grants full ownership of those files." Same syntax as `.gitignore`. With `.gitattributes` listed in `client/sdk/.genignore`, speakeasy stops emitting it.

Reference: speakeasy ships their own `.genignore` containing `.gitattributes` in their studio SDK (`speakeasy-api/speakeasy:internal/studio/sdk/.genignore`).

Practical impact for `mise run git:squash-gen`: with the override gone, `client/sdk/**.ts` is correctly flagged linguist-generated, so the tool scrubs SDK churn out of feature commits into the consolidated `chore(gen):` tip.

## Test plan
- [ ] After merging, run `mise run gen:all` and confirm `client/sdk/.gitattributes` is NOT recreated
- [ ] Confirm `git check-attr linguist-generated client/sdk/src/sdk/usersessions.ts` reports `set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)