### PR TITLE
feat(dashboard): org-level Device Agent install + MDM page

### DIFF
--- a/.changeset/device-agent-dashboard-page.md
+++ b/.changeset/device-agent-dashboard-page.md
@@ -1,0 +1,7 @@
+---
+"dashboard": minor
+---
+
+Add an org-level Device Agent page (`/<org>/device-agent`) under the Secure nav group: per-OS install instructions for the Speakeasy device agent, `managed.json` MDM configuration reference (schema, paths, example), and self-service `org_token` generation via the new `agent` API-key scope (mint/rotate from the page, with a ready-to-paste `managed.json` copied to the clipboard).
+
+Also patches the CLI loopback callback (`CliCallback.tsx`) to append `&email=<userEmail>` to the redirect, which the device agent's one-shot OAuth-loopback enrollment requires.

--- a/client/dashboard/src/components/code.tsx
+++ b/client/dashboard/src/components/code.tsx
@@ -2,12 +2,44 @@ import { cn } from "@/lib/utils";
 import { Button, Theme, useMoonshineConfig } from "@speakeasy-api/moonshine";
 import { Check, Copy } from "lucide-react";
 import React, { useEffect } from "react";
-import { BuiltinTheme, codeToHtml } from "shiki";
+import {
+  BuiltinTheme,
+  type BundledLanguage,
+  codeToHtml,
+  codeToTokens,
+  type ThemedToken,
+} from "shiki";
 
 const DEFAULT_THEME_PER_MODE: Record<Theme, BuiltinTheme> = {
   light: "github-light-default",
   dark: "github-dark-default",
 };
