### PR TITLE
feat(dashboard): show Preview badge in Webhooks page header

### DIFF
--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -7,6 +7,7 @@ import { useRBAC } from "@/hooks/useRBAC";
 import { capitalize, cn } from "@/lib/utils.ts";
 import React from "react";
 import { Link, useLocation, useParams } from "react-router";
+import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge.tsx";
 import { Heading } from "./ui/heading.tsx";
 
 function PageHeaderComponent({
@@ -85,11 +86,13 @@ function PageHeaderBreadcrumbs({
   className,
   substitutions = {}, // Any segment and how it should be displayed, for example toolset slug -> toolset name
   skipSegments = [], // Segments to skip/hide from breadcrumbs
+  stage,
 }: {
   fullWidth?: boolean;
   className?: string;
   substitutions?: Record<string, string | undefined>;
   skipSegments?: string[];
+  stage?: ReleaseStage;
 }) {
   const params = useParams();
   const { orgSlug, projectSlug } = useSlugs();
@@ -217,6 +220,7 @@ function PageHeaderBreadcrumbs({
             )}
           </React.Fragment>
         ))}
+        {stage && <ReleaseStageBadge stage={stage} />}
       </div>
     </PageHeader.Title>
   );

--- a/client/dashboard/src/pages/org/OrgWebhooks.tsx
+++ b/client/dashboard/src/pages/org/OrgWebhooks.tsx
@@ -1,5 +1,4 @@
 import { Page } from "@/components/page-layout";
-import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
 import { Switch } from "@/components/ui/switch";
@@ -43,7 +42,7 @@ export default function OrgWebhooks() {
   return (
     <Page>
       <Page.Header>
-        <Page.Header.Breadcrumbs />
+        <Page.Header.Breadcrumbs stage="preview" />
       </Page.Header>
       <Page.Body>{content}</Page.Body>
     </Page>
@@ -66,10 +65,9 @@ function OrgWebhooksInner() {
 
   return (
     <>
-      <Stack direction="horizontal" gap={2} align="center" className="mb-4">
-        <Heading variant="h3">Webhooks</Heading>
-        <ReleaseStageBadge stage="preview" />
-      </Stack>
+      <Heading variant="h3" className="mb-4">
+        Webhooks
+      </Heading>
       <Type muted small className="mb-6">
         Configure webhook delivery for various platform events.
       </Type>


### PR DESCRIPTION
## Summary

- Move the Preview release-stage badge from the body heading into the shared `Page.Header.Breadcrumbs`, so it renders in both the feature-enabled and `WebhooksDisabled` states (the badge was previously only visible inside `OrgWebhooksInner`, which is gated by the `webhooks` product feature).
- Add an optional `stage?: ReleaseStage` prop on `Page.Header.Breadcrumbs` that renders a `<ReleaseStageBadge>` next to the breadcrumb list — mirrors the existing convention on `PageSection.Title`.
- Remove the now-redundant inline badge from `OrgWebhooksInner` to avoid double-stamping the page.

## Test plan

- [ ] Visit `/{org}/webhooks` as a user with the `webhooks` product feature enabled → Preview badge appears next to "Webhooks" in the top breadcrumb bar, no longer in the body heading.
- [ ] Visit `/{org}/webhooks` as a user without the `webhooks` product feature → Preview badge still appears in the top breadcrumb bar (previously absent in this state).
- [ ] Hover the badge → tooltip "Preview features are early and may change..." renders.
- [ ] Other pages using `Page.Header.Breadcrumbs` without `stage` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)