### PR TITLE
fix: properly compare role ids during invite flow

### DIFF
--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -29,6 +29,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/organizations/server"
 	gen "github.com/speakeasy-api/gram/server/gen/organizations"
 	"github.com/speakeasy-api/gram/server/gen/types"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
@@ -60,7 +61,6 @@ type OrganizationProvider interface {
 	DeleteOrganizationMembership(ctx context.Context, workosMembershipID string) error
 	CreateOrganizationMembership(ctx context.Context, workosUserID, workosOrgID, roleSlug string) (string, error)
 	GetOrganizationDomainPolicy(ctx context.Context, workosOrgID string) (*workos.OrganizationDomainPolicy, error)
-	ListRoles(ctx context.Context, workosOrgID string) ([]workos.Role, error)
 	GenerateAdminPortalLink(ctx context.Context, workosOrgID string, intent workos.PortalIntent, returnURL string) (string, error)
 }
 
@@ -362,26 +362,26 @@ func (s *Service) resolveInviteRoleSlug(ctx context.Context, organizationID stri
 		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role id is required").Log(ctx, logger)
 	}
 
-	// Resolve the WorkOS role ID sent by the dashboard into a WorkOS role slug
-	// so the invite stores the slug needed at acceptance time.
-	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, organizationID)
+	// The dashboard sends a Gram local role UUID (as returned by
+	// /rpc/access.listRoles). Resolve it against the local roles table to
+	// recover the WorkOS slug stored on the invite for acceptance time.
+	roleUUID, err := uuid.Parse(roleID)
 	if err != nil {
-		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeUnexpected, err, "get organization metadata").Log(ctx, logger)
-	}
-	if !org.WorkosID.Valid || org.WorkosID.String == "" {
-		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "organization is not linked to WorkOS").Log(ctx, logger)
-	}
-	roles, err := s.orgs.ListRoles(ctx, org.WorkosID.String)
-	if err != nil {
-		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeUnexpected, err, "list roles for invite").Log(ctx, logger)
-	}
-	for _, r := range roles {
-		if r.ID == roleID {
-			return conv.ToPGText(r.Slug), nil
-		}
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role not found").Log(ctx, logger)
 	}
 
