### PR TITLE
fix(dashboard): show source deployment logs + gate Deployments nav behind feature flag

### DIFF
--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -45,6 +45,42 @@ If you find yourself copy-pasting a JSX structure — even with minor variations
 
 Never use immediately-invoked function expressions inside JSX (`{(() => { ... })()} `). Extract to a named sub-component or a variable above the return statement.
 
+#### No multi-line or nested ternaries
+
+A ternary that wraps onto multiple lines, or chains a second `?:` inside a branch, is unreadable. Reach for one of these instead:
+
+- A `switch` statement when mapping a discriminator (e.g. a `kind` / `type` string) to one of several values.
+- A small **named helper function**, hoisted to module scope when the mapping is pure (e.g. converting a frontend enum to a backend constant). The helper labels the intent at the call site and the JSX stays flat.
+- An object lookup when the keys are statically known and the values are simple constants.
+
+```tsx
+// ❌ wrong — nested multi-line ternary
+attachmentType={
+  sourceKind === "function"
+    ? "functions"
+    : sourceKind === "externalmcp" || sourceKind === "remotemcp"
+      ? "external_mcp"
+      : "openapi"
+}
+
+// ✅ right — hoisted helper with a switch
+function attachmentTypeForSourceKind(sourceKind: string | undefined): string {
+  switch (sourceKind) {
+    case "function":
+      return "functions";
+    case "externalmcp":
+    case "remotemcp":
+      return "external_mcp";
+    default:
+      return "openapi";
+  }
+}
+
+attachmentType={attachmentTypeForSourceKind(sourceKind)}
+```
+
+Single-line, single-branch ternaries (`isOpen ? "x" : "y"`) are fine.
+
 #### Keep components focused
 
 A component that has grown past ~150 lines of JSX is doing too much. Break it up. If a page has multiple tabs, each tab's content is its own component.

--- a/.changeset/deployments-page-feature-flag.md
+++ b/.changeset/deployments-page-feature-flag.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Gate the top-level Deployments nav item behind the `gram-deployments-page` PostHog feature flag. Defaults to true (visible to all orgs); flip off for specific orgs via PostHog org-group targeting (`organization_slug`). The page route itself is not gated — direct URLs and cross-page links to `/deployments` continue to work.

--- a/.changeset/deployments-page-feature-flag.md
+++ b/.changeset/deployments-page-feature-flag.md
@@ -1,5 +1,0 @@
----
-"dashboard": patch
----
-
-Gate the top-level Deployments nav item behind the `gram-deployments-page` PostHog feature flag. Defaults to true (visible to all orgs); flip off for specific orgs via PostHog org-group targeting (`organization_slug`). The page route itself is not gated — direct URLs and cross-page links to `/deployments` continue to work.

--- a/.changeset/source-deployments-logs-empty.md
+++ b/.changeset/source-deployments-logs-empty.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the empty "Logs" panel on a source's Deployments tab. The embedded panel was comparing a kind string (e.g. `"function"`) against log events' `attachmentId` (a UUID) and was also sending the wrong type token (`"function"` instead of the backend's `"functions"`). Now filters on `event.attachmentType` with the correct backend constants (`functions`, `openapi`, `external_mcp`), so per-source deployment logs render as expected.

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -72,12 +72,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
 
   const isAssistantsEnabled = telemetry.isFeatureEnabled("assistants") ?? false;
+  // Default true: opt-out via PostHog org-group targeting on `gram-deployments-page`.
+  const isDeploymentsPageEnabled =
+    telemetry.isFeatureEnabled("gram-deployments-page") ?? true;
 
   const connectActive = [
     routes.sources,
     routes.catalog,
     routes.playground,
-    routes.deployments,
+    ...(isDeploymentsPageEnabled ? [routes.deployments] : []),
   ].some((r) => r.active);
 
   const buildActive = [
@@ -116,7 +119,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     routes.sources,
     routes.catalog,
     routes.playground,
-    routes.deployments,
+    ...(isDeploymentsPageEnabled ? [routes.deployments] : []),
     routes.mcp,
     ...(isAssistantsEnabled ? [routes.assistants] : []),
     routes.clis,
@@ -164,10 +167,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 item={routes.playground}
                 scope={["mcp:read", "mcp:write", "mcp:connect"]}
               />
-              <ScopeGatedNavItem
-                item={routes.deployments}
-                scope={["project:read", "project:write"]}
-              />
+              {isDeploymentsPageEnabled && (
+                <ScopeGatedNavItem
+                  item={routes.deployments}
+                  scope={["project:read", "project:write"]}
+                />
+              )}
             </CollapsibleNavGroup>
 
             {/* Build group */}

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -262,15 +262,23 @@ export const LogsTabContent = ({
       }));
   }, [deploymentLogs.events, assetNameMap]);
 
