### PR TITLE
mig: support custom regex detection rules

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2683,6 +2683,7 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   -- Empty/NULL means every rule in the selected categories runs. Scanner
   -- drops any finding whose canonical rule_id appears here.
   disabled_rules TEXT[],
+  custom_rule_ids TEXT[] NOT NULL DEFAULT '{}',
   action TEXT NOT NULL DEFAULT 'flag',
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,
   user_message TEXT,
@@ -2700,6 +2701,30 @@ CREATE TABLE IF NOT EXISTS risk_policies (
 
 CREATE INDEX IF NOT EXISTS risk_policies_project_id_idx
 ON risk_policies (project_id)
+WHERE deleted IS FALSE;
+
+CREATE TABLE IF NOT EXISTS risk_custom_detection_rules (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  organization_id TEXT NOT NULL,
+  rule_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  regex TEXT,
+  severity TEXT NOT NULL DEFAULT 'medium',
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+
+  CONSTRAINT risk_custom_detection_rules_pkey PRIMARY KEY (id),
+  CONSTRAINT risk_custom_detection_rules_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+  CONSTRAINT risk_custom_detection_rules_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS risk_custom_detection_rules_project_rule_id_key
+ON risk_custom_detection_rules (project_id, rule_id)
 WHERE deleted IS FALSE;
 
 -- Individual findings produced by scanning a chat message against a risk policy.

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1184,6 +1184,21 @@ type RemoteSessionIssuer struct {
 	Deleted                           bool
 }
 
+type RiskCustomDetectionRule struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	RuleID         string
+	Title          string
+	Description    string
+	Regex          pgtype.Text
+	Severity       string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
+}
+
 type RiskPolicy struct {
 	ID                   uuid.UUID
 	ProjectID            uuid.UUID
@@ -1194,6 +1209,7 @@ type RiskPolicy struct {
 	PresidioEntities     []string
 	PromptInjectionRules []string
 	DisabledRules        []string
+	CustomRuleIds        []string
 	Action               string
 	AutoName             bool
 	UserMessage          pgtype.Text

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -19,6 +19,7 @@ type RiskPolicy struct {
 	PresidioEntities     []string
 	PromptInjectionRules []string
 	DisabledRules        []string
+	CustomRuleIds        []string
 	Action               string
 	AutoName             bool
 	UserMessage          pgtype.Text

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -19,7 +19,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -40,6 +40,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
+		&i.CustomRuleIds,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -154,7 +155,7 @@ VALUES (
   , $12
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -198,6 +199,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
+		&i.CustomRuleIds,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -391,7 +393,7 @@ func (q *Queries) GetRiskOverviewCounts(ctx context.Context, arg GetRiskOverview
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -416,6 +418,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
+		&i.CustomRuleIds,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,
@@ -460,7 +463,7 @@ type InsertRiskResultsParams struct {
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -487,6 +490,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
+			&i.CustomRuleIds,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -507,7 +511,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -533,6 +537,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
+			&i.CustomRuleIds,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -553,7 +558,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -581,6 +586,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
+			&i.CustomRuleIds,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -601,7 +607,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -632,6 +638,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
+			&i.CustomRuleIds,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -885,7 +892,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -911,6 +918,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.PresidioEntities,
 			&i.PromptInjectionRules,
 			&i.DisabledRules,
+			&i.CustomRuleIds,
 			&i.Action,
 			&i.AutoName,
 			&i.UserMessage,
@@ -1658,7 +1666,7 @@ SET name = $1
 WHERE id = $10
   AND project_id = $11
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, sources, presidio_entities, prompt_injection_rules, disabled_rules, custom_rule_ids, action, auto_name, user_message, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -1700,6 +1708,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.PresidioEntities,
 		&i.PromptInjectionRules,
 		&i.DisabledRules,
+		&i.CustomRuleIds,
 		&i.Action,
 		&i.AutoName,
 		&i.UserMessage,

--- a/server/migrations/20260528120324_add-custom-detection-rules.sql
+++ b/server/migrations/20260528120324_add-custom-detection-rules.sql
@@ -1,0 +1,22 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "custom_rule_ids" text[] NOT NULL DEFAULT '{}';
+-- Create "risk_custom_detection_rules" table
+CREATE TABLE "risk_custom_detection_rules" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "rule_id" text NOT NULL,
+  "title" text NOT NULL,
+  "description" text NOT NULL DEFAULT '',
+  "regex" text NULL,
+  "severity" text NOT NULL DEFAULT 'medium',
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_custom_detection_rules_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "risk_custom_detection_rules_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "risk_custom_detection_rules_project_rule_id_key" to table: "risk_custom_detection_rules"
+CREATE UNIQUE INDEX "risk_custom_detection_rules_project_rule_id_key" ON "risk_custom_detection_rules" ("project_id", "rule_id") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:2UlUyfACnYMD+Fg515jeLiIr0Rb3jakdADSj/qo3myo=
+h1:yNNnv2Az5LIsw3p9iidcsO7mp8IbC89aYhELw1PF6HU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -193,3 +193,4 @@ h1:2UlUyfACnYMD+Fg515jeLiIr0Rb3jakdADSj/qo3myo=
 20260527093220_org-metadata-add-scim-sso-enabled.sql h1:Nq+Q4qTzQijE3X3vl2YDbZkq+8o0EHA0rA/5cFk0hlw=
 20260527214516_remote_session_client_user_session_issuers.sql h1:FR8pLqwNWxorR6HIc3DbE/dSytFx44OpPXTEvErcIRM=
 20260528094046_chat-messages-add-risk-analyzed-at.sql h1:p0/C4C1jFr/WH5l/W4fSLi+yqBP0EQYYWD5j6WB3Stk=
+20260528120324_add-custom-detection-rules.sql h1:nvGeihJOJMbo8CUamKuoMlHi6D8r9jJtMK80c+X60NU=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/2992 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project-scoped custom regex detection rules linked to risk policies via `custom_rule_ids` to support the Detection Rules UI (Linear 9s6m). Updates models/queries to surface `custom_rule_ids` and adds the `RiskCustomDetectionRule` DB model.

- **New Features**
  - New `risk_custom_detection_rules` table (project/org scoped) with `rule_id`, `title`, `description`, `regex`, `severity`, soft delete, and unique `(project_id, rule_id)` for non-deleted rows; FKs to `projects` and `organization_metadata`.
  - Expose `risk_policies.custom_rule_ids` (default `[]`) across models/queries.

- **Migration**
  - Run `20260528120324_add-custom-detection-rules.sql`.
  - No backfill; existing policies default to empty `custom_rule_ids`.

<sup>Written for commit 1e6396bc04cb947c4c9b51a87ace190406edf470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3082?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

