### PR TITLE
fix(assistants): bound reap Fly calls and add janitor heartbeat

### DIFF
--- a/.changeset/age-2525-bound-fly-reap-calls.md
+++ b/.changeset/age-2525-bound-fly-reap-calls.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Make the assistant-runtime reaper resilient to Fly Machines API calls that hang on missing machines. Each Destroy/List call is now bounded by its own timeout, and the Temporal janitor activity uses a heartbeat for liveness rather than relying on a short overall timeout that turned tombstone-machine hangs into elevated workflow-failure alerts.

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -870,20 +870,19 @@ func (f *FlyRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRe
 	}
 
 	if metadata.MachineID != "" {
-		destroyCtx, cancel := context.WithTimeout(ctx, flyRuntimeReapCallTimeout)
-		err := flapsClient.Destroy(destroyCtx, metadata.AppName, fly.RemoveMachineInput{
+		destroyCtx, cancelDestroy := context.WithTimeout(ctx, flyRuntimeReapCallTimeout)
+		defer cancelDestroy()
+		if err := flapsClient.Destroy(destroyCtx, metadata.AppName, fly.RemoveMachineInput{
 			ID:   metadata.MachineID,
 			Kill: true,
-		}, "")
-		cancel()
-		if err != nil && !isFlyNotFound(err) {
+		}, ""); err != nil && !isFlyNotFound(err) {
 			return fmt.Errorf("destroy assistant fly runtime machine: %w", err)
 		}
 	}
 
-	listCtx, cancel := context.WithTimeout(ctx, flyRuntimeReapCallTimeout)
+	listCtx, cancelList := context.WithTimeout(ctx, flyRuntimeReapCallTimeout)
+	defer cancelList()
 	machines, err := flapsClient.List(listCtx, metadata.AppName, "")
-	cancel()
 	switch {
 	case err == nil:
 		for _, m := range machines {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -31,8 +31,8 @@ const (
 	defaultFlyRuntimeHealthTimeout  = 45 * time.Second
 	defaultFlyRuntimeRequestTimeout = 2 * time.Minute
 
-	// flyRuntimeReapCallTimeout caps a single Destroy/List call during reap
-	// so one wedged row cannot consume the parent activity's deadline.
+	// flyRuntimeReapCallTimeout caps a single Fly API call during reap so
+	// one wedged row cannot consume the parent activity's deadline.
 	flyRuntimeReapCallTimeout = 30 * time.Second
 
 	flyMachineMetadataAssistantID   = "gram_assistant_id"
@@ -900,7 +900,9 @@ func (f *FlyRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRe
 		return fmt.Errorf("list assistant fly runtime machines: %w", err)
 	}
 
-	return f.deleteApp(ctx, metadata.AppName)
+	deleteCtx, cancel := context.WithTimeout(ctx, flyRuntimeReapCallTimeout)
+	defer cancel()
+	return f.deleteApp(deleteCtx, metadata.AppName)
 }
 
 func (f *FlyRuntimeBackend) deleteApp(ctx context.Context, appName string) error {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -31,6 +31,10 @@ const (
 	defaultFlyRuntimeHealthTimeout  = 45 * time.Second
 	defaultFlyRuntimeRequestTimeout = 2 * time.Minute
 
+	// flyRuntimeReapCallTimeout caps a single Destroy/List call during reap
+	// so one wedged row cannot consume the parent activity's deadline.
+	flyRuntimeReapCallTimeout = 30 * time.Second
+
 	flyMachineMetadataAssistantID   = "gram_assistant_id"
 	flyMachineMetadataProjectID     = "gram_assistant_project_id"
 	flyMachineMetadataRole          = "gram_role"
@@ -866,15 +870,20 @@ func (f *FlyRuntimeBackend) Reap(ctx context.Context, runtime assistantRuntimeRe
 	}
 
 	if metadata.MachineID != "" {
-		if err := flapsClient.Destroy(ctx, metadata.AppName, fly.RemoveMachineInput{
+		destroyCtx, cancel := context.WithTimeout(ctx, flyRuntimeReapCallTimeout)
+		err := flapsClient.Destroy(destroyCtx, metadata.AppName, fly.RemoveMachineInput{
 			ID:   metadata.MachineID,
 			Kill: true,
-		}, ""); err != nil && !isFlyNotFound(err) {
+		}, "")
+		cancel()
+		if err != nil && !isFlyNotFound(err) {
 			return fmt.Errorf("destroy assistant fly runtime machine: %w", err)
 		}
 	}
 
-	machines, err := flapsClient.List(ctx, metadata.AppName, "")
+	listCtx, cancel := context.WithTimeout(ctx, flyRuntimeReapCallTimeout)
+	machines, err := flapsClient.List(listCtx, metadata.AppName, "")
+	cancel()
 	switch {
 	case err == nil:
 		for _, m := range machines {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1012,6 +1012,9 @@ type ReapInactiveAssistantRuntimesParams struct {
 	// BatchSize caps how many runtime rows one sweep will reap. Keeps the
 	// activity duration bounded under Temporal's StartToCloseTimeout.
 	BatchSize int32
+	// OnRowProcessed, if set, fires once per row after the reap attempt
+	// (success or failure).
+	OnRowProcessed func()
 }
 
 // ReapInactiveAssistantRuntimes drives the long-inactivity janitor. It picks
@@ -1048,6 +1051,9 @@ func (s *ServiceCore) ReapInactiveAssistantRuntimes(ctx context.Context, params 
 			result.Reaped++
 		} else {
 			result.Errors++
+		}
+		if params.OnRowProcessed != nil {
+			params.OnRowProcessed()
 		}
 	}
 	return result, nil

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1171,6 +1171,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesCollectsOnlyInactive(t *testing
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
 		BatchSize:           10,
+		OnRowProcessed:      nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, result.Reaped)
@@ -1205,6 +1206,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesSkipsAssistantWithRecentActivit
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
 		BatchSize:           10,
+		OnRowProcessed:      nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, result.Reaped)
@@ -1255,6 +1257,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesReapsSiblingsAcrossSweeps(t *te
 	first, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
 		BatchSize:           1,
+		OnRowProcessed:      nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, first.Reaped)
@@ -1262,6 +1265,7 @@ func TestServiceCoreReapInactiveAssistantRuntimesReapsSiblingsAcrossSweeps(t *te
 	second, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
 		BatchSize:           10,
+		OnRowProcessed:      nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, second.Reaped, "sibling row must remain a candidate after the first reap")
@@ -1285,13 +1289,16 @@ func TestServiceCoreReapInactiveAssistantRuntimesReapsStaleRowsRegardlessOfState
 	backend := testRuntimeBackend{backend: runtimeBackendFlyIO, reapCalls: reapCalls}
 	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil)
 
+	rowProcessed := &atomic.Int64{}
 	result, err := core.ReapInactiveAssistantRuntimes(t.Context(), ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: 7 * 24 * time.Hour,
 		BatchSize:           10,
+		OnRowProcessed:      func() { rowProcessed.Add(1) },
 	})
 	require.NoError(t, err)
 	require.Equal(t, 2, result.Reaped)
 	require.EqualValues(t, 2, reapCalls.Load())
+	require.EqualValues(t, 2, rowProcessed.Load(), "OnRowProcessed must fire once per row so the activity can heartbeat")
 }
 
 type testRuntimeBackend struct {

--- a/server/internal/background/activities/reap_assistant_runtimes.go
+++ b/server/internal/background/activities/reap_assistant_runtimes.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"time"
 
+	"go.temporal.io/sdk/activity"
+
 	"github.com/speakeasy-api/gram/server/internal/assistants"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
@@ -42,6 +44,9 @@ func (r *ReapInactiveAssistantRuntimes) Do(ctx context.Context, req ReapInactive
 	result, err := r.core.ReapInactiveAssistantRuntimes(ctx, assistants.ReapInactiveAssistantRuntimesParams{
 		InactivityThreshold: req.InactivityThreshold,
 		BatchSize:           req.BatchSize,
+		OnRowProcessed: func() {
+			activity.RecordHeartbeat(ctx)
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("reap inactive assistant runtimes: %w", err)

--- a/server/internal/background/assistant_runtime_janitor.go
+++ b/server/internal/background/assistant_runtime_janitor.go
@@ -25,11 +25,21 @@ const (
 	// covering up to 4800 rows/day on the steady state.
 	AssistantRuntimeJanitorInterval = time.Hour
 
-	// AssistantRuntimeJanitorBatchSize caps rows reaped per sweep. The
-	// activity makes one external API call per row (e.g. Fly DeleteApp)
-	// so the bound also keeps the Temporal activity within its
-	// StartToCloseTimeout.
+	// AssistantRuntimeJanitorBatchSize caps rows reaped per sweep. Each row
+	// makes one or two Fly Machines API calls; per-call timeouts bound each
+	// call so the sweep can never wedge on a single row.
 	AssistantRuntimeJanitorBatchSize int32 = 200
+
+	// assistantRuntimeJanitorActivityTimeout is the upper bound on a single
+	// sweep, sized for the worst case where every row in the batch hits the
+	// per-call Fly timeout twice. Liveness is enforced by the heartbeat
+	// timeout, not this ceiling.
+	assistantRuntimeJanitorActivityTimeout = 4 * time.Hour
+
+	// assistantRuntimeJanitorHeartbeatTimeout must comfortably exceed the
+	// worst-case time the reap loop can spend on a single row (Destroy +
+	// List, each bounded by flyRuntimeReapCallTimeout).
+	assistantRuntimeJanitorHeartbeatTimeout = 2 * time.Minute
 
 	// AssistantRuntimeJanitorInactivityThreshold is the quiet period an
 	// assistant must have before its backend resources become eligible
@@ -71,10 +81,16 @@ func AssistantRuntimeJanitorWorkflow(ctx workflow.Context, params AssistantRunti
 
 	logger := workflow.GetLogger(ctx)
 
+	// HeartbeatTimeout is the liveness signal; the reap loop beats after
+	// each row. StartToCloseTimeout is just a ceiling for the worst-case
+	// sweep wall time. MaximumAttempts is 2 so a transient DB error on the
+	// initial candidate list does not waste the hourly slot; per-row Fly
+	// failures are already swallowed inside the activity and do not retry.
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 10 * time.Minute,
+		StartToCloseTimeout: assistantRuntimeJanitorActivityTimeout,
+		HeartbeatTimeout:    assistantRuntimeJanitorHeartbeatTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts:    3,
+			MaximumAttempts:    2,
 			InitialInterval:    5 * time.Second,
 			MaximumInterval:    1 * time.Minute,
 			BackoffCoefficient: 2,
@@ -110,7 +126,7 @@ func AddAssistantRuntimeJanitorSchedule(ctx context.Context, temporalEnv *tenv.E
 			ID:                 assistantRuntimeJanitorWorkflowID,
 			Workflow:           AssistantRuntimeJanitorWorkflow,
 			TaskQueue:          string(temporalEnv.Queue()),
-			WorkflowRunTimeout: 15 * time.Minute,
+			WorkflowRunTimeout: assistantRuntimeJanitorActivityTimeout + 15*time.Minute,
 			Args: []any{AssistantRuntimeJanitorWorkflowParams{
 				InactivityThreshold: 0,
 				BatchSize:           0,

--- a/server/internal/background/assistant_runtime_janitor.go
+++ b/server/internal/background/assistant_runtime_janitor.go
@@ -31,15 +31,17 @@ const (
 	AssistantRuntimeJanitorBatchSize int32 = 200
 
 	// assistantRuntimeJanitorActivityTimeout is the upper bound on a single
-	// sweep, sized for the worst case where every row in the batch hits the
-	// per-call Fly timeout twice. Liveness is enforced by the heartbeat
-	// timeout, not this ceiling.
-	assistantRuntimeJanitorActivityTimeout = 4 * time.Hour
+	// sweep, sized for the pathological case where every row in the batch
+	// hits the per-call Fly timeout on every call (Destroy + List +
+	// DeleteApp). Liveness is enforced by the heartbeat timeout, not this
+	// ceiling.
+	assistantRuntimeJanitorActivityTimeout = 6 * time.Hour
 
 	// assistantRuntimeJanitorHeartbeatTimeout must comfortably exceed the
-	// worst-case time the reap loop can spend on a single row (Destroy +
-	// List, each bounded by flyRuntimeReapCallTimeout).
-	assistantRuntimeJanitorHeartbeatTimeout = 2 * time.Minute
+	// worst-case time the reap loop can spend on a single row. Each row
+	// makes up to three Fly calls (Destroy, List, DeleteApp), each
+	// bounded by flyRuntimeReapCallTimeout.
+	assistantRuntimeJanitorHeartbeatTimeout = 3 * time.Minute
 
 	// AssistantRuntimeJanitorInactivityThreshold is the quiet period an
 	// assistant must have before its backend resources become eligible


### PR DESCRIPTION
## Summary

- Cap each Fly Machines API call inside `FlyRuntimeBackend.Reap` (Destroy + List) with a 30s sub-context so a single wedged row cannot ride the parent activity's deadline. Cancel/timeout is treated as a real failure, not benign — the row stays a candidate.
- Switch the runtime-janitor activity from a tight `StartToCloseTimeout` to a 4h ceiling plus a 2m `HeartbeatTimeout`. The reap loop now beats once per row via an `OnRowProcessed` hook on `ReapInactiveAssistantRuntimesParams`, so the workflow-failure metric reflects worker liveness rather than how long a poisoned batch happens to take.
- Drop `MaximumAttempts` to 2 — per-row Fly errors are absorbed inside the activity, so retries only buy a transient DB-blip recovery on the candidate-list query.

Closes [AGE-2525](https://linear.app/speakeasy/issue/AGE-2525).

Context: INC-372 (2026-05-26). A deleted assistant accumulated tombstone machine IDs that hung the flaps DELETE on lease acquisition forever; every sweep timed out the activity and tripped monitor 274771871. Manual app deletion unblocked that specific assistant; this PR removes the class of failure.

✻ Clauded...