### PR TITLE
mig: make remote_session_issuers org-scopable

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -828,7 +828,8 @@ WHERE deleted IS FALSE;
 -- MCP backend
 CREATE TABLE IF NOT EXISTS remote_session_issuers (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
-  project_id uuid NOT NULL,
+  project_id uuid,
+  organization_id TEXT,
 
   slug TEXT NOT NULL,
   issuer TEXT NOT NULL,
@@ -851,11 +852,16 @@ CREATE TABLE IF NOT EXISTS remote_session_issuers (
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
 
   CONSTRAINT remote_session_issuers_pkey PRIMARY KEY (id),
-  CONSTRAINT remote_session_issuers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+  CONSTRAINT remote_session_issuers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT remote_session_issuers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS remote_session_issuers_project_slug_key
 ON remote_session_issuers (project_id, slug)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS remote_session_issuers_organization_id_idx
+ON remote_session_issuers (organization_id)
 WHERE deleted IS FALSE;
 
 -- Remote Session Clients are records of Gram's client registrations with

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1166,7 +1166,8 @@ type RemoteSessionClientUserSessionIssuer struct {
 
 type RemoteSessionIssuer struct {
 	ID                                uuid.UUID
-	ProjectID                         uuid.UUID
+	ProjectID                         uuid.NullUUID
+	OrganizationID                    pgtype.Text
 	Slug                              string
 	Issuer                            string
 	AuthorizationEndpoint             pgtype.Text

--- a/server/internal/mcp/remotesession_resolver_integration_test.go
+++ b/server/internal/mcp/remotesession_resolver_integration_test.go
@@ -217,7 +217,7 @@ func createIssuerGatedExternalMCPFixture(
 
 	remoteRepo := remotesessions_repo.New(ti.conn)
 	remoteIssuer, err := remoteRepo.CreateRemoteSessionIssuer(ctx, remotesessions_repo.CreateRemoteSessionIssuerParams{
-		ProjectID:                         toolset.ProjectID,
+		ProjectID:                         uuid.NullUUID{UUID: toolset.ProjectID, Valid: true},
 		Slug:                              "resolver-extmcp-rsi-" + suffix,
 		Issuer:                            "https://upstream.example/" + suffix,
 		AuthorizationEndpoint:             conv.ToPGText("https://upstream.example/" + suffix + "/authorize"),

--- a/server/internal/mcp/remotesession_resolver_test.go
+++ b/server/internal/mcp/remotesession_resolver_test.go
@@ -169,7 +169,7 @@ func createRemoteSessionResolverFixture(
 
 	remoteRepo := remotesessions_repo.New(ti.conn)
 	remoteIssuer, err := remoteRepo.CreateRemoteSessionIssuer(ctx, remotesessions_repo.CreateRemoteSessionIssuerParams{
-		ProjectID:                         *authCtx.ProjectID,
+		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Slug:                              "resolver-rsi-" + suffix,
 		Issuer:                            "https://upstream.example/" + suffix,
 		AuthorizationEndpoint:             conv.ToPGText("https://upstream.example/" + suffix + "/authorize"),

--- a/server/internal/mv/remotesessionissuer.go
+++ b/server/internal/mv/remotesessionissuer.go
@@ -9,9 +9,14 @@ import (
 )
 
 func BuildRemoteSessionIssuerView(row repo.RemoteSessionIssuer) *types.RemoteSessionIssuer {
+	projectID := ""
+	if row.ProjectID.Valid {
+		projectID = row.ProjectID.UUID.String()
+	}
+
 	return &types.RemoteSessionIssuer{
 		ID:                                row.ID.String(),
-		ProjectID:                         row.ProjectID.UUID.String(),
+		ProjectID:                         projectID,
 		Slug:                              row.Slug,
 		Issuer:                            row.Issuer,
 		AuthorizationEndpoint:             conv.FromPGText[string](row.AuthorizationEndpoint),

--- a/server/internal/mv/remotesessionissuer.go
+++ b/server/internal/mv/remotesessionissuer.go
@@ -11,7 +11,7 @@ import (
 func BuildRemoteSessionIssuerView(row repo.RemoteSessionIssuer) *types.RemoteSessionIssuer {
 	return &types.RemoteSessionIssuer{
 		ID:                                row.ID.String(),
-		ProjectID:                         row.ProjectID.String(),
+		ProjectID:                         row.ProjectID.UUID.String(),
 		Slug:                              row.Slug,
 		Issuer:                            row.Issuer,
 		AuthorizationEndpoint:             conv.FromPGText[string](row.AuthorizationEndpoint),

--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -110,7 +110,7 @@ func CreateIssuerGatedToolset(
 	require.NoError(t, err)
 
 	rsi, err := remoteRepo.CreateRemoteSessionIssuer(ctx, remotesessions_repo.CreateRemoteSessionIssuerParams{
-		ProjectID:                         *authCtx.ProjectID,
+		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Slug:                              "rsi-" + suffix,
 		Issuer:                            meta.Issuer,
 		AuthorizationEndpoint:             conv.ToPGText(meta.AuthorizationEndpoint),

--- a/server/internal/remotesessions/challenge_audience_e2e_test.go
+++ b/server/internal/remotesessions/challenge_audience_e2e_test.go
@@ -74,7 +74,7 @@ func TestBuildAuthorizationUrl_AudienceResolution(t *testing.T) {
 			q := repo.New(ti.conn)
 			slugSuffix := strings.ReplaceAll(tc.name, " ", "-")
 			issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
-				ProjectID:                         *authCtx.ProjectID,
+				ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 				Slug:                              "auth-aud-" + slugSuffix,
 				Issuer:                            "https://idp.example.com",
 				AuthorizationEndpoint:             conv.ToPGText("https://idp.example.com/authorize"),

--- a/server/internal/remotesessions/challenge_scope_e2e_test.go
+++ b/server/internal/remotesessions/challenge_scope_e2e_test.go
@@ -75,7 +75,7 @@ func TestBuildAuthorizationUrl_ScopeResolution(t *testing.T) {
 			q := repo.New(ti.conn)
 			slugSuffix := strings.ReplaceAll(tc.name, " ", "-")
 			issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
-				ProjectID:                         *authCtx.ProjectID,
+				ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 				Slug:                              "auth-scope-" + slugSuffix,
 				Issuer:                            "https://idp.example.com",
 				AuthorizationEndpoint:             conv.ToPGText("https://idp.example.com/authorize"),

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -188,7 +188,7 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 	// cannot graft a client onto an unrelated tenant's issuer.
 	if _, err := txRepo.GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
 		ID:        issuerID,
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").Log(ctx, logger)

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -129,7 +129,7 @@ func (s *Service) CreateRemoteSessionIssuer(ctx context.Context, payload *gen.Cr
 	txRepo := repo.New(dbtx)
 
 	issuer, err := txRepo.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
-		ProjectID:                         *authCtx.ProjectID,
+		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Slug:                              payload.Slug,
 		Issuer:                            payload.Issuer,
 		AuthorizationEndpoint:             conv.PtrToPGText(payload.AuthorizationEndpoint),
@@ -208,7 +208,7 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 
 	existing, err := txRepo.GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
 		ID:        issuerID,
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -233,7 +233,7 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 		Oidc:                              conv.PtrToPGBool(payload.Oidc),
 		Passthrough:                       conv.PtrToPGBool(payload.Passthrough),
 		ID:                                issuerID,
-		ProjectID:                         *authCtx.ProjectID,
+		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -283,7 +283,7 @@ func (s *Service) ListRemoteSessionIssuers(ctx context.Context, payload *gen.Lis
 	}
 
 	rows, err := repo.New(s.db).ListRemoteSessionIssuersByProjectID(ctx, repo.ListRemoteSessionIssuersByProjectIDParams{
-		ProjectID:  *authCtx.ProjectID,
+		ProjectID:  uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Cursor:     cursor,
 		LimitValue: limit,
 	})
@@ -336,7 +336,7 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 		}
 		issuer, err = repo.New(s.db).GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
 			ID:        issuerID,
-			ProjectID: *authCtx.ProjectID,
+			ProjectID: uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -351,7 +351,7 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 		var err error
 		issuer, err = repo.New(s.db).GetRemoteSessionIssuerBySlug(ctx, repo.GetRemoteSessionIssuerBySlugParams{
 			Slug:      *payload.Slug,
-			ProjectID: *authCtx.ProjectID,
+			ProjectID: uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -401,7 +401,7 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 
 	deleted, err := txRepo.DeleteRemoteSessionIssuer(ctx, repo.DeleteRemoteSessionIssuerParams{
 		ID:        issuerID,
-		ProjectID: *authCtx.ProjectID,
+		ProjectID: uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/server/internal/remotesessions/repo/models.go
+++ b/server/internal/remotesessions/repo/models.go
@@ -47,7 +47,8 @@ type RemoteSessionClient struct {
 
 type RemoteSessionIssuer struct {
 	ID                                uuid.UUID
-	ProjectID                         uuid.UUID
+	ProjectID                         uuid.NullUUID
+	OrganizationID                    pgtype.Text
 	Slug                              string
 	Issuer                            string
 	AuthorizationEndpoint             pgtype.Text

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -147,11 +147,11 @@ VALUES (
     $12,
     $13
 )
-RETURNING id, project_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRemoteSessionIssuerParams struct {
-	ProjectID                         uuid.UUID
+	ProjectID                         uuid.NullUUID
 	Slug                              string
 	Issuer                            string
 	AuthorizationEndpoint             pgtype.Text
@@ -188,6 +188,7 @@ func (q *Queries) CreateRemoteSessionIssuer(ctx context.Context, arg CreateRemot
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Slug,
 		&i.Issuer,
 		&i.AuthorizationEndpoint,
@@ -248,12 +249,12 @@ const deleteRemoteSessionIssuer = `-- name: DeleteRemoteSessionIssuer :one
 UPDATE remote_session_issuers
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteRemoteSessionIssuerParams struct {
 	ID        uuid.UUID
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 }
 
 func (q *Queries) DeleteRemoteSessionIssuer(ctx context.Context, arg DeleteRemoteSessionIssuerParams) (RemoteSessionIssuer, error) {
@@ -262,6 +263,7 @@ func (q *Queries) DeleteRemoteSessionIssuer(ctx context.Context, arg DeleteRemot
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Slug,
 		&i.Issuer,
 		&i.AuthorizationEndpoint,
@@ -496,14 +498,14 @@ func (q *Queries) GetRemoteSessionClientWithIssuerByID(ctx context.Context, id u
 }
 
 const getRemoteSessionIssuerByID = `-- name: GetRemoteSessionIssuerByID :one
-SELECT id, project_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
 
 type GetRemoteSessionIssuerByIDParams struct {
 	ID        uuid.UUID
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 }
 
 func (q *Queries) GetRemoteSessionIssuerByID(ctx context.Context, arg GetRemoteSessionIssuerByIDParams) (RemoteSessionIssuer, error) {
@@ -512,6 +514,7 @@ func (q *Queries) GetRemoteSessionIssuerByID(ctx context.Context, arg GetRemoteS
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Slug,
 		&i.Issuer,
 		&i.AuthorizationEndpoint,
@@ -533,14 +536,14 @@ func (q *Queries) GetRemoteSessionIssuerByID(ctx context.Context, arg GetRemoteS
 }
 
 const getRemoteSessionIssuerBySlug = `-- name: GetRemoteSessionIssuerBySlug :one
-SELECT id, project_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers
 WHERE slug = $1 AND project_id = $2 AND deleted IS FALSE
 `
 
 type GetRemoteSessionIssuerBySlugParams struct {
 	Slug      string
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 }
 
 func (q *Queries) GetRemoteSessionIssuerBySlug(ctx context.Context, arg GetRemoteSessionIssuerBySlugParams) (RemoteSessionIssuer, error) {
@@ -549,6 +552,7 @@ func (q *Queries) GetRemoteSessionIssuerBySlug(ctx context.Context, arg GetRemot
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Slug,
 		&i.Issuer,
 		&i.AuthorizationEndpoint,
@@ -814,7 +818,7 @@ func (q *Queries) ListRemoteSessionClientsForUserSessionIssuer(ctx context.Conte
 }
 
 const listRemoteSessionIssuersByProjectID = `-- name: ListRemoteSessionIssuersByProjectID :many
-SELECT id, project_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -824,7 +828,7 @@ LIMIT $3
 `
 
 type ListRemoteSessionIssuersByProjectIDParams struct {
-	ProjectID  uuid.UUID
+	ProjectID  uuid.NullUUID
 	Cursor     uuid.NullUUID
 	LimitValue int32
 }
@@ -841,6 +845,7 @@ func (q *Queries) ListRemoteSessionIssuersByProjectID(ctx context.Context, arg L
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,
+			&i.OrganizationID,
 			&i.Slug,
 			&i.Issuer,
 			&i.AuthorizationEndpoint,
@@ -1069,7 +1074,7 @@ SET
     passthrough = COALESCE($12, passthrough),
     updated_at = clock_timestamp()
 WHERE id = $13 AND project_id = $14 AND deleted IS FALSE
-RETURNING id, project_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, oidc, passthrough, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRemoteSessionIssuerParams struct {
@@ -1086,7 +1091,7 @@ type UpdateRemoteSessionIssuerParams struct {
 	Oidc                              pgtype.Bool
 	Passthrough                       pgtype.Bool
 	ID                                uuid.UUID
-	ProjectID                         uuid.UUID
+	ProjectID                         uuid.NullUUID
 }
 
 // Three-state semantics on the nullable endpoint columns: an omitted narg
@@ -1116,6 +1121,7 @@ func (q *Queries) UpdateRemoteSessionIssuer(ctx context.Context, arg UpdateRemot
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Slug,
 		&i.Issuer,
 		&i.AuthorizationEndpoint,

--- a/server/internal/remotesessions/tokenservice_audience_test.go
+++ b/server/internal/remotesessions/tokenservice_audience_test.go
@@ -77,7 +77,7 @@ func setupRefreshFixtureWithAudience(t *testing.T, audience pgtype.Text, spy *up
 		slugSuffix = "aud-unset"
 	}
 	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
-		ProjectID:                         *authCtx.ProjectID,
+		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Slug:                              "refresh-" + slugSuffix,
 		Issuer:                            tokenServer.URL,
 		AuthorizationEndpoint:             conv.ToPGText(tokenServer.URL + "/authorize"),

--- a/server/internal/remotesessions/tokenservice_authmethod_test.go
+++ b/server/internal/remotesessions/tokenservice_authmethod_test.go
@@ -99,7 +99,7 @@ func setupRefreshFixture(t *testing.T, authMethod string, spy *upstreamSpy) (con
 	authzEP := tokenServer.URL + "/authorize"
 	tokenEP := tokenServer.URL + "/token"
 	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
-		ProjectID:                         *authCtx.ProjectID,
+		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Slug:                              "auth-method-" + strings.ReplaceAll(authMethod, "_", "-"),
 		Issuer:                            tokenServer.URL,
 		AuthorizationEndpoint:             conv.ToPGText(authzEP),

--- a/server/migrations/20260528192406_age-2484-remote-session-issuers-organization-id.sql
+++ b/server/migrations/20260528192406_age-2484-remote-session-issuers-organization-id.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "remote_session_issuers" table
+ALTER TABLE "remote_session_issuers" ALTER COLUMN "project_id" DROP NOT NULL, ADD COLUMN "organization_id" text NULL, ADD CONSTRAINT "remote_session_issuers_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Create index "remote_session_issuers_organization_id_idx" to table: "remote_session_issuers"
+CREATE INDEX CONCURRENTLY "remote_session_issuers_organization_id_idx" ON "remote_session_issuers" ("organization_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:VMHEEBAL9Ktv8P0tV5Awcn0xnTDebVFSG93N/IG8Vg8=
+h1:WpO3t/j2s1Y3t8G1YwdMrkRRLkeeFMujFCzteCK/A3c=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -195,3 +195,4 @@ h1:VMHEEBAL9Ktv8P0tV5Awcn0xnTDebVFSG93N/IG8Vg8=
 20260528094046_chat-messages-add-risk-analyzed-at.sql h1:p0/C4C1jFr/WH5l/W4fSLi+yqBP0EQYYWD5j6WB3Stk=
 20260528120324_add-custom-detection-rules.sql h1:nvGeihJOJMbo8CUamKuoMlHi6D8r9jJtMK80c+X60NU=
 20260528145659_add-mcp-server-id-to-mcp-metadata.sql h1:fnNq7bTqxCG1Ipb70XLaZh9oZcypAonT/OvqOlQH8oI=
+20260528192406_age-2484-remote-session-issuers-organization-id.sql h1:ptd3XyEBDWDB1mrd4Xsg3u2dj/W79WcRch4X8myUYbw=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2484/database-migration-to-add-organization-id-to-remote-session-issuers

## Summary

Adds a nullable `organization_id` text column (FK `organization_metadata` `ON DELETE CASCADE`, partial BTREE index on undeleted rows) and drops `NOT NULL` on `project_id`. Expand step only — application code still requires `project_id`; the fast-follow issue AGE-2485 wires up `organization_id` in the management API and backfills the existing 38 production rows.

The `DROP NOT NULL` on `project_id` cascades into SQLc-regenerated types (`ProjectID` becomes `uuid.NullUUID`), which forces mechanical updates at the handler/test call sites that still pass `*authCtx.ProjectID`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `remote_session_issuers` organization‑scopable by adding `organization_id` and allowing `project_id` to be null. Expand-only step for Linear AGE-2484; the app still requires `project_id` and backfill will happen in AGE-2485.

- **Migration**
  - Add nullable `organization_id` (FK to `organization_metadata` with ON DELETE CASCADE).
  - Drop NOT NULL on `project_id`.
  - Add partial index `remote_session_issuers_organization_id_idx` on undeleted rows.

- **Refactors**
  - Regenerate `sqlc` models: `ProjectID` -> `uuid.NullUUID`; add `OrganizationID` to issuer models; guard nullable `ProjectID` in the view (return empty string until AGE-2485).
  - Update handlers/tests to pass `uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true}`.

<sup>Written for commit afc45e1d5380470bc76e775c13cd8badb0059e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3075?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