+
+/**
+ * A slot lets the caller host an interactive React node inline inside the
+ * highlighted code, in place of a sentinel string. Keyed by the exact token
+ * text shiki produces for the sentinel — for a JSON value that's the quoted
+ * form, e.g. `"\"__SLOT_orgToken__\""`. Used opt-in: passing `slots` switches
+ * CodeBlock to a token-rendered path (real React nodes) instead of the default
+ * dangerouslySetInnerHTML path, so existing usages are unaffected.
+ */
+export type CodeBlockSlot = {
+  /** React node rendered inline where the sentinel token was. */
+  node: React.ReactNode;
+  /** Text substituted for the sentinel when copying, so the clipboard stays
+   *  valid while the slot is unfilled. Defaults to "". */
+  copyText?: string;
+};
+
+// shiki FontStyle is a bitmask: Italic=1, Bold=2, Underline=4 (None=0/-1).
+function fontStyleProps(fs?: number): React.CSSProperties {
+  if (!fs || fs < 0) return {};
+  return {
+    fontStyle: fs & 1 ? "italic" : undefined,
+    fontWeight: fs & 2 ? "bold" : undefined,
+    textDecoration: fs & 4 ? "underline" : undefined,
+  };
+}
 
 export function CodeBlock({
   children: code,
@@ -17,6 +49,7 @@ export function CodeBlock({
   copyable = true,
   onCopy,
   preClassName,
+  slots,
 }: {
   children: string;
   language?: string;
@@ -25,15 +58,31 @@ export function CodeBlock({
   copyable?: boolean;
   onCopy?: () => void;
   preClassName?: string;
+  slots?: Record<string, CodeBlockSlot>;
 }) {
   const { theme } = useMoonshineConfig();
+  const hasSlots = !!slots && Object.keys(slots).length > 0;
   const [highlightedCode, setHighlightedCode] = React.useState<string | null>(
     null,
   );
+  const [tokenResult, setTokenResult] = React.useState<Awaited<
+    ReturnType<typeof codeToTokens>
+  > | null>(null);
   const [copied, setCopied] = React.useState(false);
 
+  // What the copy button actually writes: with slots, substitute each sentinel
+  // with its copyText so an unfilled inline action never leaks the sentinel.
+  const copyText = React.useMemo(() => {
+    if (!slots) return code;
+    let out = code;
+    for (const [sentinel, slot] of Object.entries(slots)) {
+      out = out.split(sentinel).join(slot.copyText ?? "");
+    }
+    return out;
+  }, [code, slots]);
+
   const handleCopy = () => {
-    navigator.clipboard.writeText(code);
+    navigator.clipboard.writeText(copyText);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
     onCopy?.();
@@ -41,39 +90,115 @@ export function CodeBlock({
 
   useEffect(() => {
     if (!language) return;
+    let cancelled = false;
 
-    codeToHtml(code, {
-      lang: language,
-      theme: DEFAULT_THEME_PER_MODE[theme],
-      transformers: [
-        {
-          pre(node) {
-            // the github shiki themes come with a pre-defined background color, we don't want that
-            node.properties.class = cn(
-              "!bg-transparent",
-              preClassName,
-              theme === "dark" ? "dark" : "light",
-            );
+    if (hasSlots) {
+      // codeToTokens types `lang` stricter than codeToHtml's loose string; the
+      // prop is a free-form string, so narrow it the same way callers expect.
+      codeToTokens(code, {
+        lang: language as BundledLanguage,
+        theme: DEFAULT_THEME_PER_MODE[theme],
+      }).then((res) => {
+        if (!cancelled) setTokenResult(res);
+      });
+    } else {
+      codeToHtml(code, {
+        lang: language,
+        theme: DEFAULT_THEME_PER_MODE[theme],
+        transformers: [
+          {
+            pre(node) {
+              // the github shiki themes come with a pre-defined background color, we don't want that
+              node.properties.class = cn(
+                "!bg-transparent",
+                preClassName,
+                theme === "dark" ? "dark" : "light",
+              );
+            },
           },
-        },
-      ],
-    }).then(setHighlightedCode);
-  }, [code, language, preClassName, theme]);
+        ],
+      }).then((html) => {
+        if (!cancelled) setHighlightedCode(html);
+      });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language, preClassName, theme, hasSlots]);
 
   const baseClasses =
     "rounded-md font-mono text-sm text-wrap overflow-x-auto border break-all whitespace-pre-wrap truncate";
+  const innerClasses = cn(baseClasses, "p-4 pr-12", innerClassName);
+  // Shown until the async highlight resolves (and as the slot-path placeholder).
+  const fallback = <div className={innerClasses}>{code}</div>;
+
+  // Token-rendered path: shiki tokens as real React nodes so a slot can host an
+  // interactive element inline. Mirrors shiki's <pre><code> structure so the
+  // visual matches the default path.
+  const renderTokens = (result: Awaited<ReturnType<typeof codeToTokens>>) => {
+    const lines = result.tokens as ThemedToken[][];
+    return (
+      <pre
+        className={cn(
+          "!bg-transparent break-all whitespace-pre-wrap",
+          preClassName,
+        )}
+        style={{ color: result.fg }}
+      >
+        <code>
+          {lines.map((line, li) => (
+            <React.Fragment key={li}>
+              {line.map((tok, ti) => {
+                // Match by substring rather than exact token text: the caller
+                // keys slots by a plain sentinel (e.g. "__SLOT_orgToken__") and
+                // shiki may wrap it (quotes, etc.) in the token it emits, so the
+                // page doesn't have to know shiki's exact tokenization.
+                const slotKey =
+                  slots &&
+                  Object.keys(slots).find((k) => tok.content.includes(k));
+                if (slotKey) {
+                  return (
+                    <React.Fragment key={ti}>
+                      {slots[slotKey].node}
+                    </React.Fragment>
+                  );
+                }
+                return (
+                  <span
+                    key={ti}
+                    style={{
+                      color: tok.color,
+                      ...fontStyleProps(tok.fontStyle),
+                    }}
+                  >
+                    {tok.content}
+                  </span>
+                );
+              })}
+              {li < lines.length - 1 ? "\n" : null}
+            </React.Fragment>
+          ))}
+        </code>
+      </pre>
+    );
+  };
 
   return (
     <div className={cn("group relative", className)}>
-      {highlightedCode ? (
+      {hasSlots ? (
+        tokenResult ? (
+          <div className={innerClasses}>{renderTokens(tokenResult)}</div>
+        ) : (
+          fallback
+        )
+      ) : highlightedCode ? (
         <div
-          className={cn(baseClasses, "p-4 pr-12", innerClassName)}
+          className={innerClasses}
           dangerouslySetInnerHTML={{ __html: highlightedCode ?? "" }}
         />
       ) : (
-        <div className={cn(baseClasses, "p-4 pr-12", innerClassName)}>
-          {code}
-        </div>
+        fallback
       )}
       {copyable && (
         <Button

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -69,6 +69,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const secureActive = [
     orgRoutes.auditLogs,
     orgRoutes.identity,
+    orgRoutes.deviceAgent,
     orgRoutes.access,
   ].some((r) => r.active);
 
@@ -90,6 +91,7 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     orgRoutes.adminSettings,
     orgRoutes.auditLogs,
     orgRoutes.identity,
+    orgRoutes.deviceAgent,
     orgRoutes.access,
   ];
   const activeRoute = allOrgNavRoutes.find((r) => r.active);
@@ -160,6 +162,10 @@ export function OrgSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               />
               <ScopeGatedNavItem
                 item={orgRoutes.identity}
+                scope={["org:read", "org:admin"]}
+              />
+              <ScopeGatedNavItem
+                item={orgRoutes.deviceAgent}
                 scope={["org:read", "org:admin"]}
               />
               {isRbacEnabled && (

--- a/client/dashboard/src/hooks/useAgentToken.ts
+++ b/client/dashboard/src/hooks/useAgentToken.ts
@@ -86,10 +86,17 @@ export function useAgentToken(opts: {
       // when this fires, and an empty snapshot would silently skip rotation,
       // leaving the old key(s) live. Exclude the key we just minted (data.id),
       // which the fresh list now includes, so we never revoke it.
-      const fresh = await queryClient.fetchQuery(buildListAPIKeysQuery(client));
-      const stale = (fresh.keys ?? []).filter(
+      let stale = (keysData?.keys ?? []).filter(
         (k) => k.id !== data.id && k.scopes.includes(AGENT_SCOPE),
       );
+      try {
+        const fresh = await queryClient.fetchQuery(buildListAPIKeysQuery(client));
+        stale = (fresh.keys ?? []).filter(
+          (k) => k.id !== data.id && k.scopes.includes(AGENT_SCOPE),
+        );
+      } catch {
+        // Fall back to cached keysData if the refresh fails.
+      }
       for (const k of stale) {
         revokeKeyMutation.mutate({
           security: { sessionHeaderGramSession: "" },

--- a/client/dashboard/src/hooks/useAgentToken.ts
+++ b/client/dashboard/src/hooks/useAgentToken.ts
@@ -1,6 +1,8 @@
 import { useRBAC } from "@/hooks/useRBAC";
 import { useCreateAPIKeyMutation } from "@gram/client/react-query/createAPIKey";
+import { useGramContext } from "@gram/client/react-query";
 import {
+  buildListAPIKeysQuery,
   invalidateListAPIKeys,
   useListAPIKeys,
 } from "@gram/client/react-query/listAPIKeys";
@@ -43,6 +45,7 @@ export function useAgentToken(opts: {
 }): UseAgentToken {
   const { buildCopyText } = opts;
   const queryClient = useQueryClient();
+  const client = useGramContext();
 
   // Gate on the org:admin *scope* (RBAC), matching the API Keys page. When RBAC
   // isn't enabled (local dev / non-enterprise) hasAnyScope returns true.
@@ -77,8 +80,15 @@ export function useAgentToken(opts: {
       // Rotation: now that a fresh key exists, revoke the prior agent key(s).
       // Revoking is a soft-delete; the partial unique index on (org, name) is
       // WHERE deleted IS FALSE, so it also frees their names.
-      const stale = (keysData?.keys ?? []).filter((k) =>
-        k.scopes.includes(AGENT_SCOPE),
+      //
+      // Fetch the authoritative list rather than trusting the component's
+      // cached keysData: that query may not have loaded (or may be mid-refetch)
+      // when this fires, and an empty snapshot would silently skip rotation,
+      // leaving the old key(s) live. Exclude the key we just minted (data.id),
+      // which the fresh list now includes, so we never revoke it.
+      const fresh = await queryClient.fetchQuery(buildListAPIKeysQuery(client));
+      const stale = (fresh.keys ?? []).filter(
+        (k) => k.id !== data.id && k.scopes.includes(AGENT_SCOPE),
       );
       for (const k of stale) {
         revokeKeyMutation.mutate({

--- a/client/dashboard/src/hooks/useAgentToken.ts
+++ b/client/dashboard/src/hooks/useAgentToken.ts
@@ -1,0 +1,121 @@
+import { useRBAC } from "@/hooks/useRBAC";
+import { useCreateAPIKeyMutation } from "@gram/client/react-query/createAPIKey";
+import {
+  invalidateListAPIKeys,
+  useListAPIKeys,
+} from "@gram/client/react-query/listAPIKeys";
+import { useRevokeAPIKeyMutation } from "@gram/client/react-query/revokeAPIKey";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+const AGENT_SCOPE = "agent";
+
+export type UseAgentToken = {
+  /** The secret minted this session, or null. Returned only once at creation. */
+  generatedToken: string | null;
+  /** Whether the post-generate clipboard write succeeded. */
+  autoCopied: boolean;
+  /** True while the create request is in flight. */
+  isPending: boolean;
+  /** True if the create request failed. */
+  isError: boolean;
+  /** Whether the caller may mint keys (requires the org:admin scope). */
+  canGenerate: boolean;
+  /** Whether an agent key already exists — so the action rotates, not creates. */
+  hasExistingAgentKey: boolean;
+  /** Mint a fresh agent key (rotating: revokes prior agent keys on success). */
+  generate: () => void;
+};
+
+/**
+ * useAgentToken mints — and rotates — the org's `agent`-scoped API key, i.e.
+ * the device agent's `org_token`. On a successful mint it best-effort copies a
+ * caller-built payload (e.g. a ready-to-paste managed.json) to the clipboard,
+ * then revokes any prior agent key(s). Create runs before revoke so a failed
+ * create never leaves the org without an agent key.
+ *
+ * Lives as a hook (rather than inline in the page) so the rotation invariant is
+ * testable in isolation and reusable by other surfaces that mint agent keys.
+ */
+export function useAgentToken(opts: {
+  /** Builds the text to copy once a token is minted (e.g. a managed.json). */
+  buildCopyText: (token: string) => string;
+}): UseAgentToken {
+  const { buildCopyText } = opts;
+  const queryClient = useQueryClient();
+
+  // Gate on the org:admin *scope* (RBAC), matching the API Keys page. When RBAC
+  // isn't enabled (local dev / non-enterprise) hasAnyScope returns true.
+  const { hasAnyScope } = useRBAC();
+  const canGenerate = hasAnyScope(["org:admin"]);
+
+  // Listing keys needs org:admin, so only fetch when the user can act on it.
+  const { data: keysData } = useListAPIKeys(undefined, undefined, {
+    enabled: canGenerate,
+  });
+  const hasExistingAgentKey = (keysData?.keys ?? []).some((k) =>
+    k.scopes.includes(AGENT_SCOPE),
+  );
+
+  const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [autoCopied, setAutoCopied] = useState(false);
+
+  const revokeKeyMutation = useRevokeAPIKeyMutation();
+  const createKeyMutation = useCreateAPIKeyMutation({
+    onSuccess: async (data) => {
+      if (!data.key) return;
+      setGeneratedToken(data.key);
+      // Best-effort: drop the payload straight onto the clipboard. Clipboard
+      // writes need transient user activation, which a slow request can outlive,
+      // so this may reject — the caller can still surface a manual copy path.
+      try {
+        await navigator.clipboard.writeText(buildCopyText(data.key));
+        setAutoCopied(true);
+      } catch {
+        setAutoCopied(false);
+      }
+      // Rotation: now that a fresh key exists, revoke the prior agent key(s).
+      // Revoking is a soft-delete; the partial unique index on (org, name) is
+      // WHERE deleted IS FALSE, so it also frees their names.
+      const stale = (keysData?.keys ?? []).filter((k) =>
+        k.scopes.includes(AGENT_SCOPE),
+      );
+      for (const k of stale) {
+        revokeKeyMutation.mutate({
+          security: { sessionHeaderGramSession: "" },
+          request: { id: k.id },
+        });
+      }
+      // Refresh the cached key list so it reflects the new key + revocations.
+      await invalidateListAPIKeys(queryClient, [{ gramSession: "" }]);
+    },
+  });
+
+  const generate = () => {
+    createKeyMutation.mutate({
+      security: { sessionHeaderGramSession: "" },
+      request: {
+        createKeyForm: {
+          // Unique per mint (to the second): the (org, name) unique index would
+          // otherwise reject a same-day re-create, and create runs before the
+          // old key is revoked.
+          name: `device-agent ${new Date()
+            .toISOString()
+            .slice(0, 19)
+            .replace("T", " ")}`,
+          scopes: [AGENT_SCOPE],
+        },
+      },
+    });
+  };
+
+  return {
+    generatedToken,
+    autoCopied,
+    isPending: createKeyMutation.isPending,
+    isError: createKeyMutation.isError,
+    canGenerate,
+    hasExistingAgentKey,
+    generate,
+  };
+}

--- a/client/dashboard/src/hooks/useAgentToken.ts
+++ b/client/dashboard/src/hooks/useAgentToken.ts
@@ -90,7 +90,9 @@ export function useAgentToken(opts: {
         (k) => k.id !== data.id && k.scopes.includes(AGENT_SCOPE),
       );
       try {
-        const fresh = await queryClient.fetchQuery(buildListAPIKeysQuery(client));
+        const fresh = await queryClient.fetchQuery(
+          buildListAPIKeysQuery(client),
+        );
         stale = (fresh.keys ?? []).filter(
           (k) => k.id !== data.id && k.scopes.includes(AGENT_SCOPE),
         );

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -57,7 +57,9 @@ export default function CliCallback(props: CliCallbackProps) {
     }
 
     createProducerKey(createKey, session.session)
-      .then((key) => transmitKey(localCallbackUrl, key, projectSlug))
+      .then((key) =>
+        transmitKey(localCallbackUrl, key, projectSlug, session.user.email),
+      )
       .catch((err) => {
         setError(
           err instanceof Error ? err.message : "Failed to create API key",
@@ -146,11 +148,15 @@ async function transmitKey(
   callbackUrl: string,
   apiKey: string,
   projectSlug: string | null,
+  userEmail: string,
 ): Promise<void> {
   const url = new URL(callbackUrl);
   url.searchParams.set("api_key", apiKey);
   if (projectSlug) {
     url.searchParams.set("project", projectSlug);
+  }
+  if (userEmail) {
+    url.searchParams.set("email", userEmail);
   }
 
   window.location.replace(url.toString());

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -756,21 +756,14 @@ export default function DeviceAgent() {
         <RequireScope scope={["org:read", "org:admin"]} level="page">
           <Page.Section>
             <Page.Section.Title stage="preview">
-              Device Agent
+              Install the agent
             </Page.Section.Title>
             <Page.Section.Description>
               The Speakeasy device agent runs on developer laptops and enforces
               your org's required AI-tool plugins and MCP configuration, then
-              reports compliance back to Speakeasy.
-            </Page.Section.Description>
-          </Page.Section>
-
-          <Page.Section>
-            <Page.Section.Title>Install the agent</Page.Section.Title>
-            <Page.Section.Description>
-              Download the daemon + CLI and register the background service. The
-              same steps work whether you run them by hand or script them in
-              your MDM deployment.
+              reports compliance back to Speakeasy. Download the daemon + CLI
+              and register the background service — the same steps work whether
+              you run them by hand or script them in your MDM deployment.
             </Page.Section.Description>
             <Page.Section.Body>
               <InstallAgent />

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -2,13 +2,16 @@ import { CodeBlock } from "@/components/code";
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
+import { Link as ExternalLink } from "@/components/ui/link";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
 import { useOrganization } from "@/contexts/Auth";
-import { useCreateAPIKeyMutation } from "@gram/client/react-query/createAPIKey";
+import { useAgentToken } from "@/hooks/useAgentToken";
+import { useOrgRoutes } from "@/routes";
 import { Button, Icon } from "@speakeasy-api/moonshine";
+import { useQuery } from "@tanstack/react-query";
 import React from "react";
+import { Link } from "react-router";
 
 // Public, unauthenticated bucket the release pipeline publishes to. The
 // manifest (releases.json) lists the current version + per-platform URLs;
@@ -16,6 +19,140 @@ import React from "react";
 const RELEASES_BASE =
   "https://storage.googleapis.com/speakeasy-device-agent-releases-prod";
 const MANIFEST_URL = `${RELEASES_BASE}/releases.json`;
+
+// Shared inline-link styling for the anchors/Links on this page.
+const LINK_CLASS = "underline underline-offset-2 hover:text-foreground";
+
+type ReleaseArtifact = {
+  goos: string;
+  goarch: string;
+  url: string;
+  sha256: string;
+  size: number;
+};
+type ReleaseBinary = { version: string; artifacts: ReleaseArtifact[] };
+type ReleasesManifest = { latest: Record<string, ReleaseBinary> };
+
+// useAgentReleases fetches the public release manifest so we can render direct
+// download links. A browser fetch (unlike the curl steps) needs CORS on the
+// bucket — enabled in gram-infra. When the fetch fails (CORS not yet deployed,
+// offline) DownloadAgent falls back to a link to the raw manifest.
+function useAgentReleases() {
+  return useQuery<ReleasesManifest>({
+    queryKey: ["device-agent-releases"],
+    queryFn: async () => {
+      const res = await fetch(MANIFEST_URL, {
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) throw new Error(`release manifest: HTTP ${res.status}`);
+      return res.json() as Promise<ReleasesManifest>;
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}
+
+const PLATFORM_LABELS: Record<string, string> = {
+  "darwin/arm64": "macOS · Apple Silicon",
+  "darwin/amd64": "macOS · Intel",
+  "windows/amd64": "Windows · x64",
+  "linux/amd64": "Linux · x64",
+  "linux/arm64": "Linux · arm64",
+};
+const platformKey = (a: { goos: string; goarch: string }) =>
+  `${a.goos}/${a.goarch}`;
+
+// DownloadAgent renders per-platform download links for the daemon + CLI from
+// the latest release manifest — what IT needs to bundle the binaries into an
+// MDM payload (or grab them directly). Degrades to a manifest link on failure.
+function DownloadAgent() {
+  const { data, isLoading, isError } = useAgentReleases();
+
+  if (isLoading) {
+    return (
+      <Type small muted>
+        Loading the latest release…
+      </Type>
+    );
+  }
+
+  const daemon = data?.latest["speakeasyd"];
+  const cli = data?.latest["speakeasy"];
+  if (isError || !daemon || !cli) {
+    return (
+      <Alert variant="warning">
+        <Icon name="triangle-alert" className="h-4 w-4" />
+        <AlertTitle>Couldn't load the latest release</AlertTitle>
+        <AlertDescription>
+          Open the{" "}
+          <ExternalLink to={MANIFEST_URL} external>
+            release manifest
+          </ExternalLink>{" "}
+          for the current version and per-platform download URLs.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  const artifactFor = (bin: ReleaseBinary, key: string) =>
+    bin.artifacts.find((a) => platformKey(a) === key);
+  const platforms = Array.from(new Set(daemon.artifacts.map(platformKey))).sort(
+    (a, b) => a.localeCompare(b),
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Type small muted>
+        Latest release: <code>v{daemon.version}</code>. Download both binaries
+        for every platform you target.
+      </Type>
+      <Table headers={["Platform", "Daemon (speakeasyd)", "CLI (speakeasy)"]}>
+        {platforms.map((key) => {
+          const d = artifactFor(daemon, key);
+          const c = artifactFor(cli, key);
+          return (
+            <tr key={key} className="border-t">
+              <td className="px-4 py-2">{PLATFORM_LABELS[key] ?? key}</td>
+              <td className="px-4 py-2">
+                {d ? (
+                  <a
+                    href={d.url}
+                    title={`sha256: ${d.sha256}`}
+                    className={LINK_CLASS}
+                  >
+                    speakeasyd
+                  </a>
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td className="px-4 py-2">
+                {c ? (
+                  <a
+                    href={c.url}
+                    title={`sha256: ${c.sha256}`}
+                    className={LINK_CLASS}
+                  >
+                    speakeasy
+                  </a>
+                ) : (
+                  "—"
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </Table>
+      <Type small muted>
+        Hover a link for its <code>sha256</code>, or read the full{" "}
+        <ExternalLink to={MANIFEST_URL} external>
+          manifest
+        </ExternalLink>
+        .
+      </Type>
+    </div>
+  );
+}
 
 function SubHeading({ children }: { children: React.ReactNode }) {
   return <Type className="mb-2 font-medium">{children}</Type>;
@@ -80,99 +217,113 @@ function SetupTab({
   );
 }
 
-function MacInstall() {
+// {bash,ps}VersionAssign return the shell line that sets VERSION for the
+// download snippets. When we've resolved the latest release from the manifest
+// we inline it (a concrete, copy-and-run value); otherwise we fall back to a
+// self-resolving one-liner so the snippet still works before the fetch lands
+// or if it fails.
+function bashVersionAssign(version: string | null) {
+  return version
+    ? `VERSION=${version}`
+    : `VERSION=$(curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version')`;
+}
+function psVersionAssign(version: string | null) {
+  return version
+    ? `$VERSION = "${version}"`
+    : `$VERSION = (Invoke-RestMethod ${MANIFEST_URL}).latest.speakeasyd.version`;
+}
+
+// SkipIfDownloadedNote tells users they can skip the download step if they've
+// already grabbed the binaries from the links above (e.g. to bundle them into
+// an MDM payload).
+function SkipIfDownloadedNote() {
+  return (
+    <StepNote>
+      Already downloaded the binaries from the links above (e.g. to bundle them
+      into your MDM payload)? Skip this step.
+    </StepNote>
+  );
+}
+
+function MacInstall({ version }: { version: string | null }) {
   return (
     <ol className="flex flex-col gap-5">
-      <Step n={1} title="Find the current version">
-        <StepNote>
-          The manifest lists the latest published version for each binary.
-        </StepNote>
-        <CodeBlock language="bash">{`curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version'`}</CodeBlock>
-      </Step>
-      <Step n={2} title="Download the daemon + CLI">
+      <Step n={1} title="Download the daemon + CLI">
+        <SkipIfDownloadedNote />
         <StepNote>
           Apple Silicon shown — swap <code>darwin_arm64</code> for{" "}
-          <code>darwin_amd64</code> on Intel. Replace <code>0.1.0</code> with
-          the version from step 1.
+          <code>darwin_amd64</code> on Intel.
         </StepNote>
-        <CodeBlock language="bash">{`VERSION=0.1.0
+        <CodeBlock language="bash">{`${bashVersionAssign(version)}
 BASE=${RELEASES_BASE}/v$VERSION
 curl -fSL -o speakeasyd "$BASE/speakeasyd_\${VERSION}_darwin_arm64"
 curl -fSL -o speakeasy  "$BASE/speakeasy_\${VERSION}_darwin_arm64"`}</CodeBlock>
       </Step>
-      <Step n={3} title="Make them executable and move into your PATH">
+      <Step n={2} title="Make them executable and move into your PATH">
         <CodeBlock language="bash">{`chmod +x speakeasyd speakeasy
 sudo mv speakeasyd speakeasy /usr/local/bin/`}</CodeBlock>
       </Step>
-      <Step n={4} title="Register and start the background service">
+      <Step n={3} title="Register and start the background service">
         <StepNote>
           Installs <code>speakeasyd</code> as a LaunchAgent so it runs on login.
         </StepNote>
         <CodeBlock language="bash">{`speakeasyd -service install
 speakeasyd -service start`}</CodeBlock>
       </Step>
-      <Step n={5} title="Verify it's running">
+      <Step n={4} title="Verify it's running">
         <CodeBlock language="bash">{`speakeasy status`}</CodeBlock>
       </Step>
     </ol>
   );
 }
 
-function WindowsInstall() {
+function WindowsInstall({ version }: { version: string | null }) {
   return (
     <ol className="flex flex-col gap-5">
-      <Step n={1} title="Find the current version">
-        <CodeBlock language="powershell">{`(Invoke-RestMethod ${MANIFEST_URL}).latest.speakeasyd.version`}</CodeBlock>
-      </Step>
-      <Step n={2} title="Download the daemon + CLI">
-        <StepNote>
-          Replace <code>0.1.0</code> with the version from step 1.
-        </StepNote>
-        <CodeBlock language="powershell">{`$VERSION = "0.1.0"
+      <Step n={1} title="Download the daemon + CLI">
+        <SkipIfDownloadedNote />
+        <CodeBlock language="powershell">{`${psVersionAssign(version)}
 $BASE = "${RELEASES_BASE}/v$VERSION"
 Invoke-WebRequest "$BASE/speakeasyd_\${VERSION}_windows_amd64.exe" -OutFile speakeasyd.exe
 Invoke-WebRequest "$BASE/speakeasy_\${VERSION}_windows_amd64.exe"  -OutFile speakeasy.exe`}</CodeBlock>
       </Step>
-      <Step n={3} title="Register and start the Windows service">
+      <Step n={2} title="Register and start the Windows service">
         <CodeBlock language="powershell">{`.\\speakeasyd.exe -service install
 .\\speakeasyd.exe -service start`}</CodeBlock>
       </Step>
-      <Step n={4} title="Verify it's running">
+      <Step n={3} title="Verify it's running">
         <CodeBlock language="powershell">{`.\\speakeasy.exe status`}</CodeBlock>
       </Step>
     </ol>
   );
 }
 
-function LinuxInstall() {
+function LinuxInstall({ version }: { version: string | null }) {
   return (
     <ol className="flex flex-col gap-5">
-      <Step n={1} title="Find the current version">
-        <CodeBlock language="bash">{`curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version'`}</CodeBlock>
-      </Step>
-      <Step n={2} title="Download the daemon + CLI">
+      <Step n={1} title="Download the daemon + CLI">
+        <SkipIfDownloadedNote />
         <StepNote>
           amd64 shown — swap <code>linux_amd64</code> for{" "}
-          <code>linux_arm64</code> on ARM. Replace <code>0.1.0</code> with the
-          version from step 1.
+          <code>linux_arm64</code> on ARM.
         </StepNote>
-        <CodeBlock language="bash">{`VERSION=0.1.0
+        <CodeBlock language="bash">{`${bashVersionAssign(version)}
 BASE=${RELEASES_BASE}/v$VERSION
 curl -fSL -o speakeasyd "$BASE/speakeasyd_\${VERSION}_linux_amd64"
 curl -fSL -o speakeasy  "$BASE/speakeasy_\${VERSION}_linux_amd64"`}</CodeBlock>
       </Step>
-      <Step n={3} title="Make them executable and move into your PATH">
+      <Step n={2} title="Make them executable and move into your PATH">
         <CodeBlock language="bash">{`chmod +x speakeasyd speakeasy
 sudo mv speakeasyd speakeasy /usr/local/bin/`}</CodeBlock>
       </Step>
-      <Step n={4} title="Register and start the background service">
+      <Step n={3} title="Register and start the background service">
         <StepNote>
           Installs <code>speakeasyd</code> as a systemd service.
         </StepNote>
         <CodeBlock language="bash">{`speakeasyd -service install
 speakeasyd -service start`}</CodeBlock>
       </Step>
-      <Step n={5} title="Verify it's running">
+      <Step n={4} title="Verify it's running">
         <CodeBlock language="bash">{`speakeasy status`}</CodeBlock>
       </Step>
     </ol>
@@ -258,94 +409,199 @@ function Table({
   );
 }
 
-function ManualSetup() {
+// InstallAgent is the shared install path: download the binaries and register
+// the background service. The same steps work whether you run them by hand
+// (personal) or script them in an MDM postinstall (fleet) — only identity
+// differs afterward (see the "Set the user's identity" section).
+function InstallAgent() {
+  // Resolve the latest version once and inline it into the per-OS download
+  // commands; the same value powers DownloadAgent's links. Null while loading
+  // or if the fetch fails — the snippets fall back to a self-resolving line.
+  const { data } = useAgentReleases();
+  const version = data?.latest["speakeasyd"]?.version ?? null;
+
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-6">
       <Type muted>
         The agent is two binaries: <code>speakeasyd</code>, the background
         daemon that does the enforcement, and <code>speakeasy</code>, the CLI
-        you use to check status and enroll. Pick your platform.
+        for status and enrollment. The steps are the same for everyone — run
+        them by hand for a personal setup, or script them in your MDM payload's
+        postinstall (run them in the logged-in user's context, since the agent
+        runs as that user).
+        {version ? (
+          <>
+            {" "}
+            The commands pull the latest release (<code>v{version}</code>).
+          </>
+        ) : null}
       </Type>
-      <Tabs defaultValue="macos">
-        <TabsList className="grid w-full max-w-md grid-cols-3">
-          <TabsTrigger value="macos">macOS</TabsTrigger>
-          <TabsTrigger value="windows">Windows</TabsTrigger>
-          <TabsTrigger value="linux">Linux</TabsTrigger>
-        </TabsList>
-        <TabsContent value="macos" className="pt-4">
-          <MacInstall />
-        </TabsContent>
-        <TabsContent value="windows" className="pt-4">
-          <WindowsInstall />
-        </TabsContent>
-        <TabsContent value="linux" className="pt-4">
-          <LinuxInstall />
-        </TabsContent>
-      </Tabs>
-      <Alert variant="info" className="mt-2">
-        <Icon name="info" className="h-4 w-4" />
-        <AlertTitle>Enrolling a personal install</AlertTitle>
-        <AlertDescription>
-          On a device <em>not</em> managed by MDM, sign in with{" "}
-          <code>speakeasy enroll</code> — it opens a browser, you sign in, and
-          the agent stores your email locally. MDM-managed devices skip this;
-          their identity comes from <code>managed.json</code>.
-        </AlertDescription>
-      </Alert>
+
+      <div>
+        <SubHeading>Download</SubHeading>
+        <Type small muted className="mb-3">
+          The install commands below fetch these for you. Grab them directly if
+          you'd rather bundle the binaries into your MDM payload (
+          <code>sha256</code> is available for each binary for verification
+          purposes).
+        </Type>
+        <DownloadAgent />
+      </div>
+
+      <div>
+        <SubHeading>Install and register the service</SubHeading>
+        <Tabs defaultValue="macos" className="mt-2">
+          <TabsList className="grid w-full max-w-md grid-cols-3">
+            <TabsTrigger value="macos">macOS</TabsTrigger>
+            <TabsTrigger value="windows">Windows</TabsTrigger>
+            <TabsTrigger value="linux">Linux</TabsTrigger>
+          </TabsList>
+          <TabsContent value="macos" className="pt-4">
+            <MacInstall version={version} />
+          </TabsContent>
+          <TabsContent value="windows" className="pt-4">
+            <WindowsInstall version={version} />
+          </TabsContent>
+          <TabsContent value="linux" className="pt-4">
+            <LinuxInstall version={version} />
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   );
 }
 
-function FleetSetup() {
-  const { name: orgName, slug: orgSlug } = useOrganization();
-  const [generatedToken, setGeneratedToken] = React.useState<string | null>(
-    null,
+// ManualIdentity is the personal/PoC identity path: sign in once with the CLI.
+function ManualIdentity() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Type muted>
+        On a device that isn't MDM-managed, set identity by signing in once
+        after installing — no <code>managed.json</code> required.
+      </Type>
+      <CodeBlock language="bash">{`speakeasy enroll`}</CodeBlock>
+      <Type small muted>
+        It opens a browser, you sign in, and the agent stores your email locally
+        in <code>local.json</code>. If IT later pushes a{" "}
+        <code>managed.json</code>, that takes precedence.
+      </Type>
+    </div>
   );
+}
 
-  const createKeyMutation = useCreateAPIKeyMutation({
-    onSuccess: (data) => {
-      if (data.key) setGeneratedToken(data.key);
-    },
-  });
+// Sentinel JSON value for org_token until one is generated. CodeBlock matches
+// the token shiki emits for this value and swaps it for an inline "Generate"
+// button (see the slots wiring in FleetIdentity).
+const ORG_TOKEN_SENTINEL = "__SLOT_orgToken__";
+
+// GenerateInlineButton is a compact button sized to sit inline in the code, in
+// place of the org_token value.
+function GenerateInlineButton({
+  onClick,
+  pending,
+  disabled,
+  existing,
+}: {
+  onClick: () => void;
+  pending: boolean;
+  disabled?: boolean;
+  existing: boolean;
+}) {
+  const label = existing ? "Rotate token" : "Generate token";
+  const pendingLabel = existing ? "Rotating…" : "Generating…";
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={onClick}
+      disabled={pending || disabled}
+      title={
+        disabled
+          ? "Generating an agent token requires the org:admin role."
+          : existing
+            ? "An agent token already exists — this mints a fresh one to drop into managed.json."
+            : undefined
+      }
+      className="-my-1 inline-flex h-6 items-center px-2 py-0 align-middle text-xs"
+    >
+      <Button.LeftIcon>
+        <Icon name="key-round" className="h-3 w-3" />
+      </Button.LeftIcon>
+      <Button.Text>{pending ? pendingLabel : label}</Button.Text>
+    </Button>
+  );
+}
+
+// FleetIdentity is the MDM identity path: deploy a managed.json so IT sets
+// identity centrally. Includes inline org_token generation/rotation.
+function FleetIdentity() {
+  const { name: orgName, slug: orgSlug } = useOrganization();
+  const apiKeysHref = useOrgRoutes().apiKeys.href();
 
   // org_slug / org_name are org-level constants, safe to prefill. email is
   // per-user: this fleet-wide file must not pin one identity, so the example
   // shows an MDM substitution placeholder ($EMAIL) rather than the viewing
   // admin's address — the MDM swaps it per device, or it's omitted and the user
-  // enrolls manually. org_token is an `agent`-scoped API key; once generated we
-  // splice it in so the whole managed.json is copy-ready (it's returned once).
-  const exampleManagedJson = JSON.stringify(
-    {
-      v: 1,
-      email: "$EMAIL",
-      org_token: generatedToken ?? "spk_org_REPLACE_ME",
-      org_slug: orgSlug || "acme-corp",
-      org_name: orgName || "Acme Corporation",
-      auto_update: "notify",
-    },
-    null,
-    2,
+  // enrolls manually.
+  const buildManagedJson = (orgToken: string) =>
+    JSON.stringify(
+      {
+        v: 1,
+        email: "$EMAIL",
+        org_token: orgToken,
+        org_slug: orgSlug || "acme-corp",
+        org_name: orgName || "Acme Corporation",
+        auto_update: "notify",
+      },
+      null,
+      2,
+    );
+
+  // Mint/rotate the org_token (an agent-scoped key) and copy the ready-to-paste
+  // managed.json on success. See useAgentToken for the create→revoke ordering.
+  const {
+    generatedToken,
+    autoCopied,
+    isPending,
+    isError,
+    canGenerate,
+    hasExistingAgentKey,
+    generate,
+  } = useAgentToken({ buildCopyText: buildManagedJson });
+
+  // org_token starts as a sentinel that CodeBlock renders as an inline
+  // "generate" button; once minted we splice the real key in (returned once).
+  const exampleManagedJson = buildManagedJson(
+    generatedToken ?? ORG_TOKEN_SENTINEL,
   );
 
-  const handleGenerate = () => {
-    createKeyMutation.mutate({
-      security: { sessionHeaderGramSession: "" },
-      request: {
-        createKeyForm: {
-          name: `device-agent ${new Date().toISOString().slice(0, 10)}`,
-          scopes: ["agent"],
+  // Host the inline action only while no token exists. CodeBlock matches the
+  // sentinel as a substring of whatever token shiki emits (it ends up quoted as
+  // a JSON value), so we key by the bare sentinel; copyText keeps a
+  // copied-but-ungenerated file valid.
+  const slots = generatedToken
+    ? undefined
+    : {
+        [ORG_TOKEN_SENTINEL]: {
+          node: (
+            <GenerateInlineButton
+              onClick={generate}
+              pending={isPending}
+              disabled={!canGenerate}
+              existing={hasExistingAgentKey}
+            />
+          ),
+          copyText: "spk_org_REPLACE_ME",
         },
-      },
-    });
-  };
+      };
 
   return (
     <div className="flex flex-col gap-8">
       <Type muted>
-        IT provisions a <code>managed.json</code> file via your MDM (Kandji,
-        Jamf, Intune, …) and deploys the agent binaries alongside it. The agent
-        reads the file at startup and applies the identity automatically — no
-        per-user enrollment on the device.
+        On an MDM-managed device the agent reads its identity from a{" "}
+        <code>managed.json</code> that IT deploys (Kandji, Jamf, Intune, …) — no
+        per-user enrollment. IT owns this file; the agent only reads it, and it
+        wins over anything a user sets locally.
       </Type>
 
       <div>
@@ -405,93 +661,59 @@ function FleetSetup() {
 
       <div>
         <SubHeading>Example managed.json</SubHeading>
-        <CodeBlock language="json">{exampleManagedJson}</CodeBlock>
+        <CodeBlock language="json" slots={slots}>
+          {exampleManagedJson}
+        </CodeBlock>
         <Type small muted className="mt-2">
           <code>org_slug</code> and <code>org_name</code> are pre-filled for
           this org. <code>email</code> is per-user — have your MDM substitute
           its per-user email variable (Kandji / Jamf <code>$EMAIL</code>, or
           your platform's equivalent) so one profile serves the whole fleet, or
           omit <code>email</code> and have each user run{" "}
-          <code>speakeasy enroll</code>. Generate the <code>org_token</code>{" "}
-          below.
+          <code>speakeasy enroll</code>. Click{" "}
+          <strong className="text-foreground">Generate token</strong> in the
+          example to mint the <code>org_token</code>.
         </Type>
 
         <div className="mt-4 flex flex-col gap-3">
-          <RequireScope
-            scope="org:admin"
-            level="component"
-            reason="Generating an agent token requires the org:admin role."
-          >
-            <Button
-              onClick={handleGenerate}
-              disabled={createKeyMutation.isPending}
-            >
-              <Button.LeftIcon>
-                <Icon name="key-round" className="h-4 w-4" />
-              </Button.LeftIcon>
-              <Button.Text>
-                {createKeyMutation.isPending
-                  ? "Generating…"
-                  : generatedToken
-                    ? "Generate a new token"
-                    : "Generate agent token"}
-              </Button.Text>
-            </Button>
-          </RequireScope>
-
           {generatedToken && (
             <Alert variant="warning">
               <Icon name="triangle-alert" className="h-4 w-4" />
-              <AlertTitle>Copy your managed.json now</AlertTitle>
+              <AlertTitle>
+                {autoCopied
+                  ? "managed.json copied to your clipboard"
+                  : "Copy your managed.json now"}
+              </AlertTitle>
               <AlertDescription>
-                The new <code>org_token</code> is spliced into the example above
-                and is shown only once — copy the file now, you won't be able to
-                retrieve this token again. Manage or revoke agent tokens anytime
-                under Settings → API Keys.
+                {autoCopied
+                  ? "We've copied the full managed.json — with the new org_token — to your clipboard; paste it into your MDM profile."
+                  : "The new org_token is spliced into the example above — copy the file now."}{" "}
+                The <code>org_token</code> is shown only once and can't be
+                retrieved again. Manage or revoke agent tokens anytime under
+                Settings →{" "}
+                <Link to={apiKeysHref} className={LINK_CLASS}>
+                  API Keys
+                </Link>
+                .
               </AlertDescription>
             </Alert>
           )}
 
-          {createKeyMutation.isError && (
+          {isError && (
             <Alert variant="destructive">
               <Icon name="triangle-alert" className="h-4 w-4" />
               <AlertTitle>Couldn't generate a token</AlertTitle>
               <AlertDescription>
                 Something went wrong creating the agent token. Try again, or
-                create one under Settings → API Keys with the Agent scope.
+                create one under Settings →{" "}
+                <Link to={apiKeysHref} className={LINK_CLASS}>
+                  API Keys
+                </Link>{" "}
+                with the Agent scope.
               </AlertDescription>
             </Alert>
           )}
         </div>
-      </div>
-
-      <div>
-        <SubHeading>How the agent applies it</SubHeading>
-        <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
-          <li>
-            <strong className="text-foreground">Startup:</strong> the daemon
-            reads <code>managed.json</code> (and <code>local.json</code>) when
-            it boots and resolves the merged identity.
-          </li>
-          <li>
-            <strong className="text-foreground">Live updates:</strong> the
-            daemon watches both files; when MDM pushes a new{" "}
-            <code>managed.json</code> the agent reloads within ~100 ms, no
-            restart required.
-          </li>
-          <li>
-            <strong className="text-foreground">Sign out:</strong> a user
-            signing out clears only <code>local.json</code>;{" "}
-            <code>managed.json</code> is untouched, so the device stays enrolled
-            under the managed identity.
-          </li>
-          <li>
-            <strong className="text-foreground">Invalid file:</strong> a
-            malformed file or a <code>v</code> newer than the agent supports is
-            rejected and surfaced in <code>speakeasy status</code>; the last
-            good config is not retained.
-          </li>
-        </ul>
       </div>
 
       <div>
@@ -549,8 +771,8 @@ export default function DeviceAgent() {
                 <AlertDescription>
                   Signed <code>.pkg</code> / <code>.msi</code> /{" "}
                   <code>.deb</code> installers and one-click MDM binary
-                  deployment are still being built. Until they ship, use the
-                  manual steps below (the binaries are published but not yet
+                  deployment are still being built. Until they ship, follow the
+                  install steps below (the binaries are published but not yet
                   code-signed). The managed configuration is fully supported
                   today.
                 </AlertDescription>
@@ -559,10 +781,22 @@ export default function DeviceAgent() {
           </Page.Section>
 
           <Page.Section>
-            <Page.Section.Title>Set up</Page.Section.Title>
+            <Page.Section.Title>Install the agent</Page.Section.Title>
             <Page.Section.Description>
-              Choose how you're deploying the agent. Fleet deployment is the
-              recommended path for an org; manual install is handy for testing.
+              Download the daemon + CLI and register the background service. The
+              same steps work whether you run them by hand or script them in
+              your MDM deployment.
+            </Page.Section.Description>
+            <Page.Section.Body>
+              <InstallAgent />
+            </Page.Section.Body>
+          </Page.Section>
+
+          <Page.Section>
+            <Page.Section.Title>Set the user's identity</Page.Section.Title>
+            <Page.Section.Description>
+              How the agent learns who's on the device. Fleet is the recommended
+              path for an org; personal enrollment is handy for testing.
             </Page.Section.Description>
             <Page.Section.Body>
               <Tabs defaultValue="fleet" className="gap-6">
@@ -570,36 +804,23 @@ export default function DeviceAgent() {
                   <SetupTab
                     value="fleet"
                     icon="building-2"
-                    title="Fleet deployment (recommended)"
-                    desc="IT pushes the agent + a managed.json to every device via MDM. No per-user step; identity is set by IT."
+                    title="Fleet (MDM)"
+                    desc="Deploy a managed.json so IT sets identity centrally — no per-user step."
                   />
                   <SetupTab
-                    value="manual"
+                    value="personal"
                     icon="user"
-                    title="Manual install (personal / PoC)"
-                    desc="Install the binaries yourself and sign in with speakeasy enroll. Good for testing."
+                    title="Personal / PoC"
+                    desc="Each user signs in once with speakeasy enroll. Good for testing."
                   />
                 </TabsList>
                 <TabsContent value="fleet" className="pt-2">
-                  <FleetSetup />
+                  <FleetIdentity />
                 </TabsContent>
-                <TabsContent value="manual" className="pt-2">
-                  <ManualSetup />
+                <TabsContent value="personal" className="pt-2">
+                  <ManualIdentity />
                 </TabsContent>
               </Tabs>
-            </Page.Section.Body>
-          </Page.Section>
-
-          <Page.Section>
-            <Page.Section.Title>
-              Coming soon <Badge variant="secondary">In progress</Badge>
-            </Page.Section.Title>
-            <Page.Section.Body>
-              <Type small muted>
-                Signed installer packages (<code>.pkg</code> / <code>.msi</code>{" "}
-                / <code>.deb</code>), one-click MDM binary deployment, and the
-                menu-bar UI download will land here as they ship.
-              </Type>
             </Page.Section.Body>
           </Page.Section>
         </RequireScope>

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -68,7 +68,7 @@ function SetupTab({
   return (
     <TabsTrigger
       value={value}
-      className="border-border data-[state=active]:border-primary data-[state=active]:ring-primary h-auto flex-col items-start gap-1 rounded-lg p-4 text-left whitespace-normal data-[state=active]:ring-1"
+      className="border-border data-[state=active]:border-primary data-[state=active]:ring-primary h-auto flex-col items-start justify-start gap-1 rounded-lg p-4 text-left whitespace-normal data-[state=active]:ring-1"
     >
       <div className="flex items-center gap-2">
         <Icon name={icon} className="h-4 w-4" />

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -620,14 +620,13 @@ function FleetIdentity() {
         <SubHeading>File location</SubHeading>
         <Type small muted className="mb-3">
           Deploy the file to the fixed system path for each OS. Create the
-          directory <code>0755</code> and the file <code>0644</code> (or
+          directory <code>0755</code> and the file <code>0640</code> (or
           equivalent ACLs on Windows). The file must be{" "}
           <strong>readable by the user the agent runs as</strong> — the agent
           runs as the logged-in user, not root, so owner-only{" "}
           <code>0600 root:wheel</code> on macOS won't work; use{" "}
-          <code>0644</code> or a read ACL for the user. The agent only reads
-          this file; it never writes it.
-        </Type>
+          <code>0640</code> with an explicit group/read ACL for the agent user.
+          The agent only reads this file; it never writes it.
         <Table headers={["OS", "Path", "Owner"]}>
           {MANAGED_CONFIG_PATHS.map((row) => (
             <tr key={row.os} className="border-t">

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -15,11 +15,9 @@ const RELEASES_BASE =
   "https://storage.googleapis.com/speakeasy-device-agent-releases-prod";
 const MANIFEST_URL = `${RELEASES_BASE}/releases.json`;
 
-// Example version used in the copy/paste snippets. Operators substitute the
-// current version (see the "find the version" step in each tab) — we keep a
-// concrete value here rather than a literal <VERSION> so the blocks paste and
-// run as-is once edited.
-const EXAMPLE_VERSION = "0.1.0";
+function SubHeading({ children }: { children: React.ReactNode }) {
+  return <Type className="mb-2 font-medium">{children}</Type>;
+}
 
 function Step({
   n,
@@ -38,39 +36,53 @@ function Step({
         </span>
         <Type className="font-medium">{title}</Type>
       </div>
-      {children && <div className="ml-7">{children}</div>}
+      {children && <div className="ml-7 flex flex-col gap-2">{children}</div>}
     </li>
+  );
+}
+
+// stepNote renders the muted "why" line under a step's command block.
+function StepNote({ children }: { children: React.ReactNode }) {
+  return (
+    <Type small muted>
+      {children}
+    </Type>
   );
 }
 
 function MacInstall() {
   return (
     <ol className="flex flex-col gap-5">
-      <Step n={1} title="Find the current version in the manifest">
+      <Step n={1} title="Find the current version">
+        <StepNote>
+          The manifest lists the latest published version for each binary.
+        </StepNote>
         <CodeBlock language="bash">{`curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version'`}</CodeBlock>
       </Step>
-      <Step
-        n={2}
-        title="Download the daemon + CLI (Apple Silicon shown; use darwin_amd64 for Intel)"
-      >
-        <CodeBlock language="bash">{`VERSION=${EXAMPLE_VERSION}
+      <Step n={2} title="Download the daemon + CLI">
+        <StepNote>
+          Apple Silicon shown — swap <code>darwin_arm64</code> for{" "}
+          <code>darwin_amd64</code> on Intel. Replace <code>0.1.0</code> with
+          the version from step 1.
+        </StepNote>
+        <CodeBlock language="bash">{`VERSION=0.1.0
 BASE=${RELEASES_BASE}/v$VERSION
-curl -fSL -o speakeasyd "$BASE/speakeasyd_${"${VERSION}"}_darwin_arm64"
-curl -fSL -o speakeasy  "$BASE/speakeasy_${"${VERSION}"}_darwin_arm64"`}</CodeBlock>
+curl -fSL -o speakeasyd "$BASE/speakeasyd_\${VERSION}_darwin_arm64"
+curl -fSL -o speakeasy  "$BASE/speakeasy_\${VERSION}_darwin_arm64"`}</CodeBlock>
       </Step>
       <Step n={3} title="Make them executable and move into your PATH">
         <CodeBlock language="bash">{`chmod +x speakeasyd speakeasy
 sudo mv speakeasyd speakeasy /usr/local/bin/`}</CodeBlock>
       </Step>
-      <Step n={4} title="Register and start the daemon (LaunchAgent)">
+      <Step n={4} title="Register and start the background service">
+        <StepNote>
+          Installs <code>speakeasyd</code> as a LaunchAgent so it runs on login.
+        </StepNote>
         <CodeBlock language="bash">{`speakeasyd -service install
 speakeasyd -service start`}</CodeBlock>
       </Step>
-      <Step
-        n={5}
-        title="Enroll (personal / PoC only — MDM-managed devices are configured by IT, see below)"
-      >
-        <CodeBlock language="bash">{`speakeasy enroll`}</CodeBlock>
+      <Step n={5} title="Verify it's running">
+        <CodeBlock language="bash">{`speakeasy status`}</CodeBlock>
       </Step>
     </ol>
   );
@@ -79,24 +91,24 @@ speakeasyd -service start`}</CodeBlock>
 function WindowsInstall() {
   return (
     <ol className="flex flex-col gap-5">
-      <Step n={1} title="Find the current version in the manifest">
+      <Step n={1} title="Find the current version">
         <CodeBlock language="powershell">{`(Invoke-RestMethod ${MANIFEST_URL}).latest.speakeasyd.version`}</CodeBlock>
       </Step>
       <Step n={2} title="Download the daemon + CLI">
-        <CodeBlock language="powershell">{`$VERSION = "${EXAMPLE_VERSION}"
+        <StepNote>
+          Replace <code>0.1.0</code> with the version from step 1.
+        </StepNote>
+        <CodeBlock language="powershell">{`$VERSION = "0.1.0"
 $BASE = "${RELEASES_BASE}/v$VERSION"
-Invoke-WebRequest "$BASE/speakeasyd_${"${VERSION}"}_windows_amd64.exe" -OutFile speakeasyd.exe
-Invoke-WebRequest "$BASE/speakeasy_${"${VERSION}"}_windows_amd64.exe"  -OutFile speakeasy.exe`}</CodeBlock>
+Invoke-WebRequest "$BASE/speakeasyd_\${VERSION}_windows_amd64.exe" -OutFile speakeasyd.exe
+Invoke-WebRequest "$BASE/speakeasy_\${VERSION}_windows_amd64.exe"  -OutFile speakeasy.exe`}</CodeBlock>
       </Step>
       <Step n={3} title="Register and start the Windows service">
         <CodeBlock language="powershell">{`.\\speakeasyd.exe -service install
 .\\speakeasyd.exe -service start`}</CodeBlock>
       </Step>
-      <Step
-        n={4}
-        title="Enroll (personal / PoC only — MDM-managed devices are configured by IT, see below)"
-      >
-        <CodeBlock language="powershell">{`.\\speakeasy.exe enroll`}</CodeBlock>
+      <Step n={4} title="Verify it's running">
+        <CodeBlock language="powershell">{`.\\speakeasy.exe status`}</CodeBlock>
       </Step>
     </ol>
   );
@@ -105,31 +117,33 @@ Invoke-WebRequest "$BASE/speakeasy_${"${VERSION}"}_windows_amd64.exe"  -OutFile 
 function LinuxInstall() {
   return (
     <ol className="flex flex-col gap-5">
-      <Step n={1} title="Find the current version in the manifest">
+      <Step n={1} title="Find the current version">
         <CodeBlock language="bash">{`curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version'`}</CodeBlock>
       </Step>
-      <Step
-        n={2}
-        title="Download the daemon + CLI (amd64 shown; use linux_arm64 for ARM)"
-      >
-        <CodeBlock language="bash">{`VERSION=${EXAMPLE_VERSION}
+      <Step n={2} title="Download the daemon + CLI">
+        <StepNote>
+          amd64 shown — swap <code>linux_amd64</code> for{" "}
+          <code>linux_arm64</code> on ARM. Replace <code>0.1.0</code> with the
+          version from step 1.
+        </StepNote>
+        <CodeBlock language="bash">{`VERSION=0.1.0
 BASE=${RELEASES_BASE}/v$VERSION
-curl -fSL -o speakeasyd "$BASE/speakeasyd_${"${VERSION}"}_linux_amd64"
-curl -fSL -o speakeasy  "$BASE/speakeasy_${"${VERSION}"}_linux_amd64"`}</CodeBlock>
+curl -fSL -o speakeasyd "$BASE/speakeasyd_\${VERSION}_linux_amd64"
+curl -fSL -o speakeasy  "$BASE/speakeasy_\${VERSION}_linux_amd64"`}</CodeBlock>
       </Step>
       <Step n={3} title="Make them executable and move into your PATH">
         <CodeBlock language="bash">{`chmod +x speakeasyd speakeasy
 sudo mv speakeasyd speakeasy /usr/local/bin/`}</CodeBlock>
       </Step>
-      <Step n={4} title="Register and start the daemon (systemd)">
+      <Step n={4} title="Register and start the background service">
+        <StepNote>
+          Installs <code>speakeasyd</code> as a systemd service.
+        </StepNote>
         <CodeBlock language="bash">{`speakeasyd -service install
 speakeasyd -service start`}</CodeBlock>
       </Step>
-      <Step
-        n={5}
-        title="Enroll (personal / PoC only — MDM-managed devices are configured by IT, see below)"
-      >
-        <CodeBlock language="bash">{`speakeasy enroll`}</CodeBlock>
+      <Step n={5} title="Verify it's running">
+        <CodeBlock language="bash">{`speakeasy status`}</CodeBlock>
       </Step>
     </ol>
   );
@@ -153,39 +167,39 @@ const MANAGED_CONFIG_FIELDS = [
   {
     field: "v",
     type: "integer",
-    required: true,
-    notes: "Schema version. Currently 1.",
+    required: "yes",
+    notes: "Schema version. Currently 1; the agent rejects files with v > 1.",
   },
   {
     field: "email",
     type: "string",
-    required: true,
+    required: "yes",
     notes:
       "The user's verified work email. Shown in the agent UI as the enrolled identity.",
   },
   {
     field: "org_token",
     type: "string",
-    required: true,
+    required: "yes",
     notes: "Bearer token the agent uses to call Speakeasy. Treat as a secret.",
   },
   {
     field: "org_slug",
     type: "string",
-    required: false,
-    notes: "Short org identifier (e.g. acme-corp).",
+    required: "no",
+    notes: "Short org identifier (e.g. acme-corp). Used in URLs and IDs.",
   },
   {
     field: "org_name",
     type: "string",
-    required: false,
-    notes: "Display name (e.g. Acme Corporation).",
+    required: "no",
+    notes: "Display name (e.g. Acme Corporation). Shown in the UI.",
   },
   {
     field: "auto_update",
     type: "string",
-    required: false,
-    notes: 'One of "disabled" (default), "notify", or "automatic".',
+    required: "no",
+    notes: '"disabled" (default), "notify", or "automatic". See below.',
   },
 ];
 
@@ -197,6 +211,31 @@ const EXAMPLE_MANAGED_JSON = `{
   "org_name": "Acme Corporation",
   "auto_update": "notify"
 }`;
+
+function Table({
+  headers,
+  children,
+}: {
+  headers: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50 text-muted-foreground">
+          <tr>
+            {headers.map((h) => (
+              <th key={h} className="px-4 py-2 text-left font-medium">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
 
 export default function DeviceAgent() {
   return (
@@ -210,33 +249,71 @@ export default function DeviceAgent() {
             <Page.Section.Title>Device Agent</Page.Section.Title>
             <Page.Section.Description>
               The Speakeasy device agent runs on developer laptops and enforces
-              your org's required AI-tool plugins and MCP configuration. Deploy
-              it fleet-wide via MDM, or install it individually for testing.
+              your org's required AI-tool plugins and MCP configuration, then
+              reports compliance back to Speakeasy.
             </Page.Section.Description>
             <Page.Section.Body>
-              <Alert variant="info">
-                <Icon name="info" className="h-4 w-4" />
-                <AlertTitle>
-                  Interim install — signed installers in progress
-                </AlertTitle>
-                <AlertDescription>
-                  Signed <code>.pkg</code> / <code>.msi</code> /{" "}
-                  <code>.deb</code> installers and one-click MDM binary
-                  deployment are still being built. Until they ship, use the
-                  manual steps below (the binaries are published but not yet
-                  code-signed). The <strong>managed configuration</strong> below
-                  is fully supported today.
-                </AlertDescription>
-              </Alert>
+              <div className="flex flex-col gap-4">
+                <div className="grid gap-4 @2xl/main:grid-cols-2">
+                  <div className="rounded-lg border p-4">
+                    <div className="mb-1 flex items-center gap-2">
+                      <Icon name="building-2" className="h-4 w-4" />
+                      <Type className="font-medium">
+                        Fleet deployment (recommended)
+                      </Type>
+                    </div>
+                    <Type small muted>
+                      IT pushes the agent + a <code>managed.json</code> to every
+                      device via MDM. No per-user step; identity is set by IT.
+                      See{" "}
+                      <a href="#managed-config" className="underline">
+                        Managed configuration
+                      </a>
+                      .
+                    </Type>
+                  </div>
+                  <div className="rounded-lg border p-4">
+                    <div className="mb-1 flex items-center gap-2">
+                      <Icon name="user" className="h-4 w-4" />
+                      <Type className="font-medium">
+                        Manual install (personal / PoC)
+                      </Type>
+                    </div>
+                    <Type small muted>
+                      Install the binaries yourself and sign in with{" "}
+                      <code>speakeasy enroll</code>. Good for testing. Follow{" "}
+                      <a href="#install" className="underline">
+                        Install the agent
+                      </a>
+                      .
+                    </Type>
+                  </div>
+                </div>
+                <Alert variant="info">
+                  <Icon name="info" className="h-4 w-4" />
+                  <AlertTitle>
+                    Interim install — signed installers in progress
+                  </AlertTitle>
+                  <AlertDescription>
+                    Signed <code>.pkg</code> / <code>.msi</code> /{" "}
+                    <code>.deb</code> installers and one-click MDM binary
+                    deployment are still being built. Until they ship, use the
+                    manual steps below (the binaries are published but not yet
+                    code-signed). The managed configuration is fully supported
+                    today.
+                  </AlertDescription>
+                </Alert>
+              </div>
             </Page.Section.Body>
           </Page.Section>
 
           <Page.Section>
+            <div id="install" />
             <Page.Section.Title>Install the agent</Page.Section.Title>
             <Page.Section.Description>
-              Download the daemon (<code>speakeasyd</code>) and CLI (
-              <code>speakeasy</code>) for your platform, then register the
-              daemon as a managed service.
+              The agent is two binaries: <code>speakeasyd</code>, the background
+              daemon that does the enforcement, and <code>speakeasy</code>, the
+              CLI you use to check status and enroll. Pick your platform.
             </Page.Section.Description>
             <Page.Section.Body>
               <Tabs defaultValue="macos">
@@ -255,99 +332,104 @@ export default function DeviceAgent() {
                   <LinuxInstall />
                 </TabsContent>
               </Tabs>
+              <Alert variant="info" className="mt-4">
+                <Icon name="info" className="h-4 w-4" />
+                <AlertTitle>Enrolling a personal install</AlertTitle>
+                <AlertDescription>
+                  On a device <em>not</em> managed by MDM, sign in with{" "}
+                  <code>speakeasy enroll</code> — it opens a browser, you sign
+                  in, and the agent stores your email locally. MDM-managed
+                  devices skip this; their identity comes from{" "}
+                  <code>managed.json</code>.
+                </AlertDescription>
+              </Alert>
             </Page.Section.Body>
           </Page.Section>
 
           <Page.Section>
-            <Page.Section.Title>MDM configuration</Page.Section.Title>
+            <div id="managed-config" />
+            <Page.Section.Title>Managed configuration</Page.Section.Title>
             <Page.Section.Description>
               For fleet deployment, IT provisions a <code>managed.json</code>{" "}
               file via your MDM (Kandji, Jamf, Intune, …). The agent reads it at
-              startup — no per-user enrollment step on the device.
+              startup and applies the identity automatically — no per-user
+              enrollment on the device.
             </Page.Section.Description>
             <Page.Section.Body>
-              <div className="flex flex-col gap-6">
+              <div className="flex flex-col gap-8">
                 <div>
-                  <Type className="mb-2 font-medium">File location</Type>
-                  <Type small muted className="mb-3">
-                    Deploy the file to the fixed system path for each OS,
-                    created with <code>0700</code> directory perms /{" "}
-                    <code>0600</code> on the file (or equivalent ACLs on
-                    Windows). The agent only reads it — it never writes it.
+                  <SubHeading>Two config layers</SubHeading>
+                  <Type small muted>
+                    The agent merges two files per field, with{" "}
+                    <code>managed.json</code> (IT-owned) always winning over{" "}
+                    <code>local.json</code> (written by a user's{" "}
+                    <code>speakeasy enroll</code>). So IT can set{" "}
+                    <code>org_token</code> centrally while a user's email comes
+                    from either layer. On a fully MDM-managed device,{" "}
+                    <code>managed.json</code> supplies everything and the device
+                    shows as "Provisioned by IT".
                   </Type>
-                  <div className="overflow-hidden rounded-lg border">
-                    <table className="w-full text-sm">
-                      <thead className="bg-muted/50 text-muted-foreground">
-                        <tr>
-                          <th className="px-4 py-2 text-left font-medium">
-                            OS
-                          </th>
-                          <th className="px-4 py-2 text-left font-medium">
-                            Path
-                          </th>
-                          <th className="px-4 py-2 text-left font-medium">
-                            Owner
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {MANAGED_CONFIG_PATHS.map((row) => (
-                          <tr key={row.os} className="border-t">
-                            <td className="px-4 py-2">{row.os}</td>
-                            <td className="px-4 py-2 font-mono text-xs">
-                              {row.path}
-                            </td>
-                            <td className="px-4 py-2">{row.owner}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
                 </div>
 
                 <div>
-                  <Type className="mb-2 font-medium">Schema</Type>
-                  <div className="overflow-hidden rounded-lg border">
-                    <table className="w-full text-sm">
-                      <thead className="bg-muted/50 text-muted-foreground">
-                        <tr>
-                          <th className="px-4 py-2 text-left font-medium">
-                            Field
-                          </th>
-                          <th className="px-4 py-2 text-left font-medium">
-                            Type
-                          </th>
-                          <th className="px-4 py-2 text-left font-medium">
-                            Required
-                          </th>
-                          <th className="px-4 py-2 text-left font-medium">
-                            Notes
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {MANAGED_CONFIG_FIELDS.map((row) => (
-                          <tr key={row.field} className="border-t align-top">
-                            <td className="px-4 py-2 font-mono text-xs">
-                              {row.field}
-                            </td>
-                            <td className="px-4 py-2">{row.type}</td>
-                            <td className="px-4 py-2">
-                              {row.required ? "yes" : "no"}
-                            </td>
-                            <td className="text-muted-foreground px-4 py-2">
-                              {row.notes}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                  <SubHeading>File location</SubHeading>
+                  <Type small muted className="mb-3">
+                    Deploy the file to the fixed system path for each OS. Create
+                    the directory <code>0700</code> and the file{" "}
+                    <code>0600</code> (or equivalent ACLs on Windows). The file
+                    must be{" "}
+                    <strong>readable by the user the agent runs as</strong> —
+                    the agent runs as the logged-in user, not root, so{" "}
+                    <code>0600 root:wheel</code> on macOS won't work; use{" "}
+                    <code>0644</code> or a read ACL for the user. The agent only
+                    reads this file; it never writes it.
+                  </Type>
+                  <Table headers={["OS", "Path", "Owner"]}>
+                    {MANAGED_CONFIG_PATHS.map((row) => (
+                      <tr key={row.os} className="border-t">
+                        <td className="px-4 py-2">{row.os}</td>
+                        <td className="px-4 py-2 font-mono text-xs">
+                          {row.path}
+                        </td>
+                        <td className="px-4 py-2">{row.owner}</td>
+                      </tr>
+                    ))}
+                  </Table>
                 </div>
 
                 <div>
-                  <Type className="mb-2 font-medium">Example managed.json</Type>
+                  <SubHeading>Schema</SubHeading>
+                  <Table headers={["Field", "Type", "Required", "Notes"]}>
+                    {MANAGED_CONFIG_FIELDS.map((row) => (
+                      <tr key={row.field} className="border-t align-top">
+                        <td className="px-4 py-2 font-mono text-xs">
+                          {row.field}
+                        </td>
+                        <td className="px-4 py-2">{row.type}</td>
+                        <td className="px-4 py-2">{row.required}</td>
+                        <td className="text-muted-foreground px-4 py-2">
+                          {row.notes}
+                        </td>
+                      </tr>
+                    ))}
+                  </Table>
+                  <Type small muted className="mt-2">
+                    <code>auto_update</code> controls self-update:{" "}
+                    <code>"disabled"</code> never checks, <code>"notify"</code>{" "}
+                    surfaces available updates without installing, and{" "}
+                    <code>"automatic"</code> downloads and installs them. For
+                    MDM fleets, <code>"notify"</code> keeps IT in control of
+                    what rolls out.
+                  </Type>
+                </div>
+
+                <div>
+                  <SubHeading>Example managed.json</SubHeading>
                   <CodeBlock language="json">{EXAMPLE_MANAGED_JSON}</CodeBlock>
+                  <Type small muted className="mt-2">
+                    Only <code>v</code>, <code>email</code>, and{" "}
+                    <code>org_token</code> are required; the rest are optional.
+                  </Type>
                 </div>
 
                 <Alert variant="warning">
@@ -362,15 +444,62 @@ export default function DeviceAgent() {
                 </Alert>
 
                 <div>
-                  <Type className="mb-2 font-medium">Deploying via MDM</Type>
+                  <SubHeading>How the agent applies it</SubHeading>
+                  <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+                    <li>
+                      <strong className="text-foreground">Startup:</strong> the
+                      daemon reads <code>managed.json</code> (and{" "}
+                      <code>local.json</code>) when it boots and resolves the
+                      merged identity.
+                    </li>
+                    <li>
+                      <strong className="text-foreground">Live updates:</strong>{" "}
+                      the daemon watches both files; when MDM pushes a new{" "}
+                      <code>managed.json</code> the agent reloads within ~100
+                      ms, no restart required.
+                    </li>
+                    <li>
+                      <strong className="text-foreground">Sign out:</strong> a
+                      user signing out clears only <code>local.json</code>;{" "}
+                      <code>managed.json</code> is untouched, so the device
+                      stays enrolled under the managed identity.
+                    </li>
+                    <li>
+                      <strong className="text-foreground">Invalid file:</strong>{" "}
+                      a malformed file or a <code>v</code> newer than the agent
+                      supports is rejected and surfaced in{" "}
+                      <code>speakeasy status</code>; the last good config is not
+                      retained.
+                    </li>
+                  </ul>
+                </div>
+
+                <div>
+                  <SubHeading>Security</SubHeading>
+                  <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+                    <li>
+                      <code>org_token</code> is a credential — distribute it the
+                      way you'd distribute any API key, and don't commit it or
+                      paste it into chat.
+                    </li>
+                    <li>
+                      The agent never writes <code>managed.json</code> and does
+                      not log the token or email (PII is redacted at the logging
+                      layer).
+                    </li>
+                  </ul>
+                </div>
+
+                <div>
+                  <SubHeading>Deploying via MDM</SubHeading>
                   <Type small muted>
-                    The exact mechanics vary by platform. The common pattern:
-                    package <code>managed.json</code> as a custom configuration
-                    profile that drops the file at the path above with the right
-                    permissions, then scope it to your target device groups.
-                    Managed configuration always takes precedence over a user's
-                    local enrollment, so an MDM-provisioned device shows as
-                    "Provisioned by IT" and ignores any local sign-in.
+                    Mechanics vary by platform. The common pattern: package{" "}
+                    <code>managed.json</code> as a custom configuration profile
+                    that drops the file at the path above with the right
+                    permissions, then scope it to your target device groups. If
+                    the agent isn't picking up the file, confirm the path with{" "}
+                    <code>speakeasy config path</code>, check that the file is
+                    readable by the logged-in user, and validate the JSON.
                   </Type>
                 </div>
               </div>

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -5,6 +5,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
+import { useOrganization, useUser } from "@/contexts/Auth";
 import { Icon } from "@speakeasy-api/moonshine";
 import React from "react";
 
@@ -47,6 +48,34 @@ function StepNote({ children }: { children: React.ReactNode }) {
     <Type small muted>
       {children}
     </Type>
+  );
+}
+
+// SetupTab renders a bordered card that doubles as a tab trigger. The two
+// setup paths (fleet vs manual) switch the panel below instead of jumping to
+// an anchor.
+function SetupTab({
+  value,
+  icon,
+  title,
+  desc,
+}: {
+  value: string;
+  icon: React.ComponentProps<typeof Icon>["name"];
+  title: string;
+  desc: React.ReactNode;
+}) {
+  return (
+    <TabsTrigger
+      value={value}
+      className="border-border data-[state=active]:border-primary data-[state=active]:ring-primary h-auto flex-col items-start gap-1 rounded-lg p-4 text-left whitespace-normal data-[state=active]:ring-1"
+    >
+      <div className="flex items-center gap-2">
+        <Icon name={icon} className="h-4 w-4" />
+        <span className="font-medium">{title}</span>
+      </div>
+      <span className="text-muted-foreground text-sm font-normal">{desc}</span>
+    </TabsTrigger>
   );
 }
 
@@ -203,15 +232,6 @@ const MANAGED_CONFIG_FIELDS = [
   },
 ];
 
-const EXAMPLE_MANAGED_JSON = `{
-  "v": 1,
-  "email": "jane.doe@acme.corp",
-  "org_token": "spk_org_REPLACE_ME",
-  "org_slug": "acme-corp",
-  "org_name": "Acme Corporation",
-  "auto_update": "notify"
-}`;
-
 function Table({
   headers,
   children,
@@ -237,7 +257,205 @@ function Table({
   );
 }
 
+function ManualSetup() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Type muted>
+        The agent is two binaries: <code>speakeasyd</code>, the background
+        daemon that does the enforcement, and <code>speakeasy</code>, the CLI
+        you use to check status and enroll. Pick your platform.
+      </Type>
+      <Tabs defaultValue="macos">
+        <TabsList className="grid w-full max-w-md grid-cols-3">
+          <TabsTrigger value="macos">macOS</TabsTrigger>
+          <TabsTrigger value="windows">Windows</TabsTrigger>
+          <TabsTrigger value="linux">Linux</TabsTrigger>
+        </TabsList>
+        <TabsContent value="macos" className="pt-4">
+          <MacInstall />
+        </TabsContent>
+        <TabsContent value="windows" className="pt-4">
+          <WindowsInstall />
+        </TabsContent>
+        <TabsContent value="linux" className="pt-4">
+          <LinuxInstall />
+        </TabsContent>
+      </Tabs>
+      <Alert variant="info" className="mt-2">
+        <Icon name="info" className="h-4 w-4" />
+        <AlertTitle>Enrolling a personal install</AlertTitle>
+        <AlertDescription>
+          On a device <em>not</em> managed by MDM, sign in with{" "}
+          <code>speakeasy enroll</code> — it opens a browser, you sign in, and
+          the agent stores your email locally. MDM-managed devices skip this;
+          their identity comes from <code>managed.json</code>.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+function FleetSetup({ exampleManagedJson }: { exampleManagedJson: string }) {
+  return (
+    <div className="flex flex-col gap-8">
+      <Type muted>
+        IT provisions a <code>managed.json</code> file via your MDM (Kandji,
+        Jamf, Intune, …) and deploys the agent binaries alongside it. The agent
+        reads the file at startup and applies the identity automatically — no
+        per-user enrollment on the device.
+      </Type>
+
+      <div>
+        <SubHeading>Two config layers</SubHeading>
+        <Type small muted>
+          The agent merges two files per field, with <code>managed.json</code>{" "}
+          (IT-owned) always winning over <code>local.json</code> (written by a
+          user's <code>speakeasy enroll</code>). So IT can set{" "}
+          <code>org_token</code> centrally while a user's email comes from
+          either layer. On a fully MDM-managed device, <code>managed.json</code>{" "}
+          supplies everything and the device shows as "Provisioned by IT".
+        </Type>
+      </div>
+
+      <div>
+        <SubHeading>File location</SubHeading>
+        <Type small muted className="mb-3">
+          Deploy the file to the fixed system path for each OS. Create the
+          directory <code>0700</code> and the file <code>0600</code> (or
+          equivalent ACLs on Windows). The file must be{" "}
+          <strong>readable by the user the agent runs as</strong> — the agent
+          runs as the logged-in user, not root, so <code>0600 root:wheel</code>{" "}
+          on macOS won't work; use <code>0644</code> or a read ACL for the user.
+          The agent only reads this file; it never writes it.
+        </Type>
+        <Table headers={["OS", "Path", "Owner"]}>
+          {MANAGED_CONFIG_PATHS.map((row) => (
+            <tr key={row.os} className="border-t">
+              <td className="px-4 py-2">{row.os}</td>
+              <td className="px-4 py-2 font-mono text-xs">{row.path}</td>
+              <td className="px-4 py-2">{row.owner}</td>
+            </tr>
+          ))}
+        </Table>
+      </div>
+
+      <div>
+        <SubHeading>Schema</SubHeading>
+        <Table headers={["Field", "Type", "Required", "Notes"]}>
+          {MANAGED_CONFIG_FIELDS.map((row) => (
+            <tr key={row.field} className="border-t align-top">
+              <td className="px-4 py-2 font-mono text-xs">{row.field}</td>
+              <td className="px-4 py-2">{row.type}</td>
+              <td className="px-4 py-2">{row.required}</td>
+              <td className="text-muted-foreground px-4 py-2">{row.notes}</td>
+            </tr>
+          ))}
+        </Table>
+        <Type small muted className="mt-2">
+          <code>auto_update</code> controls self-update: <code>"disabled"</code>{" "}
+          never checks, <code>"notify"</code> surfaces available updates without
+          installing, and <code>"automatic"</code> downloads and installs them.
+          For MDM fleets, <code>"notify"</code> keeps IT in control of what
+          rolls out.
+        </Type>
+      </div>
+
+      <div>
+        <SubHeading>Example managed.json</SubHeading>
+        <CodeBlock language="json">{exampleManagedJson}</CodeBlock>
+        <Type small muted className="mt-2">
+          Pre-filled with this org's <code>email</code>, <code>org_slug</code>,
+          and <code>org_name</code>. Replace <code>org_token</code> with the
+          token from your Speakeasy representative — that's the only value you
+          have to supply.
+        </Type>
+      </div>
+
+      <Alert variant="warning">
+        <Icon name="triangle-alert" className="h-4 w-4" />
+        <AlertTitle>Where the org token comes from</AlertTitle>
+        <AlertDescription>
+          Self-service <code>org_token</code> issuance is part of the Speakeasy
+          control plane, which is still in progress. For now, contact your
+          Speakeasy representative to obtain a token for your organization.
+        </AlertDescription>
+      </Alert>
+
+      <div>
+        <SubHeading>How the agent applies it</SubHeading>
+        <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+          <li>
+            <strong className="text-foreground">Startup:</strong> the daemon
+            reads <code>managed.json</code> (and <code>local.json</code>) when
+            it boots and resolves the merged identity.
+          </li>
+          <li>
+            <strong className="text-foreground">Live updates:</strong> the
+            daemon watches both files; when MDM pushes a new{" "}
+            <code>managed.json</code> the agent reloads within ~100 ms, no
+            restart required.
+          </li>
+          <li>
+            <strong className="text-foreground">Sign out:</strong> a user
+            signing out clears only <code>local.json</code>;{" "}
+            <code>managed.json</code> is untouched, so the device stays enrolled
+            under the managed identity.
+          </li>
+          <li>
+            <strong className="text-foreground">Invalid file:</strong> a
+            malformed file or a <code>v</code> newer than the agent supports is
+            rejected and surfaced in <code>speakeasy status</code>; the last
+            good config is not retained.
+          </li>
+        </ul>
+      </div>
+
+      <div>
+        <SubHeading>Security</SubHeading>
+        <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
+          <li>
+            <code>org_token</code> is a credential — distribute it the way you'd
+            distribute any API key, and don't commit it or paste it into chat.
+          </li>
+          <li>
+            The agent never writes <code>managed.json</code> and does not log
+            the token or email (PII is redacted at the logging layer).
+          </li>
+        </ul>
+      </div>
+
+      <div>
+        <SubHeading>Deploying via MDM</SubHeading>
+        <Type small muted>
+          Mechanics vary by platform. The common pattern: package{" "}
+          <code>managed.json</code> as a custom configuration profile that drops
+          the file at the path above with the right permissions, then scope it
+          to your target device groups. If the agent isn't picking up the file,
+          confirm the path with <code>speakeasy config path</code>, check that
+          the file is readable by the logged-in user, and validate the JSON.
+        </Type>
+      </div>
+    </div>
+  );
+}
+
 export default function DeviceAgent() {
+  const { name: orgName, slug: orgSlug } = useOrganization();
+  const { email } = useUser();
+
+  const exampleManagedJson = JSON.stringify(
+    {
+      v: 1,
+      email: email || "jane.doe@acme.corp",
+      org_token: "spk_org_REPLACE_ME",
+      org_slug: orgSlug || "acme-corp",
+      org_name: orgName || "Acme Corporation",
+      auto_update: "notify",
+    },
+    null,
+    2,
+  );
+
   return (
     <Page>
       <Page.Header>
@@ -253,256 +471,52 @@ export default function DeviceAgent() {
               reports compliance back to Speakeasy.
             </Page.Section.Description>
             <Page.Section.Body>
-              <div className="flex flex-col gap-4">
-                <div className="grid gap-4 @2xl/main:grid-cols-2">
-                  <div className="rounded-lg border p-4">
-                    <div className="mb-1 flex items-center gap-2">
-                      <Icon name="building-2" className="h-4 w-4" />
-                      <Type className="font-medium">
-                        Fleet deployment (recommended)
-                      </Type>
-                    </div>
-                    <Type small muted>
-                      IT pushes the agent + a <code>managed.json</code> to every
-                      device via MDM. No per-user step; identity is set by IT.
-                      See{" "}
-                      <a href="#managed-config" className="underline">
-                        Managed configuration
-                      </a>
-                      .
-                    </Type>
-                  </div>
-                  <div className="rounded-lg border p-4">
-                    <div className="mb-1 flex items-center gap-2">
-                      <Icon name="user" className="h-4 w-4" />
-                      <Type className="font-medium">
-                        Manual install (personal / PoC)
-                      </Type>
-                    </div>
-                    <Type small muted>
-                      Install the binaries yourself and sign in with{" "}
-                      <code>speakeasy enroll</code>. Good for testing. Follow{" "}
-                      <a href="#install" className="underline">
-                        Install the agent
-                      </a>
-                      .
-                    </Type>
-                  </div>
-                </div>
-                <Alert variant="info">
-                  <Icon name="info" className="h-4 w-4" />
-                  <AlertTitle>
-                    Interim install — signed installers in progress
-                  </AlertTitle>
-                  <AlertDescription>
-                    Signed <code>.pkg</code> / <code>.msi</code> /{" "}
-                    <code>.deb</code> installers and one-click MDM binary
-                    deployment are still being built. Until they ship, use the
-                    manual steps below (the binaries are published but not yet
-                    code-signed). The managed configuration is fully supported
-                    today.
-                  </AlertDescription>
-                </Alert>
-              </div>
-            </Page.Section.Body>
-          </Page.Section>
-
-          <Page.Section>
-            <div id="install" />
-            <Page.Section.Title>Install the agent</Page.Section.Title>
-            <Page.Section.Description>
-              The agent is two binaries: <code>speakeasyd</code>, the background
-              daemon that does the enforcement, and <code>speakeasy</code>, the
-              CLI you use to check status and enroll. Pick your platform.
-            </Page.Section.Description>
-            <Page.Section.Body>
-              <Tabs defaultValue="macos">
-                <TabsList className="grid w-full max-w-md grid-cols-3">
-                  <TabsTrigger value="macos">macOS</TabsTrigger>
-                  <TabsTrigger value="windows">Windows</TabsTrigger>
-                  <TabsTrigger value="linux">Linux</TabsTrigger>
-                </TabsList>
-                <TabsContent value="macos" className="pt-4">
-                  <MacInstall />
-                </TabsContent>
-                <TabsContent value="windows" className="pt-4">
-                  <WindowsInstall />
-                </TabsContent>
-                <TabsContent value="linux" className="pt-4">
-                  <LinuxInstall />
-                </TabsContent>
-              </Tabs>
-              <Alert variant="info" className="mt-4">
+              <Alert variant="info">
                 <Icon name="info" className="h-4 w-4" />
-                <AlertTitle>Enrolling a personal install</AlertTitle>
+                <AlertTitle>
+                  Interim install — signed installers in progress
+                </AlertTitle>
                 <AlertDescription>
-                  On a device <em>not</em> managed by MDM, sign in with{" "}
-                  <code>speakeasy enroll</code> — it opens a browser, you sign
-                  in, and the agent stores your email locally. MDM-managed
-                  devices skip this; their identity comes from{" "}
-                  <code>managed.json</code>.
+                  Signed <code>.pkg</code> / <code>.msi</code> /{" "}
+                  <code>.deb</code> installers and one-click MDM binary
+                  deployment are still being built. Until they ship, use the
+                  manual steps below (the binaries are published but not yet
+                  code-signed). The managed configuration is fully supported
+                  today.
                 </AlertDescription>
               </Alert>
             </Page.Section.Body>
           </Page.Section>
 
           <Page.Section>
-            <div id="managed-config" />
-            <Page.Section.Title>Managed configuration</Page.Section.Title>
+            <Page.Section.Title>Set up</Page.Section.Title>
             <Page.Section.Description>
-              For fleet deployment, IT provisions a <code>managed.json</code>{" "}
-              file via your MDM (Kandji, Jamf, Intune, …). The agent reads it at
-              startup and applies the identity automatically — no per-user
-              enrollment on the device.
+              Choose how you're deploying the agent. Fleet deployment is the
+              recommended path for an org; manual install is handy for testing.
             </Page.Section.Description>
             <Page.Section.Body>
-              <div className="flex flex-col gap-8">
-                <div>
-                  <SubHeading>Two config layers</SubHeading>
-                  <Type small muted>
-                    The agent merges two files per field, with{" "}
-                    <code>managed.json</code> (IT-owned) always winning over{" "}
-                    <code>local.json</code> (written by a user's{" "}
-                    <code>speakeasy enroll</code>). So IT can set{" "}
-                    <code>org_token</code> centrally while a user's email comes
-                    from either layer. On a fully MDM-managed device,{" "}
-                    <code>managed.json</code> supplies everything and the device
-                    shows as "Provisioned by IT".
-                  </Type>
-                </div>
-
-                <div>
-                  <SubHeading>File location</SubHeading>
-                  <Type small muted className="mb-3">
-                    Deploy the file to the fixed system path for each OS. Create
-                    the directory <code>0700</code> and the file{" "}
-                    <code>0600</code> (or equivalent ACLs on Windows). The file
-                    must be{" "}
-                    <strong>readable by the user the agent runs as</strong> —
-                    the agent runs as the logged-in user, not root, so{" "}
-                    <code>0600 root:wheel</code> on macOS won't work; use{" "}
-                    <code>0644</code> or a read ACL for the user. The agent only
-                    reads this file; it never writes it.
-                  </Type>
-                  <Table headers={["OS", "Path", "Owner"]}>
-                    {MANAGED_CONFIG_PATHS.map((row) => (
-                      <tr key={row.os} className="border-t">
-                        <td className="px-4 py-2">{row.os}</td>
-                        <td className="px-4 py-2 font-mono text-xs">
-                          {row.path}
-                        </td>
-                        <td className="px-4 py-2">{row.owner}</td>
-                      </tr>
-                    ))}
-                  </Table>
-                </div>
-
-                <div>
-                  <SubHeading>Schema</SubHeading>
-                  <Table headers={["Field", "Type", "Required", "Notes"]}>
-                    {MANAGED_CONFIG_FIELDS.map((row) => (
-                      <tr key={row.field} className="border-t align-top">
-                        <td className="px-4 py-2 font-mono text-xs">
-                          {row.field}
-                        </td>
-                        <td className="px-4 py-2">{row.type}</td>
-                        <td className="px-4 py-2">{row.required}</td>
-                        <td className="text-muted-foreground px-4 py-2">
-                          {row.notes}
-                        </td>
-                      </tr>
-                    ))}
-                  </Table>
-                  <Type small muted className="mt-2">
-                    <code>auto_update</code> controls self-update:{" "}
-                    <code>"disabled"</code> never checks, <code>"notify"</code>{" "}
-                    surfaces available updates without installing, and{" "}
-                    <code>"automatic"</code> downloads and installs them. For
-                    MDM fleets, <code>"notify"</code> keeps IT in control of
-                    what rolls out.
-                  </Type>
-                </div>
-
-                <div>
-                  <SubHeading>Example managed.json</SubHeading>
-                  <CodeBlock language="json">{EXAMPLE_MANAGED_JSON}</CodeBlock>
-                  <Type small muted className="mt-2">
-                    Only <code>v</code>, <code>email</code>, and{" "}
-                    <code>org_token</code> are required; the rest are optional.
-                  </Type>
-                </div>
-
-                <Alert variant="warning">
-                  <Icon name="triangle-alert" className="h-4 w-4" />
-                  <AlertTitle>Where the org token comes from</AlertTitle>
-                  <AlertDescription>
-                    Self-service <code>org_token</code> issuance is part of the
-                    Speakeasy control plane, which is still in progress. For
-                    now, contact your Speakeasy representative to obtain a token
-                    for your organization.
-                  </AlertDescription>
-                </Alert>
-
-                <div>
-                  <SubHeading>How the agent applies it</SubHeading>
-                  <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
-                    <li>
-                      <strong className="text-foreground">Startup:</strong> the
-                      daemon reads <code>managed.json</code> (and{" "}
-                      <code>local.json</code>) when it boots and resolves the
-                      merged identity.
-                    </li>
-                    <li>
-                      <strong className="text-foreground">Live updates:</strong>{" "}
-                      the daemon watches both files; when MDM pushes a new{" "}
-                      <code>managed.json</code> the agent reloads within ~100
-                      ms, no restart required.
-                    </li>
-                    <li>
-                      <strong className="text-foreground">Sign out:</strong> a
-                      user signing out clears only <code>local.json</code>;{" "}
-                      <code>managed.json</code> is untouched, so the device
-                      stays enrolled under the managed identity.
-                    </li>
-                    <li>
-                      <strong className="text-foreground">Invalid file:</strong>{" "}
-                      a malformed file or a <code>v</code> newer than the agent
-                      supports is rejected and surfaced in{" "}
-                      <code>speakeasy status</code>; the last good config is not
-                      retained.
-                    </li>
-                  </ul>
-                </div>
-
-                <div>
-                  <SubHeading>Security</SubHeading>
-                  <ul className="text-muted-foreground flex flex-col gap-2 text-sm">
-                    <li>
-                      <code>org_token</code> is a credential — distribute it the
-                      way you'd distribute any API key, and don't commit it or
-                      paste it into chat.
-                    </li>
-                    <li>
-                      The agent never writes <code>managed.json</code> and does
-                      not log the token or email (PII is redacted at the logging
-                      layer).
-                    </li>
-                  </ul>
-                </div>
-
-                <div>
-                  <SubHeading>Deploying via MDM</SubHeading>
-                  <Type small muted>
-                    Mechanics vary by platform. The common pattern: package{" "}
-                    <code>managed.json</code> as a custom configuration profile
-                    that drops the file at the path above with the right
-                    permissions, then scope it to your target device groups. If
-                    the agent isn't picking up the file, confirm the path with{" "}
-                    <code>speakeasy config path</code>, check that the file is
-                    readable by the logged-in user, and validate the JSON.
-                  </Type>
-                </div>
-              </div>
+              <Tabs defaultValue="fleet" className="gap-6">
+                <TabsList className="grid h-auto w-full gap-4 bg-transparent p-0 @2xl/main:grid-cols-2">
+                  <SetupTab
+                    value="fleet"
+                    icon="building-2"
+                    title="Fleet deployment (recommended)"
+                    desc="IT pushes the agent + a managed.json to every device via MDM. No per-user step; identity is set by IT."
+                  />
+                  <SetupTab
+                    value="manual"
+                    icon="user"
+                    title="Manual install (personal / PoC)"
+                    desc="Install the binaries yourself and sign in with speakeasy enroll. Good for testing."
+                  />
+                </TabsList>
+                <TabsContent value="fleet" className="pt-2">
+                  <FleetSetup exampleManagedJson={exampleManagedJson} />
+                </TabsContent>
+                <TabsContent value="manual" className="pt-2">
+                  <ManualSetup />
+                </TabsContent>
+              </Tabs>
             </Page.Section.Body>
           </Page.Section>
 

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -496,7 +496,7 @@ export default function DeviceAgent() {
             </Page.Section.Description>
             <Page.Section.Body>
               <Tabs defaultValue="fleet" className="gap-6">
-                <TabsList className="grid h-auto w-full gap-4 bg-transparent p-0 @2xl/main:grid-cols-2">
+                <TabsList className="grid h-auto w-full items-stretch gap-4 bg-transparent p-0 @2xl/main:grid-cols-2">
                   <SetupTab
                     value="fleet"
                     icon="building-2"

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -464,7 +464,9 @@ export default function DeviceAgent() {
       <Page.Body>
         <RequireScope scope={["org:read", "org:admin"]} level="page">
           <Page.Section>
-            <Page.Section.Title>Device Agent</Page.Section.Title>
+            <Page.Section.Title stage="preview">
+              Device Agent
+            </Page.Section.Title>
             <Page.Section.Description>
               The Speakeasy device agent runs on developer laptops and enforces
               your org's required AI-tool plugins and MCP configuration, then

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -6,7 +6,8 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
 import { useOrganization, useUser } from "@/contexts/Auth";
-import { Icon } from "@speakeasy-api/moonshine";
+import { useCreateAPIKeyMutation } from "@gram/client/react-query/createAPIKey";
+import { Button, Icon } from "@speakeasy-api/moonshine";
 import React from "react";
 
 // Public, unauthenticated bucket the release pipeline publishes to. The
@@ -295,7 +296,47 @@ function ManualSetup() {
   );
 }
 
-function FleetSetup({ exampleManagedJson }: { exampleManagedJson: string }) {
+function FleetSetup() {
+  const { name: orgName, slug: orgSlug } = useOrganization();
+  const { email } = useUser();
+  const [generatedToken, setGeneratedToken] = React.useState<string | null>(
+    null,
+  );
+
+  const createKeyMutation = useCreateAPIKeyMutation({
+    onSuccess: (data) => {
+      if (data.key) setGeneratedToken(data.key);
+    },
+  });
+
+  // The agent's org_token is just an `agent`-scoped API key. Once generated we
+  // splice it into the example below so the whole managed.json is copy-ready;
+  // the raw key is only returned once, so there's nothing to re-fetch later.
+  const exampleManagedJson = JSON.stringify(
+    {
+      v: 1,
+      email: email || "jane.doe@acme.corp",
+      org_token: generatedToken ?? "spk_org_REPLACE_ME",
+      org_slug: orgSlug || "acme-corp",
+      org_name: orgName || "Acme Corporation",
+      auto_update: "notify",
+    },
+    null,
+    2,
+  );
+
+  const handleGenerate = () => {
+    createKeyMutation.mutate({
+      security: { sessionHeaderGramSession: "" },
+      request: {
+        createKeyForm: {
+          name: `device-agent ${new Date().toISOString().slice(0, 10)}`,
+          scopes: ["agent"],
+        },
+      },
+    });
+  };
+
   return (
     <div className="flex flex-col gap-8">
       <Type muted>
@@ -365,21 +406,58 @@ function FleetSetup({ exampleManagedJson }: { exampleManagedJson: string }) {
         <CodeBlock language="json">{exampleManagedJson}</CodeBlock>
         <Type small muted className="mt-2">
           Pre-filled with this org's <code>email</code>, <code>org_slug</code>,
-          and <code>org_name</code>. Replace <code>org_token</code> with the
-          token from your Speakeasy representative — that's the only value you
-          have to supply.
+          and <code>org_name</code>. Generate the <code>org_token</code> below —
+          it's the only value you have to supply.
         </Type>
-      </div>
 
-      <Alert variant="warning">
-        <Icon name="triangle-alert" className="h-4 w-4" />
-        <AlertTitle>Where the org token comes from</AlertTitle>
-        <AlertDescription>
-          Self-service <code>org_token</code> issuance is part of the Speakeasy
-          control plane, which is still in progress. For now, contact your
-          Speakeasy representative to obtain a token for your organization.
-        </AlertDescription>
-      </Alert>
+        <div className="mt-4 flex flex-col gap-3">
+          <RequireScope
+            scope="org:admin"
+            level="component"
+            reason="Generating an agent token requires the org:admin role."
+          >
+            <Button
+              onClick={handleGenerate}
+              disabled={createKeyMutation.isPending}
+            >
+              <Button.LeftIcon>
+                <Icon name="key-round" className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>
+                {createKeyMutation.isPending
+                  ? "Generating…"
+                  : generatedToken
+                    ? "Generate a new token"
+                    : "Generate agent token"}
+              </Button.Text>
+            </Button>
+          </RequireScope>
+
+          {generatedToken && (
+            <Alert variant="warning">
+              <Icon name="triangle-alert" className="h-4 w-4" />
+              <AlertTitle>Copy your managed.json now</AlertTitle>
+              <AlertDescription>
+                The new <code>org_token</code> is spliced into the example above
+                and is shown only once — copy the file now, you won't be able to
+                retrieve this token again. Manage or revoke agent tokens anytime
+                under Settings → API Keys.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {createKeyMutation.isError && (
+            <Alert variant="destructive">
+              <Icon name="triangle-alert" className="h-4 w-4" />
+              <AlertTitle>Couldn't generate a token</AlertTitle>
+              <AlertDescription>
+                Something went wrong creating the agent token. Try again, or
+                create one under Settings → API Keys with the Agent scope.
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+      </div>
 
       <div>
         <SubHeading>How the agent applies it</SubHeading>
@@ -440,22 +518,6 @@ function FleetSetup({ exampleManagedJson }: { exampleManagedJson: string }) {
 }
 
 export default function DeviceAgent() {
-  const { name: orgName, slug: orgSlug } = useOrganization();
-  const { email } = useUser();
-
-  const exampleManagedJson = JSON.stringify(
-    {
-      v: 1,
-      email: email || "jane.doe@acme.corp",
-      org_token: "spk_org_REPLACE_ME",
-      org_slug: orgSlug || "acme-corp",
-      org_name: orgName || "Acme Corporation",
-      auto_update: "notify",
-    },
-    null,
-    2,
-  );
-
   return (
     <Page>
       <Page.Header>
@@ -513,7 +575,7 @@ export default function DeviceAgent() {
                   />
                 </TabsList>
                 <TabsContent value="fleet" className="pt-2">
-                  <FleetSetup exampleManagedJson={exampleManagedJson} />
+                  <FleetSetup />
                 </TabsContent>
                 <TabsContent value="manual" className="pt-2">
                   <ManualSetup />

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -76,8 +76,8 @@ function DownloadAgent() {
     );
   }
 
-  const daemon = data?.latest["speakeasyd"];
-  const cli = data?.latest["speakeasy"];
+  const daemon = data?.latest?.["speakeasyd"];
+  const cli = data?.latest?.["speakeasy"];
   if (isError || !daemon || !cli) {
     return (
       <Alert variant="warning">
@@ -620,12 +620,13 @@ function FleetIdentity() {
         <SubHeading>File location</SubHeading>
         <Type small muted className="mb-3">
           Deploy the file to the fixed system path for each OS. Create the
-          directory <code>0700</code> and the file <code>0600</code> (or
+          directory <code>0755</code> and the file <code>0644</code> (or
           equivalent ACLs on Windows). The file must be{" "}
           <strong>readable by the user the agent runs as</strong> — the agent
-          runs as the logged-in user, not root, so <code>0600 root:wheel</code>{" "}
-          on macOS won't work; use <code>0644</code> or a read ACL for the user.
-          The agent only reads this file; it never writes it.
+          runs as the logged-in user, not root, so owner-only{" "}
+          <code>0600 root:wheel</code> on macOS won't work; use{" "}
+          <code>0644</code> or a read ACL for the user. The agent only reads
+          this file; it never writes it.
         </Type>
         <Table headers={["OS", "Path", "Owner"]}>
           {MANAGED_CONFIG_PATHS.map((row) => (

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -627,6 +627,7 @@ function FleetIdentity() {
           <code>0600 root:wheel</code> on macOS won't work; use{" "}
           <code>0640</code> with an explicit group/read ACL for the agent user.
           The agent only reads this file; it never writes it.
+        </Type>
         <Table headers={["OS", "Path", "Owner"]}>
           {MANAGED_CONFIG_PATHS.map((row) => (
             <tr key={row.os} className="border-t">

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -1,0 +1,396 @@
+import { CodeBlock } from "@/components/code";
+import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Type } from "@/components/ui/type";
+import { Icon } from "@speakeasy-api/moonshine";
+import React from "react";
+
+// Public, unauthenticated bucket the release pipeline publishes to. The
+// manifest (releases.json) lists the current version + per-platform URLs;
+// binaries live under v{version}/.
+const RELEASES_BASE =
+  "https://storage.googleapis.com/speakeasy-device-agent-releases-prod";
+const MANIFEST_URL = `${RELEASES_BASE}/releases.json`;
+
+// Example version used in the copy/paste snippets. Operators substitute the
+// current version (see the "find the version" step in each tab) — we keep a
+// concrete value here rather than a literal <VERSION> so the blocks paste and
+// run as-is once edited.
+const EXAMPLE_VERSION = "0.1.0";
+
+function Step({
+  n,
+  title,
+  children,
+}: {
+  n: number;
+  title: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <li className="flex flex-col gap-2">
+      <div className="flex items-baseline gap-2">
+        <span className="bg-muted text-muted-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+          {n}
+        </span>
+        <Type className="font-medium">{title}</Type>
+      </div>
+      {children && <div className="ml-7">{children}</div>}
+    </li>
+  );
+}
+
+function MacInstall() {
+  return (
+    <ol className="flex flex-col gap-5">
+      <Step n={1} title="Find the current version in the manifest">
+        <CodeBlock language="bash">{`curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version'`}</CodeBlock>
+      </Step>
+      <Step
+        n={2}
+        title="Download the daemon + CLI (Apple Silicon shown; use darwin_amd64 for Intel)"
+      >
+        <CodeBlock language="bash">{`VERSION=${EXAMPLE_VERSION}
+BASE=${RELEASES_BASE}/v$VERSION
+curl -fSL -o speakeasyd "$BASE/speakeasyd_${"${VERSION}"}_darwin_arm64"
+curl -fSL -o speakeasy  "$BASE/speakeasy_${"${VERSION}"}_darwin_arm64"`}</CodeBlock>
+      </Step>
+      <Step n={3} title="Make them executable and move into your PATH">
+        <CodeBlock language="bash">{`chmod +x speakeasyd speakeasy
+sudo mv speakeasyd speakeasy /usr/local/bin/`}</CodeBlock>
+      </Step>
+      <Step n={4} title="Register and start the daemon (LaunchAgent)">
+        <CodeBlock language="bash">{`speakeasyd -service install
+speakeasyd -service start`}</CodeBlock>
+      </Step>
+      <Step
+        n={5}
+        title="Enroll (personal / PoC only — MDM-managed devices are configured by IT, see below)"
+      >
+        <CodeBlock language="bash">{`speakeasy enroll`}</CodeBlock>
+      </Step>
+    </ol>
+  );
+}
+
+function WindowsInstall() {
+  return (
+    <ol className="flex flex-col gap-5">
+      <Step n={1} title="Find the current version in the manifest">
+        <CodeBlock language="powershell">{`(Invoke-RestMethod ${MANIFEST_URL}).latest.speakeasyd.version`}</CodeBlock>
+      </Step>
+      <Step n={2} title="Download the daemon + CLI">
+        <CodeBlock language="powershell">{`$VERSION = "${EXAMPLE_VERSION}"
+$BASE = "${RELEASES_BASE}/v$VERSION"
+Invoke-WebRequest "$BASE/speakeasyd_${"${VERSION}"}_windows_amd64.exe" -OutFile speakeasyd.exe
+Invoke-WebRequest "$BASE/speakeasy_${"${VERSION}"}_windows_amd64.exe"  -OutFile speakeasy.exe`}</CodeBlock>
+      </Step>
+      <Step n={3} title="Register and start the Windows service">
+        <CodeBlock language="powershell">{`.\\speakeasyd.exe -service install
+.\\speakeasyd.exe -service start`}</CodeBlock>
+      </Step>
+      <Step
+        n={4}
+        title="Enroll (personal / PoC only — MDM-managed devices are configured by IT, see below)"
+      >
+        <CodeBlock language="powershell">{`.\\speakeasy.exe enroll`}</CodeBlock>
+      </Step>
+    </ol>
+  );
+}
+
+function LinuxInstall() {
+  return (
+    <ol className="flex flex-col gap-5">
+      <Step n={1} title="Find the current version in the manifest">
+        <CodeBlock language="bash">{`curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version'`}</CodeBlock>
+      </Step>
+      <Step
+        n={2}
+        title="Download the daemon + CLI (amd64 shown; use linux_arm64 for ARM)"
+      >
+        <CodeBlock language="bash">{`VERSION=${EXAMPLE_VERSION}
+BASE=${RELEASES_BASE}/v$VERSION
+curl -fSL -o speakeasyd "$BASE/speakeasyd_${"${VERSION}"}_linux_amd64"
+curl -fSL -o speakeasy  "$BASE/speakeasy_${"${VERSION}"}_linux_amd64"`}</CodeBlock>
+      </Step>
+      <Step n={3} title="Make them executable and move into your PATH">
+        <CodeBlock language="bash">{`chmod +x speakeasyd speakeasy
+sudo mv speakeasyd speakeasy /usr/local/bin/`}</CodeBlock>
+      </Step>
+      <Step n={4} title="Register and start the daemon (systemd)">
+        <CodeBlock language="bash">{`speakeasyd -service install
+speakeasyd -service start`}</CodeBlock>
+      </Step>
+      <Step
+        n={5}
+        title="Enroll (personal / PoC only — MDM-managed devices are configured by IT, see below)"
+      >
+        <CodeBlock language="bash">{`speakeasy enroll`}</CodeBlock>
+      </Step>
+    </ol>
+  );
+}
+
+const MANAGED_CONFIG_PATHS = [
+  {
+    os: "macOS",
+    path: "/Library/Application Support/Speakeasy/managed.json",
+    owner: "root",
+  },
+  { os: "Linux", path: "/etc/speakeasy/managed.json", owner: "root" },
+  {
+    os: "Windows",
+    path: "%ProgramData%\\Speakeasy\\managed.json",
+    owner: "SYSTEM",
+  },
+];
+
+const MANAGED_CONFIG_FIELDS = [
+  {
+    field: "v",
+    type: "integer",
+    required: true,
+    notes: "Schema version. Currently 1.",
+  },
+  {
+    field: "email",
+    type: "string",
+    required: true,
+    notes:
+      "The user's verified work email. Shown in the agent UI as the enrolled identity.",
+  },
+  {
+    field: "org_token",
+    type: "string",
+    required: true,
+    notes: "Bearer token the agent uses to call Speakeasy. Treat as a secret.",
+  },
+  {
+    field: "org_slug",
+    type: "string",
+    required: false,
+    notes: "Short org identifier (e.g. acme-corp).",
+  },
+  {
+    field: "org_name",
+    type: "string",
+    required: false,
+    notes: "Display name (e.g. Acme Corporation).",
+  },
+  {
+    field: "auto_update",
+    type: "string",
+    required: false,
+    notes: 'One of "disabled" (default), "notify", or "automatic".',
+  },
+];
+
+const EXAMPLE_MANAGED_JSON = `{
+  "v": 1,
+  "email": "jane.doe@acme.corp",
+  "org_token": "spk_org_REPLACE_ME",
+  "org_slug": "acme-corp",
+  "org_name": "Acme Corporation",
+  "auto_update": "notify"
+}`;
+
+export default function DeviceAgent() {
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs />
+      </Page.Header>
+      <Page.Body>
+        <RequireScope scope={["org:read", "org:admin"]} level="page">
+          <Page.Section>
+            <Page.Section.Title>Device Agent</Page.Section.Title>
+            <Page.Section.Description>
+              The Speakeasy device agent runs on developer laptops and enforces
+              your org's required AI-tool plugins and MCP configuration. Deploy
+              it fleet-wide via MDM, or install it individually for testing.
+            </Page.Section.Description>
+            <Page.Section.Body>
+              <Alert variant="info">
+                <Icon name="info" className="h-4 w-4" />
+                <AlertTitle>
+                  Interim install — signed installers in progress
+                </AlertTitle>
+                <AlertDescription>
+                  Signed <code>.pkg</code> / <code>.msi</code> /{" "}
+                  <code>.deb</code> installers and one-click MDM binary
+                  deployment are still being built. Until they ship, use the
+                  manual steps below (the binaries are published but not yet
+                  code-signed). The <strong>managed configuration</strong> below
+                  is fully supported today.
+                </AlertDescription>
+              </Alert>
+            </Page.Section.Body>
+          </Page.Section>
+
+          <Page.Section>
+            <Page.Section.Title>Install the agent</Page.Section.Title>
+            <Page.Section.Description>
+              Download the daemon (<code>speakeasyd</code>) and CLI (
+              <code>speakeasy</code>) for your platform, then register the
+              daemon as a managed service.
+            </Page.Section.Description>
+            <Page.Section.Body>
+              <Tabs defaultValue="macos">
+                <TabsList className="grid w-full max-w-md grid-cols-3">
+                  <TabsTrigger value="macos">macOS</TabsTrigger>
+                  <TabsTrigger value="windows">Windows</TabsTrigger>
+                  <TabsTrigger value="linux">Linux</TabsTrigger>
+                </TabsList>
+                <TabsContent value="macos" className="pt-4">
+                  <MacInstall />
+                </TabsContent>
+                <TabsContent value="windows" className="pt-4">
+                  <WindowsInstall />
+                </TabsContent>
+                <TabsContent value="linux" className="pt-4">
+                  <LinuxInstall />
+                </TabsContent>
+              </Tabs>
+            </Page.Section.Body>
+          </Page.Section>
+
+          <Page.Section>
+            <Page.Section.Title>MDM configuration</Page.Section.Title>
+            <Page.Section.Description>
+              For fleet deployment, IT provisions a <code>managed.json</code>{" "}
+              file via your MDM (Kandji, Jamf, Intune, …). The agent reads it at
+              startup — no per-user enrollment step on the device.
+            </Page.Section.Description>
+            <Page.Section.Body>
+              <div className="flex flex-col gap-6">
+                <div>
+                  <Type className="mb-2 font-medium">File location</Type>
+                  <Type small muted className="mb-3">
+                    Deploy the file to the fixed system path for each OS,
+                    created with <code>0700</code> directory perms /{" "}
+                    <code>0600</code> on the file (or equivalent ACLs on
+                    Windows). The agent only reads it — it never writes it.
+                  </Type>
+                  <div className="overflow-hidden rounded-lg border">
+                    <table className="w-full text-sm">
+                      <thead className="bg-muted/50 text-muted-foreground">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-medium">
+                            OS
+                          </th>
+                          <th className="px-4 py-2 text-left font-medium">
+                            Path
+                          </th>
+                          <th className="px-4 py-2 text-left font-medium">
+                            Owner
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {MANAGED_CONFIG_PATHS.map((row) => (
+                          <tr key={row.os} className="border-t">
+                            <td className="px-4 py-2">{row.os}</td>
+                            <td className="px-4 py-2 font-mono text-xs">
+                              {row.path}
+                            </td>
+                            <td className="px-4 py-2">{row.owner}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                <div>
+                  <Type className="mb-2 font-medium">Schema</Type>
+                  <div className="overflow-hidden rounded-lg border">
+                    <table className="w-full text-sm">
+                      <thead className="bg-muted/50 text-muted-foreground">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-medium">
+                            Field
+                          </th>
+                          <th className="px-4 py-2 text-left font-medium">
+                            Type
+                          </th>
+                          <th className="px-4 py-2 text-left font-medium">
+                            Required
+                          </th>
+                          <th className="px-4 py-2 text-left font-medium">
+                            Notes
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {MANAGED_CONFIG_FIELDS.map((row) => (
+                          <tr key={row.field} className="border-t align-top">
+                            <td className="px-4 py-2 font-mono text-xs">
+                              {row.field}
+                            </td>
+                            <td className="px-4 py-2">{row.type}</td>
+                            <td className="px-4 py-2">
+                              {row.required ? "yes" : "no"}
+                            </td>
+                            <td className="text-muted-foreground px-4 py-2">
+                              {row.notes}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                <div>
+                  <Type className="mb-2 font-medium">Example managed.json</Type>
+                  <CodeBlock language="json">{EXAMPLE_MANAGED_JSON}</CodeBlock>
+                </div>
+
+                <Alert variant="warning">
+                  <Icon name="triangle-alert" className="h-4 w-4" />
+                  <AlertTitle>Where the org token comes from</AlertTitle>
+                  <AlertDescription>
+                    Self-service <code>org_token</code> issuance is part of the
+                    Speakeasy control plane, which is still in progress. For
+                    now, contact your Speakeasy representative to obtain a token
+                    for your organization.
+                  </AlertDescription>
+                </Alert>
+
+                <div>
+                  <Type className="mb-2 font-medium">Deploying via MDM</Type>
+                  <Type small muted>
+                    The exact mechanics vary by platform. The common pattern:
+                    package <code>managed.json</code> as a custom configuration
+                    profile that drops the file at the path above with the right
+                    permissions, then scope it to your target device groups.
+                    Managed configuration always takes precedence over a user's
+                    local enrollment, so an MDM-provisioned device shows as
+                    "Provisioned by IT" and ignores any local sign-in.
+                  </Type>
+                </div>
+              </div>
+            </Page.Section.Body>
+          </Page.Section>
+
+          <Page.Section>
+            <Page.Section.Title>
+              Coming soon <Badge variant="secondary">In progress</Badge>
+            </Page.Section.Title>
+            <Page.Section.Body>
+              <Type small muted>
+                Signed installer packages (<code>.pkg</code> / <code>.msi</code>{" "}
+                / <code>.deb</code>), one-click MDM binary deployment, and the
+                menu-bar UI download will land here as they ship.
+              </Type>
+            </Page.Section.Body>
+          </Page.Section>
+        </RequireScope>
+      </Page.Body>
+    </Page>
+  );
+}

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
-import { useOrganization, useUser } from "@/contexts/Auth";
+import { useOrganization } from "@/contexts/Auth";
 import { useCreateAPIKeyMutation } from "@gram/client/react-query/createAPIKey";
 import { Button, Icon } from "@speakeasy-api/moonshine";
 import React from "react";
@@ -203,9 +203,9 @@ const MANAGED_CONFIG_FIELDS = [
   {
     field: "email",
     type: "string",
-    required: "yes",
+    required: "yes*",
     notes:
-      "The user's verified work email. Shown in the agent UI as the enrolled identity.",
+      "Per-user work email, shown in the agent UI as the enrolled identity. Have your MDM substitute it per device (e.g. $EMAIL), or omit it and let the user supply it via speakeasy enroll. *Required unless provided by manual enrollment.",
   },
   {
     field: "org_token",
@@ -298,7 +298,6 @@ function ManualSetup() {
 
 function FleetSetup() {
   const { name: orgName, slug: orgSlug } = useOrganization();
-  const { email } = useUser();
   const [generatedToken, setGeneratedToken] = React.useState<string | null>(
     null,
   );
@@ -309,13 +308,16 @@ function FleetSetup() {
     },
   });
 
-  // The agent's org_token is just an `agent`-scoped API key. Once generated we
-  // splice it into the example below so the whole managed.json is copy-ready;
-  // the raw key is only returned once, so there's nothing to re-fetch later.
+  // org_slug / org_name are org-level constants, safe to prefill. email is
+  // per-user: this fleet-wide file must not pin one identity, so the example
+  // shows an MDM substitution placeholder ($EMAIL) rather than the viewing
+  // admin's address — the MDM swaps it per device, or it's omitted and the user
+  // enrolls manually. org_token is an `agent`-scoped API key; once generated we
+  // splice it in so the whole managed.json is copy-ready (it's returned once).
   const exampleManagedJson = JSON.stringify(
     {
       v: 1,
-      email: email || "jane.doe@acme.corp",
+      email: "$EMAIL",
       org_token: generatedToken ?? "spk_org_REPLACE_ME",
       org_slug: orgSlug || "acme-corp",
       org_name: orgName || "Acme Corporation",
@@ -405,9 +407,13 @@ function FleetSetup() {
         <SubHeading>Example managed.json</SubHeading>
         <CodeBlock language="json">{exampleManagedJson}</CodeBlock>
         <Type small muted className="mt-2">
-          Pre-filled with this org's <code>email</code>, <code>org_slug</code>,
-          and <code>org_name</code>. Generate the <code>org_token</code> below —
-          it's the only value you have to supply.
+          <code>org_slug</code> and <code>org_name</code> are pre-filled for
+          this org. <code>email</code> is per-user — have your MDM substitute
+          its per-user email variable (Kandji / Jamf <code>$EMAIL</code>, or
+          your platform's equivalent) so one profile serves the whole fleet, or
+          omit <code>email</code> and have each user run{" "}
+          <code>speakeasy enroll</code>. Generate the <code>org_token</code>{" "}
+          below.
         </Type>
 
         <div className="mt-4 flex flex-col gap-3">

--- a/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
+++ b/client/dashboard/src/pages/device-agent/DeviceAgent.tsx
@@ -763,22 +763,6 @@ export default function DeviceAgent() {
               your org's required AI-tool plugins and MCP configuration, then
               reports compliance back to Speakeasy.
             </Page.Section.Description>
-            <Page.Section.Body>
-              <Alert variant="info">
-                <Icon name="info" className="h-4 w-4" />
-                <AlertTitle>
-                  Interim install — signed installers in progress
-                </AlertTitle>
-                <AlertDescription>
-                  Signed <code>.pkg</code> / <code>.msi</code> /{" "}
-                  <code>.deb</code> installers and one-click MDM binary
-                  deployment are still being built. Until they ship, follow the
-                  install steps below (the binaries are published but not yet
-                  code-signed). The managed configuration is fully supported
-                  today.
-                </AlertDescription>
-              </Alert>
-            </Page.Section.Body>
           </Page.Section>
 
           <Page.Section>

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -800,6 +800,7 @@ const ORG_ROUTE_STRUCTURE = {
     title: "Device Agent",
     url: "device-agent",
     icon: "laptop",
+    stage: "preview",
     component: DeviceAgent,
   },
   access: {

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -21,6 +21,7 @@ import ChatSessions from "./pages/chatLogs/ChatLogs";
 import CLIs from "./pages/CLIs";
 import Deployment from "./pages/deployments/deployment/Deployment";
 import Deployments, { DeploymentsRoot } from "./pages/deployments/Deployments";
+import DeviceAgent from "./pages/device-agent/DeviceAgent";
 import Elements from "./pages/elements/Elements";
 import EnvironmentPage from "./pages/environments/Environment";
 import Environments, {
@@ -794,6 +795,12 @@ const ORG_ROUTE_STRUCTURE = {
     url: "identity",
     icon: "fingerprint",
     component: OrgIdentity,
+  },
+  deviceAgent: {
+    title: "Device Agent",
+    url: "device-agent",
+    icon: "laptop",
+    component: DeviceAgent,
   },
   access: {
     title: "Roles & Permissions",


### PR DESCRIPTION
## Summary

Dashboard support for the Speakeasy device agent. Two pieces:

1. **Org-level Device Agent page** (`pages/device-agent/DeviceAgent.tsx`) under the **Secure** nav group — install instructions + MDM configuration reference.
2. **CLI loopback callback patch** (`pages/cli/CliCallback.tsx`) — passes the enrolled user's email through the OAuth loopback redirect, which the device agent's enrollment flow requires.

## 1. Device Agent page

Routed at `/<org>/device-agent` (in `ORG_ROUTE_STRUCTURE`, rendered in the Secure sidebar group alongside Audit Logs / Identity / Roles & Permissions). Gated `org:read` / `org:admin`.

- **Install the agent** — per-OS tabs (macOS / Windows / Linux): look up the current version in the public release manifest, download `speakeasyd` + `speakeasy`, register the daemon as a managed service (`-service install`), enroll. Real commands against the live releases bucket.
- **MDM configuration** — `managed.json` schema, per-OS paths + owners, example file, config-profile guidance.
- **Honest "in progress" callouts** — signed installers, one-click MDM deployment, and self-service `org_token` issuance aren't shipped yet; the page says so rather than documenting vaporware.

## 2. CLI loopback callback (enrollment)

`transmitKey` now appends `&email=<userEmail>` to the loopback callback URL (alongside `api_key` / `project`). The device agent's one-shot OAuth-loopback enrollment reads the enrolled identity from this redirect; its local listener rejects callbacks missing the email parameter. This is the dashboard-side change the agent has needed (previously carried as a local patch for testing against a local control plane).

## Scope note

The page documents the **interim** install path (unsigned binaries from the public bucket + manual `-service install`). Signed installers + turnkey MDM are tracked separately (SEL-17 on the agent side). The `managed.json` config + the enrollment callback are accurate and useful today.

## Status / testing

- `tsc` / `oxfmt` / `eslint` clean on all four touched files.
- **Not yet rendered against a live dashboard by CI.** Reviewer should eyeball the page at `/<org>/device-agent` and exercise the enrollment loopback.


🤖 Generated with [Claude Code](https://claude.com/claude-code)