### PR TITLE
feat(risk): event-driven per-message risk analysis

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1037,7 +1037,8 @@ func newStartCommand() *cli.Command {
 				logger,
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
-			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, authzEngine, riskSignaler, completionsClient, shadowMCPClient, auditLogger, cache.NewRedisCacheAdapter(redisClient), c.String("pi-classifier-url") != "")
+			analyzeNewMsgSignaler := &background.TemporalAnalyzeNewMessageSignaler{TemporalEnv: temporalEnv, Logger: logger}
+			riskService := risk.NewService(logger, tracerProvider, db, sessionManager, authzEngine, riskSignaler, analyzeNewMsgSignaler, completionsClient, shadowMCPClient, auditLogger, cache.NewRedisCacheAdapter(redisClient), c.String("pi-classifier-url") != "")
 			chatWriter.AddObserver(riskService)
 			risk.Attach(mux, riskService)
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -541,7 +541,8 @@ func newWorkerCommand() *cli.Command {
 				logger,
 			)
 			shutdownFuncs = append(shutdownFuncs, riskSignaler.Shutdown)
-			chatWriter.AddObserver(risk.NewObserver(logger, tracerProvider, db, riskSignaler, auditLogger))
+			analyzeNewMsgSignaler := &background.TemporalAnalyzeNewMessageSignaler{TemporalEnv: temporalEnv, Logger: logger}
+			chatWriter.AddObserver(risk.NewObserver(logger, tracerProvider, db, riskSignaler, analyzeNewMsgSignaler, auditLogger))
 
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -2104,6 +2104,7 @@ func (s *ServiceCore) selfHealCorruptHistory(ctx context.Context, chatID uuid.UU
 	nextGen := currentGen + 1
 	empty := conv.ToPGTextEmpty("")
 	base := chatrepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "user",

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -76,6 +76,7 @@ type Activities struct {
 	analyzeSegment                  *resolution_activities.AnalyzeSegment
 	getUserFeedbackForChat          *resolution_activities.GetUserFeedbackForChat
 	fetchUnanalyzedMessages         *risk_analysis.FetchUnanalyzed
+	getRiskPolicyMetadata           *risk_analysis.GetRiskPolicyMetadata
 	analyzeBatch                    *risk_analysis.AnalyzeBatch
 	admitAssistantThreads           *activities.AdmitAssistantThreads
 	processAssistantThread          *activities.ProcessAssistantThread
@@ -167,6 +168,7 @@ func NewActivities(
 		analyzeSegment:                  resolution_activities.NewAnalyzeSegment(logger, db, chatClient, telemetryLogger),
 		getUserFeedbackForChat:          resolution_activities.NewGetUserFeedbackForChat(logger, db),
 		fetchUnanalyzedMessages:         risk_analysis.NewFetchUnanalyzed(logger, tracerProvider, db),
+		getRiskPolicyMetadata:           risk_analysis.NewGetRiskPolicyMetadata(logger, tracerProvider, db),
 		analyzeBatch:                    risk_analysis.NewAnalyzeBatch(logger, tracerProvider, meterProvider, db, piiScanner, piScanner, shadowMCPClient, telemetryrepo.New(chConn)),
 		admitAssistantThreads:           activities.NewAdmitAssistantThreads(assistantsCore),
 		processAssistantThread:          activities.NewProcessAssistantThread(assistantsCore),
@@ -358,6 +360,14 @@ func (a *Activities) FetchUnanalyzedMessages(ctx context.Context, input risk_ana
 	result, err := a.fetchUnanalyzedMessages.Do(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("fetch unanalyzed messages: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) GetRiskPolicyMetadata(ctx context.Context, input risk_analysis.GetRiskPolicyMetadataArgs) (*risk_analysis.GetRiskPolicyMetadataResult, error) {
+	result, err := a.getRiskPolicyMetadata.Do(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("get risk policy metadata: %w", err)
 	}
 	return result, nil
 }

--- a/server/internal/background/activities/risk_analysis/get_policy_metadata.go
+++ b/server/internal/background/activities/risk_analysis/get_policy_metadata.go
@@ -1,0 +1,83 @@
+package risk_analysis
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+// GetRiskPolicyMetadata loads the active fields of a risk policy needed to
+// drive AnalyzeBatch without re-fetching unanalyzed message IDs. The
+// event-driven workflow (AnalyzeNewMessageWorkflow) already knows which IDs
+// to process from its signal queue, so it only needs the policy's current
+// version and scanner configuration.
+type GetRiskPolicyMetadata struct {
+	logger *slog.Logger
+	tracer trace.Tracer
+	db     *pgxpool.Pool
+}
+
+func NewGetRiskPolicyMetadata(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool) *GetRiskPolicyMetadata {
+	return &GetRiskPolicyMetadata{
+		logger: logger,
+		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"),
+		db:     db,
+	}
+}
+
+type GetRiskPolicyMetadataArgs struct {
+	ProjectID    uuid.UUID
+	RiskPolicyID uuid.UUID
+}
+
+type GetRiskPolicyMetadataResult struct {
+	Enabled              bool
+	OrganizationID       string
+	PolicyVersion        int64
+	Sources              []string
+	PresidioEntities     []string
+	PromptInjectionRules []string
+}
+
+func (a *GetRiskPolicyMetadata) Do(ctx context.Context, args GetRiskPolicyMetadataArgs) (_ *GetRiskPolicyMetadataResult, err error) {
+	ctx, span := a.tracer.Start(ctx, "risk.getPolicyMetadata", trace.WithAttributes(
+		attribute.String("risk.project_id", args.ProjectID.String()),
+		attribute.String("risk.policy_id", args.RiskPolicyID.String()),
+	))
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	policy, err := repo.New(a.db).GetRiskPolicy(ctx, repo.GetRiskPolicyParams{
+		ID:        args.RiskPolicyID,
+		ProjectID: args.ProjectID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get risk policy: %w", err)
+	}
+
+	span.SetAttributes(
+		attribute.Int64("risk.policy_version", policy.Version),
+		attribute.Bool("risk.policy_enabled", policy.Enabled),
+	)
+
+	return &GetRiskPolicyMetadataResult{
+		Enabled:              policy.Enabled,
+		OrganizationID:       policy.OrganizationID,
+		PolicyVersion:        policy.Version,
+		Sources:              policy.Sources,
+		PresidioEntities:     policy.PresidioEntities,
+		PromptInjectionRules: policy.PromptInjectionRules,
+	}, nil
+}

--- a/server/internal/background/analyze_new_message.go
+++ b/server/internal/background/analyze_new_message.go
@@ -1,0 +1,184 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	SignalAnalyzeMessageRequested = "analyze-message-requested"
+
+	analyzeMessageBatchSize = 100
+)
+
+// AnalyzeNewMessageParams identifies the policy this workflow analyzes for.
+// Message IDs arrive via SignalAnalyzeMessageRequested rather than the
+// workflow params, so SignalWithStart can coalesce per-message signals onto
+// a single per-policy run.
+type AnalyzeNewMessageParams struct {
+	ProjectID    uuid.UUID
+	RiskPolicyID uuid.UUID
+}
+
+// AnalyzeMessageSignalPayload is delivered with SignalAnalyzeMessageRequested.
+// Each signal carries exactly one message ID; the workflow drains all queued
+// signals into a single batch before invoking AnalyzeBatch.
+type AnalyzeMessageSignalPayload struct {
+	MessageID uuid.UUID
+}
+
+// AnalyzeNewMessageWorkflow is the event-driven counterpart to
+// DrainRiskAnalysisWorkflow. The drain workflow exists for backfill triggered
+// by policy create/update and explicit user requests; this workflow is
+// signaled per newly-captured chat message and never scans the database for
+// unanalyzed work. It drains the signal channel into a batch, calls
+// AnalyzeBatch on the risk task queue, then loops if more signals arrived
+// during processing. With no pending signals at the end of a cycle the
+// workflow exits cleanly; the next signal restarts it via SignalWithStart.
+func AnalyzeNewMessageWorkflow(ctx workflow.Context, params AnalyzeNewMessageParams) error {
+	logger := workflow.GetLogger(ctx)
+	signalCh := workflow.GetSignalChannel(ctx, SignalAnalyzeMessageRequested)
+
+	activityOpts := workflow.ActivityOptions{
+		StartToCloseTimeout: 1 * time.Minute,
+		HeartbeatTimeout:    30 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    60 * time.Second,
+		},
+	}
+	metaCtx := workflow.WithActivityOptions(ctx, activityOpts)
+
+	analyzeBatchOpts := activityOpts
+	analyzeBatchOpts.TaskQueue = RiskAnalysisTaskQueue(tenv.TaskQueueName(workflow.GetInfo(ctx).TaskQueueName))
+	analyzeBatchOpts.StartToCloseTimeout = analyzeBatchStartToCloseTimeout
+	analyzeBatchOpts.HeartbeatTimeout = 60 * time.Second
+	analyzeBatchCtx := workflow.WithActivityOptions(ctx, analyzeBatchOpts)
+
+	var a *Activities
+
+	// Drain the start-of-run signal queue. SignalWithStart leaves the
+	// triggering signal in the channel so the first pass collects at
+	// least one ID; subsequent passes pick up signals that arrived while
+	// AnalyzeBatch was running.
+	pending := drainPendingMessageIDs(signalCh)
+	for len(pending) > 0 {
+		var meta risk_analysis.GetRiskPolicyMetadataResult
+		err := workflow.ExecuteActivity(metaCtx, a.GetRiskPolicyMetadata, risk_analysis.GetRiskPolicyMetadataArgs{
+			ProjectID:    params.ProjectID,
+			RiskPolicyID: params.RiskPolicyID,
+		}).Get(ctx, &meta)
+		if err != nil {
+			logger.Error("get risk policy metadata", "error", err.Error())
+			// Drop the in-flight IDs; the policy lookup itself failed so
+			// retrying with the same IDs would just fail again. The next
+			// signal will start a fresh run that can re-read the policy.
+			return nil
+		}
+		if !meta.Enabled {
+			// Drain any signals that piled up while we were checking so
+			// the next SignalWithStart starts a clean run.
+			drainPendingMessageIDs(signalCh)
+			return nil
+		}
+
+		for _, batch := range chunkUUIDs(pending, analyzeMessageBatchSize) {
+			err := workflow.ExecuteActivity(analyzeBatchCtx, a.AnalyzeBatch, risk_analysis.AnalyzeBatchArgs{
+				ProjectID:            params.ProjectID,
+				OrganizationID:       meta.OrganizationID,
+				RiskPolicyID:         params.RiskPolicyID,
+				PolicyVersion:        meta.PolicyVersion,
+				MessageIDs:           batch,
+				Sources:              meta.Sources,
+				PresidioEntities:     meta.PresidioEntities,
+				PromptInjectionRules: meta.PromptInjectionRules,
+			}).Get(ctx, nil)
+			if err != nil {
+				logger.Error("analyze batch failed", "error", err.Error())
+			}
+		}
+
+		pending = drainPendingMessageIDs(signalCh)
+	}
+
+	return nil
+}
+
+// drainPendingMessageIDs consumes all queued AnalyzeMessageSignalPayload
+// signals and returns the message IDs they carried. Nil-UUID payloads (an
+// uninitialized struct) are skipped so a malformed signal cannot poison the
+// batch.
+func drainPendingMessageIDs(ch workflow.ReceiveChannel) []uuid.UUID {
+	var out []uuid.UUID
+	for {
+		var payload AnalyzeMessageSignalPayload
+		if !ch.ReceiveAsync(&payload) {
+			return out
+		}
+		if payload.MessageID == uuid.Nil {
+			continue
+		}
+		out = append(out, payload.MessageID)
+	}
+}
+
+// AnalyzeNewMessageSignaler delivers per-message signals to the analyze
+// workflow. There is intentionally no throttling wrapper: every message must
+// reach the workflow or it will silently miss analysis.
+type AnalyzeNewMessageSignaler interface {
+	SignalNewMessage(ctx context.Context, params AnalyzeNewMessageParams, messageID uuid.UUID) error
+}
+
+type TemporalAnalyzeNewMessageSignaler struct {
+	TemporalEnv *tenv.Environment
+	Logger      *slog.Logger
+}
+
+func (s *TemporalAnalyzeNewMessageSignaler) SignalNewMessage(ctx context.Context, params AnalyzeNewMessageParams, messageID uuid.UUID) error {
+	if messageID == uuid.Nil {
+		return fmt.Errorf("signal analyze workflow: message ID is nil")
+	}
+
+	wfID := analyzeNewMessageWorkflowID(params.RiskPolicyID)
+
+	_, err := s.TemporalEnv.Client().SignalWithStartWorkflow(
+		ctx,
+		wfID,
+		SignalAnalyzeMessageRequested,
+		AnalyzeMessageSignalPayload{MessageID: messageID},
+		client.StartWorkflowOptions{
+			ID:                    wfID,
+			TaskQueue:             string(s.TemporalEnv.Queue()),
+			WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		},
+		AnalyzeNewMessageWorkflow,
+		params,
+	)
+	if err != nil {
+		return fmt.Errorf("signal-with-start analyze workflow: %w", err)
+	}
+
+	s.Logger.DebugContext(ctx, "temporal signal-with-start sent for analyze workflow",
+		attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+		attr.SlogTemporalWorkflowID(wfID),
+	)
+	return nil
+}
+
+func analyzeNewMessageWorkflowID(policyID uuid.UUID) string {
+	return fmt.Sprintf("v1:analyze-new-message:%s", policyID.String())
+}

--- a/server/internal/background/analyze_new_message_test.go
+++ b/server/internal/background/analyze_new_message_test.go
@@ -1,0 +1,245 @@
+package background
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+)
+
+func TestAnalyzeNewMessageWorkflowID(t *testing.T) {
+	t.Parallel()
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	wfID := analyzeNewMessageWorkflowID(id)
+	require.Equal(t, "v1:analyze-new-message:550e8400-e29b-41d4-a716-446655440000", wfID)
+}
+
+func TestAnalyzeNewMessageWorkflow_DrainsBatch(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	projectID := uuid.New()
+	policyID := uuid.New()
+
+	msgs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+
+	var (
+		mu              sync.Mutex
+		metaCallCount   int
+		analyzedBatches [][]uuid.UUID
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, args risk_analysis.GetRiskPolicyMetadataArgs) (*risk_analysis.GetRiskPolicyMetadataResult, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			metaCallCount++
+			require.Equal(t, projectID, args.ProjectID)
+			require.Equal(t, policyID, args.RiskPolicyID)
+			return &risk_analysis.GetRiskPolicyMetadataResult{
+				Enabled:        true,
+				OrganizationID: "org-1",
+				PolicyVersion:  7,
+			}, nil
+		},
+		activity.RegisterOptions{Name: "GetRiskPolicyMetadata"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, args risk_analysis.AnalyzeBatchArgs) (*risk_analysis.AnalyzeBatchResult, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			require.Equal(t, projectID, args.ProjectID)
+			require.Equal(t, policyID, args.RiskPolicyID)
+			require.Equal(t, int64(7), args.PolicyVersion)
+			batch := append([]uuid.UUID(nil), args.MessageIDs...)
+			analyzedBatches = append(analyzedBatches, batch)
+			return &risk_analysis.AnalyzeBatchResult{Processed: len(args.MessageIDs)}, nil
+		},
+		activity.RegisterOptions{Name: "AnalyzeBatch"},
+	)
+
+	env.RegisterDelayedCallback(func() {
+		for _, id := range msgs {
+			env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: id})
+		}
+	}, 0)
+
+	env.ExecuteWorkflow(AnalyzeNewMessageWorkflow, AnalyzeNewMessageParams{
+		ProjectID:    projectID,
+		RiskPolicyID: policyID,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, metaCallCount)
+	require.Len(t, analyzedBatches, 1)
+	require.ElementsMatch(t, msgs, analyzedBatches[0])
+}
+
+func TestAnalyzeNewMessageWorkflow_NoSignalsExits(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ risk_analysis.GetRiskPolicyMetadataArgs) (*risk_analysis.GetRiskPolicyMetadataResult, error) {
+			t.Fatal("GetRiskPolicyMetadata should not be called with no signals")
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "GetRiskPolicyMetadata"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ risk_analysis.AnalyzeBatchArgs) (*risk_analysis.AnalyzeBatchResult, error) {
+			t.Fatal("AnalyzeBatch should not be called with no signals")
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "AnalyzeBatch"},
+	)
+
+	env.ExecuteWorkflow(AnalyzeNewMessageWorkflow, AnalyzeNewMessageParams{
+		ProjectID:    uuid.New(),
+		RiskPolicyID: uuid.New(),
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}
+
+func TestAnalyzeNewMessageWorkflow_DisabledPolicyShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ risk_analysis.GetRiskPolicyMetadataArgs) (*risk_analysis.GetRiskPolicyMetadataResult, error) {
+			return &risk_analysis.GetRiskPolicyMetadataResult{Enabled: false}, nil
+		},
+		activity.RegisterOptions{Name: "GetRiskPolicyMetadata"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ risk_analysis.AnalyzeBatchArgs) (*risk_analysis.AnalyzeBatchResult, error) {
+			t.Fatal("AnalyzeBatch should not be called when policy is disabled")
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "AnalyzeBatch"},
+	)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: uuid.New()})
+		// A signal that arrives after the disabled check should be drained
+		// so the next SignalWithStart starts a clean run.
+		env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: uuid.New()})
+	}, 0)
+
+	env.ExecuteWorkflow(AnalyzeNewMessageWorkflow, AnalyzeNewMessageParams{
+		ProjectID:    uuid.New(),
+		RiskPolicyID: uuid.New(),
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}
+
+func TestAnalyzeNewMessageWorkflow_MidCycleSignalCausesSecondLoop(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	firstBatchMsg := uuid.New()
+	secondBatchMsg := uuid.New()
+
+	var (
+		mu              sync.Mutex
+		analyzedBatches [][]uuid.UUID
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ risk_analysis.GetRiskPolicyMetadataArgs) (*risk_analysis.GetRiskPolicyMetadataResult, error) {
+			return &risk_analysis.GetRiskPolicyMetadataResult{Enabled: true, PolicyVersion: 1}, nil
+		},
+		activity.RegisterOptions{Name: "GetRiskPolicyMetadata"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, args risk_analysis.AnalyzeBatchArgs) (*risk_analysis.AnalyzeBatchResult, error) {
+			mu.Lock()
+			batchIdx := len(analyzedBatches)
+			analyzedBatches = append(analyzedBatches, append([]uuid.UUID(nil), args.MessageIDs...))
+			mu.Unlock()
+			// Inject a fresh signal during the first analyze call to force
+			// the workflow into a second drain pass.
+			if batchIdx == 0 {
+				env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: secondBatchMsg})
+			}
+			return &risk_analysis.AnalyzeBatchResult{Processed: len(args.MessageIDs)}, nil
+		},
+		activity.RegisterOptions{Name: "AnalyzeBatch"},
+	)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: firstBatchMsg})
+	}, 0)
+
+	env.ExecuteWorkflow(AnalyzeNewMessageWorkflow, AnalyzeNewMessageParams{
+		ProjectID:    uuid.New(),
+		RiskPolicyID: uuid.New(),
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Len(t, analyzedBatches, 2)
+	require.ElementsMatch(t, []uuid.UUID{firstBatchMsg}, analyzedBatches[0])
+	require.ElementsMatch(t, []uuid.UUID{secondBatchMsg}, analyzedBatches[1])
+}
+
+func TestAnalyzeNewMessageWorkflow_NilUUIDSkipped(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	realMsg := uuid.New()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ risk_analysis.GetRiskPolicyMetadataArgs) (*risk_analysis.GetRiskPolicyMetadataResult, error) {
+			return &risk_analysis.GetRiskPolicyMetadataResult{Enabled: true}, nil
+		},
+		activity.RegisterOptions{Name: "GetRiskPolicyMetadata"},
+	)
+
+	var analyzedBatch []uuid.UUID
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, args risk_analysis.AnalyzeBatchArgs) (*risk_analysis.AnalyzeBatchResult, error) {
+			analyzedBatch = append([]uuid.UUID(nil), args.MessageIDs...)
+			return &risk_analysis.AnalyzeBatchResult{Processed: len(args.MessageIDs)}, nil
+		},
+		activity.RegisterOptions{Name: "AnalyzeBatch"},
+	)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: uuid.Nil})
+		env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: realMsg})
+		env.SignalWorkflow(SignalAnalyzeMessageRequested, AnalyzeMessageSignalPayload{MessageID: uuid.Nil})
+	}, 0)
+
+	env.ExecuteWorkflow(AnalyzeNewMessageWorkflow, AnalyzeNewMessageParams{
+		ProjectID:    uuid.New(),
+		RiskPolicyID: uuid.New(),
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, []uuid.UUID{realMsg}, analyzedBatch)
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -296,6 +296,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.MarkTriggerFired)
 	// Risk analysis activities — AnalyzeBatch on the dedicated worker.
 	temporalWorker.RegisterActivity(activities.FetchUnanalyzedMessages)
