### PR TITLE
chore(dashboard): fix collapsed sidenav icon alignment and active highlight

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { useSidebar } from "@/components/ui/sidebar-context";
 import { useSlugs } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Scope } from "@/hooks/useRBAC";
@@ -66,6 +67,7 @@ function ScopeGatedTopLevelItem({
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const routes = useRoutes();
   const { orgSlug } = useSlugs();
+  const { state } = useSidebar();
   const telemetry = useTelemetry();
   const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
 
@@ -127,7 +129,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     routes.settings,
   ];
   const activeRoute = allNavRoutes.find((r) => r.active);
-  const activeItem = activeRoute?.title;
+  // In collapsed mode, sub-items are hidden — fall back to group highlight.
+  // Top-level items (Home, Settings) have no activeGroup, so keep activeItem for those.
+  const activeItem =
+    state === "collapsed" && activeGroup ? undefined : activeRoute?.title;
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -137,7 +142,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           defaultOpenGroups={!activeGroup ? ["Connect", "Build"] : undefined}
           activeItem={activeItem}
         >
-          <SidebarMenu className="gap-1 px-2">
+          <SidebarMenu className="gap-1 px-2 group-data-[collapsible=icon]:px-0">
             {/* Home — top-level, no group */}
             <ScopeGatedTopLevelItem item={routes.home} scope="project:read" />
 

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -397,6 +397,7 @@ export function NavButton({
       onMouseEnter={navItem.onMouseEnter}
       onMouseLeave={navItem.onMouseLeave}
       onMouseMove={navItem.onMouseMove}
+      className="group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:w-fit"
     >
       <Link
         to={href ?? "#"}
@@ -404,7 +405,7 @@ export function NavButton({
         onClick={handleClick}
         className={cn(
           "relative z-[1] flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm transition-colors hover:no-underline",
-          "group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2!",
+          "group-data-[collapsible=icon]:min-w-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2!",
           active
             ? "text-foreground font-semibold"
             : "text-muted-foreground hover:text-foreground font-medium",
@@ -421,7 +422,7 @@ export function NavButton({
         <Type
           variant="small"
           className={cn(
-            "transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0",
+            "transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0",
             active && "font-semibold",
             isLoading && "nav-shimmer",
           )}
@@ -476,13 +477,14 @@ export function CollapsibleNavGroup({
           onMouseEnter={navItem.onMouseEnter}
           onMouseLeave={navItem.onMouseLeave}
           onMouseMove={navItem.onMouseMove}
+          className="group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:w-fit"
         >
           <Link
             to={defaultHref ?? "#"}
             onClick={handleClick}
             className={cn(
               "relative z-[1] flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors hover:no-underline",
-              "group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-2!",
+              "group-data-[collapsible=icon]:min-w-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2!",
               "cursor-pointer outline-hidden",
               isOpen
                 ? "text-foreground font-semibold"


### PR DESCRIPTION
## Summary

- Fix icon centering in collapsed sidebar — text was `opacity-0` but still in flex layout, pushing icons off-center. Now uses `display:none` (`hidden`)
- Fix oversized active highlight — wrapper div stretched full-width; now constrained with `w-fit` + `mx-auto`
- Fix missing active highlight for grouped items in collapsed mode — falls back to parent group highlight since sub-items are hidden
- Remove double horizontal padding (`SidebarMenu px-2` + sidebar container `p-2`) in collapsed mode

## Test plan

- [ ] Collapse sidebar and verify all icons are centered with equal padding
- [ ] Verify active highlight is square and properly aligned on all items
- [ ] Navigate to a sub-page (e.g. Sources) and collapse — parent group (Connect) should highlight
- [ ] Navigate to Home/Settings and collapse — icon should highlight directly
- [ ] Expand/collapse sidebar and verify smooth animation (no jank)