### PR TITLE
fix(dashboard): move beta badge from Secure group header to sub-items

### DIFF
--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -519,10 +519,11 @@ export function CollapsibleNavGroup({
             <span className="flex-1 truncate transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0">
               {label}
             </span>
-            {stage && (
+            {stage && isOpen && (
               <ReleaseStageBadge
                 stage={stage}
-                className="transition-opacity duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:opacity-0"
+                noTooltip
+                className="-my-1 origin-left scale-75 transition-opacity duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:opacity-0"
               />
             )}
           </Link>


### PR DESCRIPTION
## Summary

- Beta badge on the "Secure" group header was rendering at full Moonshine Badge size — visually jarring compared to the scaled-down badges used elsewhere in the nav
- Gated the badge render on `isOpen` so it only appears when the section is expanded (not in the collapsed/header-only state)
- Added `scale-75` and `noTooltip` to match the size of other nav badges

## Visual

<img width="426" height="681" alt="Screenshot 2026-05-28 at 4 00 50 PM" src="https://github.com/user-attachments/assets/9898e8e6-21e9-4ee5-9ff9-69051c953c90" /><img width="426" height="681" alt="Screenshot 2026-05-28 at 4 01 12 PM" src="https://github.com/user-attachments/assets/9d6ced9b-69dd-45ff-a16e-01c3a381c242" />



## Root cause

`CollapsibleNavGroup` rendered the badge unconditionally at full size with no `scale-75`. Showing a large "Beta" label on a collapsed section header made it feel like the entire nav area was in beta rather than just labeling an open section.

## Test plan

- [x] Secure section collapsed — no Beta badge visible on the header
- [x] Secure section expanded — small Beta badge appears next to "Secure" label
- [x] Collapsed sidebar (icon-only mode) — no badge visible