+	temporalWorker.RegisterActivity(activities.GetRiskPolicyMetadata)
 	riskWorker.RegisterActivity(activities.AnalyzeBatch)
 	// Assistant activities
 	temporalWorker.RegisterActivity(activities.AdmitAssistantThreads)
@@ -343,8 +344,9 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(TriggerCronWorkflow)
 	temporalWorker.RegisterWorkflow(TriggerDispatchWorkflow)
 	temporalWorker.RegisterWorkflow(TriggerWakeWorkflow)
-	// Risk analysis workflow
+	// Risk analysis workflows
 	temporalWorker.RegisterWorkflow(DrainRiskAnalysisWorkflow)
+	temporalWorker.RegisterWorkflow(AnalyzeNewMessageWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantCoordinatorWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantThreadWorkflow)
 	temporalWorker.RegisterWorkflow(AssistantReaperWorkflow)

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1153,9 +1153,9 @@ const (
 	maxConcurrentChatAssetWork = 32
 )
 
-func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, assetStorage assets.BlobStore, rows []chatMessageRow) error {
+func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, assetStorage assets.BlobStore, rows []chatMessageRow) ([]uuid.UUID, error) {
 	if len(rows) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// uploadResult holds the result of uploading a single message to asset storage.
@@ -1293,6 +1293,7 @@ func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, asset
 		}
 
 		dbrows[i] = repo.CreateChatMessageParams{
+			ID:               uuid.Nil,
 			ChatID:           row.chatID,
 			ProjectID:        row.projectID,
 			Role:             row.role,
@@ -1319,13 +1320,18 @@ func storeMessages(ctx context.Context, logger *slog.Logger, tx repo.DBTX, asset
 		}
 	}
 
