### PR TITLE
fix(dashboard): preserve failing MCP status across paginated trace pages (AGE-2543 follow-up)

### DIFF
--- a/client/dashboard/src/components/observe/LogsMCP.tsx
+++ b/client/dashboard/src/components/observe/LogsMCP.tsx
@@ -40,6 +40,7 @@ import { LogFilterBar } from "@/pages/logs/LogFilterBar";
 import { TraceRow } from "@/pages/logs/TraceRow";
 import { TriggerLogRow } from "@/pages/logs/TriggerLogRow";
 import {
+  mergeTraceSummariesByTraceId,
   useAttributeLogsQuery,
   type TraceSummary,
 } from "@/pages/logs/use-attribute-logs-query";
@@ -263,24 +264,7 @@ export function LogsMCPContent() {
   const allTraces = useMemo(() => {
     const raw = data?.pages.flatMap((page) => page.toolCalls) ?? [];
     if (!hasStructuredFilters) return raw;
-
-    const merged = new Map<string, ToolCallSummary>();
-    for (const trace of raw) {
-      const existing = merged.get(trace.traceId);
-      if (existing) {
-        existing.logCount += trace.logCount;
-        if (
-          BigInt(trace.startTimeUnixNano) < BigInt(existing.startTimeUnixNano)
-        ) {
-          existing.startTimeUnixNano = trace.startTimeUnixNano;
-        }
-      } else {
-        merged.set(trace.traceId, { ...trace });
-      }
-    }
-    return Array.from(merged.values()).sort((a, b) =>
-      a.startTimeUnixNano < b.startTimeUnixNano ? 1 : -1,
-    );
+    return mergeTraceSummariesByTraceId(raw);
   }, [data?.pages, hasStructuredFilters]);
 
   const handleServerChange = useCallback(

--- a/client/dashboard/src/pages/logs/use-attribute-logs-query.test.ts
+++ b/client/dashboard/src/pages/logs/use-attribute-logs-query.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { TelemetryLogRecord } from "@gram/client/models/components/telemetrylogrecord";
-import { logsToTraceSummaries } from "./use-attribute-logs-query";
+import type { ToolCallSummary } from "@gram/client/models/components/toolcallsummary";
+import {
+  logsToTraceSummaries,
+  mergeTraceSummariesByTraceId,
+} from "./use-attribute-logs-query";
 
 function makeLog({
   id,
@@ -124,5 +128,59 @@ describe("logsToTraceSummaries", () => {
         httpStatusCode: 500,
       }),
     ]);
+  });
+});
+
+describe("mergeTraceSummariesByTraceId", () => {
+  it("surfaces the error code across paginated trace summaries", () => {
+    // Simulates a single trace whose 200 handshake and 500 tool call land on
+    // separate pages of the infinite query. The merge must keep the 500.
+    const pageOne: ToolCallSummary = {
+      traceId: "trace-paginated",
+      gramUrn: "urn:tool:paginated",
+      startTimeUnixNano: "2",
+      logCount: 1,
+      httpStatusCode: 200,
+    };
+    const pageTwo: ToolCallSummary = {
+      traceId: "trace-paginated",
+      gramUrn: "urn:tool:paginated",
+      startTimeUnixNano: "1",
+      logCount: 1,
+      httpStatusCode: 500,
+    };
+
+    const merged = mergeTraceSummariesByTraceId([pageOne, pageTwo]);
+
+    expect(merged).toEqual([
+      expect.objectContaining({
+        traceId: "trace-paginated",
+        httpStatusCode: 500,
+        logCount: 2,
+        startTimeUnixNano: "1",
+      }),
+    ]);
+  });
+
+  it("retains a defined status when a later page has no code", () => {
+    const merged = mergeTraceSummariesByTraceId([
+      {
+        traceId: "trace-no-status-on-second",
+        gramUrn: "urn:tool:x",
+        startTimeUnixNano: "2",
+        logCount: 1,
+        httpStatusCode: 500,
+      },
+      {
+        traceId: "trace-no-status-on-second",
+        gramUrn: "urn:tool:x",
+        startTimeUnixNano: "1",
+        logCount: 1,
+      },
+    ]);
+
+    expect(merged[0]).toEqual(
+      expect.objectContaining({ httpStatusCode: 500, logCount: 2 }),
+    );
   });
 });

--- a/client/dashboard/src/pages/logs/use-attribute-logs-query.ts
+++ b/client/dashboard/src/pages/logs/use-attribute-logs-query.ts
@@ -146,6 +146,41 @@ export function logsToTraceSummaries(
   return summaries;
 }
 
