### PR TITLE
chore: remove elements process from madprocs config

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -40,10 +40,6 @@ procs:
     cmd: ["mise", "run", "start:dashboard"]
     stop:
       send-keys: ["<C-c>"]
-  elements:
-    cmd: ["mise", "run", "start:elements"]
-    stop:
-      send-keys: ["<C-c>"]
   lima:
     cmd: ["mise", "run", "start:lima"]
     stop:


### PR DESCRIPTION
## Summary

- Remove the `elements` process entry from `mprocs.yaml` so it no longer auto-starts in the madprocs dev dashboard

## Test plan

- [ ] Run `madprocs` and verify elements tab is gone
- [ ] Verify remaining processes still start correctly