-	return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role not found").Log(ctx, logger)
+	role, err := accessrepo.New(s.db).GetOrganizationRoleByID(ctx, accessrepo.GetOrganizationRoleByIDParams{
+		OrganizationID: organizationID,
+		ID:             roleUUID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeBadRequest, nil, "role not found").Log(ctx, logger)
+	case err != nil:
+		return pgtype.Text{String: "", Valid: false}, oops.E(oops.CodeUnexpected, err, "get role for invite").Log(ctx, logger)
+	}
+
+	return conv.ToPGText(role.WorkosSlug), nil
 }
 
 func (s *Service) RevokeInvite(ctx context.Context, payload *gen.RevokeInvitePayload) error {

--- a/server/internal/organizations/mock_organizations_test.go
+++ b/server/internal/organizations/mock_organizations_test.go
@@ -39,17 +39,6 @@ func (m *MockOrganizationProvider) CreateOrganizationMembership(ctx context.Cont
 	return args.String(0), nil
 }
 
-func (m *MockOrganizationProvider) ListRoles(ctx context.Context, workosOrgID string) ([]thirdpartyworkos.Role, error) {
-	args := m.Called(ctx, workosOrgID)
-	if err := args.Error(1); err != nil {
-		return nil, fmt.Errorf("mock ListRoles: %w", err)
-	}
-	if roles, ok := args.Get(0).([]thirdpartyworkos.Role); ok {
-		return roles, nil
-	}
-	return nil, nil
-}
-
 func (m *MockOrganizationProvider) GetOrganizationDomainPolicy(ctx context.Context, workosOrgID string) (*thirdpartyworkos.OrganizationDomainPolicy, error) {
 	for _, call := range m.ExpectedCalls {
 		if call.Method == "GetOrganizationDomainPolicy" {

--- a/server/internal/organizations/sendinvite_test.go
+++ b/server/internal/organizations/sendinvite_test.go
@@ -89,12 +89,10 @@ func TestService_SendInvite_WithRoleID(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
 
-	roleID := "test-role"
-
-	ti.orgs.On("ListRoles", mock.Anything, mock.Anything).Return([]thirdpartyworkos.Role{
-		{ID: "test-role", Slug: "member", Name: "Member"},
-	}, nil).Once()
+	roleID := seedLocalRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "member", "Member")
 
 	invite, err := ti.service.SendInvite(ctx, &gen.SendInvitePayload{
 		Email:  "test@example.com",
@@ -111,11 +109,10 @@ func TestService_SendInvite_AuditLog(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
 
-	roleID := "role-member"
-	ti.orgs.On("ListRoles", mock.Anything, mock.Anything).Return([]thirdpartyworkos.Role{
-		{ID: "role-member", Slug: "member", Name: "Member"},
-	}, nil).Once()
+	roleID := seedLocalRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "member", "Member")
 
 	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationInviteCreate)
 	require.NoError(t, err)
@@ -217,11 +214,8 @@ func TestService_SendInvite_UnknownRoleID(t *testing.T) {
 
 	ctx, ti := newTestOrganizationsService(t)
 
-	roleID := "nonexistent-role"
-
-	ti.orgs.On("ListRoles", mock.Anything, mock.Anything).Return([]thirdpartyworkos.Role{
-		{ID: "some-other-role", Slug: "member", Name: "Member"},
-	}, nil).Once()
+	// A well-formed UUID that does not correspond to any role in this org.
+	roleID := "00000000-0000-0000-0000-000000000000"
 
 	_, err := ti.service.SendInvite(ctx, &gen.SendInvitePayload{
 		Email:  "test@example.com",

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -5,10 +5,12 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	svix "github.com/svix/svix-webhooks/go"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -25,6 +27,33 @@ import (
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/require"
 )
+
+// seedLocalRole inserts an organization_roles row and returns its Gram local
+// UUID — the same identifier the dashboard receives from access.listRoles and
+// sends back in invite payloads.
+func seedLocalRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, slug, name string) string {
+	t.Helper()
+
+	now := time.Now().UTC()
+	_, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    organizationID,
+		WorkosSlug:        slug,
+		WorkosName:        name,
+		WorkosDescription: conv.ToPGTextEmpty(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+
+	row, err := accessrepo.New(conn).GetOrganizationRoleBySlug(ctx, accessrepo.GetOrganizationRoleBySlugParams{
+		OrganizationID: organizationID,
+		WorkosSlug:     slug,
+	})
+	require.NoError(t, err)
+
+	return row.ID.String()
+}
 
 // stubOrgFeatures returns false for all features — tests use the WorkOS fallback path.
 type stubOrgFeatures struct{}

--- a/server/internal/organizations/updateinviterole_test.go
+++ b/server/internal/organizations/updateinviterole_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
-	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,13 +32,11 @@ func TestService_UpdateInviteRole(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ti.orgs.On("ListRoles", mock.Anything, mock.Anything).Return([]thirdpartyworkos.Role{
-		{ID: "role-admin", Slug: "admin", Name: "Admin"},
-	}, nil).Once()
+	adminRoleID := seedLocalRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "admin", "Admin")
 
 	res, err := ti.service.UpdateInviteRole(ctx, &gen.UpdateInviteRolePayload{
 		InvitationID: row.ID.String(),
-		RoleID:       "role-admin",
+		RoleID:       adminRoleID,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -71,16 +67,14 @@ func TestService_UpdateInviteRole_AuditLog(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ti.orgs.On("ListRoles", mock.Anything, mock.Anything).Return([]thirdpartyworkos.Role{
-		{ID: "role-admin", Slug: "admin", Name: "Admin"},
-	}, nil).Once()
+	adminRoleID := seedLocalRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "admin", "Admin")
 
 	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationInviteRoleUpdate)
 	require.NoError(t, err)
 
 	res, err := ti.service.UpdateInviteRole(ctx, &gen.UpdateInviteRolePayload{
 		InvitationID: row.ID.String(),
-		RoleID:       "role-admin",
+		RoleID:       adminRoleID,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -107,10 +101,14 @@ func TestService_UpdateInviteRole_NotFound(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	adminRoleID := seedLocalRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "admin", "Admin")
 
 	res, err := ti.service.UpdateInviteRole(ctx, &gen.UpdateInviteRolePayload{
 		InvitationID: "00000000-0000-0000-0000-000000000000",
-		RoleID:       "role-admin",
+		RoleID:       adminRoleID,
 	})
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
@@ -140,9 +138,11 @@ func TestService_UpdateInviteRole_WrongOrganization(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	adminRoleID := seedLocalRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "admin", "Admin")
+
 	res, err := ti.service.UpdateInviteRole(ctx, &gen.UpdateInviteRolePayload{
 		InvitationID: row.ID.String(),
-		RoleID:       "role-admin",
+		RoleID:       adminRoleID,
 	})
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
@@ -166,13 +166,10 @@ func TestService_UpdateInviteRole_UnknownRoleID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ti.orgs.On("ListRoles", mock.Anything, mock.Anything).Return([]thirdpartyworkos.Role{
-		{ID: "role-member", Slug: "member", Name: "Member"},
-	}, nil).Once()
-
+	// A well-formed UUID that does not correspond to any role in this org.
 	res, err := ti.service.UpdateInviteRole(ctx, &gen.UpdateInviteRolePayload{
 		InvitationID: row.ID.String(),
-		RoleID:       "missing-role",
+		RoleID:       "00000000-0000-0000-0000-000000000000",
 	})
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
@@ -197,13 +194,11 @@ func TestService_UpdateInviteRole_AllowsOrgAdminGrant(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ti.orgs.On("ListRoles", mock.Anything, mock.Anything).Return([]thirdpartyworkos.Role{
-		{ID: "role-admin", Slug: "admin", Name: "Admin"},
-	}, nil).Once()
+	adminRoleID := seedLocalRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "admin", "Admin")
 
 	res, err := ti.service.UpdateInviteRole(ctx, &gen.UpdateInviteRolePayload{
 		InvitationID: row.ID.String(),
-		RoleID:       "role-admin",
+		RoleID:       adminRoleID,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, res)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the invite flow to resolve role IDs using local org role UUIDs and store the correct WorkOS role slug on invites. Removes reliance on WorkOS role listing and makes role validation consistent.

- **Bug Fixes**
  - Accepts the local role UUID from the dashboard (from `rpc/access.listRoles`) and looks up the role via `accessrepo` to get the WorkOS slug.
  - Returns a 400 with “role not found” for invalid or unknown UUIDs; keeps audit logging behavior unchanged.
  - Removes `ListRoles` from the organization provider and related test mocks; tests now seed local roles via a helper.

<sup>Written for commit 8bbaddffc9ff51a15df92eb438fe0b57b1a24393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3089?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

