### PR TITLE
chore(remotemcp): clean batch request error envelope on remote MCP

### DIFF
--- a/server/internal/remotemcp/proxy/errors.go
+++ b/server/internal/remotemcp/proxy/errors.go
@@ -13,6 +13,14 @@ import (
 // truncation — streamed responses are not subject to this cap.
 var ErrBodyTooLarge = errors.New("body exceeded max size")
 
+// ErrBatchRequest is returned by [UserRequest.ParseJSONRPCMessages] when the
+// inbound POST body is a JSON array. MCP Streamable HTTP § Sending Messages to
+// the Server disallows batched (array) request bodies in the current spec
+// revision, so the proxy rejects them ahead of the JSON-RPC decoder to surface
+// a clean envelope (JSON-RPC error code -32600, "batch requests are not
+// supported") rather than a generic decode failure.
+var ErrBatchRequest = errors.New("batch requests are not supported")
+
 // classifyForwardError maps a [http.Client.Do] failure into a typed proxy
 // error. timedOut is true when the failure was caused by the proxy's own
 // phase-1 timer firing (vs. a parent-context cancellation from the user

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -344,6 +344,19 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 
 	userReq := &UserRequest{UserHTTPRequest: r, JSONRPCMessages: nil, body: nil, dirty: false}
 	if parseErr := userReq.ParseJSONRPCMessages(p.MaxBufferedBodyBytes); parseErr != nil {
+		// Batch (array) bodies are rejected ahead of the decoder so the
+		// user sees a spec-shaped JSON-RPC error envelope instead of a
+		// generic decode error. No id can be extracted from a batch
+		// body, so writeRejection takes the invalid-id branch (HTTP 400
+		// + envelope without the "id" field) per MCP Streamable HTTP.
+		if errors.Is(parseErr, ErrBatchRequest) {
+			responseBytes = p.writeRejection(ctx, w, span, jsonrpc.ID{}, &RejectError{
+				Code:    RejectCodeInvalidRequest,
+				Message: ErrBatchRequest.Error(),
+				Data:    nil,
+			})
+			return nil
+		}
 		return oops.E(oops.CodeBadRequest, parseErr, "invalid jsonrpc request").Log(ctx, p.Logger)
 	}
 

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -735,6 +735,88 @@ func TestProxy_Post_OversizedUserBodyReturnsError(t *testing.T) {
 	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
 }
 
+func TestProxy_Post_BatchRequestBodyReturnsJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	// MCP Streamable HTTP § Sending Messages to the Server disallows
+	// batched (array) request bodies. The proxy must reject ahead of the
+	// decoder with a spec-shaped JSON-RPC envelope (code -32600, HTTP 400,
+	// no "id" field since no id can be extracted from a batch body) rather
+	// than the generic decode-error envelope a stray array would otherwise
+	// produce.
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called when the user request body is a batch")
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+
+	batchBody := `[{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}]`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(batchBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req), "batch rejection writes a JSON-RPC envelope rather than returning an error")
+	require.Equal(t, http.StatusBadRequest, rr.Code, "batch bodies have no decodable id; writeRejection uses the invalid-id branch (HTTP 400)")
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	require.Contains(t, rr.Body.String(), `"code":-32600`, "JSON-RPC InvalidRequest code per spec for malformed/disallowed request shapes")
+	require.Contains(t, rr.Body.String(), "batch requests are not supported")
+	require.NotContains(t, rr.Body.String(), `"id":`, "no id is present on batch bodies; envelope omits the id field")
+}
+
+func TestProxy_Post_BatchRequestBodyWithLeadingWhitespaceReturnsJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	// JSON permits leading whitespace (RFC 8259 § 2) so the peek must
+	// skip it before checking for the array marker — otherwise a batch
+	// body with a leading newline would slip past detection and fall
+	// through to the generic decode error.
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream must not be called when the user request body is a batch")
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+
+	batchBody := "  \n\t\r [{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}]"
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(batchBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), `"code":-32600`)
+	require.Contains(t, rr.Body.String(), "batch requests are not supported")
+}
+
+func TestProxy_Post_SingleMessageBodyWithLeadingWhitespaceStillParses(t *testing.T) {
+	t.Parallel()
+
+	// Defensive: the whitespace-aware batch peek must not false-positive
+	// on a valid single-message body whose JSON object happens to be
+	// preceded by whitespace. The first non-whitespace byte for a
+	// well-formed request is '{', which falls through to the decoder.
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+
+	paddedBody := "  \n  " + initializeRequest
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(paddedBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, paddedBody, gotBody, "leading whitespace is forwarded verbatim along with the body")
+}
+
 func TestProxy_Get_LongStreamsAreNotSubjectToCumulativeCap(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotemcp/proxy/user_request.go
+++ b/server/internal/remotemcp/proxy/user_request.go
@@ -69,6 +69,15 @@ func (r *UserRequest) ParseJSONRPCMessages(maxBytes int64) error {
 		return nil
 	}
 
+	// MCP Streamable HTTP § Sending Messages to the Server disallows
+	// batched (array) request bodies. Peek the first non-whitespace byte
+	// and surface [ErrBatchRequest] ahead of the JSON-RPC decoder so the
+	// proxy can emit a clean rejection envelope instead of a generic
+	// decode error string.
+	if firstNonWhitespaceByte(body) == '[' {
+		return ErrBatchRequest
+	}
+
 	msg, err := jsonrpc.DecodeMessage(body)
 	if err != nil {
 		return fmt.Errorf("decode jsonrpc message: %w", err)
@@ -76,6 +85,21 @@ func (r *UserRequest) ParseJSONRPCMessages(maxBytes int64) error {
 	r.JSONRPCMessages = []jsonrpc.Message{msg}
 
 	return nil
+}
+
+// firstNonWhitespaceByte returns the first byte of body that is not JSON
+// whitespace (space, tab, LF, or CR per RFC 8259 § 2). Returns 0 if body
+// is empty or contains only whitespace.
+func firstNonWhitespaceByte(body []byte) byte {
+	for _, b := range body {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return b
+		}
+	}
+	return 0
 }
 
 // refreshBody re-marshals JSONRPCMessages back to wire bytes and replaces


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2081/proxy-clean-error-envelope-for-json-rpc-batch-requests

Peek the first non-whitespace byte of the user request body in `ParseJSONRPCMessages` and return `ErrBatchRequest` when it's `[`. `Post()` routes that sentinel through `writeRejection` so batch (JSON array) bodies on remote MCP now surface a spec-shaped JSON-RPC error envelope (code `-32600`, `"batch requests are not supported"`, HTTP 400) instead of the generic `decode jsonrpc message: ...` that `jsonrpc.DecodeMessage` otherwise produces.

The fix lives in the proxy package because the body has already been read and failed to decode before any `UserRequestInterceptor` runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject JSON-RPC batch request bodies on remote MCP and return a spec-shaped error envelope (-32600, "batch requests are not supported", HTTP 400) instead of a generic decode error. Satisfies AGE-2081.

- **Bug Fixes**
  - Detect array bodies by peeking the first non-whitespace byte in `ParseJSONRPCMessages` and return `ErrBatchRequest`.
  - Map `ErrBatchRequest` in `Post` to `writeRejection` for a clean JSON-RPC InvalidRequest response (no id).
  - Added tests for batch rejection (with/without leading whitespace) and for valid single-message bodies.

<sup>Written for commit 276e86ebf892db0a77064ba18a9539f9be2d7f3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3078?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

