### PR TITLE
fix(elements): derive protocol-sniffing proxy port from ELEMENTS_STORYBOOK_PORT

### DIFF
--- a/elements/.storybook/vite.config.mts
+++ b/elements/.storybook/vite.config.mts
@@ -127,7 +127,9 @@ export default defineConfig(({ mode }) => {
       tailwindcss(),
       apiMiddlewarePlugin(),
       cspPlugin(),
-      protocolSniffingPlugin(6006),
+      protocolSniffingPlugin(
+        parseInt(process.env.ELEMENTS_STORYBOOK_PORT ?? "6007") - 1,
+      ),
     ],
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary

- `protocolSniffingPlugin` in `elements/.storybook/vite.config.mts` had port `6006` hardcoded
- The plugin binds three consecutive ports (proxy, internal HTTPS, HTTP redirect), so any worktree starting storybook would always try to claim 6006/6007/6008 — conflicting with the main worktree
- Fix derives the proxy port as `ELEMENTS_STORYBOOK_PORT - 1`, preserving the existing 6006/6007 default while honouring worktree-specific port assignments from `mise.local.toml`

## Test plan

- [x] Start storybook in main worktree (`ELEMENTS_STORYBOOK_PORT=6007`) — proxy on 6006, storybook on 6007 as before
- [x] Start storybook in a secondary worktree with a different `ELEMENTS_STORYBOOK_PORT` — no port conflict