+	ids, err := assignMessageIDs(dbrows)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to assign chat message ids").Log(ctx, logger)
+	}
+
 	// Batch insert all messages.
 	crepo := repo.New(tx)
 	if _, err := crepo.CreateChatMessage(ctx, dbrows); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to insert chat messages").Log(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to insert chat messages").Log(ctx, logger)
 	}
 
-	return nil
+	return ids, nil
 }
 
 // enrichChatsWithMetrics fetches token and cost metrics from ClickHouse and adds them to chat overviews.

--- a/server/internal/chat/message_capture_strategy.go
+++ b/server/internal/chat/message_capture_strategy.go
@@ -338,6 +338,7 @@ func buildAssistantRows(
 		content = ""
 	}
 	base := repo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           request.ChatID,
 		Role:             "assistant",
 		ProjectID:        projectID,

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -50,13 +50,19 @@ func (w *ChatMessageWriter) AddObserver(obs MessageObserver) {
 }
 
 // Write inserts messages via the pool and notifies observers on success.
+// Any params with a nil ID receive a freshly-generated UUIDv7 so downstream
+// observers always see the primary keys that were just persisted.
 func (w *ChatMessageWriter) Write(ctx context.Context, projectID uuid.UUID, params []repo.CreateChatMessageParams) (int64, error) {
+	ids, err := assignMessageIDs(params)
+	if err != nil {
+		return 0, fmt.Errorf("assign chat message ids: %w", err)
+	}
 	n, err := repo.New(w.db).CreateChatMessage(ctx, params)
 	if err != nil {
 		return 0, fmt.Errorf("create chat messages: %w", err)
 	}
 	if n > 0 {
-		w.notifyMessagesStored(ctx, projectID)
+		w.notifyMessagesStored(ctx, projectID, ids)
 	}
 	return n, nil
 }
