### PR TITLE
chore: explictly disable sdk generation extras

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1150,7 +1150,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Regenerate SDK
-        run: mise run gen:sdk --skip-upload-spec
+        run: mise run gen:sdk
 
       # Prevent perpetual failure for code samples digest.
       - name: Restore .speakeasy/workflow.lock

--- a/.mise-tasks/gen/sdk.sh
+++ b/.mise-tasks/gen/sdk.sh
@@ -7,7 +7,7 @@
 set -e
 
 generate() {
-  speakeasy run --skip-versioning --skip-upload-spec
+  speakeasy run --skip-versioning --skip-upload-spec --minimal
 }
 
 check_inputs() {

--- a/.mise-tasks/gen/sdk.sh
+++ b/.mise-tasks/gen/sdk.sh
@@ -7,7 +7,7 @@
 set -e
 
 generate() {
-  speakeasy run --skip-versioning --skip-upload-spec "${args[@]}"
+  speakeasy run --skip-versioning --skip-upload-spec
 }
 
 check_inputs() {

--- a/.mise-tasks/gen/sdk.sh
+++ b/.mise-tasks/gen/sdk.sh
@@ -3,20 +3,11 @@
 #MISE description="Generate SDK from OpenAPI spec"
 
 #USAGE flag "-c --check" help="Check if the Gram-Internal OpenAPI output is up-to-date"
-#USAGE flag "-s --skip-versioning" help="Skip automatic SDK version increments"
-#USAGE flag "-u --skip-upload-spec" help="Skip uploading the spec to the Speakeasy registry"
 
 set -e
 
 generate() {
-  args=()
-  if [[ "${usage_skip_versioning:-}" == "true" ]]; then
-    args+=(--skip-versioning)
-  fi
-  if [[ "${usage_skip_upload_spec:-}" == "true" ]]; then
-    args+=(--skip-upload-spec)
-  fi
-  speakeasy run "${args[@]}"
+  speakeasy run --skip-versioning --skip-upload-spec "${args[@]}"
 }
 
 check_inputs() {

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -13,8 +13,6 @@ targets:
         sourceNamespace: gram-api-description
         sourceRevisionDigest: sha256:d9e283c3235fc106db59eca268cbfbd8cb4b914b410d3490bfc674e09dd577cf
         sourceBlobDigest: sha256:97af901c580d544725fc5f117b3123dba70bad3a791204ae27a57f9ff3394da5
-        codeSamplesNamespace: gram-api-description-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:6ef245bd50ee42edd50f8997905b9b772378cf38415fc6c7c6e2db279db933e6
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: pinned
@@ -25,8 +23,6 @@ workflow:
             overlays:
                 - location: overlays/goa.yaml
             output: .speakeasy/out.openapi.yaml
-            registry:
-                location: registry.speakeasyapi.dev/gram/gram/gram-api-description
         Gram-Public:
             inputs:
                 - location: server/gen/http/openapi3.yaml
@@ -41,9 +37,3 @@ workflow:
             target: typescript
             source: Gram-Internal
             output: client/sdk
-            codeSamples:
-                registry:
-                    location: registry.speakeasyapi.dev/gram/gram/gram-api-description-typescript-code-samples
-                labelOverride:
-                    fixedValue: Typescript (SDK)
-                blocking: false

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -7,8 +7,6 @@ sources:
         overlays:
             - location: overlays/goa.yaml
         output: .speakeasy/out.openapi.yaml
-        registry:
-            location: registry.speakeasyapi.dev/gram/gram/gram-api-description
     Gram-Public:
         inputs:
             - location: server/gen/http/openapi3.yaml
@@ -23,9 +21,3 @@ targets:
         target: typescript
         source: Gram-Internal
         output: client/sdk
-        codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/gram/gram/gram-api-description-typescript-code-samples
-            labelOverride:
-                fixedValue: Typescript (SDK)
-            blocking: false


### PR DESCRIPTION
This change updates the SDK generation task to disable versioning, uploading of openapi to registry and code sample generation. This is to speed up the task.