-  const activeSourceFilter =
-    attachmentType ?? (selectedSource !== "all" ? selectedSource : undefined);
+  const activeAttachmentIdFilter =
+    selectedSource !== "all" ? selectedSource : undefined;
 
   const visibleEvents = useMemo(() => {
-    if (!activeSourceFilter) return deploymentLogs.events;
-    return deploymentLogs.events.filter(
-      (event) => event.attachmentId === activeSourceFilter,
-    );
-  }, [deploymentLogs.events, activeSourceFilter]);
+    let events = deploymentLogs.events;
+    if (attachmentType) {
+      events = events.filter(
+        (event) => event.attachmentType === attachmentType,
+      );
+    }
+    if (activeAttachmentIdFilter) {
+      events = events.filter(
+        (event) => event.attachmentId === activeAttachmentIdFilter,
+      );
+    }
+    return events;
+  }, [deploymentLogs.events, attachmentType, activeAttachmentIdFilter]);
 
   const parsedLogs = useMemo(
     () =>

--- a/client/dashboard/src/pages/sources/SourceDetails.tsx
+++ b/client/dashboard/src/pages/sources/SourceDetails.tsx
@@ -39,6 +39,20 @@ import { SourceToolsTab } from "./SourceToolsTab";
 import { SourceMCPServersTab } from "./SourceMCPServersTab";
 import { SourceSettingsTab } from "./SourceSettingsTab";
 
+// Map dashboard source kinds to backend deployment_logs.attachment_type values.
+// See server/internal/deployments/events/log.go.
+function attachmentTypeForSourceKind(sourceKind: string | undefined): string {
+  switch (sourceKind) {
+    case "function":
+      return "functions";
+    case "externalmcp":
+    case "remotemcp":
+      return "external_mcp";
+    default:
+      return "openapi";
+  }
+}
+
 export default function SourceDetails() {
   const { sourceKind, sourceSlug } = useParams<{
     sourceKind: string;
@@ -345,13 +359,7 @@ export default function SourceDetails() {
             >
               <SourceDeploymentsPanel
                 sourceKind={sourceKind}
-                attachmentType={
-                  sourceKind === "function"
-                    ? "functions"
-                    : sourceKind === "externalmcp" || sourceKind === "remotemcp"
-                      ? "external_mcp"
-                      : "openapi"
-                }
+                attachmentType={attachmentTypeForSourceKind(sourceKind)}
               />
             </Suspense>
           </TabsContent>

--- a/client/dashboard/src/pages/sources/SourceDetails.tsx
+++ b/client/dashboard/src/pages/sources/SourceDetails.tsx
@@ -346,7 +346,11 @@ export default function SourceDetails() {
               <SourceDeploymentsPanel
                 sourceKind={sourceKind}
                 attachmentType={
-                  sourceKind === "function" ? "function" : "openapi"
+                  sourceKind === "function"
+                    ? "functions"
+                    : sourceKind === "externalmcp" || sourceKind === "remotemcp"
+                      ? "external_mcp"
+                      : "openapi"
                 }
               />
             </Suspense>


### PR DESCRIPTION
## Summary

Two dashboard-only changes scoped to the Deployments surface:

### 1. Fix empty Logs panel on source overview's Deployments tab

The embedded panel was always rendering "No logs to display" because of two bugs that combined:

- `LogsTabContent.tsx` was comparing the `attachmentType` kind string (e.g. `"function"`) against `event.attachmentId` (a UUID).
- `SourceDetails.tsx` was passing `"function"` while the backend (`server/internal/deployments/events/log.go:122-128`) writes `attachment_type` as `"functions"` (plural). Also corrected the mapping for `externalmcp`/`remotemcp` source kinds (`external_mcp`).

Now filters on `event.attachmentType` with the correct backend constants. The user-selected source-picker dropdown still filters on `event.attachmentId` and can compose with the type filter.

### 2. Gate the top-level Deployments nav item behind `gram-deployments-page`

Adds a PostHog feature flag for nav-bar visibility on the Deployments item.

- **Default:** ON (preserves current behavior for all orgs).
- **Targeting:** opt out specific orgs in PostHog via the `organization_slug` group.
- **Scope:** nav-bar only — `/deployments` continues to resolve and cross-page links (e.g. "View all" from a source's Deployments tab) still work.

## Test plan

- [ ] Function source's Deployments tab → Logs panel populates for deployments with function-processing logs.
- [ ] OpenAPI source's Deployments tab → Logs panel populates with that deployment's OpenAPI logs.
- [ ] Standalone `/deployments/<id>` page (non-embedded) — All-sources view shows everything; source dropdown still narrows correctly.
- [ ] Flag `gram-deployments-page` disabled for a test org → Deployments item disappears from the Connect nav group; visiting `/deployments` directly still works.
- [ ] Flag missing or unresolved → Deployments item still visible (default ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
