### PR TITLE
mig: fetch unanalyzed query and logic optimizations

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1307,6 +1307,11 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
+  -- Set when all active risk policies have analyzed this message.
+  -- NULL means unanalyzed (or analysis was reset). Best-effort: policy
+  -- version rescans and backfills are coordinated outside this field.
+  risk_analyzed_at timestamptz,
+
   CONSTRAINT chat_messages_pkey PRIMARY KEY (id),
   CONSTRAINT chat_messages_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
   CONSTRAINT chat_messages_seq_key UNIQUE (seq)
@@ -1317,6 +1322,12 @@ CREATE INDEX IF NOT EXISTS chat_messages_chat_id_generation_seq_idx ON chat_mess
 CREATE INDEX IF NOT EXISTS chat_messages_project_id_id_idx
 ON chat_messages (project_id, id)
 WHERE project_id IS NOT NULL;
+
+-- Partial index over unanalyzed messages only. Shrinks toward zero at steady
+-- state, making FetchUnanalyzedMessageIDs an index-only scan on a tiny set.
+CREATE INDEX IF NOT EXISTS chat_messages_risk_analyzed_at_null_idx
+ON chat_messages (project_id, id)
+WHERE risk_analyzed_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS chat_resolutions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/chat/repo/models.go
+++ b/server/internal/chat/repo/models.go
@@ -53,6 +53,7 @@ type ChatMessage struct {
 	ContentHash      []byte
 	Generation       int32
 	CreatedAt        pgtype.Timestamptz
+	RiskAnalyzedAt   pgtype.Timestamptz
 }
 
 type ChatResolution struct {

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -550,7 +550,7 @@ func (q *Queries) GetMaxGenerationForChat(ctx context.Context, chatID uuid.UUID)
 }
 
 const getToolCallMessages = `-- name: GetToolCallMessages :many
-SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, content_hash, generation, created_at FROM chat_messages
+SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, content_hash, generation, created_at, risk_analyzed_at FROM chat_messages
 WHERE chat_id = $1
   AND role = 'tool'
 ORDER BY created_at ASC
@@ -595,6 +595,7 @@ func (q *Queries) GetToolCallMessages(ctx context.Context, chatID uuid.UUID) ([]
 			&i.ContentHash,
 			&i.Generation,
 			&i.CreatedAt,
+			&i.RiskAnalyzedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -765,7 +766,7 @@ func (q *Queries) InsertUserFeedback(ctx context.Context, arg InsertUserFeedback
 }
 
 const listChatMessages = `-- name: ListChatMessages :many
-SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, content_hash, generation, created_at FROM chat_messages 
+SELECT id, seq, chat_id, project_id, role, content, content_raw, content_asset_url, model, message_id, finish_reason, tool_calls, prompt_tokens, completion_tokens, total_tokens, storage_error, user_id, external_user_id, origin, user_agent, ip_address, source, tool_call_id, tool_urn, tool_outcome, tool_outcome_notes, content_hash, generation, created_at, risk_analyzed_at FROM chat_messages 
 WHERE chat_id = $1 AND (project_id IS NULL OR project_id = $2::uuid) 
 ORDER BY seq ASC
 `
@@ -814,6 +815,7 @@ func (q *Queries) ListChatMessages(ctx context.Context, arg ListChatMessagesPara
 			&i.ContentHash,
 			&i.Generation,
 			&i.CreatedAt,
+			&i.RiskAnalyzedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -826,7 +828,7 @@ func (q *Queries) ListChatMessages(ctx context.Context, arg ListChatMessagesPara
 }
 
 const listChatMessagesByGeneration = `-- name: ListChatMessagesByGeneration :many
-SELECT cm.id, cm.seq, cm.chat_id, cm.project_id, cm.role, cm.content, cm.content_raw, cm.content_asset_url, cm.model, cm.message_id, cm.finish_reason, cm.tool_calls, cm.prompt_tokens, cm.completion_tokens, cm.total_tokens, cm.storage_error, cm.user_id, cm.external_user_id, cm.origin, cm.user_agent, cm.ip_address, cm.source, cm.tool_call_id, cm.tool_urn, cm.tool_outcome, cm.tool_outcome_notes, cm.content_hash, cm.generation, cm.created_at FROM chat_messages cm
+SELECT cm.id, cm.seq, cm.chat_id, cm.project_id, cm.role, cm.content, cm.content_raw, cm.content_asset_url, cm.model, cm.message_id, cm.finish_reason, cm.tool_calls, cm.prompt_tokens, cm.completion_tokens, cm.total_tokens, cm.storage_error, cm.user_id, cm.external_user_id, cm.origin, cm.user_agent, cm.ip_address, cm.source, cm.tool_call_id, cm.tool_urn, cm.tool_outcome, cm.tool_outcome_notes, cm.content_hash, cm.generation, cm.created_at, cm.risk_analyzed_at FROM chat_messages cm
 WHERE cm.chat_id = $1
   AND (cm.project_id IS NULL OR cm.project_id = $2::uuid)
   AND cm.generation = $3::integer
