### PR TITLE
fix: preserve logout storage preferences

### DIFF
--- a/.changeset/tasty-deer-learn.md
+++ b/.changeset/tasty-deer-learn.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Preserve theme and saved project favorites when logging out.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -28,6 +28,7 @@ import { SdkProvider } from "./contexts/SdkProvider.tsx";
 import { TelemetryProvider } from "./contexts/TelemetryProvider.tsx";
 import { RBACDevToolbar } from "./components/dev-toolbar";
 import { usePageTitle } from "./hooks/use-page-title";
+import { PREFERRED_THEME_STORAGE_KEY } from "./lib/local-storage-keys";
 import CliCallback from "./pages/cli/CliCallback";
 import SlackRegister from "./pages/slackapp/SlackRegister";
 import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
@@ -64,13 +65,13 @@ export default function App() {
       faviconAlt.href = theme === "dark" ? "/favicon-dark.ico" : "/favicon.ico";
     }
 
-    localStorage.setItem("preferred-theme", theme);
+    localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, theme);
 
     setTheme(theme);
   };
 
   useEffect(() => {
-    const savedTheme = localStorage.getItem("preferred-theme") as
+    const savedTheme = localStorage.getItem(PREFERRED_THEME_STORAGE_KEY) as
       | "light"
       | "dark"
       | null;

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -1,4 +1,5 @@
 import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
+import { clearStorageForLogout } from "@/lib/logout-storage";
 import { getServerURL } from "@/lib/utils";
 import { datadogRum } from "@datadog/browser-rum";
 import { Gram } from "@gram/client";
@@ -55,12 +56,7 @@ export const SdkProvider = ({ children }: { children: React.ReactNode }) => {
       datadogRum.clearUser();
       telemetry.reset();
       document.cookie = "gram_admin_override=; path=/; max-age=0;";
-      if (typeof localStorage !== "undefined") {
-        localStorage.clear();
-      }
-      if (typeof sessionStorage !== "undefined") {
-        sessionStorage?.clear();
-      }
+      clearStorageForLogout();
     });
 
     const gram = new Gram({

--- a/client/dashboard/src/hooks/useProjectFavorites.ts
+++ b/client/dashboard/src/hooks/useProjectFavorites.ts
@@ -1,12 +1,11 @@
 import { useCallback, useMemo } from "react";
 
 import { useLocalStorageState } from "@/hooks/useLocalStorageState";
-
-const STORAGE_PREFIX = "gram:org-favorites:";
+import { PROJECT_FAVORITES_STORAGE_PREFIX } from "@/lib/local-storage-keys";
 
 export function useProjectFavorites(orgId: string) {
   const [favoriteIds, setFavoriteIds] = useLocalStorageState<string[]>(
-    `${STORAGE_PREFIX}${orgId}`,
+    `${PROJECT_FAVORITES_STORAGE_PREFIX}${orgId}`,
     [],
   );
 

--- a/client/dashboard/src/lib/local-storage-keys.ts
+++ b/client/dashboard/src/lib/local-storage-keys.ts
@@ -1,0 +1,2 @@
+export const PREFERRED_THEME_STORAGE_KEY = "preferred-theme";
+export const PROJECT_FAVORITES_STORAGE_PREFIX = "gram:org-favorites:";

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  PREFERRED_THEME_STORAGE_KEY,
+  PROJECT_FAVORITES_STORAGE_PREFIX,
+} from "./local-storage-keys";
+import { clearStorageForLogout } from "./logout-storage";
+
+function createStorage(): Storage {
+  const items = new Map<string, string>();
+
+  return {
+    get length() {
+      return items.size;
+    },
+    clear: () => items.clear(),
+    getItem: (key: string) => items.get(key) ?? null,
+    key: (index: number) => Array.from(items.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      items.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      items.set(key, value);
+    },
+  };
+}
+
+describe("clearStorageForLogout", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorage(),
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: createStorage(),
+    });
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("preserves preferred theme and organization favorites while clearing other local storage", () => {
+    const favoritesKey = `${PROJECT_FAVORITES_STORAGE_PREFIX}org_123`;
+
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(favoritesKey, '["project_123"]');
+    window.localStorage.setItem("preferredProject", "project-slug");
+    window.localStorage.setItem("pylon_user_email", "user@example.com");
+
+    clearStorageForLogout();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "light",
+    );
+    expect(window.localStorage.getItem(favoritesKey)).toBe('["project_123"]');
+    expect(window.localStorage.getItem("preferredProject")).toBeNull();
+    expect(window.localStorage.getItem("pylon_user_email")).toBeNull();
+  });
+
+  it("clears session storage", () => {
+    window.sessionStorage.setItem("temporary", "value");
+
+    clearStorageForLogout();
+
+    expect(window.sessionStorage.getItem("temporary")).toBeNull();
+  });
+});

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -1,0 +1,42 @@
+import {
+  PREFERRED_THEME_STORAGE_KEY,
+  PROJECT_FAVORITES_STORAGE_PREFIX,
+} from "@/lib/local-storage-keys";
+
+const PRESERVED_LOCAL_STORAGE_KEYS = new Set([PREFERRED_THEME_STORAGE_KEY]);
+const PRESERVED_LOCAL_STORAGE_PREFIXES = [PROJECT_FAVORITES_STORAGE_PREFIX];
+
+function shouldPreserveLocalStorageKey(key: string) {
+  return (
+    PRESERVED_LOCAL_STORAGE_KEYS.has(key) ||
+    PRESERVED_LOCAL_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
+  );
+}
+
+export function clearStorageForLogout() {
+  const local = typeof window !== "undefined" ? window.localStorage : undefined;
+  const session =
+    typeof window !== "undefined" ? window.sessionStorage : undefined;
+
+  if (local) {
+    const preserved = new Map<string, string>();
+
+    for (let i = 0; i < local.length; i++) {
+      const key = local.key(i);
+      if (!key || !shouldPreserveLocalStorageKey(key)) continue;
+
+      const value = local.getItem(key);
+      if (value !== null) {
+        preserved.set(key, value);
+      }
+    }
+
+    local.clear();
+
+    for (const [key, value] of preserved) {
+      local.setItem(key, value);
+    }
+  }
+
+  session?.clear();
+}


### PR DESCRIPTION
## Summary
- Preserve `preferred-theme` and `gram:org-favorites:*` `localStorage` entries when logout clears browser storage.
- Keep clearing other `localStorage` entries, plus all `sessionStorage`.
- Centralize dashboard `localStorage` key constants so the favorites hook, theme setup, and logout cleanup share the same key names.

## Why
Log out previously called `localStorage.clear()`, which removed user preferences such as theme and saved project favorites. This keeps the logout cleanup behavior for auth-related state while retaining nonsensitive user preferences.

## Test Plan
- `cd client/dashboard && pnpm test src/lib/logout-storage.test.ts`
- `cd client/dashboard && pnpm lint`