### PR TITLE
fix(webhooks): correct inverted capability check in CreatePortalSession

### DIFF
--- a/.changeset/chatty-jokes-tap.md
+++ b/.changeset/chatty-jokes-tap.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Svix app portal now correctly grants full capabilities to org admins and read-only access to non-admin members.

--- a/server/internal/organizations/createportalsession_test.go
+++ b/server/internal/organizations/createportalsession_test.go
@@ -61,10 +61,9 @@ func TestService_CreatePortalSession(t *testing.T) {
 	ti.svixSrv.AssertExpectations(t)
 }
 
-// TestService_CreatePortalSession_AdminGrantGetsViewBaseAccess verifies that a user with
-// org:admin gets a portal session. Admins receive VIEW_BASE capabilities only (they manage
-// webhooks through Gram's own UI, not the Svix portal).
-func TestService_CreatePortalSession_AdminGrantGetsViewBaseAccess(t *testing.T) {
+// TestService_CreatePortalSession_AdminGrantGetsFullAccess verifies that a user with
+// org:admin gets a portal session with full Svix capabilities.
+func TestService_CreatePortalSession_AdminGrantGetsFullAccess(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
@@ -87,10 +86,9 @@ func TestService_CreatePortalSession_AdminGrantGetsViewBaseAccess(t *testing.T) 
 	ti.svixSrv.AssertExpectations(t)
 }
 
-// TestService_CreatePortalSession_ReadGrantGetsFullAccess verifies that a user with org:read
-// but not org:admin gets a portal session with full Svix capabilities (they are a webhook
-// consumer configuring their own endpoints).
-func TestService_CreatePortalSession_ReadGrantGetsFullAccess(t *testing.T) {
+// TestService_CreatePortalSession_ReadGrantGetsMinimumAccess verifies that a user with org:read
+// but not org:admin gets a portal session with VIEW_BASE capabilities only.
+func TestService_CreatePortalSession_ReadGrantGetsMinimumAccess(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsServiceRBAC(t)

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -853,7 +853,7 @@ func (s *Service) CreatePortalSession(ctx context.Context, payload *gen.CreatePo
 	// capabilities in svix.
 	var caps *[]models.AppPortalCapability
 	readCheckErr := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgRead, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil})
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err != nil {
+	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: ac.ActiveOrganizationID, Dimensions: nil}); err == nil {
 		caps = new(fullSvixAppPortalCapabilities())
 	} else if readCheckErr == nil {
 		caps = new(minimumSvixAppPortalCapabilities())


### PR DESCRIPTION
This change fixes an inverted condition that caused org admins to receive VIEW_BASE (minimum) Svix portal capabilities while read-only members incorrectly received full admin capabilities. The test names and comments are updated to match the intended behaviour.