### PR TITLE
fix(dashboard): fix sidebar nav hover highlight snap-back

### DIFF
--- a/.changeset/brown-states-mix.md
+++ b/.changeset/brown-states-mix.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fixed sidebar nav hover highlight snapping back to active route when moving between items.

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -265,12 +265,23 @@ export function NavGroupProvider({
 // Hook for registering item ref + hover handlers
 // ---------------------------------------------------------------------------
 
-// Settle-based hover intent: only triggers when the mouse slows down
-// inside the centre vertical zone of the element, ignoring edge hovers
-// and fast drive-by movements.
-const SETTLE_INTERVAL_MS = 100;
-const SETTLE_THRESHOLD_PX = 4;
-const CENTER_ZONE = 0.3; // fraction of height from each edge to exclude
+// Settle-based hover intent — fires setHoveredItem only when the mouse has
+// genuinely paused on an element, filtering out fast drive-by movements.
+//
+// Every SETTLE_INTERVAL_MS the interval compares current vs previous mouse Y.
+// If the delta is below SETTLE_THRESHOLD_PX the mouse is considered settled.
+// While the mouse is still moving (dy !== 0) an additional CENTER_ZONE guard
+// rejects triggers near the top/bottom edge, preventing false fires when
+// passing through item boundaries at low speed. Once the mouse is fully stopped
+// (dy === 0) the edge guard is skipped so a mouse parked at any position
+// within the element still triggers correctly.
+//
+// hoveredItem is cleared at the container level (onMouseLeave on the wrapper
+// div), not here, so the highlight stays on the last item while moving between
+// items rather than snapping back to the active route on every item exit.
+const SETTLE_INTERVAL_MS = 50; // ms between settle checks; lower = more responsive
+const SETTLE_THRESHOLD_PX = 4; // max Y movement per interval to count as settled
+const CENTER_ZONE = 0.3; // fraction of height from each edge excluded while moving
 
 function useNavItem(id: string) {
   const { registerRef, setHoveredItem } = React.useContext(NavGroupContext);
@@ -308,14 +319,17 @@ function useNavItem(id: string) {
       s.intervalId = setInterval(() => {
         const dy = s.curY - s.prevY;
         if (Math.abs(dy) < SETTLE_THRESHOLD_PX) {
-          // Check mouse is in centre vertical zone of the element
-          const el = elRef.current;
-          if (el) {
-            const rect = el.getBoundingClientRect();
-            const margin = rect.height * CENTER_ZONE;
-            if (s.curY < rect.top + margin || s.curY > rect.bottom - margin) {
-              s.prevY = s.curY;
-              return; // too close to edge — keep waiting
+          // Only apply edge exclusion while mouse is still moving — a stopped
+          // mouse at the edge should still trigger.
+          if (dy !== 0) {
+            const el = elRef.current;
+            if (el) {
+              const rect = el.getBoundingClientRect();
+              const margin = rect.height * CENTER_ZONE;
+              if (s.curY < rect.top + margin || s.curY > rect.bottom - margin) {
+                s.prevY = s.curY;
+                return; // too close to edge — keep waiting
+              }
             }
           }
           if (s.intervalId) clearInterval(s.intervalId);

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -235,7 +235,11 @@ export function NavGroupProvider({
 
   return (
     <NavGroupContext.Provider value={value}>
-      <div ref={containerRef} className="relative">
+      <div
+        ref={containerRef}
+        className="relative"
+        onMouseLeave={() => setHoveredItem(null)}
+      >
         {highlightRect && (
           <motion.div
             className="bg-card ring-border/50 pointer-events-none absolute rounded-lg ring-1"
@@ -331,8 +335,7 @@ function useNavItem(id: string) {
       clearInterval(s.intervalId);
       s.intervalId = null;
     }
-    setHoveredItem(null);
-  }, [setHoveredItem]);
+  }, []);
 
   React.useEffect(() => {
     const s = stateRef.current;


### PR DESCRIPTION
## Summary

This fixes some slight bugs with how the hover slider was behaving. Main one was it would snap back to the the last place if you hovered too long and then went to the next item. The other minor one was if you moved too fast it wouldn't register and the slider would never move

---

- Moved `setHoveredItem(null)` from individual item `onMouseLeave` to the container div's `onMouseLeave` — highlight now stays on the last-hovered item while moving between items, and only returns to the active route when the mouse leaves the sidebar entirely
- Reduced settle poll interval from 100ms → 50ms for snappier response
- Fixed edge zone deadlock: `CENTER_ZONE` was blocking the settle trigger even when the mouse was fully stopped at the edge of an item — now bypassed when `dy === 0`

## Root cause

Each nav item's `onMouseLeave` called `setHoveredItem(null)` immediately, snapping the sliding highlight back to the active route before the next item could settle. Because the settle interval takes up to 100ms to fire, this created a visible snap-to-active → slide-to-new-item sequence on every transition. Separately, the `CENTER_ZONE` edge exclusion had no escape hatch for a stopped mouse, causing the highlight to never trigger when the mouse landed precisely at the top or bottom of an item.

## Test plan

- [x] Hover between nav items — highlight slides smoothly without snapping back to active route
- [x] Move mouse quickly to a nav item and stop — highlight triggers within ~50ms regardless of where in the item the mouse lands (top, center, bottom)
- [x] Move mouse off the sidebar entirely — highlight returns to active route
- [x] Fast drive-by movements across items don't trigger the highlight

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar nav hover highlight snap-back and makes hover intent more responsive. The highlight now stays on the last hovered item and only resets when the cursor leaves the sidebar; settling is faster and reliable at item edges.

- **Bug Fixes**
  - Moved clearing of `hoveredItem` to the container `onMouseLeave`.
  - Reduced settle interval from 100ms to 50ms for quicker hover detection.
  - Skipped edge exclusion when the mouse is stopped (`dy === 0`) to prevent edge deadlocks.

<sup>Written for commit 73745bee6fe3db1c762c693b92a2bd48fe226286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3092?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