@@ -77,10 +83,15 @@ func (w *ChatMessageWriter) WriteTurn(ctx context.Context, projectID uuid.UUID, 
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
-	if err := w.storeMessages(ctx, tx, pending); err != nil {
+	pendingIDs, err := w.storeMessages(ctx, tx, pending)
+	if err != nil {
 		return fmt.Errorf("store pending chat messages: %w", err)
 	}
 
+	assistantIDs, err := assignMessageIDs(assistants)
+	if err != nil {
+		return fmt.Errorf("assign assistant chat message ids: %w", err)
+	}
 	n, err := repo.New(tx).CreateChatMessage(ctx, assistants)
 	if err != nil {
 		return fmt.Errorf("store assistant chat messages: %w", err)
@@ -91,7 +102,10 @@ func (w *ChatMessageWriter) WriteTurn(ctx context.Context, projectID uuid.UUID, 
 	}
 
 	if int64(len(pending))+n > 0 {
-		w.notifyMessagesStored(ctx, projectID)
+		all := make([]uuid.UUID, 0, len(pendingIDs)+len(assistantIDs))
+		all = append(all, pendingIDs...)
+		all = append(all, assistantIDs...)
+		w.notifyMessagesStored(ctx, projectID, all)
 	}
 	return nil
 }
@@ -104,22 +118,24 @@ func (w *ChatMessageWriter) WriteWithAssets(ctx context.Context, projectID uuid.
 	if len(rows) == 0 {
 		return nil
 	}
-	if err := w.storeMessages(ctx, w.db, rows); err != nil {
+	ids, err := w.storeMessages(ctx, w.db, rows)
+	if err != nil {
 		return err
 	}
-	w.notifyMessagesStored(ctx, projectID)
+	w.notifyMessagesStored(ctx, projectID, ids)
 	return nil
 }
 
 // storeMessages uploads message content to asset storage in parallel, then
 // batch-inserts the messages via the given DBTX. Used by WriteWithAssets
-// (with the pool) and WriteTurn (with a transaction).
-func (w *ChatMessageWriter) storeMessages(ctx context.Context, tx repo.DBTX, rows []chatMessageRow) error {
+// (with the pool) and WriteTurn (with a transaction). Returns the IDs of the
+// inserted rows in the order they were written.
+func (w *ChatMessageWriter) storeMessages(ctx context.Context, tx repo.DBTX, rows []chatMessageRow) ([]uuid.UUID, error) {
 	return storeMessages(ctx, w.logger, tx, w.assetStorage, rows)
 }
 
 // notifyMessagesStored fires all registered observers asynchronously.
-func (w *ChatMessageWriter) notifyMessagesStored(ctx context.Context, projectID uuid.UUID) {
+func (w *ChatMessageWriter) notifyMessagesStored(ctx context.Context, projectID uuid.UUID, messageIDs []uuid.UUID) {
 	if w == nil || len(w.observers) == 0 {
 		return
 	}
@@ -135,7 +151,26 @@ func (w *ChatMessageWriter) notifyMessagesStored(ctx context.Context, projectID 
 		)
 
 		for _, obs := range w.observers {
-			obs.OnMessagesStored(ctx, projectID)
+			obs.OnMessagesStored(ctx, projectID, messageIDs)
 		}
 	}()
+}
+
+// assignMessageIDs walks params, generating a UUIDv7 for any row whose ID is
+// nil, and returns the resulting IDs in order. Time-ordered v7s preserve the
+// insertion ordering the chat_messages.id default (generate_uuidv7()) relies
+// on for replay determinism.
+func assignMessageIDs(params []repo.CreateChatMessageParams) ([]uuid.UUID, error) {
+	ids := make([]uuid.UUID, len(params))
+	for i := range params {
+		if params[i].ID == uuid.Nil {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return nil, fmt.Errorf("generate uuid v7: %w", err)
+			}
+			params[i].ID = id
+		}
+		ids[i] = params[i].ID
+	}
+	return ids, nil
 }

--- a/server/internal/chat/observer.go
+++ b/server/internal/chat/observer.go
@@ -6,8 +6,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// MessageObserver is notified when new chat messages are stored.
+// MessageObserver is notified when new chat messages are stored. The
+// messageIDs slice contains every ID just persisted, in insertion order, so
+// observers can route per-message work without re-querying the database.
 // Implementations must not block; heavy work should be dispatched asynchronously.
 type MessageObserver interface {
-	OnMessagesStored(ctx context.Context, projectID uuid.UUID)
+	OnMessagesStored(ctx context.Context, projectID uuid.UUID, messageIDs []uuid.UUID)
 }

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -34,7 +34,8 @@ RETURNING id;
 
 -- name: CreateChatMessage :copyfrom
 INSERT INTO chat_messages (
-    chat_id
+    id
+  , chat_id
   , role
   , project_id
   , content
@@ -59,7 +60,8 @@ INSERT INTO chat_messages (
   , generation
 )
 VALUES (
-    @chat_id
+    @id::uuid
+  , @chat_id
   , @role
   , @project_id::uuid
   , @content

--- a/server/internal/chat/repo/copyfrom.go
+++ b/server/internal/chat/repo/copyfrom.go
@@ -29,6 +29,7 @@ func (r *iteratorForCreateChatMessage) Next() bool {
 
 func (r iteratorForCreateChatMessage) Values() ([]interface{}, error) {
 	return []interface{}{
+		r.rows[0].ID,
 		r.rows[0].ChatID,
 		r.rows[0].Role,
 		r.rows[0].ProjectID,
@@ -60,5 +61,5 @@ func (r iteratorForCreateChatMessage) Err() error {
 }
 
 func (q *Queries) CreateChatMessage(ctx context.Context, arg []CreateChatMessageParams) (int64, error) {
-	return q.db.CopyFrom(ctx, []string{"chat_messages"}, []string{"chat_id", "role", "project_id", "content", "content_raw", "content_asset_url", "storage_error", "model", "message_id", "tool_call_id", "user_id", "external_user_id", "finish_reason", "tool_calls", "prompt_tokens", "completion_tokens", "total_tokens", "origin", "user_agent", "ip_address", "source", "content_hash", "generation"}, &iteratorForCreateChatMessage{rows: arg})
+	return q.db.CopyFrom(ctx, []string{"chat_messages"}, []string{"id", "chat_id", "role", "project_id", "content", "content_raw", "content_asset_url", "storage_error", "model", "message_id", "tool_call_id", "user_id", "external_user_id", "finish_reason", "tool_calls", "prompt_tokens", "completion_tokens", "total_tokens", "origin", "user_agent", "ip_address", "source", "content_hash", "generation"}, &iteratorForCreateChatMessage{rows: arg})
 }

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -209,6 +209,7 @@ func (q *Queries) CountChatsWithResolutions(ctx context.Context, arg CountChatsW
 }
 
 type CreateChatMessageParams struct {
+	ID               uuid.UUID
 	ChatID           uuid.UUID
 	Role             string
 	ProjectID        uuid.UUID

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -254,6 +254,7 @@ func (s *Service) writeCodexToolCallRequestToPG(ctx context.Context, payload *ge
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -299,6 +300,7 @@ func (s *Service) writeCodexToolCallResultToPG(ctx context.Context, payload *gen
 	chatID := sessionIDToUUID(metadata.SessionID)
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "tool",
@@ -345,6 +347,7 @@ func (s *Service) writeCodexUserPromptToPG(ctx context.Context, payload *gen.Cod
 	chatID := sessionIDToUUID(metadata.SessionID)
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "user",

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -574,6 +574,7 @@ func (s *Service) writeCursorToolCallRequestToPG(ctx context.Context, payload *g
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -636,6 +637,7 @@ func (s *Service) writeCursorToolCallResultToPG(ctx context.Context, payload *ge
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "tool",
@@ -683,6 +685,7 @@ func (s *Service) persistCursorAgentResponse(ctx context.Context, payload *gen.C
 	chatID := sessionIDToUUID(*payload.ConversationID)
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -746,6 +749,7 @@ func (s *Service) persistCursorUserPrompt(ctx context.Context, payload *gen.Curs
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        parsedProjectID,
 		Role:             "user",

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -269,6 +269,7 @@ func (s *Service) persistConversationEvent(ctx context.Context, payload *gen.Cla
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             role,
@@ -338,6 +339,7 @@ func (s *Service) writeToolCallRequestToPG(ctx context.Context, payload *gen.Cla
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "assistant",
@@ -389,6 +391,7 @@ func (s *Service) writeToolCallResultToPG(ctx context.Context, payload *gen.Clau
 	}
 
 	msgParams := chatRepo.CreateChatMessageParams{
+		ID:               uuid.Nil,
 		ChatID:           chatID,
 		ProjectID:        projectID,
 		Role:             "tool",

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -53,47 +53,58 @@ type RiskAnalysisSignaler interface {
 	SignalNewMessages(ctx context.Context, params background.DrainRiskAnalysisParams) error
 }
 
+// AnalyzeNewMessageSignaler delivers a per-message signal to the event-driven
+// analyze workflow. Indirected through this interface so tests can stub it.
+type AnalyzeNewMessageSignaler interface {
+	SignalNewMessage(ctx context.Context, params background.AnalyzeNewMessageParams, messageID uuid.UUID) error
+}
+
 type Service struct {
-	tracer           trace.Tracer
-	logger           *slog.Logger
-	db               *pgxpool.Pool
-	repo             *repo.Queries
-	auth             *auth.Auth
-	authz            *authz.Engine
-	signaler         RiskAnalysisSignaler
-	completionClient openrouter.CompletionClient
-	shadowMCPClient  *shadowmcp.Client
-	audit            *audit.Logger
-	cache            cache.Cache
-	piClassifier     bool
+	tracer                trace.Tracer
+	logger                *slog.Logger
+	db                    *pgxpool.Pool
+	repo                  *repo.Queries
+	auth                  *auth.Auth
+	authz                 *authz.Engine
+	signaler              RiskAnalysisSignaler
+	analyzeNewMsgSignaler AnalyzeNewMessageSignaler
+	completionClient      openrouter.CompletionClient
+	shadowMCPClient       *shadowmcp.Client
+	audit                 *audit.Logger
+	cache                 cache.Cache
+	piClassifier          bool
 }
 
 var _ chat.MessageObserver = (*Service)(nil)
 
-// NewObserver creates a lightweight chat.MessageObserver that signals the risk
-// drain workflow when new messages are stored. Use this in contexts (e.g. the
-// worker process) where the full risk Service is not needed.
+// NewObserver creates a lightweight chat.MessageObserver that signals the
+// event-driven analyze workflow per stored message. Use this in contexts
+// (e.g. the worker process) where the full risk Service is not needed. The
+// drain signaler stays available so explicit backfill paths (policy
+// create/update, manual retro) can still kick the drain workflow.
 func NewObserver(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
 	db *pgxpool.Pool,
 	signaler RiskAnalysisSignaler,
+	analyzeNewMsgSignaler AnalyzeNewMessageSignaler,
 	auditLogger *audit.Logger,
 ) chat.MessageObserver {
 	return &Service{
 		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
 
-		logger:           logger.With(attr.SlogComponent("risk")),
-		db:               db,
-		repo:             repo.New(db),
-		auth:             nil,
-		authz:            nil,
-		signaler:         signaler,
-		completionClient: nil,
-		shadowMCPClient:  nil,
-		audit:            auditLogger,
-		cache:            nil,
-		piClassifier:     false,
+		logger:                logger.With(attr.SlogComponent("risk")),
+		db:                    db,
+		repo:                  repo.New(db),
+		auth:                  nil,
+		authz:                 nil,
+		signaler:              signaler,
+		analyzeNewMsgSignaler: analyzeNewMsgSignaler,
+		completionClient:      nil,
+		shadowMCPClient:       nil,
+		audit:                 auditLogger,
+		cache:                 nil,
+		piClassifier:          false,
 	}
 }
 
@@ -104,6 +115,7 @@ func NewService(
 	sessions *sessions.Manager,
 	authzEngine *authz.Engine,
 	signaler RiskAnalysisSignaler,
+	analyzeNewMsgSignaler AnalyzeNewMessageSignaler,
 	completionClient openrouter.CompletionClient,
 	shadowMCPClient *shadowmcp.Client,
 	auditLogger *audit.Logger,
@@ -113,18 +125,19 @@ func NewService(
 	logger = logger.With(attr.SlogComponent("risk"))
 
 	return &Service{
-		tracer:           tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
-		logger:           logger,
-		db:               db,
-		repo:             repo.New(db),
-		auth:             auth.New(logger, db, sessions, authzEngine),
-		authz:            authzEngine,
-		signaler:         signaler,
-		completionClient: completionClient,
-		shadowMCPClient:  shadowMCPClient,
-		audit:            auditLogger,
-		cache:            redisCache,
-		piClassifier:     piClassifier,
+		tracer:                tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
+		logger:                logger,
+		db:                    db,
+		repo:                  repo.New(db),
+		auth:                  auth.New(logger, db, sessions, authzEngine),
+		authz:                 authzEngine,
+		signaler:              signaler,
+		analyzeNewMsgSignaler: analyzeNewMsgSignaler,
+		completionClient:      completionClient,
+		shadowMCPClient:       shadowMCPClient,
+		audit:                 auditLogger,
+		cache:                 redisCache,
+		piClassifier:          piClassifier,
 	}
 }
 
@@ -160,10 +173,21 @@ func (s *Service) GetRiskCapabilities(ctx context.Context, payload *gen.GetRiskC
 // OnMessagesStored implements chat.MessageObserver. The caller
 // (notifyObservers) already dispatches this in a goroutine with a
 // detached context, so this method can safely perform I/O.
-func (s *Service) OnMessagesStored(ctx context.Context, projectID uuid.UUID) {
+//
+// Each enabled policy gets one SignalWithStart per stored message. The
+// drain workflow is intentionally NOT signaled here; it remains reserved
+// for explicit backfill (policy create/update, manual retro trigger).
+func (s *Service) OnMessagesStored(ctx context.Context, projectID uuid.UUID, messageIDs []uuid.UUID) {
+	if len(messageIDs) == 0 {
+		return
+	}
+
 	policies, err := s.repo.ListEnabledRiskPoliciesByProject(ctx, projectID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "list enabled risk policies for observer", attr.SlogError(err))
+		return
+	}
+	if len(policies) == 0 {
 		return
 	}
 
@@ -172,25 +196,27 @@ func (s *Service) OnMessagesStored(ctx context.Context, projectID uuid.UUID) {
 		attr.SlogRiskPolicyCount(len(policies)),
 	)
 
-	// Each SignalNewMessages call round-trips to Temporal (~20ms),
-	// and this runs on the chat-message hot path. Fan out so total
-	// latency is the slowest signal, not the sum of all signals.
+	// Each SignalWithStartWorkflow round-trips to Temporal (~20 ms) and
+	// runs on the chat-message hot path. Fan out across (policy, message)
+	// so total latency is the slowest signal, not the sum.
 	var wg sync.WaitGroup
-	wg.Add(len(policies))
+	wg.Add(len(policies) * len(messageIDs))
 	for _, p := range policies {
-		go func(p repo.RiskPolicy) {
-			defer wg.Done()
-			if err := s.signaler.SignalNewMessages(ctx, background.DrainRiskAnalysisParams{
-				ProjectID:    p.ProjectID,
-				RiskPolicyID: p.ID,
-				MaxMessages:  background.DefaultRecentMessagesBudget,
-			}); err != nil {
-				s.logger.ErrorContext(ctx, "signal risk drain workflow",
-					attr.SlogError(err),
-					attr.SlogRiskPolicyID(p.ID.String()),
-				)
-			}
-		}(p)
+		params := background.AnalyzeNewMessageParams{
+			ProjectID:    p.ProjectID,
+			RiskPolicyID: p.ID,
+		}
+		for _, msgID := range messageIDs {
+			go func(params background.AnalyzeNewMessageParams, msgID uuid.UUID) {
+				defer wg.Done()
+				if err := s.analyzeNewMsgSignaler.SignalNewMessage(ctx, params, msgID); err != nil {
+					s.logger.ErrorContext(ctx, "signal analyze workflow",
+						attr.SlogError(err),
+						attr.SlogRiskPolicyID(params.RiskPolicyID.String()),
+					)
+				}
+			}(params, msgID)
+		}
 	}
 	wg.Wait()
 }

--- a/server/internal/risk/observer_test.go
+++ b/server/internal/risk/observer_test.go
@@ -36,12 +36,25 @@ func TestOnMessagesStored_SignalsEnabledPolicies(t *testing.T) {
 
 	// Reset signaler calls from create.
 	ti.signaler.calls = nil
+	ti.analyzeNewMsgSignaler.calls = nil
 
-	ti.service.OnMessagesStored(ctx, *authCtx.ProjectID)
+	msgA := uuid.New()
+	msgB := uuid.New()
+	ti.service.OnMessagesStored(ctx, *authCtx.ProjectID, []uuid.UUID{msgA, msgB})
 
-	// Only the enabled policy should have been signaled.
-	require.Len(t, ti.signaler.calls, 1)
-	require.Equal(t, *authCtx.ProjectID, ti.signaler.calls[0].ProjectID)
+	// Drain workflow is not signaled from the observer hot path.
+	require.Empty(t, ti.signaler.calls)
+
+	// One SignalNewMessage per (enabled policy, message ID). Disabled policy
+	// is filtered out before fan-out.
+	require.Len(t, ti.analyzeNewMsgSignaler.calls, 2)
+	seen := map[uuid.UUID]int{}
+	for _, c := range ti.analyzeNewMsgSignaler.calls {
+		require.Equal(t, *authCtx.ProjectID, c.Params.ProjectID)
+		seen[c.MessageID]++
+	}
+	require.Equal(t, 1, seen[msgA])
+	require.Equal(t, 1, seen[msgB])
 }
 
 func TestOnMessagesStored_NoPolicies(t *testing.T) {
@@ -49,7 +62,19 @@ func TestOnMessagesStored_NoPolicies(t *testing.T) {
 	ctx, ti := newTestRiskService(t)
 
 	// No policies created — should not signal anything.
-	ti.service.OnMessagesStored(ctx, uuid.New())
+	ti.service.OnMessagesStored(ctx, uuid.New(), []uuid.UUID{uuid.New()})
 
 	require.Empty(t, ti.signaler.calls)
+	require.Empty(t, ti.analyzeNewMsgSignaler.calls)
+}
+
+func TestOnMessagesStored_NoMessages(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	// Empty messageIDs slice short-circuits before policy lookup.
+	ti.service.OnMessagesStored(ctx, uuid.New(), nil)
+
+	require.Empty(t, ti.signaler.calls)
+	require.Empty(t, ti.analyzeNewMsgSignaler.calls)
 }

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -57,12 +57,27 @@ func (s *signalerStub) SignalNewMessages(_ context.Context, params background.Dr
 	return nil
 }
 
+type analyzeNewMsgSignalerCall struct {
+	Params    background.AnalyzeNewMessageParams
+	MessageID uuid.UUID
+}
+
+type analyzeNewMsgSignalerStub struct {
+	calls []analyzeNewMsgSignalerCall
+}
+
+func (s *analyzeNewMsgSignalerStub) SignalNewMessage(_ context.Context, params background.AnalyzeNewMessageParams, messageID uuid.UUID) error {
+	s.calls = append(s.calls, analyzeNewMsgSignalerCall{Params: params, MessageID: messageID})
+	return nil
+}
+
 type testInstance struct {
-	service        *risk.Service
-	conn           *pgxpool.Pool
-	sessionManager *sessions.Manager
-	signaler       *signalerStub
-	chatRepo       *chatrepo.Queries
+	service               *risk.Service
+	conn                  *pgxpool.Pool
+	sessionManager        *sessions.Manager
+	signaler              *signalerStub
+	analyzeNewMsgSignaler *analyzeNewMsgSignalerStub
+	chatRepo              *chatrepo.Queries
 }
 
 func newTestRiskService(t *testing.T) (context.Context, *testInstance) {
@@ -85,6 +100,7 @@ func newTestRiskService(t *testing.T) (context.Context, *testInstance) {
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
 	sig := &signalerStub{}
+	analyzeSig := &analyzeNewMsgSignalerStub{}
 
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
@@ -94,14 +110,15 @@ func newTestRiskService(t *testing.T) (context.Context, *testInstance) {
 	shadowMCPClient := shadowmcp.NewClient(logger, conn, cache.NewRedisCacheAdapter(redisClient))
 	auditLogger := audit.NewLogger()
 
-	svc := risk.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, sig, nil, shadowMCPClient, auditLogger, cache.NewRedisCacheAdapter(redisClient), false)
+	svc := risk.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, sig, analyzeSig, nil, shadowMCPClient, auditLogger, cache.NewRedisCacheAdapter(redisClient), false)
 
 	return ctx, &testInstance{
-		service:        svc,
-		conn:           conn,
-		sessionManager: sessionManager,
-		signaler:       sig,
-		chatRepo:       chatrepo.New(conn),
+		service:               svc,
+		conn:                  conn,
+		sessionManager:        sessionManager,
+		signaler:              sig,
+		analyzeNewMsgSignaler: analyzeSig,
+		chatRepo:              chatrepo.New(conn),
 	}
 }
 


### PR DESCRIPTION
## Why

The risk drain workflow was being signaled on every chat-message ingest. Each run paid for a `FetchUnanalyzedMessages` activity that re-scanned the DB even though the caller already knew exactly which messages had just been stored. The query is an anti-join across `chat_messages` × `risk_results` that scales with table size and is currently bleeding prod (INC-374). The drain workflow itself should be reserved for explicit backfill (policy create, policy update, manual retro), not the ingest hot path.

## What changed

### Before

- DB filled `chat_messages.id` via `DEFAULT generate_uuidv7()` inside a `:copyfrom`; the writer never saw the IDs.
- `MessageObserver.OnMessagesStored(ctx, projectID)` notified observers without IDs.
- `risk.Service.OnMessagesStored` signaled `DrainRiskAnalysisWorkflow` per enabled policy.
- Drain ran `FetchUnanalyzedMessages` (anti-join) on every ingest.

### After

- Chat writer generates `uuid.NewV7()` IDs in Go (`assignMessageIDs` helper) and includes them in the `:copyfrom` insert. Time-ordered v7s preserve the same insertion ordering the DB default relied on.
- `MessageObserver.OnMessagesStored(ctx, projectID, messageIDs []uuid.UUID)` — new signature carries the exact IDs in insertion order.
- New `AnalyzeNewMessageWorkflow` (`v1:analyze-new-message:<policyID>`):
  - Signal `analyze-message-requested` carries one `MessageID` per signal.
  - Drains the channel into a batch, loads policy metadata via a slim new `GetRiskPolicyMetadata` activity, invokes `AnalyzeBatch` on the dedicated risk task queue, then loops if more signals arrived mid-cycle.
  - Exits cleanly when the channel is empty; next signal restarts it via `SignalWithStart`.
- New `TemporalAnalyzeNewMessageSignaler` — no throttling, every message reaches the workflow.
- `risk.Service.OnMessagesStored` fans one signal per `(enabled policy, messageID)`. The drain workflow is no longer invoked from this path.
- `CreateRiskPolicy`, `UpdateRiskPolicy`, `TriggerRiskAnalysis` continue to call the throttled drain signaler for backfill.

## Test plan

- [x] `go build ./server/...`
- [x] `mise lint:server`
- [x] `mise go:tidy`
- [x] `go test ./server/internal/background/... ./server/internal/chat/... ./server/internal/risk/... ./server/internal/hooks/... ./server/internal/assistants/...`
- [x] New unit tests in `analyze_new_message_test.go`: batch drain, no-signal exit, disabled policy short-circuit + drain, mid-cycle signal causes a second loop, nil-UUID payload skipped.
- [x] Updated `observer_test.go` asserts one `SignalNewMessage` per `(enabled policy, messageID)` and no `SignalNewMessages` (drain) calls from the observer path.
- [ ] Local Temporal smoke: send a chat through the OpenRouter proxy, observe one `AnalyzeNewMessageWorkflow` per enabled policy on the Temporal dashboard, verify `risk_results` rows land and `DrainRiskAnalysisWorkflow` is not invoked on the ingest path.