### PR TITLE
mig: add mcp_server_id to mcp_metadata

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1554,46 +1554,6 @@ CREATE TABLE IF NOT EXISTS toolset_prompts (
 CREATE UNIQUE INDEX IF NOT EXISTS toolset_prompts_toolset_id_prompt_name_key
 ON toolset_prompts (toolset_id, prompt_name);
 
-CREATE TABLE IF NOT EXISTS mcp_metadata (
-  id UUID NOT NULL DEFAULT generate_uuidv7(),
-  toolset_id UUID NOT NULL,
-  project_id UUID NOT NULL,
-  external_documentation_url TEXT,
-  external_documentation_text TEXT,
-  logo_id UUID,
-  instructions TEXT,
-  header_display_names JSONB NOT NULL DEFAULT '{}'::JSONB, -- DEPRECATED: use mcp_environment_configs table instead
-  default_environment_id UUID, -- Informs mcp_environment_configs which environment to load from by default
-  installation_override_url TEXT, -- URL to redirect to instead of the default installation page
-
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-
-  CONSTRAINT mcp_metadata_pkey PRIMARY KEY (id),
-  CONSTRAINT mcp_metadata_logo_id FOREIGN KEY (logo_id) REFERENCES assets (id) ON DELETE SET NULL,
-  CONSTRAINT mcp_metadata_toolset_id FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE CASCADE,
-  CONSTRAINT mcp_metadata_project_id FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
-  CONSTRAINT mcp_metadata_toolset_id_key UNIQUE (toolset_id),
-  CONSTRAINT mcp_metadata_default_environment_id_fkey FOREIGN KEY (default_environment_id) REFERENCES environments (id) ON DELETE SET NULL
-);
-
-CREATE TABLE IF NOT EXISTS mcp_environment_configs (
-  id UUID NOT NULL DEFAULT generate_uuidv7(),
-  project_id UUID NOT NULL,
-  mcp_metadata_id UUID NOT NULL,
-  variable_name TEXT NOT NULL,
-  header_display_name TEXT,
-  provided_by TEXT NOT NULL DEFAULT 'user', -- 'user', 'system', 'none'
-
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-
-  CONSTRAINT mcp_environment_configs_pkey PRIMARY KEY (id),
-  CONSTRAINT mcp_environment_configs_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
-  CONSTRAINT mcp_environment_configs_mcp_metadata_id_fkey FOREIGN KEY (mcp_metadata_id) REFERENCES mcp_metadata (id) ON DELETE CASCADE,
-  CONSTRAINT mcp_environment_configs_mcp_metadata_id_variable_name_key UNIQUE (mcp_metadata_id, variable_name)
-);
-
 CREATE TABLE IF NOT EXISTS users (
   id TEXT NOT NULL,
   email TEXT NOT NULL,
@@ -2490,6 +2450,57 @@ WHERE remote_mcp_server_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS mcp_servers_toolset_id_idx
 ON mcp_servers (toolset_id)
 WHERE toolset_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS mcp_metadata (
+  id UUID NOT NULL DEFAULT generate_uuidv7(),
+  toolset_id UUID,
+  mcp_server_id UUID,
+  project_id UUID NOT NULL,
+  external_documentation_url TEXT,
+  external_documentation_text TEXT,
+  logo_id UUID,
+  instructions TEXT,
+  header_display_names JSONB NOT NULL DEFAULT '{}'::JSONB, -- DEPRECATED: use mcp_environment_configs table instead
+  default_environment_id UUID, -- Informs mcp_environment_configs which environment to load from by default
+  installation_override_url TEXT, -- URL to redirect to instead of the default installation page
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT mcp_metadata_pkey PRIMARY KEY (id),
+  CONSTRAINT mcp_metadata_logo_id FOREIGN KEY (logo_id) REFERENCES assets (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_metadata_toolset_id FOREIGN KEY (toolset_id) REFERENCES toolsets (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_metadata_mcp_server_id_fkey FOREIGN KEY (mcp_server_id) REFERENCES mcp_servers (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_metadata_project_id FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_metadata_default_environment_id_fkey FOREIGN KEY (default_environment_id) REFERENCES environments (id) ON DELETE SET NULL,
+  -- Exactly one backend must be set: either a toolset or an MCP server.
+  CONSTRAINT mcp_metadata_backend_exclusivity_check CHECK ((toolset_id IS NULL) != (mcp_server_id IS NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_metadata_toolset_id_key
+ON mcp_metadata (toolset_id)
+WHERE toolset_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_metadata_mcp_server_id_key
+ON mcp_metadata (mcp_server_id)
+WHERE mcp_server_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS mcp_environment_configs (
+  id UUID NOT NULL DEFAULT generate_uuidv7(),
+  project_id UUID NOT NULL,
+  mcp_metadata_id UUID NOT NULL,
+  variable_name TEXT NOT NULL,
+  header_display_name TEXT,
+  provided_by TEXT NOT NULL DEFAULT 'user', -- 'user', 'system', 'none'
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT mcp_environment_configs_pkey PRIMARY KEY (id),
+  CONSTRAINT mcp_environment_configs_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_environment_configs_mcp_metadata_id_fkey FOREIGN KEY (mcp_metadata_id) REFERENCES mcp_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT mcp_environment_configs_mcp_metadata_id_variable_name_key UNIQUE (mcp_metadata_id, variable_name)
+);
 
 -- MCP Endpoints: addressable slugs for an MCP server. A NULL custom_domain_id
 -- represents a Gram-hosted endpoint (resolved by slug alone); a non-NULL

--- a/server/internal/collections/attachserver_test.go
+++ b/server/internal/collections/attachserver_test.go
@@ -135,7 +135,7 @@ func TestCollectionsService_ListServers_IncludesUserProvidedEnvironmentHeaders(t
 
 	mcpRepo := mcpmetarepo.New(ti.conn)
 	metadata, err := mcpRepo.UpsertMetadata(ctx, mcpmetarepo.UpsertMetadataParams{
-		ToolsetID:                 toolsetID,
+		ToolsetID:                 uuid.NullUUID{UUID: toolsetID, Valid: true},
 		ProjectID:                 *authCtx.ProjectID,
 		ExternalDocumentationUrl:  pgtype.Text{Valid: false},
 		ExternalDocumentationText: pgtype.Text{Valid: false},

--- a/server/internal/collections/impl.go
+++ b/server/internal/collections/impl.go
@@ -611,7 +611,7 @@ func (s *Service) collectionRemoteHeaders(ctx context.Context, mcpMetaRepo *mcpm
 		)
 	}
 
-	metadataRecord, err := mcpMetaRepo.GetMetadataForToolset(ctx, toolset.ID)
+	metadataRecord, err := mcpMetaRepo.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolset.ID, Valid: true})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return headers, nil

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -675,7 +675,8 @@ type McpEnvironmentConfig struct {
 
 type McpMetadatum struct {
 	ID                        uuid.UUID
-	ToolsetID                 uuid.UUID
+	ToolsetID                 uuid.NullUUID
+	McpServerID               uuid.NullUUID
 	ProjectID                 uuid.UUID
 	ExternalDocumentationUrl  pgtype.Text
 	ExternalDocumentationText pgtype.Text

--- a/server/internal/environments/shared.go
+++ b/server/internal/environments/shared.go
@@ -126,7 +126,7 @@ func (e *EnvironmentEntries) LoadMCPAttachedEnvironment(
 	projectID uuid.UUID,
 	toolsetID uuid.UUID,
 ) (map[string]string, error) {
-	mcpMetadata, err := e.mcpMetadataRepo.GetMetadataForToolset(ctx, toolsetID)
+	mcpMetadata, err := e.mcpMetadataRepo.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolsetID, Valid: true})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return map[string]string{}, nil

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -892,7 +892,7 @@ func (s *Service) loadToolset(ctx context.Context, mcpSlug string, customDomainI
 func (s *Service) loadHeaderDisplayNames(ctx context.Context, toolsetID uuid.UUID) map[string]string {
 	result := make(map[string]string)
 
-	displayNamesJSON, err := s.mcpMetadataRepo.GetHeaderDisplayNames(ctx, toolsetID)
+	displayNamesJSON, err := s.mcpMetadataRepo.GetHeaderDisplayNames(ctx, uuid.NullUUID{UUID: toolsetID, Valid: true})
 	if err != nil {
 		// Not found or error - return empty map, this is non-critical
 		return result

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -82,7 +82,7 @@ func fetchInstructions(ctx context.Context, logger *slog.Logger, toolsetsRepo *t
 		return ""
 	}
 
-	metadata, err := metadataRepo.GetMetadataForToolset(ctx, toolset.ID)
+	metadata, err := metadataRepo.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolset.ID, Valid: true})
 	if err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {
 			logger.WarnContext(ctx, "failed to fetch MCP metadata for instructions", attr.SlogError(err))

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -652,7 +652,7 @@ func filterOmittedEnvVars(
 	repo *mcpmetadata_repo.Queries,
 	toolsetID uuid.UUID,
 ) error {
-	rawMetadata, err := repo.GetMetadataForToolset(ctx, toolsetID)
+	rawMetadata, err := repo.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolsetID, Valid: true})
 	if err != nil {
 		// Fallback behavior for backwards compatibility
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -297,7 +297,7 @@ func TestServePublic_ServerInstructionsInInitializeResponse(t *testing.T) {
 
 	instructions := "You have tools for searching the Test Hub. Use them wisely."
 	_, err = metadataRepo.UpsertMetadata(ctx, metadata_repo.UpsertMetadataParams{
-		ToolsetID:                toolset.ID,
+		ToolsetID:                uuid.NullUUID{UUID: toolset.ID, Valid: true},
 		ProjectID:                *authCtx.ProjectID,
 		ExternalDocumentationUrl: pgtype.Text{String: "", Valid: false},
 		LogoID:                   uuid.NullUUID{Valid: false},

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -656,9 +656,14 @@ func ToMCPMetadata(ctx context.Context, queries *repo.Queries, record repo.McpMe
 		}
 	}
 
+	var toolsetIDStr string
+	if record.ToolsetID.Valid {
+		toolsetIDStr = record.ToolsetID.UUID.String()
+	}
+
 	metadata := &types.McpMetadata{
 		ID:                        record.ID.String(),
-		ToolsetID:                 record.ToolsetID.UUID.String(),
+		ToolsetID:                 toolsetIDStr,
 		CreatedAt:                 record.CreatedAt.Time.Format(time.RFC3339),
 		UpdatedAt:                 record.UpdatedAt.Time.Format(time.RFC3339),
 		ExternalDocumentationURL:  conv.FromPGText[string](record.ExternalDocumentationUrl),

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -236,7 +236,7 @@ func (s *Service) GetMcpMetadata(ctx context.Context, payload *gen.GetMcpMetadat
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch toolset").Log(ctx, s.logger, attr.SlogToolsetSlug(string(payload.ToolsetSlug)))
 	}
 
-	record, err := s.repo.GetMetadataForToolset(ctx, toolset.ID)
+	record, err := s.repo.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolset.ID, Valid: true})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return nil, oops.E(oops.CodeNotFound, err, "no MCP install page metadata for this toolset")
@@ -291,7 +291,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 	)
 
 	var existing *types.McpMetadata
-	existingRow, err := mcpr.GetMetadataForToolset(ctx, toolset.ID)
+	existingRow, err := mcpr.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolset.ID, Valid: true})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		// No existing metadata, proceed with creation
@@ -356,7 +356,7 @@ func (s *Service) SetMcpMetadata(ctx context.Context, payload *gen.SetMcpMetadat
 	}
 
 	result, err := mcpr.UpsertMetadata(ctx, repo.UpsertMetadataParams{
-		ToolsetID:                 toolset.ID,
+		ToolsetID:                 uuid.NullUUID{UUID: toolset.ID, Valid: true},
 		ProjectID:                 *authCtx.ProjectID,
 		ExternalDocumentationUrl:  externalDocURL,
 		ExternalDocumentationText: externalDocText,
@@ -469,7 +469,7 @@ func (s *Service) ExportMcpMetadata(ctx context.Context, payload *gen.ExportMcpM
 	headerDisplayNames := make(map[string]string)
 	variableProvidedBy := make(map[string]string)
 
-	metadataRecord, metadataErr := s.repo.GetMetadataForToolset(ctx, toolset.ID)
+	metadataRecord, metadataErr := s.repo.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolset.ID, Valid: true})
 	if metadataErr == nil {
 		if metadataRecord.LogoID.Valid {
 			logoURLValue := *s.serverURL
@@ -658,7 +658,7 @@ func ToMCPMetadata(ctx context.Context, queries *repo.Queries, record repo.McpMe
 
 	metadata := &types.McpMetadata{
 		ID:                        record.ID.String(),
-		ToolsetID:                 record.ToolsetID.String(),
+		ToolsetID:                 record.ToolsetID.UUID.String(),
 		CreatedAt:                 record.CreatedAt.Time.Format(time.RFC3339),
 		UpdatedAt:                 record.UpdatedAt.Time.Format(time.RFC3339),
 		ExternalDocumentationURL:  conv.FromPGText[string](record.ExternalDocumentationUrl),
@@ -796,7 +796,7 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 	var instructions string
 	headerDisplayNames := make(map[string]string)
 	variableProvidedBy := make(map[string]string)
-	metadataRecord, metadataErr := s.repo.GetMetadataForToolset(ctx, toolset.ID)
+	metadataRecord, metadataErr := s.repo.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: toolset.ID, Valid: true})
 	if metadataErr != nil {
 		if !errors.Is(metadataErr, pgx.ErrNoRows) {
 			s.logger.WarnContext(ctx, "failed to load MCP install page metadata", attr.SlogToolsetID(toolset.ID.String()), attr.SlogError(metadataErr))

--- a/server/internal/mcpmetadata/queries.sql
+++ b/server/internal/mcpmetadata/queries.sql
@@ -1,6 +1,7 @@
 -- name: GetMetadataForToolset :one
 SELECT id,
        toolset_id,
+       mcp_server_id,
        project_id,
        external_documentation_url,
        external_documentation_text,
@@ -27,7 +28,7 @@ INSERT INTO mcp_metadata (
     default_environment_id,
     installation_override_url
 ) VALUES (@toolset_id, @project_id, @external_documentation_url, @external_documentation_text, @logo_id, @instructions, @default_environment_id, @installation_override_url)
-ON CONFLICT (toolset_id)
+ON CONFLICT (toolset_id) WHERE toolset_id IS NOT NULL
 DO UPDATE SET project_id = EXCLUDED.project_id,
               external_documentation_url = EXCLUDED.external_documentation_url,
               external_documentation_text = EXCLUDED.external_documentation_text,
@@ -38,6 +39,7 @@ DO UPDATE SET project_id = EXCLUDED.project_id,
               updated_at = clock_timestamp()
 RETURNING id,
           toolset_id,
+          mcp_server_id,
           project_id,
           external_documentation_url,
           external_documentation_text,

--- a/server/internal/mcpmetadata/repo/models.go
+++ b/server/internal/mcpmetadata/repo/models.go
@@ -22,7 +22,8 @@ type McpEnvironmentConfig struct {
 
 type McpMetadatum struct {
 	ID                        uuid.UUID
-	ToolsetID                 uuid.UUID
+	ToolsetID                 uuid.NullUUID
+	McpServerID               uuid.NullUUID
 	ProjectID                 uuid.UUID
 	ExternalDocumentationUrl  pgtype.Text
 	ExternalDocumentationText pgtype.Text

--- a/server/internal/mcpmetadata/repo/queries.sql.go
+++ b/server/internal/mcpmetadata/repo/queries.sql.go
@@ -44,7 +44,7 @@ FROM mcp_metadata
 WHERE toolset_id = $1
 `
 
-func (q *Queries) GetHeaderDisplayNames(ctx context.Context, toolsetID uuid.UUID) ([]byte, error) {
+func (q *Queries) GetHeaderDisplayNames(ctx context.Context, toolsetID uuid.NullUUID) ([]byte, error) {
 	row := q.db.QueryRow(ctx, getHeaderDisplayNames, toolsetID)
 	var header_display_names []byte
 	err := row.Scan(&header_display_names)
@@ -54,6 +54,7 @@ func (q *Queries) GetHeaderDisplayNames(ctx context.Context, toolsetID uuid.UUID
 const getMetadataForToolset = `-- name: GetMetadataForToolset :one
 SELECT id,
        toolset_id,
+       mcp_server_id,
        project_id,
        external_documentation_url,
        external_documentation_text,
@@ -70,12 +71,13 @@ ORDER BY updated_at DESC
 LIMIT 1
 `
 
-func (q *Queries) GetMetadataForToolset(ctx context.Context, toolsetID uuid.UUID) (McpMetadatum, error) {
+func (q *Queries) GetMetadataForToolset(ctx context.Context, toolsetID uuid.NullUUID) (McpMetadatum, error) {
 	row := q.db.QueryRow(ctx, getMetadataForToolset, toolsetID)
 	var i McpMetadatum
 	err := row.Scan(
 		&i.ID,
 		&i.ToolsetID,
+		&i.McpServerID,
 		&i.ProjectID,
 		&i.ExternalDocumentationUrl,
 		&i.ExternalDocumentationText,
@@ -196,7 +198,7 @@ INSERT INTO mcp_metadata (
     default_environment_id,
     installation_override_url
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-ON CONFLICT (toolset_id)
+ON CONFLICT (toolset_id) WHERE toolset_id IS NOT NULL
 DO UPDATE SET project_id = EXCLUDED.project_id,
               external_documentation_url = EXCLUDED.external_documentation_url,
               external_documentation_text = EXCLUDED.external_documentation_text,
@@ -207,6 +209,7 @@ DO UPDATE SET project_id = EXCLUDED.project_id,
               updated_at = clock_timestamp()
 RETURNING id,
           toolset_id,
+          mcp_server_id,
           project_id,
           external_documentation_url,
           external_documentation_text,
@@ -220,7 +223,7 @@ RETURNING id,
 `
 
 type UpsertMetadataParams struct {
-	ToolsetID                 uuid.UUID
+	ToolsetID                 uuid.NullUUID
 	ProjectID                 uuid.UUID
 	ExternalDocumentationUrl  pgtype.Text
 	ExternalDocumentationText pgtype.Text
@@ -245,6 +248,7 @@ func (q *Queries) UpsertMetadata(ctx context.Context, arg UpsertMetadataParams) 
 	err := row.Scan(
 		&i.ID,
 		&i.ToolsetID,
+		&i.McpServerID,
 		&i.ProjectID,
 		&i.ExternalDocumentationUrl,
 		&i.ExternalDocumentationText,

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1174,7 +1174,7 @@ func TestServeInstallPage_ExternalMCP_FiltersNonUserProvidedHeaders(t *testing.T
 
 	mcpRepo := mcpmetadata_repo.New(ti.conn)
 	metadata, err := mcpRepo.UpsertMetadata(ctx, mcpmetadata_repo.UpsertMetadataParams{
-		ToolsetID: toolset.ID,
+		ToolsetID: uuid.NullUUID{UUID: toolset.ID, Valid: true},
 		ProjectID: projectID,
 	})
 	require.NoError(t, err)

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -1423,7 +1423,7 @@ func environmentVariablesForTools(ctx context.Context, tx DBTX, toolsetID uuid.U
 	// Fetch header display names from MCP metadata (if available)
 	headerDisplayNames := make(map[string]string)
 	if toolsetID != uuid.Nil {
-		displayNamesJSON, err := mcpmetadataRepo.GetHeaderDisplayNames(ctx, toolsetID)
+		displayNamesJSON, err := mcpmetadataRepo.GetHeaderDisplayNames(ctx, uuid.NullUUID{UUID: toolsetID, Valid: true})
 		if err == nil && len(displayNamesJSON) > 0 {
 			// Parse the JSONB data into a map
 			_ = json.Unmarshal(displayNamesJSON, &headerDisplayNames)

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1358,7 +1358,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 			// toolset without an mcp_metadata row simply has no user-provided
 			// env vars — UpsertMetadata is explicit, not auto-created on publish.
 			if r.ToolsetIsPublic {
-				metadata, metaErr := mcpMeta.GetMetadataForToolset(ctx, r.ToolsetID)
+				metadata, metaErr := mcpMeta.GetMetadataForToolset(ctx, uuid.NullUUID{UUID: r.ToolsetID, Valid: true})
 				switch {
 				case errors.Is(metaErr, pgx.ErrNoRows):
 					// No metadata configured → no env configs to surface.

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -671,7 +671,7 @@ func TestPluginsService_PublishPlugins_PublicToolsetEnvConfigs(t *testing.T) {
 	// Create MCP metadata + environment config for the public toolset.
 	mcpRepo := mcpmetarepo.New(ti.conn)
 	metadata, err := mcpRepo.UpsertMetadata(ctx, mcpmetarepo.UpsertMetadataParams{
-		ToolsetID:                 toolset.ID,
+		ToolsetID:                 uuid.NullUUID{UUID: toolset.ID, Valid: true},
 		ProjectID:                 *authCtx.ProjectID,
 		ExternalDocumentationUrl:  pgtype.Text{Valid: false},
 		ExternalDocumentationText: pgtype.Text{Valid: false},
@@ -752,7 +752,7 @@ func TestPluginsService_PublishPlugins_SkipsUserEnvConfigsWithoutHeaderName(t *t
 
 	mcpRepo := mcpmetarepo.New(ti.conn)
 	metadata, err := mcpRepo.UpsertMetadata(ctx, mcpmetarepo.UpsertMetadataParams{
-		ToolsetID:                 toolset.ID,
+		ToolsetID:                 uuid.NullUUID{UUID: toolset.ID, Valid: true},
 		ProjectID:                 *authCtx.ProjectID,
 		ExternalDocumentationUrl:  pgtype.Text{Valid: false},
 		ExternalDocumentationText: pgtype.Text{Valid: false},
@@ -1180,7 +1180,7 @@ func TestPluginsService_PublishPlugins_CodexPublicToolsetEnvHeaders(t *testing.T
 
 	mcpRepo := mcpmetarepo.New(ti.conn)
 	metadata, err := mcpRepo.UpsertMetadata(ctx, mcpmetarepo.UpsertMetadataParams{
-		ToolsetID:                 toolset.ID,
+		ToolsetID:                 uuid.NullUUID{UUID: toolset.ID, Valid: true},
 		ProjectID:                 *authCtx.ProjectID,
 		ExternalDocumentationUrl:  pgtype.Text{Valid: false},
 		ExternalDocumentationText: pgtype.Text{Valid: false},

--- a/server/migrations/20260528145659_add-mcp-server-id-to-mcp-metadata.sql
+++ b/server/migrations/20260528145659_add-mcp-server-id-to-mcp-metadata.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Modify "mcp_metadata" table
+ALTER TABLE "mcp_metadata" DROP CONSTRAINT "mcp_metadata_toolset_id_key", ADD CONSTRAINT "mcp_metadata_backend_exclusivity_check" CHECK ((toolset_id IS NULL) <> (mcp_server_id IS NULL)), ALTER COLUMN "toolset_id" DROP NOT NULL, ADD COLUMN "mcp_server_id" uuid NULL, ADD CONSTRAINT "mcp_metadata_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Create index "mcp_metadata_toolset_id_key" to table: "mcp_metadata"
+CREATE UNIQUE INDEX CONCURRENTLY "mcp_metadata_toolset_id_key" ON "mcp_metadata" ("toolset_id") WHERE (toolset_id IS NOT NULL);
+-- Create index "mcp_metadata_mcp_server_id_key" to table: "mcp_metadata"
+CREATE UNIQUE INDEX CONCURRENTLY "mcp_metadata_mcp_server_id_key" ON "mcp_metadata" ("mcp_server_id") WHERE (mcp_server_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:yNNnv2Az5LIsw3p9iidcsO7mp8IbC89aYhELw1PF6HU=
+h1:VMHEEBAL9Ktv8P0tV5Awcn0xnTDebVFSG93N/IG8Vg8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -194,3 +194,4 @@ h1:yNNnv2Az5LIsw3p9iidcsO7mp8IbC89aYhELw1PF6HU=
 20260527214516_remote_session_client_user_session_issuers.sql h1:FR8pLqwNWxorR6HIc3DbE/dSytFx44OpPXTEvErcIRM=
 20260528094046_chat-messages-add-risk-analyzed-at.sql h1:p0/C4C1jFr/WH5l/W4fSLi+yqBP0EQYYWD5j6WB3Stk=
 20260528120324_add-custom-detection-rules.sql h1:nvGeihJOJMbo8CUamKuoMlHi6D8r9jJtMK80c+X60NU=
+20260528145659_add-mcp-server-id-to-mcp-metadata.sql h1:fnNq7bTqxCG1Ipb70XLaZh9oZcypAonT/OvqOlQH8oI=


### PR DESCRIPTION
[AGE-2573](https://linear.app/speakeasy/issue/AGE-2573/schema-migration-mcp-metadata-supports-mcp-server-id-alongside-toolset)

Expand-contract migration so a single `mcp_metadata` row can reference either a `toolsets.id` (today) or an `mcp_servers.id` (new). Mirrors the XOR pattern already on `mcp_servers`: nullable `mcp_server_id` with FK `ON DELETE CASCADE`, `toolset_id` relaxed to nullable, table-level `UNIQUE` replaced with two partial unique indexes, and a `CHECK` enforcing exactly one backend is set. Existing toolset-backed rows satisfy the new check unchanged.

`mcp_metadata` and `mcp_environment_configs` blocks relocated in `schema.sql` to sit after `mcp_servers` so the new FK resolves inline (no forward references, per project convention).

**Scope notes** — the issue scoped this PR as schema-only with application code and new queries deferred to [AGE-2239](https://linear.app/speakeasy/issue/AGE-2239/install-page-metadata-for-remote-mcp-backed-mcp-servers), but two follow-on edits were required to keep the existing upsert working and avoid broader churn:

- `mcpmetadata/queries.sql`: added `mcp_server_id` to the `GetMetadataForToolset` `SELECT` and `UpsertMetadata` `RETURNING` so sqlc keeps the unified `McpMetadatum` type. Without it sqlc would emit per-query `Row` types and force signature changes across ~7 call sites.
- `mcpmetadata/queries.sql`: `ON CONFLICT (toolset_id)` now carries the `WHERE toolset_id IS NOT NULL` predicate so Postgres can infer the partial unique index as the upsert arbiter.

Existing call sites that previously passed `uuid.UUID` to repo methods now wrap with `uuid.NullUUID{Valid: true}`; behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `mcp_metadata` to reference either a `toolsets.id` or an `mcp_servers.id`, paving the way for metadata on remote MCP-backed servers. Supports AGE-2573 and fixes nullable toolset handling in conversion to avoid zero-UUIDs.

- **Migration**
  - Add nullable `mcp_server_id` FK (ON DELETE CASCADE) and relax `toolset_id` to nullable; enforce XOR via CHECK so exactly one is set.
  - Replace table-level UNIQUE with partial unique indexes on `toolset_id` and `mcp_server_id` when non-null.
  - Relocate `mcp_metadata` and `mcp_environment_configs` in `schema.sql` to follow `mcp_servers` for inline FK resolution.
  - Add migration to apply the column, FK, CHECK, and indexes concurrently.

- **Refactors**
  - Update `mcpmetadata/queries.sql` to select/return `mcp_server_id` and add `WHERE toolset_id IS NOT NULL` to the `ON CONFLICT` clause.
  - Change repo params/return types to `uuid.NullUUID` for `toolset_id` and update call sites; behavior unchanged.
  - Guard nullable `toolset_id` in `ToMCPMetadata` so server-backed rows emit an empty ToolsetID string instead of a zero UUID.

<sup>Written for commit f1f9aa04d567b38c5416424bddd932e5c55d2a88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3077?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

