### PR TITLE
fix(dashboard): surface failing HTTP status in filtered MCP trace summaries

### DIFF
--- a/client/dashboard/src/pages/logs/use-attribute-logs-query.test.ts
+++ b/client/dashboard/src/pages/logs/use-attribute-logs-query.test.ts
@@ -64,4 +64,65 @@ describe("logsToTraceSummaries", () => {
       }),
     ]);
   });
+
+  it("surfaces the failing status code when a trace mixes success and error logs", () => {
+    const summaries = logsToTraceSummaries([
+      makeLog({
+        id: "ok-log",
+        timeUnixNano: "1",
+        traceId: "trace-mixed",
+        attributes: {
+          gram: {
+            event: { source: "tool_call" },
+            tool: { urn: "urn:tool:failing" },
+          },
+          http: { response: { status_code: 200 } },
+        },
+      }),
+      makeLog({
+        id: "err-log",
+        timeUnixNano: "2",
+        traceId: "trace-mixed",
+        attributes: {
+          http: { response: { status_code: 500 } },
+        },
+      }),
+    ]);
+
+    expect(summaries).toEqual([
+      expect.objectContaining({
+        traceId: "trace-mixed",
+        httpStatusCode: 500,
+      }),
+    ]);
+  });
+
+  it("surfaces the error code regardless of log iteration order", () => {
+    const summaries = logsToTraceSummaries([
+      makeLog({
+        id: "err-log",
+        timeUnixNano: "2",
+        traceId: "trace-err-first",
+        attributes: {
+          gram: { tool: { urn: "urn:tool:err-first" } },
+          http: { response: { status_code: 500 } },
+        },
+      }),
+      makeLog({
+        id: "ok-log",
+        timeUnixNano: "1",
+        traceId: "trace-err-first",
+        attributes: {
+          http: { response: { status_code: 200 } },
+        },
+      }),
+    ]);
+
+    expect(summaries).toEqual([
+      expect.objectContaining({
+        traceId: "trace-err-first",
+        httpStatusCode: 500,
+      }),
+    ]);
+  });
 });

--- a/client/dashboard/src/pages/logs/use-attribute-logs-query.ts
+++ b/client/dashboard/src/pages/logs/use-attribute-logs-query.ts
@@ -99,9 +99,15 @@ export function logsToTraceSummaries(
         const urn = getNestedAttr(log.attributes, "gram.tool.urn");
         if (typeof urn === "string") gramUrn = urn;
       }
-      if (httpStatusCode === undefined) {
-        const code = getNestedAttr(log.attributes, "http.response.status_code");
-        if (typeof code === "number") httpStatusCode = code;
+      // Prefer the highest HTTP status code seen in the trace so a trace
+      // containing both a 200 (e.g. MCP handshake) and a 500 (failed tool
+      // call) surfaces as failed. Picking the first code latches onto
+      // whichever log iterates first and can mislead the row indicator green.
+      const code = getNestedAttr(log.attributes, "http.response.status_code");
+      if (typeof code === "number") {
+        if (httpStatusCode === undefined || code > httpStatusCode) {
+          httpStatusCode = code;
+        }
       }
       if (!eventSource) {
         if (typeof src === "string") eventSource = src;


### PR DESCRIPTION
## Summary

- The MCP Logs view rendered a green status indicator for failed traces when an MCP server filter was applied — the trace's HTTP status was being taken from whichever log iterated first in the client-side grouper, so a 200 from an MCP handshake/auth could mask a 500 from the actual tool call.
- `logsToTraceSummaries` now keeps the highest HTTP status code seen across the trace's logs, so a 500 always wins over a 200 in the same trace.
- Server-side aggregation (used in the unfiltered path) is untouched — only the filtered client-side grouping was broken in this way.

Fixes [AGE-2543](https://linear.app/speakeasy/issue/AGE-2543/bug-fix-misleading-green-status-indicator-for-failed-mcp-logs).

## Why the filter path differs

The Logs page has two query paths:

- **Unfiltered** → `telemetrySearchToolCalls` → ClickHouse `trace_summaries` MV (one row per trace).
- **MCP server filter applied** → `telemetrySearchLogs` → `logsToTraceSummaries` groups raw logs client-side.

The bug lived in the second path: `if (httpStatusCode === undefined) { ... }` set the code only the first time it saw one. The fix replaces "first wins" with "max wins."

## Test plan

- [x] `pnpm test use-attribute-logs-query` — 3/3 pass, including two new cases (mixed 200/500 trace surfaces 500; log iteration order does not change the outcome).
- [ ] Manual: open Logs → MCP, filter by a server that has a failing trace, confirm the left-edge dot and status badge are red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