@@ -881,6 +883,7 @@ func (q *Queries) ListChatMessagesByGeneration(ctx context.Context, arg ListChat
 			&i.ContentHash,
 			&i.Generation,
 			&i.CreatedAt,
+			&i.RiskAnalyzedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1132,7 +1135,7 @@ func (q *Queries) ListChats(ctx context.Context, arg ListChatsParams) ([]ListCha
 }
 
 const listLatestGenerationChatMessages = `-- name: ListLatestGenerationChatMessages :many
-SELECT cm.id, cm.seq, cm.chat_id, cm.project_id, cm.role, cm.content, cm.content_raw, cm.content_asset_url, cm.model, cm.message_id, cm.finish_reason, cm.tool_calls, cm.prompt_tokens, cm.completion_tokens, cm.total_tokens, cm.storage_error, cm.user_id, cm.external_user_id, cm.origin, cm.user_agent, cm.ip_address, cm.source, cm.tool_call_id, cm.tool_urn, cm.tool_outcome, cm.tool_outcome_notes, cm.content_hash, cm.generation, cm.created_at FROM chat_messages cm
+SELECT cm.id, cm.seq, cm.chat_id, cm.project_id, cm.role, cm.content, cm.content_raw, cm.content_asset_url, cm.model, cm.message_id, cm.finish_reason, cm.tool_calls, cm.prompt_tokens, cm.completion_tokens, cm.total_tokens, cm.storage_error, cm.user_id, cm.external_user_id, cm.origin, cm.user_agent, cm.ip_address, cm.source, cm.tool_call_id, cm.tool_urn, cm.tool_outcome, cm.tool_outcome_notes, cm.content_hash, cm.generation, cm.created_at, cm.risk_analyzed_at FROM chat_messages cm
 WHERE cm.chat_id = $1
   AND (cm.project_id IS NULL OR cm.project_id = $2::uuid)
   AND cm.generation = (SELECT MAX(generation) FROM chat_messages WHERE chat_id = $1)
@@ -1184,6 +1187,7 @@ func (q *Queries) ListLatestGenerationChatMessages(ctx context.Context, arg List
 			&i.ContentHash,
 			&i.Generation,
 			&i.CreatedAt,
+			&i.RiskAnalyzedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -267,6 +267,7 @@ type ChatMessage struct {
 	ContentHash      []byte
 	Generation       int32
 	CreatedAt        pgtype.Timestamptz
+	RiskAnalyzedAt   pgtype.Timestamptz
 }
 
 type ChatResolution struct {

--- a/server/migrations/20260528094046_chat-messages-add-risk-analyzed-at.sql
+++ b/server/migrations/20260528094046_chat-messages-add-risk-analyzed-at.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "chat_messages" table
+ALTER TABLE "chat_messages" ADD COLUMN "risk_analyzed_at" timestamptz NULL;
+-- Create index "chat_messages_risk_analyzed_at_null_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_risk_analyzed_at_null_idx" ON "chat_messages" ("project_id", "id") WHERE (risk_analyzed_at IS NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:On+ZEg6dsf7eBowIVa9/gZdvmsWAjyc9JGqU/i9AkII=
+h1:2UlUyfACnYMD+Fg515jeLiIr0Rb3jakdADSj/qo3myo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -192,3 +192,4 @@ h1:On+ZEg6dsf7eBowIVa9/gZdvmsWAjyc9JGqU/i9AkII=
 20260526164519_add-risk-policies-disabled-rules.sql h1:SmIuD/9RiaBWGHZBadLnVzwVdQ7x0riPTboR6+M0GLE=
 20260527093220_org-metadata-add-scim-sso-enabled.sql h1:Nq+Q4qTzQijE3X3vl2YDbZkq+8o0EHA0rA/5cFk0hlw=
 20260527214516_remote_session_client_user_session_issuers.sql h1:FR8pLqwNWxorR6HIc3DbE/dSytFx44OpPXTEvErcIRM=
+20260528094046_chat-messages-add-risk-analyzed-at.sql h1:p0/C4C1jFr/WH5l/W4fSLi+yqBP0EQYYWD5j6WB3Stk=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/3080 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `risk_analyzed_at` to `chat_messages` and a partial index on NULL to make fetching unanalyzed messages fast. Updates server models and read queries to include this field; no behavior change yet.

- **Migration**
  - Apply the new migration; the index is created concurrently (no downtime).
  - No backfill required; existing rows stay NULL until analysis sets a timestamp.

<sup>Written for commit 820330c0b07197c2fcf2745a7568ce418e036c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3081?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

