### PR TITLE
fix(dashboard): keep risk overview visible when policies disabled but history exists

### DIFF
--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -318,14 +318,22 @@ function SecurityOverviewContent() {
     );
   }
 
+  const hasHistoricActivity =
+    (overview?.messagesScanned ?? 0) > 0 || (overview?.findings ?? 0) > 0;
+
   // Only collapse to the empty state once data has actually arrived —
   // during the first fetch we render the full shell with skeletons so the
-  // layout never blinks between "Loading…" and the real page.
-  if (overview && overview.activePolicies === 0) {
+  // layout never blinks between "Loading…" and the real page. Also keep the
+  // full overview visible whenever the selected range contains historic
+  // activity, so disabling every policy doesn't hide prior scans and
+  // findings.
+  if (overview && overview.activePolicies === 0 && !hasHistoricActivity) {
     return <NoPoliciesEmptyState />;
   }
 
   const hasFindings = (overview?.findings ?? 0) > 0;
+  const policiesDisabledWithHistory =
+    !!overview && overview.activePolicies === 0 && hasHistoricActivity;
 
   // Brief security-flavoured context for the AI Insights sidebar. Numbers are
   // pulled from the current risk overview query so the assistant can reason
@@ -383,6 +391,31 @@ function SecurityOverviewContent() {
         />
       )}
       <RiskOverviewShell rangeLabel={rangeLabel} controls={controls}>
+        {policiesDisabledWithHistory && (
+          <div className="bg-muted/30 flex items-start gap-3 rounded-lg border border-dashed px-4 py-3">
+            <Icon
+              name="circle-alert"
+              className="text-muted-foreground mt-0.5 size-4 shrink-0"
+            />
+            <div className="min-w-0 flex-1">
+              <Type small className="font-medium">
+                All risk policies are disabled
+              </Type>
+              <Type small muted>
+                Showing historic findings only — new chat messages will not be
+                scanned until a policy is re-enabled.
+              </Type>
+            </div>
+            <Button variant="secondary" size="sm" asChild>
+              <Link to={routes.policyCenter.href()}>
+                <Button.Text>Manage Policies</Button.Text>
+                <Button.RightIcon>
+                  <Icon name="arrow-right" />
+                </Button.RightIcon>
+              </Link>
+            </Button>
+          </div>
+        )}
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           {isOverviewLoading ? (
             <Skeleton className="h-[100px] rounded-lg" />


### PR DESCRIPTION
## Summary
- The risk overview short-circuited to the "Create a risk policy" empty state whenever `activePolicies === 0`, hiding the page entirely for users who toggle all their policies off.
- `activePolicies` (current configuration) and `findings`/`messagesScanned` (historic activity in range) have orthogonal lifecycles — disabling every policy shouldn't erase the view of prior scans.
- Only collapse to the empty state when there's truly nothing to show (zero active policies **and** no historic activity), and surface an inline banner when policies are disabled but historic data is still in range, so users know why no new findings are arriving.

Root cause: `client/dashboard/src/pages/security/SecurityOverview.tsx:324`.

## Test plan
- [ ] Project with active policies and findings — overview renders normally (no banner).
- [ ] Project with all policies disabled but historic findings in selected range — overview renders with metrics/charts and the "All risk policies are disabled" banner above the metric cards.
- [ ] Project with no active policies and no historic data — falls through to `NoPoliciesEmptyState` (unchanged behavior).
- [ ] Adjust the time range so historic findings fall outside it while policies remain disabled — empty state should re-engage (since the API returns 0 findings + 0 messages_scanned for that window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)