### PR TITLE
fix(test): fix nav-menu tests failing due to missing router context

### DIFF
--- a/client/dashboard/src/components/nav-menu.test.tsx
+++ b/client/dashboard/src/components/nav-menu.test.tsx
@@ -6,11 +6,10 @@ import {
   screen,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NavButton } from "./nav-menu";
+import { NAV_LOADING_DURATION_MS, NavButton } from "./nav-menu";
 
-// Stub the sidebar primitive so it doesn't pull in TooltipProvider /
-// react-router context. The behavior under test is the click → spinner →
-// auto-revert state machine inside NavButton, not the underlying button.
+// Stub sidebar primitives to prevent real Radix/Tailwind sidebar from
+// loading. NavButton doesn't render these but nav-menu.tsx imports them.
 vi.mock("@/components/ui/sidebar", () => ({
   SidebarMenu: ({ children }: { children: React.ReactNode }) => (
     <ul>{children}</ul>
@@ -18,28 +17,42 @@ vi.mock("@/components/ui/sidebar", () => ({
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => (
     <li>{children}</li>
   ),
-  SidebarMenuButton: ({
+}));
+
+// Mock Link as a plain <a> so NavButton renders without a RouterProvider.
+// The behavior under test is the click → nav-shimmer → auto-revert state machine,
+// not routing; data-testid keeps existing click targets working.
+vi.mock("react-router", () => ({
+  Link: ({
     children,
     onClick,
+    to: _to,
+    target,
   }: {
     children: React.ReactNode;
-    onClick?: () => void;
-    tooltip?: unknown;
-    href?: string;
+    onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+    to: string;
     target?: string;
-    isActive?: boolean;
-    className?: string;
   }) => (
-    <button onClick={onClick} data-testid="nav-button">
+    <a data-testid="nav-button" onClick={onClick} target={target}>
       {children}
-    </button>
+    </a>
   ),
 }));
 
-// Type renders as a plain span — the real component isn't relevant here.
+// Type renders as a plain span; className is forwarded so tests can observe
+// loading state via the nav-shimmer class that NavButton applies.
 vi.mock("./ui/type", () => ({
-  Type: ({ children }: { children: React.ReactNode }) => (
-    <span>{children}</span>
+  Type: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <span data-testid="nav-label" className={className}>
+      {children}
+    </span>
   ),
 }));
 
@@ -65,41 +78,37 @@ describe("NavButton click loading state", () => {
     vi.useRealTimers();
   });
 
-  it("renders the icon and not the spinner by default", () => {
+  it("renders the icon with no loading state by default", () => {
     render(<NavButton title="Home" Icon={TestIcon} />);
-    expect(screen.getByTestId("nav-icon")).toBeTruthy();
-    expect(screen.queryByTestId("nav-spinner")).toBeNull();
+    screen.getByTestId("nav-icon");
+    expect(screen.getByTestId("nav-label").className).not.toContain(
+      "nav-shimmer",
+    );
   });
 
-  it("swaps the icon for a spinner on click and reverts after 600ms", () => {
+  it("adds nav-shimmer on click and removes it after 600ms", () => {
     render(<NavButton title="Home" Icon={TestIcon} />);
+    const label = screen.getByTestId("nav-label");
 
     fireEvent.click(screen.getByTestId("nav-button"));
 
-    // After click: icon gone, spinner present (lucide Loader2 renders an
-    // <svg class="lucide-loader-circle">; .animate-spin is a more reliable
-    // marker than testid since we don't mock lucide).
-    expect(screen.queryByTestId("nav-icon")).toBeNull();
-    const spinner = document.querySelector(".animate-spin");
-    expect(spinner).toBeTruthy();
+    expect(label.className).toContain("nav-shimmer");
 
-    // Advance past the loading duration — icon returns.
     act(() => {
-      vi.advanceTimersByTime(600);
+      vi.advanceTimersByTime(NAV_LOADING_DURATION_MS);
     });
 
-    expect(screen.getByTestId("nav-icon")).toBeTruthy();
-    expect(document.querySelector(".animate-spin")).toBeNull();
+    expect(label.className).not.toContain("nav-shimmer");
   });
 
-  it("skips the spinner for external (target=_blank) links", () => {
+  it("skips nav-shimmer for external (target=_blank) links", () => {
     render(<NavButton title="Docs" Icon={TestIcon} target="_blank" />);
+    const label = screen.getByTestId("nav-label");
 
     fireEvent.click(screen.getByTestId("nav-button"));
 
     // External link: clicked but never enters loading state.
-    expect(screen.getByTestId("nav-icon")).toBeTruthy();
-    expect(document.querySelector(".animate-spin")).toBeNull();
+    expect(label.className).not.toContain("nav-shimmer");
   });
 
   it("invokes the onClick callback the consumer passed in", () => {

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -9,7 +9,7 @@ import { ProductTierBadge } from "./product-tier-badge";
 import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge";
 import { Type } from "./ui/type";
 
-const NAV_LOADING_DURATION_MS = 600;
+export const NAV_LOADING_DURATION_MS = 600;
 
 export function NavMenu({
   items,


### PR DESCRIPTION
## Summary

- `NavButton` renders `<Link>` from `react-router` directly; tests had a stale `SidebarMenuButton` mock but no `Link` mock, so every `render()` threw a RouterProvider error
- Added `vi.mock("react-router")` rendering `Link` as `<a data-testid="nav-button">` — forwards `onClick` so the click→loading state machine still exercises real component code
- Rewrote three test assertions from a spinner that was never implemented to the actual `nav-shimmer` class `NavButton` applies to the label on load; exported `NAV_LOADING_DURATION_MS` so the test uses the constant rather than a magic `600`

## Root cause

The component was at some point refactored from a `SidebarMenuButton`-based structure to rendering `<Link>` directly, but the test was never updated. The stale `SidebarMenuButton` mock silently did nothing, and the missing `Link` mock caused every test to fail with "useNavigation must be used within a RouterProvider" before any assertions ran.

## Test plan

- [x] `pnpm vitest run src/components/nav-menu.test.tsx` — 5/5 pass
- [x] `pnpm vitest run` — 399/399 pass (1 pre-existing failure in `useObserveFilters.test.tsx` due to unbuilt `@gram-ai/elements` package, unrelated to this change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing nav-menu tests by mocking `react-router` `Link` to remove the missing RouterProvider error and aligning assertions with the real loading UI. Also exports `NAV_LOADING_DURATION_MS` to avoid hardcoded values in tests.

- **Bug Fixes**
  - Replaced stale `@/components/ui/sidebar` button stub with `vi.mock("react-router")` that renders `Link` as `<a data-testid="nav-button">` and forwards `onClick`.
  - Updated `Type` mock to forward `className` so tests assert the `nav-shimmer` class.
  - Rewrote assertions to check `nav-shimmer` instead of a non-existent spinner and imported `NAV_LOADING_DURATION_MS` instead of hardcoding 600.

<sup>Written for commit 3465043648a6cafea69a25434ea52d8f93bcfa7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3076?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

