### PR TITLE
feat(dashboard): metric cards display human-readable numbers

### DIFF
--- a/.changeset/cute-buttons-beg.md
+++ b/.changeset/cute-buttons-beg.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Metric cards now display abbreviated numbers (1.5K, 2.3M) instead of raw comma-separated values.

--- a/client/dashboard/src/components/chart/MetricCard.tsx
+++ b/client/dashboard/src/components/chart/MetricCard.tsx
@@ -1,5 +1,6 @@
 import { Icon, type IconName } from "@speakeasy-api/moonshine";
 import { SimpleTooltip } from "@/components/ui/tooltip";
+import { formatCompact } from "@/lib/format";
 import { getValueColor, ThresholdConfig } from "./chartUtils";
 
 type AccentColor = "red" | "orange" | "yellow" | "green" | "blue" | "purple";
@@ -8,7 +9,7 @@ export type MetricCardProps = {
   title: string;
   value: number;
   previousValue?: number;
-  format?: "number" | "currency" | "percent" | "ms" | "seconds";
+  format?: "compact" | "number" | "currency" | "percent" | "ms" | "seconds";
   icon?: IconName;
   invertDelta?: boolean;
   thresholds?: ThresholdConfig;
@@ -23,7 +24,7 @@ export function MetricCard(props: MetricCardProps) {
     title,
     value,
     previousValue = 0,
-    format = "number",
+    format = "compact",
     icon,
     invertDelta = false,
     thresholds,
@@ -33,6 +34,8 @@ export function MetricCard(props: MetricCardProps) {
   } = props;
   const formatValue = (v: number) => {
     switch (format) {
+      case "compact":
+        return formatCompact(v);
       case "percent":
         return `${v.toFixed(1)}%`;
       case "ms":

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -2,6 +2,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ChartCard } from "@/components/chart/ChartCard";
 import { formatChartLabel, smoothData } from "@/components/chart/chartUtils";
 import { ReleaseStageBadge } from "@/components/release-stage-badge";
+import { formatCompact } from "@/lib/format";
 import { MetricCard } from "@/components/chart/MetricCard";
 import { InsightsConfig } from "@/components/insights-sidebar";
 import { useInsightsState } from "@/components/insights-context";
@@ -100,14 +101,8 @@ function formatCost(value: number): string {
   return "$0.00";
 }
 
-function formatTokens(value: number): string {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
-  return value.toLocaleString();
-}
-
 function formatValue(value: number, mode: ValueMode): string {
-  return mode === "cost" ? formatCost(value) : formatTokens(value);
+  return mode === "cost" ? formatCost(value) : formatCompact(value);
 }
 
 function formatPlatform(value: string): string {
@@ -442,7 +437,7 @@ export function InsightsAgentsContent() {
         mcpConfig={mcpConfig}
         title="What would you like to know about AI agent costs?"
         subtitle="Ask about token spend, model costs, and usage by team or client"
-        contextInfo={`Agents tab: ${activeUsers} active users, ${formatTokens(totalTokens)} tokens, ${formatCost(totalCost)} total cost in ${rangeLabel}. ${clientBreakdown.length} client types, ${modelBreakdown.length} models.`}
+        contextInfo={`Agents tab: ${activeUsers} active users, ${formatCompact(totalTokens)} tokens, ${formatCost(totalCost)} total cost in ${rangeLabel}. ${clientBreakdown.length} client types, ${modelBreakdown.length} models.`}
         suggestions={[
           {
             title: "Cost Summary",
@@ -540,12 +535,12 @@ export function InsightsAgentsContent() {
                   value={filteredTotalTokens}
                   icon="gauge"
                   accentColor="blue"
-                  subtext={`${formatTokens(filteredTotalTokens)} across ${filteredTotalSessions.toLocaleString()} sessions`}
+                  subtext={`${formatCompact(filteredTotalTokens)} across ${formatCompact(filteredTotalSessions)} sessions`}
                 />
                 <MetricCard
                   title="Total Cost"
                   value={filteredTotalCost}
-                  format="number"
+                  format="currency"
                   icon="credit-card"
                   accentColor="purple"
                   subtext={
@@ -1069,7 +1064,7 @@ function EmployeeCostTable({
         width: "1fr",
         render: (role) => (
           <span className="font-mono tabular-nums">
-            {formatTokens(role.totalInputTokens)}
+            {formatCompact(role.totalInputTokens)}
           </span>
         ),
       },
@@ -1082,7 +1077,7 @@ function EmployeeCostTable({
         width: "1fr",
         render: (role) => (
           <span className="font-mono tabular-nums">
-            {formatTokens(role.totalOutputTokens)}
+            {formatCompact(role.totalOutputTokens)}
           </span>
         ),
       },
@@ -1147,7 +1142,7 @@ function EmployeeCostTable({
         width: "0.8fr",
         render: (user) => (
           <span className="font-mono tabular-nums">
-            {formatTokens(user.totalInputTokens)}
+            {formatCompact(user.totalInputTokens)}
           </span>
         ),
       },
@@ -1160,7 +1155,7 @@ function EmployeeCostTable({
         width: "0.8fr",
         render: (user) => (
           <span className="font-mono tabular-nums">
-            {formatTokens(user.totalOutputTokens)}
+            {formatCompact(user.totalOutputTokens)}
           </span>
         ),
       },
@@ -1174,7 +1169,7 @@ function EmployeeCostTable({
           <span
             className={cn("font-mono tabular-nums", !isCost && "font-semibold")}
           >
-            {formatTokens(user.totalTokens)}
+            {formatCompact(user.totalTokens)}
           </span>
         ),
       },

--- a/client/dashboard/src/lib/format.test.ts
+++ b/client/dashboard/src/lib/format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatCompact } from "./format";
+
+describe("formatCompact", () => {
+  it("passes through small numbers unchanged", () => {
+    expect(formatCompact(0)).toBe("0");
+    expect(formatCompact(42)).toBe("42");
+    expect(formatCompact(999)).toBe("999");
+  });
+
+  it("abbreviates thousands with K", () => {
+    expect(formatCompact(1_000)).toBe("1K");
+    expect(formatCompact(1_500)).toBe("1.5K");
+    expect(formatCompact(999_999)).toBe("1M"); // Intl rounds up
+  });
+
+  it("abbreviates millions with M", () => {
+    expect(formatCompact(1_000_000)).toBe("1M");
+    expect(formatCompact(2_300_000)).toBe("2.3M");
+  });
+
+  it("abbreviates billions with B", () => {
+    expect(formatCompact(1_000_000_000)).toBe("1B");
+    expect(formatCompact(1_100_000_000)).toBe("1.1B");
+  });
+
+  it("drops trailing zeros on round values", () => {
+    expect(formatCompact(1_000)).toBe("1K");
+    expect(formatCompact(10_000)).toBe("10K");
+    expect(formatCompact(1_000_000)).toBe("1M");
+  });
+
+  it("handles negative numbers", () => {
+    expect(formatCompact(-1_500)).toBe("-1.5K");
+    expect(formatCompact(-1_000_000)).toBe("-1M");
+  });
+});

--- a/client/dashboard/src/lib/format.ts
+++ b/client/dashboard/src/lib/format.ts
@@ -1,0 +1,8 @@
+const compactFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+export function formatCompact(value: number): string {
+  return compactFormatter.format(value);
+}

--- a/client/dashboard/src/pages/security/RiskOverviewCategoryDetail.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewCategoryDetail.tsx
@@ -205,7 +205,7 @@ function RiskOverviewCategoryDetailContent() {
               <MetricCard
                 title="Findings"
                 value={overviewCategory?.findings ?? totalCount}
-                format="number"
+                format="compact"
                 icon="flag"
               />
             </div>

--- a/client/dashboard/src/pages/security/RiskOverviewUserDetail.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewUserDetail.tsx
@@ -144,13 +144,13 @@ function RiskOverviewUserDetailContent() {
               <MetricCard
                 title="Findings"
                 value={userEntry?.findings ?? 0}
-                format="number"
+                format="compact"
                 icon="flag"
               />
               <MetricCard
                 title="Chat Sessions"
                 value={totalChats}
-                format="number"
+                format="compact"
                 icon="message-square"
               />
             </div>

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -390,7 +390,7 @@ function SecurityOverviewContent() {
             <MetricCard
               title="Events Scanned"
               value={overview?.messagesScanned ?? 0}
-              format="number"
+              format="compact"
               icon="scan-search"
             />
           )}
@@ -400,7 +400,7 @@ function SecurityOverviewContent() {
             <MetricCard
               title="Findings"
               value={overview?.findings ?? 0}
-              format="number"
+              format="compact"
               icon="flag"
             />
           )}
@@ -410,7 +410,7 @@ function SecurityOverviewContent() {
             <MetricCard
               title="Flagged Sessions"
               value={overview?.flaggedSessions ?? 0}
-              format="number"
+              format="compact"
               icon="message-square"
             />
           )}
@@ -420,7 +420,7 @@ function SecurityOverviewContent() {
             <MetricCard
               title="Active Policies"
               value={overview?.activePolicies ?? 0}
-              format="number"
+              format="compact"
               icon="shield-check"
             />
           )}


### PR DESCRIPTION
## Summary

- Add `formatCompact` util in `src/lib/format.ts` using `Intl.NumberFormat notation: "compact"` — produces `1.5K`, `2.3M`, `1.1B`; handles negatives and drops trailing zeros natively
- Add `"compact"` as new `MetricCard` format variant; change default from `"number"` to `"compact"` so all metric cards abbreviate by default; `"number"` preserved as `toLocaleString()` escape hatch
- Remove local `formatTokens` from `InsightsAgents.tsx` in favour of shared `formatCompact`; fix cost MetricCard that was incorrectly using `format="number"` → `format="currency"`

## Root cause

Metric cards passed large integers directly to `toLocaleString()`, producing unreadable values like `1,234,567`. There was no shared abbreviation utility — `InsightsAgents.tsx` had its own `formatTokens` using a manual K/M chain with `toFixed(1)`, which produced trailing zeros (`1.0K`) and missed billions.

## Test plan

- [x] Metric cards on Insights > Agents show abbreviated token counts (e.g. `1.5M` not `1,500,000`)
- [x] Total Cost MetricCard shows currency format (`$1.23`), not compact
- [x] Security Overview metric cards (Events Scanned, Findings, Flagged Sessions, Active Policies) show compact numbers
- [x] Small values (< 1000) still show exact (`42`, not `42.0`)
- [x] Round thousands drop trailing zero (`1K` not `1.0K`)