### PR TITLE
fix(dashboard): show member names in "Most Agent Sessions by User"

### DIFF
--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -82,6 +82,10 @@ export function ProjectDashboard() {
 
   const { data: membersData, isPending: isMembersPending } = useMembers();
   const members = useMemo(() => membersData?.members ?? [], [membersData]);
+  const memberById = useMemo(
+    () => new Map(members.map((m) => [m.id, m])),
+    [members],
+  );
 
   const { data: topUsersSearchData, isPending: isTopUsersPending } = useQuery({
     queryKey: ["project", "topUsers", from.toISOString(), to.toISOString()],
@@ -111,7 +115,6 @@ export function ProjectDashboard() {
 
   const topUsersByTokens = useMemo(() => {
     if (!topUsersSearchData) return [];
-    const memberById = new Map(members.map((m) => [m.id, m]));
     return [...topUsersSearchData]
       .sort(
         (a, b) =>
@@ -125,7 +128,7 @@ export function ProjectDashboard() {
         label: memberById.get(u.userId)?.name ?? u.userId,
         value: u.totalInputTokens + u.totalOutputTokens,
       }));
-  }, [topUsersSearchData, members]);
+  }, [topUsersSearchData, memberById]);
 
   const isTopUsersLoading =
     logsEnabled && (isTopUsersPending || isMembersPending);
@@ -398,31 +401,39 @@ export function ProjectDashboard() {
                     <ul className="divide-border divide-y">
                       {(overview?.summary.topUsers ?? [])
                         .slice(0, 5)
-                        .map((user, i) => (
-                          <li
-                            key={user.userId}
-                            className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
-                          >
-                            <Avatar className="size-8 shrink-0">
-                              <AvatarFallback
-                                className={cn(
-                                  "text-xs font-medium",
-                                  avatarColor(i),
-                                )}
-                              >
-                                {emailInitials(user.userId)}
-                              </AvatarFallback>
-                            </Avatar>
-                            <div className="min-w-0 flex-1">
-                              <p className="truncate text-sm font-medium">
-                                {user.userId}
-                              </p>
-                              <p className="text-muted-foreground text-xs">
-                                {user.activityCount.toLocaleString()} calls
-                              </p>
-                            </div>
-                          </li>
-                        ))}
+                        .map((user, i) => {
+                          const member = memberById.get(user.userId);
+                          const displayName = member?.name ?? user.userId;
+                          return (
+                            <li
+                              key={user.userId}
+                              className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+                            >
+                              <Avatar className="size-8 shrink-0">
+                                <AvatarFallback
+                                  className={cn(
+                                    "text-xs font-medium",
+                                    avatarColor(i),
+                                  )}
+                                >
+                                  {emailInitials(
+                                    member?.email ??
+                                      member?.name ??
+                                      user.userId,
+                                  )}
+                                </AvatarFallback>
+                              </Avatar>
+                              <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm font-medium">
+                                  {displayName}
+                                </p>
+                                <p className="text-muted-foreground text-xs">
+                                  {user.activityCount.toLocaleString()} calls
+                                </p>
+                              </div>
+                            </li>
+                          );
+                        })}
                     </ul>
                   )}
                 </DashboardCard>

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -130,6 +130,28 @@ export function ProjectDashboard() {
       }));
   }, [topUsersSearchData, memberById]);
 
+  // Most Agent Sessions by User reads from the same trusted telemetrySearchUsers
+  // data as Top Users (rather than overview.summary.topUsers), ranking by the
+  // number of distinct agent sessions (totalChats = unique gen_ai.conversation.id,
+  // which every hook source stamps with its session id). Names resolve via the
+  // shared memberById map; internal users only, so raw auth IDs no longer leak.
+  const topUsersBySessions = useMemo(() => {
+    if (!topUsersSearchData) return [];
+    return [...topUsersSearchData]
+      .filter((u) => u.totalChats > 0)
+      .sort((a, b) => b.totalChats - a.totalChats)
+      .slice(0, 5)
+      .map((u) => {
+        const member = memberById.get(u.userId);
+        return {
+          userId: u.userId,
+          name: member?.name ?? u.userId,
+          initialsSource: member?.email ?? member?.name ?? u.userId,
+          sessions: u.totalChats,
+        };
+      });
+  }, [topUsersSearchData, memberById]);
+
   const isTopUsersLoading =
     logsEnabled && (isTopUsersPending || isMembersPending);
 
