### PR TITLE
fix(dashboard): clear logs search via Escape or empty box, not just ×

### DIFF
--- a/client/dashboard/src/pages/logs/LogFilterBar.tsx
+++ b/client/dashboard/src/pages/logs/LogFilterBar.tsx
@@ -192,8 +192,13 @@ export function LogFilterBar({
         }
       }
       onSearchInputChange(value);
+      // Emptying the box clears the applied search without needing the ×
+      // button, so results refresh as soon as the query is gone.
+      if (step === "key" && value === "") {
+        onSearchSubmit("");
+      }
     },
-    [step, onSearchInputChange, handleOpSelect],
+    [step, onSearchInputChange, handleOpSelect, onSearchSubmit],
   );
 
   const handleValueSubmit = () => {
@@ -264,10 +269,17 @@ export function LogFilterBar({
         }
         break;
       case "Escape":
-        if (popoverOpen) {
-          e.preventDefault();
+        e.preventDefault();
+        if (step === "operator") {
+          // Cancel an in-progress filter build without touching the applied
+          // search.
+          resetFlow();
+        } else {
+          // Key step: mirror the × button — clear the box and the applied
+          // search so results refresh without forcing a click.
           onSearchInputChange("");
           resetFlow();
+          onSearchSubmit("");
         }
         break;
       case "Backspace":


### PR DESCRIPTION
## What

Follow-up to #3093 (AGE-2594). On the MCP Server Logs page, the filter search bar could only be cleared by clicking the `×` button — pressing **Escape** or deleting the text out of the box left the results still filtered.

## Why

`LogFilterBar` tracks the live `searchInput` separately from the parent's applied `searchQuery` (which drives the data fetch). They only sync on submit. The `×` button called `onSearchSubmit("")` to clear the applied query, but:

- **Escape** only cleared the local input and reset the filter-builder flow — it never called `onSearchSubmit`, so the applied query lingered (and it was gated behind the popover being open).
- **Emptying the box** updated `searchInput` to `""` but never re-submitted, so `searchQuery` stayed set and results remained filtered until an explicit submit.

So `×` was the only way to actually clear the search — the same "stuck filter" class of bug as the parent ticket.

## How

- **Escape** in the key step now mirrors the `×`: clears the input, resets the flow, and calls `onSearchSubmit("")`. In the operator step it still just cancels the in-progress filter build without touching an applied search.
- **Emptying the box** in the key step now calls `onSearchSubmit("")` so results refresh as soon as the query is gone.

Clearing when nothing is applied is a no-op (`searchQuery` is already null → no refetch).

## Scope

Frontend-only, single file. No backend, migration, or SDK changes.

## Testing

- `tsc -p tsconfig.app.json --noEmit` — clean.
- `eslint` — clean.
- Not yet click-tested against a live dashboard.
