### PR TITLE
fix(dashboard): preserve Pylon chat history on refresh (AGE-2560)

### DIFF
--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -36,15 +36,6 @@ import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
 export default function App() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
 
-  // Initialize Pylon widget in production only
-  useEffect(() => {
-    if (import.meta.env.PROD) {
-      import("./lib/pylon").then((module) => {
-        module.initializePylon();
-      });
-    }
-  }, []);
-
   const applyTheme = (theme: "light" | "dark") => {
     const root = document.documentElement;
     if (root.classList.contains(theme)) return;

--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -6,6 +6,7 @@ import {
 import { SessionInfoResponse } from "@gram/client/models/operations";
 import { useSessionInfo } from "@gram/client/react-query";
 import { createContext, useContext, useEffect } from "react";
+import { initializePylon, PYLON_APP_ID } from "@/lib/pylon";
 
 // We don't include accountType here because it is actively confusing. See useProductTier
 type Session = Omit<
@@ -163,27 +164,29 @@ export const useIsAdmin = () => {
 
 export function usePylonInAppChat(user: User | undefined) {
   useEffect(() => {
-    if (!user) {
+    if (!user || !import.meta.env.PROD) {
       return;
     }
-    const random = Math.random().toString(36).substring(7) + "-anonymous";
     const email = user.email;
-    const displayName = user.displayName || random;
+    const displayName = user.displayName || email;
 
-    window.pylon = {
-      chat_settings: {
-        app_id: "f9cade16-8d3c-4826-9a2a-034fad495102",
-        email: email,
-        name: displayName,
-        avatar_url: user?.photoUrl,
-        ...(user?.signature && { email_hash: user.signature }),
-        hide_default_launcher: true,
-      },
+    const chatSettings = {
+      app_id: PYLON_APP_ID,
+      email,
+      name: displayName,
+      avatar_url: user.photoUrl,
+      // email_hash is the server-signed HMAC of the email — Pylon uses it
+      // to recognize the returning user and replay their thread history.
+      // Without it the visitor is treated as anonymous on every refresh.
+      ...(user.signature && { email_hash: user.signature }),
+      hide_default_launcher: true,
     };
 
-    if (window.Pylon) {
-      window.Pylon("setNewIssueCustomFields", { gram: true });
-    }
+    // Set chat_settings *before* the Pylon script is injected so the
+    // widget sees the identified user on first execution. initializePylon
+    // is idempotent; re-running it just refreshes chat_settings.
+    initializePylon(chatSettings);
+    window.Pylon?.("setNewIssueCustomFields", { gram: true });
 
     // This is for the marketing site
     localStorage.setItem("pylon_user_email", email);

--- a/client/dashboard/src/lib/pylon.ts
+++ b/client/dashboard/src/lib/pylon.ts
@@ -1,11 +1,26 @@
 /**
- * Pylon widget initialization
- * This module loads the Pylon chat widget script dynamically.
+ * Pylon widget initialization.
+ *
+ * Pylon's widget reads `window.pylon.chat_settings` once on script
+ * execution to associate the visitor with their persisted thread history.
+ * If chat_settings isn't present when the script runs, the visitor is
+ * treated as anonymous and starts a fresh thread on every load —
+ * which is why we must set chat_settings *before* injecting the script.
+ *
  * The default launcher bubble is hidden via CSS — chat is triggered
  * from the "Support" button in the header instead.
  */
 
-const PYLON_APP_ID = "f9cade16-8d3c-4826-9a2a-034fad495102";
+export const PYLON_APP_ID = "f9cade16-8d3c-4826-9a2a-034fad495102";
+
+export type PylonChatSettings = {
+  app_id: string;
+  email: string;
+  name: string;
+  avatar_url?: string;
+  email_hash?: string;
+  hide_default_launcher?: boolean;
+};
 
 declare global {
   interface Window {
@@ -14,29 +29,31 @@ declare global {
       e: (args: unknown) => void;
     };
     pylon?: {
-      chat_settings: {
-        app_id: string;
-        email: string;
-        name: string;
-        avatar_url?: string;
-        email_hash?: string;
-        hide_default_launcher?: boolean;
-      };
+      chat_settings: PylonChatSettings;
     };
   }
 }
 
+let initialized = false;
+
 /**
- * Initialize the Pylon widget by injecting the script tag
+ * Initialize the Pylon widget. Idempotent — subsequent calls update
+ * `window.pylon.chat_settings` so re-identification reflects the latest
+ * user data but never injects a second script tag.
  */
-export function initializePylon(): void {
-  // Hide the default Pylon chat bubble so it doesn't overlap the
-  // playground composer. Inject the style before the script loads.
+export function initializePylon(chatSettings: PylonChatSettings): void {
+  // Always keep chat_settings in sync with the latest user identity.
+  window.pylon = { chat_settings: chatSettings };
+
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+
   const style = document.createElement("style");
   style.textContent = `#pylon-chat-bubble { display: none !important; }`;
   document.head.appendChild(style);
 
-  // Set up the Pylon queue before the script loads
   const queue: unknown[] = [];
   const enqueue = (args: unknown) => {
     queue.push(args);
@@ -51,7 +68,6 @@ export function initializePylon(): void {
 
   window.Pylon = pylonFn;
 
-  // Load the Pylon script
   const script = document.createElement("script");
   script.setAttribute("type", "text/javascript");
   script.setAttribute("async", "true");


### PR DESCRIPTION
Fixes [AGE-2560](https://linear.app/speakeasy/issue/AGE-2560/bug-pylon-chat-threads-lose-history-on-refresh).

## Problem

Pylon chat threads lost their history on every page refresh. Customers signed in, sent messages, refreshed, and were dropped into a fresh anonymous thread.

## Root cause

Pylon's widget reads `window.pylon.chat_settings` **once on script execution** to identify the visitor. If `chat_settings` (in particular `email_hash`, the server-signed HMAC of the email) isn't set when the script runs, the widget initializes the visitor as anonymous — and anonymous visitors get a new thread on every load.

The dashboard injected the Pylon script eagerly in `App.tsx` on mount, but `chat_settings` was only written later by `usePylonInAppChat` in `AuthProvider` after `useSessionInfo` resolved. Under normal network conditions the script won the race, so users routinely refreshed into anonymous sessions.

## Fix

Make `initializePylon` accept `chat_settings` as an argument and write `window.pylon` **synchronously before** injecting the `<script>` tag. Drive it from `usePylonInAppChat` once the user is known, so the widget always sees the identified user on first execution.

- `lib/pylon.ts` — `initializePylon(chatSettings)` writes `window.pylon` first, then injects the script. Idempotent: re-running it refreshes `chat_settings` without re-injecting the script.
- `App.tsx` — drop the eager `initializePylon()` effect (no user available at App mount).
- `contexts/Auth.tsx` — `usePylonInAppChat` builds `chatSettings` from the resolved user and calls `initializePylon`. Production-gated (was previously gated in `App.tsx`).

Also dropped a throwaway random fallback `name` that changed on every refresh when `displayName` was empty — falls back to `email` instead, which is stable.

## Test plan

- [ ] Local dev: confirm Pylon is still silent (gated behind `import.meta.env.PROD`).
- [ ] Prod (preview): sign in, open Pylon, send a message, refresh, confirm thread history persists.
- [ ] Prod (preview): confirm the support button in the header still opens/closes the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