@@ -358,7 +380,7 @@ export function ProjectDashboard() {
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <DashboardCard
                   title="Most Agent Sessions by User"
-                  tooltip="End users ranked by agent activity in the selected period. When agent sessions exist, activity counts chat messages; otherwise it counts tool calls from tool events."
+                  tooltip="Employees ranked by the number of distinct agent sessions in the selected period."
                   action={
                     <CardActions>
                       <ExploreWithAIButton
@@ -393,47 +415,38 @@ export function ProjectDashboard() {
                     </CardActions>
                   }
                 >
-                  {isOverviewPending ? (
+                  {isTopUsersLoading ? (
                     <SkeletonList />
-                  ) : (overview?.summary.topUsers.length ?? 0) === 0 ? (
+                  ) : topUsersBySessions.length === 0 ? (
                     <EmptyState message="No session activity recorded" />
                   ) : (
                     <ul className="divide-border divide-y">
-                      {(overview?.summary.topUsers ?? [])
-                        .slice(0, 5)
-                        .map((user, i) => {
-                          const member = memberById.get(user.userId);
-                          const displayName = member?.name ?? user.userId;
-                          return (
-                            <li
-                              key={user.userId}
-                              className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+                      {topUsersBySessions.map((user, i) => (
+                        <li
+                          key={user.userId}
+                          className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+                        >
+                          <Avatar className="size-8 shrink-0">
+                            <AvatarFallback
+                              className={cn(
+                                "text-xs font-medium",
+                                avatarColor(i),
+                              )}
                             >
-                              <Avatar className="size-8 shrink-0">
-                                <AvatarFallback
-                                  className={cn(
-                                    "text-xs font-medium",
-                                    avatarColor(i),
-                                  )}
-                                >
-                                  {emailInitials(
-                                    member?.email ??
-                                      member?.name ??
-                                      user.userId,
-                                  )}
-                                </AvatarFallback>
-                              </Avatar>
-                              <div className="min-w-0 flex-1">
-                                <p className="truncate text-sm font-medium">
-                                  {displayName}
-                                </p>
-                                <p className="text-muted-foreground text-xs">
-                                  {user.activityCount.toLocaleString()} calls
-                                </p>
-                              </div>
-                            </li>
-                          );
-                        })}
+                              {emailInitials(user.initialsSource)}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium">
+                              {user.name}
+                            </p>
+                            <p className="text-muted-foreground text-xs">
+                              {user.sessions.toLocaleString()}{" "}
+                              {user.sessions === 1 ? "session" : "sessions"}
+                            </p>
+                          </div>
+                        </li>
+                      ))}
                     </ul>
                   )}
                 </DashboardCard>


### PR DESCRIPTION
## What

The Project Overview **"Most Agent Sessions by User"** card rendered raw auth IDs (`auth0|...`) instead of member names because it read from `overview.summary.topUsers`.

Rather than resolve IDs against that source, this re-points the card at the same **`telemetrySearchUsers`** data already powering the **"Top Users"** card (#2985 / #2989) — the source we trust most — and ranks by the number of **distinct agent sessions**.

## How

- New `topUsersBySessions` memo over the existing `telemetrySearchUsers` data (no new query, no backend change), sorted by `totalChats` — the count of unique `gen_ai.conversation.id` per user. Every hook source (Claude Code, Cursor, Codex) stamps its session id onto that attribute, so `totalChats` is the agent-session count per user.
- Member names resolve via a shared `memberById` map lifted to component scope. `userType: "internal"` only, so raw auth IDs no longer leak into the card.
- The card now displays "N sessions" and uses the `searchUsers` + `useMembers` loading state.

## Testing

- `cd client/dashboard && npx tsc --noEmit` → no errors.

Fixes [AGE-2597](https://linear.app/speakeasy/issue/AGE-2597/bug-investigate-identities-missing-in-most-agent-sessions-by-user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