+/**
+ * Merges per-page trace summaries by traceId. Used by the filtered logs view,
+ * which paginates the raw log stream and may receive the same trace split
+ * across pages. Mirrors the within-page rule in logsToTraceSummaries: a
+ * trace's status is the highest code seen across all its logs.
+ */
+export function mergeTraceSummariesByTraceId(
+  raw: ToolCallSummary[],
+): ToolCallSummary[] {
+  const merged = new Map<string, ToolCallSummary>();
+  for (const trace of raw) {
+    const existing = merged.get(trace.traceId);
+    if (existing) {
+      existing.logCount += trace.logCount;
+      if (
+        BigInt(trace.startTimeUnixNano) < BigInt(existing.startTimeUnixNano)
+      ) {
+        existing.startTimeUnixNano = trace.startTimeUnixNano;
+      }
+      if (
+        trace.httpStatusCode !== undefined &&
+        (existing.httpStatusCode === undefined ||
+          trace.httpStatusCode > existing.httpStatusCode)
+      ) {
+        existing.httpStatusCode = trace.httpStatusCode;
+      }
+    } else {
+      merged.set(trace.traceId, { ...trace });
+    }
+  }
+  return Array.from(merged.values()).sort((a, b) =>
+    a.startTimeUnixNano < b.startTimeUnixNano ? 1 : -1,
+  );
+}
+
 function toSdkFilters(filters: ActiveLogFilter[]): LogFilter[] {
   return filters.map((f) => {
     let values: string[] | undefined;

--- a/client/dashboard/src/pages/logs/use-attribute-logs-query.ts
+++ b/client/dashboard/src/pages/logs/use-attribute-logs-query.ts
@@ -158,24 +158,27 @@ export function mergeTraceSummariesByTraceId(
   const merged = new Map<string, ToolCallSummary>();
   for (const trace of raw) {
     const existing = merged.get(trace.traceId);
-    if (existing) {
-      existing.logCount += trace.logCount;
-      if (
-        BigInt(trace.startTimeUnixNano) < BigInt(existing.startTimeUnixNano)
-      ) {
-        existing.startTimeUnixNano = trace.startTimeUnixNano;
-      }
-      if (
-        trace.httpStatusCode !== undefined &&
-        (existing.httpStatusCode === undefined ||
-          trace.httpStatusCode > existing.httpStatusCode)
-      ) {
-        existing.httpStatusCode = trace.httpStatusCode;
-      }
-    } else {
+
+    if (!existing) {
       merged.set(trace.traceId, { ...trace });
+      continue;
+    }
+
+    existing.logCount += trace.logCount;
+    if (BigInt(trace.startTimeUnixNano) < BigInt(existing.startTimeUnixNano)) {
+      existing.startTimeUnixNano = trace.startTimeUnixNano;
+    }
+
+    if (trace.httpStatusCode === undefined) continue;
+
+    if (
+      existing.httpStatusCode === undefined ||
+      trace.httpStatusCode > existing.httpStatusCode
+    ) {
+      existing.httpStatusCode = trace.httpStatusCode;
     }
   }
+
   return Array.from(merged.values()).sort((a, b) =>
     a.startTimeUnixNano < b.startTimeUnixNano ? 1 : -1,
   );


### PR DESCRIPTION
## Summary

Follow-up to #3035 (AGE-2543). That PR fixed the misleading green status
**within a single page** by taking the max HTTP status code across a
trace's logs in `logsToTraceSummaries`. This PR closes the same gap
**across pages**.

The filtered MCP logs view runs an infinite query, and the same
`traceId` can land on more than one page. The cross-page merge in
`LogsMCP.tsx` only summed `logCount` and adjusted `startTimeUnixNano` —
it never reconciled `httpStatusCode`. So a 500 tool call on page 2 could
still be masked by a 200 handshake from page 1.

## Changes

- Extracted the merge into `mergeTraceSummariesByTraceId`, exported next
  to `logsToTraceSummaries` (they're a pair).
- Applied the same "max status code wins" rule across pages.
- Replaced the inline merge in `LogsMCP.tsx` with the new helper.
- Added vitest coverage for the cross-page case and the case where a
  later page lacks any status code.

## Test plan

- [x] `pnpm test src/pages/logs/use-attribute-logs-query.test.ts` — 5 passing
- [x] `pnpm tsc -p tsconfig.app.json --noEmit` — no new errors in
      touched files
- [ ] Manually verify in dashboard: with an MCP server filter applied,
      traces whose tool calls returned 5xx show red status even when the
      trace's logs are split across multiple pages of the infinite query

🤖 Generated with [Claude Code](https://claude.com/claude-code)
