### PR TITLE
fix(dashboard): make logs search bars clearable via Escape / empty box

### DIFF
--- a/.changeset/age-2594-logs-search-clear.md
+++ b/.changeset/age-2594-logs-search-clear.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Logs filter search bars can now be cleared with the Escape key or by emptying the box, not just the × button. This applies to the MCP Server Logs filter bar and the shared SearchBar (Agent Sessions, etc.). Escape only clears when there is text to clear, so an empty box lets the key bubble to close a surrounding popover.

--- a/client/dashboard/src/components/ui/search-bar.tsx
+++ b/client/dashboard/src/components/ui/search-bar.tsx
@@ -33,10 +33,12 @@ export function SearchBar({
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => {
           // Escape clears the search, matching the × button. Only when there
-          // is something to clear, so an empty box lets Escape bubble (e.g. to
-          // close a surrounding popover).
+          // is something to clear: stop propagation so this Escape only clears,
+          // then an empty box lets the next Escape bubble (e.g. to close a
+          // surrounding popover).
           if (e.key === "Escape" && value) {
             e.preventDefault();
+            e.stopPropagation();
             onChange("");
           }
         }}

--- a/client/dashboard/src/components/ui/search-bar.tsx
+++ b/client/dashboard/src/components/ui/search-bar.tsx
@@ -31,6 +31,15 @@ export function SearchBar({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          // Escape clears the search, matching the × button. Only when there
+          // is something to clear, so an empty box lets Escape bubble (e.g. to
+          // close a surrounding popover).
+          if (e.key === "Escape" && value) {
+            e.preventDefault();
+            onChange("");
+          }
+        }}
         disabled={disabled}
         className="min-w-0 flex-1 bg-transparent outline-none disabled:cursor-not-allowed"
       />

--- a/client/dashboard/src/pages/logs/LogFilterBar.tsx
+++ b/client/dashboard/src/pages/logs/LogFilterBar.tsx
@@ -269,14 +269,17 @@ export function LogFilterBar({
         }
         break;
       case "Escape":
-        e.preventDefault();
         if (step === "operator") {
           // Cancel an in-progress filter build without touching the applied
           // search.
+          e.preventDefault();
           resetFlow();
-        } else {
+        } else if (searchInput) {
           // Key step: mirror the × button — clear the box and the applied
-          // search so results refresh without forcing a click.
+          // search so results refresh without forcing a click. When the box is
+          // already empty there is nothing to clear, so let Escape bubble (e.g.
+          // to close a surrounding popover) instead of swallowing it.
+          e.preventDefault();
           onSearchInputChange("");
           resetFlow();
           onSearchSubmit("");

--- a/client/dashboard/src/pages/logs/LogFilterBar.tsx
+++ b/client/dashboard/src/pages/logs/LogFilterBar.tsx
@@ -271,15 +271,18 @@ export function LogFilterBar({
       case "Escape":
         if (step === "operator") {
           // Cancel an in-progress filter build without touching the applied
-          // search.
+          // search. Consume the key so it doesn't also close a surrounding
+          // popover.
           e.preventDefault();
+          e.stopPropagation();
           resetFlow();
         } else if (searchInput) {
           // Key step: mirror the × button — clear the box and the applied
-          // search so results refresh without forcing a click. When the box is
-          // already empty there is nothing to clear, so let Escape bubble (e.g.
-          // to close a surrounding popover) instead of swallowing it.
+          // search so results refresh without forcing a click. Consume the
+          // key so this first Escape only clears; once the box is empty the
+          // next Escape bubbles (e.g. to close a surrounding popover).
           e.preventDefault();
+          e.stopPropagation();
           onSearchInputChange("");
           resetFlow();
           onSearchSubmit("");

--- a/client/dashboard/src/pages/logs/LogFilterBar.tsx
+++ b/client/dashboard/src/pages/logs/LogFilterBar.tsx
@@ -192,8 +192,13 @@ export function LogFilterBar({
         }
       }
       onSearchInputChange(value);
+      // Emptying the box clears the applied search without needing the ×
+      // button, so results refresh as soon as the query is gone.
+      if (step === "key" && value === "") {
+        onSearchSubmit("");
+      }
     },
-    [step, onSearchInputChange, handleOpSelect],
+    [step, onSearchInputChange, handleOpSelect, onSearchSubmit],
   );
 
   const handleValueSubmit = () => {
@@ -264,10 +269,17 @@ export function LogFilterBar({
         }
         break;
       case "Escape":
-        if (popoverOpen) {
-          e.preventDefault();
+        e.preventDefault();
+        if (step === "operator") {
+          // Cancel an in-progress filter build without touching the applied
+          // search.
+          resetFlow();
+        } else {
+          // Key step: mirror the × button — clear the box and the applied
+          // search so results refresh without forcing a click.
           onSearchInputChange("");
           resetFlow();
+          onSearchSubmit("");
         }
         break;
       case "Backspace":


### PR DESCRIPTION
## What

Follow-up to #3093 (AGE-2594). Makes the free-text search bars on the logs pages clearable consistently — via **Escape** and by **emptying the box**, not only the `×` button.

## Why

Two search bars were involved, both with the same "only the × clears it" friction:

**1. `LogFilterBar`** (MCP Server Logs). It tracks the live `searchInput` separately from the parent's applied `searchQuery` (which drives the data fetch); they only sync on submit. The `×` called `onSearchSubmit("")`, but Escape only cleared the local input (and was gated on the popover being open), and emptying the box never re-submitted — so the applied query lingered.

**2. The shared `SearchBar`** (`components/ui/search-bar.tsx`, used by Agent Sessions' `ChatLogsFilters` and elsewhere). It had an `×` button but no Escape handling. Emptying the box already clears for its consumers since their `onChange` fires live.

## How

**`LogFilterBar`:**

- Escape in the key step now mirrors the `×`: clears the input, resets the flow, and calls `onSearchSubmit("")`. In the operator step it still just cancels the in-progress filter build.
- Emptying the box in the key step now calls `onSearchSubmit("")`.

**`SearchBar`:**

- Escape clears the search (only when there's something to clear, so an empty box lets Escape bubble to e.g. close a surrounding popover).

This brings Agent Sessions and every other `SearchBar` consumer in line with the logs filter bar. The dropdown-only bars (Tool Logs `ObserveFilterBar`, `MCPServerFilter`, Insights filter bars) have no free-text box, so they're unaffected — they clear by deselection.

## Scope

Frontend-only, 2 files. No backend, migration, or SDK changes.

## Testing

- `tsc -p tsconfig.app.json --noEmit` — clean.
- `eslint` — clean.
- Not yet click-tested against a live dashboard.
