### PR TITLE
fix(dashboard): active users count should not exceed org members

### DIFF
--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -197,6 +197,17 @@ export function InsightsAgentsContent() {
     () => new Map((membersData?.members ?? []).map((m) => [m.id, m])),
     [membersData],
   );
+  const memberIdentifiers = useMemo(() => {
+    const ids = new Set<string>();
+    for (const m of membersData?.members ?? []) {
+      ids.add(m.id);
+      ids.add(m.email.toLowerCase());
+    }
+    return ids;
+  }, [membersData]);
+  const isOrgMember = (userId: string) =>
+    memberIdentifiers.has(userId) ||
+    memberIdentifiers.has(userId.toLowerCase());
 
   const usersQuery = useQuery({
     queryKey: [
@@ -270,7 +281,9 @@ export function InsightsAgentsContent() {
 
   const totalTokens = users.reduce((s, u) => s + effectiveTokens(u), 0);
   const totalCost = users.reduce((s, u) => s + u.totalCost, 0);
-  const activeUsers = users.filter((u) => effectiveTokens(u) > 0).length;
+  const activeUsers = users.filter(
+    (u) => effectiveTokens(u) > 0 && isOrgMember(u.userId),
+  ).length;
 
   const clientBreakdown = useMemo(() => {
     const map = new Map<
@@ -411,7 +424,7 @@ export function InsightsAgentsContent() {
     0,
   );
   const filteredActiveUsers = filteredUserRows.filter(
-    (u) => u.totalTokens > 0,
+    (u) => u.totalTokens > 0 && isOrgMember(u.userId),
   ).length;
 
   const isLoading =


### PR DESCRIPTION
## Summary

- Fixes bug where "Active Users" count on the Costs page could exceed the total org members count
- The metric was counting all users with telemetry activity, including non-org members (contractors, former employees)
- Now filters active users to only count those matching org members by ID or email

## Test plan

- [ ] Navigate to `/insights/costs` page
- [ ] Verify "Active Users" count is always ≤ org members count in the subtext
- [ ] Test with a time range that includes activity from users not in the org

Slack: https://speakeasyapi.slack.com/archives/C0ARJG28X29/p1779823303445269?thread_ts=1779822680.366439&cid=C0ARJG28X29

https://claude.ai/code/session_01WjHebxX59uGGG2mnsXLKxk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjHebxX59uGGG2mnsXLKxk)_