### PR TITLE
feat(dashboard): add tool variations menu to source detail Tools tab

### DIFF
--- a/.changeset/brave-snakes-drift.md
+++ b/.changeset/brave-snakes-drift.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+add tool variations menu to source detail Tools tab

--- a/client/dashboard/src/components/tool-list/ToolList.tsx
+++ b/client/dashboard/src/components/tool-list/ToolList.tsx
@@ -7,6 +7,7 @@ import { TextArea } from "@/components/ui/textarea";
 import { TagsVariationEditor } from "@/components/tool-variation-tags-editor";
 import { useCommandPalette } from "@/contexts/CommandPalette";
 import { useLatestDeployment } from "@/hooks/toolTypes";
+import { ToolUpdateFields } from "@/hooks/useToolUpdate";
 import { TOOL_NAME_REGEX } from "@/lib/constants";
 import { Tool, Toolset, isHttpTool } from "@/lib/toolTypes";
 import { cn } from "@/lib/utils";
@@ -29,25 +30,15 @@ import { Type } from "../ui/type";
 import { MethodBadge } from "./MethodBadge";
 import { SubtoolsBadge } from "./SubtoolsBadge";
 
-export type ToolListUpdateFields = {
-  name?: string;
-  description?: string;
-  title?: string;
-  readOnlyHint?: boolean;
-  destructiveHint?: boolean;
-  idempotentHint?: boolean;
-  openWorldHint?: boolean;
-  // tri-state:
-  //   undefined = no override (use source tags)
-  //   []        = explicit empty override
-  //   [...]     = explicit override
-  tags?: string[] | undefined;
-};
-
 interface ToolListProps {
   tools: Tool[]; // Accepts all tool types, filters to Tool internally
   toolset?: Toolset; // Optionally specificy the toolset to provide rows with additional context
-  onToolUpdate?: (tool: Tool, updates: ToolListUpdateFields) => void;
+  onToolUpdate?: (
+    tool: Tool,
+    updates: ToolUpdateFields,
+  ) => void | Promise<void>;
+  /** True while a tool update is in flight; disables Save in the edit dialog. */
+  isToolUpdating?: boolean;
   onToolsRemove?: (toolUrns: string[]) => void;
   onAddToToolset?: (toolUrns: string[]) => void;
   onCreateToolset?: (toolUrns: string[]) => void;
@@ -268,6 +259,7 @@ function ToolRow({
   availableToolUrns, // Context for the subtools badge
   groupName,
   onUpdate,
+  isUpdating,
   isSelected,
   isFocused,
   onCheckboxChange,
@@ -279,7 +271,8 @@ function ToolRow({
   tool: Tool;
   availableToolUrns?: string[];
   groupName: string;
-  onUpdate?: (updates: ToolListUpdateFields) => void;
+  onUpdate?: (updates: ToolUpdateFields) => void | Promise<void>;
+  isUpdating?: boolean;
   isSelected: boolean;
   isFocused: boolean;
   onCheckboxChange: (checked: boolean) => void;
@@ -350,29 +343,38 @@ function ToolRow({
     setEditDialogOpen(true);
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (editType === "name" && !TOOL_NAME_REGEX.test(editValue)) {
       setError("Tool name may only contain letters, numbers, and underscores");
       return;
     }
 
+    let updates: ToolUpdateFields;
     if (editType === "annotations") {
-      onUpdate?.({
+      updates = {
         title: annotTitle || undefined,
         readOnlyHint: annotReadOnly,
         destructiveHint: annotDestructive,
         idempotentHint: annotIdempotent,
         openWorldHint: annotOpenWorld,
-      });
+      };
     } else if (editType === "tags") {
       // tags key must always be present so the upsert form spread correctly
       // overwrites any prior variation tags (sending undefined drops the key
       // from the wire body, signalling no override).
-      onUpdate?.({ tags: tagsValue });
+      updates = { tags: tagsValue };
     } else {
-      onUpdate?.({ [editType]: editValue });
+      updates = { [editType]: editValue };
     }
-    setEditDialogOpen(false);
+
+    try {
+      await onUpdate?.(updates);
+      setEditDialogOpen(false);
+    } catch (err) {
+      // Toast is surfaced by useToolUpdate's onError; keep inline message for
+      // dialog visibility.
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
   };
 
   const handleCopyName = async () => {
@@ -648,10 +650,16 @@ function ToolRow({
             {error && <p className="text-destructive text-sm">{error}</p>}
           </div>
           <Dialog.Footer>
-            <Button variant="ghost" onClick={() => setEditDialogOpen(false)}>
+            <Button
+              variant="ghost"
+              onClick={() => setEditDialogOpen(false)}
+              disabled={isUpdating}
+            >
               Cancel
             </Button>
-            <Button onClick={handleSave}>Save</Button>
+            <Button onClick={handleSave} disabled={isUpdating}>
+              Save
+            </Button>
           </Dialog.Footer>
         </Dialog.Content>
       </Dialog>
@@ -742,6 +750,7 @@ export function ToolList({
   tools,
   toolset,
   onToolUpdate,
+  isToolUpdating,
   onToolsRemove,
   onAddToToolset,
   onCreateToolset,
@@ -1097,6 +1106,7 @@ export function ToolList({
                           .filter((urn) => !selectedForRemoval.has(urn))}
                         tool={tool}
                         onUpdate={(updates) => onToolUpdate?.(tool, updates)}
+                        isUpdating={isToolUpdating}
                         isSelected={
                           selectionMode === "add"
                             ? selectedSet.has(toolId)

--- a/client/dashboard/src/hooks/useToolUpdate.ts
+++ b/client/dashboard/src/hooks/useToolUpdate.ts
@@ -1,0 +1,94 @@
+import { useSdkClient } from "@/contexts/Sdk";
+import { useTelemetry } from "@/contexts/Telemetry";
+import { Tool } from "@/lib/toolTypes";
+import { Confirm } from "@gram/client/models/components";
+import { invalidateTemplate } from "@gram/client/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { toast } from "sonner";
+
+export type ToolUpdateFields = {
+  name?: string;
+  description?: string;
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+  // tri-state:
+  //   undefined = no override (use source tags)
+  //   []        = explicit empty override
+  //   [...]     = explicit override
+  tags?: string[] | undefined;
+};
+
+export type UseToolUpdateOptions = {
+  /** Telemetry event name to capture on success (e.g. "toolset_event", "source_event"). */
+  telemetryEvent: string;
+  /** Called after a successful update so the caller can refresh its view. */
+  onSuccess?: () => void;
+};
+
+/**
+ * Shared mutation for updating a tool's overrides. Routes prompt-template tools
+ * through `templates.update` and all other tool types through the global tool
+ * variation upsert. Returns a stable `updateTool` callback plus an `isUpdating`
+ * flag callers can wire into Save-button disabled state to prevent
+ * double-submission.
+ */
+export function useToolUpdate({
+  telemetryEvent,
+  onSuccess,
+}: UseToolUpdateOptions) {
+  const queryClient = useQueryClient();
+  const telemetry = useTelemetry();
+  const client = useSdkClient();
+
+  const { mutateAsync, isPending } = useMutation<
+    void,
+    Error,
+    { tool: Tool; updates: ToolUpdateFields }
+  >({
+    mutationFn: async ({ tool, updates }) => {
+      if (tool.type === "prompt") {
+        await client.templates.update({
+          updatePromptTemplateForm: {
+            ...tool,
+            ...updates,
+          },
+        });
+        invalidateTemplate(queryClient, [{ name: tool.name }]);
+      } else {
+        await client.variations.upsertGlobal({
+          upsertGlobalToolVariationForm: {
+            ...tool.variation,
+            confirm: tool.variation?.confirm as Confirm,
+            ...updates,
+            srcToolName: tool.canonicalName,
+            srcToolUrn: tool.toolUrn,
+          },
+        });
+      }
+
+      telemetry.capture(telemetryEvent, {
+        action: "tool_variation_updated",
+        tool_name: tool.name,
+        overridden_fields: Object.keys(updates).join(", "),
+      });
+    },
+    onSuccess: () => {
+      toast.success("Tool updated");
+      onSuccess?.();
+    },
+    onError: (err) => {
+      toast.error(`Failed to update tool: ${err.message}`);
+    },
+  });
+
+  const updateTool = useCallback(
+    (tool: Tool, updates: ToolUpdateFields) => mutateAsync({ tool, updates }),
+    [mutateAsync],
+  );
+
+  return { updateTool, isUpdating: isPending };
+}

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -39,12 +39,13 @@ import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useToolset } from "@/hooks/toolTypes";
+import { useToolUpdate } from "@/hooks/useToolUpdate";
 import { FeatureRequestModal } from "@/components/FeatureRequestModal";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
 import { useProductTier } from "@/hooks/useProductTier";
 import { useCustomDomain, useMcpUrl } from "@/hooks/useToolsetUrl";
 import { isNotFoundError } from "@/lib/route-errors";
-import { Tool, Toolset, useGroupedTools } from "@/lib/toolTypes";
+import { Toolset, useGroupedTools } from "@/lib/toolTypes";
 import { cn, getServerURL } from "@/lib/utils";
 import {
   useAttachServer,
@@ -55,13 +56,11 @@ import { PromptsTabContent } from "@/pages/toolsets/PromptsTab";
 import { ResourcesTabContent } from "@/pages/toolsets/resources/ResourcesTab";
 import { ServerTabContent } from "@/pages/toolsets/ServerTab";
 import { useRoutes } from "@/routes";
-import { Confirm } from "@gram/client/models/components";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
 import {
   invalidateAllGetPeriodUsage,
   invalidateAllListToolsets,
   invalidateAllToolset,
-  invalidateTemplate,
   buildCollectionsListServersQuery,
   useAddOAuthProxyServerMutation,
   useExportMcpMetadataMutation,
@@ -1149,48 +1148,10 @@ function MCPToolsTab({ toolset }: { toolset: Toolset }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- recalculate only when the set of group keys changes
   }, [groupKeysJoined]);
 
-  const handleToolUpdate = async (
-    tool: Tool,
-    updates: {
-      name?: string;
-      description?: string;
-      title?: string;
-      readOnlyHint?: boolean;
-      destructiveHint?: boolean;
-      idempotentHint?: boolean;
-      openWorldHint?: boolean;
-      tags?: string[] | undefined;
-    },
-  ) => {
-    if (tool.type === "prompt") {
-      await client.templates.update({
-        updatePromptTemplateForm: {
-          ...tool,
-          ...updates,
-        },
-      });
-      invalidateTemplate(queryClient, [{ name: tool.name }]);
-    } else {
-      await client.variations.upsertGlobal({
-        upsertGlobalToolVariationForm: {
-          ...tool.variation,
-          confirm: tool.variation?.confirm as Confirm,
-          ...updates,
-          srcToolName: tool.canonicalName,
-          srcToolUrn: tool.toolUrn,
-        },
-      });
-    }
-
-    telemetry.capture("toolset_event", {
-      action: "tool_variation_updated",
-      tool_name: tool.name,
-      overridden_fields: Object.keys(updates).join(", "),
-    });
-
-    toast.success("Tool updated");
-    refetch();
-  };
+  const { updateTool, isUpdating } = useToolUpdate({
+    telemetryEvent: "toolset_event",
+    onSuccess: refetch,
+  });
 
   // For external MCP proxy servers, show the server info instead of tools list
   if (isExternalMcpProxy && fullToolset) {
@@ -1277,7 +1238,8 @@ function MCPToolsTab({ toolset }: { toolset: Toolset }) {
         <ToolList
           tools={toolsToDisplay}
           toolset={fullToolset}
-          onToolUpdate={canWrite ? handleToolUpdate : undefined}
+          onToolUpdate={canWrite ? updateTool : undefined}
+          isToolUpdating={isUpdating}
           onToolsRemove={canWrite ? handleToolsRemove : undefined}
           onTestInPlayground={handleTestInPlayground}
           readOnly={!canWrite}

--- a/client/dashboard/src/pages/sources/SourceDetails.tsx
+++ b/client/dashboard/src/pages/sources/SourceDetails.tsx
@@ -23,13 +23,16 @@ import {
 } from "@gram/client/react-query/index.js";
 import { telemetryGetObservabilityOverview } from "@gram/client/funcs/telemetryGetObservabilityOverview";
 import { useGramContext } from "@gram/client/react-query/_context";
-import { useQuery } from "@tanstack/react-query";
 import { unwrapAsync } from "@gram/client/types/fp";
 import type { GetObservabilityOverviewResult } from "@gram/client/models/components";
 import { useLogsEnabledErrorCheck } from "@/hooks/useLogsEnabled";
 import { useListTools } from "@/hooks/toolTypes";
+import { useRBAC } from "@/hooks/useRBAC";
+import { useToolUpdate } from "@/hooks/useToolUpdate";
+import { invalidateAllListTools } from "@gram/client/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Badge, Button } from "@speakeasy-api/moonshine";
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { Navigate, useParams } from "react-router";
 import { SourceDeploymentsPanel } from "./SourceDeploymentsPanel";
 import ExternalMCPDetails from "./external-mcp/ExternalMCPDetails";
@@ -175,6 +178,18 @@ export default function SourceDetails() {
   const isOpenAPI = sourceKind === "http" || sourceKind === "openapi";
   const sourceType = isOpenAPI ? "OpenAPI" : "Function";
 
+  const { hasScope } = useRBAC();
+  const canWriteTools = hasScope("mcp:write");
+  const queryClient = useQueryClient();
+  const refetchTools = useCallback(
+    () => invalidateAllListTools(queryClient),
+    [queryClient],
+  );
+  const { updateTool, isUpdating } = useToolUpdate({
+    telemetryEvent: "source_event",
+    onSuccess: refetchTools,
+  });
+
   const uniqueRuntimes = useMemo(() => {
     if (isOpenAPI) return [];
     const runtimes = new Set<string>();
@@ -309,6 +324,8 @@ export default function SourceDetails() {
               relatedTools={relatedTools}
               isOpenAPI={isOpenAPI}
               uniqueRuntimes={uniqueRuntimes}
+              onToolUpdate={canWriteTools ? updateTool : undefined}
+              isToolUpdating={isUpdating}
             />
           </TabsContent>
 

--- a/client/dashboard/src/pages/sources/SourceToolActions.tsx
+++ b/client/dashboard/src/pages/sources/SourceToolActions.tsx
@@ -60,7 +60,7 @@ export function SourceToolActions({
 
   // Memoize so TagsVariationEditor's downstream memoization isn't invalidated
   // by a fresh `[]` reference on every render.
-  const baseTags = useMemo(() => tool.tags ?? [], [tool]);
+  const baseTags = useMemo(() => tool.tags ?? [], [tool.tags]);
 
   const openEditDialog = (mode: EditMode) => {
     setEditMode(mode);

--- a/client/dashboard/src/pages/sources/SourceToolActions.tsx
+++ b/client/dashboard/src/pages/sources/SourceToolActions.tsx
@@ -1,0 +1,337 @@
+import { TagsVariationEditor } from "@/components/tool-variation-tags-editor";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { MoreActions } from "@/components/ui/more-actions";
+import { Switch } from "@/components/ui/switch";
+import { TextArea } from "@/components/ui/textarea";
+import { Type } from "@/components/ui/type";
+import { ToolUpdateFields } from "@/hooks/useToolUpdate";
+import { TOOL_NAME_REGEX } from "@/lib/constants";
+import { Tool } from "@/lib/toolTypes";
+import { Icon, Stack } from "@speakeasy-api/moonshine";
+import { useMemo, useState } from "react";
+
+type EditMode = "name" | "description" | "annotations" | "tags";
+type SourceTool = Extract<Tool, { type: "http" | "function" }>;
+
+const DIALOG_TITLES: Record<EditMode, string> = {
+  name: "Edit tool name",
+  description: "Edit description",
+  annotations: "Edit annotations",
+  tags: "Edit tags",
+};
+
+function dialogDescription(mode: EditMode, toolName: string): string {
+  switch (mode) {
+    case "name":
+      return `Update the name of tool '${toolName}'`;
+    case "description":
+      return `Update the description of tool '${toolName}'`;
+    case "annotations":
+      return `Override behavior hints for '${toolName}'`;
+    case "tags":
+      return `Override tags for '${toolName}'`;
+  }
+}
+
+export function SourceToolActions({
+  tool,
+  onUpdate,
+  isUpdating,
+}: {
+  tool: SourceTool;
+  onUpdate: (updates: ToolUpdateFields) => void | Promise<void>;
+  isUpdating?: boolean;
+}) {
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [editMode, setEditMode] = useState<EditMode>("name");
+  const [editValue, setEditValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const [annotTitle, setAnnotTitle] = useState("");
+  const [annotReadOnly, setAnnotReadOnly] = useState(false);
+  const [annotDestructive, setAnnotDestructive] = useState(false);
+  const [annotIdempotent, setAnnotIdempotent] = useState(false);
+  const [annotOpenWorld, setAnnotOpenWorld] = useState(false);
+
+  const [tagsValue, setTagsValue] = useState<string[] | undefined>(undefined);
+
+  // Memoize so TagsVariationEditor's downstream memoization isn't invalidated
+  // by a fresh `[]` reference on every render.
+  const baseTags = useMemo(() => tool.tags ?? [], [tool]);
+
+  const openEditDialog = (mode: EditMode) => {
+    setEditMode(mode);
+    setError(null);
+
+    switch (mode) {
+      case "annotations":
+        setAnnotTitle(tool.variation?.title ?? tool.annotations?.title ?? "");
+        setAnnotReadOnly(
+          tool.variation?.readOnlyHint ??
+            tool.annotations?.readOnlyHint ??
+            false,
+        );
+        setAnnotDestructive(
+          tool.variation?.destructiveHint ??
+            tool.annotations?.destructiveHint ??
+            false,
+        );
+        setAnnotIdempotent(
+          tool.variation?.idempotentHint ??
+            tool.annotations?.idempotentHint ??
+            false,
+        );
+        setAnnotOpenWorld(
+          tool.variation?.openWorldHint ??
+            tool.annotations?.openWorldHint ??
+            false,
+        );
+        break;
+      case "tags":
+        setTagsValue(tool.variation?.tags);
+        break;
+      case "name":
+        setEditValue(tool.name);
+        break;
+      case "description":
+        setEditValue(tool.description);
+        break;
+    }
+
+    setEditDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (editMode === "name" && !TOOL_NAME_REGEX.test(editValue)) {
+      setError("Tool name may only contain letters, numbers, and underscores");
+      return;
+    }
+
+    let updates: ToolUpdateFields;
+    switch (editMode) {
+      case "annotations":
+        updates = {
+          title: annotTitle || undefined,
+          readOnlyHint: annotReadOnly,
+          destructiveHint: annotDestructive,
+          idempotentHint: annotIdempotent,
+          openWorldHint: annotOpenWorld,
+        };
+        break;
+      case "tags":
+        // tags key must always be present so the upsert form spread correctly
+        // overwrites any prior variation tags (sending undefined drops the key
+        // from the wire body, signalling no override).
+        updates = { tags: tagsValue };
+        break;
+      case "name":
+        updates = { name: editValue };
+        break;
+      case "description":
+        updates = { description: editValue };
+        break;
+    }
+
+    try {
+      await onUpdate(updates);
+      setEditDialogOpen(false);
+    } catch (err) {
+      // Toast is surfaced by useToolUpdate's onError; keep inline message for
+      // dialog visibility.
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleCopyName = async () => {
+    await navigator.clipboard.writeText(tool.name);
+  };
+
+  const actions = [
+    {
+      label: "Edit name",
+      onClick: () => openEditDialog("name"),
+      icon: "pencil" as const,
+    },
+    {
+      label: "Edit description",
+      onClick: () => openEditDialog("description"),
+      icon: "pencil" as const,
+    },
+    {
+      label: "Edit annotations",
+      onClick: () => openEditDialog("annotations"),
+      icon: "pencil" as const,
+    },
+    {
+      label: "Edit tags",
+      onClick: () => openEditDialog("tags"),
+      icon: "pencil" as const,
+    },
+    {
+      label: "Copy name",
+      onClick: handleCopyName,
+      icon: "copy" as const,
+    },
+  ];
+
+  return (
+    <>
+      <MoreActions actions={actions} />
+
+      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>{DIALOG_TITLES[editMode]}</Dialog.Title>
+            <Dialog.Description>
+              {dialogDescription(editMode, tool.name)}
+            </Dialog.Description>
+          </Dialog.Header>
+          <div className="space-y-4 py-4">
+            {editMode === "annotations" && (
+              <Stack gap={4}>
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Title</Label>
+                  <Input
+                    value={annotTitle}
+                    onChange={setAnnotTitle}
+                    placeholder="Display name override"
+                  />
+                </div>
+                <div className="space-y-3">
+                  <Label className="text-sm font-medium">Behavior Hints</Label>
+                  <div className="space-y-2">
+                    <AnnotationToggle
+                      label="Read-only"
+                      description="Tool does not modify its environment"
+                      checked={annotReadOnly}
+                      onCheckedChange={setAnnotReadOnly}
+                    />
+                    <AnnotationToggle
+                      label="Destructive"
+                      description="Tool may perform destructive updates"
+                      checked={annotDestructive}
+                      onCheckedChange={setAnnotDestructive}
+                    />
+                    <AnnotationToggle
+                      label="Idempotent"
+                      description="Repeated calls with same arguments have no additional effect"
+                      checked={annotIdempotent}
+                      onCheckedChange={setAnnotIdempotent}
+                    />
+                    <AnnotationToggle
+                      label="Open-world"
+                      description="Tool interacts with external entities"
+                      checked={annotOpenWorld}
+                      onCheckedChange={setAnnotOpenWorld}
+                    />
+                  </div>
+                </div>
+              </Stack>
+            )}
+            {editMode === "tags" && (
+              <TagsVariationEditor
+                baseTags={baseTags}
+                value={tagsValue}
+                onChange={setTagsValue}
+              />
+            )}
+            {editMode === "name" && (
+              <Stack gap={2}>
+                <Input
+                  value={editValue}
+                  onChange={setEditValue}
+                  placeholder="Tool name"
+                />
+                {tool.variation?.name &&
+                  tool.variation?.name !== tool.canonical?.name && (
+                    <Stack direction="horizontal" gap={2} align="center">
+                      <Icon
+                        name="layers-2"
+                        size="small"
+                        className="text-muted-foreground/70"
+                      />
+                      <Type small muted>
+                        Original name:
+                      </Type>
+                      <Type small muted>
+                        {tool.canonical?.name}
+                      </Type>
+                    </Stack>
+                  )}
+              </Stack>
+            )}
+            {editMode === "description" && (
+              <Stack gap={2}>
+                <TextArea
+                  value={editValue}
+                  onChange={setEditValue}
+                  placeholder="Tool description"
+                  rows={3}
+                />
+                {tool.variation?.description &&
+                  tool.variation?.description !==
+                    tool.canonical?.description && (
+                    <Stack className="border-border/70 rounded-md border p-2">
+                      <Type small muted className="inline font-medium">
+                        <Icon
+                          name="layers-2"
+                          size="small"
+                          className="text-muted-foreground/70 inline align-text-bottom"
+                        />{" "}
+                        Original Description
+                      </Type>
+                      <Type small muted>
+                        {tool.canonical?.description}
+                      </Type>
+                    </Stack>
+                  )}
+              </Stack>
+            )}
+            {error && <p className="text-destructive text-sm">{error}</p>}
+          </div>
+          <Dialog.Footer>
+            <Button
+              variant="ghost"
+              onClick={() => setEditDialogOpen(false)}
+              disabled={isUpdating}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={isUpdating}>
+              Save
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    </>
+  );
+}
+
+function AnnotationToggle({
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <p className="text-sm">{label}</p>
+        <p className="text-muted-foreground text-xs">{description}</p>
+      </div>
+      <Switch
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        aria-label={`${label} hint`}
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/sources/SourceToolsTab.tsx
+++ b/client/dashboard/src/pages/sources/SourceToolsTab.tsx
@@ -1,11 +1,23 @@
+import { ToolVariationBadge } from "@/components/tool-variation-badge";
 import { SearchBar } from "@/components/ui/search-bar";
 import { Type } from "@/components/ui/type";
+import { ToolUpdateFields } from "@/hooks/useToolUpdate";
 import type { Tool } from "@/lib/toolTypes";
 import { Badge } from "@speakeasy-api/moonshine";
 import { useState } from "react";
+import { SourceToolActions } from "./SourceToolActions";
 
 type HttpTool = Extract<Tool, { type: "http" }>;
 type FunctionTool = Extract<Tool, { type: "function" }>;
+type OnToolUpdate = (
+  tool: Tool,
+  updates: ToolUpdateFields,
+) => void | Promise<void>;
+
+type ToolActionsProps = {
+  onToolUpdate?: OnToolUpdate;
+  isToolUpdating?: boolean;
+};
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
 
@@ -58,7 +70,11 @@ function FilterPill({
   );
 }
 
-function HttpToolRow({ tool }: { tool: HttpTool }) {
+function HttpToolRow({
+  tool,
+  onToolUpdate,
+  isToolUpdating,
+}: { tool: HttpTool } & ToolActionsProps) {
   return (
     <div className="hover:bg-muted/30 grid grid-cols-[80px_40%_1fr] items-center border-b px-4 py-3 transition-colors last:border-b-0">
       <div>
@@ -69,12 +85,28 @@ function HttpToolRow({ tool }: { tool: HttpTool }) {
       <div className="text-muted-foreground truncate pr-3 font-mono text-sm">
         {tool.path}
       </div>
-      <div className="truncate text-sm">{tool.name}</div>
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm">{tool.name}</span>
+          <ToolVariationBadge tool={tool} />
+        </div>
+        {onToolUpdate && (
+          <SourceToolActions
+            tool={tool}
+            onUpdate={(updates) => onToolUpdate(tool, updates)}
+            isUpdating={isToolUpdating}
+          />
+        )}
+      </div>
     </div>
   );
 }
 
-function FunctionToolRow({ tool }: { tool: FunctionTool }) {
+function FunctionToolRow({
+  tool,
+  onToolUpdate,
+  isToolUpdating,
+}: { tool: FunctionTool } & ToolActionsProps) {
   return (
     <div className="hover:bg-muted/30 grid grid-cols-[120px_1fr_1.5fr] items-center gap-4 border-b px-4 py-3 transition-colors last:border-b-0">
       <div>
@@ -82,9 +114,21 @@ function FunctionToolRow({ tool }: { tool: FunctionTool }) {
           <Badge.Text>{tool.runtime}</Badge.Text>
         </Badge>
       </div>
-      <div className="truncate font-mono text-sm">{tool.name}</div>
-      <div className="text-muted-foreground truncate text-sm">
-        {tool.description}
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="truncate font-mono text-sm">{tool.name}</span>
+        <ToolVariationBadge tool={tool} />
+      </div>
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="text-muted-foreground truncate text-sm">
+          {tool.description}
+        </div>
+        {onToolUpdate && (
+          <SourceToolActions
+            tool={tool}
+            onUpdate={(updates) => onToolUpdate(tool, updates)}
+            isUpdating={isToolUpdating}
+          />
+        )}
       </div>
     </div>
   );
@@ -142,13 +186,15 @@ function FilteredToolsList({
   methodFilter,
   runtimeFilter,
   searchQuery,
+  onToolUpdate,
+  isToolUpdating,
 }: {
   tools: Tool[];
   isOpenAPI: boolean;
   methodFilter: string | null;
   runtimeFilter: string | null;
   searchQuery: string;
-}) {
+} & ToolActionsProps) {
   const filtered = tools.filter((tool) => {
     if (isOpenAPI) {
       if (tool.type !== "http") return false;
@@ -186,9 +232,23 @@ function FilteredToolsList({
     <>
       {filtered.map((tool) => {
         if (tool.type === "http")
-          return <HttpToolRow key={tool.toolUrn} tool={tool} />;
+          return (
+            <HttpToolRow
+              key={tool.toolUrn}
+              tool={tool}
+              onToolUpdate={onToolUpdate}
+              isToolUpdating={isToolUpdating}
+            />
+          );
         if (tool.type === "function")
-          return <FunctionToolRow key={tool.toolUrn} tool={tool} />;
+          return (
+            <FunctionToolRow
+              key={tool.toolUrn}
+              tool={tool}
+              onToolUpdate={onToolUpdate}
+              isToolUpdating={isToolUpdating}
+            />
+          );
         return null;
       })}
     </>
@@ -199,11 +259,13 @@ export function SourceToolsTab({
   relatedTools,
   isOpenAPI,
   uniqueRuntimes,
+  onToolUpdate,
+  isToolUpdating,
 }: {
   relatedTools: Tool[];
   isOpenAPI: boolean;
   uniqueRuntimes: string[];
-}) {
+} & ToolActionsProps) {
   const [methodFilter, setMethodFilter] = useState<string | null>(null);
   const [runtimeFilter, setRuntimeFilter] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -303,6 +365,8 @@ export function SourceToolsTab({
               methodFilter={methodFilter}
               runtimeFilter={runtimeFilter}
               searchQuery={searchQuery}
+              onToolUpdate={onToolUpdate}
+              isToolUpdating={isToolUpdating}
             />
           </div>
         </div>


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2350/add-tool-variations-options-to-source-tools-pages

Mirror the MCP detail page's ellipsis menu on the source detail Tools tab so users can edit a tool's name, description, annotations, and tags directly from the source. Variations are global (keyed by source tool URN), so edits affect the underlying tool everywhere it's used.

Extract the variation upsert into a shared `useToolUpdate` hook backed by `useMutation`, gated on `mcp:write`. Add the variation badge to source rows for visual confirmation of overrides. Disable Save/Cancel during the in-flight upsert to prevent the double-submit race that also existed on the MCP page.

Telemetry uses a new `source_event` capture with the existing `tool_variation_updated` action.

<img width="1294" height="684" alt="CleanShot 2026-05-28 at 09 33 17" src="https://github.com/user-attachments/assets/67d28b88-c757-4e34-84c9-df591f3ee497" />
<img width="1295" height="640" alt="CleanShot 2026-05-28 at 09 33 06" src="https://github.com/user-attachments/assets/b0359f61-63ac-4099-9b0a-effaa681a525" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a tool variations menu to the Source Details → Tools tab so users can edit a tool’s name, description, annotations, and tags directly from the source. Variations are global (keyed by the source tool URN) and ship with RBAC gating, a variation badge, safer saves, and new telemetry; satisfies Linear AGE-2350.

- New Features
  - Ellipsis menu on source tool rows to edit name, description, annotations, and tags; includes Copy name; mirrors MCP.
  - Variation badge on rows; telemetry via `source_event` with `tool_variation_updated`.

- Refactors
  - Introduce shared `useToolUpdate` hook (`useMutation`, gated by `mcp:write`) used by Source and MCP; disables Save/Cancel while updating and invalidates queries on success.
  - Fix `useMemo` dependency to avoid stale UI.

<sup>Written for commit cd239c05b6d7e23a36aa71d17a379978f3226dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3083?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



