### PR TITLE
fix(dashboard): expose Destructive CLI Commands in policy form

### DIFF
--- a/.changeset/age-2542-destructive-cli-policy-form.md
+++ b/.changeset/age-2542-destructive-cli-policy-form.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+expose the Destructive CLI Commands category in the risk policy form so customers can opt into `cli_destructive` scanning, and stop silently stripping the source when editing policies that had it set via the API

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -74,6 +74,7 @@ const AVAILABLE_CATEGORIES: Set<RuleCategory> = new Set([
   ...PRESIDIO_CATEGORIES,
   "shadow_mcp",
   "destructive_tool",
+  "cli_destructive",
   "prompt_injection",
 ]);
 
@@ -83,9 +84,18 @@ const ALL_CATEGORIES: RuleCategory[] = [
   ...PRESIDIO_CATEGORIES,
   "shadow_mcp",
   "destructive_tool",
+  "cli_destructive",
   "prompt_injection",
   "off_policy",
 ];
+
+/** Categories whose source the server rejects with action=block; the form
+ * must force flag when any of these are selected. Mirrors validateSourceAction
+ * in server/internal/risk/impl.go. */
+const FLAG_ONLY_CATEGORIES: Set<RuleCategory> = new Set([
+  "destructive_tool",
+  "cli_destructive",
+]);
 
 /** Derive selected categories from a policy's sources + presidioEntities.
  *
@@ -100,6 +110,7 @@ function policyToCategories(
   if (sources.includes("gitleaks")) cats.add("secrets");
   if (sources.includes("shadow_mcp")) cats.add("shadow_mcp");
   if (sources.includes("destructive_tool")) cats.add("destructive_tool");
+  if (sources.includes("cli_destructive")) cats.add("cli_destructive");
   if (sources.includes("prompt_injection")) cats.add("prompt_injection");
   for (const cat of PRESIDIO_CATEGORIES) {
     const wireEntities = DETECTION_RULES[cat].map((r) =>
@@ -126,6 +137,7 @@ function categoriesToPayload(cats: Set<RuleCategory>) {
   if (cats.has("secrets")) sources.push("gitleaks");
   if (cats.has("shadow_mcp")) sources.push("shadow_mcp");
   if (cats.has("destructive_tool")) sources.push("destructive_tool");
+  if (cats.has("cli_destructive")) sources.push("cli_destructive");
   if (cats.has("prompt_injection")) sources.push("prompt_injection");
   for (const cat of PRESIDIO_CATEGORIES) {
     if (cats.has(cat)) {
@@ -226,10 +238,10 @@ function PolicyCenterContent() {
   const handleSave = () => {
     const { sources, presidioEntities, promptInjectionRules } =
       categoriesToPayload(selectedCategories);
-    const action =
-      sources.includes("destructive_tool") && formAction === "block"
-        ? "flag"
-        : formAction;
+    const flagOnly = [...FLAG_ONLY_CATEGORIES].some((c) =>
+      selectedCategories.has(c),
+    );
+    const action = flagOnly && formAction === "block" ? "flag" : formAction;
     if (editingPolicy) {
       updateMutation.mutate({
         request: {
@@ -625,9 +637,11 @@ function PolicySheetBody({
   const [expandedCategory, setExpandedCategory] = useState<RuleCategory | null>(
     null,
   );
-  const destructiveToolsSelected = selectedCategories.has("destructive_tool");
+  const flagOnlySelected = [...FLAG_ONLY_CATEGORIES].some((c) =>
+    selectedCategories.has(c),
+  );
   const actionValue =
-    destructiveToolsSelected && formAction === "block" ? "flag" : formAction;
+    flagOnlySelected && formAction === "block" ? "flag" : formAction;
 
   return (
     <div className="space-y-6 py-4">
@@ -726,7 +740,7 @@ function PolicySheetBody({
                       setSelectedCategories(next);
                       if (
                         checked &&
-                        cat === "destructive_tool" &&
+                        FLAG_ONLY_CATEGORIES.has(cat) &&
                         formAction === "block"
                       ) {
                         setFormAction("flag");
@@ -774,7 +788,7 @@ function PolicySheetBody({
         <RadioGroup
           value={actionValue}
           onValueChange={(v) => {
-            if (destructiveToolsSelected && v === "block") {
+            if (flagOnlySelected && v === "block") {
               return;
             }
             setFormAction(v as PolicyAction);
@@ -782,8 +796,7 @@ function PolicySheetBody({
         >
           <div className="border-border divide-border divide-y rounded-lg border">
             {ACTION_OPTIONS.map((opt) => {
-              const disabled =
-                destructiveToolsSelected && opt.value === "block";
+              const disabled = flagOnlySelected && opt.value === "block";
 
               return (
                 <label
@@ -811,7 +824,8 @@ function PolicySheetBody({
                     </div>
                     {disabled && (
                       <div className="text-destructive mt-1 text-xs font-medium">
-                        Destructive Tools supports flagging only.
+                        Destructive Tools and Destructive CLI Commands support
+                        flagging only.
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

The `cli_destructive` source had no checkbox in New Policy / Edit Policy, so customers couldn't opt into it from the dashboard. Worse, opening a policy that already had `cli_destructive` in its sources (set via the API/SDK) and saving silently stripped the source — the form always re-derives `sources` from `selectedCategories`, and the mapping didn't know about `cli_destructive`.

This adds the missing wiring in four spots (`AVAILABLE_CATEGORIES`, `ALL_CATEGORIES`, `policyToCategories`, `categoriesToPayload`) and replaces the `destructive_tool`-only flag-only guard with a `FLAG_ONLY_CATEGORIES` set so future flag-only sources only need to be added in one place. Server-side validation (`validateSourceAction` in `server/internal/risk/impl.go`) already rejects `block` for both sources; the UI now matches.

Linear: AGE-2542

## Test plan

- [ ] Open the policy creation sheet and verify a new "Destructive CLI Commands" row appears between "Destructive Tools" and "Prompt Injection"
- [ ] Check the new category and verify Action defaults to / forces Flag, with the disabled Block radio showing the updated copy ("Destructive Tools and Destructive CLI Commands support flagging only.")
- [ ] Save a policy with only Destructive CLI Commands selected and verify it persists with `sources: ["cli_destructive"]`
- [ ] Reopen the same policy and verify the checkbox is still ticked (round-trip via `policyToCategories` / `categoriesToPayload`)
- [ ] (Optional, recommended) Audit existing policies for any rows whose `sources` contains `cli_destructive` so we know if anyone hit the data-loss path before this fix
