### PR TITLE
chore(dashboard): show /mcp/ instead of /x/mcp/ for MCP endpoint URLs

### DIFF
--- a/client/dashboard/src/hooks/useToolsetUrl.ts
+++ b/client/dashboard/src/hooks/useToolsetUrl.ts
@@ -49,7 +49,7 @@ export function useCustomDomains(enabled = true): {
 
 // useMcpEndpointUrl resolves the runtime install URL for a single mcp_endpoint
 // row. Platform-domain endpoints (`custom_domain_id` empty) resolve under the
-// Gram-hosted `/x/mcp/<slug>` runtime path; custom-domain endpoints resolve
+// Gram-hosted `/mcp/<slug>` runtime path; custom-domain endpoints resolve
 // under the matching `custom_domains.domain` value with the same suffix.
 // Returns `undefined` when the endpoint has no slug or when its custom domain
 // hasn't resolved yet (loading or denied), so callers can gracefully render an
@@ -78,7 +78,7 @@ export function useMcpEndpointUrl(endpoint: McpEndpoint | undefined): {
     serverURL = `https://${match.domain}`;
   }
 
-  const mcpUrl = `${serverURL}/x/mcp/${endpoint.slug}`;
+  const mcpUrl = `${serverURL}/mcp/${endpoint.slug}`;
   return { mcpUrl, installPageUrl: `${mcpUrl}/install` };
 }
 

--- a/client/dashboard/src/pages/mcp/x/tabs/EndpointsTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/EndpointsTab.tsx
@@ -272,8 +272,8 @@ function EndpointRow({
   };
 
   const urlPrefix = customDomainLabel
-    ? `https://${customDomainLabel}/x/mcp/`
-    : `${getServerURL()}/x/mcp/`;
+    ? `https://${customDomainLabel}/mcp/`
+    : `${getServerURL()}/mcp/`;
 
   return (
     <div className="rounded-md border p-3">
@@ -412,7 +412,7 @@ function NewEndpointRow({
         <Stack direction="horizontal" align="center" className="min-w-0 flex-1">
           {!customDomainId && (
             <Type muted mono variant="small">
-              {`${getServerURL()}/x/mcp/`}
+              {`${getServerURL()}/mcp/`}
             </Type>
           )}
           <Input
@@ -524,7 +524,7 @@ function NewCustomDomainEndpointRow({
             </SelectContent>
           </Select>
           <Type muted mono variant="small">
-            /x/mcp/
+            /mcp/
           </Type>
           <Input
             value={slug}

--- a/client/dashboard/src/pages/mcp/x/useMcpEndpointSlugValidation.ts
+++ b/client/dashboard/src/pages/mcp/x/useMcpEndpointSlugValidation.ts
@@ -10,8 +10,9 @@ import { useEffect, useState } from "react";
 // (the canonical check for the mcp_endpoints table) AND
 // `toolsets.checkMCPSlugAvailability` (which spans the legacy toolsets table).
 // The dual check is intentional and temporary while toolsets-backed MCP
-// servers continue to live under `/mcp/<mcpSlug>` and Remote-MCP-backed
-// servers live under `/x/mcp/<slug>` — until the AGE-1902 / AGE-1880 cutover
+// servers and mcp_endpoints-backed servers share the same `/mcp/<slug>`
+// runtime path (the runtime resolves mcp_endpoints first, then falls back to
+// toolsets.mcp_slug — see AGE-2555). Until the AGE-1902 / AGE-1880 cutover
 // consolidates both onto mcp_servers/mcp_endpoints, a slug taken by either
 // namespace would collide at runtime if reused.
 //

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -349,8 +349,8 @@ const ROUTE_STRUCTURE = {
       // MCP data moves to mcp_servers/mcp_endpoints. Until then this route is
       // distinct so the new mcp_servers-backed details page renders against
       // mcp_servers without disturbing the existing toolset-backed path. The
-      // `x/` prefix is the generic experimental namespace shared with the
-      // `/x/mcp/{slug}` runtime path that already serves these servers.
+      // `x/` prefix is the dashboard's generic experimental namespace; the
+      // runtime path for these servers is `/mcp/{slug}` (see AGE-2555).
       x: {
         title: "MCP Server Details",
         url: "x/:mcpServerSlug",


### PR DESCRIPTION
[AGE-2577](https://linear.app/speakeasy/issue/AGE-2577/update-dashboard-for-xmcp-to-mcp-migration)

AGE-2555 made `/mcp/{slug}` resolve through both `mcp_endpoints` → `mcp_servers` and the legacy `toolsets` fallback, so the dashboard no longer needs to display the dev-time `/x/mcp/` prefix for mcp_endpoint rows. Updates the Overview tab Client Install URLs (via `useMcpEndpointUrl`) and the Endpoints tab existing/new platform/new custom-domain row prefixes. Also refreshes nearby comments that described the old dual-runtime split.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the dashboard to show `/mcp/{slug}` for MCP endpoint URLs instead of `/x/mcp/`. Aligns with AGE-2577 and AGE-2555, where `/mcp/{slug}` resolves to `mcp_endpoints` first and falls back to legacy `toolsets`.

- **Refactors**
  - `useMcpEndpointUrl`: returns `/mcp/<slug>` and `/mcp/<slug>/install`.
  - Endpoints tab: switched URL prefixes and input hints to `/mcp/` for platform and custom domains.
  - Updated nearby comments and route docs to reflect the unified `/mcp/{slug}` runtime path and fallback behavior.

<sup>Written for commit 1f2dadf413483e7c2b84734127134dea5c702731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3084?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

