### PR TITLE
fix(dashboard): source logs filter options from full value universe

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -179,11 +179,9 @@ export function InsightsToolsContent() {
     logFilters,
     selectedHookTypes,
     activeFilters,
-    addKnownServers,
     serverOptions,
     handleServerSelectionChange,
     userEmailOptions,
-    addKnownUserEmails,
     handleUserEmailSelectionChange,
     addFilter,
     handleHookTypesChange,
@@ -274,19 +272,6 @@ export function InsightsToolsContent() {
     enabled: !roleFilterPending,
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (!summaryData) return;
-    addKnownServers(summaryData.breakdown.map((r) => r.serverName));
-  }, [summaryData, addKnownServers]);
-
-  useEffect(() => {
-    addKnownUserEmails(
-      groupedTraces
-        .map((t) => t.userEmail)
-        .filter((e): e is string => Boolean(e)),
-    );
-  }, [groupedTraces, addKnownUserEmails]);
 
   const refetch = useCallback(() => {
     refetchLogs();

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -40,7 +40,7 @@ import {
   Chart as ChartJS,
 } from "chart.js";
 import { Settings } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { useObserveFilters } from "@/components/observe/useObserveFilters";
 import { perPage } from "@/components/observe/observeFilterUtils";
@@ -78,11 +78,9 @@ export function LogsTools() {
     logFilters,
     selectedHookTypes,
     activeFilters,
-    addKnownServers,
     serverOptions,
     handleServerSelectionChange,
     userEmailOptions,
-    addKnownUserEmails,
     handleUserEmailSelectionChange,
     addFilter,
     handleHookTypesChange,
@@ -150,22 +148,6 @@ export function LogsTools() {
   const groupedTraces = useMemo(() => {
     return tracesData?.pages.flatMap((page) => page.traces) ?? [];
   }, [tracesData]);
-
-  useEffect(() => {
-    addKnownServers(
-      groupedTraces
-        .map((t) => t.toolSource)
-        .filter((s): s is string => Boolean(s)),
-    );
-  }, [groupedTraces, addKnownServers]);
-
-  useEffect(() => {
-    addKnownUserEmails(
-      groupedTraces
-        .map((t) => t.userEmail)
-        .filter((e): e is string => Boolean(e)),
-    );
-  }, [groupedTraces, addKnownUserEmails]);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const container = e.currentTarget;

--- a/client/dashboard/src/components/observe/useObserveFilters.ts
+++ b/client/dashboard/src/components/observe/useObserveFilters.ts
@@ -1,6 +1,7 @@
 import { getPresetRange, type DateRangePreset } from "@gram-ai/elements";
+import { telemetryGetHooksSummary } from "@gram/client/funcs/telemetryGetHooksSummary";
 import type { TypesToInclude } from "@gram/client/models/components";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router";
 import type { FilterChip } from "@/components/observe/ObserveFilterBar";
 import {
@@ -14,9 +15,19 @@ import {
 import { DEFAULT_HOOK_TYPES, VALID_HOOK_TYPES } from "./observeFilterConstants";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useRoles } from "@gram/client/react-query/roles.js";
+import { useGramContext } from "@gram/client/react-query";
+import { unwrapAsync } from "@gram/client/types/fp";
+import { useQuery } from "@tanstack/react-query";
 
 const SERVER_FILTER_PATH = "gram.tool_call.source";
 const USER_EMAIL_FILTER_PATH = "user.email";
+
+// Sentinel labels the hooks summary substitutes for empty values. They are
+// display-only ("local" for a missing server, "Unknown" for a missing email)
+// and do not round-trip as real filter values, so they are excluded from the
+// dropdown options.
+const SERVER_SENTINEL = "local";
+const USER_EMAIL_SENTINEL = "Unknown";
 
 function parseHookTypesParam(raw: string | null): TypesToInclude[] {
   if (!raw) return [...DEFAULT_HOOK_TYPES];
@@ -65,9 +76,7 @@ export function useObserveFilters() {
     () => parseHookTypesParam(searchParams.get("hookTypes")),
     [searchParams],
   );
-  const [knownServers, setKnownServers] = useState<string[]>([]);
-  const [knownUserEmails, setKnownUserEmails] = useState<string[]>([]);
-
+  const client = useGramContext();
   const { data: membersData, isLoading: membersLoading } = useMembers();
   const { data: rolesData } = useRoles();
 
@@ -157,11 +166,6 @@ export function useObserveFilters() {
     [customRange, dateRange],
   );
 
-  useEffect(() => {
-    setKnownServers([]);
-    setKnownUserEmails([]);
-  }, [from, to]);
-
   const logFilters = useMemo(
     () => buildLogFilters(activeFilters, roleEmails),
     [activeFilters, roleEmails],
@@ -169,37 +173,44 @@ export function useObserveFilters() {
 
   const roleFilterPending = selectedRoleIds.length > 0 && membersLoading;
 
-  const addKnownServers = useCallback((names: string[]) => {
-    if (names.length === 0) return;
-    setKnownServers((prev) => {
-      const merged = [...new Set([...prev, ...names])];
-      return merged.length === prev.length ? prev : merged;
-    });
-  }, []);
-
-  const addKnownUserEmails = useCallback((emails: string[]) => {
-    if (emails.length === 0) return;
-    setKnownUserEmails((prev) => {
-      const merged = [...new Set([...prev, ...emails])];
-      return merged.length === prev.length ? prev : merged;
-    });
-  }, []);
+  // Fetch the full universe of servers and users for the selected time range.
+  // Deliberately omits the active server/email/role/type filters so the
+  // dropdowns always offer every value in the window — otherwise a filter that
+  // returns no results would leave the dropdown empty and the user stuck,
+  // unable to pivot to a different value. Keyed only on the range so the query
+  // is shared across every page that uses this hook.
+  const { data: filterOptionsSummary } = useQuery({
+    queryKey: ["hooks-filter-options", from.toISOString(), to.toISOString()],
+    queryFn: () =>
+      unwrapAsync(
+        telemetryGetHooksSummary(client, {
+          getHooksSummaryPayload: { from, to },
+        }),
+      ),
+    throwOnError: false,
+  });
 
   const serverOptions = useMemo(() => {
     const selected = activeFilters
       .filter((f) => f.path === SERVER_FILTER_PATH)
       .flatMap((f) => f.filters)
       .filter(Boolean);
-    return [...new Set([...knownServers, ...selected])];
-  }, [knownServers, activeFilters]);
+    const known = (filterOptionsSummary?.servers ?? [])
+      .map((s) => s.serverName)
+      .filter((name) => name && name !== SERVER_SENTINEL);
+    return [...new Set([...known, ...selected])];
+  }, [filterOptionsSummary, activeFilters]);
 
   const userEmailOptions = useMemo(() => {
     const selected = activeFilters
       .filter((f) => f.path === USER_EMAIL_FILTER_PATH)
       .flatMap((f) => f.filters)
       .filter(Boolean);
-    return [...new Set([...knownUserEmails, ...selected])];
-  }, [knownUserEmails, activeFilters]);
+    const known = (filterOptionsSummary?.users ?? [])
+      .map((u) => u.userEmail)
+      .filter((email) => email && email !== USER_EMAIL_SENTINEL);
+    return [...new Set([...known, ...selected])];
+  }, [filterOptionsSummary, activeFilters]);
 
   const handleUserEmailSelectionChange = useCallback(
     (values: string[]) => {
@@ -318,10 +329,8 @@ export function useObserveFilters() {
     to,
     logFilters,
     serverOptions,
-    addKnownServers,
     handleServerSelectionChange,
     userEmailOptions,
-    addKnownUserEmails,
     handleUserEmailSelectionChange,
     addFilter,
     handleHookTypesChange,


### PR DESCRIPTION
## What

Fixes [AGE-2594](https://linear.app/speakeasy/issue/AGE-2594). The server/user filter dropdowns on the **Tool Logs** and **Insights → Tools** pages got stuck whenever a filter returned no results, and only ever offered values that happened to be in the already-loaded rows.

## Why

Both pages share `useObserveFilters`, which built `serverOptions` / `userEmailOptions` from `knownServers` / `knownUserEmails` — sets accumulated _only_ from loaded result rows and reset on every date-range change. When a filter matched nothing, no new values were added, so the dropdown collapsed to just the currently-selected value. You could clear a filter but couldn't pivot to a different one.

## How

- Added a single `getHooksSummary` query keyed only on the time range (no server/email/type filters), so it returns the **full universe** of servers and users for the window regardless of the filtered result set.
- Derive `serverOptions` from `servers[].serverName` and `userEmailOptions` from `users[].userEmail`, unioned with any currently-selected URL values.
- Excluded the `'local'` / `'Unknown'` display sentinels — they never round-trip as real filter values (also removes a silently-broken `'local'` option Insights used to show).
- Removed the now-dead `knownServers` / `knownUserEmails` state, the `addKnown*` callbacks, the reset effect, and four accumulation `useEffect`s. Net **−24 lines**.

The query is keyed on `[from, to]` only, so it's shared across both pages and across filter changes (one cache entry per time window), and the universe is now derived during render instead of synced via effects.

## Scope

Frontend-only — no backend, migration, or SDK changes.

## Testing

- `tsc -p tsconfig.app.json --noEmit` — clean on all changed files.
- `eslint` — clean on all changed files.
- Not yet click-tested against a live dashboard with real telemetry.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AGE-2594: server and user filters on Tool Logs and Insights → Tools no longer get stuck when a filter returns no results. Dropdowns now show the full set of servers and users for the selected time range so you can pivot filters even with empty results.

- **Bug Fixes**
  - Added a `[from, to]`-keyed `useQuery` using `@gram/client/funcs/telemetryGetHooksSummary` (via `@tanstack/react-query`) to fetch the full universe of servers/users for the window, independent of active filters.
  - Build `serverOptions` from `servers[].serverName` and `userEmailOptions` from `users[].userEmail`, unioned with currently selected values; exclude the display-only sentinels "local" and "Unknown".
  - Removed `knownServers`/`knownUserEmails` state and related effects/callbacks, simplifying the hook and preventing option collapse on no-result filters.

<sup>Written for commit cbfaab78aeaffb530cf99facd3eeddf9b78c79a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/3093?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

