### PR TITLE
fix: specify explicit Svix app portal capabilities for admins

### DIFF
--- a/.changeset/clear-birds-look.md
+++ b/.changeset/clear-birds-look.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Updated the create portal session endpoint for svix webhooks to request all capabilities for admins explicitly. Previously it was specifying an empty slice of capabilities, which appeared to result in a read only session.

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -1315,7 +1315,14 @@ func organizationUserToGen(row *orgrepo.ListOrganizationUsersRow) *gen.Organizat
 }
 
 func fullSvixAppPortalCapabilities() []models.AppPortalCapability {
-	return []models.AppPortalCapability{}
+	return []models.AppPortalCapability{
+		models.APPPORTALCAPABILITY_VIEW_BASE,
+		models.APPPORTALCAPABILITY_VIEW_ENDPOINT_SECRET,
+		models.APPPORTALCAPABILITY_MANAGE_ENDPOINT_SECRET,
+		models.APPPORTALCAPABILITY_MANAGE_TRANSFORMATIONS,
+		models.APPPORTALCAPABILITY_CREATE_ATTEMPTS,
+		models.APPPORTALCAPABILITY_MANAGE_ENDPOINT,
+	}
 }
 func minimumSvixAppPortalCapabilities() []models.AppPortalCapability {
 	return []models.AppPortalCapability{models.APPPORTALCAPABILITY_VIEW_BASE}


### PR DESCRIPTION
This change updates the create portal session endpoint for svix webhooks to request all capabilities for admins explicitly. Previously it was specifying an empty slice of capabilities, which appeared to result in a read only session.