### PR TITLE
feat(dashboard): full-height sidebar shell (Vercel-style layout)

### DIFF
--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -38,15 +38,15 @@ export const AppLayout = () => {
 
   return (
     <SidebarProvider
+      // Sidebar runs full height (top: 0). The TopHeader now lives inside
+      // the content column, not above the sidebar — so --header-offset is
+      // zero by default, and only the impersonation banner shifts the
+      // sidebar down when present.
       style={
         {
           "--sidebar-width": "14rem",
-          ...(isImpersonating
-            ? {
-                "--header-offset": "5.75rem",
-                "--banner-offset": "2.25rem",
-              }
-            : undefined),
+          "--header-offset": isImpersonating ? "2.25rem" : "0rem",
+          ...(isImpersonating ? { "--banner-offset": "2.25rem" } : undefined),
         } as React.CSSProperties
       }
     >
@@ -97,12 +97,12 @@ const AppLayoutContent = ({
   isImpersonating: boolean;
 }) => {
   return (
-    <div className="flex h-screen w-full flex-col">
-      {isImpersonating && <ImpersonationBanner />}
-      <TopHeader />
-      <BrandGradientLine />
-      <div className="flex w-full flex-1 overflow-hidden pt-2">
-        <AppSidebar variant="inset" />
+    <div className="flex h-screen w-full">
+      <AppSidebar variant="inset" />
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        {isImpersonating && <ImpersonationBanner />}
+        <TopHeader />
+        <BrandGradientLine />
         <SidebarInset>
           <GlobalInsightsWrapper>
             <MembershipSyncGuard>
@@ -208,22 +208,18 @@ export const OrgLayout = () => {
       style={
         {
           "--sidebar-width": "14rem",
-          ...(isImpersonating
-            ? {
-                "--header-offset": "5.75rem",
-                "--banner-offset": "2.25rem",
-              }
-            : undefined),
+          "--header-offset": isImpersonating ? "2.25rem" : "0rem",
+          ...(isImpersonating ? { "--banner-offset": "2.25rem" } : undefined),
         } as React.CSSProperties
       }
     >
       <ModalProvider>
-        <div className="flex h-screen w-full flex-col">
-          {isImpersonating && <ImpersonationBanner />}
-          <TopHeader />
-          <BrandGradientLine />
-          <div className="flex w-full flex-1 overflow-hidden pt-2">
-            <OrgSidebar variant="inset" />
+        <div className="flex h-screen w-full">
+          <OrgSidebar variant="inset" />
+          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            {isImpersonating && <ImpersonationBanner />}
+            <TopHeader />
+            <BrandGradientLine />
             <SidebarInset>
               <MembershipSyncGuard>
                 <Outlet />

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -8,9 +8,12 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarHeader,
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { SidebarBrand } from "@/components/sidebar-brand";
+import { SidebarUserMenu } from "@/components/sidebar-user-menu";
 import { useSlugs } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Scope } from "@/hooks/useRBAC";
@@ -131,7 +134,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
   return (
     <Sidebar collapsible="icon" {...props}>
-      <SidebarContent className="pt-5">
+      <SidebarHeader>
+        <SidebarBrand />
+      </SidebarHeader>
+      <SidebarContent className="pt-2">
         <NavGroupProvider
           activeGroup={activeGroup}
           defaultOpenGroups={!activeGroup ? ["Connect", "Build"] : undefined}
@@ -239,8 +245,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </Link>
         </div>
       </SidebarContent>
-      <SidebarFooter className="group-data-[collapsible=icon]:hidden">
-        <FreeTierExceededNotification />
+      <SidebarFooter className="gap-1">
+        <div className="group-data-[collapsible=icon]:hidden">
+          <FreeTierExceededNotification />
+        </div>
+        <SidebarUserMenu />
       </SidebarFooter>
       <FeatureRequestModal
         isOpen={isUpgradeModalOpen}

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -8,9 +8,13 @@ import { RequireScope } from "@/components/require-scope";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { SidebarBrand } from "@/components/sidebar-brand";
+import { SidebarUserMenu } from "@/components/sidebar-user-menu";
 import { useIsAdmin } from "@/contexts/Auth";
 import { Scope, useRBAC } from "@/hooks/useRBAC";
 import { AppRoute, useOrgRoutes } from "@/routes";
@@ -97,7 +101,10 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
   return (
     <Sidebar collapsible="icon" {...props}>
-      <SidebarContent className="pt-5">
+      <SidebarHeader>
+        <SidebarBrand />
+      </SidebarHeader>
+      <SidebarContent className="pt-2">
         <NavGroupProvider
           activeGroup={activeGroup}
           defaultOpenGroups={["Settings", "Secure"]}
@@ -172,6 +179,9 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           </SidebarMenu>
         </NavGroupProvider>
       </SidebarContent>
+      <SidebarFooter>
+        <SidebarUserMenu />
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/client/dashboard/src/components/sidebar-brand.tsx
+++ b/client/dashboard/src/components/sidebar-brand.tsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router";
+
+import { useOrganization } from "@/contexts/Auth";
+import { useRBAC } from "@/hooks/useRBAC";
+
+import { GramLogo } from "./gram-logo";
+
+/**
+ * Top-of-sidebar brand strip: Gram logo, then a hairline divider with the
+ * current org slug below. Mounts inside <SidebarHeader>. When the sidebar
+ * collapses to icons we hide the wordmark.
+ */
+export function SidebarBrand() {
+  const organization = useOrganization();
+  const { hasAnyScope } = useRBAC();
+  const canAccessOrgRoutes = hasAnyScope(["org:read", "org:admin"]);
+
+  return (
+    <div className="flex flex-col gap-2 px-2 pt-2 pb-1">
+      <Link
+        to={canAccessOrgRoutes ? `/${organization.slug}` : "#"}
+        className="flex items-center gap-2 hover:no-underline"
+      >
+        <GramLogo className="w-24 group-data-[collapsible=icon]:w-6" />
+      </Link>
+      <div className="text-muted-foreground truncate px-1 text-xs font-medium group-data-[collapsible=icon]:hidden">
+        {organization.slug}
+      </div>
+    </div>
+  );
+}

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useState } from "react";
+
+import { useIsAdmin, useUser } from "@/contexts/Auth";
+import { useSdkClient, useSlugs } from "@/contexts/Sdk";
+import { useRBAC } from "@/hooks/useRBAC";
+import { useOrgRoutes, useRoutes } from "@/routes";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  ThemeSwitcher,
+} from "@speakeasy-api/moonshine";
+import {
+  ArrowRightLeftIcon,
+  BugIcon,
+  CreditCardIcon,
+  LogOutIcon,
+  MailIcon,
+  MessageCircleIcon,
+  SettingsIcon,
+} from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+
+export function SidebarUserMenu() {
+  const routes = useRoutes();
+  const orgRoutes = useOrgRoutes();
+  const user = useUser();
+  const isAdmin = useIsAdmin();
+  const client = useSdkClient();
+  const { projectSlug } = useSlugs();
+  const { hasAnyScope } = useRBAC();
+  const canAccessOrgRoutes = hasAnyScope(["org:read", "org:admin"]);
+  const [pylonOpen, setPylonOpen] = useState(false);
+
+  const togglePylon = useCallback(() => {
+    if (pylonOpen) {
+      window.Pylon?.("hide");
+    } else {
+      window.Pylon?.("show");
+    }
+    setPylonOpen((prev) => !prev);
+  }, [pylonOpen]);
+
+  const userInitials =
+    user.displayName
+      ?.split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2) ||
+    user.email?.slice(0, 2).toUpperCase() ||
+    "?";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="hover:bg-sidebar-accent flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors group-data-[collapsible=icon]:justify-center"
+        >
+          <Avatar className="size-7 shrink-0">
+            <AvatarImage
+              src={user.photoUrl}
+              alt={user.displayName || user.email}
+            />
+            <AvatarFallback className="text-[10px]">
+              {userInitials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 flex-1 group-data-[collapsible=icon]:hidden">
+            <div className="text-foreground truncate text-sm font-medium">
+              {user.displayName || "User"}
+            </div>
+            <div className="text-muted-foreground truncate text-xs">
+              {user.email}
+            </div>
+          </div>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        side="top"
+        className="w-56"
+        sideOffset={8}
+      >
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm leading-none font-medium">
+              {user.displayName || "User"}
+            </p>
+            <p className="text-muted-foreground text-xs leading-none">
+              {user.email}
+            </p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {projectSlug && (
+            <DropdownMenuItem onClick={() => routes.settings.goTo()}>
+              <SettingsIcon className="mr-2 h-4 w-4" />
+              Project Settings
+            </DropdownMenuItem>
+          )}
+          {canAccessOrgRoutes && (
+            <DropdownMenuItem onClick={() => orgRoutes.billing.goTo()}>
+              <CreditCardIcon className="mr-2 h-4 w-4" />
+              Billing
+            </DropdownMenuItem>
+          )}
+          {isAdmin && (
+            <DropdownMenuItem onClick={() => orgRoutes.adminSettings.goTo()}>
+              <ArrowRightLeftIcon className="mr-2 h-4 w-4" />
+              Organization Override
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {"Pylon" in window && (
+            <DropdownMenuItem onClick={togglePylon}>
+              <MessageCircleIcon className="mr-2 h-4 w-4" />
+              {pylonOpen ? "Close Support" : "Get Support"}
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem asChild>
+            <a href="mailto:gram@speakeasy.com">
+              <MailIcon className="mr-2 h-4 w-4" />
+              Email Team
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <a
+              href="https://github.com/speakeasy-api/gram/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <BugIcon className="mr-2 h-4 w-4" />
+              Bug or Feature Request
+            </a>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <div className="flex items-center justify-between px-2 py-1.5">
+          <span className="text-muted-foreground text-xs">Theme</span>
+          <ThemeSwitcher />
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={async () => {
+            await client.auth.logout();
+            window.location.href = "/login";
+          }}
+        >
+          <LogOutIcon className="mr-2 h-4 w-4" />
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/client/dashboard/src/components/top-header.tsx
+++ b/client/dashboard/src/components/top-header.tsx
@@ -1,40 +1,13 @@
-import {
-  useIsAdmin,
-  useOrganization,
-  useProject,
-  useUser,
-} from "@/contexts/Auth";
-import { useSdkClient, useSlugs } from "@/contexts/Sdk";
-import { useOrgRoutes, useRoutes } from "@/routes";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-  ThemeSwitcher,
-} from "@speakeasy-api/moonshine";
-import {
-  BugIcon,
-  CheckIcon,
-  ChevronsUpDown,
-  ArrowRightLeftIcon,
-  CreditCardIcon,
-  LogOutIcon,
-  MailIcon,
-  MessageCircleIcon,
-  PlusIcon,
-  SettingsIcon,
-} from "lucide-react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
+
+import { useOrganization, useProject } from "@/contexts/Auth";
+import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { useRBAC } from "@/hooks/useRBAC";
-import { GramLogo } from "./gram-logo";
+import { CheckIcon, ChevronsUpDown, PlusIcon } from "lucide-react";
+
 import { InputDialog } from "./input-dialog";
 import { ProjectAvatar } from "./project-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { Button } from "./ui/button";
 import {
   Command,
@@ -45,40 +18,24 @@ import {
   CommandList,
 } from "./ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { SidebarTrigger } from "./ui/sidebar";
 
+/**
+ * Slim top strip that sits only over the content column. Org/logo/user
+ * chrome moved into the sidebar (SidebarBrand + SidebarUserMenu); what
+ * remains is per-page context: sidebar trigger, breadcrumb anchor, project
+ * switcher, and right-side external links.
+ */
 export function TopHeader() {
-  const routes = useRoutes();
-  const orgRoutes = useOrgRoutes();
   const organization = useOrganization();
   const project = useProject();
-  const user = useUser();
   const { projectSlug } = useSlugs();
   const [open, setOpen] = useState(false);
-  const isAdmin = useIsAdmin();
   const { hasAnyScope } = useRBAC();
   const canAccessOrgRoutes = hasAnyScope(["org:read", "org:admin"]);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [pylonOpen, setPylonOpen] = useState(false);
-  const togglePylon = useCallback(() => {
-    if (pylonOpen) {
-      window.Pylon?.("hide");
-    } else {
-      window.Pylon?.("show");
-    }
-    setPylonOpen((prev) => !prev);
-  }, [pylonOpen]);
   const [newProjectName, setNewProjectName] = useState("");
   const client = useSdkClient();
-
-  const userInitials =
-    user.displayName
-      ?.split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2) ||
-    user.email?.slice(0, 2).toUpperCase() ||
-    "?";
 
   const handleProjectSelect = (slug: string) => {
     if (slug === "new-project") {
@@ -103,226 +60,107 @@ export function TopHeader() {
 
   return (
     <>
-      <header className="dark:bg-background flex h-14 shrink-0 items-center border-b bg-white pr-4 pl-5">
-        <div className="flex items-center gap-3">
-          {/* Logo */}
+      <header className="dark:bg-background flex h-12 shrink-0 items-center gap-2 border-b bg-white px-3">
+        <SidebarTrigger className="text-muted-foreground hover:text-foreground" />
+
+        {canAccessOrgRoutes ? (
           <Link
-            to={projectSlug ? routes.home.href() : `/${organization.slug}`}
-            className="flex items-center hover:no-underline"
+            to={`/${organization.slug}`}
+            className="text-foreground/80 hover:text-foreground hover:bg-accent rounded-md px-2 py-1 text-sm font-medium whitespace-nowrap transition-colors hover:no-underline"
           >
-            <GramLogo className="w-28" />
+            {organization.slug}
           </Link>
-
-          {/* Separator */}
-          <span className="text-muted-foreground/50 text-xl select-none">
-            /
+        ) : (
+          <span className="text-foreground/80 cursor-default rounded-md px-2 py-1 text-sm font-medium whitespace-nowrap">
+            {organization.slug}
           </span>
+        )}
 
-          {/* Org link */}
-          {canAccessOrgRoutes ? (
-            <Link
-              to={`/${organization.slug}`}
-              className="text-foreground/80 hover:text-foreground hover:bg-accent rounded-md px-2 py-1 text-base font-medium whitespace-nowrap transition-colors hover:no-underline"
-            >
-              {organization.slug}
-            </Link>
-          ) : (
-            <span className="text-foreground/80 cursor-default rounded-md px-2 py-1 text-base font-medium whitespace-nowrap">
-              {organization.slug}
+        {projectSlug && (
+          <>
+            <span className="text-muted-foreground/50 text-base select-none">
+              /
             </span>
-          )}
-
-          {/* Project Switcher - hidden on org-level pages */}
-          {projectSlug && (
-            <>
-              <span className="text-muted-foreground/50 text-xl select-none">
-                /
-              </span>
-              <Popover open={open} onOpenChange={setOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className="relative -left-1 h-8 gap-2 !px-2"
-                  >
-                    <ProjectAvatar
-                      project={project}
-                      className="h-5 w-5 shrink-0 rounded"
-                    />
-                    <span className="text-base font-medium">
-                      {project?.slug || projectSlug || "Select"}
-                    </span>
-                    <ChevronsUpDown className="text-muted-foreground h-4 w-4 shrink-0" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[240px] p-0" align="start">
-                  <Command className="border-none">
-                    <div className="border-b">
-                      <CommandInput
-                        placeholder="Find Project..."
-                        className="h-10"
-                      />
-                    </div>
-                    <CommandList className="max-h-[250px] !p-1">
-                      <CommandEmpty>No projects found.</CommandEmpty>
-                      <CommandGroup heading="Projects">
-                        {[...organization.projects]
-                          .sort((a, b) => a.slug.localeCompare(b.slug))
-                          .map((p) => (
-                            <CommandItem
-                              key={p.id}
-                              value={p.slug}
-                              onSelect={() => handleProjectSelect(p.slug)}
-                              className="flex cursor-pointer items-center gap-2"
-                            >
-                              <ProjectAvatar
-                                project={p}
-                                className="h-5 w-5 shrink-0 rounded"
-                              />
-                              <span className="flex-1 truncate">{p.slug}</span>
-                              {p.id === project.id && (
-                                <CheckIcon className="h-4 w-4 shrink-0" />
-                              )}
-                            </CommandItem>
-                          ))}
-                      </CommandGroup>
-                    </CommandList>
-                  </Command>
-                  <button
-                    onClick={() => handleProjectSelect("new-project")}
-                    className="hover:bg-accent flex w-full cursor-pointer items-center gap-2 border-t px-3 py-2 text-sm"
-                  >
-                    <PlusIcon className="text-muted-foreground h-5 w-5 shrink-0" />
-                    <span>Create Project</span>
-                  </button>
-                </PopoverContent>
-              </Popover>
-            </>
-          )}
-        </div>
-
-        {/* Right side - Nav links, Theme toggle & User menu */}
-        <div className="ml-auto flex items-center gap-4">
-          <nav className="hidden items-center gap-2 lg:flex">
-            {"Pylon" in window && (
-              <Button
-                variant="default"
-                size="sm"
-                className="text-sm"
-                onClick={togglePylon}
-              >
-                {pylonOpen ? "Close Support" : "Get Support"}
-              </Button>
-            )}
-            <Button variant="outline" size="sm" className="text-sm" asChild>
-              <a
-                href="https://www.speakeasy.com/docs/mcp"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Docs
-              </a>
-            </Button>
-            <Button variant="outline" size="sm" className="text-sm" asChild>
-              <a
-                href="https://www.speakeasy.com/changelog?product=mcp-platform"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Changelog
-              </a>
-            </Button>
-          </nav>
-          <ThemeSwitcher />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                className="size-9 rounded-full border border-[#dbdbdb] p-0 dark:border-[#333]/30"
-              >
-                <Avatar className="size-9">
-                  <AvatarImage
-                    src={user.photoUrl}
-                    alt={user.displayName || user.email}
+            <Popover open={open} onOpenChange={setOpen}>
+              <PopoverTrigger asChild>
+                <Button variant="ghost" className="h-8 gap-2 !px-2">
+                  <ProjectAvatar
+                    project={project}
+                    className="h-5 w-5 shrink-0 rounded"
                   />
-                  <AvatarFallback className="text-xs">
-                    {userInitials}
-                  </AvatarFallback>
-                </Avatar>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuLabel className="font-normal">
-                <div className="flex flex-col space-y-1">
-                  <p className="text-sm leading-none font-medium">
-                    {user.displayName || "User"}
-                  </p>
-                  <p className="text-muted-foreground text-xs leading-none">
-                    {user.email}
-                  </p>
-                </div>
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                {projectSlug && (
-                  <DropdownMenuItem onClick={() => routes.settings.goTo()}>
-                    <SettingsIcon className="mr-2 h-4 w-4" />
-                    Project Settings
-                  </DropdownMenuItem>
-                )}
-                {canAccessOrgRoutes && (
-                  <DropdownMenuItem onClick={() => orgRoutes.billing.goTo()}>
-                    <CreditCardIcon className="mr-2 h-4 w-4" />
-                    Billing
-                  </DropdownMenuItem>
-                )}
-                {isAdmin && (
-                  <DropdownMenuItem
-                    onClick={() => orgRoutes.adminSettings.goTo()}
-                  >
-                    <ArrowRightLeftIcon className="mr-2 h-4 w-4" />
-                    Organization Override
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                {"Pylon" in window && (
-                  <DropdownMenuItem onClick={togglePylon}>
-                    <MessageCircleIcon className="mr-2 h-4 w-4" />
-                    {pylonOpen ? "Close Support" : "Get Support"}
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem asChild>
-                  <a href="mailto:gram@speakeasy.com">
-                    <MailIcon className="mr-2 h-4 w-4" />
-                    Email Team
-                  </a>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <a
-                    href="https://github.com/speakeasy-api/gram/issues/new"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <BugIcon className="mr-2 h-4 w-4" />
-                    Bug or Feature Request
-                  </a>
-                </DropdownMenuItem>
-              </DropdownMenuGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={async () => {
-                  await client.auth.logout();
-                  window.location.href = "/login";
-                }}
-              >
-                <LogOutIcon className="mr-2 h-4 w-4" />
-                Log out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  <span className="text-sm font-medium">
+                    {project?.slug || projectSlug || "Select"}
+                  </span>
+                  <ChevronsUpDown className="text-muted-foreground h-4 w-4 shrink-0" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[240px] p-0" align="start">
+                <Command className="border-none">
+                  <div className="border-b">
+                    <CommandInput
+                      placeholder="Find Project..."
+                      className="h-10"
+                    />
+                  </div>
+                  <CommandList className="max-h-[250px] !p-1">
+                    <CommandEmpty>No projects found.</CommandEmpty>
+                    <CommandGroup heading="Projects">
+                      {[...organization.projects]
+                        .sort((a, b) => a.slug.localeCompare(b.slug))
+                        .map((p) => (
+                          <CommandItem
+                            key={p.id}
+                            value={p.slug}
+                            onSelect={() => handleProjectSelect(p.slug)}
+                            className="flex cursor-pointer items-center gap-2"
+                          >
+                            <ProjectAvatar
+                              project={p}
+                              className="h-5 w-5 shrink-0 rounded"
+                            />
+                            <span className="flex-1 truncate">{p.slug}</span>
+                            {p.id === project.id && (
+                              <CheckIcon className="h-4 w-4 shrink-0" />
+                            )}
+                          </CommandItem>
+                        ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+                <button
+                  onClick={() => handleProjectSelect("new-project")}
+                  className="hover:bg-accent flex w-full cursor-pointer items-center gap-2 border-t px-3 py-2 text-sm"
+                >
+                  <PlusIcon className="text-muted-foreground h-5 w-5 shrink-0" />
+                  <span>Create Project</span>
+                </button>
+              </PopoverContent>
+            </Popover>
+          </>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="outline" size="sm" className="text-xs" asChild>
+            <a
+              href="https://www.speakeasy.com/docs/mcp"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Docs
+            </a>
+          </Button>
+          <Button variant="outline" size="sm" className="text-xs" asChild>
+            <a
+              href="https://www.speakeasy.com/changelog?product=mcp-platform"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Changelog
+            </a>
+          </Button>
         </div>
       </header>
+
       {createDialogOpen && (
         <InputDialog
           open={createDialogOpen}


### PR DESCRIPTION
## Summary

Stacks on top of #3014 — flips the app layout grid so the sidebar runs the full vertical extent of the page (top: 0 → bottom: 0), Vercel-style. The `TopHeader` is no longer a full-width strip across the whole app; it sits only over the content column.

### What moved where

| Element              | Before            | After                                         |
| -------------------- | ----------------- | --------------------------------------------- |
| Gram logo            | TopHeader (left)  | SidebarBrand (top of sidebar)                 |
| Org slug             | TopHeader (left)  | SidebarBrand + breadcrumb anchor in TopHeader |
| User avatar dropdown | TopHeader (right) | SidebarUserMenu (bottom of sidebar)           |
| Theme switcher       | TopHeader (right) | Inside the user dropdown                      |
| Project switcher     | TopHeader         | TopHeader (unchanged)                         |
| Docs / Changelog     | TopHeader         | TopHeader (unchanged)                         |

### Layout change

```
Before:                          After:
+--------------------+           +------+--------------+
| TopHeader (full)   |           |      | TopHeader    |
+------+-------------+           |      +--------------+
| Side | Content     |           | Side | Content      |
| bar  |             |           | bar  |              |
|      |             |           |      |              |
+------+-------------+           +------+--------------+
```

### Why this PR targets the org-home branch

The org home redesign (#3014) and this shell change touch overlapping surface. Landing them as one PR would explode the diff; sequencing them lets each get a focused review. Once both ship, the combined effect is the Vercel-style org overview we've been iterating on.

### New components

- `SidebarBrand` — reusable logo + org-slug strip mounted in both `AppSidebar` and `OrgSidebar` via `<SidebarHeader>`
- `SidebarUserMenu` — user dropdown extracted from TopHeader, mounted in `<SidebarFooter>`. ThemeSwitcher folded in.

### CSS variable change

`--header-offset` defaults to `0rem` (previously `3.5rem` when not impersonating). Only the impersonation banner shifts the sidebar down now — the TopHeader no longer takes vertical space above the sidebar because it lives inside the content column.

## Test plan

- [ ] Org-level pages (`/<orgSlug>`, `/<orgSlug>/audit-logs`, `/<orgSlug>/team`, `/<orgSlug>/access`) — sidebar extends full height, TopHeader strip is only over the right column
- [ ] Project-level pages (`/<orgSlug>/projects/<slug>` and sub-pages) — same; project switcher still works in the TopHeader
- [ ] Sidebar trigger (collapse to icon) — toggles via the SidebarTrigger button in TopHeader
- [ ] User dropdown — opens upward from the sidebar footer; Project Settings / Billing / Org Override / Email Team / Bug Request / Logout all wired
- [ ] Theme switch from inside the user dropdown
- [ ] Impersonation banner — when active, sidebar starts at 2.25rem (below banner); when inactive, sidebar starts at 0
- [ ] Mobile / narrow viewport — sidebar collapses correctly, no visual breakage
