### PR TITLE
mig: add remote session client <-> user session issuer join table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -862,7 +862,7 @@ WHERE deleted IS FALSE;
 -- upstream authorization servers
 CREATE TABLE IF NOT EXISTS remote_session_clients (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
-  project_id uuid NOT NULL,
+  project_id uuid,
   remote_session_issuer_id uuid NOT NULL,
   user_session_issuer_id uuid NOT NULL,
 
@@ -895,6 +895,22 @@ CREATE TABLE IF NOT EXISTS remote_session_clients (
   CONSTRAINT remote_session_clients_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS remote_session_client_user_session_issuers (
+  remote_session_client_id uuid NOT NULL,
+  user_session_issuer_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT remote_session_client_user_session_issuers_pkey PRIMARY KEY (remote_session_client_id, user_session_issuer_id),
+  CONSTRAINT remote_session_client_user_session_issuers_client_fkey FOREIGN KEY (remote_session_client_id) REFERENCES remote_session_clients (id) ON DELETE CASCADE,
+  CONSTRAINT remote_session_client_user_session_issuers_issuer_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS remote_session_client_user_session_issuers_issuer_idx
+ON remote_session_client_user_session_issuers (user_session_issuer_id, remote_session_client_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS remote_session_client_user_session_issuers_one_per_issuer
+ON remote_session_client_user_session_issuers (user_session_issuer_id);
+
 -- Remote sessions represent credentials for an external resource that have
 -- been granted to a single Gram subject
 CREATE TABLE IF NOT EXISTS remote_sessions (
@@ -921,6 +937,10 @@ CREATE TABLE IF NOT EXISTS remote_sessions (
 
 CREATE UNIQUE INDEX IF NOT EXISTS remote_sessions_subject_client_key
 ON remote_sessions (subject_urn, remote_session_client_id)
+WHERE deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS remote_sessions_subject_client_issuer_key
+ON remote_sessions (subject_urn, remote_session_client_id, user_session_issuer_id)
 WHERE deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS toolsets (

--- a/server/internal/conv/from.go
+++ b/server/internal/conv/from.go
@@ -85,6 +85,11 @@ func PtrToNullUUID(s *string) (uuid.NullUUID, error) {
 	return uuid.NullUUID{UUID: id, Valid: true}, nil
 }
 
+// ToNullUUID converts a required UUID into a valid uuid.NullUUID.
+func ToNullUUID(id uuid.UUID) uuid.NullUUID {
+	return uuid.NullUUID{UUID: id, Valid: true}
+}
+
 // FromNullableUUID converts a uuid.NullUUID to a *string. If the NullUUID is
 // not valid, it returns nil.
 func FromNullableUUID(u uuid.NullUUID) *string {

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1139,7 +1139,7 @@ type RemoteSession struct {
 
 type RemoteSessionClient struct {
 	ID                      uuid.UUID
-	ProjectID               uuid.UUID
+	ProjectID               uuid.NullUUID
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	ClientID                string
@@ -1154,6 +1154,12 @@ type RemoteSessionClient struct {
 	UpdatedAt               pgtype.Timestamptz
 	DeletedAt               pgtype.Timestamptz
 	Deleted                 bool
+}
+
+type RemoteSessionClientUserSessionIssuer struct {
+	RemoteSessionClientID uuid.UUID
+	UserSessionIssuerID   uuid.UUID
+	CreatedAt             pgtype.Timestamptz
 }
 
 type RemoteSessionIssuer struct {

--- a/server/internal/mcp/remotelogin_integration_test.go
+++ b/server/internal/mcp/remotelogin_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
@@ -285,7 +286,7 @@ func runRemoteLoginRoundTrip(
 	}
 
 	sessions, err := remotesessions_repo.New(ti.conn).ListRemoteSessionsByProjectID(ctx, remotesessions_repo.ListRemoteSessionsByProjectIDParams{
-		ProjectID:  result.Toolset.ProjectID,
+		ProjectID:  conv.ToNullUUID(result.Toolset.ProjectID),
 		LimitValue: 10,
 	})
 	require.NoError(t, err)

--- a/server/internal/mcp/remotesession_resolver_integration_test.go
+++ b/server/internal/mcp/remotesession_resolver_integration_test.go
@@ -233,7 +233,7 @@ func createIssuerGatedExternalMCPFixture(
 	})
 	require.NoError(t, err)
 	remoteClient, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
-		ProjectID:             toolset.ProjectID,
+		ProjectID:             conv.ToNullUUID(toolset.ProjectID),
 		RemoteSessionIssuerID: remoteIssuer.ID,
 		UserSessionIssuerID:   userIssuer.ID,
 		ClientID:              "resolver-extmcp-client-" + suffix,

--- a/server/internal/mcp/remotesession_resolver_test.go
+++ b/server/internal/mcp/remotesession_resolver_test.go
@@ -186,7 +186,7 @@ func createRemoteSessionResolverFixture(
 	require.NoError(t, err)
 
 	remoteClient, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
-		ProjectID:             *authCtx.ProjectID,
+		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID: remoteIssuer.ID,
 		UserSessionIssuerID:   userIssuer.ID,
 		ClientID:              "resolver-client-" + suffix,

--- a/server/internal/mv/remotesessionclient.go
+++ b/server/internal/mv/remotesessionclient.go
@@ -1,6 +1,7 @@
 package mv
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
@@ -8,7 +9,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
-func BuildRemoteSessionClientView(row repo.RemoteSessionClient) *types.RemoteSessionClient {
+func BuildRemoteSessionClientView(row repo.RemoteSessionClient) (*types.RemoteSessionClient, error) {
+	if !row.ProjectID.Valid {
+		return nil, fmt.Errorf("remote_session_client %s has null project_id", row.ID)
+	}
+
 	var issuedAt string
 	if row.ClientIDIssuedAt.Valid {
 		issuedAt = row.ClientIDIssuedAt.Time.Format(time.RFC3339)
@@ -20,7 +25,7 @@ func BuildRemoteSessionClientView(row repo.RemoteSessionClient) *types.RemoteSes
 	}
 	return &types.RemoteSessionClient{
 		ID:                      row.ID.String(),
-		ProjectID:               row.ProjectID.String(),
+		ProjectID:               row.ProjectID.UUID.String(),
 		RemoteSessionIssuerID:   row.RemoteSessionIssuerID.String(),
 		UserSessionIssuerID:     row.UserSessionIssuerID.String(),
 		ClientID:                row.ClientID,
@@ -31,5 +36,5 @@ func BuildRemoteSessionClientView(row repo.RemoteSessionClient) *types.RemoteSes
 		Audience:                conv.FromPGText[string](row.Audience),
 		CreatedAt:               row.CreatedAt.Time.Format(time.RFC3339),
 		UpdatedAt:               row.UpdatedAt.Time.Format(time.RFC3339),
-	}
+	}, nil
 }

--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -139,7 +139,7 @@ func CreateIssuerGatedToolset(
 	require.NoError(t, err)
 
 	rsc, err := remoteRepo.CreateRemoteSessionClient(ctx, remotesessions_repo.CreateRemoteSessionClientParams{
-		ProjectID:             *authCtx.ProjectID,
+		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID: rsi.ID,
 		UserSessionIssuerID:   usi.ID,
 		ClientID:              clientID,

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -179,7 +179,7 @@ func (m *ChallengeManager) ListClients(
 ) ([]Client, error) {
 	rows, err := remotesessions_repo.New(m.db).ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessions_repo.ListRemoteSessionClientsForUserSessionIssuerParams{
 		UserSessionIssuerID: userSessionIssuerID,
-		ProjectID:           projectID,
+		ProjectID:           conv.ToNullUUID(projectID),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list remote session clients: %w", err)
@@ -368,7 +368,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	queries := remotesessions_repo.New(m.db)
 	clientRow, err := queries.GetRemoteSessionClientByID(ctx, remotesessions_repo.GetRemoteSessionClientByIDParams{
 		ID:        state.RemoteSessionClientID,
-		ProjectID: state.ProjectID,
+		ProjectID: conv.ToNullUUID(state.ProjectID),
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "load remote session client").Log(ctx, logger)

--- a/server/internal/remotesessions/challenge_audience_e2e_test.go
+++ b/server/internal/remotesessions/challenge_audience_e2e_test.go
@@ -93,7 +93,7 @@ func TestBuildAuthorizationUrl_AudienceResolution(t *testing.T) {
 			userIssuer := createUserSessionIssuer(t, ctx, ti.conn, "usi-aud-"+slugSuffix)
 
 			_, err = q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
-				ProjectID:               *authCtx.ProjectID,
+				ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 				RemoteSessionIssuerID:   issuer.ID,
 				UserSessionIssuerID:     userIssuer,
 				ClientID:                "aud-cid",

--- a/server/internal/remotesessions/challenge_scope_e2e_test.go
+++ b/server/internal/remotesessions/challenge_scope_e2e_test.go
@@ -94,7 +94,7 @@ func TestBuildAuthorizationUrl_ScopeResolution(t *testing.T) {
 			userIssuer := createUserSessionIssuer(t, ctx, ti.conn, "usi-scope-"+slugSuffix)
 
 			client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
-				ProjectID:               *authCtx.ProjectID,
+				ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 				RemoteSessionIssuerID:   issuer.ID,
 				UserSessionIssuerID:     userIssuer,
 				ClientID:                "scope-cid",

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -73,7 +73,7 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 	txRepo := repo.New(dbtx)
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
-		ProjectID:               *authCtx.ProjectID,
+		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuerID,
 		UserSessionIssuerID:     userIssuerID,
 		ClientID:                clientID,
@@ -104,7 +104,12 @@ func (s *Service) CreateRemoteSessionClient(ctx context.Context, payload *gen.Cr
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
 	}
 
-	return mv.BuildRemoteSessionClientView(created), nil
+	view, err := mv.BuildRemoteSessionClientView(created)
+	if err != nil {
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+	}
+
+	return view, nil
 }
 
 // CloneClientFromOAuthProxyProvider mints a remote_session_client by lifting
@@ -197,7 +202,7 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 	}
 
 	created, err := txRepo.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
-		ProjectID:               *authCtx.ProjectID,
+		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuerID,
 		UserSessionIssuerID:     userIssuerID,
 		ClientID:                clientID,
@@ -228,7 +233,12 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").Log(ctx, logger)
 	}
 
-	return mv.BuildRemoteSessionClientView(created), nil
+	view, err := mv.BuildRemoteSessionClientView(created)
+	if err != nil {
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+	}
+
+	return view, nil
 }
 
 // resolveProxyClientCredentials pulls client_id and client_secret out of an
@@ -312,7 +322,7 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 
 	existing, err := txRepo.GetRemoteSessionClientByID(ctx, repo.GetRemoteSessionClientByIDParams{
 		ID:        clientID,
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: conv.ToNullUUID(*authCtx.ProjectID),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -321,7 +331,10 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 		return nil, oops.E(oops.CodeUnexpected, err, "get remote session client").Log(ctx, logger)
 	}
 
-	beforeView := mv.BuildRemoteSessionClientView(existing)
+	beforeView, err := mv.BuildRemoteSessionClientView(existing)
+	if err != nil {
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+	}
 
 	var secretCiphertext pgtype.Text
 	if payload.ClientSecret != nil && *payload.ClientSecret != "" {
@@ -340,7 +353,7 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 		Scope:                   payload.Scope,
 		Audience:                conv.PtrToPGText(payload.Audience),
 		ID:                      clientID,
-		ProjectID:               *authCtx.ProjectID,
+		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -349,7 +362,10 @@ func (s *Service) UpdateRemoteSessionClient(ctx context.Context, payload *gen.Up
 		return nil, oops.E(oops.CodeUnexpected, err, "update remote session client").Log(ctx, logger)
 	}
 
-	afterView := mv.BuildRemoteSessionClientView(updated)
+	afterView, err := mv.BuildRemoteSessionClientView(updated)
+	if err != nil {
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+	}
 
 	if err := s.auditLogger.LogRemoteSessionClientUpdate(ctx, dbtx, audit.LogRemoteSessionClientUpdateEvent{
 		OrganizationID:         authCtx.ActiveOrganizationID,
@@ -401,7 +417,7 @@ func (s *Service) ListRemoteSessionClients(ctx context.Context, payload *gen.Lis
 	}
 
 	rows, err := repo.New(s.db).ListRemoteSessionClientsByProjectID(ctx, repo.ListRemoteSessionClientsByProjectIDParams{
-		ProjectID:             *authCtx.ProjectID,
+		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID: issuerFilter,
 		UserSessionIssuerID:   userIssuerFilter,
 		Cursor:                cursor,
@@ -413,7 +429,11 @@ func (s *Service) ListRemoteSessionClients(ctx context.Context, payload *gen.Lis
 
 	items := make([]*types.RemoteSessionClient, 0, len(rows))
 	for _, row := range rows {
-		items = append(items, mv.BuildRemoteSessionClientView(row))
+		item, err := mv.BuildRemoteSessionClientView(row)
+		if err != nil {
+			return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+		}
+		items = append(items, item)
 	}
 
 	var nextCursor *string
@@ -447,7 +467,7 @@ func (s *Service) GetRemoteSessionClient(ctx context.Context, payload *gen.GetRe
 
 	client, err := repo.New(s.db).GetRemoteSessionClientByID(ctx, repo.GetRemoteSessionClientByIDParams{
 		ID:        clientID,
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: conv.ToNullUUID(*authCtx.ProjectID),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -456,7 +476,12 @@ func (s *Service) GetRemoteSessionClient(ctx context.Context, payload *gen.GetRe
 		return nil, oops.E(oops.CodeUnexpected, err, "get remote session client").Log(ctx, logger)
 	}
 
-	return mv.BuildRemoteSessionClientView(client), nil
+	view, err := mv.BuildRemoteSessionClientView(client)
+	if err != nil {
+		return nil, oops.E(oops.CodeInvariantViolation, err, "build remote session client view").Log(ctx, logger)
+	}
+
+	return view, nil
 }
 
 // DeleteRemoteSessionClient soft-deletes a client and cascades the soft-delete
@@ -490,7 +515,7 @@ func (s *Service) DeleteRemoteSessionClient(ctx context.Context, payload *gen.De
 
 	deleted, err := txRepo.DeleteRemoteSessionClient(ctx, repo.DeleteRemoteSessionClientParams{
 		ID:        clientID,
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: conv.ToNullUUID(*authCtx.ProjectID),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/server/internal/remotesessions/repo/models.go
+++ b/server/internal/remotesessions/repo/models.go
@@ -28,7 +28,7 @@ type RemoteSession struct {
 
 type RemoteSessionClient struct {
 	ID                      uuid.UUID
-	ProjectID               uuid.UUID
+	ProjectID               uuid.NullUUID
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	ClientID                string

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -68,7 +68,7 @@ RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, clie
 `
 
 type CreateRemoteSessionClientParams struct {
-	ProjectID               uuid.UUID
+	ProjectID               uuid.NullUUID
 	RemoteSessionIssuerID   uuid.UUID
 	UserSessionIssuerID     uuid.UUID
 	ClientID                string
@@ -217,7 +217,7 @@ RETURNING id, project_id, remote_session_issuer_id, user_session_issuer_id, clie
 
 type DeleteRemoteSessionClientParams struct {
 	ID        uuid.UUID
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 }
 
 func (q *Queries) DeleteRemoteSessionClient(ctx context.Context, arg DeleteRemoteSessionClientParams) (RemoteSessionClient, error) {
@@ -365,7 +365,7 @@ WHERE s.id = $1 AND c.project_id = $2 AND s.deleted IS FALSE AND c.deleted IS FA
 
 type GetRemoteSessionByIDParams struct {
 	ID        uuid.UUID
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 }
 
 func (q *Queries) GetRemoteSessionByID(ctx context.Context, arg GetRemoteSessionByIDParams) (RemoteSession, error) {
@@ -397,7 +397,7 @@ WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 
 type GetRemoteSessionClientByIDParams struct {
 	ID        uuid.UUID
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 }
 
 func (q *Queries) GetRemoteSessionClientByID(ctx context.Context, arg GetRemoteSessionClientByIDParams) (RemoteSessionClient, error) {
@@ -675,7 +675,7 @@ LIMIT $5
 `
 
 type ListRemoteSessionClientsByProjectIDParams struct {
-	ProjectID             uuid.UUID
+	ProjectID             uuid.NullUUID
 	RemoteSessionIssuerID uuid.NullUUID
 	UserSessionIssuerID   uuid.NullUUID
 	Cursor                uuid.NullUUID
@@ -753,7 +753,7 @@ ORDER BY c.id ASC
 
 type ListRemoteSessionClientsForUserSessionIssuerParams struct {
 	UserSessionIssuerID uuid.UUID
-	ProjectID           uuid.UUID
+	ProjectID           uuid.NullUUID
 }
 
 type ListRemoteSessionClientsForUserSessionIssuerRow struct {
@@ -883,7 +883,7 @@ LIMIT $5
 `
 
 type ListRemoteSessionsByProjectIDParams struct {
-	ProjectID             uuid.UUID
+	ProjectID             uuid.NullUUID
 	SubjectUrn            pgtype.Text
 	RemoteSessionClientID uuid.NullUUID
 	Cursor                uuid.NullUUID
@@ -944,7 +944,7 @@ RETURNING s.id, s.subject_urn, s.user_session_issuer_id, s.remote_session_client
 
 type RevokeRemoteSessionParams struct {
 	ID        uuid.UUID
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 }
 
 func (q *Queries) RevokeRemoteSession(ctx context.Context, arg RevokeRemoteSessionParams) (RemoteSession, error) {
@@ -1004,7 +1004,7 @@ type UpdateRemoteSessionClientParams struct {
 	Scope                   []string
 	Audience                pgtype.Text
 	ID                      uuid.UUID
-	ProjectID               uuid.UUID
+	ProjectID               uuid.NullUUID
 }
 
 func (q *Queries) UpdateRemoteSessionClient(ctx context.Context, arg UpdateRemoteSessionClientParams) (RemoteSessionClient, error) {

--- a/server/internal/remotesessions/sessionhandlers.go
+++ b/server/internal/remotesessions/sessionhandlers.go
@@ -46,7 +46,7 @@ func (s *Service) ListRemoteSessions(ctx context.Context, payload *gen.ListRemot
 	}
 
 	rows, err := repo.New(s.db).ListRemoteSessionsByProjectID(ctx, repo.ListRemoteSessionsByProjectIDParams{
-		ProjectID:             *authCtx.ProjectID,
+		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
 		SubjectUrn:            subjectFilter,
 		RemoteSessionClientID: clientFilter,
 		Cursor:                cursor,
@@ -100,7 +100,7 @@ func (s *Service) RevokeRemoteSession(ctx context.Context, payload *gen.RevokeRe
 
 	revoked, err := txRepo.RevokeRemoteSession(ctx, repo.RevokeRemoteSessionParams{
 		ID:        sessionID,
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: conv.ToNullUUID(*authCtx.ProjectID),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/server/internal/remotesessions/sessionhandlers_test.go
+++ b/server/internal/remotesessions/sessionhandlers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -31,7 +32,7 @@ func TestListRemoteSessions(t *testing.T) {
 	// Soft-delete one row directly so it must be excluded from the listing.
 	_, err := repo.New(ti.conn).RevokeRemoteSession(ctx, repo.RevokeRemoteSessionParams{
 		ID:        soft.ID,
-		ProjectID: liveProjectID(t, ctx),
+		ProjectID: conv.ToNullUUID(liveProjectID(t, ctx)),
 	})
 	require.NoError(t, err)
 

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -128,7 +128,7 @@ func (m *ChallengeManager) ResolveOneAccessToken(
 	subject urn.SessionSubject,
 ) (string, error) {
 	clients, err := remotesessions_repo.New(m.db).ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessions_repo.ListRemoteSessionClientsForUserSessionIssuerParams{
-		ProjectID:           projectID,
+		ProjectID:           conv.ToNullUUID(projectID),
 		UserSessionIssuerID: userSessionIssuerID,
 	})
 	if err != nil {

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -98,7 +98,7 @@ func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *up
 	secretCiphertext, err := enc.Encrypt([]byte("aud-secret"))
 	require.NoError(t, err)
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
-		ProjectID:               *authCtx.ProjectID,
+		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuer.ID,
 		UserSessionIssuerID:     userIssuer,
 		ClientID:                "aud-cid",

--- a/server/internal/remotesessions/tokenservice_authmethod_test.go
+++ b/server/internal/remotesessions/tokenservice_authmethod_test.go
@@ -120,7 +120,7 @@ func setupRefreshFixture(t *testing.T, authMethod string, spy *upstreamSpy) (con
 	secretCiphertext, err := enc.Encrypt([]byte(clientSecret))
 	require.NoError(t, err)
 	client, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
-		ProjectID:               *authCtx.ProjectID,
+		ProjectID:               conv.ToNullUUID(*authCtx.ProjectID),
 		RemoteSessionIssuerID:   issuer.ID,
 		UserSessionIssuerID:     userIssuer,
 		ClientID:                externalCID,

--- a/server/internal/xmcp/serveoauth_integration_test.go
+++ b/server/internal/xmcp/serveoauth_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
@@ -266,7 +267,7 @@ func TestHandleRemoteLoginCallback_AnonymousSubject(t *testing.T) {
 	require.Contains(t, cbW.Header().Get("Location"), parentID)
 
 	sessions, err := remotesessions_repo.New(ti.conn).ListRemoteSessionsByProjectID(ctx, remotesessions_repo.ListRemoteSessionsByProjectIDParams{
-		ProjectID:  result.McpServer.ProjectID,
+		ProjectID:  conv.ToNullUUID(result.McpServer.ProjectID),
 		LimitValue: 10,
 	})
 	require.NoError(t, err)

--- a/server/migrations/20260527214516_remote_session_client_user_session_issuers.sql
+++ b/server/migrations/20260527214516_remote_session_client_user_session_issuers.sql
@@ -1,0 +1,19 @@
+-- atlas:txmode none
+
+-- Modify "remote_session_clients" table
+ALTER TABLE "remote_session_clients" ALTER COLUMN "project_id" DROP NOT NULL;
+-- Create index "remote_sessions_subject_client_issuer_key" to table: "remote_sessions"
+CREATE UNIQUE INDEX CONCURRENTLY "remote_sessions_subject_client_issuer_key" ON "remote_sessions" ("subject_urn", "remote_session_client_id", "user_session_issuer_id") WHERE (deleted IS FALSE);
+-- Create "remote_session_client_user_session_issuers" table
+CREATE TABLE "remote_session_client_user_session_issuers" (
+  "remote_session_client_id" uuid NOT NULL,
+  "user_session_issuer_id" uuid NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("remote_session_client_id", "user_session_issuer_id"),
+  CONSTRAINT "remote_session_client_user_session_issuers_client_fkey" FOREIGN KEY ("remote_session_client_id") REFERENCES "remote_session_clients" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "remote_session_client_user_session_issuers_issuer_fkey" FOREIGN KEY ("user_session_issuer_id") REFERENCES "user_session_issuers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "remote_session_client_user_session_issuers_issuer_idx" to table: "remote_session_client_user_session_issuers"
+CREATE INDEX "remote_session_client_user_session_issuers_issuer_idx" ON "remote_session_client_user_session_issuers" ("user_session_issuer_id", "remote_session_client_id");
+-- Create index "remote_session_client_user_session_issuers_one_per_issuer" to table: "remote_session_client_user_session_issuers"
+CREATE UNIQUE INDEX "remote_session_client_user_session_issuers_one_per_issuer" ON "remote_session_client_user_session_issuers" ("user_session_issuer_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GElRjM+zydzRJTPrs7OdFEJhGORGqV4PYerkXileU5U=
+h1:On+ZEg6dsf7eBowIVa9/gZdvmsWAjyc9JGqU/i9AkII=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -191,3 +191,4 @@ h1:GElRjM+zydzRJTPrs7OdFEJhGORGqV4PYerkXileU5U=
 20260526132630_add_custom_domain_provisioner_kind.sql h1:XoZWJ1F8RtKzAlz18m9242K03La7QV3hDlDRfWO5wQM=
 20260526164519_add-risk-policies-disabled-rules.sql h1:SmIuD/9RiaBWGHZBadLnVzwVdQ7x0riPTboR6+M0GLE=
 20260527093220_org-metadata-add-scim-sso-enabled.sql h1:Nq+Q4qTzQijE3X3vl2YDbZkq+8o0EHA0rA/5cFk0hlw=
+20260527214516_remote_session_client_user_session_issuers.sql h1:FR8pLqwNWxorR6HIc3DbE/dSytFx44OpPXTEvErcIRM=


### PR DESCRIPTION
**Description**

Adds the AGE-2519 expand-step schema changes for moving `remote_session_clients` from the legacy direct `user_session_issuer_id` binding toward the new join-table model, and propagates the generated nullable `project_id` type through the affected Go paths.

**Changes**

- Makes `remote_session_clients.project_id` nullable for future catalog/default clients.
- Keeps `remote_session_clients.user_session_issuer_id` `NOT NULL` for the early dual-write phase.
- Adds `remote_session_client_user_session_issuers` with:
  - composite primary key on `(remote_session_client_id, user_session_issuer_id)`
  - foreign keys to `remote_session_clients` and `user_session_issuers`
  - issuer-first lookup index
  - unique issuer-side index preserving the near-term “one client per issuer” invariant
- Adds `remote_sessions_subject_client_issuer_key` for future issuer-scoped remote session uniqueness.
- Keeps the existing `remote_sessions_subject_client_key` intact so current UPSERT behavior remains deploy-safe.
- Regenerates SQLC/database models for nullable `remote_session_clients.project_id`.
- Propagates `uuid.NullUUID` through remote-session client/session handlers, consent and token lookup paths, and affected test helpers.
- Treats null `project_id` as an invariant violation in project-scoped management API views for now.