### PR TITLE
mig: granular per-rule toggles within policy categories

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2644,6 +2644,11 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   sources TEXT[] NOT NULL,
   presidio_entities TEXT[],
   prompt_injection_rules TEXT[],
+  -- Canonical rule_ids (e.g. 'secret.aws_access_token', 'pii.credit_card')
+  -- the policy author has unchecked within an otherwise-enabled category.
+  -- Empty/NULL means every rule in the selected categories runs. Scanner
+  -- drops any finding whose canonical rule_id appears here.
+  disabled_rules TEXT[],
   action TEXT NOT NULL DEFAULT 'flag',
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,
   user_message TEXT,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1184,6 +1184,7 @@ type RiskPolicy struct {
 	Sources              []string
 	PresidioEntities     []string
 	PromptInjectionRules []string
+	DisabledRules        []string
 	Action               string
 	AutoName             bool
 	UserMessage          pgtype.Text

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -18,6 +18,7 @@ type RiskPolicy struct {
 	Sources              []string
 	PresidioEntities     []string
 	PromptInjectionRules []string
+	DisabledRules        []string
 	Action               string
 	AutoName             bool
 	UserMessage          pgtype.Text

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -19,7 +19,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -39,6 +39,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.Sources,
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
+		&i.DisabledRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -151,7 +152,7 @@ VALUES (
   , $11
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -192,6 +193,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.Sources,
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
+		&i.DisabledRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -385,7 +387,7 @@ func (q *Queries) GetRiskOverviewCounts(ctx context.Context, arg GetRiskOverview
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -409,6 +411,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.Sources,
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
+		&i.DisabledRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -453,7 +456,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -479,6 +482,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.Sources,
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
+			&i.DisabledRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -499,7 +503,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -524,6 +528,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.Sources,
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
+			&i.DisabledRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -544,7 +549,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -571,6 +576,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.Sources,
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
+			&i.DisabledRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -591,7 +597,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -621,6 +627,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.Sources,
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
+			&i.DisabledRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -874,7 +881,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -899,6 +906,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.Sources,
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
+			&i.DisabledRules,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -1644,7 +1652,7 @@ SET name = $1
 WHERE id = $9
   AND project_id = $10
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -1683,6 +1691,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.Sources,
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
+		&i.DisabledRules,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,

--- a/server/migrations/20260526164519_add-risk-policies-disabled-rules.sql
+++ b/server/migrations/20260526164519_add-risk-policies-disabled-rules.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "disabled_rules" text[] NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Tde4180Fyb/TU0GH4tuCrrrk63Cn0NBBe+XPEC8Nr6k=
+h1:SlyAQFtiG9gUR0aWkki9alJdXj3Xu02x5fO074/HecM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -189,3 +189,4 @@ h1:Tde4180Fyb/TU0GH4tuCrrrk63Cn0NBBe+XPEC8Nr6k=
 20260522040618_add_legacy_callback_url_to_remote_session_clients.sql h1:LrHAK7LBxV+2oO4pYEz7dImXUpI0C9b3+0Q0as7GthA=
 20260522194835_add_function_tool_definitions_tags.sql h1:zNH0ilgmHU+szGwhIBKT3xSSrj0+ayoUk5nhCsgPFtU=
 20260526132630_add_custom_domain_provisioner_kind.sql h1:XoZWJ1F8RtKzAlz18m9242K03La7QV3hDlDRfWO5wQM=
+20260526164519_add-risk-policies-disabled-rules.sql h1:SmIuD/9RiaBWGHZBadLnVzwVdQ7x0riPTboR6+M0GLE=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/2994 so the database changes can land independently.