### PR TITLE
fix(security): optimizes unanalyzed messages query (INC-374)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2707,6 +2707,11 @@ CREATE TABLE IF NOT EXISTS risk_results (
 CREATE INDEX IF NOT EXISTS risk_results_project_policy_version_message_idx
 ON risk_results (project_id, risk_policy_id, risk_policy_version, chat_message_id);
 
+-- Leading chat_message_id gives the FetchUnanalyzedMessageIDs anti-join a
+-- selective first key (UUID), avoiding a full-policy scan per outer row.
+CREATE INDEX IF NOT EXISTS risk_results_message_policy_coverage_idx
+ON risk_results (chat_message_id, project_id, risk_policy_id, risk_policy_version);
+
 CREATE INDEX IF NOT EXISTS risk_results_project_chat_message_idx
 ON risk_results (project_id, chat_message_id);
 

--- a/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
+++ b/server/internal/background/activities/risk_analysis/fetch_unanalyzed.go
@@ -84,7 +84,7 @@ func (a *FetchUnanalyzed) Do(ctx context.Context, args FetchUnanalyzedArgs) (_ *
 	}
 
 	ids, err := queries.FetchUnanalyzedMessageIDs(ctx, repo.FetchUnanalyzedMessageIDsParams{
-		ProjectID:         uuid.NullUUID{UUID: args.ProjectID, Valid: true},
+		ProjectID:         args.ProjectID,
 		RiskPolicyID:      args.RiskPolicyID,
 		RiskPolicyVersion: policy.Version,
 		BatchLimit:        args.BatchLimit,

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -410,25 +410,27 @@ LEFT JOIN findings_by_bucket ON findings_by_bucket.bucket_start = buckets.bucket
 ORDER BY buckets.bucket_start ASC, categories.category ASC;
 
 -- name: FetchUnanalyzedMessageIDs :many
--- uuidv7 is k-sortable. The existing composite index
--- chat_messages_project_id_id_idx (project_id, id) lets Postgres satisfy
--- ORDER BY cm.id DESC with an Index Only Scan Backward, so we get
--- "most recent first" without a Sort node or any new index. Combined
--- with LIMIT this lets the planner stop scanning early when only the
--- recent tail is needed (verified via EXPLAIN ANALYZE: LIMIT 100 over a
--- 15k-message table scans ~2k rows in ~2ms).
+-- uuidv7 is k-sortable. chat_messages_project_id_id_idx (project_id, id)
+-- satisfies ORDER BY cm.id DESC via Index Only Scan Backward — no Sort node.
+-- The LATERAL LEFT JOIN forces a Nested Loop plan so the planner cannot choose
+-- a Hash Anti-Join that materialises all risk_results for the policy version.
+-- risk_results_message_policy_coverage_idx (chat_message_id, project_id,
+-- risk_policy_id, risk_policy_version) serves the inner probe: chat_message_id
+-- leads so selectivity is near-1, giving O(log n) per outer row and early
+-- termination as soon as LIMIT is satisfied.
 SELECT cm.id
 FROM chat_messages cm
+LEFT JOIN LATERAL (
+  SELECT 1 AS analyzed
+  FROM risk_results rr
+  WHERE rr.chat_message_id = cm.id
+    AND rr.project_id = @project_id
+    AND rr.risk_policy_id = @risk_policy_id
+    AND rr.risk_policy_version = @risk_policy_version
+  LIMIT 1
+) analyzed ON TRUE
 WHERE cm.project_id = @project_id
-  AND NOT EXISTS (
-    SELECT 1
-    FROM risk_results rr
-    WHERE rr.chat_message_id = cm.id
-      AND rr.project_id = @project_id
-      AND rr.risk_policy_id = @risk_policy_id
-      AND rr.risk_policy_version = @risk_policy_version
-    LIMIT 1
-  )
+  AND analyzed.analyzed IS NULL
 ORDER BY cm.id DESC
 LIMIT @batch_limit;
 

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -246,34 +246,36 @@ func (q *Queries) DeleteRiskResultsForMessages(ctx context.Context, arg DeleteRi
 const fetchUnanalyzedMessageIDs = `-- name: FetchUnanalyzedMessageIDs :many
 SELECT cm.id
 FROM chat_messages cm
+LEFT JOIN LATERAL (
+  SELECT 1 AS analyzed
+  FROM risk_results rr
+  WHERE rr.chat_message_id = cm.id
+    AND rr.project_id = $1
+    AND rr.risk_policy_id = $2
+    AND rr.risk_policy_version = $3
+  LIMIT 1
+) analyzed ON TRUE
 WHERE cm.project_id = $1
-  AND NOT EXISTS (
-    SELECT 1
-    FROM risk_results rr
-    WHERE rr.chat_message_id = cm.id
-      AND rr.project_id = $1
-      AND rr.risk_policy_id = $2
-      AND rr.risk_policy_version = $3
-    LIMIT 1
-  )
+  AND analyzed.analyzed IS NULL
 ORDER BY cm.id DESC
 LIMIT $4
 `
 
 type FetchUnanalyzedMessageIDsParams struct {
-	ProjectID         uuid.NullUUID
+	ProjectID         uuid.UUID
 	RiskPolicyID      uuid.UUID
 	RiskPolicyVersion int64
 	BatchLimit        int32
 }
 
-// uuidv7 is k-sortable. The existing composite index
-// chat_messages_project_id_id_idx (project_id, id) lets Postgres satisfy
-// ORDER BY cm.id DESC with an Index Only Scan Backward, so we get
-// "most recent first" without a Sort node or any new index. Combined
-// with LIMIT this lets the planner stop scanning early when only the
-// recent tail is needed (verified via EXPLAIN ANALYZE: LIMIT 100 over a
-// 15k-message table scans ~2k rows in ~2ms).
+// uuidv7 is k-sortable. chat_messages_project_id_id_idx (project_id, id)
+// satisfies ORDER BY cm.id DESC via Index Only Scan Backward — no Sort node.
+// The LATERAL LEFT JOIN forces a Nested Loop plan so the planner cannot choose
+// a Hash Anti-Join that materialises all risk_results for the policy version.
+// risk_results_message_policy_coverage_idx (chat_message_id, project_id,
+// risk_policy_id, risk_policy_version) serves the inner probe: chat_message_id
+// leads so selectivity is near-1, giving O(log n) per outer row and early
+// termination as soon as LIMIT is satisfied.
 func (q *Queries) FetchUnanalyzedMessageIDs(ctx context.Context, arg FetchUnanalyzedMessageIDsParams) ([]uuid.UUID, error) {
 	rows, err := q.db.Query(ctx, fetchUnanalyzedMessageIDs,
 		arg.ProjectID,

--- a/server/migrations/20260527110456_risk-results-add-message-policy-coverage-idx.sql
+++ b/server/migrations/20260527110456_risk-results-add-message-policy-coverage-idx.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "risk_results_message_policy_coverage_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_message_policy_coverage_idx" ON "risk_results" ("chat_message_id", "project_id", "risk_policy_id", "risk_policy_version");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GElRjM+zydzRJTPrs7OdFEJhGORGqV4PYerkXileU5U=
+h1:D8XdJpQNdkSvFjWSZy3IWrnN5AmColNprrL6c9rx8qg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -191,3 +191,4 @@ h1:GElRjM+zydzRJTPrs7OdFEJhGORGqV4PYerkXileU5U=
 20260526132630_add_custom_domain_provisioner_kind.sql h1:XoZWJ1F8RtKzAlz18m9242K03La7QV3hDlDRfWO5wQM=
 20260526164519_add-risk-policies-disabled-rules.sql h1:SmIuD/9RiaBWGHZBadLnVzwVdQ7x0riPTboR6+M0GLE=
 20260527093220_org-metadata-add-scim-sso-enabled.sql h1:Nq+Q4qTzQijE3X3vl2YDbZkq+8o0EHA0rA/5cFk0hlw=
+20260527110456_risk-results-add-message-policy-coverage-idx.sql h1:XlpEMZJbHkXeKA/VuV4BNjSIrCGTgMacyQE1KpiRp4g=


### PR DESCRIPTION
**Root cause:** The original NOT EXISTS query let the planner choose a Hash Anti-Join — it materialized all risk_results
  for the given policy/version into a hash table, then scanned all chat_messages. In production with millions of rows
  that hash build dominates.
<img width="1564" height="278" alt="Screenshot 2026-05-27 at 12 15 43" src="https://github.com/user-attachments/assets/3a51f3f7-76cd-435d-b8ab-76e0e654ce36" />

<img width="438" height="650" alt="Screenshot 2026-05-27 at 12 14 09" src="https://github.com/user-attachments/assets/e13b4247-f732-4a88-8654-4140507211b1" />

  **_Fix: two-part_**

  _Part 1_
  1. New index (migration 20260527110456):
  CREATE INDEX CONCURRENTLY risk_results_message_policy_coverage_idx
  ON risk_results (chat_message_id, project_id, risk_policy_id, risk_policy_version);
  
  _Part 2_
  1. Leading with chat_message_id (UUID, near-unique) means each inner probe hits ~1 row rather than all rows for a
  policy/version.
  2. Query rewrite — NOT EXISTS → LEFT JOIN LATERAL:
  LATERAL forces Nested Loop; the planner can't substitute a Hash Anti-Join. The resulting plan is:
    - Index Only Scan Backward on chat_messages_project_id_id_idx (ORDER BY without Sort)
    - Index Only Scan on the new index with all 4 columns as Index Cond (not a Join Filter)
    - LIMIT terminates as soon as 100 unanalyzed messages are found
  3. Caller fix in fetch_unanalyzed.go: removed the now-unnecessary uuid.NullUUID{...} wrapping since ProjectID is now
  uuid.UUID.