### PR TITLE
fix: derive org ID as UUIDv5 from WorkOS ID in Register

### DIFF
--- a/.changeset/uuid-v5-register-org-id.md
+++ b/.changeset/uuid-v5-register-org-id.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Derive org IDs as deterministic UUIDv5 from WorkOS org ID during Register and auto-provisioning, replacing the previous `"org_" + random UUID` format which was not a valid UUID.

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -74,9 +74,13 @@ func (m *mockWorkOSFetcher) EnsureOrgExternalID(_ context.Context, _, _ string) 
 	return nil
 }
 
+func (m *mockWorkOSFetcher) UpdateOrganizationExternalID(_ context.Context, _, _ string) error {
+	return nil
+}
+
 func (m *mockWorkOSFetcher) CreateOrganization(_ context.Context, name, gramOrgID string) (string, error) {
 	m.createdOrgs = append(m.createdOrgs, createdOrgRecord{Name: name, ExternalID: gramOrgID})
-	return "workos_org_" + gramOrgID, nil
+	return "workos_org_" + name, nil
 }
 
 func (m *mockWorkOSFetcher) CreateOrganizationMembership(_ context.Context, workosUserID, workosOrgID, _ string) (string, error) {
@@ -1118,25 +1122,27 @@ func TestE2E_Register_CreatesWorkOSOrg(t *testing.T) {
 	err = inst.service.Register(ctx, &gen.RegisterPayload{OrgName: "WorkOS Test Org"})
 	require.NoError(t, err)
 
-	// Assert WorkOS CreateOrganization was called with the Gram org ID as external_id.
+	// Assert WorkOS CreateOrganization was called.
 	require.Len(t, fetcher.createdOrgs, 1, "should have called CreateOrganization once")
 	assert.Equal(t, "WorkOS Test Org", fetcher.createdOrgs[0].Name)
-	assert.NotEmpty(t, fetcher.createdOrgs[0].ExternalID, "external_id should be the Gram org ID")
+
+	// The mock returns "workos_org_<name>" as the WorkOS org ID.
+	workosOrgID := "workos_org_WorkOS Test Org"
+	expectedGramOrgID := orgid.FromWorkOSID(workosOrgID)
 
 	// Assert WorkOS membership was created.
 	require.Len(t, fetcher.createdMemberships, 1, "should have called CreateOrganizationMembership once")
 	assert.Equal(t, workosUserID, fetcher.createdMemberships[0].WorkOSUserID)
-	assert.Equal(t, "workos_org_"+fetcher.createdOrgs[0].ExternalID, fetcher.createdMemberships[0].WorkOSOrgID)
+	assert.Equal(t, workosOrgID, fetcher.createdMemberships[0].WorkOSOrgID)
 
 	// Verify workos_id was stored on the Gram org row.
 	ctx, err = inst.sessionManager.Authenticate(ctx, callbackResult.SessionToken)
 	require.NoError(t, err)
 	orgQueries := orgRepo.New(inst.conn)
-	gramOrgID := fetcher.createdOrgs[0].ExternalID
-	dbOrg, err := orgQueries.GetOrganizationMetadata(ctx, gramOrgID)
+	dbOrg, err := orgQueries.GetOrganizationMetadata(ctx, expectedGramOrgID)
 	require.NoError(t, err)
 	assert.True(t, dbOrg.WorkosID.Valid, "workos_id should be stored on org")
-	assert.Equal(t, "workos_org_"+gramOrgID, dbOrg.WorkosID.String)
+	assert.Equal(t, workosOrgID, dbOrg.WorkosID.String)
 }
 
 // TestE2E_Register_RejectsWhenOrgAlreadyActive verifies that Register returns

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.opentelemetry.io/otel/codes"
@@ -77,6 +78,7 @@ type WorkOSClient interface {
 	GetOrganization(ctx context.Context, orgID string) (*workos.Organization, error)
 	EnsureUserExternalID(ctx context.Context, workosUserID, gramUserID string) error
 	EnsureOrgExternalID(ctx context.Context, workosOrgID, gramOrgID string) error
+	UpdateOrganizationExternalID(ctx context.Context, workosOrgID, externalID string) error
 	CreateOrganization(ctx context.Context, name, gramOrgID string) (string, error)
 	CreateOrganizationMembership(ctx context.Context, workosUserID, workosOrgID, roleSlug string) (string, error)
 	GetOrgMembership(ctx context.Context, workosUserID, workosOrgID string) (*workos.Member, error)
@@ -612,35 +614,41 @@ func (r *Resolver) BuildAuthorizationURL(ctx context.Context, params Authorizati
 	return authURL, nil
 }
 
-// ProvisionOrgInWorkOS creates a WorkOS organization and membership for a
-// locally-created org. Used by Register and auto-provisioning flows.
-// Non-fatal: logs errors but does not fail the caller.
-// ProvisionOrgInWorkOS creates a WorkOS organization with gramOrgID as the
-// external_id, then creates a membership linking the user. Returns the WorkOS
-// org ID so the caller can store it on the Gram org row. Returns ("", nil)
-// when no WorkOS client is configured (e.g. tests, OSS).
-func (r *Resolver) ProvisionOrgInWorkOS(ctx context.Context, gramOrgID, orgName, gramUserID string) (string, error) {
+// ProvisionOrgInWorkOS creates a WorkOS organization, derives a deterministic
+// Gram org ID (UUIDv5) from the returned WorkOS org ID, sets the external_id
+// on the WorkOS org to the derived Gram ID, and creates a membership linking
+// the user. Returns (workosOrgID, gramOrgID, err).
+// When no WorkOS client is configured (tests, OSS), returns a random UUID as gramOrgID.
+func (r *Resolver) ProvisionOrgInWorkOS(ctx context.Context, orgName, gramUserID string) (string, string, error) {
 	if r.workosClient == nil {
-		return "", nil
+		return "", uuid.New().String(), nil
 	}
 
 	// Look up user's WorkOS ID from the database.
 	user, err := r.userRepo.GetUser(ctx, gramUserID)
 	if err != nil {
-		return "", fmt.Errorf("look up user for WorkOS provisioning: %w", err)
+		return "", "", fmt.Errorf("look up user for WorkOS provisioning: %w", err)
 	}
 	if !user.WorkosID.Valid {
-		return "", fmt.Errorf("user %s has no workos_id", gramUserID)
+		return "", "", fmt.Errorf("user %s has no workos_id", gramUserID)
 	}
 
-	workosOrgID, err := r.workosClient.CreateOrganization(ctx, orgName, gramOrgID)
+	// Create the WorkOS org first, then derive the Gram org ID from it.
+	workosOrgID, err := r.workosClient.CreateOrganization(ctx, orgName, "")
 	if err != nil {
-		return "", fmt.Errorf("create WorkOS organization: %w", err)
+		return "", "", fmt.Errorf("create WorkOS organization: %w", err)
+	}
+
+	gramOrgID := orgid.FromWorkOSID(workosOrgID)
+
+	// Back-fill the external_id so WorkOS knows the Gram org ID.
+	if err := r.workosClient.UpdateOrganizationExternalID(ctx, workosOrgID, gramOrgID); err != nil {
+		return "", "", fmt.Errorf("set external_id on WorkOS organization: %w", err)
 	}
 
 	if _, err := r.workosClient.CreateOrganizationMembership(ctx, user.WorkosID.String, workosOrgID, "admin"); err != nil {
-		return "", fmt.Errorf("create WorkOS organization membership: %w", err)
+		return "", "", fmt.Errorf("create WorkOS organization membership: %w", err)
 	}
 
-	return workosOrgID, nil
+	return workosOrgID, gramOrgID, nil
 }

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -724,10 +724,8 @@ func (s *Service) Register(ctx context.Context, payload *gen.RegisterPayload) (e
 		return oops.E(oops.CodeUnexpected, err, "error finding unique slug").Log(ctx, s.logger)
 	}
 
-	gramOrgID := "org_" + uuid.New().String()
-
-	// Provision the WorkOS org first so it exists before we create the Gram org.
-	workosOrgID, err := s.identity.ProvisionOrgInWorkOS(ctx, gramOrgID, payload.OrgName, authCtx.UserID)
+	// Provision the WorkOS org first, then derive a deterministic UUIDv5 org ID from the WorkOS ID.
+	workosOrgID, gramOrgID, err := s.identity.ProvisionOrgInWorkOS(ctx, payload.OrgName, authCtx.UserID)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error provisioning organization in WorkOS").Log(ctx, s.logger)
 	}
@@ -774,10 +772,8 @@ func (s *Service) autoProvisionForAssistants(ctx context.Context, userInfo *sess
 		return "", fmt.Errorf("find unique slug: %w", err)
 	}
 
-	gramOrgID := "org_" + uuid.New().String()
-
-	// Provision the WorkOS org first so it exists before we create the Gram org.
-	workosOrgID, err := s.identity.ProvisionOrgInWorkOS(ctx, gramOrgID, orgName, userInfo.UserID)
+	// Provision the WorkOS org first, then derive a deterministic UUIDv5 org ID from the WorkOS ID.
+	workosOrgID, gramOrgID, err := s.identity.ProvisionOrgInWorkOS(ctx, orgName, userInfo.UserID)
 	if err != nil {
 		return "", fmt.Errorf("provision org in WorkOS: %w", err)
 	}

--- a/server/internal/thirdparty/workos/stub.go
+++ b/server/internal/thirdparty/workos/stub.go
@@ -398,12 +398,14 @@ func (s *StubClient) GetOrgMembership(_ context.Context, workOSUserID, workOSOrg
 	return nil, nil
 }
 
-func (s *StubClient) CreateOrganization(_ context.Context, name, gramOrgID string) (string, error) {
+func (s *StubClient) CreateOrganization(_ context.Context, name, _ string) (string, error) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	workosOrgID := fmt.Sprintf("org_%s", gramOrgID)
-	s.orgState(workosOrgID) // initialize
+	workosOrgID := fmt.Sprintf("org_workos_%d", s.next)
+	s.next++
+	state := s.orgState(workosOrgID)
+	state.organization.Name = name
 
 	return workosOrgID, nil
 }


### PR DESCRIPTION
## Summary

- `Register` and `autoProvisionForAssistants` were generating org IDs as `"org_" + uuid.New()` — a prefixed string that isn't a valid UUID
- Now creates the WorkOS org first, then derives a deterministic UUIDv5 from the WorkOS org ID using `orgid.FromWorkOSID()`, matching the existing convention used across the codebase
- Back-fills `external_id` on the WorkOS org immediately after creation
- Added `UpdateOrganizationExternalID` to the `WorkOSClient` interface

## Changes

| File | What |
|------|------|
| `server/internal/auth/identity/identity.go` | Changed `ProvisionOrgInWorkOS` — removed `gramOrgID` param, returns `(workosOrgID, gramOrgID, err)`, derives ID via UUIDv5 |
| `server/internal/auth/impl.go` | Updated `Register` and `autoProvisionForAssistants` callers |
| `server/internal/thirdparty/workos/stub.go` | Updated `StubClient.CreateOrganization` for new flow |
| `server/internal/auth/e2e_test.go` | Updated mock + test assertions for derived org IDs |

## Test plan

- [x] All 24 register tests pass (`TestService_Register`, `TestE2E_Register_*`)
- [x] Full `go build ./...` clean
